### PR TITLE
FluentProvider: Adding ability to auto style correctly when in High Contrast mode

### DIFF
--- a/change/@fluentui-react-button-607e6b68-6ef5-4c02-8c89-01f94fd0697e.json
+++ b/change/@fluentui-react-button-607e6b68-6ef5-4c02-8c89-01f94fd0697e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing some High Contrast styles on hover and pressed states.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-0405ed58-a240-4695-b684-496a248ac99c.json
+++ b/change/@fluentui-react-provider-0405ed58-a240-4695-b684-496a248ac99c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "FluentProvider: Adding ability to auto style correctly when in High Contrast mode.",
+  "packageName": "@fluentui/react-provider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-01338672-c865-4968-be9e-0a27f1cbc900.json
+++ b/change/@fluentui-react-theme-01338672-c865-4968-be9e-0a27f1cbc900.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding high contrast colors to themes.",
+  "packageName": "@fluentui/react-theme",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -42,7 +42,7 @@ const useRootStyles = makeStyles({
     ':hover': {
       background: theme.alias.color.neutral.neutralBackground1Hover,
       borderColor: theme.alias.color.neutral.neutralStroke1Hover,
-      color: theme.alias.color.neutral.neutralForeground1,
+      color: theme.alias.color.neutral.neutralForeground2Hover,
 
       cursor: 'pointer',
     },
@@ -50,7 +50,7 @@ const useRootStyles = makeStyles({
     ':active': {
       background: theme.alias.color.neutral.neutralBackground1Pressed,
       borderColor: theme.alias.color.neutral.neutralStroke1Pressed,
-      color: theme.alias.color.neutral.neutralForeground1,
+      color: theme.alias.color.neutral.neutralForeground2Pressed,
 
       outline: 'none',
     },

--- a/packages/react-provider/src/components/FluentProvider/useThemeStyleTag.ts
+++ b/packages/react-provider/src/components/FluentProvider/useThemeStyleTag.ts
@@ -69,7 +69,7 @@ export const useThemeStyleTag = (options: Pick<FluentProviderState, 'theme' | 't
 
     // result: .fluent-provider1 { --css-var: '#fff' }
     return `.${styleTagId} { ${cssVarsAsString} }`;
-  }, [hcMediaQuery, styleTagId, theme]);
+  }, [styleTagId, theme]);
   const previousCssRule = usePrevious(cssRule);
 
   if (styleTag && previousCssRule !== cssRule) {

--- a/packages/react-provider/src/components/FluentProvider/useThemeStyleTag.ts
+++ b/packages/react-provider/src/components/FluentProvider/useThemeStyleTag.ts
@@ -3,7 +3,8 @@ import { themeToCSSVariables } from '@fluentui/react-theme';
 import * as React from 'react';
 import type { FluentProviderState } from './FluentProvider.types';
 
-const hcMediaQuery = window.matchMedia('screen and (-ms-high-contrast: active), (forced-colors: active)');
+const hcMediaQuery =
+  window && window.matchMedia && window.matchMedia('screen and (-ms-high-contrast: active), (forced-colors: active)');
 const globalHcColorTokens = [
   '--global-color-hcButtonFace',
   '--global-color-hcButtonText',
@@ -48,7 +49,7 @@ export const useThemeStyleTag = (options: Pick<FluentProviderState, 'theme' | 't
   const cssRule = React.useMemo(() => {
     const cssVars = themeToCSSVariables(theme);
     let cssVarsAsString = Object.keys(cssVars).reduce((cssVarRule, cssVar) => {
-      if (hcMediaQuery.matches) {
+      if (hcMediaQuery && hcMediaQuery.matches) {
         if (globalHcColorTokens.includes(cssVar)) {
           cssVarRule += `${cssVar}: ${globalHcColorTokensToValuesMapping[cssVar]}; `;
         } else if (cssVar.includes('highContrast')) {
@@ -62,13 +63,13 @@ export const useThemeStyleTag = (options: Pick<FluentProviderState, 'theme' | 't
       return cssVarRule;
     }, '');
 
-    if (hcMediaQuery.matches) {
+    if (hcMediaQuery && hcMediaQuery.matches) {
       cssVarsAsString += 'forced-color-adjust: none;';
     }
 
     // result: .fluent-provider1 { --css-var: '#fff' }
     return `.${styleTagId} { ${cssVarsAsString} }`;
-  }, [styleTagId, theme]);
+  }, [hcMediaQuery, styleTagId, theme]);
   const previousCssRule = usePrevious(cssRule);
 
   if (styleTag && previousCssRule !== cssRule) {

--- a/packages/react-theme/etc/react-theme.api.md
+++ b/packages/react-theme/etc/react-theme.api.md
@@ -430,6 +430,7 @@ export type Theme = {
     };
     alias: {
         color: Record<keyof GlobalSharedColors, SharedColorTokens> & {
+            highContrast: NeutralColorTokens;
             neutral: NeutralColorTokens;
         };
         shadow: ShadowLevelTokens;

--- a/packages/react-theme/src/types.ts
+++ b/packages/react-theme/src/types.ts
@@ -413,6 +413,7 @@ export type Theme = {
   };
   alias: {
     color: Record<keyof GlobalSharedColors, SharedColorTokens> & {
+      highContrast: NeutralColorTokens;
       neutral: NeutralColorTokens;
     };
     shadow: ShadowLevelTokens;

--- a/packages/react-theme/src/utils/createDarkTheme.ts
+++ b/packages/react-theme/src/utils/createDarkTheme.ts
@@ -1,5 +1,6 @@
 import { createShadowLevelTokens } from './shadows';
 import { generateSharedColorTokens, neutralColorTokens } from '../alias/dark';
+import { neutralColorTokens as highContrastColorTokens } from '../alias/highContrast';
 import { createGlobalTheme } from '../global/utils';
 import type { BrandVariants, Theme } from '../types';
 
@@ -10,6 +11,7 @@ export const createDarkTheme: (brand: BrandVariants) => Theme = brand => {
     alias: {
       color: {
         ...generateSharedColorTokens(global.palette),
+        highContrast: highContrastColorTokens,
         neutral: neutralColorTokens,
       } as Theme['alias']['color'],
       shadow: createShadowLevelTokens(neutralColorTokens.neutralShadowAmbient, neutralColorTokens.neutralShadowKey),

--- a/packages/react-theme/src/utils/createHighContrastTheme.ts
+++ b/packages/react-theme/src/utils/createHighContrastTheme.ts
@@ -10,6 +10,7 @@ export const createHighContrastTheme: (brand: BrandVariants) => Theme = brand =>
     alias: {
       color: {
         ...generateSharedColorTokens(global.palette),
+        highContrast: neutralColorTokens,
         neutral: neutralColorTokens,
       } as Theme['alias']['color'],
       shadow: createShadowLevelTokens(neutralColorTokens.neutralShadowAmbient, neutralColorTokens.neutralShadowKey),

--- a/packages/react-theme/src/utils/createLightTheme.ts
+++ b/packages/react-theme/src/utils/createLightTheme.ts
@@ -1,4 +1,5 @@
 import { createShadowLevelTokens } from './shadows';
+import { neutralColorTokens as highContrastColorTokens } from '../alias/highContrast';
 import { generateSharedColorTokens, neutralColorTokens } from '../alias/light';
 import { createGlobalTheme } from '../global/utils';
 import type { BrandVariants, Theme } from '../types';
@@ -10,6 +11,7 @@ export const createLightTheme: (brand: BrandVariants) => Theme = brand => {
     alias: {
       color: {
         ...generateSharedColorTokens(global.palette),
+        highContrast: highContrastColorTokens,
         neutral: neutralColorTokens,
       } as Theme['alias']['color'],
       shadow: createShadowLevelTokens(neutralColorTokens.neutralShadowAmbient, neutralColorTokens.neutralShadowKey),


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR makes changes in the `FluentProvider` to add the ability to auto change the styles to be correct when in High Contrast mode.

Here is an example of how this is working in the `Button` component:

__Before:__
![WithoutAutoHC](https://user-images.githubusercontent.com/7798177/130857521-7afac956-975f-44e0-8ce2-68a9513779f8.gif)

__After:__
![AutoHC](https://user-images.githubusercontent.com/7798177/130857529-ddbd519e-8190-4294-a486-883fe2ad8788.gif)
