### PR TITLE
Fix/type imports: pass 10

### DIFF
--- a/change/@fluentui-react-cards-b75611b0-8334-489c-98f8-825823fbc424.json
+++ b/change/@fluentui-react-cards-b75611b0-8334-489c-98f8-825823fbc424.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/react-cards",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-6383b918-04d2-4f71-981a-996b8b3bfeac.json
+++ b/change/@fluentui-react-checkbox-6383b918-04d2-4f71-981a-996b8b3bfeac.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-compose-d80ce812-2a25-429f-9fdd-3bd24f11dd89.json
+++ b/change/@fluentui-react-compose-d80ce812-2a25-429f-9fdd-3bd24f11dd89.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/react-compose",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-conformance-af6fa217-48ef-424b-97c6-958def8e30d2.json
+++ b/change/@fluentui-react-conformance-af6fa217-48ef-424b-97c6-958def8e30d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/react-conformance",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-conformance-af6fa217-48ef-424b-97c6-958def8e30d2.json
+++ b/change/@fluentui-react-conformance-af6fa217-48ef-424b-97c6-958def8e30d2.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
   "packageName": "@fluentui/react-conformance",
   "email": "dzearing@hotmail.com",

--- a/change/@fluentui-react-context-selector-dadbea50-f8d8-44ca-a014-bd75a1937010.json
+++ b/change/@fluentui-react-context-selector-dadbea50-f8d8-44ca-a014-bd75a1937010.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-b85a4859-a680-44eb-bd1e-e38c47914617.json
+++ b/change/@fluentui-react-divider-b85a4859-a680-44eb-bd1e-e38c47914617.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating TypeScript type-only imports/exports to use import/export type syntax.",
+  "packageName": "@fluentui/react-divider",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluentui/react-icons-northstar/src/utils/createSvgIcon.ts
+++ b/packages/fluentui/react-icons-northstar/src/utils/createSvgIcon.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useFluentContext, useStyles, getUnhandledProps } from '@fluentui/react-bindings';
-
-import { SvgIconCreateFnParams, SvgIconProps } from './types';
+import type { SvgIconCreateFnParams, SvgIconProps } from './types';
 
 export const svgIconClassName = 'ui-icon';
 export const svgIconDisplayName = 'SvgIcon';

--- a/packages/fluentui/react-icons-northstar/src/utils/types.ts
+++ b/packages/fluentui/react-icons-northstar/src/utils/types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { AccessibilityAttributes } from '@fluentui/accessibility';
-import { ComponentSlotStyle, ComponentVariablesInput } from '@fluentui/styles';
-import { ComponentDesignProp } from '@fluentui/react-bindings';
+import type { AccessibilityAttributes } from '@fluentui/accessibility';
+import type { ComponentSlotStyle, ComponentVariablesInput } from '@fluentui/styles';
+import type { ComponentDesignProp } from '@fluentui/react-bindings';
 
 // copy from @fluentui/react
 export type SvgIconSizeValue = 'smallest' | 'smaller' | 'small' | 'medium' | 'large' | 'larger' | 'largest';

--- a/packages/fluentui/react-icons-northstar/tsconfig.json
+++ b/packages/fluentui/react-icons-northstar/tsconfig.json
@@ -7,7 +7,8 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "noUnusedParameters": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "isolatedModules": true
   },
   "include": ["src", "test"],
   "references": [

--- a/packages/fluentui/react-northstar-styles-renderer/src/noopRenderer.ts
+++ b/packages/fluentui/react-northstar-styles-renderer/src/noopRenderer.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Renderer } from './types';
+import type { Renderer } from './types';
 
 // Provides a minimal functionality to render components without styles and without runtime errors.
 

--- a/packages/fluentui/react-northstar-styles-renderer/src/types.ts
+++ b/packages/fluentui/react-northstar-styles-renderer/src/types.ts
@@ -1,5 +1,5 @@
-import { ICSSInJSStyle, FontFace } from '@fluentui/styles';
 import * as React from 'react';
