### PR TITLE
Fix Callout position bug when the 'target' prop has changed.

### DIFF
--- a/change/@fluentui-react-b824c408-0218-4cd4-8b88-e83590f3b739.json
+++ b/change/@fluentui-react-b824c408-0218-4cd4-8b88-e83590f3b739.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix position bug of Callout when target prop has changed.",
+  "packageName": "@fluentui/react",
+  "email": "kinhln@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -244,7 +244,12 @@ function usePositions(
         }
       }, calloutElement.current);
 
-      return () => async.cancelAnimationFrame(timerId);
+      previousTarget.current = target;
+
+      return () => {
+        async.cancelAnimationFrame(timerId);
+        previousTarget.current = undefined;
+      };
     }
   }, [
     hidden,
@@ -260,8 +265,6 @@ function usePositions(
     props,
     target,
   ]);
-
-  previousTarget.current = target;
 
   return positions;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes

In my previous commit (#19228) to fix the Callout position bug, I made a mistake by setting the `previousTarget` value outside the `useEffect()` block. As a result, for certain cases, inside `useEffect()`, `previousTarget` is incorrectly equal to `target`.

The correct fix is to set `previousTarget` at the end of `useEffect()` block. This guarantees if `target` value has changed, we will detect that inside `useEffect()`.

#### Focus areas to test

Tested in Office Online app.