### PR TITLE
(react-slider) - Temporarily reverting slot implementation to mergeProps

### DIFF
--- a/packages/react-slider/etc/react-slider.api.md
+++ b/packages/react-slider/etc/react-slider.api.md
@@ -4,9 +4,10 @@
 
 ```ts
 
-import type { ComponentProps } from '@fluentui/react-utilities';
-import type { ComponentState } from '@fluentui/react-utilities';
+import { ComponentPropsCompat } from '@fluentui/react-utilities';
+import { ComponentStateCompat } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
+import { ShorthandPropsCompat } from '@fluentui/react-utilities';
 
 // @public
 export const renderSlider: (state: SliderState) => JSX.Element;
@@ -14,8 +15,12 @@ export const renderSlider: (state: SliderState) => JSX.Element;
 // @public
 export const Slider: React_2.ForwardRefExoticComponent<SliderProps & React_2.RefAttributes<HTMLElement>>;
 
+// @public
+export type SliderDefaultedProps = 'rail' | 'sliderWrapper' | 'trackWrapper' | 'track' | 'thumbWrapper' | 'thumb' | 'activeRail';
+
 // @public (undocumented)
-export interface SliderCommon extends Omit<React_2.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+export interface SliderProps extends ComponentPropsCompat, Omit<React_2.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
+    activeRail?: ShorthandPropsCompat<React_2.HTMLAttributes<HTMLElement> & React_2.RefAttributes<HTMLElement>>;
     ariaValueText?: (value: number) => string;
     defaultValue?: number;
     disabled?: boolean;
@@ -26,37 +31,31 @@ export interface SliderCommon extends Omit<React_2.HTMLAttributes<HTMLDivElement
         value: number;
     }) => void;
     origin?: number;
-    size: 'small' | 'medium';
+    rail?: ShorthandPropsCompat<React_2.HTMLAttributes<HTMLElement>>;
+    size?: 'small' | 'medium';
+    sliderWrapper?: ShorthandPropsCompat<React_2.HTMLAttributes<HTMLElement>>;
     step?: number;
+    thumb?: ShorthandPropsCompat<React_2.HTMLAttributes<HTMLElement> & React_2.RefAttributes<HTMLElement>>;
+    thumbWrapper?: ShorthandPropsCompat<React_2.HTMLAttributes<HTMLElement> & React_2.RefAttributes<HTMLElement>>;
+    track?: ShorthandPropsCompat<React_2.HTMLAttributes<HTMLElement>>;
+    trackWrapper?: ShorthandPropsCompat<React_2.HTMLAttributes<HTMLElement>>;
     value?: number;
     vertical?: boolean;
 }
 
 // @public
-export interface SliderProps extends ComponentProps<Partial<SliderSlots>>, Partial<SliderCommon> {
-}
+export type SliderShorthandProps = 'rail' | 'sliderWrapper' | 'trackWrapper' | 'track' | 'thumbWrapper' | 'thumb' | 'activeRail';
 
 // @public
-export const sliderShorthandProps: Array<keyof SliderSlots>;
+export const sliderShorthandProps: SliderShorthandProps[];
 
 // @public
-export type SliderSlots = {
-    rail: React_2.HTMLAttributes<HTMLElement>;
-    sliderWrapper: React_2.HTMLAttributes<HTMLElement>;
-    trackWrapper: React_2.HTMLAttributes<HTMLElement>;
-    track: React_2.HTMLAttributes<HTMLElement>;
-    thumbWrapper: React_2.HTMLAttributes<HTMLElement> & React_2.RefAttributes<HTMLDivElement>;
-    thumb: React_2.HTMLAttributes<HTMLElement> & React_2.RefAttributes<HTMLElement>;
-    activeRail: React_2.HTMLAttributes<HTMLElement> & React_2.RefAttributes<HTMLDivElement>;
-};
-
-// @public
-export interface SliderState extends ComponentState<SliderSlots>, SliderCommon {
+export interface SliderState extends ComponentStateCompat<SliderProps, SliderShorthandProps, SliderDefaultedProps> {
     ref: React_2.Ref<HTMLElement>;
 }
 
 // @public
-export const useSlider: (props: SliderProps, ref: React_2.Ref<HTMLElement>) => SliderState;
+export const useSlider: (props: SliderProps, ref: React_2.Ref<HTMLElement>, defaultProps?: SliderProps | undefined) => SliderState;
 
 // @public
 export const useSliderStyles: (state: SliderState) => SliderState;

--- a/packages/react-slider/src/components/Slider/Slider.types.ts
+++ b/packages/react-slider/src/components/Slider/Slider.types.ts
@@ -1,48 +1,45 @@
 import * as React from 'react';
-import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import { ComponentPropsCompat, ComponentStateCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
 
-/**
- * Names of the shorthand properties in SliderProps
- */
-export type SliderSlots = {
+export interface SliderProps
+  extends ComponentPropsCompat,
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
   /**
    * The Slider's base. It is used to visibly display the min and max selectable values.
    */
-  rail: React.HTMLAttributes<HTMLElement>;
+  rail?: ShorthandPropsCompat<React.HTMLAttributes<HTMLElement>>;
 
   /**
    * The wrapper around the Slider component.
    */
-  sliderWrapper: React.HTMLAttributes<HTMLElement>;
+  sliderWrapper?: ShorthandPropsCompat<React.HTMLAttributes<HTMLElement>>;
 
   /**
    * The wrapper around the Slider's track. It is primarily used to handle the positioning of the track.
    */
-  trackWrapper: React.HTMLAttributes<HTMLElement>;
+  trackWrapper?: ShorthandPropsCompat<React.HTMLAttributes<HTMLElement>>;
 
   /**
    * The bar showing the current selected area adjacent to the Slider's thumb.
    */
-  track: React.HTMLAttributes<HTMLElement>;
+  track?: ShorthandPropsCompat<React.HTMLAttributes<HTMLElement>>;
 
   /**
    * The wrapper around the Slider's thumb. It is primarily used to handle the dragging animation from translateX.
    */
-  thumbWrapper: React.HTMLAttributes<HTMLElement> & React.RefAttributes<HTMLDivElement>;
+  thumbWrapper?: ShorthandPropsCompat<React.HTMLAttributes<HTMLElement> & React.RefAttributes<HTMLElement>>;
 
   /**
    * The draggable icon used to select a given value from the Slider.
    * This is the element containing `role = 'slider'`.
    */
-  thumb: React.HTMLAttributes<HTMLElement> & React.RefAttributes<HTMLElement>;
+  thumb?: ShorthandPropsCompat<React.HTMLAttributes<HTMLElement> & React.RefAttributes<HTMLElement>>;
 
   /**
    * The area in which the Slider's rail allows for the thumb to be dragged.
    */
-  activeRail: React.HTMLAttributes<HTMLElement> & React.RefAttributes<HTMLDivElement>;
-};
+  activeRail?: ShorthandPropsCompat<React.HTMLAttributes<HTMLElement> & React.RefAttributes<HTMLElement>>;
 
-export interface SliderCommon extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
   /**
    * The starting value for an uncontrolled Slider.
    * Mutually exclusive with `value` prop.
@@ -123,14 +120,33 @@ export interface SliderCommon extends Omit<React.HTMLAttributes<HTMLDivElement>,
 }
 
 /**
- * Slider Props
+ * Names of the shorthand properties in SliderProps
  */
-export interface SliderProps extends ComponentProps<Partial<SliderSlots>>, Partial<SliderCommon> {}
+export type SliderShorthandProps =
+  | 'rail'
+  | 'sliderWrapper'
+  | 'trackWrapper'
+  | 'track'
+  | 'thumbWrapper'
+  | 'thumb'
+  | 'activeRail';
+
+/**
+ * Names of SliderProps that have a default value in useSlider
+ */
+export type SliderDefaultedProps =
+  | 'rail'
+  | 'sliderWrapper'
+  | 'trackWrapper'
+  | 'track'
+  | 'thumbWrapper'
+  | 'thumb'
+  | 'activeRail';
 
 /**
  * State used in rendering Slider
  */
-export interface SliderState extends ComponentState<SliderSlots>, SliderCommon {
+export interface SliderState extends ComponentStateCompat<SliderProps, SliderShorthandProps, SliderDefaultedProps> {
   /**
    * Ref to the root element
    */

--- a/packages/react-slider/src/components/Slider/Slider.types.ts
+++ b/packages/react-slider/src/components/Slider/Slider.types.ts
@@ -103,7 +103,7 @@ export interface SliderProps
    * The size of the Slider.
    * @default 'medium'
    */
-  size: 'small' | 'medium';
+  size?: 'small' | 'medium';
 
   /**
    * Triggers a callback when the value has been changed. This will be called on every individual step.

--- a/packages/react-slider/src/components/Slider/renderSlider.tsx
+++ b/packages/react-slider/src/components/Slider/renderSlider.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import { getSlots } from '@fluentui/react-utilities';
+import { getSlotsCompat } from '@fluentui/react-utilities';
 import { sliderShorthandProps } from './useSlider';
-import type { SliderSlots, SliderState } from './Slider.types';
+import type { SliderState } from './Slider.types';
 
 /**
  * Render the final JSX of Slider
  */
 export const renderSlider = (state: SliderState) => {
-  const { slots, slotProps } = getSlots<SliderSlots>(state, sliderShorthandProps);
+  const { slots, slotProps } = getSlotsCompat(state, sliderShorthandProps);
 
   return (
     <slots.root {...slotProps.root}>

--- a/packages/react-slider/src/components/Slider/useSlider.ts
+++ b/packages/react-slider/src/components/Slider/useSlider.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { resolveShorthand } from '@fluentui/react-utilities';
+import { makeMergeProps, resolveShorthandProps } from '@fluentui/react-utilities';
 import { useSliderState } from './useSliderState';
-import type { SliderProps, SliderSlots, SliderState } from './Slider.types';
+import { SliderProps, SliderShorthandProps, SliderState } from './Slider.types';
 
 /**
  * Array of all shorthand properties listed in SliderShorthandProps
  */
-export const sliderShorthandProps: Array<keyof SliderSlots> = [
+export const sliderShorthandProps: SliderShorthandProps[] = [
   'rail',
   'sliderWrapper',
   'trackWrapper',
@@ -19,19 +19,26 @@ export const sliderShorthandProps: Array<keyof SliderSlots> = [
 /**
  * Given user props, returns state and render function for a Slider.
  */
-export const useSlider = (props: SliderProps, ref: React.Ref<HTMLElement>): SliderState => {
-  const state: SliderState = {
-    ref,
-    size: 'medium',
-    ...props,
-    sliderWrapper: resolveShorthand(props.sliderWrapper, { required: true }),
-    rail: resolveShorthand(props.rail, { required: true }),
-    trackWrapper: resolveShorthand(props.trackWrapper, { required: true }),
-    track: resolveShorthand(props.track, { required: true }),
-    thumbWrapper: resolveShorthand(props.thumbWrapper, { required: true }),
-    thumb: resolveShorthand(props.thumb, { required: true }),
-    activeRail: resolveShorthand(props.activeRail, { required: true }),
-  };
+export const useSlider = (props: SliderProps, ref: React.Ref<HTMLElement>, defaultProps?: SliderProps): SliderState => {
+  const mergeProps = makeMergeProps<SliderState>({
+    deepMerge: sliderShorthandProps,
+  });
+
+  const state = mergeProps(
+    {
+      ref,
+      size: 'medium',
+      sliderWrapper: { as: 'div', children: null },
+      rail: { as: 'div', children: null },
+      trackWrapper: { as: 'div', children: null },
+      track: { as: 'div', children: null },
+      thumbWrapper: { as: 'div', children: null },
+      thumb: { as: 'div', children: null },
+      activeRail: { as: 'div', children: null },
+    },
+    defaultProps && resolveShorthandProps(defaultProps, sliderShorthandProps),
+    resolveShorthandProps(props, sliderShorthandProps),
+  );
 
   useSliderState(state);
 

--- a/packages/react-slider/src/components/Slider/useSlider.ts
+++ b/packages/react-slider/src/components/Slider/useSlider.ts
@@ -27,7 +27,6 @@ export const useSlider = (props: SliderProps, ref: React.Ref<HTMLElement>, defau
   const state = mergeProps(
     {
       ref,
-      size: 'medium',
       sliderWrapper: { as: 'div', children: null },
       rail: { as: 'div', children: null },
       trackWrapper: { as: 'div', children: null },

--- a/packages/react-slider/src/components/Slider/useSliderState.tsx
+++ b/packages/react-slider/src/components/Slider/useSliderState.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useBoolean, useControllableState, useEventCallback, useId, useUnmount } from '@fluentui/react-utilities';
-import type { SliderSlots, SliderState, SliderCommon } from './Slider.types';
+import type { SliderState } from './Slider.types';
 
 /**
  * Validates that the `value` is a number and falls between the min and max.
@@ -46,7 +46,7 @@ const on = (element: Element, eventName: string, callback: (ev: any) => void) =>
   return () => element.removeEventListener(eventName, callback);
 };
 
-export const useSliderState = (state: Pick<SliderState, keyof SliderCommon | keyof SliderSlots | 'as' | 'ref'>) => {
+export const useSliderState = (state: SliderState) => {
   const {
     as = 'div',
     value,

--- a/packages/react-slider/src/components/Slider/useSliderStyles.ts
+++ b/packages/react-slider/src/components/Slider/useSliderStyles.ts
@@ -289,7 +289,8 @@ export const useSliderStyles = (state: SliderState): SliderState => {
 
   state.className = mergeClasses(
     rootStyles.root,
-    rootStyles[state.size],
+    // TODO: Remove once compat is reverted
+    rootStyles[state.size || 'medium'],
     state.vertical ? rootStyles.vertical : rootStyles.horizontal,
     !state.disabled && rootStyles.enabled,
     rootStyles.focusIndicator,


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes

Temporarily reverting the `react-slider` package back to using `mergeProps` while the latest slot RFC under goes review.
