### PR TITLE
fix(Tooltip): fix default appearance in HC theme

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -54,6 +54,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `MenuItem` apply focus styles for vertical menu from `getBorderFocusStyles` @annabratseiko ([#19419](https://github.com/microsoft/fluentui/pull/19419))
 - Fix default `Tooltip` (`pointing: false`) to have 4px distance to trigger  @yuanboxue-amber ([#19478](https://github.com/microsoft/fluentui/pull/19478))
 - Replace `SplitButton` shadow-box by `Divider`  @chassunc ([#19477](https://github.com/microsoft/fluentui/pull/19477))
+- Fix `Tooltip` appearance in high contrast theme @yuanboxue-amber ([#19559](https://github.com/microsoft/fluentui/pull/19559))
 
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))

--- a/packages/fluentui/docs/src/examples/components/Tooltip/Types/TooltipExamplePointing.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Tooltip/Types/TooltipExamplePointing.shorthand.steps.ts
@@ -2,6 +2,7 @@ import { buttonClassName } from '@fluentui/react-northstar';
 import { ScreenerTestsConfig } from '@fluentui/scripts/screener';
 
 const config: ScreenerTestsConfig = {
+  themes: ['teams', 'teamsDark', 'teamsHighContrast'],
   steps: [
     builder => builder.hover(`.${buttonClassName}`).snapshot('Shows tooltip'),
     (builder, keys) =>

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Tooltip/tooltipContentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Tooltip/tooltipContentVariables.ts
@@ -4,4 +4,6 @@ export const tooltipContentVariables = (siteVars): Partial<TooltipContentVariabl
   boxShadow: undefined,
   color: siteVars.colors.black,
   backgroundColor: siteVars.colors.white,
+  subtleBackgroundColor: siteVars.colors.white,
+  subtleForegroundColor: siteVars.colors.black,
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

PR #19024 added 'subtle' style for tooltip and made it default. But HC theme was broken. This PR fixes it

Before:  
![Screenshot 2021-08-30 at 16 15 37](https://user-images.githubusercontent.com/28751745/131353426-2587529d-d2e3-4b1d-94ec-cb83d015d75e.png)

After:
![Screenshot 2021-08-30 at 16 15 47](https://user-images.githubusercontent.com/28751745/131353437-869f4188-9814-4440-ba0d-50362be10593.png)
 


#### Focus areas to test

(optional)
