### PR TITLE
Panel: header and footer now reflow properly when zoomed in

### DIFF
--- a/change/@fluentui-react-6112fdea-f8c4-4731-90f1-466f69c0e659.json
+++ b/change/@fluentui-react-6112fdea-f8c4-4731-90f1-466f69c0e659.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Panel: header and footer now reflow properly when zoomed in.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Panel/Panel.base.tsx
+++ b/packages/react/src/components/Panel/Panel.base.tsx
@@ -241,16 +241,16 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
               style={customWidthStyles}
               elementToFocusOnDismiss={elementToFocusOnDismiss}
             >
-              <div className={_classNames.commands} data-is-visible={true}>
-                {onRenderNavigation(this.props, this._onRenderNavigation)}
-              </div>
               <div className={_classNames.contentInner}>
-                {(this._hasCustomNavigation || !hasCloseButton) &&
-                  onRenderHeader(this.props, this._onRenderHeader, this._headerTextId)}
                 <div ref={this._allowScrollOnPanel} className={_classNames.scrollableContent} data-is-scrollable={true}>
+                  <div className={_classNames.commands} data-is-visible={true}>
+                    {onRenderNavigation(this.props, this._onRenderNavigation)}
+                  </div>
+                  {(this._hasCustomNavigation || !hasCloseButton) &&
+                    onRenderHeader(this.props, this._onRenderHeader, this._headerTextId)}
                   {onRenderBody(this.props, this._onRenderBody)}
+                  {onRenderFooter(this.props, this._onRenderFooter)}
                 </div>
