### PR TITLE
Fix type imports: pass 5

### DIFF
--- a/change/@fluentui-react-focus-31fc47f9-5965-4c37-8db7-239723883f86.json
+++ b/change/@fluentui-react-focus-31fc47f9-5965-4c37-8db7-239723883f86.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export syntax.",
+  "packageName": "@fluentui/react-focus",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-hooks-710e932f-9467-4be1-81ed-e1990d711d02.json
+++ b/change/@fluentui-react-hooks-710e932f-9467-4be1-81ed-e1990d711d02.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export syntax.",
+  "packageName": "@fluentui/react-hooks",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icon-provider-c9096879-7add-45d3-bd81-b403c3772162.json
+++ b/change/@fluentui-react-icon-provider-c9096879-7add-45d3-bd81-b403c3772162.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export syntax.",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icons-mdl2-f0488348-fdc7-4b15-ae89-5a2d13ce67e6.json
+++ b/change/@fluentui-react-icons-mdl2-f0488348-fdc7-4b15-ae89-5a2d13ce67e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export syntax.",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-24851ecd-1eaa-4a6c-b4cc-65672b994008.json
+++ b/change/@fluentui-react-image-24851ecd-1eaa-4a6c-b4cc-65672b994008.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export syntax.",
+  "packageName": "@fluentui/react-image",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-focus/etc/react-focus.api.md
+++ b/packages/react-focus/etc/react-focus.api.md
@@ -4,8 +4,8 @@
 
 ```ts
 
-import { IRefObject } from '@fluentui/utilities';
-import { Point } from '@fluentui/utilities';
+import type { IRefObject } from '@fluentui/utilities';
+import type { Point } from '@fluentui/utilities';
 import * as React_2 from 'react';
 
 // @public (undocumented)
@@ -26,7 +26,7 @@ export class FocusZone extends React_2.Component<IFocusZoneProps> implements IFo
     // (undocumented)
     render(): React_2.ReactNode;
     setFocusAlignment(point: Point): void;
-    }
+}
 
 // @public (undocumented)
 export enum FocusZoneDirection {
@@ -102,7 +102,6 @@ export interface IFocusZoneProps extends React_2.HTMLAttributes<HTMLElement> {
     shouldResetActiveElementWhenTabFromZone?: boolean;
     stopFocusPropagation?: boolean;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-focus/src/common/isConformant.ts
+++ b/packages/react-focus/src/common/isConformant.ts
@@ -1,4 +1,5 @@
-import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
+import type { IsConformantOptions } from '@fluentui/react-conformance';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },

--- a/packages/react-focus/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.test.tsx
@@ -6,8 +6,9 @@ import { getCode, EnterKey } from '@fluentui/keyboard-key';
 import { setRTL, KeyCodes } from '@fluentui/utilities';
 import { resetIds } from '@fluentui/utilities';
 import { FocusZone } from './FocusZone';
-import { FocusZoneDirection, FocusZoneTabbableElements, IFocusZone } from './FocusZone.types';
+import { FocusZoneDirection, FocusZoneTabbableElements } from './FocusZone.types';
 import { isConformant } from '../../common/isConformant';
+import type { IFocusZone } from './FocusZone.types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FocusZoneDirection, FocusZoneTabbableElements, IFocusZone, IFocusZoneProps } from './FocusZone.types';
+import { FocusZoneDirection, FocusZoneTabbableElements } from './FocusZone.types';
 import {
   KeyCodes,
   css,
@@ -22,13 +22,15 @@ import {
   shouldWrapFocus,
   warnDeprecations,
   portalContainsElement,
-  Point,
   getWindow,
   findScrollableParent,
   createMergedRef,
 } from '@fluentui/utilities';
 import { mergeStyles } from '@fluentui/merge-styles';
-import { getTheme, ITheme } from '@fluentui/style-utilities';
+import { getTheme } from '@fluentui/style-utilities';
+import type { IFocusZone, IFocusZoneProps } from './FocusZone.types';
+import type { Point } from '@fluentui/utilities';
+import type { ITheme } from '@fluentui/style-utilities';
 
 const IS_FOCUSABLE_ATTRIBUTE = 'data-is-focusable';
 const IS_ENTER_DISABLED_ATTRIBUTE = 'data-disable-click-on-enter';

--- a/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IRefObject, Point } from '@fluentui/utilities';
+import type { IRefObject, Point } from '@fluentui/utilities';
 
 /**
  * FocusZone component class interface.

--- a/packages/react-focus/tsconfig.json
+++ b/packages/react-focus/tsconfig.json
@@ -17,7 +17,8 @@
     "preserveConstEnums": true,
     "lib": ["es2015", "dom", "es2015.promise"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["jest", "custom-global"]
+    "types": ["jest", "custom-global"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -5,9 +5,9 @@
 ```ts
 
 import { Async } from '@fluentui/utilities';
