### PR TITLE
Fix type imports: pass 7

### DIFF
--- a/change/@fluentui-public-docsite-setup-ec393613-6811-4d5f-8e4b-fd90c59e95ac.json
+++ b/change/@fluentui-public-docsite-setup-ec393613-6811-4d5f-8e4b-fd90c59e95ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/public-docsite-setup",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-accordion-1b6860d4-6e5d-4089-a844-57b24efde970.json
+++ b/change/@fluentui-react-accordion-1b6860d4-6e5d-4089-a844-57b24efde970.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/react-accordion",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-2a209379-ebf0-40a1-9ba3-41c43b5e5cb7.json
+++ b/change/@fluentui-react-aria-2a209379-ebf0-40a1-9ba3-41c43b5e5cb7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/react-aria",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-05155947-3cac-4ea3-aa22-c566d33845ba.json
+++ b/change/@fluentui-react-avatar-05155947-3cac-4ea3-aa22-c566d33845ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-bbef588c-ba55-492e-b28c-1573a05be4d0.json
+++ b/change/@fluentui-react-badge-bbef588c-ba55-492e-b28c-1573a05be4d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/react-badge",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-e8613e9d-7c1b-4ed7-9af1-9c3073d18d76.json
+++ b/change/@fluentui-react-button-e8613e9d-7c1b-4ed7-9af1-9c3073d18d76.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/react-button",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/public-docsite-setup/src/constants.ts
+++ b/packages/public-docsite-setup/src/constants.ts
@@ -1,4 +1,4 @@
-import { ManifestVariant } from './types';
+import type { ManifestVariant } from './types';
 
 /** Name of the webpack bundle for the site */
 // "as const" means the type of the constant will literally be "fabric-site" not string

--- a/packages/public-docsite-setup/src/loadSite.ts
+++ b/packages/public-docsite-setup/src/loadSite.ts
@@ -11,7 +11,7 @@
 // uses that to determine which files to load for the rest of the site.
 //
 import { BUNDLE_NAME, MANIFEST_NAME_FORMAT } from './constants';
-import { SiteGlobals, ManifestVariant } from './types';
+import type { SiteGlobals, ManifestVariant } from './types';
 
 declare const window: Window & SiteGlobals;
 

--- a/packages/public-docsite-setup/tsconfig.json
+++ b/packages/public-docsite-setup/tsconfig.json
@@ -13,7 +13,8 @@
     "noUnusedLocals": true,
     "skipLibCheck": true,
     "lib": ["es5", "dom"],
-    "types": ["webpack-env"]
+    "types": ["webpack-env"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-accordion/etc/react-accordion.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import { ARIAButtonProps } from '@fluentui/react-aria';
-import { ComponentProps } from '@fluentui/react-utilities';
-import { ComponentState } from '@fluentui/react-utilities';
-import { Context } from '@fluentui/react-context-selector';
+import type { ARIAButtonProps } from '@fluentui/react-aria';
+import type { ComponentProps } from '@fluentui/react-utilities';
+import type { ComponentState } from '@fluentui/react-utilities';
+import type { Context } from '@fluentui/react-context-selector';
 import * as React_2 from 'react';
 
 // @public

--- a/packages/react-accordion/src/Accordion.stories.tsx
+++ b/packages/react-accordion/src/Accordion.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { RocketIcon } from './icons.stories';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion, AccordionProps } from './index';
-import { ArgType } from '@storybook/addons';
-import { AccordionHeaderProps } from './components/AccordionHeader/AccordionHeader.types';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from './index';
+import type { AccordionProps } from './index';
+import type { ArgType } from '@storybook/addons';
+import type { AccordionHeaderProps } from './components/AccordionHeader/AccordionHeader.types';
 
 interface AccordionExampleProps
   extends AccordionProps,

--- a/packages/react-accordion/src/AccordionItem.stories.tsx
+++ b/packages/react-accordion/src/AccordionItem.stories.tsx
@@ -1,14 +1,8 @@
 import * as React from 'react';
-import {
-  AccordionItem,
-  AccordionHeader,
-  AccordionPanel,
-  Accordion,
-  AccordionHeaderSize,
-  AccordionHeaderExpandIconPosition,
-} from './index';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from './index';
 import { RocketIcon } from './icons.stories';
-import { AccordionToggleData, AccordionToggleEvent } from './components/Accordion/Accordion.types';
+import type { AccordionHeaderSize, AccordionHeaderExpandIconPosition } from './index';
+import type { AccordionToggleData, AccordionToggleEvent } from './components/Accordion/Accordion.types';
 
 interface AccordionItemExampleProps {
   icon: boolean;

--- a/packages/react-accordion/src/common/isConformant.ts
+++ b/packages/react-accordion/src/common/isConformant.ts
@@ -1,4 +1,5 @@
-import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
+import type { IsConformantOptions } from '@fluentui/react-conformance';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },

--- a/packages/react-accordion/src/components/Accordion/Accordion.tsx
+++ b/packages/react-accordion/src/components/Accordion/Accordion.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-
-import { AccordionProps } from './Accordion.types';
 import { renderAccordion } from './renderAccordion';
 import { useAccordion } from './useAccordion';
 import { useAccordionContextValues } from './useAccordionContextValues';