-                {onRenderFooter(this.props, this._onRenderFooter)}
               </div>
             </FocusTrapZone>
           </div>

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -258,7 +258,14 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     commands: [
       classNames.commands,
       {
-        marginTop: 18,
+        paddingTop: 18,
+        selectors: {
+          [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
+            backgroundColor: semanticColors.bodyBackground,
+            position: 'sticky',
+            top: 0,
+          },
+        },
       },
       hasCustomNavigation && {
         marginTop: 'inherit',
@@ -334,6 +341,12 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         flexShrink: 0,
         borderTop: '1px solid transparent',
         transition: `opacity ${AnimationVariables.durationValue3} ${AnimationVariables.easeFunction2}`,
+        selectors: {
+          [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
+            position: 'sticky',
+            bottom: 0,
+          },
+        },
       },
       isFooterSticky && {
         background: semanticColors.bodyBackground,

--- a/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -165,188 +165,6 @@ exports[`Panel allows the consumer to pass through popup props 1`] = `
           />
           <div
             className=
-                ms-Panel-commands
-                {
-                  margin-top: 18px;
-                }
-            data-is-visible={true}
-          >
-            <div
-              className=
-                  ms-Panel-navigation
-                  {
-                    display: flex;
-                    justify-content: flex-end;
-                  }
-            >
-              <div
-                className=
-                    ms-Panel-header
-                    {
-                      align-self: flex-start;
-                      flex-grow: 1;
-                      padding-left: 24px;
-                      padding-right: 24px;
-                    }
-              >
-                <div
-                  aria-level={3}
-                  className=
-                      ms-Panel-headerText
-                      panel_class
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #323130;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 20px;
-                        font-weight: 600;
-                        hyphens: auto;
-                        line-height: 27px;
-                        overflow-wrap: break-word;
-                        word-break: break-word;
-                        word-wrap: break-word;
-                      }
-                  id="Panel0-headerText"
-                  role="heading"
-                >
-                  Test Panel
-                </div>
-              </div>
-              <button
-                className=
-                    ms-Button
-                    ms-Panel-closeButton
-                    ms-PanelAction-close
-                    ms-Button--icon
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      border-radius: 2px;
-                      border: none;
-                      box-sizing: border-box;
-                      color: #605e5c;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 20px;
-                      font-weight: 400;
-                      height: 32px;
-                      margin-right: 14px;
-                      outline: transparent;
-                      padding-bottom: 0;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 0;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      width: 32px;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid transparent;
-                      bottom: 2px;
-                      content: "";
-                      left: 2px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 2px;
-                      top: 2px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    &:hover {
-                      background-color: #f3f2f1;
-                      color: #323130;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      background-color: #edebe9;
-                      color: #005a9e;
-                    }
-                data-is-focusable={true}
-                data-is-visible={true}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                type="button"
-              >
-                <span
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: center;
-                      }
-                  data-automationid="splitbuttonprimary"
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Button-icon
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          flex-shrink: 0;
-                          font-size: 16px;
-                          height: 16px;
-                          line-height: 16px;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                          text-align: center;
-                        }
-                    data-icon-name="Cancel"
-                    style={
-                      Object {
-                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                      }
-                    }
-                  >
-                    
-                  </i>
-                </span>
-              </button>
-            </div>
-          </div>
-          <div
-            className=
                 ms-Panel-contentInner
                 {
                   display: flex;
@@ -363,6 +181,193 @@ exports[`Panel allows the consumer to pass through popup props 1`] = `
                   }
               data-is-scrollable={true}
             >
+              <div
+                className=
+                    ms-Panel-commands
+                    {
+                      padding-top: 18px;
+                    }
+                    @media (min-height: 480px){& {
+                      background-color: #ffffff;
+                      position: sticky;
+                      top: 0px;
+                    }
+                data-is-visible={true}
+              >
+                <div
+                  className=
+                      ms-Panel-navigation
+                      {
+                        display: flex;
+                        justify-content: flex-end;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Panel-header
+                        {
+                          align-self: flex-start;
+                          flex-grow: 1;
+                          padding-left: 24px;
+                          padding-right: 24px;
+                        }
+                  >
+                    <div
+                      aria-level={3}
+                      className=
+                          ms-Panel-headerText
+                          panel_class
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 20px;
+                            font-weight: 600;
+                            hyphens: auto;
+                            line-height: 27px;
+                            overflow-wrap: break-word;
+                            word-break: break-word;
+                            word-wrap: break-word;
+                          }
+                      id="Panel0-headerText"
+                      role="heading"
+                    >
+                      Test Panel
+                    </div>
+                  </div>
+                  <button
+                    className=
+                        ms-Button
+                        ms-Panel-closeButton
+                        ms-PanelAction-close
+                        ms-Button--icon
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          border-radius: 2px;
+                          border: none;
+                          box-sizing: border-box;
+                          color: #605e5c;
+                          cursor: pointer;
+                          display: inline-block;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 20px;
+                          font-weight: 400;
+                          height: 32px;
+                          margin-right: 14px;
+                          outline: transparent;
+                          padding-bottom: 0;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 0;
+                          position: relative;
+                          text-align: center;
+                          text-decoration: none;
+                          user-select: none;
+                          width: 32px;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                        .ms-Fabric--isFocusVisible &:focus:after {
+                          border: 1px solid transparent;
+                          bottom: 2px;
+                          content: "";
+                          left: 2px;
+                          outline: 1px solid #605e5c;
+                          position: absolute;
+                          right: 2px;
+                          top: 2px;
+                          z-index: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                          bottom: -2px;
+                          left: -2px;
+                          outline-color: ButtonText;
+                          right: -2px;
+                          top: -2px;
+                        }
+                        &:active > * {
+                          left: 0px;
+                          position: relative;
+                          top: 0px;
+                        }
+                        &:hover {
+                          background-color: #f3f2f1;
+                          color: #323130;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          border-color: Highlight;
+                          color: Highlight;
+                        }
+                        &:active {
+                          background-color: #edebe9;
+                          color: #005a9e;
+                        }
+                    data-is-focusable={true}
+                    data-is-visible={true}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className=
+                          ms-Button-flexContainer
+                          {
+                            align-items: center;
+                            display: flex;
+                            flex-wrap: nowrap;
+                            height: 100%;
+                            justify-content: center;
+                          }
+                      data-automationid="splitbuttonprimary"
+                    >
+                      <i
+                        aria-hidden={true}
+                        className=
+                            ms-Icon
+                            ms-Button-icon
+                            {
+                              display: inline-block;
+                            }
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              font-family: "FabricMDL2Icons";
+                              font-style: normal;
+                              font-weight: normal;
+                              speak: none;
+                            }
+                            {
+                              flex-shrink: 0;
+                              font-size: 16px;
+                              height: 16px;
+                              line-height: 16px;
+                              margin-bottom: 0;
+                              margin-left: 4px;
+                              margin-right: 4px;
+                              margin-top: 0;
+                              text-align: center;
+                            }
+                        data-icon-name="Cancel"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
+                      >
+                        
+                      </i>
+                    </span>
+                  </button>
+                </div>
+              </div>
               <div
                 className=
                     ms-Panel-content
@@ -560,188 +565,6 @@ exports[`Panel renders Panel correctly 1`] = `
           />
           <div
             className=
-                ms-Panel-commands
-                {
-                  margin-top: 18px;
-                }
-            data-is-visible={true}
-          >
-            <div
-              className=
-                  ms-Panel-navigation
-                  {
-                    display: flex;
-                    justify-content: flex-end;
-                  }
-            >
-              <div
-                className=
-                    ms-Panel-header
-                    {
-                      align-self: flex-start;
-                      flex-grow: 1;
-                      padding-left: 24px;
-                      padding-right: 24px;
-                    }
-              >
-                <div
-                  aria-level={3}
-                  className=
-                      ms-Panel-headerText
-                      panel_class
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #323130;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 20px;
-                        font-weight: 600;
-                        hyphens: auto;
-                        line-height: 27px;
-                        overflow-wrap: break-word;
-                        word-break: break-word;
-                        word-wrap: break-word;
-                      }
-                  id="Panel0-headerText"
-                  role="heading"
-                >
-                  Test Panel
-                </div>
-              </div>
-              <button
-                className=
-                    ms-Button
-                    ms-Panel-closeButton
-                    ms-PanelAction-close
-                    ms-Button--icon
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      border-radius: 2px;
-                      border: none;
-                      box-sizing: border-box;
-                      color: #605e5c;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 20px;
-                      font-weight: 400;
-                      height: 32px;
-                      margin-right: 14px;
-                      outline: transparent;
-                      padding-bottom: 0;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 0;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      width: 32px;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid transparent;
-                      bottom: 2px;
-                      content: "";
-                      left: 2px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 2px;
-                      top: 2px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    &:hover {
-                      background-color: #f3f2f1;
-                      color: #323130;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      background-color: #edebe9;
-                      color: #005a9e;
-                    }
-                data-is-focusable={true}
-                data-is-visible={true}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                type="button"
-              >
-                <span
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: center;
-                      }
-                  data-automationid="splitbuttonprimary"
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Button-icon
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          flex-shrink: 0;
-                          font-size: 16px;
-                          height: 16px;
-                          line-height: 16px;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                          text-align: center;
-                        }
-                    data-icon-name="Cancel"
-                    style={
-                      Object {
-                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                      }
-                    }
-                  >
-                    
-                  </i>
-                </span>
-              </button>
-            </div>
-          </div>
-          <div
-            className=
                 ms-Panel-contentInner
                 {
                   display: flex;
@@ -758,6 +581,193 @@ exports[`Panel renders Panel correctly 1`] = `
                   }
               data-is-scrollable={true}
             >
