### PR TITLE
Use Node 14 in PR/CI builds

### DIFF
--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -2,7 +2,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '12.x'
+      versionSpec: '14.x'
       checkLatest: true
     displayName: 'Install Node.js'
 


### PR DESCRIPTION
Update the Node version used in PR/CI builds to 14 so it will support newer syntax including optional chaining.