### PR TITLE
fix(useOnClickOutside): Treat right click/context menu as outside click

### DIFF
--- a/change/@fluentui-react-utilities-3f69e051-8560-427d-bb86-c70cb09c529b.json
+++ b/change/@fluentui-react-utilities-3f69e051-8560-427d-bb86-c70cb09c529b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(useOnClickOutside): Treat right click/context menu as outside click",
+  "packageName": "@fluentui/react-utilities",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/src/hooks/useOnClickOutside.test.ts
+++ b/packages/react-utilities/src/hooks/useOnClickOutside.test.ts
@@ -6,7 +6,7 @@ describe('useOnClickOutside', () => {
     jest.useRealTimers();
   });
 
-  const supportedEvents = ['click', 'touchstart', 'fuiframefocus'];
+  const supportedEvents = ['click', 'touchstart', 'contextmenu', 'fuiframefocus'];
 
   it.each(supportedEvents)('should add %s listener', event => {
     // Arrange

--- a/packages/react-utilities/src/hooks/useOnClickOutside.test.ts
+++ b/packages/react-utilities/src/hooks/useOnClickOutside.test.ts
@@ -16,7 +16,7 @@ describe('useOnClickOutside', () => {
     renderHook(() => useOnClickOutside({ element, callback: jest.fn(), refs: [] }));
 
     // Assert
-    expect(element.addEventListener).toHaveBeenCalledTimes(3);
+    expect(element.addEventListener).toHaveBeenCalledTimes(4);
     expect(element.addEventListener).toHaveBeenCalledWith(event, expect.anything(), true);
   });
 
@@ -29,7 +29,7 @@ describe('useOnClickOutside', () => {
     unmount();
 
     // Assert
-    expect(element.removeEventListener).toHaveBeenCalledTimes(3);
+    expect(element.removeEventListener).toHaveBeenCalledTimes(4);
     expect(element.removeEventListener).toHaveBeenCalledWith(event, expect.anything(), true);
   });
 

--- a/packages/react-utilities/src/hooks/useOnClickOutside.ts
+++ b/packages/react-utilities/src/hooks/useOnClickOutside.ts
@@ -78,7 +78,7 @@ export const useOnClickOutside = (options: UseOnClickOrScrollOutsideOptions) => 
     return () => {
       element?.removeEventListener('click', conditionalHandler, true);
       element?.removeEventListener('touchstart', conditionalHandler, true);
-      element?.addEventListener('contextmenu', conditionalHandler, true);
+      element?.removeEventListener('contextmenu', conditionalHandler, true);
 
       clearTimeout(timeoutId.current);
       currentEvent = undefined;

--- a/packages/react-utilities/src/hooks/useOnClickOutside.ts
+++ b/packages/react-utilities/src/hooks/useOnClickOutside.ts
@@ -67,6 +67,7 @@ export const useOnClickOutside = (options: UseOnClickOrScrollOutsideOptions) => 
       // use capture phase because React can update DOM before the event bubbles to the document
       element?.addEventListener('click', conditionalHandler, true);
       element?.addEventListener('touchstart', conditionalHandler, true);
+      element?.addEventListener('contextmenu', conditionalHandler, true);
     }
 
     // Garbage collect this event after it's no longer useful to avoid memory leaks
@@ -77,6 +78,7 @@ export const useOnClickOutside = (options: UseOnClickOrScrollOutsideOptions) => 
     return () => {
       element?.removeEventListener('click', conditionalHandler, true);
       element?.removeEventListener('touchstart', conditionalHandler, true);
+      element?.addEventListener('contextmenu', conditionalHandler, true);
 
       clearTimeout(timeoutId.current);
       currentEvent = undefined;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #19557
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Treats a right click equally as a normal click for the `useOnClickOutside`. Fixes bug for `Menu` and `Popover`

Before:
![UH318v5oO9](https://user-images.githubusercontent.com/20744592/131319565-8a8db340-7f30-4cec-a954-a24eb6d02194.gif)

After:
![KXGA0QDyQC](https://user-images.githubusercontent.com/20744592/131319737-1c9ba557-2cf5-4110-9f6f-32f52f3408dd.gif)


#### Focus areas to test

(optional)
