### PR TITLE
chore: add vNext storybook builders support and context awareness for migration generator

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,18 +9,30 @@ const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
  */
 
 /**
- *  @typedef {{check:boolean; checkOptions: Record<string,unknown>; reactDocgen: string | boolean; reactDocgenTypescriptOptions: Record<string,unknown>}} StorybookTsConfig
+ *  @typedef {{
+ *    check:boolean;
+ *    checkOptions: Record<string,unknown>;
+ *    reactDocgen: string | boolean;
+ *    reactDocgenTypescriptOptions: Record<string,unknown>
+ *  }} StorybookTsConfig
  */
 
 /**
- * @typedef {{stories: string[] ; addons: string[]; typescript: StorybookTsConfig; babel: (options:Record<string,unknown>)=>Promise<Record<string,unknown>>; webpackFinal: StorybookWebpackConfig}} StorybookConfig
+ *  @typedef {{
+ *    stories: string[];
+ *    addons: string[];
+ *    typescript: StorybookTsConfig;
+ *    babel: (options:Record<string,unknown>)=>Promise<Record<string,unknown>>;
+ *    webpackFinal: StorybookWebpackConfig;
+ *    core: {builder:'webpack5'};
+ * }} StorybookConfig
  */
 
 /**
  * @typedef  {{loader: string; options: { [index: string]: any }}} LoaderObjectDef
  */
 
