### PR TITLE
Fix type imports: pass 6

### DIFF
--- a/change/@fluentui-react-experiments-0829533b-8b0c-4c32-b4d9-f1a4f7c7daaf.json
+++ b/change/@fluentui-react-experiments-0829533b-8b0c-4c32-b4d9-f1a4f7c7daaf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export syntax.",
+  "packageName": "@fluentui/react-experiments",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-file-type-icons-805d2247-ee51-44c3-9e23-6c8051405dc1.json
+++ b/change/@fluentui-react-file-type-icons-805d2247-ee51-44c3-9e23-6c8051405dc1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export syntax.",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/Accordion/Accordion.styles.ts
+++ b/packages/react-experiments/src/components/Accordion/Accordion.styles.ts
@@ -1,4 +1,4 @@
-import { IAccordionComponent, IAccordionStylesReturnType } from './Accordion.types';
+import type { IAccordionComponent, IAccordionStylesReturnType } from './Accordion.types';
 
 export const styles: IAccordionComponent['styles'] = (props): IAccordionStylesReturnType => {
   return {

--- a/packages/react-experiments/src/components/Accordion/Accordion.tsx
+++ b/packages/react-experiments/src/components/Accordion/Accordion.tsx
@@ -1,9 +1,10 @@
 /** @jsx withSlots */
 import * as React from 'react';
 import { createComponent, withSlots, getSlots } from '@fluentui/foundation-legacy';
-import { CollapsibleSection, ICollapsibleSectionProps } from '../../CollapsibleSection';
-import { IAccordionComponent, IAccordionProps, IAccordionSlots } from './Accordion.types';
+import { CollapsibleSection } from '../../CollapsibleSection';
 import { styles } from './Accordion.styles';
+import type { ICollapsibleSectionProps } from '../../CollapsibleSection';
+import type { IAccordionComponent, IAccordionProps, IAccordionSlots } from './Accordion.types';
 
 const AccordionItemType = ((<CollapsibleSection />) as React.ReactElement<ICollapsibleSectionProps>).type;
 

--- a/packages/react-experiments/src/components/Accordion/Accordion.types.ts
+++ b/packages/react-experiments/src/components/Accordion/Accordion.types.ts
@@ -1,5 +1,5 @@
-import { IStyle } from '../../Styling';
-import { IComponent, IHTMLSlot, IStyleableComponentProps } from '@fluentui/foundation-legacy';
+import type { IStyle } from '../../Styling';
+import type { IComponent, IHTMLSlot, IStyleableComponentProps } from '@fluentui/foundation-legacy';
 
 export type IAccordionComponent = IComponent<IAccordionProps, IAccordionTokens, IAccordionStyles>;
 

--- a/packages/react-experiments/src/components/BAFAccordion/Accordion.tsx
+++ b/packages/react-experiments/src/components/BAFAccordion/Accordion.tsx
@@ -6,7 +6,7 @@ import { DefaultButton } from '@fluentui/react/lib/Button';
 import { initializeComponentRef, css, composeRenderFunction } from '@fluentui/react/lib/Utilities';
 import * as React from 'react';
 import './Accordion.scss';
-import { IAccordion, IAccordionProps } from './Accordion.types';
+import type { IAccordion, IAccordionProps } from './Accordion.types';
 
 export interface IAccordionState {
   // represents whether the accordion is currently expanded or closed.

--- a/packages/react-experiments/src/components/BAFAccordion/Accordion.types.tsx
+++ b/packages/react-experiments/src/components/BAFAccordion/Accordion.types.tsx
@@ -1,11 +1,9 @@
 /*!
  * Copyright (C) Microsoft Corporation. All rights reserved.
  */
-
-import { IButtonProps } from '@fluentui/react/lib/Button';
-import { IContextualMenuProps } from '@fluentui/react/lib/ContextualMenu';
-import { IRenderFunction } from '@fluentui/react/lib/Utilities';
-import { IComponentAs } from '@fluentui/react/lib/Utilities';
+import type { IButtonProps } from '@fluentui/react/lib/Button';
+import type { IContextualMenuProps } from '@fluentui/react/lib/ContextualMenu';
+import type { IRenderFunction, IComponentAs } from '@fluentui/react/lib/Utilities';
 
 export interface IAccordion {}
 

--- a/packages/react-experiments/src/components/Chiclet/Chiclet.base.tsx
+++ b/packages/react-experiments/src/components/Chiclet/Chiclet.base.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { ChicletCard } from './ChicletCard';
 import { ChicletXsmall } from './ChicletXsmall';
-import { IChicletProps, ChicletSize } from './Chiclet.types';
-import { IChicletCardProps } from './ChicletCard.types';
+import { ChicletSize } from './Chiclet.types';
+import type { IChicletProps } from './Chiclet.types';
+import type { IChicletCardProps } from './ChicletCard.types';
 
 export class ChicletBase extends React.Component<IChicletProps, {}> {
   public render(): JSX.Element {

--- a/packages/react-experiments/src/components/Chiclet/Chiclet.styles.ts
+++ b/packages/react-experiments/src/components/Chiclet/Chiclet.styles.ts
@@ -1,4 +1,4 @@
-import { IChicletStyleProps, IChicletStyles } from './Chiclet.types';
+import type { IChicletStyleProps, IChicletStyles } from './Chiclet.types';
 
 export const getStyles = (props: IChicletStyleProps): IChicletStyles => {
   return {

--- a/packages/react-experiments/src/components/Chiclet/Chiclet.test.tsx
+++ b/packages/react-experiments/src/components/Chiclet/Chiclet.test.tsx
@@ -3,7 +3,7 @@ import * as renderer from 'react-test-renderer';
 
 import { ChicletXsmall } from './ChicletXsmall';
 import { ChicletCard } from './ChicletCard';
-import { IChicletCardProps } from './ChicletCard.types';
+import type { IChicletCardProps } from './ChicletCard.types';
 
 describe('Chiclet', () => {
   it('renders Xsmall chiclet with a title, icon, onClick, and url', () => {

--- a/packages/react-experiments/src/components/Chiclet/Chiclet.tsx
+++ b/packages/react-experiments/src/components/Chiclet/Chiclet.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { styled } from '../../Utilities';
-import { IChicletProps, IChicletStyleProps, IChicletStyles } from './Chiclet.types';
 import { getStyles } from './Chiclet.styles';
 import { ChicletBase } from './Chiclet.base';
+import type { IChicletProps, IChicletStyleProps, IChicletStyles } from './Chiclet.types';
 
 export const Chiclet: React.FunctionComponent<IChicletProps> = styled<
   IChicletProps,

--- a/packages/react-experiments/src/components/Chiclet/Chiclet.types.ts
+++ b/packages/react-experiments/src/components/Chiclet/Chiclet.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { IStyleFunctionOrObject, IRefObject } from '../../Utilities';
-import { IStyle, ITheme } from '../../Styling';
+import type { IStyleFunctionOrObject, IRefObject } from '../../Utilities';
+import type { IStyle, ITheme } from '../../Styling';
 
 export interface IChiclet {}
 

--- a/packages/react-experiments/src/components/Chiclet/ChicletCard.base.tsx
+++ b/packages/react-experiments/src/components/Chiclet/ChicletCard.base.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { css, classNamesFunction } from '../../Utilities';
-import { IChicletCardStyles, IChicletCardStyleProps, IChicletCardProps } from './ChicletCard.types';
 import { mergeStyles } from '../../Styling';
+import type { IChicletCardStyles, IChicletCardStyleProps, IChicletCardProps } from './ChicletCard.types';
 
 const getClassNames = classNamesFunction<IChicletCardStyleProps, IChicletCardStyles>();
 

--- a/packages/react-experiments/src/components/Chiclet/ChicletCard.styles.ts
+++ b/packages/react-experiments/src/components/Chiclet/ChicletCard.styles.ts
@@ -1,5 +1,5 @@
 import { normalize, FontWeights } from '../../Styling';
-import { IChicletCardStyleProps, IChicletCardStyles } from './ChicletCard.types';
+import type { IChicletCardStyleProps, IChicletCardStyles } from './ChicletCard.types';
 
 export const getStyles = (props: IChicletCardStyleProps): IChicletCardStyles => {
   const { theme, className } = props;

--- a/packages/react-experiments/src/components/Chiclet/ChicletCard.tsx
+++ b/packages/react-experiments/src/components/Chiclet/ChicletCard.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { styled } from '../../Utilities';
-import { IChicletCardProps, IChicletCardStyleProps, IChicletCardStyles } from './ChicletCard.types';
 import { getStyles } from './ChicletCard.styles';
 import { ChicletCardBase } from './ChicletCard.base';
+import type { IChicletCardProps, IChicletCardStyleProps, IChicletCardStyles } from './ChicletCard.types';
 
 export const ChicletCard: React.FunctionComponent<IChicletCardProps> = styled<
   IChicletCardProps,

--- a/packages/react-experiments/src/components/Chiclet/ChicletCard.types.ts
+++ b/packages/react-experiments/src/components/Chiclet/ChicletCard.types.ts
@@ -1,5 +1,5 @@
-import { ITheme, IStyle } from '../../Styling';
-import { IChicletProps } from './Chiclet.types';
+import type { ITheme, IStyle } from '../../Styling';
+import type { IChicletProps } from './Chiclet.types';
 
 export interface IChicletCard {}
 

--- a/packages/react-experiments/src/components/Chiclet/ChicletXsmall.base.tsx
+++ b/packages/react-experiments/src/components/Chiclet/ChicletXsmall.base.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { css, classNamesFunction } from '../../Utilities';
-import { IChicletCardStyles, IChicletCardStyleProps } from './ChicletCard.types';
-import { IChicletCardProps } from './ChicletCard.types';
 import { mergeStyles } from '../../Styling';
+import type { IChicletCardStyles, IChicletCardStyleProps, IChicletCardProps } from './ChicletCard.types';
 
 const getClassNames = classNamesFunction<IChicletCardStyleProps, IChicletCardStyles>();
 

--- a/packages/react-experiments/src/components/Chiclet/ChicletXsmall.styles.tsx
+++ b/packages/react-experiments/src/components/Chiclet/ChicletXsmall.styles.tsx
@@ -1,5 +1,5 @@
 import { normalize, getGlobalClassNames, FontWeights } from '../../Styling';
-import { IChicletCardStyleProps, IChicletCardStyles } from './ChicletCard.types';
+import type { IChicletCardStyleProps, IChicletCardStyles } from './ChicletCard.types';
 
 const GlobalClassNames = {
   root: 'ms-ChicletXsmall',

--- a/packages/react-experiments/src/components/Chiclet/ChicletXsmall.tsx
+++ b/packages/react-experiments/src/components/Chiclet/ChicletXsmall.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { styled } from '../../Utilities';
-import { IChicletCardStyleProps, IChicletCardStyles } from './ChicletCard.types';
-import { IChicletCardProps } from './ChicletCard.types';
 import { getStyles } from './ChicletXsmall.styles';
 import { ChicletXsmallBase } from './ChicletXsmall.base';
+import type { IChicletCardStyleProps, IChicletCardStyles, IChicletCardProps } from './ChicletCard.types';
 
 export const ChicletXsmall: React.FunctionComponent<IChicletCardProps> = styled<
   IChicletCardProps,

--- a/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.state.tsx
+++ b/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.state.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useCallback, useImperativeHandle, useRef } from 'react';
 import { useControlledState } from '@fluentui/foundation-legacy';
 import { getRTL, KeyCodes } from '../../Utilities';
-import {
+import type {
   ICollapsibleSectionProps,
   ICollapsibleSectionViewProps,
   ICollapsibleSectionComponent,

--- a/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.styles.ts
+++ b/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.styles.ts
@@ -1,5 +1,5 @@
-import { ICollapsibleSectionComponent, ICollapsibleSectionStylesReturnType } from './CollapsibleSection.types';
 import { getGlobalClassNames } from '../../Styling';
+import type { ICollapsibleSectionComponent, ICollapsibleSectionStylesReturnType } from './CollapsibleSection.types';
 
 const GlobalClassNames = {
   root: 'ms-CollapsibleSection',

--- a/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.ts
+++ b/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { CollapsibleSectionView } from './CollapsibleSection.view';
 import { useCollapsibleSectionState } from './CollapsibleSection.state';
 import { collapsibleSectionStyles } from './CollapsibleSection.styles';
-import { ICollapsibleSectionProps } from './CollapsibleSection.types';
 import { createComponent } from '@fluentui/foundation-legacy';
+import type { ICollapsibleSectionProps } from './CollapsibleSection.types';
 
 export const CollapsibleSection: React.FunctionComponent<ICollapsibleSectionProps> = createComponent(
   CollapsibleSectionView,

--- a/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.types.ts
+++ b/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.types.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import {
+import type {
   IComponent,
   IComponentStyles,
   IHTMLSlot,
   ISlottableProps,
   IStyleableComponentProps,
 } from '@fluentui/foundation-legacy';
-import { IBaseProps, IRefObject } from '../../Utilities';
-import { ICollapsibleSectionTitleSlot } from './CollapsibleSectionTitle.types';
+import type { IBaseProps, IRefObject } from '../../Utilities';
+import type { ICollapsibleSectionTitleSlot } from './CollapsibleSectionTitle.types';
 
 export type ICollapsibleSectionComponent = IComponent<
   ICollapsibleSectionProps,

--- a/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.view.tsx
+++ b/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.view.tsx
@@ -1,12 +1,11 @@
 /** @jsx withSlots */
 import { withSlots, getSlots } from '@fluentui/foundation-legacy';
-
-import {
+import { CollapsibleSectionTitle } from './CollapsibleSectionTitle';
+import type {
   ICollapsibleSectionComponent,
   ICollapsibleSectionProps,
   ICollapsibleSectionSlots,
 } from './CollapsibleSection.types';
-import { CollapsibleSectionTitle } from './CollapsibleSectionTitle';
 
 export const CollapsibleSectionView: ICollapsibleSectionComponent['view'] = props => {
   const { collapsed, titleElementRef, children, onClick, onKeyDown, indent } = props;

--- a/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.styles.ts
+++ b/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.styles.ts
@@ -1,8 +1,8 @@
-import {
+import { getFocusStyle } from '@fluentui/react';
+import type {
   ICollapsibleSectionTitleComponent,
   ICollapsibleSectionTitleStylesReturnType,
 } from './CollapsibleSectionTitle.types';
-import { getFocusStyle } from '@fluentui/react';
 
 export const getStyles: ICollapsibleSectionTitleComponent['styles'] = (
   props,

--- a/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.ts
+++ b/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createComponent } from '@fluentui/foundation-legacy';
 import { CollapsibleSectionTitleView } from './CollapsibleSectionTitle.view';
 import { getStyles as styles } from './CollapsibleSectionTitle.styles';
-import { ICollapsibleSectionTitleProps } from './CollapsibleSectionTitle.types';
+import type { ICollapsibleSectionTitleProps } from './CollapsibleSectionTitle.types';
 
 export const CollapsibleSectionTitle: React.FunctionComponent<ICollapsibleSectionTitleProps> = createComponent(
   CollapsibleSectionTitleView,

--- a/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
+++ b/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { IRefObject } from '../../Utilities';
-import {
+import type { IRefObject } from '../../Utilities';
+import type {
   IComponent,
   IComponentStyles,
   IHTMLElementSlot,
@@ -8,8 +8,8 @@ import {
   ISlottableProps,
   IStyleableComponentProps,
 } from '@fluentui/foundation-legacy';
-import { ITextSlot } from '@fluentui/react';
-import { IIconSlot } from '../../utilities/factoryComponents.types';
+import type { ITextSlot } from '@fluentui/react';
+import type { IIconSlot } from '../../utilities/factoryComponents.types';
 
 export type ICollapsibleSectionTitleComponent = IComponent<
   ICollapsibleSectionTitleProps,

--- a/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.view.tsx
+++ b/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.view.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Icon, Text } from '@fluentui/react';
 import { getNativeProps, buttonProperties } from '@fluentui/react/lib/Utilities';
 import { withSlots, getSlots } from '@fluentui/foundation-legacy';
-import {
+import type {
   ICollapsibleSectionTitleComponent,
   ICollapsibleSectionTitleProps,
   ICollapsibleSectionTitleSlots,

--- a/packages/react-experiments/src/components/FloatingSuggestions/FloatingPeopleSuggestions/FloatingPeopleSuggestions.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestions/FloatingPeopleSuggestions/FloatingPeopleSuggestions.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { IPersonaProps } from '@fluentui/react/lib/Persona';
-import { IFloatingSuggestionsProps } from '../FloatingSuggestions.types';
 import { DefaultPeopleSuggestionsItem } from './defaults/DefaultPeopleSuggestionsItem';
 import { FloatingSuggestions } from '../FloatingSuggestions';
+import type { IPersonaProps } from '@fluentui/react/lib/Persona';
+import type { IFloatingSuggestionsProps } from '../FloatingSuggestions.types';
 
 type PartiallyOptional<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>> & Pick<Partial<T>, keyof T>;
 export type IFloatingPeopleSuggestionsProps<TPersona> = PartiallyOptional<

--- a/packages/react-experiments/src/components/FloatingSuggestions/FloatingPeopleSuggestions/defaults/DefaultPeopleSuggestionsItem.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestions/FloatingPeopleSuggestions/defaults/DefaultPeopleSuggestionsItem.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { css } from '@fluentui/react/lib/Utilities';
-import { Persona, PersonaSize, PersonaPresence, IPersonaProps } from '@fluentui/react/lib/Persona';
-import { ISuggestionModel } from '@fluentui/react/lib/Pickers';
+import { Persona, PersonaSize, PersonaPresence } from '@fluentui/react/lib/Persona';
 import * as stylesImport from './DefaultPeopleSuggestionsItem.scss';
+import type { IPersonaProps } from '@fluentui/react/lib/Persona';
+import type { ISuggestionModel } from '@fluentui/react/lib/Pickers';
 
 export const DefaultPeopleSuggestionsItem = <TPersona extends IPersonaProps>(
   props: ISuggestionModel<TPersona>,

--- a/packages/react-experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import * as styles from './FloatingSuggestions.scss';
 import { Async, initializeComponentRef, css, KeyCodes } from '@fluentui/react/lib/Utilities';
 import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
-import {
+import { SuggestionsControl } from './Suggestions/SuggestionsControl';
+import { SuggestionsStore } from './Suggestions/SuggestionsStore';
+import type {
   IFloatingSuggestions,
   IFloatingSuggestionsProps,
   IFloatingSuggestionsInnerSuggestionProps,
 } from './FloatingSuggestions.types';
-import { ISuggestionModel } from '@fluentui/react/lib/Pickers';
-import { SuggestionsControl } from './Suggestions/SuggestionsControl';
-import { SuggestionsStore } from './Suggestions/SuggestionsStore';
+import type { ISuggestionModel } from '@fluentui/react/lib/Pickers';
 
 export interface IFloatingSuggestionsState {
   queryString: string;

--- a/packages/react-experiments/src/components/FloatingSuggestions/FloatingSuggestions.types.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestions/FloatingSuggestions.types.ts
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import { ISuggestionModel } from '@fluentui/react/lib/Pickers';
-import { ISuggestionsControlProps } from './Suggestions/Suggestions.types';
 import { SuggestionsStore } from './Suggestions/SuggestionsStore';
-import { IBaseProps } from '@fluentui/react/lib/Utilities';
-
-import { ISuggestionsCoreProps } from './Suggestions/Suggestions.types';
+import type { ISuggestionModel } from '@fluentui/react/lib/Pickers';
+import type { ISuggestionsControlProps, ISuggestionsCoreProps } from './Suggestions/Suggestions.types';
+import type { IBaseProps } from '@fluentui/react/lib/Utilities';
 
 export interface IFloatingSuggestions<TItem> {
   /** Whether the suggestions are shown */

--- a/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/Suggestions.types.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/Suggestions.types.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { ISuggestionModel } from '@fluentui/react/lib/Pickers';
-import { ISuggestionItemProps } from './SuggestionsItem.types';
-import { IPersonaProps } from '@fluentui/react/lib/Persona';
-import { IRefObject } from '@fluentui/react/lib/Utilities';
+import type { ISuggestionModel } from '@fluentui/react/lib/Pickers';
+import type { ISuggestionItemProps } from './SuggestionsItem.types';
+import type { IPersonaProps } from '@fluentui/react/lib/Persona';
+import type { IRefObject } from '@fluentui/react/lib/Utilities';
 
 export interface ISuggestionsCoreProps<T> extends React.ClassAttributes<any> {
   /**

--- a/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsControl.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsControl.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { css, KeyCodes, initializeComponentRef } from '@fluentui/react/lib/Utilities';
-import { ISuggestionModel } from '@fluentui/react/lib/Pickers';
-import {
+import { SuggestionsCore } from './SuggestionsCore';
+import * as stylesImport from './SuggestionsControl.scss';
+import type { ISuggestionModel } from '@fluentui/react/lib/Pickers';
+import type {
   ISuggestionsHeaderFooterItemProps,
   ISuggestionsControlProps,
   ISuggestionsHeaderFooterProps,
 } from './Suggestions.types';
-import { SuggestionsCore } from './SuggestionsCore';
-import * as stylesImport from './SuggestionsControl.scss';
 
 const styles: any = stylesImport;
 

--- a/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsCore.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsCore.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { css, initializeComponentRef } from '@fluentui/react/lib/Utilities';
-import { ISuggestionModel } from '@fluentui/react/lib/Pickers';
 import { SuggestionsItem } from './SuggestionsItem';
-import { ISuggestionsCoreProps } from './Suggestions.types';
 import * as stylesImport from './SuggestionsCore.scss';
+import type { ISuggestionModel } from '@fluentui/react/lib/Pickers';
+import type { ISuggestionsCoreProps } from './Suggestions.types';
+
 const styles: any = stylesImport;
 
 /**

--- a/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsItem.styles.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsItem.styles.ts
@@ -1,5 +1,5 @@
 import { getGlobalClassNames, HighContrastSelector, getHighContrastNoAdjustStyle } from '../../../Styling';
-import { ISuggestionsItemStyleProps, ISuggestionsItemStyles } from './SuggestionsItem.types';
+import type { ISuggestionsItemStyleProps, ISuggestionsItemStyles } from './SuggestionsItem.types';
 
 export const SuggestionsItemGlobalClassNames = {
   root: 'ms-Suggestions-item',

--- a/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsItem.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsItem.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 import { classNamesFunction, css, styled } from '@fluentui/react/lib/Utilities';
-import { IProcessedStyleSet } from '@fluentui/react/lib/Styling';
 import { CommandButton, IconButton } from '@fluentui/react/lib/Button';
-import { ISuggestionItemProps, ISuggestionsItemStyleProps, ISuggestionsItemStyles } from './SuggestionsItem.types';
 import { getStyles } from './SuggestionsItem.styles';
+import type { IProcessedStyleSet } from '@fluentui/react/lib/Styling';
+import type { ISuggestionItemProps, ISuggestionsItemStyleProps, ISuggestionsItemStyles } from './SuggestionsItem.types';
 
 const getClassNames = classNamesFunction<ISuggestionsItemStyleProps, ISuggestionsItemStyles>();
 

--- a/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsItem.types.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsItem.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { IStyle, ITheme } from '../../../Styling';
-import { IRefObject, IStyleFunctionOrObject } from '../../../Utilities';
-import { ISuggestionModel } from '@fluentui/react/lib/Pickers';
+import type { IStyle, ITheme } from '../../../Styling';
+import type { IRefObject, IStyleFunctionOrObject } from '../../../Utilities';
+import type { ISuggestionModel } from '@fluentui/react/lib/Pickers';
 
 /** SuggestionItem component. */
 export interface ISuggestionsItem {}

--- a/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsStore.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsStore.ts
@@ -1,4 +1,4 @@
-import { ISuggestionModel } from '@fluentui/react/lib/Pickers';
+import type { ISuggestionModel } from '@fluentui/react/lib/Pickers';
 
 export class SuggestionsStore<T> {
   public suggestions: ISuggestionModel<T>[];

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestionItems/SuggestionItemDefault.styles.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestionItems/SuggestionItemDefault.styles.ts
@@ -1,4 +1,5 @@
-import { getGlobalClassNames, getTheme, IStyle } from '@fluentui/style-utilities';
+import { getGlobalClassNames, getTheme } from '@fluentui/style-utilities';
+import type { IStyle } from '@fluentui/style-utilities';
 
 export interface ISuggestionItemDefaultStylesProps {}
 

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestionItems/SuggestionItemDefault.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestionItems/SuggestionItemDefault.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import { css, classNamesFunction } from '../../../../Utilities';
-import { Persona, PersonaSize, IPersonaProps, PersonaPresence } from '@fluentui/react/lib/Persona';
-import { ISuggestionItemProps } from '@fluentui/react/lib/Pickers';
-import {
-  getStyles,
-  ISuggestionItemDefaultStylesProps,
-  ISuggestionItemDefaultStyles,
-} from './SuggestionItemDefault.styles';
+import { Persona, PersonaSize, PersonaPresence } from '@fluentui/react/lib/Persona';
+import { getStyles } from './SuggestionItemDefault.styles';
+import type { IPersonaProps } from '@fluentui/react/lib/Persona';
+import type { ISuggestionItemProps } from '@fluentui/react/lib/Pickers';
+import type { ISuggestionItemDefaultStylesProps, ISuggestionItemDefaultStyles } from './SuggestionItemDefault.styles';
 
 export const SuggestionItemNormal: (persona: IPersonaProps) => JSX.Element = (
   personaProps: IPersonaProps,

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { IFloatingPeopleSuggestionsProps } from './FloatingPeopleSuggestions.types';
 import { BaseFloatingSuggestions } from '../FloatingSuggestions';
-import { IPersonaProps } from '@fluentui/react/lib/Persona';
-import { IFloatingSuggestionOnRenderItemProps } from '../FloatingSuggestionsItem/FloatingSuggestionsItem.types';
 import { SuggestionItemNormal } from './FloatingPeopleSuggestionItems/SuggestionItemDefault';
+import type { IFloatingPeopleSuggestionsProps } from './FloatingPeopleSuggestions.types';
+import type { IPersonaProps } from '@fluentui/react/lib/Persona';
+import type { IFloatingSuggestionOnRenderItemProps } from '../FloatingSuggestionsItem/FloatingSuggestionsItem.types';
 
 export const FloatingPeopleSuggestions = (props: IFloatingPeopleSuggestionsProps): JSX.Element => {
   const renderSuggestionItem = React.useCallback(

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions.types.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions.types.ts
@@ -1,4 +1,4 @@
-import { IBaseFloatingSuggestionsProps } from '../FloatingSuggestions.types';
-import { IPersonaProps } from '@fluentui/react/lib/Persona';
+import type { IBaseFloatingSuggestionsProps } from '../FloatingSuggestions.types';
+import type { IPersonaProps } from '@fluentui/react/lib/Persona';
 
 export type IFloatingPeopleSuggestionsProps = IBaseFloatingSuggestionsProps<IPersonaProps>;

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.styles.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.styles.ts
@@ -1,5 +1,5 @@
 import { getGlobalClassNames, getTheme } from '@fluentui/style-utilities';
-import { IBaseFloatingSuggestionsStyles, IBaseFloatingSuggestionsStylesProps } from './FloatingSuggestions.types';
+import type { IBaseFloatingSuggestionsStyles, IBaseFloatingSuggestionsStylesProps } from './FloatingSuggestions.types';
 
 const GlobalClassNames = {
   root: 'ms-FloatingSuggestions',

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.tsx
@@ -1,10 +1,13 @@
-import { IBaseFloatingSuggestionsProps } from './FloatingSuggestions.types';
 import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
 import * as React from 'react';
 import { getStyles } from './FloatingSuggestions.styles';
 import { classNamesFunction, css } from '../../Utilities';
-import { IBaseFloatingSuggestionsStyles, IBaseFloatingSuggestionsStylesProps } from './FloatingSuggestions.types';
 import { FloatingSuggestionsList } from './FloatingSuggestionsList/FloatingSuggestionsList';
+import type {
+  IBaseFloatingSuggestionsProps,
+  IBaseFloatingSuggestionsStyles,
+  IBaseFloatingSuggestionsStylesProps,
+} from './FloatingSuggestions.types';
 
 export const BaseFloatingSuggestions = <T extends {}>(props: IBaseFloatingSuggestionsProps<T>): JSX.Element => {
   const getClassNames = classNamesFunction<IBaseFloatingSuggestionsStylesProps, IBaseFloatingSuggestionsStyles>();

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
@@ -1,14 +1,14 @@
 import * as React from 'react';
-import { ICalloutProps } from '@fluentui/react/lib/Callout';
-import { IStyle } from '@fluentui/style-utilities';
-import {
+import type { ICalloutProps } from '@fluentui/react/lib/Callout';
+import type { IStyle } from '@fluentui/style-utilities';
+import type {
   IFloatingSuggestionItemProps,
   IFloatingSuggestionOnRenderItemProps,
   IFloatingSuggestionItem,
 } from './FloatingSuggestionsItem/FloatingSuggestionsItem.types';
-import { IRenderFunction, IRefObject } from '@fluentui/utilities';
-import { IFloatingSuggestionsHeaderFooterProps } from './FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
-import { Target } from '@fluentui/react-hooks';
+import type { IRenderFunction, IRefObject } from '@fluentui/utilities';
+import type { IFloatingSuggestionsHeaderFooterProps } from './FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
+import type { Target } from '@fluentui/react-hooks';
 
 /**
  * FloatingSuggestions component props

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsComposite.test.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsComposite.test.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { create, act } from 'react-test-renderer';
 import { BaseFloatingSuggestions } from './FloatingSuggestions';
 import * as ReactDOM from 'react-dom';
-import { IFloatingSuggestionItem } from './FloatingSuggestionsItem/FloatingSuggestionsItem.types';
-import { IBaseFloatingSuggestionsProps } from './FloatingSuggestions.types';
 import * as ReactTestUtils from 'react-dom/test-utils';
+import type { IFloatingSuggestionItem } from './FloatingSuggestionsItem/FloatingSuggestionsItem.types';
+import type { IBaseFloatingSuggestionsProps } from './FloatingSuggestions.types';
 
 export interface ISimple {
   key: string;

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.styles.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.styles.ts
@@ -4,7 +4,7 @@ import {
   HighContrastSelector,
   getHighContrastNoAdjustStyle,
 } from '@fluentui/style-utilities';
-import {
+import type {
   IFloatingSuggestionHeaderFooterItemStylesProps,
   IFloatingSuggestionHeaderFooterItemStyles,
 } from './FloatingSuggestionsHeaderFooterItem.types';

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { classNamesFunction, css } from '../../../Utilities';
-import {
+import { getStyles } from './FloatingSuggestionsHeaderFooterItem.styles';
+import type {
   IFloatingSuggestionsHeaderFooterItemProps,
   IFloatingSuggestionHeaderFooterItemStylesProps,
   IFloatingSuggestionHeaderFooterItemStyles,
 } from './FloatingSuggestionsHeaderFooterItem.types';
-import { getStyles } from './FloatingSuggestionsHeaderFooterItem.styles';
 
 const getClassNames = classNamesFunction<
   IFloatingSuggestionHeaderFooterItemStylesProps,

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types.ts
@@ -1,4 +1,4 @@
-import { ITheme, IStyle } from '@fluentui/style-utilities';
+import type { ITheme, IStyle } from '@fluentui/style-utilities';
 
 export interface IFloatingSuggestionsHeaderFooterProps {
   renderItem: () => JSX.Element;

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.styles.ts
@@ -4,7 +4,10 @@ import {
   HighContrastSelector,
   getHighContrastNoAdjustStyle,
 } from '@fluentui/style-utilities';
-import { IFloatingSuggestionItemStylesProps, IFloatingSuggestionItemStyles } from './FloatingSuggestionsItem.types';
+import type {
+  IFloatingSuggestionItemStylesProps,
+  IFloatingSuggestionItemStyles,
+} from './FloatingSuggestionsItem.types';
 
 const GlobalClassNames = {
   root: 'ms-FloatingSuggestionsItem',

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import {
+import { classNamesFunction, css } from '../../../Utilities';
+import { getStyles } from './FloatingSuggestionsItem.styles';
+import { CommandButton, IconButton } from '@fluentui/react/lib/Button';
+import type {
   IFloatingSuggestionItemStylesProps,
   IFloatingSuggestionItemStyles,
   IFloatingSuggestionItemProps,
   IFloatingSuggestionOnRenderItemProps,
 } from './FloatingSuggestionsItem.types';
-import { classNamesFunction, css } from '../../../Utilities';
-import { getStyles } from './FloatingSuggestionsItem.styles';
-import { CommandButton, IconButton } from '@fluentui/react/lib/Button';
 
 export const FloatingSuggestionsItem = <T extends {}>(props: IFloatingSuggestionItemProps<T>): JSX.Element => {
   const {

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.types.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ITheme, IStyle } from '@fluentui/style-utilities';
+import type { ITheme, IStyle } from '@fluentui/style-utilities';
 
 export interface IFloatingSuggestionItemProps<T> {
   item: T;

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.styles.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.styles.ts
@@ -1,5 +1,8 @@
-import { IFloatingSuggestionsListStyleProps, IFloatingSuggestionsListStyle } from './FloatingSuggestionsList.types';
 import { getGlobalClassNames, getTheme } from '@fluentui/style-utilities';
+import type {
+  IFloatingSuggestionsListStyleProps,
+  IFloatingSuggestionsListStyle,
+} from './FloatingSuggestionsList.types';
 
 const GlobalClassNames = {
   root: 'ms-FloatingSuggestionsList',

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { classNamesFunction, css } from '../../../Utilities';
-import {
+import { FloatingSuggestionsItemMemo } from '../FloatingSuggestionsItem/FloatingSuggestionsItem';
+import { getStyles } from './FloatingSuggestionsList.styles';
+import { FloatingSuggestionsHeaderFooterItem } from '../FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem';
+import type {
   IFloatingSuggestionsListStyleProps,
   IFloatingSuggestionsListStyle,
   IFloatingSuggestionsListProps,
 } from './FloatingSuggestionsList.types';
-import { FloatingSuggestionsItemMemo } from '../FloatingSuggestionsItem/FloatingSuggestionsItem';
-import { getStyles } from './FloatingSuggestionsList.styles';
-import { IFloatingSuggestionsHeaderFooterProps } from '../FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
-import { FloatingSuggestionsHeaderFooterItem } from '../FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem';
+import type { IFloatingSuggestionsHeaderFooterProps } from '../FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
 
 const getClassNames = classNamesFunction<IFloatingSuggestionsListStyleProps, IFloatingSuggestionsListStyle>();
 

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.types.ts
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.types.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import {
+import type {
   IFloatingSuggestionOnRenderItemProps,
   IFloatingSuggestionItemProps,
   IFloatingSuggestionItem,
 } from '../FloatingSuggestionsItem/FloatingSuggestionsItem.types';
-import { IRenderFunction } from '@fluentui/utilities';
-import { IStyle } from '@fluentui/style-utilities';
-import { IFloatingSuggestionsHeaderFooterProps } from '../FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
+import type { IRenderFunction } from '@fluentui/utilities';
+import type { IStyle } from '@fluentui/style-utilities';
+import type { IFloatingSuggestionsHeaderFooterProps } from '../FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
 
 export interface IFloatingSuggestionsListProps<T> {
   suggestionItems: IFloatingSuggestionItem<T>[];

--- a/packages/react-experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/react-experiments/src/components/FolderCover/FolderCover.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { IFolderCoverProps, FolderCoverSize, FolderCoverType } from './FolderCover.types';
-import { ISize, css } from '../../Utilities';
+import { css } from '../../Utilities';
 import * as FolderCoverStylesModule from './FolderCover.scss';
 import * as SignalStylesModule from '../signals/Signal.scss';
 import { Icon } from '@fluentui/react/lib/Icon';
+import type { IFolderCoverProps, FolderCoverSize, FolderCoverType } from './FolderCover.types';
+import type { ISize } from '../../Utilities';
 
 const FolderCoverStyles = FolderCoverStylesModule as any;
 const SignalStyles = SignalStylesModule as any;

--- a/packages/react-experiments/src/components/FolderCover/FolderCover.types.ts
+++ b/packages/react-experiments/src/components/FolderCover/FolderCover.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IBaseProps, ISize } from '../../Utilities';
+import type { IBaseProps, ISize } from '../../Utilities';
 
 export type FolderCoverSize = 'small' | 'large';
 

--- a/packages/react-experiments/src/components/FolderCover/initializeFolderCovers.tsx
+++ b/packages/react-experiments/src/components/FolderCover/initializeFolderCovers.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { registerIcons, IIconOptions } from '@fluentui/style-utilities';
+import { registerIcons } from '@fluentui/style-utilities';
+import type { IIconOptions } from '@fluentui/style-utilities';
 
 const ASSET_CDN_BASE_URL =
   'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200708.002/office-ui-fabric-react-assets/foldericons';

--- a/packages/react-experiments/src/components/LayoutGroup/LayoutGroup.tsx
+++ b/packages/react-experiments/src/components/LayoutGroup/LayoutGroup.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { ILayoutGroupProps } from './LayoutGroup.types';
-import { IRawStyle, mergeStyles } from '@fluentui/react/lib/Styling';
+import { mergeStyles } from '@fluentui/react/lib/Styling';
 import { getNativeProps, divProperties } from '@fluentui/react/lib/Utilities';
+import type { ILayoutGroupProps } from './LayoutGroup.types';
+import type { IRawStyle } from '@fluentui/react/lib/Styling';
 
 export class LayoutGroup extends React.Component<ILayoutGroupProps, {}> {
   public static defaultProps: ILayoutGroupProps = {

--- a/packages/react-experiments/src/components/LayoutGroup/LayoutGroup.types.ts
+++ b/packages/react-experiments/src/components/LayoutGroup/LayoutGroup.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { IBaseProps } from '@fluentui/react/lib/Utilities';
 import { LayoutGroup } from './LayoutGroup';
+import type { IBaseProps } from '@fluentui/react/lib/Utilities';
 
 export interface ILayoutGroupProps extends IBaseProps, React.HTMLAttributes<LayoutGroup | HTMLDivElement> {
   /**

--- a/packages/react-experiments/src/components/MicroFeedback/MicroFeedback.state.ts
+++ b/packages/react-experiments/src/components/MicroFeedback/MicroFeedback.state.ts
@@ -1,5 +1,5 @@
-import { IMicroFeedbackComponent, IMicroFeedbackViewProps, VoteType } from './MicroFeedback.types';
 import { useCallback, useRef, useState } from 'react';
+import type { IMicroFeedbackComponent, IMicroFeedbackViewProps, VoteType } from './MicroFeedback.types';
 
 export type IMicroFeedbackState = Pick<
   IMicroFeedbackViewProps,

--- a/packages/react-experiments/src/components/MicroFeedback/MicroFeedback.styles.ts
+++ b/packages/react-experiments/src/components/MicroFeedback/MicroFeedback.styles.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IMicroFeedbackComponent,
   IMicroFeedbackStylesReturnType,
   IMicroFeedbackTokenReturnType,

--- a/packages/react-experiments/src/components/MicroFeedback/MicroFeedback.tsx
+++ b/packages/react-experiments/src/components/MicroFeedback/MicroFeedback.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { createComponent } from '@fluentui/foundation-legacy';
 import { useMicroFeedbackState as state } from './MicroFeedback.state';
 import { MicroFeedbackStyles as styles, MicroFeedbackTokens as tokens } from './MicroFeedback.styles';
-import { IMicroFeedbackProps } from './MicroFeedback.types';
 import { MicroFeedbackView } from './MicroFeedback.view';
+import type { IMicroFeedbackProps } from './MicroFeedback.types';
 
 export const MicroFeedback: React.FunctionComponent<IMicroFeedbackProps> = createComponent(MicroFeedbackView, {
   displayName: 'MicroFeedback',

--- a/packages/react-experiments/src/components/MicroFeedback/MicroFeedback.types.ts
+++ b/packages/react-experiments/src/components/MicroFeedback/MicroFeedback.types.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@fluentui/foundation-legacy';
-import { IButtonSlot, ICalloutSlot, IListSlot } from '../../utilities/factoryComponents.types';
-import { IBaseProps } from '../../Utilities';
-import { IStackSlot, ITextSlot } from '@fluentui/react';
+import type { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@fluentui/foundation-legacy';
+import type { IButtonSlot, ICalloutSlot, IListSlot } from '../../utilities/factoryComponents.types';
+import type { IBaseProps } from '../../Utilities';
+import type { IStackSlot, ITextSlot } from '@fluentui/react';
 
 export type IMicroFeedbackComponent = IComponent<
   IMicroFeedbackProps,

--- a/packages/react-experiments/src/components/MicroFeedback/MicroFeedback.view.tsx
+++ b/packages/react-experiments/src/components/MicroFeedback/MicroFeedback.view.tsx
@@ -1,9 +1,9 @@
 /** @jsx withSlots */
 import { Callout, FocusZone, FocusZoneDirection, List, Stack, Text } from '@fluentui/react';
-import { DefaultButton, IconButton, IButtonStyles } from '@fluentui/react/lib/Button';
+import { DefaultButton, IconButton } from '@fluentui/react/lib/Button';
 import { withSlots, getSlots } from '@fluentui/foundation-legacy';
-
-import {
+import type { IButtonStyles } from '@fluentui/react/lib/Button';
+import type {
   IMicroFeedbackComponent,
   IMicroFeedbackProps,
   IMicroFeedbackSlots,

--- a/packages/react-experiments/src/components/Pagination/PageNumber.tsx
+++ b/packages/react-experiments/src/components/Pagination/PageNumber.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DefaultButton } from '@fluentui/react/lib/Button';
-import { IPageNumberProps } from './PageNumber.types';
+import type { IPageNumberProps } from './PageNumber.types';
 
 export class PageNumber extends React.Component<IPageNumberProps, {}> {
   constructor(props: IPageNumberProps) {

--- a/packages/react-experiments/src/components/Pagination/Pagination.base.tsx
+++ b/packages/react-experiments/src/components/Pagination/Pagination.base.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { IconButton } from '@fluentui/react/lib/Button';
 import { initializeComponentRef, classNamesFunction } from '../../Utilities';
 import { PageNumber } from './PageNumber';
-import { IPaginationProps, IPaginationString, IPaginationStyleProps, IPaginationStyles } from './Pagination.types';
-import { ComboBox, IComboBoxOption, IComboBox } from '@fluentui/react/lib/ComboBox';
+import { ComboBox } from '@fluentui/react/lib/ComboBox';
 import { TooltipHost } from '@fluentui/react/lib/Tooltip';
-import { IProcessedStyleSet } from '../../Styling';
 import { DirectionalHint } from '@fluentui/react/lib/common/DirectionalHint';
+import type { IPaginationProps, IPaginationString, IPaginationStyleProps, IPaginationStyles } from './Pagination.types';
+import type { IComboBoxOption, IComboBox } from '@fluentui/react/lib/ComboBox';
+import type { IProcessedStyleSet } from '../../Styling';
 
 const getClassNames = classNamesFunction<IPaginationStyleProps, IPaginationStyles>();
 

--- a/packages/react-experiments/src/components/Pagination/Pagination.styles.ts
+++ b/packages/react-experiments/src/components/Pagination/Pagination.styles.ts
@@ -1,5 +1,6 @@
-import { IPaginationStyles, IPaginationStyleProps } from './Pagination.types';
-import { getGlobalClassNames, IStyle } from '../../Styling';
+import { getGlobalClassNames } from '../../Styling';
+import type { IPaginationStyles, IPaginationStyleProps } from './Pagination.types';
+import type { IStyle } from '../../Styling';
 
 const GlobalClassNames = {
   root: 'ms-Pagination-container',

--- a/packages/react-experiments/src/components/Pagination/Pagination.tsx
+++ b/packages/react-experiments/src/components/Pagination/Pagination.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { styled } from '../../Utilities';
-import { IPaginationProps, IPaginationStyleProps, IPaginationStyles } from './Pagination.types';
 import { getStyles } from './Pagination.styles';
 import { PaginationBase } from './Pagination.base';
+import type { IPaginationProps, IPaginationStyleProps, IPaginationStyles } from './Pagination.types';
 
 export const Pagination: React.FunctionComponent<IPaginationProps> = styled<
   IPaginationProps,

--- a/packages/react-experiments/src/components/Pagination/Pagination.types.ts
+++ b/packages/react-experiments/src/components/Pagination/Pagination.types.ts
@@ -1,6 +1,6 @@
-import { IStyle, ITheme } from '../../Styling';
-import { IStyleFunctionOrObject, IRefObject, IRenderFunction } from '../../Utilities';
-import { IIconProps } from '@fluentui/react/lib/Icon';
+import type { IStyle, ITheme } from '../../Styling';
+import type { IStyleFunctionOrObject, IRefObject, IRenderFunction } from '../../Utilities';
+import type { IIconProps } from '@fluentui/react/lib/Icon';
 
 export interface IPaginationProps {
   /**

--- a/packages/react-experiments/src/components/Persona/Persona.tsx
+++ b/packages/react-experiments/src/components/Persona/Persona.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { VerticalPersona } from './Vertical/VerticalPersona';
 import { Persona as HorizontalPersona } from '@fluentui/react';
-import { IHorizontalPersonaProps } from './Persona.types';
-import { IVerticalPersonaProps } from './Vertical/VerticalPersona.types';
+import type { IHorizontalPersonaProps } from './Persona.types';
+import type { IVerticalPersonaProps } from './Vertical/VerticalPersona.types';
 
 export const Persona = (props: IVerticalPersonaProps | IHorizontalPersonaProps): JSX.Element => {
   return props.vertical === true ? <VerticalPersona {...props} /> : <HorizontalPersona {...props} />;

--- a/packages/react-experiments/src/components/Persona/Persona.types.ts
+++ b/packages/react-experiments/src/components/Persona/Persona.types.ts
@@ -1,4 +1,4 @@
-import { IPersonaProps } from '@fluentui/react';
+import type { IPersonaProps } from '@fluentui/react';
 
 export interface IHorizontalPersonaProps extends IPersonaProps {
   vertical?: false;

--- a/packages/react-experiments/src/components/Persona/Vertical/VerticalPersona.styles.ts
+++ b/packages/react-experiments/src/components/Persona/Vertical/VerticalPersona.styles.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IVerticalPersonaComponent,
   IVerticalPersonaStylesReturnType,
   IVerticalPersonaTokenReturnType,

--- a/packages/react-experiments/src/components/Persona/Vertical/VerticalPersona.test.tsx
+++ b/packages/react-experiments/src/components/Persona/Vertical/VerticalPersona.test.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import * as TextHelpers from '../../../utilities/textHelpers';
-
-import { IVerticalPersonaComponent } from './VerticalPersona.types';
 import { VerticalPersona } from './VerticalPersona';
+import type { IVerticalPersonaComponent } from './VerticalPersona.types';
 
 const testVerticalPersonaStyles: IVerticalPersonaComponent['styles'] = {
   root: 'test-cn-root',

--- a/packages/react-experiments/src/components/Persona/Vertical/VerticalPersona.ts
+++ b/packages/react-experiments/src/components/Persona/Vertical/VerticalPersona.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { VerticalPersonaView } from './VerticalPersona.view';
 import { VerticalPersonaStyles, VerticalPersonaTokens } from './VerticalPersona.styles';
-import { IVerticalPersonaProps } from './VerticalPersona.types';
 import { createComponent } from '@fluentui/foundation-legacy';
+import type { IVerticalPersonaProps } from './VerticalPersona.types';
 
 export const VerticalPersona: React.FunctionComponent<IVerticalPersonaProps> = createComponent(VerticalPersonaView, {
   displayName: 'VerticalPersona',

--- a/packages/react-experiments/src/components/Persona/Vertical/VerticalPersona.types.ts
+++ b/packages/react-experiments/src/components/Persona/Vertical/VerticalPersona.types.ts
@@ -1,7 +1,7 @@
-import { IStyle, IFontWeight } from '@fluentui/style-utilities';
-import { IComponent, IHTMLSlot, IStyleableComponentProps } from '@fluentui/foundation-legacy';
-import { ITextSlot } from '@fluentui/react';
-import { IPersonaCoinSlot } from '../../PersonaCoin/PersonaCoin.types';
+import type { IStyle, IFontWeight } from '@fluentui/style-utilities';
+import type { IComponent, IHTMLSlot, IStyleableComponentProps } from '@fluentui/foundation-legacy';
+import type { ITextSlot } from '@fluentui/react';
+import type { IPersonaCoinSlot } from '../../PersonaCoin/PersonaCoin.types';
 
 export type IVerticalPersonaComponent = IComponent<
   IVerticalPersonaProps,

--- a/packages/react-experiments/src/components/Persona/Vertical/VerticalPersona.view.tsx
+++ b/packages/react-experiments/src/components/Persona/Vertical/VerticalPersona.view.tsx
@@ -1,8 +1,8 @@
 /** @jsx withSlots */
 import { PersonaCoin } from '../../PersonaCoin/PersonaCoin';
 import { getSlots, withSlots } from '@fluentui/foundation-legacy';
-import { IVerticalPersonaComponent, IVerticalPersonaProps, IVerticalPersonaSlots } from './VerticalPersona.types';
 import { PersonaText } from '../PersonaText/PersonaText';
+import type { IVerticalPersonaComponent, IVerticalPersonaProps, IVerticalPersonaSlots } from './VerticalPersona.types';
 
 export const VerticalPersonaView: IVerticalPersonaComponent['view'] = props => {
   const Slots = getSlots<IVerticalPersonaProps, IVerticalPersonaSlots>(props, {

--- a/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.state.ts
+++ b/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.state.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { ImageLoadState } from '@fluentui/react';
-import { IPersonaCoinViewProps, IPersonaCoinComponent } from './PersonaCoin.types';
+import type { IPersonaCoinViewProps, IPersonaCoinComponent } from './PersonaCoin.types';
 
 export const usePersonaCoinState: IPersonaCoinComponent['state'] = props => {
   // TODO: isPictureLoaded was controlled, does it need to be? it's not exposed through component props...

--- a/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.styles.ts
+++ b/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.styles.ts
@@ -1,6 +1,6 @@
-import { IPersonaProps } from '@fluentui/react';
-import { IPersonaCoinComponent, IPersonaCoinStylesReturnType } from './PersonaCoin.types';
 import { getPersonaInitialsColor } from '@fluentui/react/lib/Persona';
+import type { IPersonaProps } from '@fluentui/react';
+import type { IPersonaCoinComponent, IPersonaCoinStylesReturnType } from './PersonaCoin.types';
 
 export const DEFAULT_PERSONA_COIN_SIZE = 48;
 

--- a/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.test.tsx
+++ b/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.test.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
-
-import { IPersonaCoinComponent } from './PersonaCoin.types';
 import { PersonaCoin } from './index';
 import { Icon, Image, Text } from '@fluentui/react';
 import { setRTL } from '../../Utilities';
 import { PersonaTestImages } from '../../common/TestImages';
+import type { IPersonaCoinComponent } from './PersonaCoin.types';
 
 const testPersonaCoinStyles: IPersonaCoinComponent['styles'] = {
   root: 'test-cn-root',

--- a/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.ts
+++ b/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { createComponent } from '@fluentui/foundation-legacy';
 import { usePersonaCoinState } from './PersonaCoin.state';
 import { PersonaCoinStyles } from './PersonaCoin.styles';
-import { IPersonaCoinProps } from './PersonaCoin.types';
 import { PersonaCoinView } from './PersonaCoin.view';
+import type { IPersonaCoinProps } from './PersonaCoin.types';
 
 export const PersonaCoin: React.FunctionComponent<IPersonaCoinProps> = createComponent(PersonaCoinView, {
   displayName: 'PersonaCoin',

--- a/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.types.ts
+++ b/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.types.ts
@@ -1,15 +1,16 @@
-import { ImageLoadState, IBaseProps } from '@fluentui/react';
-import {
+import { ImageLoadState } from '@fluentui/react';
+import type { IBaseProps } from '@fluentui/react';
+import type {
   IComponentStyles,
   IHTMLSlot,
   ISlotProp,
   IComponent,
   IStyleableComponentProps,
 } from '@fluentui/foundation-legacy';
-import { IPersonaPresenceSlot } from '../../utilities/factoryComponents.types';
-import { IPersonaCoinImageSlot } from './PersonaCoinImage/PersonaCoinImage.types';
-import { IPersonaCoinSize10Slot } from './PersonaCoinSize10/PersonaCoinSize10';
-import { IPersonaCoinInitialsSlot } from './PersonaCoinInitials/PersonaCoinInitials';
+import type { IPersonaPresenceSlot } from '../../utilities/factoryComponents.types';
+import type { IPersonaCoinImageSlot } from './PersonaCoinImage/PersonaCoinImage.types';
+import type { IPersonaCoinSize10Slot } from './PersonaCoinSize10/PersonaCoinSize10';
+import type { IPersonaCoinInitialsSlot } from './PersonaCoinInitials/PersonaCoinInitials';
 
 export type IPersonaCoinComponent = IComponent<
   IPersonaCoinProps,

--- a/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.view.tsx
+++ b/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.view.tsx
@@ -1,12 +1,12 @@
 /** @jsx withSlots */
 import { withSlots, getSlots } from '@fluentui/foundation-legacy';
 import { PersonaPresence } from '../../utilities/factoryComponents';
-import { IPersonaCoinComponent, IPersonaCoinProps, IPersonaCoinSlots } from './PersonaCoin.types';
 import { PersonaCoinImage } from './PersonaCoinImage/PersonaCoinImage';
 import { DEFAULT_PERSONA_COIN_SIZE } from './PersonaCoin.styles';
 import { hideInitialsWhenImageIsLoaded } from './propHelpers';
 import PersonaCoinSize10 from './PersonaCoinSize10/PersonaCoinSize10';
 import { PersonaCoinInitials } from './PersonaCoinInitials/PersonaCoinInitials';
+import type { IPersonaCoinComponent, IPersonaCoinProps, IPersonaCoinSlots } from './PersonaCoin.types';
 
 export const PersonaCoinView: IPersonaCoinComponent['view'] = props => {
   const coinSize = props.size || DEFAULT_PERSONA_COIN_SIZE;

--- a/packages/react-experiments/src/components/PersonaCoin/PersonaCoinImage/PersonaCoinImage.tsx
+++ b/packages/react-experiments/src/components/PersonaCoin/PersonaCoinImage/PersonaCoinImage.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Image, ImageFit } from '@fluentui/react';
 import { createComponent } from '@fluentui/foundation-legacy';
-import { IPersonaCoinImageProps } from './PersonaCoinImage.types';
-import { IPersonaCoinComponent } from '../PersonaCoin.types';
 import { DEFAULT_PERSONA_COIN_SIZE } from '../PersonaCoin.styles';
+import type { IPersonaCoinImageProps } from './PersonaCoinImage.types';
+import type { IPersonaCoinComponent } from '../PersonaCoin.types';
 
 const personaCoinImageStyles: IPersonaCoinComponent['styles'] = {
   root: {

--- a/packages/react-experiments/src/components/PersonaCoin/PersonaCoinImage/PersonaCoinImage.types.ts
+++ b/packages/react-experiments/src/components/PersonaCoin/PersonaCoinImage/PersonaCoinImage.types.ts
@@ -1,6 +1,6 @@
 import { ImageLoadState } from '@fluentui/react';
-import { ISlotProp } from '@fluentui/foundation-legacy';
-import { IPersonaCoinProps } from '../PersonaCoin.types';
+import type { ISlotProp } from '@fluentui/foundation-legacy';
+import type { IPersonaCoinProps } from '../PersonaCoin.types';
 
 export type IPersonaCoinImageSlot = ISlotProp<IPersonaCoinImageProps>;
 

--- a/packages/react-experiments/src/components/PersonaCoin/PersonaCoinInitials/PersonaCoinInitials.tsx
+++ b/packages/react-experiments/src/components/PersonaCoin/PersonaCoinInitials/PersonaCoinInitials.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Icon, Text } from '@fluentui/react';
-import { ISlotProp } from '@fluentui/foundation-legacy';
-import { IPersonaCoinProps } from '../PersonaCoin.types';
 import { getInitials, getRTL } from '../../../Utilities';
+import type { ISlotProp } from '@fluentui/foundation-legacy';
+import type { IPersonaCoinProps } from '../PersonaCoin.types';
 
 export type IPersonaCoinInitialsSlot = ISlotProp<IPersonaCoinInitialsProps, string>;
 

--- a/packages/react-experiments/src/components/PersonaCoin/PersonaCoinSize10/PersonaCoinSize10.tsx
+++ b/packages/react-experiments/src/components/PersonaCoin/PersonaCoinSize10/PersonaCoinSize10.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Icon } from '@fluentui/react';
-import { ISlotProp } from '@fluentui/foundation-legacy';
+import type { ISlotProp } from '@fluentui/foundation-legacy';
 
 export interface IPersonaCoinSizeProps {}
 

--- a/packages/react-experiments/src/components/PersonaCoin/propHelpers.ts
+++ b/packages/react-experiments/src/components/PersonaCoin/propHelpers.ts
@@ -1,4 +1,4 @@
-import { IPersonaCoinViewProps } from './PersonaCoin.types';
+import type { IPersonaCoinViewProps } from './PersonaCoin.types';
 
 export function hideInitialsWhenImageIsLoaded(props: IPersonaCoinViewProps): boolean {
   // When the picture is loaded we can remove the initials from the dom.

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/CopyableItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/CopyableItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ISelectedItemProps } from '../SelectedItemsList.types';
+import type { ISelectedItemProps } from '../SelectedItemsList.types';
 
 type CopyableItemWrappedComponent<T> = React.ComponentType<ISelectedItemProps<T>>;
 

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/EditableItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/EditableItem.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { ISelectedItemProps } from '../SelectedItemsList.types';
-import { ItemCanDispatchTrigger, Item } from './ItemTrigger.types';
+import type { ISelectedItemProps } from '../SelectedItemsList.types';
+import type { ItemCanDispatchTrigger, Item } from './ItemTrigger.types';
 
 export type EditingItemComponentProps<T> = {
   item: T;

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/ItemTrigger.types.ts
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/ItemTrigger.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ISelectedItemProps } from '../SelectedItemsList.types';
+import type { ISelectedItemProps } from '../SelectedItemsList.types';
 
 export type TriggerProps<T> = ISelectedItemProps<T> & {
   onTrigger?: () => void;

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/ItemWithContextMenu.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/ItemWithContextMenu.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { ContextualMenu, DirectionalHint, IContextualMenuItem } from '@fluentui/react/lib/ContextualMenu';
-import { ItemCanDispatchTrigger } from './ItemTrigger.types';
+import { ContextualMenu, DirectionalHint } from '@fluentui/react/lib/ContextualMenu';
+import type { IContextualMenuItem } from '@fluentui/react/lib/ContextualMenu';
+import type { ItemCanDispatchTrigger } from './ItemTrigger.types';
 
 /**
  * Parameters to the EditingItem higher-order component

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/TriggerOnContextMenu.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/TriggerOnContextMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { TriggerProps } from './ItemTrigger.types';
-import { ISelectedItemProps } from '../SelectedItemsList.types';
+import type { TriggerProps } from './ItemTrigger.types';
+import type { ISelectedItemProps } from '../SelectedItemsList.types';
 
 // `extends any` to trick the parser into parsing as a type decl instead of a jsx tag
 export const TriggerOnContextMenu = <T extends any>(ItemComponent: React.ComponentType<ISelectedItemProps<T>>) => {

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { KeyCodes, getId, getNativeProps, inputProperties, css } from '@fluentui/react/lib/Utilities';
-import {
-  IBaseFloatingSuggestionsProps,
-  IBaseFloatingPickerHeaderFooterProps,
-} from '../../../FloatingSuggestionsComposite/FloatingSuggestions.types';
-import { IFloatingSuggestionItemProps } from '../../../FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.types';
-import { EditingItemComponentProps } from '../EditableItem';
 import { useFloatingSuggestionItems } from '../../../UnifiedPicker/hooks/useFloatingSuggestionItems';
 import { getStyles } from '../../../FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.styles';
 import { getStyles as getFloatingSuggestionStyles } from '../../../FloatingSuggestionsComposite/FloatingSuggestions.styles';
 import * as styles from './DefaultEditingItem.scss';
+import type {
+  IBaseFloatingSuggestionsProps,
+  IBaseFloatingPickerHeaderFooterProps,
+} from '../../../FloatingSuggestionsComposite/FloatingSuggestions.types';
+import type { IFloatingSuggestionItemProps } from '../../../FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.types';
+import type { EditingItemComponentProps } from '../EditableItem';
 
 export interface IDefaultEditingItemInnerProps<TItem> extends React.HTMLAttributes<any> {
   /**

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.test.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.test.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { create } from 'react-test-renderer';
 
 import { SelectedItemsList } from './SelectedItemsList';
-import { ISelectedItemProps, ISelectedItemsList } from './SelectedItemsList.types';
 import { mount } from 'enzyme';
+import type { ISelectedItemProps, ISelectedItemsList } from './SelectedItemsList.types';
 
 export interface ISimple {
   key: string;

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ISelectedItemsList, ISelectedItemsListProps, BaseSelectedItem } from './SelectedItemsList.types';
+import type { ISelectedItemsList, ISelectedItemsListProps, BaseSelectedItem } from './SelectedItemsList.types';
 
 const _SelectedItemsList = <TItem extends BaseSelectedItem>(
   props: ISelectedItemsListProps<TItem>,

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { IPickerItemProps } from '@fluentui/react/lib/Pickers';
-import { IRefObject } from '@fluentui/react/lib/Utilities';
-import { IDragDropEvents, IDragDropHelper } from '@fluentui/react/lib/DragDrop';
+import type { IPickerItemProps } from '@fluentui/react/lib/Pickers';
+import type { IRefObject } from '@fluentui/react/lib/Utilities';
+import type { IDragDropEvents, IDragDropHelper } from '@fluentui/react/lib/DragDrop';
+
 export interface ISelectedItemsList<T> {
   /**
    * Current value of the input

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.styles.ts
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.styles.ts
@@ -1,6 +1,6 @@
 import { FontSizes } from '@fluentui/react/lib/Styling';
 import { HighContrastSelector } from '@fluentui/react/lib/Styling';
-import { ISelectedPersonaStyleProps, ISelectedPersonaStyles } from './SelectedPersona.types';
+import type { ISelectedPersonaStyleProps, ISelectedPersonaStyles } from './SelectedPersona.types';
 
 export const getStyles = (props: ISelectedPersonaStyleProps): ISelectedPersonaStyles => {
   const { theme: maybeTheme, isSelected, isValid, buttonSize } = props;

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
-import { styled, classNamesFunction, IStyleFunctionOrObject, css, EventGroup } from '@fluentui/react/lib/Utilities';
-import { Persona, IPersonaProps, PersonaSize } from '@fluentui/react/lib/Persona';
-import { ISelectedItemProps } from '../../SelectedItemsList.types';
+import { styled, classNamesFunction, css, EventGroup } from '@fluentui/react/lib/Utilities';
+import { Persona, PersonaSize } from '@fluentui/react/lib/Persona';
 import { getStyles } from './SelectedPersona.styles';
-import { ISelectedPersonaStyles, ISelectedPersonaStyleProps } from './SelectedPersona.types';
-import { ITheme, IProcessedStyleSet } from '@fluentui/react/lib/Styling';
 import { IconButton } from '@fluentui/react/lib/Button';
-import { IDragDropOptions } from '@fluentui/react/lib/DragDrop';
 import { useId } from '@fluentui/react-hooks';
+import type { IStyleFunctionOrObject } from '@fluentui/react/lib/Utilities';
+import type { IPersonaProps } from '@fluentui/react/lib/Persona';
+import type { ISelectedItemProps } from '../../SelectedItemsList.types';
+import type { ISelectedPersonaStyles, ISelectedPersonaStyleProps } from './SelectedPersona.types';
+import type { ITheme, IProcessedStyleSet } from '@fluentui/react/lib/Styling';
+import type { IDragDropOptions } from '@fluentui/react/lib/DragDrop';
 
 const getClassNames = classNamesFunction<ISelectedPersonaStyleProps, ISelectedPersonaStyles>();
 

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.types.ts
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.types.ts
@@ -1,7 +1,7 @@
-import { ITheme, IStyle } from '@fluentui/react/lib/Styling';
-import { IStyleFunctionOrObject } from '@fluentui/react/lib/Utilities';
-import { IPersonaStyleProps, IPersonaCoinStyleProps } from '@fluentui/react/lib/Persona';
-import { IButtonStyles } from '@fluentui/react/lib/Button';
+import type { ITheme, IStyle } from '@fluentui/react/lib/Styling';
+import type { IStyleFunctionOrObject } from '@fluentui/react/lib/Utilities';
+import type { IPersonaStyleProps, IPersonaCoinStyleProps } from '@fluentui/react/lib/Persona';
+import type { IButtonStyles } from '@fluentui/react/lib/Button';
 
 export interface ISelectedPersonaStyleProps {
   theme: ITheme;

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
@@ -3,14 +3,8 @@ import { create } from 'react-test-renderer';
 
 import { people } from '@fluentui/example-data';
 import { mount } from 'enzyme';
-import {
-  SelectedPeopleList,
-  ISelectedPeopleList,
-  SelectedPersona,
-  ItemWithContextMenu,
-  TriggerOnContextMenu,
-  ItemCanDispatchTrigger,
-} from '../index';
+import { SelectedPeopleList, SelectedPersona, ItemWithContextMenu, TriggerOnContextMenu } from '../index';
+import type { ISelectedPeopleList, ItemCanDispatchTrigger } from '../index';
 
 describe('SelectedPeopleList', () => {
   it('renders nothing if nothing is provided', () => {

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { SelectedItemsList } from '../SelectedItemsList';
 import { SelectedPersona } from './Items/SelectedPersona';
-import { ISelectedItemsListProps, ISelectedItemsList, BaseSelectedItem } from '../SelectedItemsList.types';
-import { IPersonaProps } from '@fluentui/react/lib/Persona';
+import type { ISelectedItemsListProps, ISelectedItemsList, BaseSelectedItem } from '../SelectedItemsList.types';
+import type { IPersonaProps } from '@fluentui/react/lib/Persona';
 
 export type ISelectedPeopleListProps<
   TPersona extends IPersonaProps & BaseSelectedItem = IPersonaProps

--- a/packages/react-experiments/src/components/Sidebar/Sidebar.classNames.tsx
+++ b/packages/react-experiments/src/components/Sidebar/Sidebar.classNames.tsx
@@ -4,7 +4,7 @@
 
 import { mergeStyleSets } from '@fluentui/react/lib/Styling';
 import { memoizeFunction } from '@fluentui/react/lib/Utilities';
-import { ISidebarStyles } from './Sidebar.types';
+import type { ISidebarStyles } from './Sidebar.types';
 
 export interface ISidebarClassNames {
   root?: string;

--- a/packages/react-experiments/src/components/Sidebar/Sidebar.styles.tsx
+++ b/packages/react-experiments/src/components/Sidebar/Sidebar.styles.tsx
@@ -1,10 +1,11 @@
 /*!
  * Copyright (C) Microsoft Corporation. All rights reserved.
  */
-
-import { IButtonStyles } from '@fluentui/react/lib/Button';
-import { memoizeFunction, ITheme, concatStyleSets } from '@fluentui/react';
-import { ISidebarStyles, SidebarStylingConstants } from './Sidebar.types';
+import { memoizeFunction, concatStyleSets } from '@fluentui/react';
+import { SidebarStylingConstants } from './Sidebar.types';
+import type { IButtonStyles } from '@fluentui/react/lib/Button';
+import type { ITheme } from '@fluentui/react';
+import type { ISidebarStyles } from './Sidebar.types';
 
 export const sidebarFonts = {
   segoeUiSemibold:

--- a/packages/react-experiments/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/react-experiments/src/components/Sidebar/Sidebar.test.tsx
@@ -6,7 +6,8 @@ import * as Enzyme from 'enzyme';
 import { getTheme } from '@fluentui/react';
 import { CommandBarButton } from '@fluentui/react/lib/Button';
 import * as React from 'react';
-import { ISidebar, ISidebarProps, Sidebar, SidebarButton } from './index';
+import { Sidebar, SidebarButton } from './index';
+import type { ISidebar, ISidebarProps } from './index';
 
 describe('Sidebar', () => {
   let sidebarButtonExampleProps: ISidebarProps;

--- a/packages/react-experiments/src/components/Sidebar/Sidebar.tsx
+++ b/packages/react-experiments/src/components/Sidebar/Sidebar.tsx
@@ -3,18 +3,20 @@
  */
 
 import { FocusZone, FocusZoneDirection } from '@fluentui/react/lib/FocusZone';
-import { IButtonStyles } from '@fluentui/react/lib/Button';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';
 import { ScrollablePane } from '@fluentui/react/lib/ScrollablePane';
-import { concatStyleSets, ITheme } from '@fluentui/react/lib/Styling';
+import { concatStyleSets } from '@fluentui/react/lib/Styling';
 import { KeyCodes, initializeComponentRef, FocusRects } from '@fluentui/react/lib/Utilities';
 import * as React from 'react';
 import { Accordion } from '../BAFAccordion/Accordion';
-import { getSidebarClassNames, ISidebarClassNames } from './Sidebar.classNames';
+import { getSidebarClassNames } from './Sidebar.classNames';
 import { getButtonColoredStyles, getSidebarStyles, SidebarColors } from './Sidebar.styles';
-import { ISidebar, ISidebarItemProps, ISidebarProps } from './Sidebar.types';
 import { SidebarButton } from './SidebarButton';
 import { getSidebarChildrenStyles } from './SidebarButton.styles';
+import type { IButtonStyles } from '@fluentui/react/lib/Button';
+import type { ITheme } from '@fluentui/react/lib/Styling';
+import type { ISidebarClassNames } from './Sidebar.classNames';
+import type { ISidebar, ISidebarItemProps, ISidebarProps } from './Sidebar.types';
 
 export interface ISidebarState {
   // whether the sidebar is currently collapsed or not.

--- a/packages/react-experiments/src/components/Sidebar/Sidebar.types.tsx
+++ b/packages/react-experiments/src/components/Sidebar/Sidebar.types.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { IButtonProps, IButtonStyles } from '@fluentui/react/lib/Button';
-import { IContextualMenuItem } from '@fluentui/react/lib/ContextualMenu';
-import { IStyle, ITheme } from '@fluentui/react/lib/Styling';
-import { IComponentAs } from '@fluentui/react/lib/Utilities';
-import { IRefObject } from '@fluentui/react/lib/Utilities';
 import { SidebarColors } from './Sidebar.styles';
+import type { IButtonProps, IButtonStyles } from '@fluentui/react/lib/Button';
+import type { IContextualMenuItem } from '@fluentui/react/lib/ContextualMenu';
+import type { IStyle, ITheme } from '@fluentui/react/lib/Styling';
+import type { IComponentAs, IRefObject } from '@fluentui/react/lib/Utilities';
 
 export interface ISidebar {
   /**

--- a/packages/react-experiments/src/components/Sidebar/SidebarButton.styles.tsx
+++ b/packages/react-experiments/src/components/Sidebar/SidebarButton.styles.tsx
@@ -1,12 +1,12 @@
 /*!
  * Copyright (C) Microsoft Corporation. All rights reserved.
  */
-
-import { IButtonStyles } from '@fluentui/react/lib/Button';
-import { concatStyleSets, ITheme } from '@fluentui/react/lib/Styling';
+import { concatStyleSets } from '@fluentui/react/lib/Styling';
 import { memoizeFunction } from '@fluentui/react/lib/Utilities';
 import { sidebarFonts } from './Sidebar.styles';
 import { SidebarStylingConstants } from './Sidebar.types';
+import type { IButtonStyles } from '@fluentui/react/lib/Button';
+import type { ITheme } from '@fluentui/react/lib/Styling';
 
 export const getSidebarButtonStyles = memoizeFunction(
   (theme: ITheme, sidebarButtonStyles?: IButtonStyles, customStyles?: IButtonStyles): IButtonStyles => {

--- a/packages/react-experiments/src/components/Sidebar/SidebarButton.tsx
+++ b/packages/react-experiments/src/components/Sidebar/SidebarButton.tsx
@@ -2,9 +2,10 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  */
 
-import { DefaultButton, IButtonProps } from '@fluentui/react/lib/Button';
+import { DefaultButton } from '@fluentui/react/lib/Button';
 import * as React from 'react';
 import { getSidebarButtonStyles } from './SidebarButton.styles';
+import type { IButtonProps } from '@fluentui/react/lib/Button';
 
 export const SidebarButton: React.FunctionComponent<IButtonProps> = props => {
   const { styles, theme } = props;

--- a/packages/react-experiments/src/components/Slider/Slider.base.tsx
+++ b/packages/react-experiments/src/components/Slider/Slider.base.tsx
@@ -8,12 +8,12 @@ import {
   getRTLSafeKeyCode,
   warnMutuallyExclusive,
 } from '../../Utilities';
-import { ISliderProps, ISlider, ISliderStyleProps, ISliderStyles, ISliderMarks } from './Slider.types';
 import { classNamesFunction, getNativeProps, divProperties } from '../../Utilities';
 import { Label } from '@fluentui/react/lib/Label';
 import { TooltipHost } from '@fluentui/react/lib/Tooltip';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';
 import { Async, EventGroup, FocusRects } from '@fluentui/utilities';
+import type { ISliderProps, ISlider, ISliderStyleProps, ISliderStyles, ISliderMarks } from './Slider.types';
 
 /* eslint-disable deprecation/deprecation */
 

--- a/packages/react-experiments/src/components/Slider/Slider.styles.tsx
+++ b/packages/react-experiments/src/components/Slider/Slider.styles.tsx
@@ -1,6 +1,7 @@
-import { ISliderStyleProps, ISliderStyles } from './Slider.types';
-import { getGlobalClassNames, HighContrastSelector, AnimationVariables, getFocusStyle, IRawStyle } from '../../Styling';
+import { getGlobalClassNames, HighContrastSelector, AnimationVariables, getFocusStyle } from '../../Styling';
 import { getRTL } from '@fluentui/utilities';
+import type { ISliderStyleProps, ISliderStyles } from './Slider.types';
+import type { IRawStyle } from '../../Styling';
 
 /* eslint-disable deprecation/deprecation */
 

--- a/packages/react-experiments/src/components/Slider/Slider.test.tsx
+++ b/packages/react-experiments/src/components/Slider/Slider.test.tsx
@@ -5,9 +5,9 @@ import * as ReactTestUtils from 'react-dom/test-utils';
 
 import { mount } from 'enzyme';
 import { Slider } from './Slider';
-import { ISlider } from './Slider.types';
 import { ONKEYDOWN_TIMEOUT_DURATION } from './Slider.base';
 import { KeyCodes } from '../../Utilities';
+import type { ISlider } from './Slider.types';
 
 /* eslint-disable deprecation/deprecation */
 

--- a/packages/react-experiments/src/components/Slider/Slider.tsx
+++ b/packages/react-experiments/src/components/Slider/Slider.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { styled } from '../../Utilities';
-
-import { ISliderProps, ISliderStyleProps, ISliderStyles } from './Slider.types';
-
 import { SliderBase } from './Slider.base';
 import { getStyles } from './Slider.styles';
+import type { ISliderProps, ISliderStyleProps, ISliderStyles } from './Slider.types';
 
 /* eslint-disable deprecation/deprecation */
 

--- a/packages/react-experiments/src/components/Slider/Slider.types.ts
+++ b/packages/react-experiments/src/components/Slider/Slider.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { SliderBase } from './Slider.base';
-import { IStyle, ITheme } from '../../Styling';
-import { IStyleFunctionOrObject, IRefObject } from '../../Utilities';
+import type { IStyle, ITheme } from '../../Styling';
+import type { IStyleFunctionOrObject, IRefObject } from '../../Utilities';
 
 /* eslint-disable deprecation/deprecation */
 

--- a/packages/react-experiments/src/components/StaticList/List.types.ts
+++ b/packages/react-experiments/src/components/StaticList/List.types.ts
@@ -1,4 +1,4 @@
-import { IObjectWithKey } from '@fluentui/react/lib/Selection';
+import type { IObjectWithKey } from '@fluentui/react/lib/Selection';
 
 export interface IGenericListProps<TItem extends IObjectWithKey> {
   /** Optional custom class name */

--- a/packages/react-experiments/src/components/StaticList/StaticList.tsx
+++ b/packages/react-experiments/src/components/StaticList/StaticList.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { css } from '../../Utilities';
-import { IObjectWithKey } from '@fluentui/react/lib/Selection';
-import { IStaticListProps } from './StaticList.types';
-
 import * as stylesImport from './StaticList.scss';
+import type { IObjectWithKey } from '@fluentui/react/lib/Selection';
+import type { IStaticListProps } from './StaticList.types';
 
 export class StaticList<TItem extends IObjectWithKey> extends React.Component<IStaticListProps<TItem>> {
   public render(): JSX.Element {

--- a/packages/react-experiments/src/components/StaticList/StaticList.types.ts
+++ b/packages/react-experiments/src/components/StaticList/StaticList.types.ts
@@ -1,5 +1,5 @@
-import { IObjectWithKey } from '@fluentui/react/lib/Selection';
-import { IGenericListProps } from './List.types';
+import type { IObjectWithKey } from '@fluentui/react/lib/Selection';
+import type { IGenericListProps } from './List.types';
 
 export interface IStaticListProps<TItem extends IObjectWithKey> extends IGenericListProps<TItem> {
   /** Html tag to use for rendering the list, defaults to 'ul' */

--- a/packages/react-experiments/src/components/Tile/ShimmerTile/ShimmerTile.base.tsx
+++ b/packages/react-experiments/src/components/Tile/ShimmerTile/ShimmerTile.base.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { initializeComponentRef, classNamesFunction } from '../../../Utilities';
-import { IShimmerTileProps, IShimmerTileStyleProps, IShimmerTileStyles } from './ShimmerTile.types';
-import { TileSize } from '../Tile.types';
 import { TileLayoutSizes } from '../Tile';
 import { ShimmerGap, ShimmerElementsGroup, ShimmerElementType } from '@fluentui/react/lib/Shimmer';
+import type { IShimmerTileProps, IShimmerTileStyleProps, IShimmerTileStyles } from './ShimmerTile.types';
+import type { TileSize } from '../Tile.types';
 
 const ShimmerTileLayoutValues = {
   largeSquareWidth: 96,

--- a/packages/react-experiments/src/components/Tile/ShimmerTile/ShimmerTile.styles.ts
+++ b/packages/react-experiments/src/components/Tile/ShimmerTile/ShimmerTile.styles.ts
@@ -1,4 +1,4 @@
-import { IShimmerTileStyleProps, IShimmerTileStyles } from './ShimmerTile.types';
+import type { IShimmerTileStyleProps, IShimmerTileStyles } from './ShimmerTile.types';
 
 export function getStyles(props: IShimmerTileStyleProps): IShimmerTileStyles {
   return {

--- a/packages/react-experiments/src/components/Tile/ShimmerTile/ShimmerTile.tsx
+++ b/packages/react-experiments/src/components/Tile/ShimmerTile/ShimmerTile.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { styled } from '../../../Utilities';
-import { IShimmerTileProps, IShimmerTileStyleProps, IShimmerTileStyles } from './ShimmerTile.types';
 import { ShimmerTileBase } from './ShimmerTile.base';
 import { getStyles } from './ShimmerTile.styles';
+import type { IShimmerTileProps, IShimmerTileStyleProps, IShimmerTileStyles } from './ShimmerTile.types';
 
 export const ShimmerTile: React.FunctionComponent<IShimmerTileProps> = styled<
   IShimmerTileProps,

--- a/packages/react-experiments/src/components/Tile/ShimmerTile/ShimmerTile.types.ts
+++ b/packages/react-experiments/src/components/Tile/ShimmerTile/ShimmerTile.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { IStyle } from '../../../Styling';
-import { IRefObject, ISize, IStyleFunctionOrObject } from '../../../Utilities';
-import { TileSize } from '../Tile.types';
+import type { IStyle } from '../../../Styling';
+import type { IRefObject, ISize, IStyleFunctionOrObject } from '../../../Utilities';
+import type { TileSize } from '../Tile.types';
 
 export interface IShimmerTile {}
 

--- a/packages/react-experiments/src/components/Tile/Tile.tsx
+++ b/packages/react-experiments/src/components/Tile/Tile.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { ITileProps, TileSize } from './Tile.types';
 import { Check } from '@fluentui/react/lib/Check';
 import { SELECTION_CHANGE } from '@fluentui/react/lib/Selection';
-import { ISize, css, initializeComponentRef, getId, getNativeProps, divProperties, EventGroup } from '../../Utilities';
+import { css, initializeComponentRef, getId, getNativeProps, divProperties, EventGroup } from '../../Utilities';
 import * as TileStylesModule from './Tile.scss';
 import * as SignalStylesModule from '../signals/Signal.scss';
 import * as CheckStylesModule from './Check.scss';
+import type { ITileProps, TileSize } from './Tile.types';
+import type { ISize } from '../../Utilities';
 
 const TileStyles: any = TileStylesModule;
 const SignalStyles: any = SignalStylesModule;

--- a/packages/react-experiments/src/components/Tile/Tile.types.ts
+++ b/packages/react-experiments/src/components/Tile/Tile.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { IBaseProps, ISize } from '@fluentui/react/lib/Utilities';
-import { ISelection } from '@fluentui/react/lib/Selection';
+import type { IBaseProps, ISize } from '@fluentui/react/lib/Utilities';
+import type { ISelection } from '@fluentui/react/lib/Selection';
 
 export type TileSize = keyof {
   small: 'small';

--- a/packages/react-experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/react-experiments/src/components/TilesList/TilesList.tsx
@@ -1,19 +1,21 @@
 import * as React from 'react';
-import {
+import { TilesGridMode } from './TilesList.types';
+import { List, ScrollToMode } from '@fluentui/react/lib/List';
+import { FocusZone, FocusZoneDirection } from '@fluentui/react/lib/FocusZone';
+import { css, FocusRects, composeRenderFunction } from '@fluentui/react/lib/Utilities';
+import * as TilesListStylesModule from './TilesList.scss';
+import { Shimmer } from '@fluentui/react/lib/Shimmer';
+import type {
   ITilesListProps,
   ITilesGridItem,
   ITilesGridSegment,
-  TilesGridMode,
   ITileSize,
   ITilesGridItemCellProps,
   ITilesListRowProps,
   ITilesListRootProps,
 } from './TilesList.types';
-import { List, IPageProps, ScrollToMode, IListOnRenderRootProps } from '@fluentui/react/lib/List';
-import { FocusZone, FocusZoneDirection } from '@fluentui/react/lib/FocusZone';
-import { css, IRenderFunction, IRectangle, FocusRects, composeRenderFunction } from '@fluentui/react/lib/Utilities';
-import * as TilesListStylesModule from './TilesList.scss';
-import { Shimmer } from '@fluentui/react/lib/Shimmer';
+import type { IPageProps, IListOnRenderRootProps } from '@fluentui/react/lib/List';
+import type { IRenderFunction, IRectangle } from '@fluentui/react/lib/Utilities';
 
 const TilesListStyles: any = TilesListStylesModule;
 

--- a/packages/react-experiments/src/components/TilesList/TilesList.types.ts
+++ b/packages/react-experiments/src/components/TilesList/TilesList.types.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { IRefObject, IBaseProps, ISize } from '@fluentui/react/lib/Utilities';
 import { TilesList } from './TilesList';
-import { IFocusZone } from '@fluentui/react/lib/FocusZone';
-import { IListProps } from '@fluentui/react/lib/List';
-import { IRenderFunction } from '@fluentui/utilities';
+import type { IRefObject, IBaseProps, ISize } from '@fluentui/react/lib/Utilities';
+import type { IFocusZone } from '@fluentui/react/lib/FocusZone';
+import type { IListProps } from '@fluentui/react/lib/List';
+import type { IRenderFunction } from '@fluentui/utilities';
 
 export interface ITilesGridItemCellProps<TItem> {
   item: TItem;

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.test.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.test.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { create } from 'react-test-renderer';
-import { IPersonaProps } from '@fluentui/react/lib/Persona';
 import { UnifiedPeoplePicker } from './UnifiedPeoplePicker';
-import { IFloatingSuggestionItem, IFloatingPeopleSuggestionsProps } from '../../../FloatingPeopleSuggestionsComposite';
 import { people, mru } from '@fluentui/example-data';
-import { ISelectedPeopleListProps } from '../../../SelectedItemsList';
+import type { IPersonaProps } from '@fluentui/react/lib/Persona';
+import type {
+  IFloatingSuggestionItem,
+  IFloatingPeopleSuggestionsProps,
+} from '../../../FloatingPeopleSuggestionsComposite';
+import type { ISelectedPeopleListProps } from '../../../SelectedItemsList';
 
 type InputElementWrapper = ReactWrapper<React.InputHTMLAttributes<any>, any>;
 

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
-import { IUnifiedPeoplePickerProps } from './UnifiedPeoplePicker.types';
-import { IPersonaProps } from '@fluentui/react/lib/Persona';
 import { FloatingPeopleSuggestions } from '../../FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions';
-import { IFloatingPeopleSuggestionsProps } from '../../FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions.types';
-import {
-  SelectedPeopleList,
-  ISelectedPeopleListProps,
-} from '../../SelectedItemsList/SelectedPeopleList/SelectedPeopleList';
+import { SelectedPeopleList } from '../../SelectedItemsList/SelectedPeopleList/SelectedPeopleList';
 import { UnifiedPicker } from '../UnifiedPicker';
+import type { IUnifiedPeoplePickerProps } from './UnifiedPeoplePicker.types';
+import type { IPersonaProps } from '@fluentui/react/lib/Persona';
+import type { IFloatingPeopleSuggestionsProps } from '../../FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions.types';
+import type { ISelectedPeopleListProps } from '../../SelectedItemsList/SelectedPeopleList/SelectedPeopleList';
 
 export const UnifiedPeoplePicker = (props: IUnifiedPeoplePickerProps): JSX.Element => {
   const renderSelectedItems = React.useCallback(

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.types.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.types.ts
@@ -1,5 +1,5 @@
-import { IUnifiedPickerProps } from '../UnifiedPicker.types';
-import { IPersonaProps } from '@fluentui/react/lib/Persona';
+import type { IUnifiedPickerProps } from '../UnifiedPicker.types';
+import type { IPersonaProps } from '@fluentui/react/lib/Persona';
 
 export type IUnifiedPeoplePickerProps = Omit<
   IUnifiedPickerProps<IPersonaProps>,

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.styles.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.styles.ts
@@ -1,4 +1,5 @@
-import { getGlobalClassNames, getTheme, IStyle } from '@fluentui/style-utilities';
+import { getGlobalClassNames, getTheme } from '@fluentui/style-utilities';
+import type { IStyle } from '@fluentui/style-utilities';
 
 export interface IUnifiedPickerStyleProps {}
 

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.test.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { UnifiedPicker } from './UnifiedPicker';
 import { mount, ReactWrapper } from 'enzyme';
-import { ISelectedItemProps, ISelectedItemsListProps } from '../SelectedItemsList/SelectedItemsList.types';
-import { IBaseFloatingSuggestionsProps, BaseFloatingSuggestions } from '../FloatingSuggestionsComposite';
+import { BaseFloatingSuggestions } from '../FloatingSuggestionsComposite';
 import { create } from 'react-test-renderer';
 import { SelectedItemsList } from '../SelectedItemsList';
-import { IFloatingSuggestionItem } from '../../FloatingSuggestionsComposite';
+import type { ISelectedItemProps, ISelectedItemsListProps } from '../SelectedItemsList/SelectedItemsList.types';
+import type { IBaseFloatingSuggestionsProps } from '../FloatingSuggestionsComposite';
+import type { IFloatingSuggestionItem } from '../../FloatingSuggestionsComposite';
 
 export interface ISimple {
   key: string;

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
 import { getStyles } from './UnifiedPicker.styles';
 import { classNamesFunction, css, SelectionMode, Selection, KeyCodes } from '../../Utilities';
-import { DragDropHelper, IDragDropContext } from '@fluentui/react/lib/DragDrop';
-import { IUnifiedPickerStyleProps, IUnifiedPickerStyles } from './UnifiedPicker.styles';
-import { FocusZoneDirection, FocusZone, SelectionZone, Autofill, IInputProps, IDragDropEvents } from '@fluentui/react';
-import { IUnifiedPickerProps } from './UnifiedPicker.types';
+import { DragDropHelper } from '@fluentui/react/lib/DragDrop';
+import { FocusZoneDirection, FocusZone, SelectionZone, Autofill } from '@fluentui/react';
 import { useFloatingSuggestionItems } from './hooks/useFloatingSuggestionItems';
 import { useSelectedItems } from './hooks/useSelectedItems';
-import { IFloatingSuggestionItemProps } from '../../FloatingSuggestionsComposite';
 import { getTheme } from '@fluentui/react/lib/Styling';
 import { mergeStyles } from '@fluentui/merge-styles';
 import { Announced } from '@fluentui/react/lib/Announced';
+import type { IDragDropContext } from '@fluentui/react/lib/DragDrop';
+import type { IUnifiedPickerStyleProps, IUnifiedPickerStyles } from './UnifiedPicker.styles';
+import type { IInputProps, IDragDropEvents } from '@fluentui/react';
+import type { IUnifiedPickerProps } from './UnifiedPicker.types';
+import type { IFloatingSuggestionItemProps } from '../../FloatingSuggestionsComposite';
 
 export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.Element => {
   const getClassNames = classNamesFunction<IUnifiedPickerStyleProps, IUnifiedPickerStyles>();

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.types.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.types.ts
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { IRefObject } from '@fluentui/utilities';
-import { IBaseFloatingSuggestionsProps } from '../FloatingSuggestionsComposite/FloatingSuggestions.types';
-import { ISelectedItemsListProps } from '../SelectedItemsList/SelectedItemsList.types';
-import { IFocusZoneProps, IInputProps, Autofill, IDragDropEvents } from '@fluentui/react';
+import { Autofill } from '@fluentui/react';
+import type { IRefObject } from '@fluentui/utilities';
+import type { IBaseFloatingSuggestionsProps } from '../FloatingSuggestionsComposite/FloatingSuggestions.types';
+import type { ISelectedItemsListProps } from '../SelectedItemsList/SelectedItemsList.types';
+import type { IFocusZoneProps, IInputProps, IDragDropEvents } from '@fluentui/react';
 
 export interface IUnifiedPickerProps<T> {
   /**

--- a/packages/react-experiments/src/components/UnifiedPicker/hooks/useFloatingSuggestionItems.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/hooks/useFloatingSuggestionItems.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IFloatingSuggestionsHeaderFooterProps } from '../../FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
+import type { IFloatingSuggestionsHeaderFooterProps } from '../../FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
 
 export interface IUseFloatingSuggestionItems<T> {
   focusItemIndex: number;

--- a/packages/react-experiments/src/components/VirtualizedList/VirtualizedList.tsx
+++ b/packages/react-experiments/src/components/VirtualizedList/VirtualizedList.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { IVirtualizedListProps } from './VirtualizedList.types';
-import { IScrollContainerContext, ScrollContainerContextTypes } from '../../utilities/scrolling/ScrollContainer';
-import { IObjectWithKey } from '@fluentui/react/lib/Selection';
+import { ScrollContainerContextTypes } from '../../utilities/scrolling/ScrollContainer';
 import { getParent, css, initializeComponentRef, EventGroup } from '@fluentui/react/lib/Utilities';
+import type { IVirtualizedListProps } from './VirtualizedList.types';
+import type { IScrollContainerContext } from '../../utilities/scrolling/ScrollContainer';
+import type { IObjectWithKey } from '@fluentui/react/lib/Selection';
 
 interface IRange {
   /** Start of range */

--- a/packages/react-experiments/src/components/VirtualizedList/VirtualizedList.types.ts
+++ b/packages/react-experiments/src/components/VirtualizedList/VirtualizedList.types.ts
@@ -1,6 +1,6 @@
-import { IBaseProps } from '../../Utilities';
-import { IGenericListProps } from '../StaticList/List.types';
-import { IObjectWithKey } from '@fluentui/react/lib/Selection';
+import type { IBaseProps } from '../../Utilities';
+import type { IGenericListProps } from '../StaticList/List.types';
+import type { IObjectWithKey } from '@fluentui/react/lib/Selection';
 
 export interface IVirtualizedListProps<TItem extends IObjectWithKey> extends IGenericListProps<TItem>, IBaseProps {
   /** Initial height of the viewport in pixels */

--- a/packages/react-experiments/src/components/signals/Signals.Props.ts
+++ b/packages/react-experiments/src/components/signals/Signals.Props.ts
@@ -1,3 +1,2 @@
-export { ISignalProps } from './Signal';
-
-export { ISignalFieldProps } from './SignalField';
+export type { ISignalProps } from './Signal';
+export type { ISignalFieldProps } from './SignalField';

--- a/packages/react-experiments/src/components/signals/Signals.tsx
+++ b/packages/react-experiments/src/components/signals/Signals.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
-import { Icon, IIconProps } from '@fluentui/react/lib/Icon';
+import { Icon } from '@fluentui/react/lib/Icon';
 import { css } from '@fluentui/react/lib/Utilities';
-import { Signal, ISignalProps } from './Signal';
+import { Signal } from './Signal';
 import * as SignalsStyles from './Signals.scss';
 import * as SignalStyles from './Signal.scss';
 import { getRTL } from '../../Utilities';
+import type { IIconProps } from '@fluentui/react/lib/Icon';
+import type { ISignalProps } from './Signal';
 
 export * from './Signal';
 export * from './SignalField';

--- a/packages/react-experiments/src/utilities/factoryComponents.tsx
+++ b/packages/react-experiments/src/utilities/factoryComponents.tsx
@@ -1,16 +1,10 @@
 import * as React from 'react';
-import {
-  FontIcon as FabricFontIcon,
-  Icon as FabricIcon,
-  Label as FabricLabel,
-  IFontIconProps,
-  IIconProps,
-  ILabelProps,
-  IPersonaPresenceProps,
-} from '@fluentui/react';
+import { FontIcon as FabricFontIcon, Icon as FabricIcon, Label as FabricLabel } from '@fluentui/react';
 // PersonaPresence is not exported by OUFR, so we have to import it directly.
 import { PersonaPresence as FabricPersonaPresence } from '@fluentui/react/lib/PersonaPresence';
-import { createFactory, ISlottableComponentType, ISlotFactory } from '@fluentui/foundation-legacy';
+import { createFactory } from '@fluentui/foundation-legacy';
+import type { IFontIconProps, IIconProps, ILabelProps, IPersonaPresenceProps } from '@fluentui/react';
+import type { ISlottableComponentType, ISlotFactory } from '@fluentui/foundation-legacy';
 
 // TODO: All contents of this file should be moved to each respective component as they are converted to use slots.
 // TODO: createFactory should no longer have to be explicitly called with component options containing defaultProp.

--- a/packages/react-experiments/src/utilities/factoryComponents.types.tsx
+++ b/packages/react-experiments/src/utilities/factoryComponents.types.tsx
@@ -1,4 +1,5 @@
-import {
+import { PersonaPresence } from '@fluentui/react';
+import type {
   IButtonProps,
   ICalloutProps,
   IContextualMenuProps,
@@ -7,9 +8,8 @@ import {
   ILabelProps,
   IListProps,
   IPersonaPresenceProps,
-  PersonaPresence,
 } from '@fluentui/react';
-import { ISlotProp } from '@fluentui/foundation-legacy';
+import type { ISlotProp } from '@fluentui/foundation-legacy';
 
 // TODO: All contents of this file should be moved to each respective component after slots utilities are promoted.
 

--- a/packages/react-experiments/src/utilities/scrolling/ScrollContainer.tsx
+++ b/packages/react-experiments/src/utilities/scrolling/ScrollContainer.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { IScrollContainerProps } from './ScrollContainer.types';
 import { css, Async, initializeComponentRef } from '@fluentui/react/lib/Utilities';
 
 import * as ScrollContainerStyles from './ScrollContainer.scss';
+import type { IScrollContainerProps } from './ScrollContainer.types';
 
 export interface IVisibleCallback {
   (scrollTop: number): void;

--- a/packages/react-experiments/src/utilities/scrolling/ScrollContainer.types.ts
+++ b/packages/react-experiments/src/utilities/scrolling/ScrollContainer.types.ts
@@ -1,4 +1,4 @@
-import { IBaseProps } from '@fluentui/react/lib/Utilities';
+import type { IBaseProps } from '@fluentui/react/lib/Utilities';
 
 export interface IScrollContainerProps extends IBaseProps {
   /**

--- a/packages/react-experiments/tsconfig.json
+++ b/packages/react-experiments/tsconfig.json
@@ -18,7 +18,8 @@
     "skipLibCheck": true,
     "lib": ["es5", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["jest", "custom-global"]
+    "types": ["jest", "custom-global"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/react-file-type-icons/src/FileIconType.test.ts
+++ b/packages/react-file-type-icons/src/FileIconType.test.ts
@@ -1,4 +1,5 @@
-import { FileIconType, FileIconTypeInput } from './FileIconType';
+import { FileIconType } from './FileIconType';
+import type { FileIconTypeInput } from './FileIconType';
 
 let allFileTypeIconValues: FileIconType | undefined;
 

--- a/packages/react-file-type-icons/src/getFileTypeIconAsHTMLString.test.ts
+++ b/packages/react-file-type-icons/src/getFileTypeIconAsHTMLString.test.ts
@@ -1,6 +1,7 @@
 import { ICON_SIZES, DEFAULT_BASE_URL } from './initializeFileTypeIcons';
-import { DEFAULT_ICON_SIZE, FileTypeIconSize } from './getFileTypeIconProps';
+import { DEFAULT_ICON_SIZE } from './getFileTypeIconProps';
 import { getFileTypeIconAsHTMLString } from './getFileTypeIconAsHTMLString';
+import type { FileTypeIconSize } from './getFileTypeIconProps';
 
 // Currently this test file only covers the default device pixel ratio, i.e 1
 const getExpectedHTMLElement = (iconSize: FileTypeIconSize, suffix: string, expectedExt: string) => {

--- a/packages/react-file-type-icons/src/getFileTypeIconAsHTMLString.ts
+++ b/packages/react-file-type-icons/src/getFileTypeIconAsHTMLString.ts
@@ -3,8 +3,8 @@ import {
   getFileTypeIconNameFromExtensionOrType,
   getFileTypeIconSuffix,
   DEFAULT_ICON_SIZE,
-  IFileTypeIconOptions,
 } from './getFileTypeIconProps';
+import type { IFileTypeIconOptions } from './getFileTypeIconProps';
 
 /**
  * Given the `fileTypeIconOptions`, this function returns the DOM element for the `FileTypeIcon`

--- a/packages/react-file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/react-file-type-icons/src/getFileTypeIconProps.ts
@@ -1,5 +1,6 @@
 import { FileTypeIconMap } from './FileTypeIconMap';
-import { FileIconType, FileIconTypeInput } from './FileIconType';
+import { FileIconType } from './FileIconType';
+import type { FileIconTypeInput } from './FileIconType';
 
 let _extensionToIconName: { [key: string]: string };
 

--- a/packages/react-file-type-icons/src/index.ts
+++ b/packages/react-file-type-icons/src/index.ts
@@ -1,9 +1,11 @@
 export { initializeFileTypeIcons } from './initializeFileTypeIcons';
 
-export { FileTypeIconSize, IFileTypeIconOptions, ImageFileType, getFileTypeIconProps } from './getFileTypeIconProps';
+export { getFileTypeIconProps } from './getFileTypeIconProps';
 
 export { FileIconType } from './FileIconType';
 
 export { getFileTypeIconAsHTMLString } from './getFileTypeIconAsHTMLString';
 
 import './version';
+
+export type { FileTypeIconSize, IFileTypeIconOptions, ImageFileType } from './getFileTypeIconProps';

--- a/packages/react-file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/react-file-type-icons/src/initializeFileTypeIcons.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { registerIcons, IIconOptions } from '@fluentui/style-utilities';
+import { registerIcons } from '@fluentui/style-utilities';
 import { FileTypeIconMap } from './FileTypeIconMap';
+import type { IIconOptions } from '@fluentui/style-utilities';
 
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';

--- a/packages/react-file-type-icons/tsconfig.json
+++ b/packages/react-file-type-icons/tsconfig.json
@@ -13,7 +13,8 @@
     "moduleResolution": "node",
     "preserveConstEnums": false,
     "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["jest", "custom-global"]
+    "types": ["jest", "custom-global"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This change migrates the following package(s) to use import/export type syntax:

`react-experiments`
`react-file-type-icons`

For more background on why, read about the motivation (and the code-mod) here:

https://github.com/dzearing/transform-typed-imports#motivation