+import type { AccordionProps } from './Accordion.types';
 
 /**
  * Define a styled Accordion, using the `useAccordion` and `useAccordionStyles` hooks.

--- a/packages/react-accordion/src/components/Accordion/Accordion.types.ts
+++ b/packages/react-accordion/src/components/Accordion/Accordion.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
-import { AccordionItemValue } from '../AccordionItem/AccordionItem.types';
+import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import type { AccordionItemValue } from '../AccordionItem/AccordionItem.types';
 
 export type AccordionToggleEvent<E = HTMLElement> = React.MouseEvent<E> | React.KeyboardEvent<E>;
 

--- a/packages/react-accordion/src/components/Accordion/AccordionContext.ts
+++ b/packages/react-accordion/src/components/Accordion/AccordionContext.ts
@@ -1,5 +1,6 @@
-import { createContext, Context } from '@fluentui/react-context-selector';
-import { AccordionContextValue } from './Accordion.types';
+import { createContext } from '@fluentui/react-context-selector';
+import type { Context } from '@fluentui/react-context-selector';
+import type { AccordionContextValue } from './Accordion.types';
 
 export const AccordionContext: Context<AccordionContextValue> = createContext<AccordionContextValue>({
   openItems: [],

--- a/packages/react-accordion/src/components/Accordion/renderAccordion.tsx
+++ b/packages/react-accordion/src/components/Accordion/renderAccordion.tsx
@@ -1,8 +1,7 @@
 import { getSlots } from '@fluentui/react-utilities';
 import * as React from 'react';
-
-import { AccordionState, AccordionSlots, AccordionContextValues } from './Accordion.types';
 import { AccordionContext } from './AccordionContext';
+import type { AccordionState, AccordionSlots, AccordionContextValues } from './Accordion.types';
 
 /**
  * Function that renders the final JSX of the component

--- a/packages/react-accordion/src/components/Accordion/useAccordion.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordion.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useControllableState, useEventCallback } from '@fluentui/react-utilities';
-import { AccordionProps, AccordionState, AccordionToggleData, AccordionToggleEvent } from './Accordion.types';
-import { AccordionItemValue } from '../AccordionItem/AccordionItem.types';
+import type { AccordionProps, AccordionState, AccordionToggleData, AccordionToggleEvent } from './Accordion.types';
+import type { AccordionItemValue } from '../AccordionItem/AccordionItem.types';
 
 export const useAccordion = (
   {

--- a/packages/react-accordion/src/components/Accordion/useAccordionContextValues.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordionContextValues.ts
@@ -1,4 +1,4 @@
-import { AccordionContextValues, AccordionState } from './Accordion.types';
+import type { AccordionContextValues, AccordionState } from './Accordion.types';
 
 export function useAccordionContextValues(state: AccordionState): AccordionContextValues {
   const { navigable, openItems, requestToggle } = state;

--- a/packages/react-accordion/src/components/AccordionHeader/AccordionHeader.tsx
+++ b/packages/react-accordion/src/components/AccordionHeader/AccordionHeader.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { useAccordionHeader } from './useAccordionHeader';
-import { AccordionHeaderProps } from './AccordionHeader.types';
 import { renderAccordionHeader } from './renderAccordionHeader';
 import { useAccordionHeaderStyles } from './useAccordionHeaderStyles';
 import { useAccordionHeaderContextValues } from './useAccordionHeaderContextValues';
+import type { AccordionHeaderProps } from './AccordionHeader.types';
 
 /**
  * Define a styled AccordionHeader, using the `useAccordionHeader` and `useAccordionHeaderStyles` hooks.

--- a/packages/react-accordion/src/components/AccordionHeader/AccordionHeader.types.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/AccordionHeader.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
-import { AccordionHeaderExpandIconProps } from './AccordionHeaderExpandIcon';
-import { ARIAButtonProps } from '@fluentui/react-aria';
+import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import type { AccordionHeaderExpandIconProps } from './AccordionHeaderExpandIcon';
+import type { ARIAButtonProps } from '@fluentui/react-aria';
 
 export type AccordionHeaderSize = 'small' | 'medium' | 'large' | 'extra-large';
 export type AccordionHeaderExpandIconPosition = 'start' | 'end';

--- a/packages/react-accordion/src/components/AccordionHeader/AccordionHeaderContext.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/AccordionHeaderContext.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionHeaderContextValue } from './AccordionHeader.types';
+import type { AccordionHeaderContextValue } from './AccordionHeader.types';
 
 export const AccordionHeaderContext = React.createContext<AccordionHeaderContextValue>({
   open: false,

--- a/packages/react-accordion/src/components/AccordionHeader/AccordionHeaderExpandIcon.tsx
+++ b/packages/react-accordion/src/components/AccordionHeader/AccordionHeaderExpandIcon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useAccordionHeaderContext } from './AccordionHeaderContext';
-import { AccordionHeaderContextValue } from './AccordionHeader.types';
+import type { AccordionHeaderContextValue } from './AccordionHeader.types';
 
 export type AccordionHeaderExpandIconProps = React.HTMLAttributes<HTMLSpanElement>;
 

--- a/packages/react-accordion/src/components/AccordionHeader/renderAccordionHeader.tsx
+++ b/packages/react-accordion/src/components/AccordionHeader/renderAccordionHeader.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
-
-import { AccordionHeaderState, AccordionHeaderSlots, AccordionHeaderContextValues } from './AccordionHeader.types';
 import { accordionHeaderShorthandProps } from './useAccordionHeader';
 import { AccordionHeaderContext } from './AccordionHeaderContext';
+import type { AccordionHeaderState, AccordionHeaderSlots, AccordionHeaderContextValues } from './AccordionHeader.types';
 
 /**
  * Function that renders the final JSX of the component

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { useMergedRefs, useId, resolveShorthand, useEventCallback } from '@fluentui/react-utilities';
-import { AccordionHeaderProps, AccordionHeaderState, AccordionHeaderSlots } from './AccordionHeader.types';
 import { useAccordionItemContext } from '../AccordionItem/index';
 import { AccordionHeaderExpandIcon } from './AccordionHeaderExpandIcon';
 import { useARIAButton } from '@fluentui/react-aria';
+import type { AccordionHeaderProps, AccordionHeaderState, AccordionHeaderSlots } from './AccordionHeader.types';
 
 /**
  * Const listing which props are shorthand props.

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeaderContextValues.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeaderContextValues.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {
+import type {
   AccordionHeaderContextValue,
   AccordionHeaderState,
   AccordionHeaderContextValues,

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
@@ -1,6 +1,6 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { AccordionHeaderState } from './AccordionHeader.types';
 import { createFocusIndicatorStyleRule } from '@fluentui/react-tabster';
+import type { AccordionHeaderState } from './AccordionHeader.types';
 
 const useStyles = makeStyles({
   // TODO: this should be extracted to another package

--- a/packages/react-accordion/src/components/AccordionItem/AccordionItem.tsx
+++ b/packages/react-accordion/src/components/AccordionItem/AccordionItem.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useAccordionItem } from './useAccordionItem';
 import { useAccordionItemContextValues } from './useAccordionItemContextValues';
-import { AccordionItemProps } from './AccordionItem.types';
 import { renderAccordionItem } from './renderAccordionItem';
+import type { AccordionItemProps } from './AccordionItem.types';
 
 /**
  * Define a styled AccordionItem, using the `useAccordionItem` and `useAccordionItemStyles` hooks.

--- a/packages/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
+++ b/packages/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
 
 export interface AccordionItemContextValue {
   open: boolean;

--- a/packages/react-accordion/src/components/AccordionItem/AccordionItemContext.ts
+++ b/packages/react-accordion/src/components/AccordionItem/AccordionItemContext.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItemContextValue } from './AccordionItem.types';
+import type { AccordionItemContextValue } from './AccordionItem.types';
 
 // No default value.
 export const AccordionItemContext = React.createContext<AccordionItemContextValue>({

--- a/packages/react-accordion/src/components/AccordionItem/renderAccordionItem.tsx
+++ b/packages/react-accordion/src/components/AccordionItem/renderAccordionItem.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
-import { AccordionItemState, AccordionItemSlots, AccordionItemContextValues } from './AccordionItem.types';
 import { accordionItemShorthandProps } from './useAccordionItem';
 import { AccordionItemContext } from './AccordionItemContext';
+import type { AccordionItemState, AccordionItemSlots, AccordionItemContextValues } from './AccordionItem.types';
 
 /**
  * Function that renders the final JSX of the component

--- a/packages/react-accordion/src/components/AccordionItem/useAccordionItem.ts
+++ b/packages/react-accordion/src/components/AccordionItem/useAccordionItem.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { AccordionItemProps, AccordionItemState, AccordionItemSlots } from './AccordionItem.types';
 import { useTabsterAttributes } from '@fluentui/react-tabster';
 import { useContextSelector } from '@fluentui/react-context-selector';
 import { AccordionContext } from '../Accordion/AccordionContext';
-import { AccordionToggleEvent } from '../Accordion/Accordion.types';
+import type { AccordionItemProps, AccordionItemState, AccordionItemSlots } from './AccordionItem.types';
+import type { AccordionToggleEvent } from '../Accordion/Accordion.types';
 
 /**
  * Const listing which props are shorthand props.

--- a/packages/react-accordion/src/components/AccordionItem/useAccordionItemContextValues.ts
+++ b/packages/react-accordion/src/components/AccordionItem/useAccordionItemContextValues.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItemContextValue, AccordionItemContextValues, AccordionItemState } from './AccordionItem.types';
+import type { AccordionItemContextValue, AccordionItemContextValues, AccordionItemState } from './AccordionItem.types';
 
 export function useAccordionItemContextValues(state: AccordionItemState): AccordionItemContextValues {
   const { disabled, onHeaderClick, open } = state;

--- a/packages/react-accordion/src/components/AccordionPanel/AccordionPanel.test.tsx
+++ b/packages/react-accordion/src/components/AccordionPanel/AccordionPanel.test.tsx
@@ -3,7 +3,7 @@ import { AccordionPanel } from './AccordionPanel';
 import * as renderer from 'react-test-renderer';
 import { ReactWrapper } from 'enzyme';
 import { isConformant } from '../../common/isConformant';
-import { AccordionPanelProps } from './AccordionPanel.types';
+import type { AccordionPanelProps } from './AccordionPanel.types';
 
 describe('AccordionPanel', () => {
   isConformant({

--- a/packages/react-accordion/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/react-accordion/src/components/AccordionPanel/AccordionPanel.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useAccordionPanel } from './useAccordionPanel';
-import { AccordionPanelProps } from './AccordionPanel.types';
 import { renderAccordionPanel } from './renderAccordionPanel';
 import { useAccordionPanelStyles } from './useAccordionPanelStyles';
+import type { AccordionPanelProps } from './AccordionPanel.types';
 
 /**
  * Define a styled AccordionPanel, using the `useAccordionPanel` and `useAccordionPanelStyles` hooks.

--- a/packages/react-accordion/src/components/AccordionPanel/AccordionPanel.types.ts
+++ b/packages/react-accordion/src/components/AccordionPanel/AccordionPanel.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
 
 export type AccordionPanelSlots = {};
 

--- a/packages/react-accordion/src/components/AccordionPanel/renderAccordionPanel.tsx
+++ b/packages/react-accordion/src/components/AccordionPanel/renderAccordionPanel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
-import { AccordionPanelState, AccordionPanelSlots } from './AccordionPanel.types';
 import { accordionPanelShorthandProps } from './useAccordionPanel';
+import type { AccordionPanelState, AccordionPanelSlots } from './AccordionPanel.types';
 
 /**
  * Function that renders the final JSX of the component

--- a/packages/react-accordion/src/components/AccordionPanel/useAccordionPanel.ts
+++ b/packages/react-accordion/src/components/AccordionPanel/useAccordionPanel.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useMergedRefs, useId } from '@fluentui/react-utilities';
-import { AccordionPanelProps, AccordionPanelSlots, AccordionPanelState } from './AccordionPanel.types';
 import { useAccordionItemContext } from '../AccordionItem/index';
+import type { AccordionPanelProps, AccordionPanelSlots, AccordionPanelState } from './AccordionPanel.types';
 
 /**
  * Consts listing which props are shorthand props.

--- a/packages/react-accordion/src/components/AccordionPanel/useAccordionPanelStyles.ts
+++ b/packages/react-accordion/src/components/AccordionPanel/useAccordionPanelStyles.ts
@@ -1,5 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { AccordionPanelState } from './AccordionPanel.types';
+import type { AccordionPanelState } from './AccordionPanel.types';
 
 /**
  * Styles for the root slot

--- a/packages/react-accordion/tsconfig.json
+++ b/packages/react-accordion/tsconfig.json
@@ -11,7 +11,8 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/react-aria/etc/react-aria.api.md
+++ b/packages/react-aria/etc/react-aria.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import { ObjectShorthandProps } from '@fluentui/react-utilities';
+import type { ObjectShorthandProps } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
-import { ResolveShorthandOptions } from '@fluentui/react-utilities';
-import { ShorthandProps } from '@fluentui/react-utilities';
+import type { ResolveShorthandOptions } from '@fluentui/react-utilities';
+import type { ShorthandProps } from '@fluentui/react-utilities';
 
 // @public (undocumented)
 export type ARIAButtonAsAnchorProps = React_2.AnchorHTMLAttributes<HTMLAnchorElement> & {

--- a/packages/react-aria/src/hooks/useARIAButton.stories.tsx
+++ b/packages/react-aria/src/hooks/useARIAButton.stories.tsx
@@ -1,6 +1,8 @@
-import { ComponentState, getSlots } from '@fluentui/react-utilities';
+import { getSlots } from '@fluentui/react-utilities';
 import * as React from 'react';
-import { ARIAButtonAsElementProps, ARIAButtonProps, useARIAButton } from './useARIAButton';
+import { useARIAButton } from './useARIAButton';
+import type { ComponentState } from '@fluentui/react-utilities';
+import type { ARIAButtonAsElementProps, ARIAButtonProps } from './useARIAButton';
 
 type Slots = {
   button: ARIAButtonProps;

--- a/packages/react-aria/src/hooks/useARIAButton.test.tsx
+++ b/packages/react-aria/src/hooks/useARIAButton.test.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
-import { ARIAButtonProps, useARIAButton } from './useARIAButton';
+import { useARIAButton } from './useARIAButton';
 import { Enter, Space } from '@fluentui/keyboard-keys';
 import { renderHook } from '@testing-library/react-hooks';
 import { fireEvent, screen, render } from '@testing-library/react';
-import { getSlots, ObjectShorthandProps } from '@fluentui/react-utilities';
+import { getSlots } from '@fluentui/react-utilities';
+import type { ARIAButtonProps } from './useARIAButton';
+import type { ObjectShorthandProps } from '@fluentui/react-utilities';
 
 describe('useARIAButton', () => {
   it('should return by default shorthand props for a button', () => {

--- a/packages/react-aria/src/hooks/useARIAButton.ts
+++ b/packages/react-aria/src/hooks/useARIAButton.ts
@@ -1,12 +1,7 @@
 import * as React from 'react';
 import { Enter, Space } from '@fluentui/keyboard-keys';
-import {
-  ObjectShorthandProps,
-  resolveShorthand,
-  ResolveShorthandOptions,
-  ShorthandProps,
-  useEventCallback,
-} from '@fluentui/react-utilities';
+import { resolveShorthand, useEventCallback } from '@fluentui/react-utilities';
+import type { ObjectShorthandProps, ResolveShorthandOptions, ShorthandProps } from '@fluentui/react-utilities';
 
 function mergeARIADisabled(disabled?: boolean | 'false' | 'true'): boolean {
   if (typeof disabled === 'string') {

--- a/packages/react-aria/tsconfig.json
+++ b/packages/react-aria/tsconfig.json
@@ -11,7 +11,8 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-avatar/etc/react-avatar.api.md
@@ -4,12 +4,12 @@
 
 ```ts
 
-import { ComponentPropsCompat } from '@fluentui/react-utilities';
-import { ComponentStateCompat } from '@fluentui/react-utilities';
-import { PresenceBadgeProps } from '@fluentui/react-badge';
-import { PresenceBadgeStatus } from '@fluentui/react-badge';
+import type { ComponentPropsCompat } from '@fluentui/react-utilities';
+import type { ComponentStateCompat } from '@fluentui/react-utilities';
+import type { PresenceBadgeProps } from '@fluentui/react-badge';
+import type { PresenceBadgeStatus } from '@fluentui/react-badge';
 import * as React_2 from 'react';
-import { ShorthandPropsCompat } from '@fluentui/react-utilities';
+import type { ShorthandPropsCompat } from '@fluentui/react-utilities';
 
 // @public (undocumented)
 export const Avatar: React_2.ForwardRefExoticComponent<AvatarProps & React_2.RefAttributes<HTMLElement>>;

--- a/packages/react-avatar/src/Avatar.stories.tsx
+++ b/packages/react-avatar/src/Avatar.stories.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { StoryExample } from './StoryExample.stories';
 import { AvatarExamples as examples } from './AvatarExamples.stories';
-import { Avatar, AvatarProps, renderAvatar, useAvatar, useAvatarStyles } from './index';
+import { Avatar, renderAvatar, useAvatar, useAvatarStyles } from './index';
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import { People20Regular, Guest20Regular, Bot20Regular, Bot24Regular } from '@fluentui/react-icons';
+import type { AvatarProps } from './index';
 
 /**
  * Temporary workaround for Buttons

--- a/packages/react-avatar/src/common/isConformant.ts
+++ b/packages/react-avatar/src/common/isConformant.ts
@@ -1,4 +1,5 @@
-import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
+import type { IsConformantOptions } from '@fluentui/react-conformance';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },

--- a/packages/react-avatar/src/components/Avatar/Avatar.tsx
+++ b/packages/react-avatar/src/components/Avatar/Avatar.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { AvatarProps } from './Avatar.types';
 import { renderAvatar } from './renderAvatar';
 import { useAvatar } from './useAvatar';
 import { useAvatarStyles } from './useAvatarStyles';
+import type { AvatarProps } from './Avatar.types';
 
 export const Avatar = React.forwardRef((props: AvatarProps, ref: React.Ref<HTMLElement>) => {
   const state = useAvatar(props, ref);

--- a/packages/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { ComponentPropsCompat, ComponentStateCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
-import { PresenceBadgeProps, PresenceBadgeStatus } from '@fluentui/react-badge';
+import type { ComponentPropsCompat, ComponentStateCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
+import type { PresenceBadgeProps, PresenceBadgeStatus } from '@fluentui/react-badge';
 
 export interface AvatarProps extends ComponentPropsCompat, React.HTMLAttributes<HTMLElement> {
   /**

--- a/packages/react-avatar/src/components/Avatar/renderAvatar.tsx
+++ b/packages/react-avatar/src/components/Avatar/renderAvatar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getSlotsCompat } from '@fluentui/react-utilities';
-import { AvatarState } from './Avatar.types';
 import { avatarShorthandPropsCompat } from './useAvatar';
+import type { AvatarState } from './Avatar.types';
 
 export const renderAvatar = (state: AvatarState) => {
   const { slots, slotProps } = getSlotsCompat(state, avatarShorthandPropsCompat);

--- a/packages/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
 import { getInitials } from '../../utils/index';
-import { AvatarProps, AvatarState, AvatarNamedColor, AvatarShorthandPropsCompat } from './Avatar.types';
 import {
   Person16Regular,
   Person20Regular,
@@ -11,6 +10,7 @@ import {
   Person48Regular,
 } from '@fluentui/react-icons';
 import { PresenceBadge } from '@fluentui/react-badge';
+import type { AvatarProps, AvatarState, AvatarNamedColor, AvatarShorthandPropsCompat } from './Avatar.types';
 
 /**
  * Names of the shorthand properties in AvatarProps

--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -1,5 +1,5 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
-import { AvatarState } from './Avatar.types';
+import type { AvatarState } from './Avatar.types';
 
 //
 // TODO: All animation constants should go to theme or globals?

--- a/packages/react-avatar/tsconfig.json
+++ b/packages/react-avatar/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand"],
+    "isolatedModules": true
   }
 }

--- a/packages/react-badge/etc/react-badge.api.md
+++ b/packages/react-badge/etc/react-badge.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import { ComponentPropsCompat } from '@fluentui/react-utilities';
-import { ObjectShorthandPropsCompat } from '@fluentui/react-utilities';
+import type { ComponentPropsCompat } from '@fluentui/react-utilities';
+import type { ObjectShorthandPropsCompat } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
-import { ShorthandPropsCompat } from '@fluentui/react-utilities';
+import type { ShorthandPropsCompat } from '@fluentui/react-utilities';
 
 // @public
 export const Badge: React_2.FunctionComponent<BadgeProps & React_2.RefAttributes<HTMLElement>>;
@@ -108,7 +108,6 @@ export const usePresenceBadge: (props: PresenceBadgeProps, ref: React_2.Ref<HTML
 
 // @public
 export const usePresenceBadgeStyles: (state: PresenceBadgeState) => PresenceBadgeState;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-badge/src/common/isConformant.ts
+++ b/packages/react-badge/src/common/isConformant.ts
@@ -1,4 +1,5 @@
-import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
+import type { IsConformantOptions } from '@fluentui/react-conformance';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },

--- a/packages/react-badge/src/components/Badge/Badge.tsx
+++ b/packages/react-badge/src/components/Badge/Badge.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { BadgeProps } from './Badge.types';
 import { useBadge } from './useBadge';
 import { useBadgeStyles } from './useBadgeStyles';
 import { renderBadge } from './renderBadge';
+import type { BadgeProps } from './Badge.types';
 
 /**
  * Define a styled Badge, using the `useBadge` hook.

--- a/packages/react-badge/src/components/Badge/Badge.types.ts
+++ b/packages/react-badge/src/components/Badge/Badge.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComponentPropsCompat, ShorthandPropsCompat, ObjectShorthandPropsCompat } from '@fluentui/react-utilities';
+import type { ComponentPropsCompat, ShorthandPropsCompat, ObjectShorthandPropsCompat } from '@fluentui/react-utilities';
 
 /**
  * {@docCategory Badge}

--- a/packages/react-badge/src/components/Badge/renderBadge.tsx
+++ b/packages/react-badge/src/components/Badge/renderBadge.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getSlotsCompat } from '@fluentui/react-utilities';
-import { BadgeState } from './Badge.types';
 import { badgeShorthandPropsCompat } from './useBadge';
+import type { BadgeState } from './Badge.types';
 
 export const renderBadge = (state: BadgeState) => {
   const { slots, slotProps } = getSlotsCompat(state, badgeShorthandPropsCompat);

--- a/packages/react-badge/src/components/Badge/useBadge.ts
+++ b/packages/react-badge/src/components/Badge/useBadge.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeMergeProps, resolveShorthandProps, useMergedRefs } from '@fluentui/react-utilities';
-import { BadgeProps, BadgeState } from './Badge.types';
+import type { BadgeProps, BadgeState } from './Badge.types';
 
 /**
  * Consts listing which props are shorthand props.

--- a/packages/react-badge/src/components/Badge/useBadgeStyles.ts
+++ b/packages/react-badge/src/components/Badge/useBadgeStyles.ts
@@ -1,5 +1,5 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
-import { BadgeState } from './Badge.types';
+import type { BadgeState } from './Badge.types';
 
 const useStyles = makeStyles({
   root: theme => ({

--- a/packages/react-badge/src/components/CounterBadge/CounterBadge.tsx
+++ b/packages/react-badge/src/components/CounterBadge/CounterBadge.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { CounterBadgeProps } from './CounterBadge.types';
 import { useCounterBadge } from './useCounterBadge';
 import { useCounterBadgeStyles } from './useCounterBadgeStyles';
 import { renderBadge } from '../Badge/index';
+import type { CounterBadgeProps } from './CounterBadge.types';
 
 /**
  * Define a styled CounterBadge, using the `useCounterBadge` hook.

--- a/packages/react-badge/src/components/CounterBadge/CounterBadge.types.ts
+++ b/packages/react-badge/src/components/CounterBadge/CounterBadge.types.ts
@@ -1,4 +1,4 @@
-import { BadgeProps, BadgeState } from '../Badge/index';
+import type { BadgeProps, BadgeState } from '../Badge/index';
 
 /**
  * {@docCategory CounterBadge}

--- a/packages/react-badge/src/components/CounterBadge/useCounterBadge.ts
+++ b/packages/react-badge/src/components/CounterBadge/useCounterBadge.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { makeMergePropsCompat } from '@fluentui/react-utilities';
-import { CounterBadgeProps, CounterBadgeState } from './CounterBadge.types';
-import { useBadge, BadgeProps } from '../Badge/index';
+import { useBadge } from '../Badge/index';
+import type { CounterBadgeProps, CounterBadgeState } from './CounterBadge.types';
+import type { BadgeProps } from '../Badge/index';
 
 /**
  * Consts listing which props are shorthand props.

--- a/packages/react-badge/src/components/CounterBadge/useCounterBadgeStyles.ts
+++ b/packages/react-badge/src/components/CounterBadge/useCounterBadgeStyles.ts
@@ -1,6 +1,6 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
-import { CounterBadgeState } from './CounterBadge.types';
 import { useBadgeStyles } from '../Badge/useBadgeStyles';
+import type { CounterBadgeState } from './CounterBadge.types';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-badge/src/components/PresenceBadge/PresenceBadge.tsx
+++ b/packages/react-badge/src/components/PresenceBadge/PresenceBadge.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { PresenceBadgeProps } from './PresenceBadge.types';
 import { usePresenceBadge } from './usePresenceBadge';
 import { usePresenceBadgeStyles } from './usePresenceBadgeStyles';
 import { renderBadge } from '../../Badge';
+import type { PresenceBadgeProps } from './PresenceBadge.types';
 
 /**
  * Define a styled Badge, using the `useBadge` hook.

--- a/packages/react-badge/src/components/PresenceBadge/PresenceBadge.types.ts
+++ b/packages/react-badge/src/components/PresenceBadge/PresenceBadge.types.ts
@@ -1,4 +1,4 @@
-import { BadgeProps, BadgeState } from '../Badge/index';
+import type { BadgeProps, BadgeState } from '../Badge/index';
 
 /**
  * {@docCategory PresenceBadge}

--- a/packages/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
+++ b/packages/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { makeMergePropsCompat } from '@fluentui/react-utilities';
-import { PresenceBadgeProps, PresenceBadgeState, PresenceBadgeStatus } from './PresenceBadge.types';
-import { useBadge, BadgeProps } from '../Badge/index';
+import { useBadge } from '../Badge/index';
 import {
   SkypeMinusIcon,
   SkypeClockIcon,
@@ -9,6 +8,8 @@ import {
   SkypeCheckIcon,
   CancelIcon,
 } from './DefaultPresenceBadgeIcons';
+import type { PresenceBadgeProps, PresenceBadgeState, PresenceBadgeStatus } from './PresenceBadge.types';
+import type { BadgeProps } from '../Badge/index';
 
 /**
  * Consts listing which props are shorthand props.

--- a/packages/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
+++ b/packages/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
@@ -1,6 +1,6 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
-import { PresenceBadgeState } from './PresenceBadge.types';
 import { useBadgeStyles } from '../../Badge';
+import type { PresenceBadgeState } from './PresenceBadge.types';
 
 const useStyles = makeStyles({
   root: theme => ({

--- a/packages/react-badge/tsconfig.json
+++ b/packages/react-badge/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand"],
+    "isolatedModules": true
   }
 }

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import { ComponentPropsCompat } from '@fluentui/react-utilities';
-import { ComponentStateCompat } from '@fluentui/react-utilities';
+import type { ComponentPropsCompat } from '@fluentui/react-utilities';
+import type { ComponentStateCompat } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
-import { ShorthandPropsCompat } from '@fluentui/react-utilities';
+import type { ShorthandPropsCompat } from '@fluentui/react-utilities';
 
 // @public
 export const Button: React_2.FunctionComponent<ButtonProps & React_2.RefAttributes<HTMLElement>>;

--- a/packages/react-button/src/Button.stories.tsx
+++ b/packages/react-button/src/Button.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { Button, ButtonProps } from './Button';
+import { Button } from './Button';
 import { Playground } from './Playground.stories';
-import { PlaygroundProps } from './Playground.types.stories';
 import { buttonBaseProps } from './buttonBaseProps.stories';
+import type { ButtonProps } from './Button';
+import type { PlaygroundProps } from './Playground.types.stories';
 
 // TODO: this is here while waiting for react-icons to merge
 const SVGIcon = () => (

--- a/packages/react-button/src/CompoundButton.stories.tsx
+++ b/packages/react-button/src/CompoundButton.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { CompoundButton, CompoundButtonProps } from './CompoundButton';
+import { CompoundButton } from './CompoundButton';
 import { Playground } from './Playground.stories';
-import { PlaygroundProps, PropDefinition } from './Playground.types.stories';
 import { buttonBaseProps } from './buttonBaseProps.stories';
+import type { CompoundButtonProps } from './CompoundButton';
+import type { PlaygroundProps, PropDefinition } from './Playground.types.stories';
 
 type ExampleProps = { iconOnly?: string };
 

--- a/packages/react-button/src/MenuButton.stories.tsx
+++ b/packages/react-button/src/MenuButton.stories.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import { Menu, MenuItem, MenuList, MenuProps, MenuTrigger } from '@fluentui/react-menu';
-import { MenuButton, MenuButtonProps } from './MenuButton';
+import { Menu, MenuItem, MenuList, MenuTrigger } from '@fluentui/react-menu';
+import { MenuButton } from './MenuButton';
 import { Playground } from './Playground.stories';
-import { PlaygroundProps } from './Playground.types.stories';
 import { buttonBaseProps } from './buttonBaseProps.stories';
+import type { MenuProps } from '@fluentui/react-menu';
+import type { MenuButtonProps } from './MenuButton';
+import type { PlaygroundProps } from './Playground.types.stories';
 
 const ExampleMenu = (props: MenuButtonProps): JSX.Element => (
   <Menu>

--- a/packages/react-button/src/Playground.stories.tsx
+++ b/packages/react-button/src/Playground.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { Checkbox, Dropdown, IDropdownOption, TextField } from './tmp-components.stories';
-import { PlaygroundProps } from './Playground.types.stories';
+import { Checkbox, Dropdown, TextField } from './tmp-components.stories';
 import { makeStyles } from '@fluentui/react-make-styles';
+import type { IDropdownOption } from './tmp-components.stories';
+import type { PlaygroundProps } from './Playground.types.stories';
 
 const tableStyle: React.CSSProperties = {
   border: '1px solid black',

--- a/packages/react-button/src/ToggleButton.stories.tsx
+++ b/packages/react-button/src/ToggleButton.stories.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { useBoolean } from '@fluentui/react-utilities';
-import { ToggleButton, ToggleButtonProps } from './ToggleButton';
+import { ToggleButton } from './ToggleButton';
 import { Playground } from './Playground.stories';
-import { PlaygroundProps, PropDefinition } from './Playground.types.stories';
 import { buttonBaseProps } from './buttonBaseProps.stories';
+import type { ToggleButtonProps } from './ToggleButton';
+import type { PlaygroundProps, PropDefinition } from './Playground.types.stories';
 
 export const ToggleButtonPlayground = () => {
   const [checked, { setTrue: setTrueChecked, setFalse: setFalseChecked, toggle: toggleChecked }] = useBoolean(false);

--- a/packages/react-button/src/buttonBaseProps.stories.ts
+++ b/packages/react-button/src/buttonBaseProps.stories.ts
@@ -1,5 +1,5 @@
-import { ButtonProps } from './Button';
-import { PropDefinition } from './Playground.types.stories';
+import type { ButtonProps } from './Button';
+import type { PropDefinition } from './Playground.types.stories';
 
 type ExampleProps = { iconOnly?: string };
 

--- a/packages/react-button/src/common/isConformant.ts
+++ b/packages/react-button/src/common/isConformant.ts
@@ -1,4 +1,5 @@
-import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
+import type { IsConformantOptions } from '@fluentui/react-conformance';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },

--- a/packages/react-button/src/components/Button/Button.tsx
+++ b/packages/react-button/src/components/Button/Button.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useButton } from './useButton';
-import { ButtonProps } from './Button.types';
 import { renderButton } from './renderButton';
 import { useButtonStyles } from './useButtonStyles';
+import type { ButtonProps } from './Button.types';
 
 /**
  * Define a styled Button, using the `useButton` hook.

--- a/packages/react-button/src/components/Button/Button.types.ts
+++ b/packages/react-button/src/components/Button/Button.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComponentPropsCompat, ComponentStateCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
+import type { ComponentPropsCompat, ComponentStateCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
 
 /**
  * {@docCategory Button}

--- a/packages/react-button/src/components/Button/renderButton.tsx
+++ b/packages/react-button/src/components/Button/renderButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getSlotsCompat } from '@fluentui/react-utilities';
-import { ButtonState } from './Button.types';
 import { buttonShorthandPropsCompat } from './useButton';
+import type { ButtonState } from './Button.types';
 
 /**
  * Renders a Button component by passing the state defined props to the appropriate slots.

--- a/packages/react-button/src/components/Button/useButton.ts
+++ b/packages/react-button/src/components/Button/useButton.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
-import { ButtonProps, ButtonShorthandPropsCompat, ButtonState } from './Button.types';
 import { useButtonState } from './useButtonState';
+import type { ButtonProps, ButtonShorthandPropsCompat, ButtonState } from './Button.types';
 
 /**
  * Consts listing which props are shorthand props.

--- a/packages/react-button/src/components/Button/useButtonState.ts
+++ b/packages/react-button/src/components/Button/useButtonState.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { getCode, EnterKey, SpacebarKey } from '@fluentui/keyboard-key';
-import { ButtonState } from './Button.types';
+import type { ButtonState } from './Button.types';
 
 /**
  * The useButton hook processes the Button draft state.

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -1,6 +1,6 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import { createFocusIndicatorStyleRule } from '@fluentui/react-tabster';
-import { ButtonState } from './Button.types';
+import type { ButtonState } from './Button.types';
 
 // TODO: These are named in design specs but not hoisted to global/alias yet.
 //       We're tracking these here to determine how we can hoist them.

--- a/packages/react-button/src/components/CompoundButton/CompoundButton.tsx
+++ b/packages/react-button/src/components/CompoundButton/CompoundButton.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { CompoundButtonProps } from './CompoundButton.types';
 import { renderCompoundButton } from './renderCompoundButton';
 import { useCompoundButton } from './useCompoundButton';
 import { useCompoundButtonStyles } from './useCompoundButtonStyles';
+import type { CompoundButtonProps } from './CompoundButton.types';
 
 /**
  * Define a styled CompoundButton, using the `useCompoundButton` hook.

--- a/packages/react-button/src/components/CompoundButton/CompoundButton.types.ts
+++ b/packages/react-button/src/components/CompoundButton/CompoundButton.types.ts
@@ -1,6 +1,11 @@
 import * as React from 'react';
-import { ComponentStateCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
-import { ButtonDefaultedProps, ButtonProps, ButtonShorthandPropsCompat, ButtonState } from '../Button/Button.types';
+import type { ComponentStateCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
+import type {
+  ButtonDefaultedProps,
+  ButtonProps,
+  ButtonShorthandPropsCompat,
+  ButtonState,
+} from '../Button/Button.types';
 
 /**
  * {@docCategory Button}

--- a/packages/react-button/src/components/CompoundButton/renderCompoundButton.tsx
+++ b/packages/react-button/src/components/CompoundButton/renderCompoundButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getSlotsCompat } from '@fluentui/react-utilities';
-import { CompoundButtonState } from './CompoundButton.types';
 import { compoundButtonShorthandPropsCompat } from './useCompoundButton';
+import type { CompoundButtonState } from './CompoundButton.types';
 
 /**
  * Renders a CompoundButton component by passing the state defined props to the appropriate slots.

--- a/packages/react-button/src/components/CompoundButton/useCompoundButton.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButton.ts
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
 import { useButtonState } from '../Button/useButtonState';
-import { CompoundButtonProps, CompoundButtonShorthandPropsCompat, CompoundButtonState } from './CompoundButton.types';
+import type {
+  CompoundButtonProps,
+  CompoundButtonShorthandPropsCompat,
+  CompoundButtonState,
+} from './CompoundButton.types';
 
 /**
  * Consts listing which props are shorthand props.

--- a/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
@@ -1,6 +1,6 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import { buttonSpacing, useButtonStyles } from '../Button/useButtonStyles';
-import { CompoundButtonState } from './CompoundButton.types';
+import type { CompoundButtonState } from './CompoundButton.types';
 
 const CompoundButtonClassNames = {
   secondaryContent: 'CompoundButton-secondaryContent',

--- a/packages/react-button/src/components/MenuButton/MenuButton.tsx
+++ b/packages/react-button/src/components/MenuButton/MenuButton.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { ChevronDownIcon } from './DefaultIcons';
-import { MenuButtonProps } from './MenuButton.types';
 import { renderMenuButton } from './renderMenuButton';
 import { useMenuButton } from './useMenuButton';
 import { useMenuButtonStyles } from './useMenuButtonStyles';
+import type { MenuButtonProps } from './MenuButton.types';
 
 /**
  * Define a styled MenuButton, using the `useMenuButton` hook.

--- a/packages/react-button/src/components/MenuButton/MenuButton.types.ts
+++ b/packages/react-button/src/components/MenuButton/MenuButton.types.ts
@@ -1,6 +1,11 @@
 import * as React from 'react';
-import { ComponentStateCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
-import { ButtonDefaultedProps, ButtonProps, ButtonShorthandPropsCompat, ButtonState } from '../Button/Button.types';
+import type { ComponentStateCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
+import type {
+  ButtonDefaultedProps,
+  ButtonProps,
+  ButtonShorthandPropsCompat,
+  ButtonState,
+} from '../Button/Button.types';
 
 /**
  * {@docCategory Button}

--- a/packages/react-button/src/components/MenuButton/renderMenuButton.tsx
+++ b/packages/react-button/src/components/MenuButton/renderMenuButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getSlotsCompat } from '@fluentui/react-utilities';
-import { MenuButtonState } from './MenuButton.types';
 import { menuButtonShorthandPropsCompat } from './useMenuButton';
+import type { MenuButtonState } from './MenuButton.types';
 
 /**
  * Renders a MenuButton component by passing the state defined props to the appropriate slots.

--- a/packages/react-button/src/components/MenuButton/useMenuButton.ts
+++ b/packages/react-button/src/components/MenuButton/useMenuButton.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
-import { MenuButtonProps, MenuButtonShorthandPropsCompat, MenuButtonState } from './MenuButton.types';
 import { useMenuButtonState } from './useMenuButtonState';
+import type { MenuButtonProps, MenuButtonShorthandPropsCompat, MenuButtonState } from './MenuButton.types';
 
 /**
  * Consts listing which props are shorthand props.

--- a/packages/react-button/src/components/MenuButton/useMenuButtonState.ts
+++ b/packages/react-button/src/components/MenuButton/useMenuButtonState.ts
@@ -1,5 +1,5 @@
 import { useButtonState } from '../Button/useButtonState';
-import { MenuButtonState } from './MenuButton.types';
+import type { MenuButtonState } from './MenuButton.types';
 
 export const useMenuButtonState = (state: MenuButtonState): MenuButtonState => {
   // It behaves like a button.

--- a/packages/react-button/src/components/MenuButton/useMenuButtonStyles.ts
+++ b/packages/react-button/src/components/MenuButton/useMenuButtonStyles.ts
@@ -1,6 +1,6 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import { useButtonStyles } from '../Button/useButtonStyles';
-import { MenuButtonState } from './MenuButton.types';
+import type { MenuButtonState } from './MenuButton.types';
 
 const useMenuIconStyles = makeStyles({
   small: {

--- a/packages/react-button/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/react-button/src/components/ToggleButton/ToggleButton.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { ToggleButtonProps } from './ToggleButton.types';
 import { renderToggleButton } from './renderToggleButton';
 import { useToggleButton } from './useToggleButton';
 import { useToggleButtonStyles } from './useToggleButtonStyles';
+import type { ToggleButtonProps } from './ToggleButton.types';
 
 /**
  * Define a styled ToggleButton, using the `useToggleButton` hook.

--- a/packages/react-button/src/components/ToggleButton/ToggleButton.types.ts
+++ b/packages/react-button/src/components/ToggleButton/ToggleButton.types.ts
@@ -1,5 +1,10 @@
-import { ComponentStateCompat } from '@fluentui/react-utilities';
-import { ButtonDefaultedProps, ButtonProps, ButtonShorthandPropsCompat, ButtonState } from '../Button/Button.types';
+import type { ComponentStateCompat } from '@fluentui/react-utilities';
+import type {
+  ButtonDefaultedProps,
+  ButtonProps,
+  ButtonShorthandPropsCompat,
+  ButtonState,
+} from '../Button/Button.types';
 
 /**
  * {@docCategory Button}

--- a/packages/react-button/src/components/ToggleButton/useToggleButton.ts
+++ b/packages/react-button/src/components/ToggleButton/useToggleButton.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useButton } from '../Button/useButton';
-import { ToggleButtonProps, ToggleButtonState } from './ToggleButton.types';
 import { useChecked } from './useChecked';
+import type { ToggleButtonProps, ToggleButtonState } from './ToggleButton.types';
 
 export const useToggleButton = (
   props: ToggleButtonProps,

--- a/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -1,6 +1,6 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import { useButtonStyles } from '../Button/useButtonStyles';
-import { ToggleButtonState } from './ToggleButton.types';
+import type { ToggleButtonState } from './ToggleButton.types';
 
 const useRootStyles = makeStyles({
   checked: theme => ({

--- a/packages/react-button/tsconfig.json
+++ b/packages/react-button/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand"],
+    "isolatedModules": true
   }
 }

--- a/packages/react-card/etc/react-card.api.md
+++ b/packages/react-card/etc/react-card.api.md
@@ -4,8 +4,8 @@
 
 ```ts
 
-import { ComponentProps } from '@fluentui/react-utilities';
-import { ComponentState } from '@fluentui/react-utilities';
+import type { ComponentProps } from '@fluentui/react-utilities';
+import type { ComponentState } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 
 // @public

--- a/packages/react-card/src/common/isConformant.ts
+++ b/packages/react-card/src/common/isConformant.ts
@@ -1,4 +1,5 @@
-import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
+import type { IsConformantOptions } from '@fluentui/react-conformance';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },

--- a/packages/react-card/src/components/Card/Card.tsx
+++ b/packages/react-card/src/components/Card/Card.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useCard } from './useCard';
-import { CardProps } from './Card.types';
 import { renderCard } from './renderCard';
 import { useCardStyles } from './useCardStyles';
+import type { CardProps } from './Card.types';
 
 /**
  * A card provides scaffolding for hosting actions and content for a single topic within a card sized object.

--- a/packages/react-card/src/components/Card/Card.types.ts
+++ b/packages/react-card/src/components/Card/Card.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
 
 /**
  * Card Props

--- a/packages/react-card/src/components/Card/renderCard.tsx
+++ b/packages/react-card/src/components/Card/renderCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
-import { CardState } from './Card.types';
 import { cardShorthandProps } from './useCard';
+import type { CardState } from './Card.types';
 
 /**
  * Render the final JSX of Card

--- a/packages/react-card/src/components/Card/useCard.ts
+++ b/packages/react-card/src/components/Card/useCard.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
-import { CardProps, CardShorthandProps, CardState } from './Card.types';
+import type { CardProps, CardShorthandProps, CardState } from './Card.types';
 
 /**
  * Array of all shorthand properties listed in CardShorthandProps

--- a/packages/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-card/src/components/Card/useCardStyles.ts
@@ -1,5 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { CardState } from './Card.types';
+import type { CardState } from './Card.types';
 
 /**
  * Styles for the root slot

--- a/packages/react-card/tsconfig.json
+++ b/packages/react-card/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "storybook__addons"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "storybook__addons"],
+    "isolatedModules": true
   }
 }


### PR DESCRIPTION
This change migrates the following package(s) to use import/export type syntax:

`react-card`
`react-button`
`react-badge`
`react-avatar`
`react-aria`
`react-accordion`
`public-docsite-setup`

For more background on why, read about the motivation (and the code-mod) here:

https://github.com/dzearing/transform-typed-imports#motivation

