### PR TITLE
Fix/type imports pass 2: web-components

### DIFF
--- a/change/@fluentui-web-components-effd8351-dc81-479f-9d1a-566e930c01ee.json
+++ b/change/@fluentui-web-components-effd8351-dc81-479f-9d1a-566e930c01ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating Typescript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/web-components",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -11,7 +11,7 @@ import { Anchor as Anchor_2 } from '@microsoft/fast-foundation';
 import { AnchoredRegion } from '@microsoft/fast-foundation';
 import { Badge as Badge_2 } from '@microsoft/fast-foundation';
 import { BaseProgress } from '@microsoft/fast-foundation';
-import { Behavior } from '@microsoft/fast-element';
+import type { Behavior } from '@microsoft/fast-element';
 import { Breadcrumb } from '@microsoft/fast-foundation';
 import { BreadcrumbItem } from '@microsoft/fast-foundation';
 import { BreadcrumbItemOptions } from '@microsoft/fast-foundation';

--- a/packages/web-components/src/accordion/accordion-item/accordion-item.styles.ts
+++ b/packages/web-components/src/accordion/accordion-item/accordion-item.styles.ts
@@ -1,8 +1,6 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import {
-  AccordionItemOptions,
   display,
-  ElementDefinitionContext,
   focusVisible,
   forcedColorsStylesheetBehavior,
 } from '@microsoft/fast-foundation';
@@ -21,6 +19,7 @@ import {
   typeRampMinus1LineHeight,
 } from '../../design-tokens';
 import { heightNumber } from '../../styles/size';
+import type { AccordionItemOptions, ElementDefinitionContext } from "@microsoft/fast-foundation";
 
 export const accordionItemStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/accordion/accordion-item/index.ts
+++ b/packages/web-components/src/accordion/accordion-item/index.ts
@@ -1,5 +1,6 @@
-import { AccordionItem, AccordionItemOptions, accordionItemTemplate as template } from '@microsoft/fast-foundation';
+import { AccordionItem, accordionItemTemplate as template } from '@microsoft/fast-foundation';
 import { accordionItemStyles as styles } from './accordion-item.styles';
