### PR TITLE
fix(Tooltip): give 4px gap between trigger and default tooltip

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -47,6 +47,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Dialog` styles border radius changed @bcalvery ([#19328](https://github.com/microsoft/fluentui/pull/19328))
 - Fix `Card` HC styles on hover @chassunc ([#19382](https://github.com/microsoft/fluentui/pull/19382))
 - Fix `Dialog` background in teams dark v2  @chassunc ([#19434](https://github.com/microsoft/fluentui/pull/19434))
+- Fix default `Tooltip` (`pointing: false`) to have 4px distance to trigger  @yuanboxue-amber ([#19478](https://github.com/microsoft/fluentui/pull/19478))
 
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))

--- a/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
@@ -263,7 +263,7 @@ export const Tooltip: React.FC<TooltipProps> &
   };
   let calculatedOffset = offset;
   if (typeof calculatedOffset === 'undefined') {
-    calculatedOffset = pointing ? [4, 4] : [0, 0];
+    calculatedOffset = [4, 4];
   }
 
   const element = (


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Default tooltip (no beak) should be 4px away from trigger. Currently it is 0. This PR updated to match design 
before:
<img width="196" alt="Screenshot 2021-08-23 at 10 28 10" src="https://user-images.githubusercontent.com/28751745/130416231-c1e81205-3846-42a9-a030-b3a0826d2180.png">
after:
<img width="190" alt="Screenshot 2021-08-23 at 10 31 52" src="https://user-images.githubusercontent.com/28751745/130416254-13b9108e-6618-4d5f-9d65-5a0e0bf80ae6.png">


#### Focus areas to test

(optional)
