### PR TITLE
Charting: Fix AreaChart rendering when using dates with only differing times

### DIFF
--- a/change/@fluentui-react-charting-7fabb26c-f9e4-4f37-b5be-589800ec4f3c.json
+++ b/change/@fluentui-react-charting-7fabb26c-f9e4-4f37-b5be-589800ec4f3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Change date parsing to use toLocalString()",
+  "packageName": "@fluentui/react-charting",
+  "email": "rkilburn@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -323,8 +323,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     while (tempArr.length) {
       const valToCheck = tempArr[0].x instanceof Date ? tempArr[0].x.toLocaleString() : tempArr[0].x;
       const filteredChartPoints: ILineChartDataPoint[] = tempArr.filter(
-        (point: ILineChartDataPoint) =>
-          (point.x instanceof Date ? point.x.toLocaleString() : point.x) === valToCheck,
+        (point: ILineChartDataPoint) => (point.x instanceof Date ? point.x.toLocaleString() : point.x) === valToCheck,
       );
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const singleDataset: any = {};

--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -232,7 +232,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     }
 
     const { xAxisCalloutData, xAxisCalloutAccessibilityData } = lineChartData![0].data[index as number];
-    const formattedDate = pointToHighlight instanceof Date ? pointToHighlight.toLocaleDateString() : pointToHighlight;
+    const formattedDate = pointToHighlight instanceof Date ? pointToHighlight.toLocaleString() : pointToHighlight;
     const modifiedXVal = pointToHighlight instanceof Date ? pointToHighlight.getTime() : pointToHighlight;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const found: any = find(this._calloutPoints, (element: { x: string | number }) => {
@@ -321,10 +321,10 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
 
     let tempArr = allChartPoints;
     while (tempArr.length) {
-      const valToCheck = tempArr[0].x instanceof Date ? tempArr[0].x.toLocaleDateString() : tempArr[0].x;
+      const valToCheck = tempArr[0].x instanceof Date ? tempArr[0].x.toLocaleString() : tempArr[0].x;
       const filteredChartPoints: ILineChartDataPoint[] = tempArr.filter(
         (point: ILineChartDataPoint) =>
-          (point.x instanceof Date ? point.x.toLocaleDateString() : point.x) === valToCheck,
+          (point.x instanceof Date ? point.x.toLocaleString() : point.x) === valToCheck,
       );
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const singleDataset: any = {};
@@ -334,9 +334,9 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
       });
       dataSet.push(singleDataset);
       // removing compared objects from array
-      const val = tempArr[0].x instanceof Date ? tempArr[0].x.toLocaleDateString() : tempArr[0].x;
+      const val = tempArr[0].x instanceof Date ? tempArr[0].x.toLocaleString() : tempArr[0].x;
       tempArr = tempArr.filter(
-        (point: ILineChartDataPoint) => (point.x instanceof Date ? point.x.toLocaleDateString() : point.x) !== val,
+        (point: ILineChartDataPoint) => (point.x instanceof Date ? point.x.toLocaleString() : point.x) !== val,
       );
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
When a series of data is passed to the AreaChart component that uses dates for its x-axis, the following error can occur if all the dates in the series occur on the same day:

`TypeError: Cannot read property 'legend' of undefined`

This is due to `_createDataSet()` within `AreaChart.base.tsx` using Date::toLocaleDateString to group the points together for rendering the chart. This creates too many keys for within the stacked dataset, and causes the error above as an index is then out of bounds later in the rendering.

This PR updates `_createDataSet()` and the callout string to use Date::toLocaleString which resolves the grouping issue, and formats the callout date to include both date and time.

#### Focus areas to test

AreaChart