+import type { ICSSInJSStyle, FontFace } from '@fluentui/styles';
 
 export type RendererParam = {
   direction: 'ltr' | 'rtl';

--- a/packages/fluentui/react-northstar-styles-renderer/tsconfig.json
+++ b/packages/fluentui/react-northstar-styles-renderer/tsconfig.json
@@ -7,7 +7,8 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "noUnusedParameters": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "isolatedModules": true
   },
   "include": ["src", "test"],
   "references": [

--- a/packages/fluentui/react-telemetry/src/TelemetryPerfFlags.tsx
+++ b/packages/fluentui/react-telemetry/src/TelemetryPerfFlags.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { defaultPerformanceFlags, StylesContextPerformance } from '@fluentui/react-bindings';
+import { defaultPerformanceFlags } from '@fluentui/react-bindings';
 
 import * as styles from './styles';
+import type { StylesContextPerformance } from '@fluentui/react-bindings';
 
 type TelemetryPerfFlagsProps = {
   flags: StylesContextPerformance;

--- a/packages/fluentui/react-telemetry/src/TelemetryPopover.tsx
+++ b/packages/fluentui/react-telemetry/src/TelemetryPopover.tsx
@@ -1,5 +1,5 @@
 import { useEventListener } from '@fluentui/react-component-event-listener';
-import { ProviderContextPrepared, Telemetry, Unstable_FluentContextProvider } from '@fluentui/react-bindings';
+import { Telemetry, Unstable_FluentContextProvider } from '@fluentui/react-bindings';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
@@ -7,6 +7,7 @@ import * as styles from './styles';
 import { TelemetryTable } from './TelemetryTable';
 import { useTelemetryState } from './useTelemetryState';
 import { TelemetryPerfFlags } from './TelemetryPerfFlags';
+import type { ProviderContextPrepared } from '@fluentui/react-bindings';
 
 export type TelemetryPopoverProps = {
   mountNode?: HTMLElement;

--- a/packages/fluentui/react-telemetry/src/TelemetryTable.tsx
+++ b/packages/fluentui/react-telemetry/src/TelemetryTable.tsx
@@ -1,25 +1,24 @@
 import { Telemetry } from '@fluentui/react-bindings';
 import * as React from 'react';
-import {
+import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
+
+import * as styles from './styles';
+import { useIntervalUpdate } from './useIntervalUpdate';
+import { useTelemetryColumns } from './useTelemetryColumns';
+import { useTelemetryData } from './useTelemetryData';
+import type {
   Cell,
   HeaderGroup,
   Row,
   TableOptions,
   TableState,
-  useFilters,
   UseFiltersColumnProps,
-  usePagination,
-  useSortBy,
   UseSortByColumnProps,
   UseSortByState,
-  useTable,
 } from 'react-table';
-
-import * as styles from './styles';
-import { useIntervalUpdate } from './useIntervalUpdate';
-import { useTelemetryColumns, CellAlign } from './useTelemetryColumns';
-import { TelemetryDataTotals, useTelemetryData } from './useTelemetryData';
-import { TelemetryState, TelemetryTableExpandNames } from './useTelemetryState';
+import type { CellAlign } from './useTelemetryColumns';
+import type { TelemetryDataTotals } from './useTelemetryData';
+import type { TelemetryState, TelemetryTableExpandNames } from './useTelemetryState';
 
 type TelemetryTableProps = {
   telemetry: Telemetry;

--- a/packages/fluentui/react-telemetry/src/styles.ts
+++ b/packages/fluentui/react-telemetry/src/styles.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { TelemetryPosition } from './useTelemetryState';
-import { CellAlign } from './useTelemetryColumns';
+import type { TelemetryPosition } from './useTelemetryState';
+import type { CellAlign } from './useTelemetryColumns';
 
 type CellColor = { backgroundColor: string; color: string };
 

--- a/packages/fluentui/react-telemetry/src/useTelemetryColumns.tsx
+++ b/packages/fluentui/react-telemetry/src/useTelemetryColumns.tsx
@@ -1,9 +1,8 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import { CellProps, Column, FilterProps, HeaderProps, UseFiltersColumnProps } from 'react-table';
-
 import * as styles from './styles';
-import { TelemetryDataTotals } from './useTelemetryData';
+import type { CellProps, Column, FilterProps, HeaderProps, UseFiltersColumnProps } from 'react-table';
+import type { TelemetryDataTotals } from './useTelemetryData';
 
 export type CellAlign = 'left' | 'right' | 'center';
 

--- a/packages/fluentui/react-telemetry/src/useTelemetryData.ts
+++ b/packages/fluentui/react-telemetry/src/useTelemetryData.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import { ComponentPerfStats, Telemetry } from '@fluentui/react-bindings';
+import { Telemetry } from '@fluentui/react-bindings';
+import type { ComponentPerfStats } from '@fluentui/react-bindings';
 
 export type TelemetryDataItem = ComponentPerfStats & {
   componentName: string;

--- a/packages/fluentui/react-telemetry/src/useTelemetryState.ts
+++ b/packages/fluentui/react-telemetry/src/useTelemetryState.ts
@@ -1,5 +1,6 @@
-import { defaultPerformanceFlags, StylesContextPerformance } from '@fluentui/react-bindings';
+import { defaultPerformanceFlags } from '@fluentui/react-bindings';
 import * as React from 'react';
+import type { StylesContextPerformance } from '@fluentui/react-bindings';
 
 export type TelemetryPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 export type TelemetryTabs = 'telemetry' | 'performance-flags';

--- a/packages/fluentui/react-telemetry/tsconfig.json
+++ b/packages/fluentui/react-telemetry/tsconfig.json
@@ -7,7 +7,8 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "noUnusedParameters": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "isolatedModules": true
   },
   "include": ["src", "test"],
   "references": [

--- a/packages/fluentui/state/src/createManager.ts
+++ b/packages/fluentui/state/src/createManager.ts
@@ -1,4 +1,4 @@
-import { AnyActions, EnhancedAction, Manager, ManagerConfig } from './types';
+import type { AnyActions, EnhancedAction, Manager, ManagerConfig } from './types';
 
 export const createManager = <State, Actions extends AnyActions>(
   config: ManagerConfig<State, Actions>,

--- a/packages/fluentui/state/src/managers/carouselManager.ts
+++ b/packages/fluentui/state/src/managers/carouselManager.ts
@@ -1,5 +1,5 @@
 import { createManager } from '../createManager';
-import { Manager, ManagerConfig } from '../types';
+import type { Manager, ManagerConfig } from '../types';
 
 export type CarouselActions = {
   setIndexes: (activeIndex: number) => void;

--- a/packages/fluentui/state/src/managers/checkboxManager.ts
+++ b/packages/fluentui/state/src/managers/checkboxManager.ts
@@ -1,5 +1,5 @@
 import { createManager } from '../createManager';
-import { Manager, ManagerConfig } from '../types';
+import type { Manager, ManagerConfig } from '../types';
 
 export type CheckboxActions = {
   toggle: (checked: boolean) => void;

--- a/packages/fluentui/state/src/managers/dialogManager.ts
+++ b/packages/fluentui/state/src/managers/dialogManager.ts
@@ -1,5 +1,5 @@
 import { createManager } from '../createManager';
-import { Manager, ManagerConfig } from '../types';
+import type { Manager, ManagerConfig } from '../types';
 
 export type DialogActions = {
   close: () => void;

--- a/packages/fluentui/state/src/managers/sliderManager.ts
+++ b/packages/fluentui/state/src/managers/sliderManager.ts
@@ -1,5 +1,5 @@
 import { createManager } from '../createManager';
-import { Manager, ManagerConfig } from '../types';
+import type { Manager, ManagerConfig } from '../types';
 
 export type SliderActions = {
   change: (value: string) => void;

--- a/packages/fluentui/state/tsconfig.json
+++ b/packages/fluentui/state/tsconfig.json
@@ -7,7 +7,8 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "noUnusedParameters": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "isolatedModules": true
   },
   "include": ["src", "test"],
   "references": []

--- a/packages/fluentui/styles/src/createTheme.ts
+++ b/packages/fluentui/styles/src/createTheme.ts
@@ -1,5 +1,5 @@
-import { ThemeInput, ThemePrepared } from './types';
 import { withDebugId } from './withDebugId';
+import type { ThemeInput, ThemePrepared } from './types';
 
 export const createTheme = <T = ThemeInput | ThemePrepared>(themeInput: T, debugId): T => {
   return withDebugId(themeInput, debugId);

--- a/packages/fluentui/styles/src/mergeThemes.ts
+++ b/packages/fluentui/styles/src/mergeThemes.ts
@@ -1,7 +1,12 @@
 import * as _ from 'lodash';
 
 import { callable } from './callable';
-import {
+import { isEnabled as isDebugEnabled } from './debugEnabled';
+import { deepmerge } from './deepmerge';
+import { objectKeyToValues } from './objectKeysToValues';
+import { toCompactArray } from './toCompactArray';
+import { withDebugId } from './withDebugId';
+import type {
   ComponentSlotStyle,
   ComponentSlotStylesInput,
   ComponentSlotStylesPrepared,
@@ -19,12 +24,6 @@ import {
   ThemeInput,
   ThemePrepared,
 } from './types';
-
-import { isEnabled as isDebugEnabled } from './debugEnabled';
-import { deepmerge } from './deepmerge';
-import { objectKeyToValues } from './objectKeysToValues';
-import { toCompactArray } from './toCompactArray';
-import { withDebugId } from './withDebugId';
 
 export const emptyTheme: ThemePrepared = {
   siteVariables: {

--- a/packages/fluentui/styles/tsconfig.json
+++ b/packages/fluentui/styles/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../../scripts/typescript/tsconfig.fluentui",
   "compilerOptions": {
     "composite": true,
-    "outDir": "dist/dts"
+    "outDir": "dist/dts",
+    "isolatedModules": true
   },
   "include": ["src", "test"],
   "references": []

--- a/packages/react-cards/etc/react-cards.api.md
+++ b/packages/react-cards/etc/react-cards.api.md
@@ -4,18 +4,18 @@
 
 ```ts
 
-import { IBaseProps } from '@fluentui/react/lib/Utilities';
-import { IComponent } from '@fluentui/foundation-legacy';
-import { IComponentStyles } from '@fluentui/foundation-legacy';
-import { ISlotProp } from '@fluentui/foundation-legacy';
-import { IStackItemProps } from '@fluentui/react/lib/Stack';
-import { IStackItemSlots } from '@fluentui/react/lib/Stack';
-import { IStackItemTokens } from '@fluentui/react/lib/Stack';
-import { IStackProps } from '@fluentui/react/lib/Stack';
-import { IStackSlot } from '@fluentui/react/lib/Stack';
-import { IStackSlots } from '@fluentui/react/lib/Stack';
-import { IStackTokens } from '@fluentui/react/lib/Stack';
-import { IStyleableComponentProps } from '@fluentui/foundation-legacy';
+import type { IBaseProps } from '@fluentui/react/lib/Utilities';
+import type { IComponent } from '@fluentui/foundation-legacy';
+import type { IComponentStyles } from '@fluentui/foundation-legacy';
+import type { ISlotProp } from '@fluentui/foundation-legacy';
+import type { IStackItemProps } from '@fluentui/react/lib/Stack';
+import type { IStackItemSlots } from '@fluentui/react/lib/Stack';
+import type { IStackItemTokens } from '@fluentui/react/lib/Stack';
+import type { IStackProps } from '@fluentui/react/lib/Stack';
+import type { IStackSlot } from '@fluentui/react/lib/Stack';
+import type { IStackSlots } from '@fluentui/react/lib/Stack';
+import type { IStackTokens } from '@fluentui/react/lib/Stack';
+import type { IStyleableComponentProps } from '@fluentui/foundation-legacy';
 import * as React_2 from 'react';
 
 // @public @deprecated (undocumented)

--- a/packages/react-cards/src/components/Card/Card.styles.ts
+++ b/packages/react-cards/src/components/Card/Card.styles.ts
@@ -1,5 +1,5 @@
 import { getGlobalClassNames, HighContrastSelector } from '@fluentui/react/lib/Styling';
-import { ICardComponent, ICardStylesReturnType, ICardTokenReturnType } from './Card.types';
+import type { ICardComponent, ICardStylesReturnType, ICardTokenReturnType } from './Card.types';
 
 const GlobalClassNames = {
   root: 'ms-Card',

--- a/packages/react-cards/src/components/Card/Card.ts
+++ b/packages/react-cards/src/components/Card/Card.ts
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { createComponent } from '@fluentui/foundation-legacy';
 import { CardView } from './Card.view';
 import { CardStyles as styles, CardTokens as tokens } from './Card.styles';
-import { ICardProps } from './Card.types';
 import { CardItem } from './CardItem/CardItem';
-import { ICardItemProps } from './CardItem/CardItem.types';
 import { CardSection } from './CardSection/CardSection';
-import { ICardSectionProps } from './CardSection/CardSection.types';
+import type { ICardProps } from './Card.types';
+import type { ICardItemProps } from './CardItem/CardItem.types';
+import type { ICardSectionProps } from './CardSection/CardSection.types';
 
 const CardStatics = {
   Item: CardItem,

--- a/packages/react-cards/src/components/Card/Card.types.ts
+++ b/packages/react-cards/src/components/Card/Card.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { IStackSlot, IStackTokens } from '@fluentui/react/lib/Stack';
-import { IBaseProps } from '@fluentui/react/lib/Utilities';
-import { IComponent, IComponentStyles, IStyleableComponentProps } from '@fluentui/foundation-legacy';
+import type { IStackSlot, IStackTokens } from '@fluentui/react/lib/Stack';
+import type { IBaseProps } from '@fluentui/react/lib/Utilities';
+import type { IComponent, IComponentStyles, IStyleableComponentProps } from '@fluentui/foundation-legacy';
 
 /**
  * @deprecated This component was experimental and is no longer being developed on, nor will it be supported in the

--- a/packages/react-cards/src/components/Card/Card.view.tsx
+++ b/packages/react-cards/src/components/Card/Card.view.tsx
@@ -2,14 +2,14 @@
 /** @jsx withSlots */
 import * as React from 'react';
 import { withSlots, getSlots } from '@fluentui/foundation-legacy';
-import { Stack, IStackComponent } from '@fluentui/react/lib/Stack';
+import { Stack } from '@fluentui/react/lib/Stack';
 import { getNativeProps, htmlElementProperties, warn, KeyCodes } from '@fluentui/react/lib/Utilities';
-
-import { ICardComponent, ICardProps, ICardSlots, ICardTokens } from './Card.types';
 import { CardItem } from './CardItem/CardItem';
-import { ICardItemProps } from './CardItem/CardItem.types';
 import { CardSection } from './CardSection/CardSection';
-import { ICardSectionProps } from './CardSection/CardSection.types';
+import type { IStackComponent } from '@fluentui/react/lib/Stack';
+import type { ICardComponent, ICardProps, ICardSlots, ICardTokens } from './Card.types';
+import type { ICardItemProps } from './CardItem/CardItem.types';
+import type { ICardSectionProps } from './CardSection/CardSection.types';
 
 /** @deprecated */
 export const CardView: ICardComponent['view'] = props => {

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.styles.ts
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.styles.ts
@@ -1,5 +1,5 @@
 import { getGlobalClassNames } from '@fluentui/react/lib/Styling';
-import { ICardItemComponent, ICardItemStylesReturnType, ICardItemTokenReturnType } from './CardItem.types';
+import type { ICardItemComponent, ICardItemStylesReturnType, ICardItemTokenReturnType } from './CardItem.types';
 
 const GlobalClassNames = {
   root: 'ms-CardItem',

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.ts
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { createComponent } from '@fluentui/foundation-legacy';
 import { CardItemStyles as styles, CardItemTokens as tokens } from './CardItem.styles';
-import { ICardItemProps } from './CardItem.types';
 import { CardItemView } from './CardItem.view';
+import type { ICardItemProps } from './CardItem.types';
 
 /**
  * @deprecated This component was experimental and is no longer being developed on, nor will it be supported in the

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.types.ts
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.types.ts
@@ -1,6 +1,6 @@
-import { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@fluentui/foundation-legacy';
-import { IStackItemProps, IStackItemSlots, IStackItemTokens } from '@fluentui/react/lib/Stack';
-import { IBaseProps } from '@fluentui/react/lib/Utilities';
+import type { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@fluentui/foundation-legacy';
+import type { IStackItemProps, IStackItemSlots, IStackItemTokens } from '@fluentui/react/lib/Stack';
+import type { IBaseProps } from '@fluentui/react/lib/Utilities';
 
 /**
  * @deprecated This component was experimental and is no longer being developed on, nor will it be supported in the

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.view.tsx
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.view.tsx
@@ -2,7 +2,7 @@
 /** @jsx withSlots */
 import { withSlots, getSlots } from '@fluentui/foundation-legacy';
 import { Stack } from '@fluentui/react/lib/Stack';
-import { ICardItemComponent, ICardItemProps, ICardItemSlots } from './CardItem.types';
+import type { ICardItemComponent, ICardItemProps, ICardItemSlots } from './CardItem.types';
 
 /** @deprecated */
 export const CardItemView: ICardItemComponent['view'] = props => {

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.styles.ts
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.styles.ts
@@ -1,5 +1,9 @@
 import { getGlobalClassNames } from '@fluentui/react/lib/Styling';
-import { ICardSectionComponent, ICardSectionStylesReturnType, ICardSectionTokenReturnType } from './CardSection.types';
+import type {
+  ICardSectionComponent,
+  ICardSectionStylesReturnType,
+  ICardSectionTokenReturnType,
+} from './CardSection.types';
 
 const GlobalClassNames = {
   root: 'ms-CardSection',

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.ts
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { createComponent } from '@fluentui/foundation-legacy';
 import { CardSectionStyles as styles, CardSectionTokens as tokens } from './CardSection.styles';
-import { ICardSectionProps } from './CardSection.types';
 import { CardSectionView } from './CardSection.view';
+import type { ICardSectionProps } from './CardSection.types';
 
 /**
  * @deprecated This component was experimental and is no longer being developed on, nor will it be supported in the

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.types.ts
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.types.ts
@@ -1,6 +1,6 @@
-import { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@fluentui/foundation-legacy';
-import { IStackProps, IStackSlots, IStackTokens } from '@fluentui/react/lib/Stack';
-import { IBaseProps } from '@fluentui/react/lib/Utilities';
+import type { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@fluentui/foundation-legacy';
+import type { IStackProps, IStackSlots, IStackTokens } from '@fluentui/react/lib/Stack';
+import type { IBaseProps } from '@fluentui/react/lib/Utilities';
 
 /**
  * @deprecated This component was experimental and is no longer being developed on, nor will it be supported in the

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.view.tsx
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.view.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { withSlots, getSlots } from '@fluentui/foundation-legacy';
 import { Stack } from '@fluentui/react/lib/Stack';
-import { ICardSectionComponent, ICardSectionProps, ICardSectionSlots } from './CardSection.types';
+import type { ICardSectionComponent, ICardSectionProps, ICardSectionSlots } from './CardSection.types';
 
 /** @deprecated */
 export const CardSectionView: ICardSectionComponent['view'] = props => {

--- a/packages/react-cards/tsconfig.json
+++ b/packages/react-cards/tsconfig.json
@@ -17,7 +17,8 @@
     "preserveConstEnums": true,
     "lib": ["es5", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["jest", "custom-global"]
+    "types": ["jest", "custom-global"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/react-checkbox/etc/react-checkbox.api.md
+++ b/packages/react-checkbox/etc/react-checkbox.api.md
@@ -4,9 +4,9 @@
 
 ```ts
 
-import { ComponentProps } from '@fluentui/react-utilities';
-import { ComponentState } from '@fluentui/react-utilities';
-import { LabelProps } from '@fluentui/react-label';
+import type { ComponentProps } from '@fluentui/react-utilities';
+import type { ComponentState } from '@fluentui/react-utilities';
+import type { LabelProps } from '@fluentui/react-label';
 import * as React_2 from 'react';
 
 // @public

--- a/packages/react-checkbox/src/common/isConformant.ts
+++ b/packages/react-checkbox/src/common/isConformant.ts
@@ -1,4 +1,5 @@
-import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
+import type { IsConformantOptions } from '@fluentui/react-conformance';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },

--- a/packages/react-checkbox/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/Checkbox.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { render, RenderResult, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { Checkbox } from './Checkbox';
 import { mount, ReactWrapper } from 'enzyme';
 import { isConformant } from '../../common/isConformant';
 import { resetIdsForTests } from '@fluentui/react-utilities';
+import type { RenderResult } from '@testing-library/react';
 
 // TODO: add more tests here, and create visual regression tests in /apps/vr-tests
 

--- a/packages/react-checkbox/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/Checkbox.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useCheckbox } from './useCheckbox';
-import { CheckboxProps } from './Checkbox.types';
 import { renderCheckbox } from './renderCheckbox';
 import { useCheckboxStyles } from './useCheckboxStyles';
+import type { CheckboxProps } from './Checkbox.types';
 
 /**
  * A Checkbox component provides a way to represent options that can be selected

--- a/packages/react-checkbox/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react-checkbox/src/components/Checkbox/Checkbox.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
-import { LabelProps } from '@fluentui/react-label';
+import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import type { LabelProps } from '@fluentui/react-label';
 
 export type CheckboxSlots = {
   /**

--- a/packages/react-checkbox/src/components/Checkbox/renderCheckbox.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/renderCheckbox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
-import { CheckboxState, CheckboxSlots } from './Checkbox.types';
 import { checkboxShorthandProps } from './useCheckbox';
+import type { CheckboxState, CheckboxSlots } from './Checkbox.types';
 
 export const renderCheckbox = (state: CheckboxState) => {
   const { slots, slotProps } = getSlots<CheckboxSlots>(state, checkboxShorthandProps);

--- a/packages/react-checkbox/src/components/Checkbox/useCheckbox.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/useCheckbox.tsx
@@ -8,8 +8,8 @@ import {
   useEventCallback,
 } from '@fluentui/react-utilities';
 import { Label } from '@fluentui/react-label';
-import { CheckboxProps, CheckboxState, CheckboxSlots } from './Checkbox.types';
 import { Mixed12Regular, Mixed16Regular, Checkmark12Regular, Checkmark16Regular } from './DefaultIcons';
+import type { CheckboxProps, CheckboxState, CheckboxSlots } from './Checkbox.types';
 
 /**
  * Array of all shorthand properties listed as the keys of CheckboxSlots

--- a/packages/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -1,6 +1,6 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import { createFocusIndicatorStyleRule } from '@fluentui/react-tabster';
-import { CheckboxState } from './Checkbox.types';
+import type { CheckboxState } from './Checkbox.types';
 
 /**
  * Styles for the root slot

--- a/packages/react-checkbox/tsconfig.json
+++ b/packages/react-checkbox/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "storybook__addons"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "storybook__addons"],
+    "isolatedModules": true
   }
 }

--- a/packages/react-compose/src/compose.test.tsx
+++ b/packages/react-compose/src/compose.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { mount, shallow } from 'enzyme';
 import compose from './compose';
 import { mergeProps } from './mergeProps';
-import { ComposePreparedOptions } from './types';
+import type { ComposePreparedOptions } from './types';
 
 describe('compose', () => {
   interface ToggleProps extends React.AllHTMLAttributes<{}> {

--- a/packages/react-compose/src/compose.ts
+++ b/packages/react-compose/src/compose.ts
@@ -1,8 +1,7 @@
 import * as React from 'react';
-
-import { ComponentWithAs, ComposedComponent, ComposeOptions, Input, InputComposeComponent } from './types';
 import { wasComposedPreviously } from './wasComposedPreviously';
 import { mergeComposeOptions } from './mergeComposeOptions';
+import type { ComponentWithAs, ComposedComponent, ComposeOptions, Input, InputComposeComponent } from './types';
 
 function compose<
   TElementType extends keyof JSX.IntrinsicElements,

--- a/packages/react-compose/src/computeDisplayNames.ts
+++ b/packages/react-compose/src/computeDisplayNames.ts
@@ -1,4 +1,5 @@
-import { ComposeOptions, ComposePreparedOptions } from './types';
+import type { ComposeOptions, ComposePreparedOptions } from './types';
+
 /**
  * Given input/parent options, which are both assumed to be defined and populated with
  * displayNames array, return a string array of display names.

--- a/packages/react-compose/src/createClassResolver.ts
+++ b/packages/react-compose/src/createClassResolver.ts
@@ -1,5 +1,5 @@
-import { GenericDictionary, ClassDictionary } from './types';
 import { appendClasses } from './appendClasses';
+import type { GenericDictionary, ClassDictionary } from './types';
 
 /**
  * `createClassResolver` is a factory function which creates a state to classmap resolver for

--- a/packages/react-compose/src/defaultComposeOptions.ts
+++ b/packages/react-compose/src/defaultComposeOptions.ts
@@ -1,4 +1,4 @@
-import { ComposePreparedOptions } from './types';
+import type { ComposePreparedOptions } from './types';
 
 export const defaultComposeOptions: Required<ComposePreparedOptions> = {
   className: process.env.NODE_ENV === 'production' ? '' : 'no-classname-🙉',

--- a/packages/react-compose/src/mergeComposeOptions.ts
+++ b/packages/react-compose/src/mergeComposeOptions.ts
@@ -1,6 +1,6 @@
-import { ComposeOptions, ComposePreparedOptions, Input } from './types';
 import { computeDisplayNames } from './computeDisplayNames';
 import { defaultComposeOptions } from './defaultComposeOptions';
+import type { ComposeOptions, ComposePreparedOptions, Input } from './types';
 
 export function mergeComposeOptions(
   input: Input,

--- a/packages/react-compose/src/mergeProps.test.ts
+++ b/packages/react-compose/src/mergeProps.test.ts
@@ -1,6 +1,6 @@
 import { mergeProps } from './mergeProps';
 import { defaultComposeOptions } from './defaultComposeOptions';
-import { ComposePreparedOptions } from './types';
+import type { ComposePreparedOptions } from './types';
 
 const nullRenderer = () => null;
 

--- a/packages/react-compose/src/mergeProps.ts
+++ b/packages/react-compose/src/mergeProps.ts
@@ -1,6 +1,6 @@
-import { ComposePreparedOptions, MergePropsResult, GenericDictionary } from './types';
 import { resolveClasses } from './resolveClasses';
 import { resolveSlotProps } from './resolveSlotProps';
+import type { ComposePreparedOptions, MergePropsResult, GenericDictionary } from './types';
 
 /**
  * Merge props takes in state and compose options, and resolves slots and slotProps.

--- a/packages/react-compose/src/mergeSlotProp.ts
+++ b/packages/react-compose/src/mergeSlotProp.ts
@@ -1,5 +1,5 @@
-import { SlotProp } from './types';
 import * as React from 'react';
+import type { SlotProp } from './types';
 
 /**
  * Merge props for a slot to a slot prop.

--- a/packages/react-compose/src/resolveClasses.ts
+++ b/packages/react-compose/src/resolveClasses.ts
@@ -1,5 +1,6 @@
-import { ComposePreparedOptions, ClassDictionary, GenericDictionary, MergePropsResult } from './types';
 import { appendClasses } from './appendClasses';
+import type { ComposePreparedOptions, ClassDictionary, GenericDictionary, MergePropsResult } from './types';
+
 /**
  * Helper utility which takes in a classes array from compose options, resolves functions,
  * merges them into a final result, and distributes classnames to slotProps within the given

--- a/packages/react-compose/src/resolveSlotProps.test.tsx
+++ b/packages/react-compose/src/resolveSlotProps.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { resolveSlotProps, NullRender } from './resolveSlotProps';
 import { defaultComposeOptions } from './defaultComposeOptions';
-import { ComposePreparedOptions } from './types';
+import type { ComposePreparedOptions } from './types';
 
 const nullRenderer = () => null;
 

--- a/packages/react-compose/src/resolveSlotProps.ts
+++ b/packages/react-compose/src/resolveSlotProps.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { defaultMappedProps } from './defaultMappedProps';
-import { ComposePreparedOptions, GenericDictionary, MergePropsResult } from './types';
 import { mergeSlotProp } from './mergeSlotProp';
+import type { ComposePreparedOptions, GenericDictionary, MergePropsResult } from './types';
 
 export const NullRender = () => null;
 

--- a/packages/react-compose/src/wasComposedPreviously.ts
+++ b/packages/react-compose/src/wasComposedPreviously.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComposedComponent, Input } from './types';
+import type { ComposedComponent, Input } from './types';
 
 /**
  * compose() allows you to pass two inputs:

--- a/packages/react-compose/tsconfig.json
+++ b/packages/react-compose/tsconfig.json
@@ -15,7 +15,8 @@
     "moduleResolution": "node",
     "lib": ["es5", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["jest", "custom-global"]
+    "types": ["jest", "custom-global"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -1,10 +1,9 @@
-import { IsConformantOptions } from './types';
-
 import { EOL } from 'os';
 import * as _ from 'lodash';
 import * as path from 'path';
 
 import { errorMessageColors, formatArray, getErrorMessage } from './utils/errorMessages';
+import type { IsConformantOptions } from './types';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -1,6 +1,4 @@
-import { TestObject, IsConformantOptions } from './types';
 import { defaultErrorMessages } from './defaultErrorMessages';
-import { ComponentDoc } from 'react-docgen-typescript';
 import { getComponent } from './utils/getComponent';
 import { mount, ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
@@ -10,6 +8,8 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import * as path from 'path';
 import consoleUtil from './utils/consoleUtil';
+import type { TestObject, IsConformantOptions } from './types';
+import type { ComponentDoc } from 'react-docgen-typescript';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 

--- a/packages/react-conformance/src/isConformant.ts
+++ b/packages/react-conformance/src/isConformant.ts
@@ -1,9 +1,8 @@
 import * as fs from 'fs';
-
-import { IsConformantOptions } from './types';
 import { defaultTests } from './defaultTests';
 import { merge } from './utils/merge';
 import { getComponentDoc } from './utils/getComponentDoc';
+import type { IsConformantOptions } from './types';
 
 export function isConformant<TProps = {}>(...testInfo: Partial<IsConformantOptions<TProps>>[]) {
   const mergedOptions = merge<IsConformantOptions>(...testInfo);

--- a/packages/react-conformance/src/types.ts
+++ b/packages/react-conformance/src/types.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { ComponentDoc } from 'react-docgen-typescript';
 import { defaultTests } from './defaultTests';
-import { mount, ComponentType } from 'enzyme';
+import { mount } from 'enzyme';
+import type { ComponentDoc } from 'react-docgen-typescript';
+import type { ComponentType } from 'enzyme';
 
 export type Tests = keyof typeof defaultTests;
 

--- a/packages/react-conformance/src/utils/getComponentDoc.ts
+++ b/packages/react-conformance/src/utils/getComponentDoc.ts
@@ -2,7 +2,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as ts from 'typescript';
 
-import { ComponentDoc, FileParser, withCompilerOptions } from 'react-docgen-typescript';
+import { withCompilerOptions } from 'react-docgen-typescript';
+import type { ComponentDoc, FileParser } from 'react-docgen-typescript';
 
 let program: ts.Program;
 let parser: FileParser;

--- a/packages/react-conformance/tsconfig.json
+++ b/packages/react-conformance/tsconfig.json
@@ -15,7 +15,8 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "lib": ["es2017", "dom"],
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/packages/react-context-selector/src/createContext.ts
+++ b/packages/react-context-selector/src/createContext.ts
@@ -1,8 +1,7 @@
 import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { unstable_NormalPriority as NormalPriority, unstable_runWithPriority as runWithPriority } from 'scheduler';
-
-import { Context, ContextValue } from './types';
+import type { Context, ContextValue } from './types';
 
 const createProvider = <Value>(Original: React.Provider<ContextValue<Value>>) => {
   const Provider: React.FC<React.ProviderProps<Value>> = props => {

--- a/packages/react-context-selector/src/useContextSelector.ts
+++ b/packages/react-context-selector/src/useContextSelector.ts
@@ -1,7 +1,6 @@
 import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 import * as React from 'react';
-
-import { Context, ContextSelector, ContextValue, ContextVersion } from './types';
+import type { Context, ContextSelector, ContextValue, ContextVersion } from './types';
 
 /**
  * Narrowing React.Reducer type to be more easily usable below.

--- a/packages/react-context-selector/src/useHasParentContext.ts
+++ b/packages/react-context-selector/src/useHasParentContext.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Context, ContextValue } from './types';
+import type { Context, ContextValue } from './types';
 
 /**
  * Utility hook for contexts created by react-context-selector to determine if a parent context exists

--- a/packages/react-context-selector/tsconfig.json
+++ b/packages/react-context-selector/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand"],
+    "isolatedModules": true
   }
 }

--- a/packages/react-divider/etc/react-divider.api.md
+++ b/packages/react-divider/etc/react-divider.api.md
@@ -4,9 +4,9 @@
 
 ```ts
 
-import { ComponentPropsCompat } from '@fluentui/react-utilities';
+import type { ComponentPropsCompat } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
-import { ShorthandPropsCompat } from '@fluentui/react-utilities';
+import type { ShorthandPropsCompat } from '@fluentui/react-utilities';
 
 // @public
 export const Divider: React_2.ForwardRefExoticComponent<DividerProps & React_2.RefAttributes<HTMLElement>>;
@@ -38,7 +38,6 @@ export const useDivider: (props: DividerProps, ref: React_2.Ref<HTMLElement>, de
 
 // @public
 export const useDividerStyles: (s: DividerState) => DividerState;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-divider/src/Divider.stories.tsx
+++ b/packages/react-divider/src/Divider.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import { ClockIcon } from './tmp-icons.stories';
-import { Divider, DividerProps } from './index';
+import { Divider } from './index';
+import type { DividerProps } from './index';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 interface DividerStoryProps {

--- a/packages/react-divider/src/common/isConformant.ts
+++ b/packages/react-divider/src/common/isConformant.ts
@@ -1,4 +1,5 @@
-import { isConformant as baseIsConformant, IsConformantOptions } from '@fluentui/react-conformance';
+import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
+import type { IsConformantOptions } from '@fluentui/react-conformance';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },

--- a/packages/react-divider/src/components/Divider/Divider.tsx
+++ b/packages/react-divider/src/components/Divider/Divider.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { DividerProps } from './Divider.types';
 import { renderDivider } from './renderDivider';
 import { useDivider } from './useDivider';
 import { useDividerStyles } from './useDividerStyles';
+import type { DividerProps } from './Divider.types';
 
 /**
  * Define a styled Divider, using the `useDivider` and `useDividerStyles` hooks.

--- a/packages/react-divider/src/components/Divider/Divider.types.ts
+++ b/packages/react-divider/src/components/Divider/Divider.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComponentPropsCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
+import type { ComponentPropsCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
 
 /**
  * {@docCategory Divider}

--- a/packages/react-divider/src/components/Divider/renderDivider.tsx
+++ b/packages/react-divider/src/components/Divider/renderDivider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getSlotsCompat } from '@fluentui/react-utilities';
-import { DividerState } from './Divider.types';
 import { dividerShorthandProps } from './useDivider';
+import type { DividerState } from './Divider.types';
 
 /**
  * Function that renders the final JSX of the component

--- a/packages/react-divider/src/components/Divider/useDivider.ts
+++ b/packages/react-divider/src/components/Divider/useDivider.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeMergeProps, resolveShorthandProps, useId, useMergedRefs } from '@fluentui/react-utilities';
-import { DividerProps, DividerState } from './Divider.types';
+import type { DividerProps, DividerState } from './Divider.types';
 
 /**
  * Consts listing which props are shorthand props.

--- a/packages/react-divider/src/components/Divider/useDividerStyles.ts
+++ b/packages/react-divider/src/components/Divider/useDividerStyles.ts
@@ -1,5 +1,5 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
-import { DividerState } from './Divider.types';
+import type { DividerState } from './Divider.types';
 
 const useStylesOverride = makeStyles({
   root: tokens => ({

--- a/packages/react-divider/tsconfig.json
+++ b/packages/react-divider/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand"]
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand"],
+    "isolatedModules": true
   }
 }


### PR DESCRIPTION
This change migrates the following package(s) to use import/export type syntax:
`@fluentui/react-icons-northstar`
`@fluentui/react-divider`
`@fluentui/react-context-selector`
`@fluentui/react-conformance`
`@fluentui/react-compose`
`@fluentui/react-checkbox`
`@fluentui/react-cards`
`@fluentui/styles`
`@fluentui/state`
`@fluentui/react-telemetry`
`@fluentui/react-northstar-styles-renderer`

For more background on why, read about the motivation (and the code-mod) here:

https://github.com/dzearing/transform-typed-imports#motivation

