### PR TITLE
chore(react-tabster): update tabster

### DIFF
--- a/change/@fluentui-react-menu-1af90dd9-446b-4467-b80a-c2d4e9f43ff5.json
+++ b/change/@fluentui-react-menu-1af90dd9-446b-4467-b80a-c2d4e9f43ff5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Upgrading tabster.",
+  "packageName": "@fluentui/react-menu",
+  "email": "marata@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-bee8acef-29f5-448f-9a51-58152289fa28.json
+++ b/change/@fluentui-react-tabster-bee8acef-29f5-448f-9a51-58152289fa28.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrading tabster.",
+  "packageName": "@fluentui/react-tabster",
+  "email": "marata@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/src/components/MenuList/__snapshots__/MenuList.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuList/__snapshots__/MenuList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MenuList renders a default state 1`] = `
 <div
   aria-labelledby=""
-  data-tabster="{\\"focusable\\":{\\"mover\\":{\\"axis\\":1,\\"navigationType\\":1,\\"cyclic\\":true}}}"
+  data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":1}}"
   role="menu"
 >
   Default MenuList

--- a/packages/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-tabster/etc/react-tabster.api.md
@@ -25,15 +25,16 @@ export const useArrowNavigationGroup: (options?: UseArrowNavigationGroupOptions 
 export interface UseArrowNavigationGroupOptions {
     axis?: 'vertical' | 'horizontal';
     circular?: boolean;
+    memorizeCurrent?: boolean;
 }
 
 // @public
 export const useFocusFinders: () => {
-    findAllFocusable: (root: HTMLElement, matcher: (el: HTMLElement) => boolean) => HTMLElement[];
-    findFirstFocusable: (root: HTMLElement) => HTMLElement | null | undefined;
-    findLastFocusable: (root: HTMLElement) => HTMLElement | null | undefined;
-    findNextFocusable: (current: HTMLElement) => HTMLElement | null | undefined;
-    findPrevFocusable: (current: HTMLElement) => HTMLElement | null | undefined;
+    findAllFocusable: (container: HTMLElement, acceptCondition: (el: HTMLElement) => boolean) => HTMLElement[];
+    findFirstFocusable: (container: HTMLElement) => HTMLElement | null | undefined;
+    findLastFocusable: (container: HTMLElement) => HTMLElement | null | undefined;
+    findNextFocusable: (currentElement: HTMLElement) => HTMLElement | null | undefined;
+    findPrevFocusable: (currentElement: HTMLElement) => HTMLElement | null | undefined;
 };
 
 // @public

--- a/packages/react-tabster/package.json
+++ b/packages/react-tabster/package.json
@@ -36,9 +36,9 @@
   "dependencies": {
     "@fluentui/make-styles": "^9.0.0-alpha.31",
     "@fluentui/react-make-styles": "^9.0.0-alpha.59",
-    "keyborg": "^0.7.1",
     "@fluentui/react-shared-contexts": "^9.0.0-alpha.23",
     "@fluentui/react-utilities": "^9.0.0-alpha.41",
+    "keyborg": "^1.0.0",
     "tabster": "^1.0.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-tabster/package.json
+++ b/packages/react-tabster/package.json
@@ -39,7 +39,7 @@
     "keyborg": "^0.7.1",
     "@fluentui/react-shared-contexts": "^9.0.0-alpha.23",
     "@fluentui/react-utilities": "^9.0.0-alpha.41",
-    "tabster": "^0.7.4",
+    "tabster": "^1.0.0",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-tabster/src/hooks/useArrowNavigationGroup.ts
+++ b/packages/react-tabster/src/hooks/useArrowNavigationGroup.ts
@@ -1,5 +1,6 @@
-import { Types } from 'tabster';
+import { Types, getMover } from 'tabster';
 import { useTabsterAttributes } from './useTabsterAttributes';
+import { useTabster } from './useTabster';
 
 export interface UseArrowNavigationGroupOptions {
   /**
@@ -11,6 +12,11 @@ export interface UseArrowNavigationGroupOptions {
    * Focus will cycle to the first/last elements of the group without stopping
    */
   circular?: boolean;
+  /**
+   * Last focused element in the group will be remembered and focused (if still
+   * available) when tabbing from outside of the group
+   */
+  memorizeCurrent?: boolean;
 }
 
 /**
@@ -18,23 +24,28 @@ export interface UseArrowNavigationGroupOptions {
  * @param options - Options to configure keyboard navigation
  */
 export const useArrowNavigationGroup = (options?: UseArrowNavigationGroupOptions) => {
+  const tabster = useTabster();
+
+  if (tabster) {
+    getMover(tabster);
+  }
+
   return useTabsterAttributes({
-    focusable: {
-      mover: {
-        axis: axisToMoverAxis(options?.axis ?? 'vertical'),
-        navigationType: Types.MoverKeys.Arrows,
-        cyclic: !!options?.circular,
-      },
+    mover: {
+      cyclic: !!options?.circular,
+      direction: axisToMoverDirection(options?.axis ?? 'vertical'),
+      memorizeCurrent: options?.memorizeCurrent,
     },
   });
 };
 
-function axisToMoverAxis(axis: UseArrowNavigationGroupOptions['axis']) {
+function axisToMoverDirection(axis: UseArrowNavigationGroupOptions['axis']): Types.MoverDirection {
   switch (axis) {
     case 'horizontal':
-      return Types.MoverAxis.Horizontal;
+      return Types.MoverDirections.Horizontal;
+
     case 'vertical':
     default:
-      return Types.MoverAxis.Vertical;
+      return Types.MoverDirections.Vertical;
   }
 }

--- a/packages/react-tabster/src/hooks/useFocusFinders.ts
+++ b/packages/react-tabster/src/hooks/useFocusFinders.ts
@@ -9,17 +9,29 @@ export const useFocusFinders = () => {
 
   // Narrow props for now and let need dictate additional props in the future
   const findAllFocusable = React.useCallback(
-    (root: HTMLElement, matcher: (el: HTMLElement) => boolean) => tabster?.focusable.findAll(root, matcher) || [],
+    (container: HTMLElement, acceptCondition: (el: HTMLElement) => boolean) =>
+      tabster?.focusable.findAll({ container, acceptCondition }) || [],
     [tabster],
   );
-  const findFirstFocusable = React.useCallback((root: HTMLElement) => tabster?.focusable.findFirst(root), [tabster]);
-  const findLastFocusable = React.useCallback((root: HTMLElement) => tabster?.focusable.findLast(root), [tabster]);
-  const findNextFocusable = React.useCallback((current: HTMLElement) => tabster?.focusable.findNext(current), [
+
+  const findFirstFocusable = React.useCallback(
+    (container: HTMLElement) => tabster?.focusable.findFirst({ container }),
+    [tabster],
+  );
+
+  const findLastFocusable = React.useCallback((container: HTMLElement) => tabster?.focusable.findLast({ container }), [
     tabster,
   ]);
-  const findPrevFocusable = React.useCallback((current: HTMLElement) => tabster?.focusable.findPrev(current), [
-    tabster,
-  ]);
+
+  const findNextFocusable = React.useCallback(
+    (currentElement: HTMLElement) => tabster?.focusable.findNext({ currentElement }),
+    [tabster],
+  );
+
+  const findPrevFocusable = React.useCallback(
+    (currentElement: HTMLElement) => tabster?.focusable.findPrev({ currentElement }),
+    [tabster],
+  );
 
   return {
     findAllFocusable,

--- a/packages/react-tabster/src/hooks/useTabsterAttributes.ts
+++ b/packages/react-tabster/src/hooks/useTabsterAttributes.ts
@@ -9,5 +9,5 @@ export const useTabsterAttributes = (props: TabsterTypes.TabsterAttributeProps):
   // but calling the hook will ensure that a tabster instance exists internally and avoids consumers doing the same
   useTabster();
 
-  return getTabsterAttribute(props, false) as TabsterTypes.TabsterDOMAttribute;
+  return getTabsterAttribute(props);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16537,6 +16537,11 @@ keyborg@^0.7.1:
   resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-0.7.1.tgz#6ee90d616a472e6b028a33b2fcb26f419e203eab"
   integrity sha512-6qap3S5enGXdpjLQ6Q6bIjmTpewc8Ur+zYWJstinWDHtDe8eF6hqxpC/e7MA8g1TS1yk6sEopokq/ZnFBSLZ7w==
 
+keyborg@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-1.0.0.tgz#2c1bd78a1d5b9357345f6cd3c1b661c21303f56e"
+  integrity sha512-kOY0HEqlIRO3qZ96j325JU/KGJz2tlRakK4h/RxCjG6c6Rf/T40vQ73cui090KYz1SCpUnWUqsCIx/SCVYW2LQ==
+
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
@@ -24150,12 +24155,12 @@ table@^6.0.4:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
 
-tabster@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-0.7.4.tgz#8d8ddafc82962517e7a4fe325e426ea2f2e2314f"
-  integrity sha512-9LtbJ2r0yL5eMK5Hu8IqDjeGryB042nqRdGQbgiGeWHzxLyZ+dTVI+BEUcYY3deoKQvKac5PnL251+K01AZS2Q==
+tabster@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-1.0.0.tgz#ba71943d0cabaa743ac028604a90284bb2e82b68"
+  integrity sha512-k6g6jVi4gXT/zFKomyeM8B6Cdsdv2eYQgdnaLI0b7N7JKKF5TMoN2hoXuMKEIc9Swt5JKV2eVJHe+C7U4h07nw==
   dependencies:
-    keyborg "^0.7.1"
+    keyborg "^1.0.0"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16532,11 +16532,6 @@ karma@^5.0.4:
     ua-parser-js "0.7.21"
     yargs "^15.3.1"
 
-keyborg@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-0.7.1.tgz#6ee90d616a472e6b028a33b2fcb26f419e203eab"
-  integrity sha512-6qap3S5enGXdpjLQ6Q6bIjmTpewc8Ur+zYWJstinWDHtDe8eF6hqxpC/e7MA8g1TS1yk6sEopokq/ZnFBSLZ7w==
-
 keyborg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-1.0.0.tgz#2c1bd78a1d5b9357345f6cd3c1b661c21303f56e"


### PR DESCRIPTION
This PR updates `keyborg` & `tabster` packages in `@fluentui/react-tabster` to v1.