### PR TITLE
Fix/type imports pass 8

### DIFF
--- a/change/@fluentui-azure-themes-2c3f7954-4048-4ede-94a9-82fdaacf03d5.json
+++ b/change/@fluentui-azure-themes-2c3f7954-4048-4ede-94a9-82fdaacf03d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/azure-themes",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-babel-make-styles-5b0c71d4-732a-4e17-a5b8-e1ad9ab45b01.json
+++ b/change/@fluentui-babel-make-styles-5b0c71d4-732a-4e17-a5b8-e1ad9ab45b01.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-date-time-utilities-cb62b8e5-6947-4247-84ed-dea9b6d6b9b7.json
+++ b/change/@fluentui-date-time-utilities-cb62b8e5-6947-4247-84ed-dea9b6d6b9b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-dom-utilities-bfc8ec61-9229-471b-8807-6620937f71c7.json
+++ b/change/@fluentui-dom-utilities-bfc8ec61-9229-471b-8807-6620937f71c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-font-icons-mdl2-50a3bd0b-b7e5-490d-bc56-d5bab5a771c2.json
+++ b/change/@fluentui-font-icons-mdl2-50a3bd0b-b7e5-490d-bc56-d5bab5a771c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-foundation-legacy-b2797881-6fb1-4d31-bbc7-a8b179449448.json
+++ b/change/@fluentui-foundation-legacy-b2797881-6fb1-4d31-bbc7-a8b179449448.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-jest-serializer-make-styles-d528bccb-7a90-4402-a54d-d82a9a74f784.json
+++ b/change/@fluentui-jest-serializer-make-styles-d528bccb-7a90-4402-a54d-d82a9a74f784.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/jest-serializer-make-styles",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-make-styles-785f90b8-9c26-49d7-a9bb-fd12b4c48953.json
+++ b/change/@fluentui-make-styles-785f90b8-9c26-49d7-a9bb-fd12b4c48953.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/make-styles",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-make-styles-webpack-loader-28f3fb0d-7c70-498d-97bf-76eca830401f.json
+++ b/change/@fluentui-make-styles-webpack-loader-28f3fb0d-7c70-498d-97bf-76eca830401f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/make-styles-webpack-loader",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/AzureCustomizations.ts
+++ b/packages/azure-themes/src/AzureCustomizations.ts
@@ -1,8 +1,8 @@
-import { ICustomizations } from '@fluentui/react';
 import { AzureThemeDark } from './azure/AzureThemeDark';
 import { AzureThemeLight } from './azure/AzureThemeLight';
 import { AzureThemeHighContrastLight } from './azure/AzureThemeHighContrastLight';
 import { AzureThemeHighContrastDark } from './azure/AzureThemeHighContrastDark';
