### PR TITLE
(react-card) - Temporarily reverting slot implementation to mergeProps

### DIFF
--- a/packages/react-card/etc/react-card.api.md
+++ b/packages/react-card/etc/react-card.api.md
@@ -4,8 +4,8 @@
 
 ```ts
 
-import { ComponentProps } from '@fluentui/react-utilities';
-import { ComponentState } from '@fluentui/react-utilities';
+import { ComponentPropsCompat } from '@fluentui/react-utilities';
+import { ComponentStateCompat } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 
 // @public
@@ -15,7 +15,7 @@ export const Card: React_2.ForwardRefExoticComponent<CardProps & React_2.RefAttr
 export type CardDefaultedProps = never;
 
 // @public
-export interface CardProps extends ComponentProps, React_2.HTMLAttributes<HTMLElement> {
+export interface CardProps extends ComponentPropsCompat, React_2.HTMLAttributes<HTMLElement> {
 }
 
 // @public
@@ -25,7 +25,7 @@ export type CardShorthandProps = never;
 export const cardShorthandProps: CardShorthandProps[];
 
 // @public
-export interface CardState extends CardProps, ComponentState {
+export interface CardState extends CardProps, ComponentStateCompat<CardProps, CardShorthandProps, CardDefaultedProps> {
     ref: React_2.Ref<HTMLElement>;
 }
 

--- a/packages/react-card/src/components/Card/Card.types.ts
+++ b/packages/react-card/src/components/Card/Card.types.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import { ComponentPropsCompat, ComponentStateCompat } from '@fluentui/react-utilities';
 
 /**
  * Card Props
  */
-export interface CardProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {
+export interface CardProps extends ComponentPropsCompat, React.HTMLAttributes<HTMLElement> {
   /*
    * TODO Add props and slots here
    * Any slot property should be listed in the cardShorthandProps array below
@@ -25,7 +25,7 @@ export type CardDefaultedProps = never; // TODO add names of properties with def
 /**
  * State used in rendering Card
  */
-export interface CardState extends CardProps, ComponentState {
+export interface CardState extends CardProps, ComponentStateCompat<CardProps, CardShorthandProps, CardDefaultedProps> {
   /**
    * Ref to the root element
    */

--- a/packages/react-card/src/components/Card/renderCard.tsx
+++ b/packages/react-card/src/components/Card/renderCard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getSlots } from '@fluentui/react-utilities';
+import { getSlotsCompat } from '@fluentui/react-utilities';
 import { CardState } from './Card.types';
 import { cardShorthandProps } from './useCard';
 
@@ -7,7 +7,7 @@ import { cardShorthandProps } from './useCard';
  * Render the final JSX of Card
  */
 export const renderCard = (state: CardState) => {
-  const { slots, slotProps } = getSlots(state, cardShorthandProps);
+  const { slots, slotProps } = getSlotsCompat(state, cardShorthandProps);
 
   return (
     <slots.root {...slotProps.root}>


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes

Temporarily reverting the `react-card` package back to using `mergeProps` while the latest slot RFC under goes review.