+              <div
+                className=
+                    ms-Panel-commands
+                    {
+                      padding-top: 18px;
+                    }
+                    @media (min-height: 480px){& {
+                      background-color: #ffffff;
+                      position: sticky;
+                      top: 0px;
+                    }
+                data-is-visible={true}
+              >
+                <div
+                  className=
+                      ms-Panel-navigation
+                      {
+                        display: flex;
+                        justify-content: flex-end;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Panel-header
+                        {
+                          align-self: flex-start;
+                          flex-grow: 1;
+                          padding-left: 24px;
+                          padding-right: 24px;
+                        }
+                  >
+                    <div
+                      aria-level={3}
+                      className=
+                          ms-Panel-headerText
+                          panel_class
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 20px;
+                            font-weight: 600;
+                            hyphens: auto;
+                            line-height: 27px;
+                            overflow-wrap: break-word;
+                            word-break: break-word;
+                            word-wrap: break-word;
+                          }
+                      id="Panel0-headerText"
+                      role="heading"
+                    >
+                      Test Panel
+                    </div>
+                  </div>
+                  <button
+                    className=
+                        ms-Button
+                        ms-Panel-closeButton
+                        ms-PanelAction-close
+                        ms-Button--icon
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          border-radius: 2px;
+                          border: none;
+                          box-sizing: border-box;
+                          color: #605e5c;
+                          cursor: pointer;
+                          display: inline-block;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 20px;
+                          font-weight: 400;
+                          height: 32px;
+                          margin-right: 14px;
+                          outline: transparent;
+                          padding-bottom: 0;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 0;
+                          position: relative;
+                          text-align: center;
+                          text-decoration: none;
+                          user-select: none;
+                          width: 32px;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                        .ms-Fabric--isFocusVisible &:focus:after {
+                          border: 1px solid transparent;
+                          bottom: 2px;
+                          content: "";
+                          left: 2px;
+                          outline: 1px solid #605e5c;
+                          position: absolute;
+                          right: 2px;
+                          top: 2px;
+                          z-index: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                          bottom: -2px;
+                          left: -2px;
+                          outline-color: ButtonText;
+                          right: -2px;
+                          top: -2px;
+                        }
+                        &:active > * {
+                          left: 0px;
+                          position: relative;
+                          top: 0px;
+                        }
+                        &:hover {
+                          background-color: #f3f2f1;
+                          color: #323130;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          border-color: Highlight;
+                          color: Highlight;
+                        }
+                        &:active {
+                          background-color: #edebe9;
+                          color: #005a9e;
+                        }
+                    data-is-focusable={true}
+                    data-is-visible={true}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className=
+                          ms-Button-flexContainer
+                          {
+                            align-items: center;
+                            display: flex;
+                            flex-wrap: nowrap;
+                            height: 100%;
+                            justify-content: center;
+                          }
+                      data-automationid="splitbuttonprimary"
+                    >
+                      <i
+                        aria-hidden={true}
+                        className=
+                            ms-Icon
+                            ms-Button-icon
+                            {
+                              display: inline-block;
+                            }
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              font-family: "FabricMDL2Icons";
+                              font-style: normal;
+                              font-weight: normal;
+                              speak: none;
+                            }
+                            {
+                              flex-shrink: 0;
+                              font-size: 16px;
+                              height: 16px;
+                              line-height: 16px;
+                              margin-bottom: 0;
+                              margin-left: 4px;
+                              margin-right: 4px;
+                              margin-top: 0;
+                              text-align: center;
+                            }
+                        data-icon-name="Cancel"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
+                      >
+                        
+                      </i>
+                    </span>
+                  </button>
+                </div>
+              </div>
               <div
                 className=
                     ms-Panel-content


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: [Bug 12294](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12294), #10905 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Moved navigation, header and footer inside scrollable content div.
- Added height based media queries that 'fixes' header and footer to panel when current viewport height meets the minimum set.
- Since navigation, header and footer are now inside the scrollable content - when user zooms in and the viewport height no longer meets the minimum, the navigation/header and footer are 'unfixed' and becomes part of the scrollable content.

![Panel Reflow (2)](https://user-images.githubusercontent.com/8649804/131082953-daed6878-7d5c-4e89-bb0f-6dfcf61663fd.gif)

