### PR TITLE
Fix positioning utility to handle cases where the positioned element doesn't fit within bounds

### DIFF
--- a/change/@fluentui-react-f8cd0d3f-b8f8-49ca-88d8-282c3354fb63.json
+++ b/change/@fluentui-react-f8cd0d3f-b8f8-49ca-88d8-282c3354fb63.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update positioning logic to handle callout positions at small screens",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Callout/Callout.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Callout/Callout.Basic.Example.tsx
@@ -11,12 +11,14 @@ export const CalloutBasicExample: React.FunctionComponent = () => {
 
   return (
     <>
+      <div style={{ padding: '150px 0' }}></div>
       <DefaultButton
         id={buttonId}
         onClick={toggleIsCalloutVisible}
         text={isCalloutVisible ? 'Hide callout' : 'Show callout'}
         className={styles.button}
       />
+      <div style={{ padding: '250px 0' }}></div>
       {isCalloutVisible && (
         <Callout
           className={styles.callout}
@@ -26,6 +28,7 @@ export const CalloutBasicExample: React.FunctionComponent = () => {
           gapSpace={0}
           target={`#${buttonId}`}
           onDismiss={toggleIsCalloutVisible}
+          alignTargetEdge={true}
           setInitialFocus
         >
           <Text block variant="xLarge" className={styles.title} id={labelId}>
@@ -50,6 +53,7 @@ const styles = mergeStyleSets({
   },
   callout: {
     width: 320,
+    maxWidth: '90%',
     padding: '20px 24px',
   },
   title: {

--- a/packages/react-examples/src/react/Callout/Callout.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Callout/Callout.Basic.Example.tsx
@@ -11,14 +11,12 @@ export const CalloutBasicExample: React.FunctionComponent = () => {
 
   return (
     <>
-      <div style={{ padding: '150px 0' }}></div>
       <DefaultButton
         id={buttonId}
         onClick={toggleIsCalloutVisible}
         text={isCalloutVisible ? 'Hide callout' : 'Show callout'}
         className={styles.button}
       />
-      <div style={{ padding: '250px 0' }}></div>
       {isCalloutVisible && (
         <Callout
           className={styles.callout}
@@ -28,7 +26,6 @@ export const CalloutBasicExample: React.FunctionComponent = () => {
           gapSpace={0}
           target={`#${buttonId}`}
           onDismiss={toggleIsCalloutVisible}
-          alignTargetEdge={true}
           setInitialFocus
         >
           <Text block variant="xLarge" className={styles.title} id={labelId}>

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2313,6 +2313,8 @@ export interface ICalendarYearStyles extends ICalendarPickerStyles {
 export interface ICalloutBeakPositionedInfo extends IPositionedData {
     // (undocumented)
     closestEdge: RectangleEdge;
+    // (undocumented)
+    hideBeak?: boolean;
 }
 
 // @public (undocumented)
@@ -4790,6 +4792,8 @@ export interface IElementPosition {
     alignmentEdge: RectangleEdge | undefined;
     // (undocumented)
     elementRectangle: Rectangle;
+    // (undocumented)
+    forcedInBounds?: boolean;
     // (undocumented)
     targetEdge: RectangleEdge;
 }

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -162,6 +162,7 @@ function usePositions(
     calloutElement,
     hostElement,
     targetRef,
+    targetAttempts,
     finalHeight,
     getBounds,
     onPositioned,

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -10,12 +10,7 @@ import {
   shallowCompare,
   getPropsWithDefaults,
 } from '../../Utilities';
-import {
-  positionCallout,
-  RectangleEdge,
-  positionCard,
-  getBoundsFromTargetWindow,
-} from '../../Positioning';
+import { positionCallout, RectangleEdge, positionCard, getBoundsFromTargetWindow } from '../../Positioning';
 import { Popup } from '../../Popup';
 import { classNamesFunction } from '../../Utilities';
 import { AnimationClassNames } from '../../Styling';

--- a/packages/react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
+++ b/packages/react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`Callout renders Callout correctly 1`] = `
       onMouseUp={[Function]}
       style={
         Object {
-          "maxHeight": 752,
+          "maxHeight": "100%",
           "outline": "none",
           "overflowY": undefined,
         }

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -764,7 +764,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                   overflow-y: auto;
                   position: relative;
                 }
-            style="outline: none; max-height: 752px;"
+            style="outline: none; max-height: 100%;"
           >
             <div
               class="ms-ComboBox-optionsContainerWrapper "
@@ -1532,7 +1532,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                   overflow-y: auto;
                   position: relative;
                 }
-            style="outline: none; max-height: 752px;"
+            style="outline: none; max-height: 100%;"
           >
             <div
               class="ms-ComboBox-optionsContainerWrapper "

--- a/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -248,7 +248,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
               onScroll={[Function]}
               style={
                 Object {
-                  "maxHeight": 752,
+                  "maxHeight": "100%",
                   "outline": "none",
                   "overflowY": undefined,
                 }

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -423,7 +423,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                   overflow-y: auto;
                   position: relative;
                 }
-            style="outline: none;"
+            style="outline: none; max-height: 100%;"
           >
             <div
               class=
@@ -1442,7 +1442,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                   overflow-y: auto;
                   position: relative;
                 }
-            style="outline: none;"
+            style="outline: none; max-height: 100%;"
           >
             <div
               class=

--- a/packages/react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
           onMouseUp={[Function]}
           style={
             Object {
-              "maxHeight": undefined,
+              "maxHeight": "100%",
               "outline": "none",
               "overflowY": "hidden",
             }
@@ -278,7 +278,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
           onMouseUp={[Function]}
           style={
             Object {
-              "maxHeight": undefined,
+              "maxHeight": "100%",
               "outline": "none",
               "overflowY": undefined,
             }

--- a/packages/react/src/components/KeytipLayer/KeytipLayer.test.tsx
+++ b/packages/react/src/components/KeytipLayer/KeytipLayer.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import { KeytipManager } from '../../utilities/keytips/KeytipManager';
 import { mount, ReactWrapper } from 'enzyme';
 import { KeytipLayerBase } from './KeytipLayer.base';
@@ -390,7 +391,9 @@ describe('KeytipLayer', () => {
         content: 'X',
         keySequences: ['b', 'x'],
       });
-      jest.runAllTimers();
+      ReactTestUtils.act(() => {
+        jest.runAllTimers();
+      });
 
       const visibleKeytips: IKeytipProps[] = ktpLayer.state('visibleKeytips');
       expect(visibleKeytips).toHaveLength(1);
@@ -406,7 +409,9 @@ describe('KeytipLayer', () => {
         content: 'X',
         keySequences: ['b', 'x'],
       });
-      jest.runAllTimers();
+      ReactTestUtils.act(() => {
+        jest.runAllTimers();
+      });
 
       const visibleKeytips: IKeytipProps[] = ktpLayer.state('visibleKeytips');
       expect(visibleKeytips).toHaveLength(0);
@@ -423,7 +428,9 @@ describe('KeytipLayer', () => {
         content: 'X',
         keySequences: ['b', 'x'],
       });
-      jest.runAllTimers();
+      ReactTestUtils.act(() => {
+        jest.runAllTimers();
+      });
 
       const visibleKeytips: IKeytipProps[] = ktpLayer.state('visibleKeytips');
       expect(visibleKeytips).toHaveLength(1);

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
       onMouseUp={[Function]}
       style={
         Object {
-          "maxHeight": undefined,
+          "maxHeight": "100%",
           "outline": "none",
           "overflowY": "hidden",
         }

--- a/packages/react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
           onMouseUp={[Function]}
           style={
             Object {
-              "maxHeight": undefined,
+              "maxHeight": "100%",
               "outline": "none",
               "overflowY": undefined,
             }

--- a/packages/react/src/utilities/positioning/positioning.test.ts
+++ b/packages/react/src/utilities/positioning/positioning.test.ts
@@ -139,8 +139,9 @@ describe('Callout Positioning', () => {
       beakWidth: 0,
     };
 
+    // should align as close to the bottom left as possible
     const validateBottomLeft: ITestValidation = {
-      callout: new Rectangle(8, 208, 100, 300),
+      callout: new Rectangle(100, 300, 100, 300),
       beak: null,
     };
 
@@ -223,6 +224,7 @@ describe('Callout Positioning', () => {
       alignmentEdge: RectangleEdge.left,
     };
     const bounds = new Rectangle(0, 500, 0, 500);
+    const target = new Rectangle(0, 100, 0, 100);
 
     // Normal positioning should target the alignment edge and the opposite of the target edge.
     // In this case, that's left (alignment) and bottom (opposite of target)
@@ -257,7 +259,11 @@ describe('Callout Positioning', () => {
     // With bounds introduced, the alignment should apply to the beak as well, aligning it to
     // the edge closest to bounds
     // In this case, that's the bottom (opposite of target) and right (closer to edge of bounds)
-    const finalizedBeakPosition = __positioningTestPackage._finalizeBeakPosition(pos, beakPos, bounds);
+    const finalizedBeakPosition = __positioningTestPackage._finalizeBeakPosition(
+      { ...pos, targetRectangle: target },
+      beakPos,
+      bounds,
+    );
     expect(finalizedBeakPosition.elementPosition.right).toBeDefined();
     expect(finalizedBeakPosition.elementPosition.bottom).toBeDefined();
     expect(finalizedBeakPosition.elementPosition.left).toBeUndefined();

--- a/packages/react/src/utilities/positioning/positioning.test.ts
+++ b/packages/react/src/utilities/positioning/positioning.test.ts
@@ -139,12 +139,15 @@ describe('Callout Positioning', () => {
       beakWidth: 0,
     };
 
-    // should align as close to the bottom left as possible
+    // when no alignment options fit within bounds, bottom left should flip to top left
+    // since there is more room at the top
     const validateBottomLeft: ITestValidation = {
-      callout: new Rectangle(100, 300, 100, 300),
+      callout: new Rectangle(100, 300, 8, 208),
       beak: null,
     };
 
+    // when no alignment options fit within bounds, top right stays top right
+    // since that side has the most room
     const validateTopRight: ITestValidation = {
       callout: new Rectangle(8, 208, 8, 208),
       beak: null,

--- a/packages/react/src/utilities/positioning/positioning.ts
+++ b/packages/react/src/utilities/positioning/positioning.ts
@@ -338,26 +338,28 @@ function _adjustFitWithinBounds(
   if (!directionalHintFixed && !coverTarget) {
     elementEstimate = _flipToFit(element, target, bounding, positionData, gap);
   }
-  const outOfBounds = _getOutOfBoundsEdges(element, bounding);
+  const outOfBounds = _getOutOfBoundsEdges(elementEstimate.elementRectangle, bounding);
 
-  if (alignTargetEdge) {
-    // The edge opposite to the alignment edge might be out of bounds.
-    // Flip alignment to see if we can get it within bounds.
-    if (elementEstimate.alignmentEdge && outOfBounds.indexOf(elementEstimate.alignmentEdge * -1) > -1) {
-      const flippedElementEstimate = _flipAlignmentEdge(elementEstimate, target, gap, coverTarget);
-      if (_isRectangleWithinBounds(flippedElementEstimate.elementRectangle, bounding)) {
-        return flippedElementEstimate;
-      } else {
-        // If the flipped elements edges are still out of bounds, try nudging it.
-        elementEstimate = _alignOutOfBoundsEdges(
-          _getOutOfBoundsEdges(flippedElementEstimate.elementRectangle, bounding),
-          elementEstimate,
-          bounding,
-        );
+  if (outOfBounds.length > 0) {
+    if (alignTargetEdge) {
+      // The edge opposite to the alignment edge might be out of bounds.
+      // Flip alignment to see if we can get it within bounds.
+      if (elementEstimate.alignmentEdge && outOfBounds.indexOf(elementEstimate.alignmentEdge * -1) > -1) {
+        const flippedElementEstimate = _flipAlignmentEdge(elementEstimate, target, gap, coverTarget);
+        if (_isRectangleWithinBounds(flippedElementEstimate.elementRectangle, bounding)) {
+          return flippedElementEstimate;
+        } else {
+          // If the flipped elements edges are still out of bounds, try nudging it.
+          elementEstimate = _alignOutOfBoundsEdges(
+            _getOutOfBoundsEdges(flippedElementEstimate.elementRectangle, bounding),
+            elementEstimate,
+            bounding,
+          );
+        }
       }
+    } else {
+      elementEstimate = _alignOutOfBoundsEdges(outOfBounds, elementEstimate, bounding);
     }
-  } else {
-    elementEstimate = _alignOutOfBoundsEdges(outOfBounds, elementEstimate, bounding);
   }
 
   return elementEstimate;

--- a/packages/react/src/utilities/positioning/positioning.ts
+++ b/packages/react/src/utilities/positioning/positioning.ts
@@ -214,7 +214,7 @@ function _getOutOfBoundsDegree(rect: Rectangle, bounds: Rectangle) {
 
 /**
  * Attempts to move the rectangle through various sides of the target to find a place to fit.
- * If no fit is found, the original position should be returned.
+ * If no fit is found, the least bad option should be returned.
  */
 function _flipToFit(
   rect: Rectangle,
@@ -279,7 +279,7 @@ function _flipToFit(
     }
   }
 
-  // nothing fit, use least-bad option
+  // nothing fits, use least-bad option
   currentEstimate = _estimatePosition(rect, target, { targetEdge: bestEdge, alignmentEdge: bestAlignment }, gap);
   return {
     elementRectangle: currentEstimate,
@@ -487,7 +487,7 @@ function _finalizeElementPosition(
   alignmentEdge?: RectangleEdge,
   coverTarget?: boolean,
   doNotFinalizeReturnEdge?: boolean,
-  forceWithinnBounds?: boolean,
+  forceWithinBounds?: boolean,
 ): IPartialIRectangle {
   const returnValue: IPartialIRectangle = {};
 
@@ -502,7 +502,7 @@ function _finalizeElementPosition(
   returnValue[RectangleEdge[returnEdge]] = _getRelativeEdgeDifference(elementRectangle, hostRect, returnEdge);
 
   // if the positioned element will still overflow, return all four edges with in-bounds values
-  if (forceWithinnBounds) {
+  if (forceWithinBounds) {
     returnValue[RectangleEdge[elementEdge * -1]] = _getRelativeEdgeDifference(
       elementRectangle,
       hostRect,

--- a/packages/react/src/utilities/positioning/positioning.ts
+++ b/packages/react/src/utilities/positioning/positioning.ts
@@ -198,13 +198,14 @@ function _isEdgeInBounds(rect: Rectangle, bounds: Rectangle, edge: RectangleEdge
 }
 
 /**
- * Returns a measure of how much a rectangle is out of bounds for a given alignment
+ * Returns a measure of how much a rectangle is out of bounds for a given alignment;
+ * this can be used to compare which rectangle is more or less out of bounds.
  * A value of 0 means the rectangle is entirely in bounds
  */
 function _getOutOfBoundsDegree(rect: Rectangle, bounds: Rectangle) {
   const breakingEdges = _getOutOfBoundsEdges(rect, bounds);
   let total = 0;
-  for (let edge of breakingEdges) {
+  for (const edge of breakingEdges) {
     total += _getRelativeEdgeDifference(rect, bounds, edge) ** 2;
   }
 
@@ -376,7 +377,6 @@ function _alignOutOfBoundsEdges(
   for (const direction of outOfBoundsEdges) {
     let edgeAttempt = _alignEdges(elementEstimate.elementRectangle, bounding, direction);
     const inBounds = _isEdgeInBounds(edgeAttempt, bounding, direction * -1);
-    // const outOfBounds = _getOutOfBoundsEdges(edgeAttempt, bounding);
     // only update estimate if the attempt didn't break out of the opposite bounding edge
     if (!inBounds) {
       edgeAttempt = _moveEdge(edgeAttempt, direction * -1, _getEdgeValue(bounding, direction * -1), false);
@@ -501,6 +501,7 @@ function _finalizeElementPosition(
   returnValue[RectangleEdge[elementEdge]] = _getRelativeEdgeDifference(elementRectangle, hostRect, elementEdge);
   returnValue[RectangleEdge[returnEdge]] = _getRelativeEdgeDifference(elementRectangle, hostRect, returnEdge);
 
+  // if the positioned element will still overflow, return all four edges with in-bounds values
   if (forceWithinnBounds) {
     returnValue[RectangleEdge[elementEdge * -1]] = _getRelativeEdgeDifference(
       elementRectangle,

--- a/packages/react/src/utilities/positioning/positioning.types.ts
+++ b/packages/react/src/utilities/positioning/positioning.types.ts
@@ -92,6 +92,7 @@ export interface ICalloutPositionedInfo extends IPositionedData {
 
 export interface ICalloutBeakPositionedInfo extends IPositionedData {
   closestEdge: RectangleEdge;
+  hideBeak?: boolean;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #18227, #18767, #16102, #19025, [12466](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12466)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

We have several positioning cases that are currently failing:
- When the element doesn't fit neatly on any side, the utility would leave it at the last side checked, even if that side was neither the original one, nor the best fit
- When the element doesn't fit neatly on any side, it would render partially offscreen, making that content entirely inaccessible
- When the callout shifted to overlay the target, the beak would still render, pointing at a random area

I updated the positioning utility and Callout with the following changes:
- When the bounding area is smaller than the positioned element, the positioning utility returns all left/top/right/bottom values, so the Callout can set all four sides within the bounds.
- CalloutContent sets its max height based on the callout, and not on the screen (the latter doesn't work in any case because of gap + padding). This is only relevant when the Callout sets both top and bottom positioning values (i.e. only when it needs to overflow).
- the positioning utility sets an extra beak prop if the beak should not be rendered because the positioned element has completely overlaid the target
-  if the positioned element cannot fully fit on any side, the positioning utility calculates the best side based on which has the most space
- fixed a few logical issues with the positioning logic that showed up when the positioned element didn't fit on any side.