-import { ISettingsMap } from '@fluentui/utilities/lib/warn';
-import { IWarnControlledUsageParams } from '@fluentui/utilities/lib/warn';
-import { Point } from '@fluentui/utilities';
+import type { ISettingsMap } from '@fluentui/utilities/lib/warn';
+import type { IWarnControlledUsageParams } from '@fluentui/utilities/lib/warn';
+import type { Point } from '@fluentui/utilities';
 import * as React_2 from 'react';
 import { Rectangle } from '@fluentui/utilities';
 
@@ -62,8 +62,8 @@ export function useControllableValue<TValue, TElement extends HTMLElement>(contr
 
 // @public (undocumented)
 export function useControllableValue<TValue, TElement extends HTMLElement, TEvent extends React_2.SyntheticEvent<TElement> | undefined>(controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined, onChange: ChangeCallback<TElement, TValue, TEvent> | undefined): Readonly<[
-    TValue | undefined,
-    (update: React_2.SetStateAction<TValue | undefined>, ev?: React_2.FormEvent<TElement>) => void
+TValue | undefined,
+(update: React_2.SetStateAction<TValue | undefined>, ev?: React_2.FormEvent<TElement>) => void
 ]>;
 
 // @public
@@ -116,7 +116,6 @@ export const useUnmount: (callback: () => void) => void;
 
 // @public
 export function useWarnings<P>(options: IWarningOptions<P>): void;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-hooks/src/useBoolean.test.tsx
+++ b/packages/react-hooks/src/useBoolean.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
-import { useBoolean, IUseBooleanCallbacks } from './useBoolean';
+import { useBoolean } from './useBoolean';
 import { validateHookValueNotChanged } from './testUtilities';
+import type { IUseBooleanCallbacks } from './useBoolean';
 
 describe('useBoolean', () => {
   it('respects initial value', () => {

--- a/packages/react-hooks/src/useRefEffect.test.tsx
+++ b/packages/react-hooks/src/useRefEffect.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
-import { useRefEffect, RefCallback } from './useRefEffect';
+import { useRefEffect } from './useRefEffect';
+import type { RefCallback } from './useRefEffect';
 
 describe('useRefEffect', () => {
   it('maintains ref.current and calls the callback and cleanup functions appropriately', () => {

--- a/packages/react-hooks/src/useTarget.ts
+++ b/packages/react-hooks/src/useTarget.ts
@@ -1,6 +1,7 @@
-import { getDocument, Point, Rectangle } from '@fluentui/utilities';
+import { getDocument, Rectangle } from '@fluentui/utilities';
 import * as React from 'react';
 import { useWindow } from '@fluentui/react-window-provider';
+import type { Point } from '@fluentui/utilities';
 
 export type Target = Element | string | MouseEvent | Point | Rectangle | null | React.RefObject<Element>;
 

--- a/packages/react-hooks/src/useWarnings.test.tsx
+++ b/packages/react-hooks/src/useWarnings.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { setWarningCallback } from '@fluentui/utilities';
-import { IWarningOptions, useWarnings } from './useWarnings';
+import { useWarnings } from './useWarnings';
+import type { IWarningOptions } from './useWarnings';
 
 // These tests don't cover the core warning utilities (which have their own tests), just the
 // integration with the hook and usage within function components.

--- a/packages/react-hooks/src/useWarnings.ts
+++ b/packages/react-hooks/src/useWarnings.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import {
-  ISettingsMap,
-  IWarnControlledUsageParams,
   warn,
   warnControlledUsage,
   warnConditionallyRequiredProps,
@@ -10,6 +8,7 @@ import {
 } from '@fluentui/utilities/lib/warn';
 import { usePrevious } from './usePrevious';
 import { useConst } from './useConst';
+import type { ISettingsMap, IWarnControlledUsageParams } from '@fluentui/utilities/lib/warn';
 
 export interface IWarningOptions<P> {
   /** Name of the component */

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -17,7 +17,8 @@
     "preserveConstEnums": true,
     "lib": ["es5", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["jest", "custom-global"]
+    "types": ["jest", "custom-global"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/react-icon-provider/etc/react-icon-provider.api.md
+++ b/packages/react-icon-provider/etc/react-icon-provider.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { IIconSubset } from '@fluentui/style-utilities';
+import type { IIconSubset } from '@fluentui/style-utilities';
 import * as React_2 from 'react';
 
 // @public
@@ -20,7 +20,6 @@ export interface IconProviderProps extends React_2.HTMLAttributes<HTMLDivElement
 
 // @public
 export const useIconSubset: () => IIconSubset | undefined;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-icon-provider/src/IconProvider.test.tsx
+++ b/packages/react-icon-provider/src/IconProvider.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { IconProvider, useIconSubset } from './IconProvider';
-import { IIconSubset } from '@fluentui/style-utilities';
+import type { IIconSubset } from '@fluentui/style-utilities';
 
 const TestOverriddenIcon = () => {
   return null;

--- a/packages/react-icon-provider/src/IconProvider.tsx
+++ b/packages/react-icon-provider/src/IconProvider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { IIconSubset } from '@fluentui/style-utilities';
-import { IconProviderProps } from './IconProvider.types';
+import type { IIconSubset } from '@fluentui/style-utilities';
+import type { IconProviderProps } from './IconProvider.types';
 
 /**
  * Context for providing the IconSubset.

--- a/packages/react-icon-provider/src/IconProvider.types.ts
+++ b/packages/react-icon-provider/src/IconProvider.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IIconSubset } from '@fluentui/style-utilities';
+import type { IIconSubset } from '@fluentui/style-utilities';
 
 /**
  * {@docCategory IconProvider}

--- a/packages/react-icon-provider/tsconfig.json
+++ b/packages/react-icon-provider/tsconfig.json
@@ -16,7 +16,8 @@
     "preserveConstEnums": true,
     "lib": ["es5", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["jest", "custom-global"]
+    "types": ["jest", "custom-global"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/react-icons-mdl2/src/index.ts
+++ b/packages/react-icons-mdl2/src/index.ts
@@ -1,6 +1,4 @@
 import './version';
-
-export { ISvgIconProps } from './utils/SvgIcon.types';
 export { default as createSvgIcon } from './utils/createSvgIcon';
 
 export { default as AcceptIcon } from './components/AcceptIcon';
@@ -1738,3 +1736,4 @@ export { default as ZoomIcon } from './components/ZoomIcon';
 export { default as ZoomInIcon } from './components/ZoomInIcon';
 export { default as ZoomOutIcon } from './components/ZoomOutIcon';
 export { default as ZoomToFitIcon } from './components/ZoomToFitIcon';
+export type { ISvgIconProps } from './utils/SvgIcon.types';

--- a/packages/react-icons-mdl2/src/utils/createSvgIcon.ts
+++ b/packages/react-icons-mdl2/src/utils/createSvgIcon.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { css, getNativeProps, htmlElementProperties } from '@fluentui/utilities';
 import * as classes from './SvgIcon.scss';
-import { ISvgIconProps } from './SvgIcon.types';
-import { SvgIconCreateFnParams } from './types';
 import { useIconSubset } from '@fluentui/react-icon-provider';
+import type { ISvgIconProps } from './SvgIcon.types';
+import type { SvgIconCreateFnParams } from './types';
 
 const createSvgIcon = <TProps = {}>({ svg, displayName }: SvgIconCreateFnParams<TProps>) => {
   const Component: React.FC<React.HTMLAttributes<HTMLSpanElement> & TProps & ISvgIconProps> = props => {

--- a/packages/react-icons-mdl2/src/utils/types.ts
+++ b/packages/react-icons-mdl2/src/utils/types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ISvgIconProps } from './SvgIcon.types';
+import type { ISvgIconProps } from './SvgIcon.types';
 
 export type SvgIconFuncArg<TProps = ISvgIconProps> = {
   classes: { [iconSlot: string]: string }; // renamed from classes

--- a/packages/react-icons-mdl2/tsconfig.json
+++ b/packages/react-icons-mdl2/tsconfig.json
@@ -16,7 +16,8 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "lib": ["es5", "dom"],
-    "types": ["jest"]
+    "types": ["jest"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/react-image/etc/react-image.api.md
+++ b/packages/react-image/etc/react-image.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { ComponentPropsCompat } from '@fluentui/react-utilities';
+import type { ComponentPropsCompat } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 
 // @public (undocumented)

--- a/packages/react-image/src/Image.stories.tsx
+++ b/packages/react-image/src/Image.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { makeStyles } from '@fluentui/react-make-styles';
-import { ArgTypes, Meta, Parameters } from '@storybook/react';
-
-import { Image, ImageProps } from './index';
+import { Image } from './index';
+import type { ArgTypes, Meta, Parameters } from '@storybook/react';
+import type { ImageProps } from './index';
 
 /**
  * Temporary Stack until there's one in its own package.

--- a/packages/react-image/src/common/isConformant.ts
+++ b/packages/react-image/src/common/isConformant.ts
@@ -1,4 +1,5 @@
-import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
+import type { IsConformantOptions } from '@fluentui/react-conformance';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },

--- a/packages/react-image/src/components/Image/Image.tsx
+++ b/packages/react-image/src/components/Image/Image.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { ImageProps } from './Image.types';
 import { renderImage } from './renderImage';
 import { useImage } from './useImage';
 import { useImageStyles } from './useImageStyles';
+import type { ImageProps } from './Image.types';
 
 export const Image: React.FunctionComponent<ImageProps & React.RefAttributes<HTMLElement>> = React.forwardRef(
   (props: ImageProps, ref: React.Ref<HTMLElement>) => {

--- a/packages/react-image/src/components/Image/Image.types.ts
+++ b/packages/react-image/src/components/Image/Image.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComponentPropsCompat } from '@fluentui/react-utilities';
+import type { ComponentPropsCompat } from '@fluentui/react-utilities';
 
 export interface ImageProps extends ComponentPropsCompat, React.ImgHTMLAttributes<HTMLImageElement> {
   /**

--- a/packages/react-image/src/components/Image/renderImage.tsx
+++ b/packages/react-image/src/components/Image/renderImage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { getSlotsCompat } from '@fluentui/react-utilities';
-import { ImageState } from './Image.types';
+import type { ImageState } from './Image.types';
 
 /**
  * Define the render function.

--- a/packages/react-image/src/components/Image/useImage.ts
+++ b/packages/react-image/src/components/Image/useImage.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
-import { ImageProps, ImageState } from './Image.types';
+import type { ImageProps, ImageState } from './Image.types';
 
 const mergeProps = makeMergeProps<ImageState>();
 

--- a/packages/react-image/src/components/Image/useImageStyles.ts
+++ b/packages/react-image/src/components/Image/useImageStyles.ts
@@ -1,5 +1,5 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
-import { ImageState } from './Image.types';
+import type { ImageState } from './Image.types';
 
 const useStyles = makeStyles({
   root: theme => ({

--- a/packages/react-image/tsconfig.json
+++ b/packages/react-image/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "storybook__addons"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "storybook__addons"],
+    "isolatedModules": true
   }
 }


### PR DESCRIPTION
This change migrates the following package(s) to use import/export type syntax:

```
react-focus
react-hooks
react-icon-provider
react-icons-mdl2
react-image
```

For more background on why, read about the motivation (and the code-mod) here:

https://github.com/dzearing/transform-typed-imports#motivation
