### PR TITLE
chore(react-slider): properly apply nx migrate-converged-pkg to adhere to new dx setup

### DIFF
--- a/change/@fluentui-react-button-d97e005b-38ee-4edf-a440-01eafa33783f.json
+++ b/change/@fluentui-react-button-d97e005b-38ee-4edf-a440-01eafa33783f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "revert(react-button): remove vNext components used in SB  from devDeps that are stale",
+  "packageName": "@fluentui/react-button",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -25,7 +25,6 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/react-menu": "^9.0.0-alpha.68",
     "@fluentui/a11y-testing": "^0.1.0",
     "@fluentui/babel-make-styles": "^9.0.0-alpha.40",
     "@fluentui/eslint-plugin": "^1.4.1",

--- a/packages/react-button/src/MenuButton.stories.tsx
+++ b/packages/react-button/src/MenuButton.stories.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuTrigger } from '@fluentui/react-menu';
+import type { MenuProps } from '@fluentui/react-menu';
 // @ts-ignore
-import type { MenuButtonProps } from './MenuButton';
 /* eslint-enable @typescript-eslint/ban-ts-comment */
 
 import { MenuButton } from './MenuButton';
 import { Playground } from './Playground.stories';
 import { buttonBaseProps } from './buttonBaseProps.stories';
-import type { MenuProps } from '@fluentui/react-menu';
+import type { MenuButtonProps } from './MenuButton';
 import type { PlaygroundProps } from './Playground.types.stories';
 
 const ExampleMenu = (props: MenuButtonProps): JSX.Element => (

--- a/packages/react-button/src/MenuButton.stories.tsx
+++ b/packages/react-button/src/MenuButton.stories.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuTrigger } from '@fluentui/react-menu';
-import type { MenuProps } from '@fluentui/react-menu';
 // @ts-ignore
+import type { MenuProps } from '@fluentui/react-menu';
 /* eslint-enable @typescript-eslint/ban-ts-comment */
 
 import { MenuButton } from './MenuButton';

--- a/packages/react-button/src/MenuButton.stories.tsx
+++ b/packages/react-button/src/MenuButton.stories.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuTrigger } from '@fluentui/react-menu';
+// @ts-ignore
+import type { MenuButtonProps } from './MenuButton';
+/* eslint-enable @typescript-eslint/ban-ts-comment */
+
 import { MenuButton } from './MenuButton';
 import { Playground } from './Playground.stories';
 import { buttonBaseProps } from './buttonBaseProps.stories';
 import type { MenuProps } from '@fluentui/react-menu';
-import type { MenuButtonProps } from './MenuButton';
 import type { PlaygroundProps } from './Playground.types.stories';
 
 const ExampleMenu = (props: MenuButtonProps): JSX.Element => (

--- a/packages/react-slider/.babelrc.json
+++ b/packages/react-slider/.babelrc.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+}

--- a/packages/react-slider/.storybook/main.js
+++ b/packages/react-slider/.storybook/main.js
@@ -1,10 +1,13 @@
 const rootMain = require('../../../.storybook/main');
 
-module.exports = /** @type {Pick<import('../../../.storybook/main').StorybookConfig,'addons'|'stories'|'webpackFinal'>} */ ({
+module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript'|'babel'>} */ ({
+  ...rootMain,
   stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/*.stories.@(ts|tsx)'],
   addons: [...rootMain.addons],
   webpackFinal: (config, options) => {
     const localConfig = { ...rootMain.webpackFinal(config, options) };
+
+    // add your own webpack tweaks if needed
 
     return localConfig;
   },

--- a/packages/react-slider/.storybook/preview.js
+++ b/packages/react-slider/.storybook/preview.js
@@ -1,3 +1,7 @@
 import * as rootPreview from '../../../.storybook/preview';
 
+/** @type {typeof rootPreview.decorators} */
 export const decorators = [...rootPreview.decorators];
+
+/** @type {typeof rootPreview.parameters} */
+export const parameters = { ...rootPreview.parameters };

--- a/packages/react-slider/package.json
+++ b/packages/react-slider/package.json
@@ -18,10 +18,11 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
-    "start-test": "just-scripts jest-watch",
-    "test": "just-scripts test",
-    "update-snapshots": "just-scripts jest -u"
+    "start": "yarn storybook",
+    "test": "jest",
+    "docs": "api-extractor run --config=config/api-extractor.local.json --local",
+    "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-slider/src && yarn docs",
+    "storybook": "start-storybook"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^1.4.1",
@@ -37,7 +38,8 @@
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-test-renderer": "^16.3.0"
+    "react-test-renderer": "^16.3.0",
+    "@fluentui/babel-make-styles": "^9.0.0-alpha.40"
   },
   "dependencies": {
     "@fluentui/react-make-styles": "^9.0.0-alpha.59",

--- a/packages/react-slider/tsconfig.json
+++ b/packages/react-slider/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,
@@ -12,7 +12,6 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "types": ["jest", "custom-global", "inline-style-expand-shorthand"],
-    "isolatedModules": true
+    "types": ["jest", "custom-global", "inline-style-expand-shorthand", "storybook__addons"]
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: additional fix for https://github.com/microsoft/fluentui/issues/18579
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- executed `yarn nx workspace-generator migrate-converged-pkg --name=@fluentui/react-slider`
- Our nx migration generator was not invoked on react-slider (looks like those changes were done manually). this PR fixes it

#### Focus areas to test

(optional)
