### PR TITLE
chore(react-switch): Temporarily revert slot implementation to mergeProps

### DIFF
--- a/packages/react-switch/etc/react-switch.api.md
+++ b/packages/react-switch/etc/react-switch.api.md
@@ -4,8 +4,8 @@
 
 ```ts
 
-import type { ComponentProps } from '@fluentui/react-utilities';
-import type { ComponentState } from '@fluentui/react-utilities';
+import type { ComponentPropsCompat } from '@fluentui/react-utilities';
+import type { ComponentStateCompat } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 
 // @public
@@ -19,17 +19,14 @@ export interface SwitchCommon extends Omit<React_2.HTMLAttributes<HTMLDivElement
 }
 
 // @public
-export interface SwitchProps extends ComponentProps<Partial<SwitchSlots>>, Partial<SwitchCommon> {
+export interface SwitchProps extends ComponentPropsCompat, Partial<SwitchCommon> {
 }
 
 // @public
-export const switchShorthandProps: Array<keyof SwitchSlots>;
+export const switchShorthandProps: readonly [];
 
 // @public
-export type SwitchSlots = {};
-
-// @public
-export interface SwitchState extends ComponentState<SwitchSlots>, SwitchCommon {
+export interface SwitchState extends ComponentStateCompat<SwitchProps> {
     ref: React_2.Ref<HTMLElement>;
 }
 

--- a/packages/react-switch/src/components/Switch/Switch.types.ts
+++ b/packages/react-switch/src/components/Switch/Switch.types.ts
@@ -1,22 +1,17 @@
 import * as React from 'react';
-import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
-
-/**
- * Names of the shorthand properties in SwitchProps
- */
-export type SwitchSlots = {};
+import type { ComponentPropsCompat, ComponentStateCompat } from '@fluentui/react-utilities';
 
 export interface SwitchCommon extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {}
 
 /**
  * Switch Props
  */
-export interface SwitchProps extends ComponentProps<Partial<SwitchSlots>>, Partial<SwitchCommon> {}
+export interface SwitchProps extends ComponentPropsCompat, Partial<SwitchCommon> {}
 
 /**
  * State used in rendering Switch
  */
-export interface SwitchState extends ComponentState<SwitchSlots>, SwitchCommon {
+export interface SwitchState extends ComponentStateCompat<SwitchProps> {
   /**
    * Ref to the root element
    */

--- a/packages/react-switch/src/components/Switch/renderSwitch.tsx
+++ b/packages/react-switch/src/components/Switch/renderSwitch.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import { getSlots } from '@fluentui/react-utilities';
+import { getSlotsCompat } from '@fluentui/react-utilities';
 import { switchShorthandProps } from './useSwitch';
-import type { SwitchSlots, SwitchState } from './Switch.types';
+import type { SwitchState } from './Switch.types';
 
 /**
  * Render the final JSX of Switch
  */
 export const renderSwitch = (state: SwitchState) => {
-  const { slots, slotProps } = getSlots<SwitchSlots>(state, switchShorthandProps);
+  const { slots, slotProps } = getSlotsCompat(state, switchShorthandProps);
 
   return <slots.root {...slotProps.root}>{state.children}</slots.root>;
 };

--- a/packages/react-switch/src/components/Switch/useSwitch.ts
+++ b/packages/react-switch/src/components/Switch/useSwitch.ts
@@ -1,20 +1,25 @@
 import * as React from 'react';
 import { useSwitchState } from './useSwitchState';
-import type { SwitchProps, SwitchSlots, SwitchState } from './Switch.types';
+import { resolveShorthandProps, makeMergeProps } from '@fluentui/react-utilities';
+import type { SwitchProps, SwitchState } from './Switch.types';
 
 /**
  * Array of all shorthand properties listed in SwitchShorthandProps
  */
-export const switchShorthandProps: Array<keyof SwitchSlots> = [];
+export const switchShorthandProps = [] as const;
+
+const mergeProps = makeMergeProps<SwitchState>({ deepMerge: switchShorthandProps });
 
 /**
  * Given user props, returns state and render function for a Switch.
  */
 export const useSwitch = (props: SwitchProps, ref: React.Ref<HTMLElement>): SwitchState => {
-  const state: SwitchState = {
-    ref,
-    ...props,
-  };
+  const state = mergeProps(
+    {
+      ref,
+    },
+    resolveShorthandProps(props, switchShorthandProps),
+  );
 
   useSwitchState(state);
 

--- a/packages/react-switch/src/components/Switch/useSwitchState.ts
+++ b/packages/react-switch/src/components/Switch/useSwitchState.ts
@@ -1,5 +1,5 @@
-import type { SwitchSlots, SwitchState, SwitchCommon } from './Switch.types';
+import type { SwitchState, SwitchCommon } from './Switch.types';
 
-export const useSwitchState = (state: Pick<SwitchState, keyof SwitchCommon | keyof SwitchSlots | 'as' | 'ref'>) => {
+export const useSwitchState = (state: Pick<SwitchState, keyof SwitchCommon | 'as' | 'ref'>) => {
   return state;
 };


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes

Temporarily reverting the `react-switch` package back to using `mergeProps` while the latest slot RFC under goes review.
