### PR TITLE
chore(react-checkbox): Temporarily revert slot implementation to mergeProps

### DIFF
--- a/change/@fluentui-react-checkbox-46f7d798-b9e5-4221-a332-7321149a23f7.json
+++ b/change/@fluentui-react-checkbox-46f7d798-b9e5-4221-a332-7321149a23f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Reverting to compat",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-checkbox/etc/react-checkbox.api.md
+++ b/packages/react-checkbox/etc/react-checkbox.api.md
@@ -4,10 +4,11 @@
 
 ```ts
 
-import { ComponentProps } from '@fluentui/react-utilities';
-import { ComponentState } from '@fluentui/react-utilities';
+import { ComponentPropsCompat } from '@fluentui/react-utilities';
+import { ComponentStateCompat } from '@fluentui/react-utilities';
 import { LabelProps } from '@fluentui/react-label';
 import * as React_2 from 'react';
+import { ShorthandPropsCompat } from '@fluentui/react-utilities';
 
 // @public
 export const Checkbox: React_2.ForwardRefExoticComponent<CheckboxProps & React_2.RefAttributes<HTMLElement>>;
@@ -33,20 +34,16 @@ export interface CheckboxOnChangeData {
 }
 
 // @public
-export interface CheckboxProps extends ComponentProps<Partial<CheckboxSlots>>, Partial<CheckboxCommons> {
+export interface CheckboxProps extends ComponentPropsCompat, Partial<CheckboxCommons> {
+    indicator?: ShorthandPropsCompat<React_2.HTMLAttributes<HTMLDivElement>>;
+    input?: ShorthandPropsCompat<React_2.InputHTMLAttributes<HTMLInputElement> & React_2.RefAttributes<HTMLInputElement>>;
 }
 
 // @public
-export const checkboxShorthandProps: (keyof CheckboxSlots)[];
-
-// @public (undocumented)
-export type CheckboxSlots = {
-    input: React_2.InputHTMLAttributes<HTMLInputElement> & React_2.RefAttributes<HTMLInputElement>;
-    indicator: React_2.HtmlHTMLAttributes<HTMLDivElement>;
-};
+export const checkboxShorthandProps: readonly ["indicator", "input"];
 
 // @public
-export interface CheckboxState extends ComponentState<CheckboxSlots>, CheckboxCommons {
+export interface CheckboxState extends ComponentStateCompat<CheckboxProps, 'input' | 'indicator', 'size' | 'labelPosition' | 'input' | 'indicator'> {
     containerClassName?: string;
     ref: React_2.Ref<HTMLElement>;
 }

--- a/packages/react-checkbox/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react-checkbox/src/components/Checkbox/Checkbox.types.ts
@@ -1,18 +1,6 @@
 import * as React from 'react';
-import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import { ComponentPropsCompat, ComponentStateCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
 import { LabelProps } from '@fluentui/react-label';
-
-export type CheckboxSlots = {
-  /**
-   * Hidden input that handles the checkbox's functionality.
-   */
-  input: React.InputHTMLAttributes<HTMLInputElement> & React.RefAttributes<HTMLInputElement>;
-
-  /**
-   * Renders the checkbox, with the checkmark icon as its child when checked.
-   */
-  indicator: React.HtmlHTMLAttributes<HTMLDivElement>;
-};
 
 /**
  * TODO:
@@ -84,12 +72,23 @@ export interface CheckboxOnChangeData {
 /**
  * Checkbox Props
  */
-export interface CheckboxProps extends ComponentProps<Partial<CheckboxSlots>>, Partial<CheckboxCommons> {}
+export interface CheckboxProps extends ComponentPropsCompat, Partial<CheckboxCommons> {
+  /**
+   * Hidden input that handles the checkbox's functionality.
+   */
+  input?: ShorthandPropsCompat<React.InputHTMLAttributes<HTMLInputElement> & React.RefAttributes<HTMLInputElement>>;
+
+  /**
+   * Renders the checkbox, with the checkmark icon as its child when checked.
+   */
+  indicator?: ShorthandPropsCompat<React.HTMLAttributes<HTMLDivElement>>;
+}
 
 /**
  * State used in rendering Checkbox
  */
-export interface CheckboxState extends ComponentState<CheckboxSlots>, CheckboxCommons {
+export interface CheckboxState
+  extends ComponentStateCompat<CheckboxProps, 'input' | 'indicator', 'size' | 'labelPosition' | 'input' | 'indicator'> {
   /**
    * Ref to the root element.
    */

--- a/packages/react-checkbox/src/components/Checkbox/renderCheckbox.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/renderCheckbox.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { getSlots } from '@fluentui/react-utilities';
-import { CheckboxState, CheckboxSlots } from './Checkbox.types';
+import { getSlotsCompat } from '@fluentui/react-utilities';
+import { CheckboxState } from './Checkbox.types';
 import { checkboxShorthandProps } from './useCheckbox';
 
 export const renderCheckbox = (state: CheckboxState) => {
-  const { slots, slotProps } = getSlots<CheckboxSlots>(state, checkboxShorthandProps);
+  const { slots, slotProps } = getSlotsCompat(state, checkboxShorthandProps);
 
   return (
     <slots.root {...slotProps.root}>

--- a/packages/react-checkbox/src/components/Checkbox/useCheckbox.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/useCheckbox.tsx
@@ -41,7 +41,9 @@ export const useCheckbox = (props: CheckboxProps, ref: React.Ref<HTMLElement>): 
         type: 'checkbox',
         children: null,
       },
-      indicator: {},
+      indicator: {
+        as: 'div',
+      },
     },
     resolveShorthandProps(props, checkboxShorthandProps),
   );

--- a/packages/react-checkbox/src/components/Checkbox/useCheckbox.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/useCheckbox.tsx
@@ -1,20 +1,23 @@
 import * as React from 'react';
 import {
-  resolveShorthand,
+  resolveShorthandProps,
+  makeMergeProps,
   useControllableState,
   useId,
   useIsomorphicLayoutEffect,
   useMergedRefs,
   useEventCallback,
 } from '@fluentui/react-utilities';
-import { Label } from '@fluentui/react-label';
-import { CheckboxProps, CheckboxState, CheckboxSlots } from './Checkbox.types';
+import { CheckboxProps, CheckboxState } from './Checkbox.types';
 import { Mixed12Regular, Mixed16Regular, Checkmark12Regular, Checkmark16Regular } from './DefaultIcons';
+import { Label } from '@fluentui/react-label';
 
 /**
  * Array of all shorthand properties listed as the keys of CheckboxSlots
  */
-export const checkboxShorthandProps: (keyof CheckboxSlots)[] = ['indicator', 'input'];
+export const checkboxShorthandProps = ['indicator', 'input'] as const;
+
+const mergeProps = makeMergeProps<CheckboxState>({ deepMerge: checkboxShorthandProps });
 
 /**
  * Create the state required to render Checkbox.
@@ -26,29 +29,22 @@ export const checkboxShorthandProps: (keyof CheckboxSlots)[] = ['indicator', 'in
  * @param ref - reference to root HTMLElement of Checkbox
  */
 export const useCheckbox = (props: CheckboxProps, ref: React.Ref<HTMLElement>): CheckboxState => {
-  const state: CheckboxState = {
-    ref,
-    id: useId('checkbox-'),
-    size: 'medium',
-    labelPosition: 'after',
-
-    ...props,
-
-    components: {
-      root: props.children !== undefined ? Label : 'span',
-      indicator: 'div',
-      input: 'input',
-    },
-
-    input: resolveShorthand(props.input, {
-      required: true,
-      defaultProps: {
+  const state: CheckboxState = mergeProps(
+    {
+      ref,
+      as: props.children !== undefined ? Label : 'span',
+      id: useId('checkbox-'),
+      size: 'medium',
+      labelPosition: 'after',
+      input: {
+        as: 'input',
         type: 'checkbox',
         children: null,
       },
-    }),
-    indicator: resolveShorthand(props.indicator, { required: true }),
-  };
+      indicator: {},
+    },
+    resolveShorthandProps(props, checkboxShorthandProps),
+  );
 
   const [checked, setCheckedInternal] = useControllableState({
     defaultState: props.defaultChecked,


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes

Temporarily reverting the `react-checkbox` package back to using `mergeProps` while the latest slot RFC under goes review.