+import type { ICustomizations } from '@fluentui/react';
 
 const { components: darkScopedSettings, ...darkThemeSettings } = AzureThemeDark;
 const { components: lightScopedSettings, ...lightThemeSettings } = AzureThemeLight;

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -1,4 +1,4 @@
-import { IAzureSemanticColors } from './IAzureSemanticColors';
+import type { IAzureSemanticColors } from './IAzureSemanticColors';
 
 export namespace BaseColors {
   export const BLUE_F0F6FF = '#F0F6FF';

--- a/packages/azure-themes/src/azure/AzureStyleSettings.ts
+++ b/packages/azure-themes/src/azure/AzureStyleSettings.ts
@@ -1,4 +1,3 @@
-import { ITheme } from '@fluentui/react';
 import { ActionButtonStyles } from './styles/ActionButton.styles';
 import { BreadcrumbStyles } from './styles/Breadcrumb.styles';
 import { CalloutContentStyles } from './styles/Callout.styles';
@@ -41,6 +40,7 @@ import { TeachingBubbleStyles } from './styles/TeachingBubble.styles';
 import { TextFieldStyles } from './styles/TextField.styles';
 import { ToggleStyles } from './styles/Toggle.styles';
 import { TooltipStyles } from './styles/Tooltip.styles';
+import type { ITheme } from '@fluentui/react';
 
 // TODO: "any" is used here to get around "is using xxx but cannot be named" TS error. Should be able to remove
 //        this 'any' once we upgrade to TS3.1+

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -1,9 +1,10 @@
-import { createTheme, Theme } from '@fluentui/react';
+import { createTheme } from '@fluentui/react';
 import { CommonSemanticColors, DarkSemanticColors } from './AzureColors';
-import { IExtendedSemanticColors } from './IExtendedSemanticColors';
 import { FontSizes } from './AzureType';
 import * as StyleConstants from './Constants';
 import { AzureStyleSettings } from './AzureStyleSettings';
+import type { Theme } from '@fluentui/react';
+import type { IExtendedSemanticColors } from './IExtendedSemanticColors';
 
 const darkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   bodyBackground: DarkSemanticColors.background,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
@@ -1,9 +1,10 @@
-import { createTheme, Theme } from '@fluentui/react';
+import { createTheme } from '@fluentui/react';
 import { CommonSemanticColors, HighContrastDarkSemanticColors } from './AzureColors';
-import { IExtendedSemanticColors } from './IExtendedSemanticColors';
 import { FontSizes } from './AzureType';
 import * as StyleConstants from './Constants';
 import { AzureStyleSettings } from './AzureStyleSettings';
+import type { Theme } from '@fluentui/react';
+import type { IExtendedSemanticColors } from './IExtendedSemanticColors';
 
 const highContrastDarkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   bodyBackground: HighContrastDarkSemanticColors.background,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
@@ -1,9 +1,10 @@
-import { createTheme, Theme } from '@fluentui/react';
+import { createTheme } from '@fluentui/react';
 import { CommonSemanticColors, HighContrastLightSemanticColors } from './AzureColors';
-import { IExtendedSemanticColors } from './IExtendedSemanticColors';
 import { FontSizes } from './AzureType';
 import * as StyleConstants from './Constants';
 import { AzureStyleSettings } from './AzureStyleSettings';
+import type { Theme } from '@fluentui/react';
+import type { IExtendedSemanticColors } from './IExtendedSemanticColors';
 
 const highContrastLightExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   bodyBackground: HighContrastLightSemanticColors.background,

--- a/packages/azure-themes/src/azure/AzureThemeLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeLight.ts
@@ -1,9 +1,10 @@
-import { createTheme, Theme } from '@fluentui/react';
+import { createTheme } from '@fluentui/react';
 import { CommonSemanticColors, LightSemanticColors } from './AzureColors';
-import { IExtendedSemanticColors } from './IExtendedSemanticColors';
 import { FontSizes } from './AzureType';
 import * as StyleConstants from './Constants';
 import { AzureStyleSettings } from './AzureStyleSettings';
+import type { Theme } from '@fluentui/react';
+import type { IExtendedSemanticColors } from './IExtendedSemanticColors';
 
 const lightExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   bodyBackground: LightSemanticColors.background,

--- a/packages/azure-themes/src/azure/IExtendedSemanticColors.ts
+++ b/packages/azure-themes/src/azure/IExtendedSemanticColors.ts
@@ -1,4 +1,4 @@
-import { ISemanticColors } from '@fluentui/react';
+import type { ISemanticColors } from '@fluentui/react';
 
 export interface IExtendedSemanticColors extends ISemanticColors {
   checkboxBorderChecked: string;

--- a/packages/azure-themes/src/azure/styles/ActionButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ActionButton.styles.ts
@@ -1,7 +1,7 @@
-import { IButtonStyles } from '@fluentui/react/lib/Button';
-import { ITheme } from '@fluentui/react/lib/Styling';
 import * as StyleConstants from '../Constants';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IButtonStyles } from '@fluentui/react/lib/Button';
+import type { ITheme } from '@fluentui/react/lib/Styling';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const ActionButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
   const { semanticColors } = theme;

--- a/packages/azure-themes/src/azure/styles/Breadcrumb.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Breadcrumb.styles.ts
@@ -1,5 +1,5 @@
-import { IBreadcrumbStyleProps, IBreadcrumbStyles } from '@fluentui/react/lib/Breadcrumb';
 import { FontWeights } from '@fluentui/react/lib/Styling';
+import type { IBreadcrumbStyleProps, IBreadcrumbStyles } from '@fluentui/react/lib/Breadcrumb';
 
 export const BreadcrumbStyles = (props: IBreadcrumbStyleProps): Partial<IBreadcrumbStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/Callout.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Callout.styles.ts
@@ -1,6 +1,6 @@
-import { ICalloutContentStyleProps, ICalloutContentStyles } from '@fluentui/react/lib/Callout';
 import { Depths } from '../AzureDepths';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { ICalloutContentStyleProps, ICalloutContentStyles } from '@fluentui/react/lib/Callout';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<ICalloutContentStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/Checkbox.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Checkbox.styles.ts
@@ -1,7 +1,7 @@
-import { ICheckboxStyleProps, ICheckboxStyles } from '@fluentui/react/lib/Checkbox';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 import { BaseColors } from '../AzureColors';
 import * as StyleConstants from '../Constants';
+import type { ICheckboxStyleProps, ICheckboxStyles } from '@fluentui/react/lib/Checkbox';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const CheckboxStyles = (props: ICheckboxStyleProps): Partial<ICheckboxStyles> => {
   const { disabled, checked, theme, indeterminate } = props;

--- a/packages/azure-themes/src/azure/styles/ChoiceGroupOptions.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ChoiceGroupOptions.styles.ts
@@ -1,6 +1,6 @@
-import { IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from '@fluentui/react/lib/ChoiceGroup';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 import * as StyleConstants from '../Constants';
+import type { IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from '@fluentui/react/lib/ChoiceGroup';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Partial<IChoiceGroupOptionStyles> => {
   const { checked, disabled, theme, hasIcon, hasImage } = props;

--- a/packages/azure-themes/src/azure/styles/ColorPicker.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ColorPicker.styles.ts
@@ -1,4 +1,5 @@
-import {
+import { Depths } from '../AzureDepths';
+import type {
   IColorPickerStyleProps,
   IColorPickerStyles,
   IColorRectangleStyleProps,
@@ -6,8 +7,7 @@ import {
   IColorSliderStyleProps,
   IColorSliderStyles,
 } from '@fluentui/react/lib/ColorPicker';
-import { Depths } from '../AzureDepths';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const ColorPickerStyles = (props: IColorPickerStyleProps): Partial<IColorPickerStyles> => {
   return {

--- a/packages/azure-themes/src/azure/styles/ColorPickerGridCell.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ColorPickerGridCell.styles.ts
@@ -1,5 +1,5 @@
-import { IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from '@fluentui/react/lib/SwatchColorPicker';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from '@fluentui/react/lib/SwatchColorPicker';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const ColorPickerGridCellStyles = (
   props: IColorPickerGridCellStyleProps,

--- a/packages/azure-themes/src/azure/styles/ComboBox.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ComboBox.styles.ts
@@ -1,8 +1,8 @@
-import { ITheme } from '@fluentui/react/lib/Styling';
 import { Depths } from '../AzureDepths';
-import { IComboBoxStyles } from '@fluentui/react/lib/ComboBox';
 import * as StyleConstants from '../Constants';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { ITheme } from '@fluentui/react/lib/Styling';
+import type { IComboBoxStyles } from '@fluentui/react/lib/ComboBox';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const ComboBoxStyles = (theme: ITheme): Partial<IComboBoxStyles> => {
   const { semanticColors } = theme;

--- a/packages/azure-themes/src/azure/styles/CommandBar.styles.ts
+++ b/packages/azure-themes/src/azure/styles/CommandBar.styles.ts
@@ -1,6 +1,6 @@
-import { ICommandBarStyleProps, ICommandBarStyles } from '@fluentui/react/lib/CommandBar';
 import * as StyleConstants from '../Constants';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { ICommandBarStyleProps, ICommandBarStyles } from '@fluentui/react/lib/CommandBar';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const CommandBarStyles = (props: ICommandBarStyleProps): Partial<ICommandBarStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/CommandBarButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/CommandBarButton.styles.ts
@@ -1,7 +1,7 @@
-import { ITheme } from '@fluentui/react';
 import { getFocusStyle } from '@fluentui/react/lib/Styling';
-import { IButtonStyles } from '@fluentui/react/lib/Button';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { ITheme } from '@fluentui/react';
+import type { IButtonStyles } from '@fluentui/react/lib/Button';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const CommandBarButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
   const { semanticColors } = theme;

--- a/packages/azure-themes/src/azure/styles/CompoundButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/CompoundButton.styles.ts
@@ -1,7 +1,7 @@
-import { IButtonStyles } from '@fluentui/react/lib/Button';
-import { ITheme } from '@fluentui/react/lib/Styling';
 import * as StyleConstants from '../Constants';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IButtonStyles } from '@fluentui/react/lib/Button';
+import type { ITheme } from '@fluentui/react/lib/Styling';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const CompoundButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
   const { semanticColors } = theme;

--- a/packages/azure-themes/src/azure/styles/ContextualMenu.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ContextualMenu.styles.ts
@@ -1,12 +1,12 @@
-import {
+import { Depths } from '../AzureDepths';
+import * as StyleConstants from '../Constants';
+import type {
   IContextualMenuStyleProps,
   IContextualMenuStyles,
   IContextualMenuItemStyleProps,
   IContextualMenuItemStyles,
 } from '@fluentui/react/lib/ContextualMenu';
-import { Depths } from '../AzureDepths';
-import * as StyleConstants from '../Constants';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const ContextualMenuStyles = (props: IContextualMenuStyleProps): Partial<IContextualMenuStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/DatePicker.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DatePicker.styles.ts
@@ -1,7 +1,7 @@
 import * as StyleConstants from '../Constants';
-import { IDatePickerStyles, IDatePickerStyleProps } from '@fluentui/react/lib/DatePicker';
 import { BaseColors } from '../AzureColors';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IDatePickerStyles, IDatePickerStyleProps } from '@fluentui/react/lib/DatePicker';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePickerStyles> => {
   const { disabled, theme } = props;

--- a/packages/azure-themes/src/azure/styles/DefaultButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DefaultButton.styles.ts
@@ -1,7 +1,7 @@
-import { IButtonStyles } from '@fluentui/react/lib/Button';
 import * as StyleConstants from '../Constants';
-import { ITheme } from '@fluentui/react/lib/Styling';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IButtonStyles } from '@fluentui/react/lib/Button';
+import type { ITheme } from '@fluentui/react/lib/Styling';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const DefaultButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
   const { semanticColors } = theme;

--- a/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
@@ -1,13 +1,13 @@
-import { ICheckStyleProps, ICheckStyles } from '@fluentui/react/lib/Check';
-import {
+import { FontSizes } from '../AzureType';
+import * as StyleConstants from '../Constants';
+import type { ICheckStyleProps, ICheckStyles } from '@fluentui/react/lib/Check';
+import type {
   IDetailsRowStyleProps,
   IDetailsRowStyles,
   IDetailsListStyleProps,
   IDetailsListStyles,
 } from '@fluentui/react/lib/DetailsList';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
-import { FontSizes } from '../AzureType';
-import * as StyleConstants from '../Constants';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const CheckStyles = (props: ICheckStyleProps): Partial<ICheckStyles> => {
   const { theme, checked } = props;

--- a/packages/azure-themes/src/azure/styles/Dialog.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Dialog.styles.ts
@@ -1,12 +1,12 @@
-import {
+import { FontSizes } from '../AzureType';
+import { BaseColors } from '../AzureColors';
+import type {
   IDialogContentStyleProps,
   IDialogContentStyles,
   IDialogFooterStyleProps,
   IDialogFooterStyles,
 } from '@fluentui/react/lib/Dialog';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
-import { FontSizes } from '../AzureType';
-import { BaseColors } from '../AzureColors';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const DialogContentStyles = (props: IDialogContentStyleProps): Partial<IDialogContentStyles> => {
   const { theme, isLargeHeader } = props;

--- a/packages/azure-themes/src/azure/styles/DocumentCard.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DocumentCard.styles.ts
@@ -1,5 +1,5 @@
-import { IDocumentCardStyles, IDocumentCardStyleProps } from '@fluentui/react/lib/DocumentCard';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IDocumentCardStyles, IDocumentCardStyleProps } from '@fluentui/react/lib/DocumentCard';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const DocumentCardStyles = (props: IDocumentCardStyleProps): Partial<IDocumentCardStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/DropDown.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DropDown.styles.ts
@@ -1,7 +1,7 @@
-import { IDropdownStyleProps, IDropdownStyles } from '@fluentui/react/lib/Dropdown';
 import { Depths } from '../AzureDepths';
 import * as StyleConstants from '../Constants';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IDropdownStyleProps, IDropdownStyles } from '@fluentui/react/lib/Dropdown';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownStyles> => {
   const { disabled, theme, hasError, isOpen } = props;

--- a/packages/azure-themes/src/azure/styles/HoverCard.styles.ts
+++ b/packages/azure-themes/src/azure/styles/HoverCard.styles.ts
@@ -1,10 +1,10 @@
-import {
+import * as StyleConstants from '../Constants';
+import type {
   IExpandingCardStyleProps,
   IExpandingCardStyles,
   IPlainCardStyleProps,
   IPlainCardStyles,
 } from '@fluentui/react/lib/HoverCard';
-import * as StyleConstants from '../Constants';
 
 export const ExpandingCardStyles = (props: IExpandingCardStyleProps): Partial<IExpandingCardStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/IconButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/IconButton.styles.ts
@@ -1,7 +1,7 @@
-import { IButtonStyles } from '@fluentui/react/lib/Button';
-import { ITheme } from '@fluentui/react/lib/Styling';
 import * as StyleConstants from '../Constants';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IButtonStyles } from '@fluentui/react/lib/Button';
+import type { ITheme } from '@fluentui/react/lib/Styling';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const IconButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
   const { semanticColors } = theme;

--- a/packages/azure-themes/src/azure/styles/Label.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Label.styles.ts
@@ -1,5 +1,5 @@
-import { ILabelStyleProps, ILabelStyles } from '@fluentui/react/lib/Label';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { ILabelStyleProps, ILabelStyles } from '@fluentui/react/lib/Label';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const LabelStyles = (props: ILabelStyleProps): Partial<ILabelStyles> => {
   const { theme, disabled } = props;

--- a/packages/azure-themes/src/azure/styles/Link.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Link.styles.ts
@@ -1,5 +1,5 @@
-import { ILinkStyleProps, ILinkStyles } from '@fluentui/react/lib/Link';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { ILinkStyleProps, ILinkStyles } from '@fluentui/react/lib/Link';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const LinkStyles = (props: ILinkStyleProps): Partial<ILinkStyles> => {
   const { isDisabled, theme } = props;

--- a/packages/azure-themes/src/azure/styles/MessageBar.styles.ts
+++ b/packages/azure-themes/src/azure/styles/MessageBar.styles.ts
@@ -1,6 +1,7 @@
-import { IStyle } from '@fluentui/react';
-import { IMessageBarStyleProps, IMessageBarStyles, MessageBarType } from '@fluentui/react/lib/MessageBar';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import { MessageBarType } from '@fluentui/react/lib/MessageBar';
+import type { IStyle } from '@fluentui/react';
+import type { IMessageBarStyleProps, IMessageBarStyles } from '@fluentui/react/lib/MessageBar';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 const generateBaseStyle = (backgroundColor: string, textColor: string): IStyle => {
   return {

--- a/packages/azure-themes/src/azure/styles/Modal.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Modal.styles.ts
@@ -1,6 +1,6 @@
-import { IModalStyles, IModalStyleProps } from '@fluentui/react';
 import { Depths } from '../AzureDepths';
 import * as StyleConstants from '../Constants';
+import type { IModalStyles, IModalStyleProps } from '@fluentui/react';
 
 export const ModalStyles = (props: IModalStyleProps): Partial<IModalStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/Nav.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Nav.styles.ts
@@ -1,5 +1,5 @@
-import { INavStyleProps, INavStyles } from '@fluentui/react/lib/Nav';
 import { borderNone } from '../Constants';
+import type { INavStyleProps, INavStyles } from '@fluentui/react/lib/Nav';
 
 export const NavStyles = (props: INavStyleProps): Partial<INavStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/Overlay.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Overlay.styles.ts
@@ -1,5 +1,5 @@
-import { IOverlayStyleProps, IOverlayStyles } from '@fluentui/react/lib/Overlay';
 import { CommonSemanticColors } from '../AzureColors';
+import type { IOverlayStyleProps, IOverlayStyles } from '@fluentui/react/lib/Overlay';
 
 export const OverlayStyles = (props: IOverlayStyleProps): Partial<IOverlayStyles> => {
   const { isDark } = props;

--- a/packages/azure-themes/src/azure/styles/Panel.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Panel.styles.ts
@@ -1,6 +1,6 @@
-import { IPanelStyles, IPanelStyleProps } from '@fluentui/react';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 import { BaseColors } from '../AzureColors';
+import type { IPanelStyles, IPanelStyleProps } from '@fluentui/react';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const PanelStyles = (props: IPanelStyleProps): Partial<IPanelStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/Pivot.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Pivot.styles.ts
@@ -1,6 +1,6 @@
-import { IPivotStyleProps, IPivotStyles } from '@fluentui/react/lib/Pivot';
 import * as StyleConstants from '../Constants';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IPivotStyleProps, IPivotStyles } from '@fluentui/react/lib/Pivot';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const PivotStyles = (props: IPivotStyleProps): Partial<IPivotStyles> => {
   const { theme, linkFormat, linkSize } = props;

--- a/packages/azure-themes/src/azure/styles/PrimaryButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/PrimaryButton.styles.ts
@@ -1,7 +1,7 @@
-import { IButtonStyles } from '@fluentui/react/lib/Button';
 import * as StyleConstants from '../Constants';
-import { ITheme } from '@fluentui/react/lib/Styling';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IButtonStyles } from '@fluentui/react/lib/Button';
+import type { ITheme } from '@fluentui/react/lib/Styling';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const PrimaryButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
   const { semanticColors } = theme;

--- a/packages/azure-themes/src/azure/styles/ProgressIndicator.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ProgressIndicator.styles.ts
@@ -1,4 +1,4 @@
-import { IProgressIndicatorStyles, IProgressIndicatorStyleProps } from '@fluentui/react/lib/ProgressIndicator';
+import type { IProgressIndicatorStyles, IProgressIndicatorStyleProps } from '@fluentui/react/lib/ProgressIndicator';
 
 export const ProgressIndicatorStyles = (props: IProgressIndicatorStyleProps): Partial<IProgressIndicatorStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/Rating.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Rating.styles.ts
@@ -1,5 +1,5 @@
-import { IRatingStyleProps, IRatingStyles } from '@fluentui/react/lib/Rating';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IRatingStyleProps, IRatingStyles } from '@fluentui/react/lib/Rating';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const RatingStyles = (props: IRatingStyleProps): Partial<IRatingStyles> => {
   const { disabled, readOnly, theme } = props;

--- a/packages/azure-themes/src/azure/styles/SearchBox.styles.ts
+++ b/packages/azure-themes/src/azure/styles/SearchBox.styles.ts
@@ -1,6 +1,6 @@
-import { ISearchBoxStyleProps, ISearchBoxStyles } from '@fluentui/react/lib/SearchBox';
 import * as StyleConstants from '../Constants';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { ISearchBoxStyleProps, ISearchBoxStyles } from '@fluentui/react/lib/SearchBox';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const SearchBoxStyles = (props: ISearchBoxStyleProps): Partial<ISearchBoxStyles> => {
   const { theme, hasFocus } = props;

--- a/packages/azure-themes/src/azure/styles/Slider.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Slider.styles.ts
@@ -1,6 +1,6 @@
-import { ISliderStyleProps, ISliderStyles } from '@fluentui/react/lib/Slider';
 import * as StyleConstants from '../Constants';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { ISliderStyleProps, ISliderStyles } from '@fluentui/react/lib/Slider';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 const SLIDER_BOX_DIMENSION: number = 8;
 const SLIDER_DIAMETER: number = 16;

--- a/packages/azure-themes/src/azure/styles/SpinButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/SpinButton.styles.ts
@@ -1,5 +1,5 @@
-import { ISpinButtonStyleProps, ISpinButtonStyles } from '@fluentui/react/lib/SpinButton';
-import { IStyleFunction } from '@fluentui/react/lib/Utilities';
+import type { ISpinButtonStyleProps, ISpinButtonStyles } from '@fluentui/react/lib/SpinButton';
+import type { IStyleFunction } from '@fluentui/react/lib/Utilities';
 
 export const SpinButtonStyles: IStyleFunction<ISpinButtonStyleProps, ISpinButtonStyles> = (
   props: ISpinButtonStyleProps,

--- a/packages/azure-themes/src/azure/styles/Suggestions.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Suggestions.styles.ts
@@ -1,5 +1,5 @@
-import { ISuggestionsStyleProps, ISuggestionsStyles } from '@fluentui/react/lib/Pickers';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { ISuggestionsStyleProps, ISuggestionsStyles } from '@fluentui/react/lib/Pickers';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const SuggestionsStyles = (props: ISuggestionsStyleProps): Partial<ISuggestionsStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/SuggestionsItem.styles.ts
+++ b/packages/azure-themes/src/azure/styles/SuggestionsItem.styles.ts
@@ -1,4 +1,4 @@
-import { ISuggestionItemProps, ISuggestionsItemStyles, ITagPickerProps } from '@fluentui/react/lib/Pickers';
+import type { ISuggestionItemProps, ISuggestionsItemStyles, ITagPickerProps } from '@fluentui/react/lib/Pickers';
 
 export const SuggestionItemStyles = (props: ISuggestionItemProps<ITagPickerProps>): Partial<ISuggestionsItemStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/TagItem.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TagItem.styles.ts
@@ -1,6 +1,6 @@
-import { ITagItemStyleProps, ITagItemStyles } from '@fluentui/react/lib/Pickers';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 import { transparent } from '../Constants';
+import type { ITagItemStyleProps, ITagItemStyles } from '@fluentui/react/lib/Pickers';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const TagItemStyles = (props: ITagItemStyleProps): Partial<ITagItemStyles> => {
   const { theme, selected } = props;

--- a/packages/azure-themes/src/azure/styles/TagPicker.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TagPicker.styles.ts
@@ -1,6 +1,6 @@
-import { IBasePickerStyles, IBasePickerStyleProps } from '@fluentui/react/lib/Pickers';
 import * as StyleConstants from '../Constants';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IBasePickerStyles, IBasePickerStyleProps } from '@fluentui/react/lib/Pickers';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const TagPickerStyles = (props: IBasePickerStyleProps): Partial<IBasePickerStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/TeachingBubble.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TeachingBubble.styles.ts
@@ -1,7 +1,7 @@
-import { ITeachingBubbleStyleProps, ITeachingBubbleStyles } from '@fluentui/react/lib/TeachingBubble';
 import { Depths } from '../AzureDepths';
 import { FontSizes } from '../AzureType';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { ITeachingBubbleStyleProps, ITeachingBubbleStyles } from '@fluentui/react/lib/TeachingBubble';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<ITeachingBubbleStyles> => {
   const { theme } = props;

--- a/packages/azure-themes/src/azure/styles/TextField.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TextField.styles.ts
@@ -1,6 +1,6 @@
-import { ITextFieldStyleProps, ITextFieldStyles } from '@fluentui/react/lib/TextField';
 import * as StyleConstants from '../Constants';
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { ITextFieldStyleProps, ITextFieldStyles } from '@fluentui/react/lib/TextField';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextFieldStyles> => {
   const { focused, disabled, hasErrorMessage, multiline, theme } = props;

--- a/packages/azure-themes/src/azure/styles/Toggle.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Toggle.styles.ts
@@ -1,5 +1,5 @@
-import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
-import { IToggleStyleProps, IToggleStyles } from '@fluentui/react/lib/Toggle';
+import type { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import type { IToggleStyleProps, IToggleStyles } from '@fluentui/react/lib/Toggle';
 
 export const ToggleStyles = (props: IToggleStyleProps): Partial<IToggleStyles> => {
   const { theme, disabled, checked } = props;

--- a/packages/azure-themes/src/azure/styles/Tooltip.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Tooltip.styles.ts
@@ -1,4 +1,4 @@
-import { ITooltipStyles, ITooltipStyleProps } from '@fluentui/react/lib/Tooltip';
+import type { ITooltipStyles, ITooltipStyleProps } from '@fluentui/react/lib/Tooltip';
 
 export const TooltipStyles = (props: ITooltipStyleProps): Partial<ITooltipStyles> => {
   return {

--- a/packages/azure-themes/tsconfig.json
+++ b/packages/azure-themes/tsconfig.json
@@ -16,7 +16,8 @@
     "skipLibCheck": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"]
+    "lib": ["es5", "dom"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/babel-make-styles/src/plugin.ts
+++ b/packages/babel-make-styles/src/plugin.ts
@@ -1,13 +1,15 @@
-import { NodePath, PluginObj, PluginPass, types as t } from '@babel/core';
+import { NodePath, types as t } from '@babel/core';
 import { declare } from '@babel/helper-plugin-utils';
 import { Module } from '@linaria/babel-preset';
-import { resolveStyleRulesForSlots, CSSRulesByBucket, StyleBucketName, MakeStyles } from '@fluentui/make-styles';
+import { resolveStyleRulesForSlots } from '@fluentui/make-styles';
 
 import { astify } from './utils/astify';
 import { evaluatePaths } from './utils/evaluatePaths';
 import { UNHANDLED_CASE_ERROR } from './constants';
-import { BabelPluginOptions } from './types';
 import { validateOptions } from './validateOptions';
+import type { PluginObj, PluginPass } from '@babel/core';
+import type { CSSRulesByBucket, StyleBucketName, MakeStyles } from '@fluentui/make-styles';
+import type { BabelPluginOptions } from './types';
 
 type AstStyleNode =
   | { kind: 'PURE_OBJECT'; nodePath: NodePath<t.ObjectExpression> }

--- a/packages/babel-make-styles/src/types.ts
+++ b/packages/babel-make-styles/src/types.ts
@@ -1,4 +1,4 @@
-import { TransformOptions } from '@babel/core';
+import type { TransformOptions } from '@babel/core';
 
 export type BabelPluginOptions = {
   /** Defines set of modules and imports handled by a plugin. */

--- a/packages/babel-make-styles/src/utils/evaluatePaths.ts
+++ b/packages/babel-make-styles/src/utils/evaluatePaths.ts
@@ -1,5 +1,6 @@
-import { NodePath, TransformOptions, types as t } from '@babel/core';
+import { NodePath, types as t } from '@babel/core';
 import { evaluatePathsInVM } from './evaluatePathsInVM';
+import type { TransformOptions } from '@babel/core';
 
 /**
  * Checks if passed paths can be evaluated by Babel, if no - fallbacks to Node evaluation.

--- a/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts
+++ b/packages/babel-make-styles/src/utils/evaluatePathsInVM.ts
@@ -1,12 +1,14 @@
-import { NodePath, TransformOptions, types as t } from '@babel/core';
+import { NodePath, types as t } from '@babel/core';
 import { Scope } from '@babel/traverse';
 import * as template from '@babel/template';
 import generator from '@babel/generator';
 import { resolveProxyValues } from '@fluentui/make-styles';
-import { Module, StrictOptions } from '@linaria/babel-preset';
+import { Module } from '@linaria/babel-preset';
 import shakerEvaluator from '@linaria/shaker';
 
 import { astify } from './astify';
+import type { TransformOptions } from '@babel/core';
+import type { StrictOptions } from '@linaria/babel-preset';
 
 const EVAL_EXPORT_NAME = '__mkPreval';
 

--- a/packages/babel-make-styles/src/validateOptions.test.ts
+++ b/packages/babel-make-styles/src/validateOptions.test.ts
@@ -1,5 +1,5 @@
 import { validateOptions } from './validateOptions';
-import { BabelPluginOptions } from './types';
+import type { BabelPluginOptions } from './types';
 
 describe('validateOptions', () => {
   it('passes on valid options', () => {

--- a/packages/babel-make-styles/src/validateOptions.ts
+++ b/packages/babel-make-styles/src/validateOptions.ts
@@ -1,7 +1,7 @@
 import Ajv from 'ajv';
 
 import { configSchema } from './schema';
-import { BabelPluginOptions } from './types';
+import type { BabelPluginOptions } from './types';
 
 const ajv = new Ajv();
 

--- a/packages/babel-make-styles/tsconfig.json
+++ b/packages/babel-make-styles/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "node"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "node"],
+    "isolatedModules": true
   }
 }

--- a/packages/date-time-utilities/src/dateFormatting/dateFormatting.defaults.ts
+++ b/packages/date-time-utilities/src/dateFormatting/dateFormatting.defaults.ts
@@ -1,4 +1,4 @@
-import { IDateGridStrings, IDateFormatting, ICalendarStrings } from './dateFormatting.types';
+import type { IDateGridStrings, IDateFormatting, ICalendarStrings } from './dateFormatting.types';
 
 /**
  * Format date to a day string representation

--- a/packages/date-time-utilities/src/dateGrid/findAvailableDate.test.ts
+++ b/packages/date-time-utilities/src/dateGrid/findAvailableDate.test.ts
@@ -1,6 +1,6 @@
-import { IAvailableDateOptions } from './dateGrid.types';
 import * as DateGrid from './findAvailableDate';
 import { MonthOfYear } from '../dateValues/dateValues';
+import type { IAvailableDateOptions } from './dateGrid.types';
 
 describe('findAvailableDate', () => {
   const defaultOptions: IAvailableDateOptions = {

--- a/packages/date-time-utilities/src/dateGrid/findAvailableDate.ts
+++ b/packages/date-time-utilities/src/dateGrid/findAvailableDate.ts
@@ -1,11 +1,10 @@
-import { IAvailableDateOptions } from './dateGrid.types';
-
 import { isRestrictedDate } from './isRestrictedDate';
 
 import { isAfterMaxDate } from './isAfterMaxDate';
 
 import { isBeforeMinDate } from './isBeforeMinDate';
 import { compareDatePart, addDays } from '../dateMath/dateMath';
+import type { IAvailableDateOptions } from './dateGrid.types';
 
 /**
  * Returns closest available date given the restriction `options`, or undefined otherwise

--- a/packages/date-time-utilities/src/dateGrid/getDayGrid.test.ts
+++ b/packages/date-time-utilities/src/dateGrid/getDayGrid.test.ts
@@ -1,8 +1,7 @@
 import { DateRangeType, DayOfWeek, FirstWeekOfYear } from '../dateValues/dateValues';
 import { addDays, compareDates } from '../dateMath/dateMath';
-import { IDayGridOptions } from './dateGrid.types';
 import * as DateGrid from './getDayGrid';
-import { IDay } from './dateGrid.types';
+import type { IDayGridOptions, IDay } from './dateGrid.types';
 
 describe('getDayGrid', () => {
   const defaultDate = new Date('Apr 1 2016');

--- a/packages/date-time-utilities/src/dateGrid/getDayGrid.ts
+++ b/packages/date-time-utilities/src/dateGrid/getDayGrid.ts
@@ -1,9 +1,9 @@
 import { addDays, compareDates, getDateRangeArray, isInDateRangeArray } from '../dateMath/dateMath';
 import { DAYS_IN_WEEK } from '../dateValues/dateValues';
-import { IDay, IDayGridOptions } from './dateGrid.types';
 import { getDateRangeTypeToUse } from './getDateRangeTypeToUse';
 import { getBoundedDateRange } from './getBoundedDateRange';
 import { isRestrictedDate } from './isRestrictedDate';
+import type { IDay, IDayGridOptions } from './dateGrid.types';
 
 /**
  * Generates a grid of days, given the `options`.

--- a/packages/date-time-utilities/src/dateGrid/isAfterMaxDate.test.ts
+++ b/packages/date-time-utilities/src/dateGrid/isAfterMaxDate.test.ts
@@ -1,6 +1,6 @@
-import { IRestrictedDatesOptions } from './dateGrid.types';
 import * as DateGrid from './isAfterMaxDate';
 import { MonthOfYear } from '../dateValues/dateValues';
+import type { IRestrictedDatesOptions } from './dateGrid.types';
 
 describe('isAfterMaxDate', () => {
   const date = new Date(2016, MonthOfYear.April, 3);

--- a/packages/date-time-utilities/src/dateGrid/isAfterMaxDate.ts
+++ b/packages/date-time-utilities/src/dateGrid/isAfterMaxDate.ts
@@ -1,5 +1,5 @@
-import { IRestrictedDatesOptions } from './dateGrid.types';
 import { compareDatePart } from '../dateMath/dateMath';
+import type { IRestrictedDatesOptions } from './dateGrid.types';
 
 /**
  * Checks if `date` happens later than max date

--- a/packages/date-time-utilities/src/dateGrid/isBeforeMinDate.test.ts
+++ b/packages/date-time-utilities/src/dateGrid/isBeforeMinDate.test.ts
@@ -1,6 +1,6 @@
 import * as DateGrid from './isBeforeMinDate';
-import { IRestrictedDatesOptions } from './dateGrid.types';
 import { MonthOfYear } from '../dateValues/dateValues';
+import type { IRestrictedDatesOptions } from './dateGrid.types';
 
 describe('isBeforeMinDate', () => {
   const date = new Date(2016, MonthOfYear.April, 3);

--- a/packages/date-time-utilities/src/dateGrid/isBeforeMinDate.ts
+++ b/packages/date-time-utilities/src/dateGrid/isBeforeMinDate.ts
@@ -1,5 +1,5 @@
-import { IRestrictedDatesOptions } from './dateGrid.types';
 import { compareDatePart } from '../dateMath/dateMath';
+import type { IRestrictedDatesOptions } from './dateGrid.types';
 
 /**
  * Checks if `date` happens earlier than min date

--- a/packages/date-time-utilities/src/dateGrid/isRestrictedDate.test.ts
+++ b/packages/date-time-utilities/src/dateGrid/isRestrictedDate.test.ts
@@ -1,6 +1,6 @@
 import * as DateGrid from './isRestrictedDate';
-import { IRestrictedDatesOptions } from './dateGrid.types';
 import { MonthOfYear } from '../dateValues/dateValues';
+import type { IRestrictedDatesOptions } from './dateGrid.types';
 
 describe('isRestrictedDate', () => {
   const date = new Date(2016, MonthOfYear.April, 3);

--- a/packages/date-time-utilities/src/dateGrid/isRestrictedDate.ts
+++ b/packages/date-time-utilities/src/dateGrid/isRestrictedDate.ts
@@ -1,7 +1,7 @@
-import { IRestrictedDatesOptions } from './dateGrid.types';
 import { compareDates } from '../dateMath/dateMath';
 import { isBeforeMinDate } from './isBeforeMinDate';
 import { isAfterMaxDate } from './isAfterMaxDate';
+import type { IRestrictedDatesOptions } from './dateGrid.types';
 
 /**
  * Checks if `date` falls into the restricted `options`

--- a/packages/date-time-utilities/tsconfig.json
+++ b/packages/date-time-utilities/tsconfig.json
@@ -17,7 +17,8 @@
     "preserveConstEnums": true,
     "skipLibCheck": true,
     "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["jest", "custom-global", "node"]
+    "types": ["jest", "custom-global", "node"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/dom-utilities/src/isVirtualElement.ts
+++ b/packages/dom-utilities/src/isVirtualElement.ts
@@ -1,4 +1,5 @@
-import { IVirtualElement } from './IVirtualElement';
+import type { IVirtualElement } from './IVirtualElement';
+
 /**
  * Determines whether or not an element has the virtual hierarchy extension.
  *

--- a/packages/dom-utilities/src/setVirtualParent.ts
+++ b/packages/dom-utilities/src/setVirtualParent.ts
@@ -1,4 +1,5 @@
-import { IVirtualElement } from './IVirtualElement';
+import type { IVirtualElement } from './IVirtualElement';
+
 /**
  * Sets the virtual parent of an element.
  * Pass `undefined` as the `parent` to clear the virtual parent.

--- a/packages/dom-utilities/tsconfig.json
+++ b/packages/dom-utilities/tsconfig.json
@@ -16,7 +16,8 @@
     "preserveConstEnums": true,
     "lib": ["es5", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["jest", "custom-global"]
+    "types": ["jest", "custom-global"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/font-icons-mdl2/etc/font-icons-mdl2.api.md
+++ b/packages/font-icons-mdl2/etc/font-icons-mdl2.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { IIconOptions } from '@fluentui/style-utilities';
+import type { IIconOptions } from '@fluentui/style-utilities';
 
 // @public @deprecated (undocumented)
 export const enum IconNames {
@@ -3614,7 +3614,6 @@ export const enum IconNames {
 
 // @public (undocumented)
 export function initializeIcons(baseUrl?: string, options?: IIconOptions): void;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/font-icons-mdl2/src/fabric-icons-0.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-0.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-1.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-1.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-10.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-10.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-11.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-11.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-12.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-12.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-13.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-13.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-14.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-14.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-15.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-15.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-16.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-16.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-17.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-17.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-2.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-2.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-3.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-3.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-4.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-4.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-5.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-5.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-6.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-6.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-7.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-7.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-8.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-8.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons-9.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-9.ts
@@ -1,10 +1,9 @@
   // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
 import {
-  IIconOptions,
-  IIconSubset,
   registerIcons
 } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from "@fluentui/style-utilities";
 
 export function initializeIcons(
   baseUrl: string = '',

--- a/packages/font-icons-mdl2/src/fabric-icons.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons.ts
@@ -1,6 +1,7 @@
 // Your use of the content in the files referenced here is subject to the terms of the license at https://aka.ms/fluentui-assets-license
 
-import { IIconOptions, IIconSubset, registerIcons } from '@fluentui/style-utilities';
+import { registerIcons } from '@fluentui/style-utilities';
+import type { IIconOptions, IIconSubset } from '@fluentui/style-utilities';
 
 export function initializeIcons(baseUrl: string = '', options?: IIconOptions): void {
   const subset: IIconSubset = {

--- a/packages/font-icons-mdl2/src/iconNames.test.ts
+++ b/packages/font-icons-mdl2/src/iconNames.test.ts
@@ -1,4 +1,5 @@
-import { IconNames, IconNamesInput } from './IconNames';
+import { IconNames } from './IconNames';
+import type { IconNamesInput } from './IconNames';
 
 // eslint-disable-next-line deprecation/deprecation
 declare const allIconNamesValues: IconNames;

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -17,8 +17,6 @@ import { initializeIcons as i14 } from './fabric-icons-14';
 import { initializeIcons as i15 } from './fabric-icons-15';
 import { initializeIcons as i16 } from './fabric-icons-16';
 import { initializeIcons as i17 } from './fabric-icons-17';
-
-import { IIconOptions } from '@fluentui/style-utilities';
 import { registerIconAliases } from './iconAliases';
 const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric/assets/icons/';
 
@@ -52,3 +50,4 @@ export function initializeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: II
 export { IconNames } from './IconNames';
 
 import './version';
+import type { IIconOptions } from '@fluentui/style-utilities';

--- a/packages/font-icons-mdl2/tsconfig.json
+++ b/packages/font-icons-mdl2/tsconfig.json
@@ -13,7 +13,8 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "preserveConstEnums": false,
-    "types": []
+    "types": [],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/foundation-legacy/etc/foundation-legacy.api.md
+++ b/packages/foundation-legacy/etc/foundation-legacy.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import { ISchemeNames } from '@fluentui/style-utilities';
-import { IStyle } from '@fluentui/style-utilities';
-import { IStyleSet } from '@fluentui/style-utilities';
-import { ITheme } from '@fluentui/style-utilities';
+import type { ISchemeNames } from '@fluentui/style-utilities';
+import type { IStyle } from '@fluentui/style-utilities';
+import type { IStyleSet } from '@fluentui/style-utilities';
+import type { ITheme } from '@fluentui/style-utilities';
 import { styled as legacyStyled } from '@fluentui/utilities';
 import * as React_2 from 'react';
 
@@ -205,7 +205,6 @@ export type ValidShorthand = string | number | boolean;
 
 // @public
 export function withSlots<P>(type: ISlot<P> | React_2.FunctionComponent<P> | string, props?: (React_2.Attributes & P) | null, ...children: React_2.ReactNode[]): ReturnType<React_2.FunctionComponent<P>>;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/foundation-legacy/src/IComponent.ts
+++ b/packages/foundation-legacy/src/IComponent.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IStyle, IStyleSet, ITheme } from '@fluentui/style-utilities';
+import type { IStyle, IStyleSet, ITheme } from '@fluentui/style-utilities';
 
 // TODO: Known TypeScript issue is widening return type checks when using function type declarations.
 //        Effect is that mistyped property keys on returned style objects will not generate errors.

--- a/packages/foundation-legacy/src/IHTMLSlots.ts
+++ b/packages/foundation-legacy/src/IHTMLSlots.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ISlotProp } from './ISlots';
+import type { ISlotProp } from './ISlots';
 
 /**
  * Generic slot definition allowing common HTML attributes. Applicable for most intrinsic slots. Please note certain

--- a/packages/foundation-legacy/src/ISlots.ts
+++ b/packages/foundation-legacy/src/ISlots.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { IStyle, ITheme } from '@fluentui/style-utilities';
-import { IComponentStyles } from './IComponent';
+import type { IStyle, ITheme } from '@fluentui/style-utilities';
+import type { IComponentStyles } from './IComponent';
 
 /**
  * Signature of components that have component factories.

--- a/packages/foundation-legacy/src/ThemeProvider.tsx
+++ b/packages/foundation-legacy/src/ThemeProvider.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import { getThemedContext, ISchemeNames, ITheme } from '@fluentui/style-utilities';
-import { Customizer, ICustomizerProps } from '@fluentui/utilities';
+import { getThemedContext } from '@fluentui/style-utilities';
+import { Customizer } from '@fluentui/utilities';
+import type { ISchemeNames, ITheme } from '@fluentui/style-utilities';
+import type { ICustomizerProps } from '@fluentui/utilities';
 
 export interface IThemeProviderProps {
   scheme?: ISchemeNames;

--- a/packages/foundation-legacy/src/createComponent.test.tsx
+++ b/packages/foundation-legacy/src/createComponent.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
-import { IStyleableComponentProps } from './IComponent';
 import { createComponent } from './createComponent';
+import type { IStyleableComponentProps } from './IComponent';
 
 describe('createComponent', () => {
   interface ITestTokens {

--- a/packages/foundation-legacy/src/createComponent.tsx
+++ b/packages/foundation-legacy/src/createComponent.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { concatStyleSets, IStyleSet, ITheme } from '@fluentui/style-utilities';
-import { Customizations, CustomizerContext, ICustomizerContext } from '@fluentui/utilities';
+import { concatStyleSets } from '@fluentui/style-utilities';
+import { Customizations, CustomizerContext } from '@fluentui/utilities';
 import { createFactory } from './slots';
 import { assign } from './utilities';
-
-import {
+import type { IStyleSet, ITheme } from '@fluentui/style-utilities';
+import type { ICustomizerContext } from '@fluentui/utilities';
+import type {
   IComponentOptions,
   ICustomizationProps,
   IStyleableComponentProps,
@@ -13,7 +14,7 @@ import {
   ITokenFunction,
   IViewComponent,
 } from './IComponent';
-import { IDefaultSlotProps, ISlotCreator, ValidProps } from './ISlots';
+import type { IDefaultSlotProps, ISlotCreator, ValidProps } from './ISlots';
 
 /**
  * Assembles a higher order component based on the following: styles, theme, view, and state.

--- a/packages/foundation-legacy/src/next/IComponent.ts
+++ b/packages/foundation-legacy/src/next/IComponent.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { IStyleSet } from '@fluentui/style-utilities';
-import { IComponentOptions as IOldComponentOptions } from '../IComponent';
-import { ISlots, ISlotDefinition, ISlottableProps } from '../ISlots';
+import type { IStyleSet } from '@fluentui/style-utilities';
+import type { IComponentOptions as IOldComponentOptions } from '../IComponent';
+import type { ISlots, ISlotDefinition, ISlottableProps } from '../ISlots';
 
 /**
  * Defines the contract for view components.

--- a/packages/foundation-legacy/src/next/ISlots.ts
+++ b/packages/foundation-legacy/src/next/ISlots.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { IStyleSet } from '@fluentui/style-utilities';
-import { ISlottableProps, ValidProps } from '../ISlots';
-import { IComponentOptions } from './IComponent';
+import type { IStyleSet } from '@fluentui/style-utilities';
+import type { ISlottableProps, ValidProps } from '../ISlots';
+import type { IComponentOptions } from './IComponent';
 
 /**
  * Signature of components created using composed.

--- a/packages/foundation-legacy/src/next/composed.test.tsx
+++ b/packages/foundation-legacy/src/next/composed.test.tsx
@@ -1,11 +1,11 @@
 /** @jsx withSlots */
 import * as renderer from 'react-test-renderer';
 import { composed, resolveSlots } from './composed';
-import { IComponentStyles } from '../IComponent';
-import { IComponent, IComponentOptions, IRecompositionComponentOptions } from './IComponent';
-import { IHTMLElementSlot, IHTMLSlot } from '../IHTMLSlots';
 import { withSlots } from '../slots';
-import { ISlotDefinition } from '../ISlots';
+import type { IComponentStyles } from '../IComponent';
+import type { IComponent, IComponentOptions, IRecompositionComponentOptions } from './IComponent';
+import type { IHTMLElementSlot, IHTMLSlot } from '../IHTMLSlots';
+import type { ISlotDefinition } from '../ISlots';
 
 describe('composed', () => {
   type ITestComponent = IComponent<ITestProps, ITestTokens, ITestStyles, ITestViewProps, ITestSlots>;

--- a/packages/foundation-legacy/src/next/composed.tsx
+++ b/packages/foundation-legacy/src/next/composed.tsx
@@ -1,19 +1,26 @@
 import * as React from 'react';
 import { mergeStyles } from '@fluentui/merge-styles';
-import { concatStyleSets, IStyleSet, ITheme } from '@fluentui/style-utilities';
-import { Customizations, CustomizerContext, ICustomizerContext } from '@fluentui/utilities';
+import { concatStyleSets } from '@fluentui/style-utilities';
+import { Customizations, CustomizerContext } from '@fluentui/utilities';
 import { createFactory, getSlots } from '../slots';
 import { assign } from '../utilities';
-import {
+import type { IStyleSet, ITheme } from '@fluentui/style-utilities';
+import type { ICustomizerContext } from '@fluentui/utilities';
+import type {
   ICustomizationProps,
   IStyleableComponentProps,
   IStylesFunctionOrObject,
   IToken,
   ITokenFunction,
 } from '../IComponent';
-import { IComponentOptions, IPartialSlotComponent, IRecompositionComponentOptions, ISlotComponent } from './IComponent';
-import { IDefaultSlotProps, ValidProps, ISlottableProps, ISlotCreator, ISlotDefinition } from '../ISlots';
-import { IFoundationComponent } from './ISlots';
+import type {
+  IComponentOptions,
+  IPartialSlotComponent,
+  IRecompositionComponentOptions,
+  ISlotComponent,
+} from './IComponent';
+import type { IDefaultSlotProps, ValidProps, ISlottableProps, ISlotCreator, ISlotDefinition } from '../ISlots';
+import type { IFoundationComponent } from './ISlots';
 
 interface IClassNamesMapNode {
   className?: string;

--- a/packages/foundation-legacy/src/slots.test.tsx
+++ b/packages/foundation-legacy/src/slots.test.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 import { withSlots, createFactory, getSlots } from './slots';
-import { IHTMLElementSlot, IHTMLSlot } from './IHTMLSlots';
-import {
+import type { IHTMLElementSlot, IHTMLSlot } from './IHTMLSlots';
+import type {
   ExtractProps,
   ExtractShorthand,
   IProcessedSlotProps,

--- a/packages/foundation-legacy/src/slots.tsx
+++ b/packages/foundation-legacy/src/slots.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { mergeCss } from '@fluentui/merge-styles';
-import { IStyle, ITheme } from '@fluentui/style-utilities';
 import { getRTL, memoizeFunction } from '@fluentui/utilities';
 import { assign } from './utilities';
-import { IFactoryOptions } from './IComponent';
-import {
+import type { IStyle, ITheme } from '@fluentui/style-utilities';
+import type { IFactoryOptions } from './IComponent';
+import type {
   ISlottableReactType,
   ISlot,
   ISlots,

--- a/packages/foundation-legacy/tsconfig.json
+++ b/packages/foundation-legacy/tsconfig.json
@@ -17,7 +17,8 @@
     "preserveConstEnums": true,
     "lib": ["es5", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["jest", "custom-global"]
+    "types": ["jest", "custom-global"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/jest-serializer-make-styles/src/index.ts
+++ b/packages/jest-serializer-make-styles/src/index.ts
@@ -1,4 +1,5 @@
-import { DEFINITION_LOOKUP_TABLE, CSSClasses } from '@fluentui/make-styles';
+import { DEFINITION_LOOKUP_TABLE } from '@fluentui/make-styles';
+import type { CSSClasses } from '@fluentui/make-styles';
 
 export function print(val: string) {
   const regexParts: string[] = [];

--- a/packages/jest-serializer-make-styles/tsconfig.json
+++ b/packages/jest-serializer-make-styles/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "@testing-library/jest-dom"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "@testing-library/jest-dom"],
+    "isolatedModules": true
   }
 }

--- a/packages/make-styles-webpack-loader/src/transformSync.ts
+++ b/packages/make-styles-webpack-loader/src/transformSync.ts
@@ -1,5 +1,6 @@
 import * as Babel from '@babel/core';
-import babelPluginMakeStyles, { BabelPluginOptions } from '@fluentui/babel-make-styles';
+import babelPluginMakeStyles from '@fluentui/babel-make-styles';
+import type { BabelPluginOptions } from '@fluentui/babel-make-styles';
 
 export type TransformOptions = {
   filename: string;

--- a/packages/make-styles-webpack-loader/src/webpackLoader.ts
+++ b/packages/make-styles-webpack-loader/src/webpackLoader.ts
@@ -1,4 +1,4 @@
-import { configSchema, BabelPluginOptions } from '@fluentui/babel-make-styles';
+import { configSchema } from '@fluentui/babel-make-styles';
 import { EvalCache, Module } from '@linaria/babel-preset';
 import * as enhancedResolve from 'enhanced-resolve';
 import { getOptions } from 'loader-utils';
@@ -6,7 +6,9 @@ import * as path from 'path';
 import { validate } from 'schema-utils';
 import * as webpack from 'webpack';
 
-import { transformSync, TransformResult, TransformOptions } from './transformSync';
+import { transformSync } from './transformSync';
+import type { BabelPluginOptions } from '@fluentui/babel-make-styles';
+import type { TransformResult, TransformOptions } from './transformSync';
 
 export type WebpackLoaderOptions = BabelPluginOptions;
 

--- a/packages/make-styles-webpack-loader/tsconfig.json
+++ b/packages/make-styles-webpack-loader/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "node"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "node"],
+    "isolatedModules": true
   }
 }

--- a/packages/make-styles/etc/make-styles.api.md
+++ b/packages/make-styles/etc/make-styles.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { Properties } from 'csstype';
+import type { Properties } from 'csstype';
 
 // @internal
 export function __styles<Slots extends string>(classesMapBySlot: CSSClassesMapBySlot<Slots>, cssRules: CSSRulesByBucket): (options: Pick<MakeStylesOptions, 'dir' | 'renderer'>) => Record<Slots, string>;

--- a/packages/make-styles/src/__styles.ts
+++ b/packages/make-styles/src/__styles.ts
@@ -1,5 +1,5 @@
 import { reduceToClassNameForSlots } from './runtime/reduceToClassNameForSlots';
-import { MakeStylesOptions, CSSClassesMapBySlot, CSSRulesByBucket } from './types';
+import type { MakeStylesOptions, CSSClassesMapBySlot, CSSRulesByBucket } from './types';
 
 /**
  * A version of makeStyles() that accepts build output as an input and skips all runtime transforms.

--- a/packages/make-styles/src/constants.ts
+++ b/packages/make-styles/src/constants.ts
@@ -1,4 +1,4 @@
-import { LookupItem, SequenceHash } from './types';
+import type { LookupItem, SequenceHash } from './types';
 
 /** @internal */
 export const HASH_PREFIX = 'f';

--- a/packages/make-styles/src/makeStaticStyles.test.ts
+++ b/packages/make-styles/src/makeStaticStyles.test.ts
@@ -2,7 +2,7 @@ import { createDOMRenderer } from './renderer/createDOMRenderer';
 import { makeStylesRendererSerializer } from './utils/test/snapshotSerializer';
 import { makeStaticStyles } from './makeStaticStyles';
 import { makeStyles } from './makeStyles';
-import { MakeStylesRenderer } from './types';
+import type { MakeStylesRenderer } from './types';
 
 expect.addSnapshotSerializer(makeStylesRendererSerializer);
 

--- a/packages/make-styles/src/makeStaticStyles.ts
+++ b/packages/make-styles/src/makeStaticStyles.ts
@@ -1,5 +1,5 @@
 import { resolveStaticStyleRules } from './runtime/resolveStaticStyleRules';
-import { MakeStaticStylesOptions, MakeStaticStyles } from './types';
+import type { MakeStaticStylesOptions, MakeStaticStyles } from './types';
 
 /**
  * Register static css.

--- a/packages/make-styles/src/makeStyles.test.ts
+++ b/packages/make-styles/src/makeStyles.test.ts
@@ -1,7 +1,7 @@
 import { createDOMRenderer } from './renderer/createDOMRenderer';
 import { makeStylesRendererSerializer } from './utils/test/snapshotSerializer';
 import { makeStyles } from './makeStyles';
-import { MakeStylesRenderer } from './types';
+import type { MakeStylesRenderer } from './types';
 
 expect.addSnapshotSerializer(makeStylesRendererSerializer);
 

--- a/packages/make-styles/src/makeStyles.ts
+++ b/packages/make-styles/src/makeStyles.ts
@@ -1,6 +1,6 @@
 import { reduceToClassNameForSlots } from './runtime/reduceToClassNameForSlots';
 import { resolveStyleRulesForSlots } from './resolveStyleRulesForSlots';
-import { CSSClassesMapBySlot, CSSRulesByBucket, MakeStylesOptions, StylesBySlots } from './types';
+import type { CSSClassesMapBySlot, CSSRulesByBucket, MakeStylesOptions, StylesBySlots } from './types';
 
 export function makeStyles<Slots extends string | number, Tokens>(
   stylesBySlots: StylesBySlots<Slots, Tokens>,

--- a/packages/make-styles/src/mergeClasses.test.ts
+++ b/packages/make-styles/src/mergeClasses.test.ts
@@ -1,8 +1,8 @@
 import { mergeClasses } from './mergeClasses';
 import { makeStyles } from './makeStyles';
 import { createDOMRenderer } from './renderer/createDOMRenderer';
-import { MakeStylesOptions } from './types';
 import { SEQUENCE_PREFIX } from './constants';
+import type { MakeStylesOptions } from './types';
 
 const options: MakeStylesOptions = {
   dir: 'ltr',

--- a/packages/make-styles/src/mergeClasses.ts
+++ b/packages/make-styles/src/mergeClasses.ts
@@ -7,7 +7,7 @@ import {
 } from './constants';
 import { hashSequence } from './runtime/utils/hashSequence';
 import { reduceToClassName } from './runtime/reduceToClassNameForSlots';
-import { CSSClassesMap } from './types';
+import type { CSSClassesMap } from './types';
 
 // Contains a mapping of previously resolved sequences of atomic classnames
 const mergeClassesCachedResults: Record<string, string> = {};

--- a/packages/make-styles/src/renderer/createDOMRenderer-node.test.ts
+++ b/packages/make-styles/src/renderer/createDOMRenderer-node.test.ts
@@ -3,9 +3,8 @@
  */
 
 // 👆 this is intentionally to test in SSR like environment
-
-import { CSSRulesByBucket } from '../types';
 import { createDOMRenderer } from './createDOMRenderer';
+import type { CSSRulesByBucket } from '../types';
 
 describe('createDOMRenderer', () => {
   it('"document" should not be defined', () => {

--- a/packages/make-styles/src/renderer/createDOMRenderer.ts
+++ b/packages/make-styles/src/renderer/createDOMRenderer.ts
@@ -1,5 +1,5 @@
-import { MakeStylesRenderer, StyleBucketName } from '../types';
 import { getStyleSheetForBucket } from './getStyleSheetForBucket';
+import type { MakeStylesRenderer, StyleBucketName } from '../types';
 
 let lastIndex = 0;
 

--- a/packages/make-styles/src/renderer/getStyleSheetForBucket.ts
+++ b/packages/make-styles/src/renderer/getStyleSheetForBucket.ts
@@ -1,4 +1,4 @@
-import { MakeStylesRenderer, StyleBucketName } from '../types';
+import type { MakeStylesRenderer, StyleBucketName } from '../types';
 
 /**
  * Ordered style buckets using their short pseudo name.

--- a/packages/make-styles/src/renderer/rehydrateRendererCache.ts
+++ b/packages/make-styles/src/renderer/rehydrateRendererCache.ts
@@ -1,4 +1,4 @@
-import { MakeStylesRenderer, StyleBucketName } from '../types';
+import type { MakeStylesRenderer, StyleBucketName } from '../types';
 
 // Regexps to extract names of classes and animations
 // https://github.com/styletron/styletron/blob/e0fcae826744eb00ce679ac613a1b10d44256660/packages/styletron-engine-atomic/src/client/client.js#L8

--- a/packages/make-styles/src/resolveStyleRulesForSlots.test.ts
+++ b/packages/make-styles/src/resolveStyleRulesForSlots.test.ts
@@ -1,5 +1,5 @@
 import { resolveStyleRulesForSlots } from './resolveStyleRulesForSlots';
-import { StylesBySlots } from './types';
+import type { StylesBySlots } from './types';
 
 describe('resolveStyleRulesForSlots', () => {
   it('returns classnames and CSS rules to apply', () => {

--- a/packages/make-styles/src/resolveStyleRulesForSlots.ts
+++ b/packages/make-styles/src/resolveStyleRulesForSlots.ts
@@ -1,6 +1,6 @@
 import { createCSSVariablesProxy } from './runtime/createCSSVariablesProxy';
 import { resolveStyleRules } from './runtime/resolveStyleRules';
-import {
+import type {
   CSSClassesMapBySlot,
   CSSRulesByBucket,
   MakeStyles,

--- a/packages/make-styles/src/runtime/compileCSS.test.ts
+++ b/packages/make-styles/src/runtime/compileCSS.test.ts
@@ -1,4 +1,5 @@
-import { compileCSS, CompileCSSOptions } from './compileCSS';
+import { compileCSS } from './compileCSS';
+import type { CompileCSSOptions } from './compileCSS';
 
 const defaultOptions: Pick<
   CompileCSSOptions,

--- a/packages/make-styles/src/runtime/compileKeyframeCSS.ts
+++ b/packages/make-styles/src/runtime/compileKeyframeCSS.ts
@@ -1,6 +1,6 @@
-import { MakeStyles } from '../types';
 import { compile, middleware, serialize, stringify, prefixer } from 'stylis';
 import { cssifyObject } from './utils/cssifyObject';
+import type { MakeStyles } from '../types';
 
 export function compileKeyframeRule(frames: MakeStyles): string {
   let css: string = '';

--- a/packages/make-styles/src/runtime/compileStaticCSS.ts
+++ b/packages/make-styles/src/runtime/compileStaticCSS.ts
@@ -1,6 +1,6 @@
-import { MakeStyles } from '../types';
 import { compileCSSRules } from './compileCSS';
 import { cssifyObject } from './utils/cssifyObject';
+import type { MakeStyles } from '../types';
 
 export function compileStaticCSS(property: string, value: MakeStyles): string {
   const cssRule = `${property} {${cssifyObject(value)}}`;

--- a/packages/make-styles/src/runtime/expandShorthand.ts
+++ b/packages/make-styles/src/runtime/expandShorthand.ts
@@ -1,5 +1,5 @@
 import { expandProperty } from 'inline-style-expand-shorthand';
-import { MakeStyles } from '../types';
+import type { MakeStyles } from '../types';
 
 /**
  * A function that expands longhand properties ("margin", "padding") to their shorthand versions ("margin-left", etc.).

--- a/packages/make-styles/src/runtime/getStyleBucketName.ts
+++ b/packages/make-styles/src/runtime/getStyleBucketName.ts
@@ -1,4 +1,4 @@
-import { StyleBucketName } from '../types';
+import type { StyleBucketName } from '../types';
 
 /**
  * Maps the long pseudo name to the short pseudo name. Pseudos that match here will be ordered, everything else will

--- a/packages/make-styles/src/runtime/reduceToClassNameForSlots.ts
+++ b/packages/make-styles/src/runtime/reduceToClassNameForSlots.ts
@@ -1,6 +1,6 @@
 import { DEFINITION_LOOKUP_TABLE } from '../constants';
 import { hashSequence } from './utils/hashSequence';
-import { CSSClassesMapBySlot, CSSClassesMap, CSSClasses } from '../types';
+import type { CSSClassesMapBySlot, CSSClassesMap, CSSClasses } from '../types';
 
 /**
  * Reduces a classname map for slot to a classname string. Uses classnames according to text directions.

--- a/packages/make-styles/src/runtime/resolveStaticStyleRules.ts
+++ b/packages/make-styles/src/runtime/resolveStaticStyleRules.ts
@@ -1,6 +1,6 @@
-import { MakeStaticStyles, CSSRulesByBucket } from '../types';
 import { compileStaticCSS } from './compileStaticCSS';
 import { compileCSSRules } from './compileCSS';
+import type { MakeStaticStyles, CSSRulesByBucket } from '../types';
 
 export function resolveStaticStyleRules(styles: MakeStaticStyles, result: CSSRulesByBucket = {}): CSSRulesByBucket {
   if (typeof styles === 'string') {

--- a/packages/make-styles/src/runtime/resolveStyleRules.test.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.test.ts
@@ -1,6 +1,6 @@
 import { makeStylesRulesSerializer } from '../utils/test/snapshotSerializer';
 import { resolveStyleRules } from './resolveStyleRules';
-import { CSSClassesMap, CSSClasses, CSSRulesByBucket } from '../types';
+import type { CSSClassesMap, CSSClasses, CSSRulesByBucket } from '../types';
 
 expect.addSnapshotSerializer(makeStylesRulesSerializer);
 

--- a/packages/make-styles/src/runtime/resolveStyleRules.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.ts
@@ -2,8 +2,7 @@ import hashString from '@emotion/hash';
 import { convert, convertProperty } from 'rtl-css-js/core';
 
 import { HASH_PREFIX } from '../constants';
-import { MakeStyles, CSSClassesMap, CSSRulesByBucket, StyleBucketName } from '../types';
-import { compileCSS, CompileCSSOptions } from './compileCSS';
+import { compileCSS } from './compileCSS';
 import { compileKeyframeRule, compileKeyframesCSS } from './compileKeyframeCSS';
 import { expandShorthand } from './expandShorthand';
 import { generateCombinedQuery } from './utils/generateCombinedMediaQuery';
@@ -16,6 +15,8 @@ import { getStyleBucketName } from './getStyleBucketName';
 import { hashClassName } from './utils/hashClassName';
 import { resolveProxyValues } from './createCSSVariablesProxy';
 import { hashPropertyKey } from './utils/hashPropertyKey';
+import type { MakeStyles, CSSClassesMap, CSSRulesByBucket, StyleBucketName } from '../types';
+import type { CompileCSSOptions } from './compileCSS';
 
 function pushToClassesMap(
   classesMap: CSSClassesMap,

--- a/packages/make-styles/src/runtime/utils/cssifyObject.ts
+++ b/packages/make-styles/src/runtime/utils/cssifyObject.ts
@@ -1,5 +1,5 @@
-import { MakeStyles } from '../../types';
 import { hyphenateProperty } from './hyphenateProperty';
+import type { MakeStyles } from '../../types';
 
 export function cssifyObject(style: MakeStyles) {
   let css = '';

--- a/packages/make-styles/src/runtime/utils/hashPropertyKey.ts
+++ b/packages/make-styles/src/runtime/utils/hashPropertyKey.ts
@@ -1,5 +1,5 @@
 import hash from '@emotion/hash';
-import { PropertyHash } from '../../types';
+import type { PropertyHash } from '../../types';
 
 export function hashPropertyKey(pseudo: string, media: string, support: string, property: string): PropertyHash {
   // uniq key based on property & selector, used for merging later

--- a/packages/make-styles/src/runtime/utils/hashSequence.ts
+++ b/packages/make-styles/src/runtime/utils/hashSequence.ts
@@ -1,7 +1,7 @@
 import hash from '@emotion/hash';
 
 import { SEQUENCE_HASH_LENGTH, SEQUENCE_PREFIX } from '../../constants';
-import { SequenceHash } from '../../types';
+import type { SequenceHash } from '../../types';
 
 function padEndHash(value: string): string {
   const hashLength = value.length;

--- a/packages/make-styles/src/types.ts
+++ b/packages/make-styles/src/types.ts
@@ -1,4 +1,4 @@
-import { Properties as CSSProperties } from 'csstype';
+import type { Properties as CSSProperties } from 'csstype';
 
 export interface MakeStyles extends Omit<CSSProperties, 'animationName'> {
   // TODO Questionable: how else would users target their own children?

--- a/packages/make-styles/src/utils/test/snapshotSerializer.ts
+++ b/packages/make-styles/src/utils/test/snapshotSerializer.ts
@@ -1,7 +1,7 @@
 import * as prettier from 'prettier';
 
 import { resolveStyleRules } from '../../runtime/resolveStyleRules';
-import { MakeStylesRenderer, CSSRulesByBucket, StyleBucketName } from '../../types';
+import type { MakeStylesRenderer, CSSRulesByBucket, StyleBucketName } from '../../types';
 
 export const makeStylesRendererSerializer: jest.SnapshotSerializerPlugin = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/make-styles/tsconfig.json
+++ b/packages/make-styles/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand"],
+    "isolatedModules": true
   }
 }


### PR DESCRIPTION
This change migrates the following package(s) to use import/export type syntax:

`@fluentui/make-styles-webpack-loader`
`@fluentui/make-styles`
`@fluentui/jest-serializer-make-styles`
`@fluentui/foundation-legacy`
`@fluentrui/font-icons-mdl2`
`@fluentui/dom-utilities`
`@fluentui/date-time-utilities`
`@fluentui/babel-make-styles`
`@fluentui/azure-themes`

For more background on why, read about the motivation (and the code-mod) here:

https://github.com/dzearing/transform-typed-imports#motivation