+import type { AccordionItemOptions } from '@microsoft/fast-foundation';
 
 /**
  * The Fluent Accordion Item Element. Implements {@link @microsoft/fast-foundation#AccordionItem},

--- a/packages/web-components/src/accordion/accordion.styles.ts
+++ b/packages/web-components/src/accordion/accordion.styles.ts
@@ -1,5 +1,5 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { display, ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
+import { display } from '@microsoft/fast-foundation';
 import {
   bodyFont,
   neutralForegroundRest,
@@ -8,6 +8,7 @@ import {
   typeRampMinus1FontSize,
   typeRampMinus1LineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const accordionStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/anchor/anchor.styles.ts
+++ b/packages/web-components/src/anchor/anchor.styles.ts
@@ -1,5 +1,4 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
 import {
   AccentButtonStyles,
   baseButtonStyles,
@@ -9,6 +8,7 @@ import {
   StealthButtonStyles,
 } from '../styles/';
 import { appearanceBehavior } from '../utilities/behaviors';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const anchorStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/anchor/index.ts
+++ b/packages/web-components/src/anchor/index.ts
@@ -1,7 +1,7 @@
 import { attr } from '@microsoft/fast-element';
 import { Anchor as FoundationAnchor, anchorTemplate as template } from '@microsoft/fast-foundation';
-import { ButtonAppearance } from '../button';
 import { anchorStyles as styles } from './anchor.styles';
+import type { ButtonAppearance } from '../button';
 
 /**
  * Types of anchor appearance.

--- a/packages/web-components/src/anchored-region/anchored-region.styles.ts
+++ b/packages/web-components/src/anchored-region/anchored-region.styles.ts
@@ -1,5 +1,5 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const anchoredRegionStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/badge/badge.styles.ts
+++ b/packages/web-components/src/badge/badge.styles.ts
@@ -1,5 +1,5 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { display, ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
+import { display } from '@microsoft/fast-foundation';
 import {
   accentFillRest,
   bodyFont,
@@ -12,6 +12,7 @@ import {
   typeRampMinus1FontSize,
   typeRampMinus1LineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const badgeStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/web-components/src/breadcrumb-item/breadcrumb-item.styles.ts
@@ -1,8 +1,6 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import {
-  BreadcrumbItemOptions,
   display,
-  ElementDefinitionContext,
   focusVisible,
   forcedColorsStylesheetBehavior,
 } from '@microsoft/fast-foundation';
@@ -19,6 +17,7 @@ import {
   typeRampBaseLineHeight,
 } from '../design-tokens';
 import { heightNumber } from '../styles/index';
+import type { BreadcrumbItemOptions, ElementDefinitionContext } from "@microsoft/fast-foundation";
 
 export const breadcrumbItemStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/breadcrumb-item/index.ts
+++ b/packages/web-components/src/breadcrumb-item/index.ts
@@ -1,5 +1,6 @@
-import { BreadcrumbItem, BreadcrumbItemOptions, breadcrumbItemTemplate as template } from '@microsoft/fast-foundation';
+import { BreadcrumbItem, breadcrumbItemTemplate as template } from '@microsoft/fast-foundation';
 import { breadcrumbItemStyles as styles } from './breadcrumb-item.styles';
+import type { BreadcrumbItemOptions } from '@microsoft/fast-foundation';
 
 /**
  * The Fluent BreadcrumbItem Element. Implements {@link @microsoft/fast-foundation#BreadcrumbItem},

--- a/packages/web-components/src/breadcrumb/breadcrumb.styles.ts
+++ b/packages/web-components/src/breadcrumb/breadcrumb.styles.ts
@@ -1,6 +1,7 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { display, ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
+import { display } from '@microsoft/fast-foundation';
 import { bodyFont, typeRampBaseFontSize, typeRampBaseLineHeight } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const breadcrumbStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -1,9 +1,7 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import {
   disabledCursor,
-  ElementDefinitionContext,
-  forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
@@ -22,6 +20,7 @@ import {
   neutralFillStealthRest,
   neutralStrokeRest,
 } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const buttonStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/card/card.styles.ts
+++ b/packages/web-components/src/card/card.styles.ts
@@ -1,13 +1,12 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import {
   display,
-  ElementDefinitionContext,
-  forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import { elevation } from '../styles';
 import { fillColor, layerCornerRadius, neutralForegroundRest } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const cardStyles: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ElementStyles =
   (context: ElementDefinitionContext, definition: FoundationElementDefinition) =>

--- a/packages/web-components/src/card/index.ts
+++ b/packages/web-components/src/card/index.ts
@@ -1,10 +1,12 @@
 import { composedParent, Card as FoundationCard, cardTemplate as template } from '@microsoft/fast-foundation';
-import { attr, Notifier, Observable } from '@microsoft/fast-element';
+import { attr, Observable } from '@microsoft/fast-element';
 import { parseColorHexRGB } from '@microsoft/fast-colors';
 import { fillColor, neutralFillLayerRecipe, neutralPalette } from '../design-tokens';
-import { Swatch, SwatchRGB } from '../color/swatch';
+import { SwatchRGB } from '../color/swatch';
 import { PaletteRGB } from '../color/palette';
 import { cardStyles as styles } from './card.styles';
+import type { Notifier } from '@microsoft/fast-element';
+import type { Swatch } from '../color/swatch';
 
 /**
  * @public

--- a/packages/web-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/src/checkbox/checkbox.styles.ts
@@ -1,9 +1,7 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import {
-  CheckboxOptions,
   disabledCursor,
   display,
-  ElementDefinitionContext,
   focusVisible,
   forcedColorsStylesheetBehavior,
 } from '@microsoft/fast-foundation';
@@ -27,6 +25,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
+import type { CheckboxOptions, ElementDefinitionContext } from "@microsoft/fast-foundation";
 
 export const checkboxStyles: (context: ElementDefinitionContext, definition: CheckboxOptions) => ElementStyles = (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/checkbox/index.ts
+++ b/packages/web-components/src/checkbox/index.ts
@@ -1,5 +1,6 @@
-import { Checkbox, CheckboxOptions, checkboxTemplate as template } from '@microsoft/fast-foundation';
+import { Checkbox, checkboxTemplate as template } from '@microsoft/fast-foundation';
 import { checkboxStyles as styles } from './checkbox.styles';
+import type { CheckboxOptions } from '@microsoft/fast-foundation';
 
 /**
  * The Fluent Checkbox Element. Implements {@link @microsoft/fast-foundation#Checkbox},

--- a/packages/web-components/src/color/palette.ts
+++ b/packages/web-components/src/color/palette.ts
@@ -1,8 +1,10 @@
 import { clamp, ColorRGBA64, ComponentStateColorPalette, parseColorHexRGB } from '@microsoft/fast-colors';
-import { Swatch, SwatchRGB } from './swatch';
+import { SwatchRGB } from './swatch';
 import { binarySearch } from './utilities/binary-search';
 import { directionByIsDark } from './utilities/direction-by-is-dark';
-import { contrast, RelativeLuminance } from './utilities/relative-luminance';
+import { contrast } from './utilities/relative-luminance';
+import type { Swatch } from './swatch';
+import type { RelativeLuminance } from './utilities/relative-luminance';
 
 /**
  * A collection of {@link Swatch} instances

--- a/packages/web-components/src/color/recipe.ts
+++ b/packages/web-components/src/color/recipe.ts
@@ -1,4 +1,4 @@
-import { Swatch } from './swatch';
+import type { Swatch } from './swatch';
 
 /** @public */
 export interface InteractiveSwatchSet {

--- a/packages/web-components/src/color/recipes/accent-fill.ts
+++ b/packages/web-components/src/color/recipes/accent-fill.ts
@@ -1,6 +1,6 @@
-import { Palette } from '../palette';
-import { InteractiveSwatchSet } from '../recipe';
-import { Swatch } from '../swatch';
+import type { Palette } from '../palette';
+import type { InteractiveSwatchSet } from '../recipe';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/accent-foreground.ts
+++ b/packages/web-components/src/color/recipes/accent-foreground.ts
@@ -1,7 +1,7 @@
-import { Palette } from '../palette';
-import { InteractiveSwatchSet } from '../recipe';
-import { Swatch } from '../swatch';
 import { directionByIsDark } from '../utilities/direction-by-is-dark';
+import type { Palette } from '../palette';
+import type { InteractiveSwatchSet } from '../recipe';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/focus-stroke.ts
+++ b/packages/web-components/src/color/recipes/focus-stroke.ts
@@ -1,6 +1,6 @@
-import { Palette } from '../palette';
-import { Swatch } from '../swatch';
 import { directionByIsDark } from '../utilities/direction-by-is-dark';
+import type { Palette } from '../palette';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/foreground-on-accent.ts
+++ b/packages/web-components/src/color/recipes/foreground-on-accent.ts
@@ -1,5 +1,5 @@
-import { Swatch } from '../swatch';
 import { black, white } from '../utilities/color-constants';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-divider.ts
+++ b/packages/web-components/src/color/recipes/neutral-divider.ts
@@ -1,6 +1,6 @@
-import { Swatch } from '../swatch';
-import { Palette } from '../palette';
 import { directionByIsDark } from '../utilities/direction-by-is-dark';
+import type { Swatch } from '../swatch';
+import type { Palette } from '../palette';
 
 /**
  * The neutralDivider color recipe

--- a/packages/web-components/src/color/recipes/neutral-fill-contrast.ts
+++ b/packages/web-components/src/color/recipes/neutral-fill-contrast.ts
@@ -1,7 +1,7 @@
-import { Palette } from '../palette';
-import { InteractiveSwatchSet } from '../recipe';
-import { Swatch } from '../swatch';
 import { directionByIsDark } from '../utilities/direction-by-is-dark';
+import type { Palette } from '../palette';
+import type { InteractiveSwatchSet } from '../recipe';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-fill-input.ts
+++ b/packages/web-components/src/color/recipes/neutral-fill-input.ts
@@ -1,7 +1,7 @@
-import { Palette } from '../palette';
-import { InteractiveSwatchSet } from '../recipe';
-import { Swatch } from '../swatch';
 import { directionByIsDark } from '../utilities/direction-by-is-dark';
+import type { Palette } from '../palette';
+import type { InteractiveSwatchSet } from '../recipe';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-fill-inverse.ts
+++ b/packages/web-components/src/color/recipes/neutral-fill-inverse.ts
@@ -1,7 +1,7 @@
-import { Palette } from '../palette';
-import { InteractiveSwatchSet } from '../recipe';
-import { Swatch } from '../swatch';
 import { directionByIsDark } from '../utilities/direction-by-is-dark';
+import type { Palette } from '../palette';
+import type { InteractiveSwatchSet } from '../recipe';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-fill-layer.ts
+++ b/packages/web-components/src/color/recipes/neutral-fill-layer.ts
@@ -1,5 +1,5 @@
-import { Palette } from '../palette';
-import { Swatch } from '../swatch';
+import type { Palette } from '../palette';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-fill-stealth.ts
+++ b/packages/web-components/src/color/recipes/neutral-fill-stealth.ts
@@ -1,6 +1,6 @@
-import { Palette } from '../palette';
-import { InteractiveSwatchSet } from '../recipe';
-import { Swatch } from '../swatch';
+import type { Palette } from '../palette';
+import type { InteractiveSwatchSet } from '../recipe';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-fill.ts
+++ b/packages/web-components/src/color/recipes/neutral-fill.ts
@@ -1,6 +1,6 @@
-import { Palette } from '../palette';
-import { InteractiveSwatchSet } from '../recipe';
-import { Swatch } from '../swatch';
+import type { Palette } from '../palette';
+import type { InteractiveSwatchSet } from '../recipe';
+import type { Swatch } from '../swatch';
 
 /**
  *

--- a/packages/web-components/src/color/recipes/neutral-foreground-hint.ts
+++ b/packages/web-components/src/color/recipes/neutral-foreground-hint.ts
@@ -1,5 +1,5 @@
-import { Palette } from '../palette';
-import { Swatch } from '../swatch';
+import type { Palette } from '../palette';
+import type { Swatch } from '../swatch';
 
 /**
  * The neutralForegroundHint color recipe

--- a/packages/web-components/src/color/recipes/neutral-foreground.ts
+++ b/packages/web-components/src/color/recipes/neutral-foreground.ts
@@ -1,5 +1,5 @@
-import { Palette } from '../palette';
-import { Swatch } from '../swatch';
+import type { Palette } from '../palette';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-layer-1.ts
+++ b/packages/web-components/src/color/recipes/neutral-layer-1.ts
@@ -1,6 +1,6 @@
-import { Palette } from '../palette';
-import { Swatch } from '../swatch';
 import { baseLayerLuminanceSwatch } from '../utilities/base-layer-luminance';
+import type { Palette } from '../palette';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-layer-2.ts
+++ b/packages/web-components/src/color/recipes/neutral-layer-2.ts
@@ -1,6 +1,6 @@
-import { Palette } from '../palette';
-import { Swatch } from '../swatch';
 import { baseLayerLuminanceSwatch } from '../utilities/base-layer-luminance';
+import type { Palette } from '../palette';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-layer-3.ts
+++ b/packages/web-components/src/color/recipes/neutral-layer-3.ts
@@ -1,6 +1,6 @@
-import { Palette } from '../palette';
-import { Swatch } from '../swatch';
 import { neutralLayer2Index } from './neutral-layer-2';
+import type { Palette } from '../palette';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-layer-4.ts
+++ b/packages/web-components/src/color/recipes/neutral-layer-4.ts
@@ -1,6 +1,6 @@
-import { Palette } from '../palette';
-import { Swatch } from '../swatch';
 import { neutralLayer2Index } from './neutral-layer-2';
+import type { Palette } from '../palette';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-layer-card-container.ts
+++ b/packages/web-components/src/color/recipes/neutral-layer-card-container.ts
@@ -1,7 +1,7 @@
 import { clamp } from '@microsoft/fast-colors';
-import { Palette } from '../palette';
-import { Swatch } from '../swatch';
 import { baseLayerLuminanceSwatch } from '../utilities/base-layer-luminance';
+import type { Palette } from '../palette';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-layer-floating.ts
+++ b/packages/web-components/src/color/recipes/neutral-layer-floating.ts
@@ -1,6 +1,6 @@
-import { Palette } from '../palette';
-import { Swatch } from '../swatch';
 import { baseLayerLuminanceSwatch } from '../utilities/base-layer-luminance';
+import type { Palette } from '../palette';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/recipes/neutral-stroke.ts
+++ b/packages/web-components/src/color/recipes/neutral-stroke.ts
@@ -1,7 +1,7 @@
-import { Palette } from '../palette';
-import { InteractiveSwatchSet } from '../recipe';
-import { Swatch } from '../swatch';
 import { directionByIsDark } from '../utilities/direction-by-is-dark';
+import type { Palette } from '../palette';
+import type { InteractiveSwatchSet } from '../recipe';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/swatch.ts
+++ b/packages/web-components/src/color/swatch.ts
@@ -1,5 +1,6 @@
 import { ColorRGBA64, rgbToRelativeLuminance } from '@microsoft/fast-colors';
-import { contrast, RelativeLuminance } from './utilities/relative-luminance';
+import { contrast } from './utilities/relative-luminance';
+import type { RelativeLuminance } from './utilities/relative-luminance';
 
 /**
  * Represents a color in a {@link Palette}

--- a/packages/web-components/src/color/utilities/base-layer-luminance.ts
+++ b/packages/web-components/src/color/utilities/base-layer-luminance.ts
@@ -1,4 +1,5 @@
-import { Swatch, SwatchRGB } from '../swatch';
+import { SwatchRGB } from '../swatch';
+import type { Swatch } from '../swatch';
 
 export function baseLayerLuminanceSwatch(luminance: number): Swatch {
   return SwatchRGB.create(luminance, luminance, luminance);

--- a/packages/web-components/src/color/utilities/direction-by-is-dark.ts
+++ b/packages/web-components/src/color/utilities/direction-by-is-dark.ts
@@ -1,5 +1,5 @@
-import { Swatch } from '../swatch';
 import { isDark } from './is-dark';
+import type { Swatch } from '../swatch';
 
 /**
  * @internal

--- a/packages/web-components/src/color/utilities/is-dark.ts
+++ b/packages/web-components/src/color/utilities/is-dark.ts
@@ -1,11 +1,11 @@
-import { Swatch } from '../swatch';
-
 /*
  * A color is in "dark" if there is more contrast between #000000 and a reference
  * color than #FFFFFF and the reference color. That threshold can be expressed as a relative luminance
  * using the contrast formula as (1 + 0.5) / (R + 0.05) === (R + 0.05) / (0 + 0.05),
  * which reduces to the following, where 'R' is the relative luminance of the reference color
  */
+import type { Swatch } from '../swatch';
+
 const target = (-0.1 + Math.sqrt(0.21)) / 2;
 
 /**

--- a/packages/web-components/src/combobox/combobox.styles.ts
+++ b/packages/web-components/src/combobox/combobox.styles.ts
@@ -1,8 +1,9 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { ComboboxOptions, disabledCursor, ElementDefinitionContext, focusVisible } from '@microsoft/fast-foundation';
+import { disabledCursor, focusVisible } from '@microsoft/fast-foundation';
 import { selectFilledStyles, selectStyles } from '../select/select.styles';
 import { appearanceBehavior } from '../utilities/behaviors';
 import { strokeWidth, typeRampBaseFontSize, typeRampBaseLineHeight } from '../design-tokens';
+import type { ComboboxOptions, ElementDefinitionContext } from "@microsoft/fast-foundation";
 
 export const comboboxStyles: (context: ElementDefinitionContext, definition: ComboboxOptions) => ElementStyles = (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/combobox/index.ts
+++ b/packages/web-components/src/combobox/index.ts
@@ -1,11 +1,8 @@
 import { attr } from '@microsoft/fast-element';
-import {
-  ComboboxOptions,
-  Combobox as FoundationCombobox,
-  comboboxTemplate as template,
-} from '@microsoft/fast-foundation';
-import { SelectAppearance } from '../select';
+import { Combobox as FoundationCombobox, comboboxTemplate as template } from '@microsoft/fast-foundation';
 import { comboboxStyles as styles } from './combobox.styles';
+import type { ComboboxOptions } from '@microsoft/fast-foundation';
+import type { SelectAppearance } from '../select';
 
 /**
  * Combobox appearances

--- a/packages/web-components/src/data-grid/data-grid-cell.styles.ts
+++ b/packages/web-components/src/data-grid/data-grid-cell.styles.ts
@@ -1,10 +1,8 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import {
   bodyFont,
@@ -16,6 +14,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const dataGridCellStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/data-grid/data-grid-row.styles.ts
+++ b/packages/web-components/src/data-grid/data-grid-row.styles.ts
@@ -1,10 +1,9 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import {
-  ElementDefinitionContext,
-  forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { neutralFillRest, neutralStrokeDividerRest, strokeWidth } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const dataGridRowStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/data-grid/data-grid.stories.ts
+++ b/packages/web-components/src/data-grid/data-grid.stories.ts
@@ -1,10 +1,11 @@
 import { html } from '@microsoft/fast-element';
-import { Button, ColumnDefinition, DataGrid, DataGridCell, DataGridRow } from '@microsoft/fast-foundation';
+import { Button, DataGrid, DataGridCell, DataGridRow } from '@microsoft/fast-foundation';
 import { GenerateHeaderOptions } from '@microsoft/fast-foundation/dist/esm/data-grid/data-grid.options';
 import addons from '@storybook/addons';
 import { STORY_RENDERED } from '@storybook/core-events';
 import DataGridTemplate from './fixtures/base.html';
 import './index';
+import type { ColumnDefinition } from '@microsoft/fast-foundation';
 
 /* eslint-disable @typescript-eslint/ban-types */
 let defaultGridElement: DataGrid | null = null;

--- a/packages/web-components/src/data-grid/data-grid.styles.ts
+++ b/packages/web-components/src/data-grid/data-grid.styles.ts
@@ -1,5 +1,5 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const dataGridStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/design-system-provider/index.ts
+++ b/packages/web-components/src/design-system-provider/index.ts
@@ -1,23 +1,9 @@
 import { parseColorHexRGB } from '@microsoft/fast-colors';
-import {
-  attr,
-  css,
-  html,
-  nullableNumberConverter,
-  Observable,
-  observable,
-  ValueConverter,
-} from '@microsoft/fast-element';
-import {
-  DesignToken,
-  DesignTokenValue,
-  display,
-  forcedColorsStylesheetBehavior,
-  FoundationElement,
-} from '@microsoft/fast-foundation';
+import { attr, css, html, nullableNumberConverter, Observable, observable } from '@microsoft/fast-element';
+import { DesignToken, display, forcedColorsStylesheetBehavior, FoundationElement } from '@microsoft/fast-foundation';
 import { Direction, SystemColors } from '@microsoft/fast-web-utilities';
-import { Palette, PaletteRGB } from '../color/palette';
-import { Swatch, SwatchRGB } from '../color/swatch';
+import { PaletteRGB } from '../color/palette';
+import { SwatchRGB } from '../color/swatch';
 import {
   accentFillActiveDelta,
   accentFillFocusDelta,
@@ -81,6 +67,10 @@ import {
   typeRampPlus6FontSize,
   typeRampPlus6LineHeight,
 } from '../design-tokens';
+import type { ValueConverter } from '@microsoft/fast-element';
+import type { DesignTokenValue } from '@microsoft/fast-foundation';
+import type { Palette } from '../color/palette';
+import type { Swatch } from '../color/swatch';
 
 /**
  * A {@link ValueConverter} that converts to and from `Swatch` values.

--- a/packages/web-components/src/design-tokens.ts
+++ b/packages/web-components/src/design-tokens.ts
@@ -1,7 +1,6 @@
 import { DesignToken } from '@microsoft/fast-foundation';
 import { Direction } from '@microsoft/fast-web-utilities';
-import { Palette, PaletteRGB } from './color/palette';
-import { Swatch } from './color/swatch';
+import { PaletteRGB } from './color/palette';
 import { accentFill as accentFillAlgorithm } from './color/recipes/accent-fill';
 import { accentForeground as accentForegroundAlgorithm } from './color/recipes/accent-foreground';
 import { foregroundOnAccent as foregroundOnAccentAlgorithm } from './color/recipes/foreground-on-accent';
@@ -27,7 +26,9 @@ import { neutralLayer4 as neutralLayer4Algorithm } from './color/recipes/neutral
 import { neutralStroke as neutralStrokeAlgorithm } from './color/recipes/neutral-stroke';
 import { accentBase, middleGrey } from './color/utilities/color-constants';
 import { StandardLuminance } from './color/utilities/base-layer-luminance';
-import { InteractiveSwatchSet } from './color/recipe';
+import type { Palette } from './color/palette';
+import type { Swatch } from './color/swatch';
+import type { InteractiveSwatchSet } from './color/recipe';
 
 /** @public */
 export interface Recipe<T> {

--- a/packages/web-components/src/dialog/dialog.styles.ts
+++ b/packages/web-components/src/dialog/dialog.styles.ts
@@ -1,7 +1,7 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
 import { elevation } from '../styles';
 import { fillColor, layerCornerRadius, strokeWidth } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const dialogStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/divider/divider.styles.ts
+++ b/packages/web-components/src/divider/divider.styles.ts
@@ -1,6 +1,7 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { display, ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
+import { display } from '@microsoft/fast-foundation';
 import { designUnit, neutralStrokeDividerRest, strokeWidth } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const dividerStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/src/flipper/flipper.styles.ts
@@ -2,8 +2,6 @@ import { css, ElementStyles } from '@microsoft/fast-element';
 import {
   disabledCursor,
   display,
-  ElementDefinitionContext,
-  FlipperOptions,
   focusVisible,
   forcedColorsStylesheetBehavior,
 } from '@microsoft/fast-foundation';
@@ -21,6 +19,7 @@ import {
   neutralStrokeRest,
   strokeWidth,
 } from '../design-tokens';
+import type { ElementDefinitionContext, FlipperOptions } from "@microsoft/fast-foundation";
 
 export const flipperStyles: (context: ElementDefinitionContext, definition: FlipperOptions) => ElementStyles = (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/flipper/index.ts
+++ b/packages/web-components/src/flipper/index.ts
@@ -1,5 +1,6 @@
-import { Flipper, FlipperOptions, flipperTemplate as template } from '@microsoft/fast-foundation';
+import { Flipper, flipperTemplate as template } from '@microsoft/fast-foundation';
 import { flipperStyles as styles } from './flipper.styles';
+import type { FlipperOptions } from '@microsoft/fast-foundation';
 
 /**
  * The Fluent Flipper Element. Implements {@link @microsoft/fast-foundation#Flipper},

--- a/packages/web-components/src/horizontal-scroll/horizontal-scroll.styles.ts
+++ b/packages/web-components/src/horizontal-scroll/horizontal-scroll.styles.ts
@@ -1,6 +1,7 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { display, ElementDefinitionContext, HorizontalScrollOptions } from '@microsoft/fast-foundation';
+import { display } from '@microsoft/fast-foundation';
 import { DirectionalStyleSheetBehavior } from '../styles';
+import type { ElementDefinitionContext, HorizontalScrollOptions } from "@microsoft/fast-foundation";
 
 const ltrActionsStyles = css`
   .scroll-prev {

--- a/packages/web-components/src/horizontal-scroll/index.ts
+++ b/packages/web-components/src/horizontal-scroll/index.ts
@@ -1,10 +1,10 @@
 import { html } from '@microsoft/fast-element';
 import {
   HorizontalScroll as FoundationHorizontalScroll,
-  HorizontalScrollOptions,
   horizontalScrollTemplate as template,
 } from '@microsoft/fast-foundation';
 import { ActionsStyles, horizontalScrollStyles as styles } from './horizontal-scroll.styles';
+import type { HorizontalScrollOptions } from '@microsoft/fast-foundation';
 
 /**
  * @internal

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -42,8 +42,10 @@ export * from './tree-view/';
 // export styles and utils
 export * from './design-tokens';
 export * from './styles';
-export { Palette, PaletteRGB } from './color/palette';
-export { InteractiveSwatchSet } from './color/recipe';
-export { Swatch, SwatchRGB } from './color/swatch';
+export { PaletteRGB } from './color/palette';
+export { SwatchRGB } from './color/swatch';
 export { isDark } from './color/utilities/is-dark';
 export { StandardLuminance } from './color/utilities/base-layer-luminance';
+export type { Palette } from './color/palette';
+export type { InteractiveSwatchSet } from './color/recipe';
+export type { Swatch } from './color/swatch';

--- a/packages/web-components/src/listbox-option/listbox-option.styles.ts
+++ b/packages/web-components/src/listbox-option/listbox-option.styles.ts
@@ -2,10 +2,8 @@ import { css, ElementStyles } from '@microsoft/fast-element';
 import {
   disabledCursor,
   display,
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import { heightNumber } from '../styles/size';
@@ -31,6 +29,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const optionStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/listbox/listbox.styles.ts
+++ b/packages/web-components/src/listbox/listbox.styles.ts
@@ -1,10 +1,8 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import {
   display,
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
@@ -16,6 +14,7 @@ import {
   neutralStrokeRest,
   strokeWidth,
 } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const listboxStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/menu-item/index.ts
+++ b/packages/web-components/src/menu-item/index.ts
@@ -1,5 +1,6 @@
-import { MenuItem, MenuItemOptions, menuItemTemplate as template } from '@microsoft/fast-foundation';
+import { MenuItem, menuItemTemplate as template } from '@microsoft/fast-foundation';
 import { menuItemStyles as styles } from './menu-item.styles';
+import type { MenuItemOptions } from '@microsoft/fast-foundation';
 
 /**
  * The Fluent Menu Item Element. Implements {@link @microsoft/fast-foundation#MenuItem},

--- a/packages/web-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/src/menu-item/menu-item.styles.ts
@@ -2,10 +2,8 @@ import { css, ElementStyles } from '@microsoft/fast-element';
 import {
   disabledCursor,
   display,
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  MenuItemOptions,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import { heightNumber } from '../styles/index';
@@ -24,6 +22,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, MenuItemOptions } from "@microsoft/fast-foundation";
 
 export const menuItemStyles: (context: ElementDefinitionContext, definition: MenuItemOptions) => ElementStyles = (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/menu/menu.styles.ts
+++ b/packages/web-components/src/menu/menu.styles.ts
@@ -1,5 +1,5 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { display, ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
+import { display } from '@microsoft/fast-foundation';
 import { elevation } from '../styles/index';
 import {
   controlCornerRadius,
@@ -9,6 +9,7 @@ import {
   neutralStrokeDividerRest,
   strokeWidth,
 } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const menuStyles: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ElementStyles =
   (context: ElementDefinitionContext, definition: FoundationElementDefinition) =>

--- a/packages/web-components/src/number-field/index.ts
+++ b/packages/web-components/src/number-field/index.ts
@@ -1,10 +1,7 @@
 import { attr } from '@microsoft/fast-element';
-import {
-  NumberField as FoundationNumberField,
-  NumberFieldOptions,
-  numberFieldTemplate as template,
-} from '@microsoft/fast-foundation';
+import { NumberField as FoundationNumberField, numberFieldTemplate as template } from '@microsoft/fast-foundation';
 import { numberFieldStyles as styles } from './number-field.styles';
+import type { NumberFieldOptions } from '@microsoft/fast-foundation';
 
 /**
  * Number field appearances

--- a/packages/web-components/src/number-field/number-field.styles.ts
+++ b/packages/web-components/src/number-field/number-field.styles.ts
@@ -2,10 +2,8 @@ import { css, ElementStyles } from '@microsoft/fast-element';
 import {
   disabledCursor,
   display,
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  NumberFieldOptions,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import { fillStateStyles, heightNumber } from '../styles/index';
@@ -29,6 +27,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, NumberFieldOptions } from "@microsoft/fast-foundation";
 
 export const numberFieldFilledStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/progress/progress-ring/index.ts
+++ b/packages/web-components/src/progress/progress-ring/index.ts
@@ -1,9 +1,6 @@
-import {
-  BaseProgress as ProgressRing,
-  ProgressRingOptions,
-  progressRingTemplate as template,
-} from '@microsoft/fast-foundation';
+import { BaseProgress as ProgressRing, progressRingTemplate as template } from '@microsoft/fast-foundation';
 import { progressRingStyles as styles } from './progress-ring.styles';
+import type { ProgressRingOptions } from '@microsoft/fast-foundation';
 
 /**
  * The Fluent Progress Ring Element. Implements {@link @microsoft/fast-foundation#BaseProgress},

--- a/packages/web-components/src/progress/progress-ring/progress-ring.styles.ts
+++ b/packages/web-components/src/progress/progress-ring/progress-ring.styles.ts
@@ -2,12 +2,11 @@ import { css, ElementStyles } from '@microsoft/fast-element';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
   display,
-  ElementDefinitionContext,
-  forcedColorsStylesheetBehavior,
-  ProgressRingOptions,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { heightNumber } from '../../styles';
 import { accentForegroundRest, neutralFillRest, neutralForegroundHint } from '../../design-tokens';
+import type { ElementDefinitionContext, ProgressRingOptions } from "@microsoft/fast-foundation";
 
 export const progressRingStyles: (context: ElementDefinitionContext, definition: ProgressRingOptions) => ElementStyles =
   (context: ElementDefinitionContext, definition: ProgressRingOptions) =>

--- a/packages/web-components/src/progress/progress/index.ts
+++ b/packages/web-components/src/progress/progress/index.ts
@@ -1,5 +1,6 @@
-import { BaseProgress as Progress, ProgressOptions, progressTemplate as template } from '@microsoft/fast-foundation';
+import { BaseProgress as Progress, progressTemplate as template } from '@microsoft/fast-foundation';
 import { progressStyles as styles } from './progress.styles';
+import type { ProgressOptions } from '@microsoft/fast-foundation';
 
 /**
  * The Fluent Progress Element. Implements {@link @microsoft/fast-foundation#BaseProgress},

--- a/packages/web-components/src/progress/progress/progress.styles.ts
+++ b/packages/web-components/src/progress/progress/progress.styles.ts
@@ -2,9 +2,7 @@ import { css, ElementStyles } from '@microsoft/fast-element';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
   display,
-  ElementDefinitionContext,
-  forcedColorsStylesheetBehavior,
-  ProgressOptions,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import {
   accentForegroundRest,
@@ -13,6 +11,7 @@ import {
   neutralForegroundHint,
   strokeWidth,
 } from '../../design-tokens';
+import type { ElementDefinitionContext, ProgressOptions } from "@microsoft/fast-foundation";
 
 export const progressStyles: (context: ElementDefinitionContext, definition: ProgressOptions) => ElementStyles = (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/src/radio-group/radio-group.styles.ts
@@ -1,6 +1,7 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { display, ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
+import { display } from '@microsoft/fast-foundation';
 import { designUnit } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const radioGroupStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/radio/index.ts
+++ b/packages/web-components/src/radio/index.ts
@@ -1,5 +1,6 @@
-import { Radio, RadioOptions, radioTemplate as template } from '@microsoft/fast-foundation';
+import { Radio, radioTemplate as template } from '@microsoft/fast-foundation';
 import { radioStyles as styles } from './radio.styles';
+import type { RadioOptions } from '@microsoft/fast-foundation';
 
 /**
  * The Fluent Radio Element. Implements {@link @microsoft/fast-foundation#Radio},

--- a/packages/web-components/src/radio/radio.styles.ts
+++ b/packages/web-components/src/radio/radio.styles.ts
@@ -3,10 +3,8 @@ import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
   disabledCursor,
   display,
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  RadioOptions,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { heightNumber } from '../styles';
 import {
@@ -26,6 +24,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, RadioOptions } from "@microsoft/fast-foundation";
 
 export const radioStyles: (context: ElementDefinitionContext, definition: RadioOptions) => ElementStyles = (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/select/index.ts
+++ b/packages/web-components/src/select/index.ts
@@ -1,6 +1,7 @@
 import { attr } from '@microsoft/fast-element';
-import { Select as FoundationSelect, SelectOptions, selectTemplate as template } from '@microsoft/fast-foundation';
+import { Select as FoundationSelect, selectTemplate as template } from '@microsoft/fast-foundation';
 import { selectStyles as styles } from './select.styles';
+import type { SelectOptions } from '@microsoft/fast-foundation';
 
 /**
  * Select appearances

--- a/packages/web-components/src/select/select.styles.ts
+++ b/packages/web-components/src/select/select.styles.ts
@@ -2,10 +2,8 @@ import { css, ElementStyles } from '@microsoft/fast-element';
 import {
   disabledCursor,
   display,
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  SelectOptions,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import { elevation } from '../styles/elevation';
@@ -36,6 +34,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, SelectOptions } from "@microsoft/fast-foundation";
 
 export const selectFilledStyles: (context: ElementDefinitionContext, definition: SelectOptions) => ElementStyles = (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/skeleton/skeleton.styles.ts
+++ b/packages/web-components/src/skeleton/skeleton.styles.ts
@@ -1,6 +1,7 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { display, ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
+import { display } from '@microsoft/fast-foundation';
 import { controlCornerRadius, neutralFillRest } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const skeletonStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/slider-label/slider-label.styles.ts
+++ b/packages/web-components/src/slider-label/slider-label.styles.ts
@@ -2,12 +2,11 @@ import { css, ElementStyles } from '@microsoft/fast-element';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
   display,
-  ElementDefinitionContext,
-  forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { heightNumber } from '../styles';
 import { bodyFont, designUnit, disabledOpacity, neutralStrokeRest } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const sliderLabelStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/slider/index.ts
+++ b/packages/web-components/src/slider/index.ts
@@ -1,5 +1,6 @@
-import { Slider, SliderOptions, sliderTemplate as template } from '@microsoft/fast-foundation';
+import { Slider, sliderTemplate as template } from '@microsoft/fast-foundation';
 import { sliderStyles as styles } from './slider.styles';
+import type { SliderOptions } from '@microsoft/fast-foundation';
 
 /**
  * The Fluent Slider Custom Element. Implements {@link @microsoft/fast-foundation#(Slider:class)},

--- a/packages/web-components/src/slider/slider.styles.ts
+++ b/packages/web-components/src/slider/slider.styles.ts
@@ -3,10 +3,8 @@ import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
   disabledCursor,
   display,
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  SliderOptions,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { heightNumber } from '../styles';
 import {
@@ -21,6 +19,7 @@ import {
   neutralStrokeHover,
   neutralStrokeRest,
 } from '../design-tokens';
+import type { ElementDefinitionContext, SliderOptions } from "@microsoft/fast-foundation";
 
 export const sliderStyles: (context: ElementDefinitionContext, definition: SliderOptions) => ElementStyles = (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/styles/direction.ts
+++ b/packages/web-components/src/styles/direction.ts
@@ -1,7 +1,9 @@
-import { Behavior, ElementStyles, FASTElement, Subscriber } from '@microsoft/fast-element';
-import { DesignTokenChangeRecord } from '@microsoft/fast-foundation';
+import { ElementStyles, FASTElement } from '@microsoft/fast-element';
 import { Direction } from '@microsoft/fast-web-utilities';
 import { direction as directionDesignToken } from '../design-tokens';
+import type { Behavior, Subscriber } from '@microsoft/fast-element';
+import type { DesignTokenChangeRecord } from '@microsoft/fast-foundation';
+
 /**
  * Behavior to conditionally apply LTR and RTL stylesheets. To determine which to apply,
  * the behavior will use the nearest DesignSystemProvider's 'direction' design system value.

--- a/packages/web-components/src/switch/index.ts
+++ b/packages/web-components/src/switch/index.ts
@@ -1,5 +1,6 @@
-import { Switch, SwitchOptions, switchTemplate as template } from '@microsoft/fast-foundation';
+import { Switch, switchTemplate as template } from '@microsoft/fast-foundation';
 import { switchStyles as styles } from './switch.styles';
+import type { SwitchOptions } from '@microsoft/fast-foundation';
 
 /**
  * The Fluent Switch Custom Element. Implements {@link @microsoft/fast-foundation#Switch},

--- a/packages/web-components/src/switch/switch.styles.ts
+++ b/packages/web-components/src/switch/switch.styles.ts
@@ -3,10 +3,8 @@ import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
   disabledCursor,
   display,
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  SwitchOptions,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { DirectionalStyleSheetBehavior, heightNumber } from '../styles';
 import {
@@ -32,6 +30,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, SwitchOptions } from "@microsoft/fast-foundation";
 
 export const switchStyles: (context: ElementDefinitionContext, defintiion: SwitchOptions) => ElementStyles = (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/tabs/tab-panel/tab-panel.styles.ts
+++ b/packages/web-components/src/tabs/tab-panel/tab-panel.styles.ts
@@ -1,6 +1,7 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { display, ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
+import { display } from '@microsoft/fast-foundation';
 import { bodyFont, density, designUnit, typeRampMinus1FontSize, typeRampMinus1LineHeight } from '../../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const tabPanelStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/tabs/tab/tab.styles.ts
+++ b/packages/web-components/src/tabs/tab/tab.styles.ts
@@ -2,10 +2,8 @@ import { css, ElementStyles } from '@microsoft/fast-element';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
   display,
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { heightNumber } from '../../styles';
 import {
@@ -20,6 +18,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const tabStyles: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ElementStyles =
   (context: ElementDefinitionContext, definition: FoundationElementDefinition) =>

--- a/packages/web-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/src/tabs/tabs.styles.ts
@@ -2,9 +2,7 @@ import { css, ElementStyles } from '@microsoft/fast-element';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import {
   display,
-  ElementDefinitionContext,
-  forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import {
   accentFillRest,
@@ -14,6 +12,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const tabsStyles: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ElementStyles =
   (context: ElementDefinitionContext, definition: FoundationElementDefinition) =>

--- a/packages/web-components/src/text-area/text-area.styles.ts
+++ b/packages/web-components/src/text-area/text-area.styles.ts
@@ -2,10 +2,8 @@ import { css, ElementStyles } from '@microsoft/fast-element';
 import {
   disabledCursor,
   display,
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import { fillStateStyles, heightNumber } from '../styles';
@@ -27,6 +25,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const textAreaFilledStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/src/text-field/text-field.styles.ts
@@ -2,10 +2,8 @@ import { css, ElementStyles } from '@microsoft/fast-element';
 import {
   disabledCursor,
   display,
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import { fillStateStyles, heightNumber } from '../styles';
@@ -27,6 +25,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const textFieldFilledStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/tooltip/tooltip.styles.ts
+++ b/packages/web-components/src/tooltip/tooltip.styles.ts
@@ -1,8 +1,6 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import {
-  ElementDefinitionContext,
-  forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { elevation } from '../styles/index';
 import {
@@ -14,6 +12,7 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const tooltipStyles: (
   context: ElementDefinitionContext,

--- a/packages/web-components/src/tree-item/index.ts
+++ b/packages/web-components/src/tree-item/index.ts
@@ -1,5 +1,6 @@
-import { treeItemTemplate as template, TreeItem, TreeItemOptions } from '@microsoft/fast-foundation';
+import { treeItemTemplate as template, TreeItem } from '@microsoft/fast-foundation';
 import { treeItemStyles as styles } from './tree-item.styles';
+import type { TreeItemOptions } from '@microsoft/fast-foundation';
 
 /**
  * The Fluent tree item Custom Element. Implements, {@link @microsoft/fast-foundation#TreeItem}

--- a/packages/web-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/src/tree-item/tree-item.styles.ts
@@ -3,10 +3,8 @@ import {
   DesignToken,
   disabledCursor,
   display,
-  ElementDefinitionContext,
   focusVisible,
-  forcedColorsStylesheetBehavior,
-  TreeItemOptions,
+  forcedColorsStylesheetBehavior
 } from '@microsoft/fast-foundation';
 import { SystemColors } from '@microsoft/fast-web-utilities';
 import { DirectionalStyleSheetBehavior, heightNumber } from '../styles/index';
@@ -31,7 +29,8 @@ import {
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
-import { Swatch } from '../color/swatch';
+import type { ElementDefinitionContext, TreeItemOptions } from "@microsoft/fast-foundation";
+import type { Swatch } from "../color/swatch";
 
 const ltr = css`
   .expand-collapse-glyph {

--- a/packages/web-components/src/tree-view/tree-view.styles.ts
+++ b/packages/web-components/src/tree-view/tree-view.styles.ts
@@ -1,5 +1,6 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { display, ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
+import { display } from '@microsoft/fast-foundation';
+import type { ElementDefinitionContext, FoundationElementDefinition } from "@microsoft/fast-foundation";
 
 export const treeViewStyles: (
   context: ElementDefinitionContext,


### PR DESCRIPTION
#### Pull request checklist

This change migrates the following package(s) to use import/export type syntax:

`packages/web-components`

For more background on why, read about the motivation (and the code-mod) here:

https://github.com/dzearing/transform-typed-imports#motivation