-module.exports = /** @type {Pick<StorybookConfig,'addons' |'stories' |'webpackFinal'>} */ ({
+module.exports = /** @type {Omit<StorybookConfig,'typescript'|'babel'>} */ ({
   stories: [],
   addons: [
     '@storybook/addon-essentials',

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -114,10 +114,11 @@ describe('migrate-converged-pkg generator', () => {
           return json;
         });
 
+        /* eslint-disable @fluentui/max-len */
         await expect(generator(tree, options)).rejects.toMatchInlineSnapshot(
-          // eslint-disable-next-line @fluentui/max-len
           `[Error: @proj/react-dummy is not converged package. Make sure to run the migration on packages with version 9.x.x]`,
         );
+        /* eslint-enable @fluentui/max-len */
       });
     });
 
@@ -425,11 +426,14 @@ describe('migrate-converged-pkg generator', () => {
       expect(tree.read(`${projectStorybookConfigPath}/main.js`)?.toString('utf-8')).toMatchInlineSnapshot(`
         "const rootMain = require('../../../.storybook/main');
 
-        module.exports = /** @type {Pick<import('../../../.storybook/main').StorybookConfig,'addons'|'stories'|'webpackFinal'>} */ ({
+        module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript'|'babel'>} */ ({
+        ...rootMain,
         stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/*.stories.@(ts|tsx)'],
         addons: [...rootMain.addons],
         webpackFinal: (config, options) => {
         const localConfig = { ...rootMain.webpackFinal(config, options) };
+
+        // add your own webpack tweaks if needed
 
         return localConfig;
         },

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -189,7 +189,7 @@ describe('migrate-converged-pkg generator', () => {
           outDir: 'dist',
           preserveConstEnums: true,
           target: 'ES2020',
-          types: ['jest', 'custom-global', 'inline-style-expand-shorthand', 'storybook__addons'],
+          types: ['jest', 'custom-global', 'inline-style-expand-shorthand'],
         },
         extends: '../../tsconfig.base.json',
         include: ['src'],
@@ -212,7 +212,6 @@ describe('migrate-converged-pkg generator', () => {
         'jest',
         'custom-global',
         'inline-style-expand-shorthand',
-        'storybook__addons',
         '@testing-library/jest-dom',
         'foo-bar',
       ]);
@@ -470,7 +469,7 @@ describe('migrate-converged-pkg generator', () => {
       };
     }
     it(`should setup package storybook when needed`, async () => {
-      const { projectStorybookConfigPath } = setup();
+      const { projectStorybookConfigPath, projectConfig } = setup();
 
       expect(tree.exists(projectStorybookConfigPath)).toBeFalsy();
 
@@ -523,6 +522,10 @@ describe('migrate-converged-pkg generator', () => {
         /** @type {typeof rootPreview.parameters} */
         export const parameters = { ...rootPreview.parameters };"
       `);
+
+      expect(readJson<TsConfig>(tree, `${projectConfig.root}/tsconfig.json`).compilerOptions.types).toContain(
+        'storybook__addons',
+      );
     });
 
     it(`should remove unused existing storybook setup`, async () => {
@@ -556,6 +559,9 @@ describe('migrate-converged-pkg generator', () => {
       expect(tree.exists(mainJsFilePath)).toBeFalsy();
       expect(Object.keys(pkgJson.scripts || [])).not.toContain(['start', 'storybook', 'build-storybook']);
       expect(tree.exists(projectStorybookConfigPath)).toBeFalsy();
+      expect(readJson<TsConfig>(tree, `${projectConfig.root}/tsconfig.json`).compilerOptions.types).not.toContain(
+        'storybook__addons',
+      );
     });
 
     it(`should work if there are no package stories in react-examples`, async () => {

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -497,7 +497,6 @@ describe('migrate-converged-pkg generator', () => {
         }
       `);
 
-      /* eslint-disable @fluentui/max-len */
       expect(tree.read(`${projectStorybookConfigPath}/main.js`)?.toString('utf-8')).toMatchInlineSnapshot(`
         "const rootMain = require('../../../.storybook/main');
 
@@ -514,7 +513,6 @@ describe('migrate-converged-pkg generator', () => {
         },
         });"
       `);
-      /* eslint-enable @fluentui/max-len */
 
       expect(tree.read(`${projectStorybookConfigPath}/preview.js`)?.toString('utf-8')).toMatchInlineSnapshot(`
         "import * as rootPreview from '../../../.storybook/preview';

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -134,7 +134,7 @@ const templates = {
       importHelpers: true,
       noUnusedLocals: true,
       preserveConstEnums: true,
-      types: ['jest', 'custom-global', 'inline-style-expand-shorthand', 'storybook__addons'],
+      types: ['jest', 'custom-global', 'inline-style-expand-shorthand'],
     } as TsConfig['compilerOptions'],
   },
   babelConfig: (options: { extraPlugins: Array<string> }) => {
@@ -439,6 +439,15 @@ function setupStorybook(tree: Tree, options: NormalizedSchema) {
     tree.write(options.paths.storybook.tsconfig, serializeJson(templates.storybook.tsconfig));
     tree.write(options.paths.storybook.main, templates.storybook.main);
     tree.write(options.paths.storybook.preview, templates.storybook.preview);
+
+    updateJson(tree, options.paths.tsconfig, (json: TsConfig) => {
+      json.compilerOptions.types = json.compilerOptions.types || [];
+
+      json.compilerOptions.types.push('storybook__addons');
+      json.compilerOptions.types = uniqueArray(json.compilerOptions.types);
+
+      return json;
+    });
   }
 
   if (sbAction === 'remove') {
@@ -449,6 +458,16 @@ function setupStorybook(tree: Tree, options: NormalizedSchema) {
       delete json.scripts.start;
       delete json.scripts.storybook;
       delete json.scripts['build-storybook'];
+
+      return json;
+    });
+
+    updateJson(tree, options.paths.tsconfig, (json: TsConfig) => {
+      json.compilerOptions.types = json.compilerOptions.types || [];
+
+      json.compilerOptions.types = json.compilerOptions.types.filter(
+        typeReference => typeReference !== 'storybook__addons',
+      );
 
       return json;
     });

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -169,7 +169,6 @@ const templates = {
       };
   `,
   storybook: {
-    /* eslint-disable @fluentui/max-len */
     main: stripIndents`
       const rootMain = require('../../../.storybook/main');
 
@@ -186,7 +185,6 @@ const templates = {
         },
       });
     `,
-    /* eslint-enable @fluentui/max-len */
     preview: stripIndents`
       import * as rootPreview from '../../../.storybook/preview';
 
@@ -448,8 +446,8 @@ function setupStorybook(tree: Tree, options: NormalizedSchema) {
     updateJson(tree, options.paths.packageJson, (json: PackageJson) => {
       json.scripts = json.scripts || {};
 
-      delete json.scripts['start'];
-      delete json.scripts['storybook'];
+      delete json.scripts.start;
+      delete json.scripts.storybook;
       delete json.scripts['build-storybook'];
 
       return json;

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -173,11 +173,14 @@ const templates = {
     main: stripIndents`
       const rootMain = require('../../../.storybook/main');
 
-      module.exports = /** @type {Pick<import('../../../.storybook/main').StorybookConfig,'addons'|'stories'|'webpackFinal'>} */ ({
+      module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript'|'babel'>} */ ({
+        ...rootMain,
         stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/*.stories.@(ts|tsx)'],
         addons: [...rootMain.addons],
         webpackFinal: (config, options) => {
           const localConfig = { ...rootMain.webpackFinal(config, options) };
+
+          // add your own webpack tweaks if needed
 
           return localConfig;
         },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes https://github.com/microsoft/fluentui/issues/19459
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

- adds builders support to root config for vNext
- adds builders support for package storybooks setup

#### Focus areas to test

(optional)
