### PR TITLE
POC for using component-specific media queries for WHCM in Fluent vNext

### DIFF
--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -59,6 +59,7 @@ const useStyles = makeStyles({
     fontFamily: theme.global.type.fontFamilies.base,
     fontWeight: theme.global.type.fontWeights.semibold,
     boxShadow: `0 0 0 ${theme.global.strokeWidth.thin} ${theme.alias.color.neutral.transparentStroke} inset`,
+    border: '1px solid transparent',
   }),
 
   textCaption2: theme => ({

--- a/packages/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
+++ b/packages/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
@@ -6,6 +6,7 @@ const useStyles = makeStyles({
   root: theme => ({
     padding: 0,
     borderWidth: theme.global.strokeWidth.thick,
+    forcedColorAdjust: 'none',
   }),
   thinBorder: theme => ({
     borderWidth: theme.global.strokeWidth.thin,

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -239,6 +239,12 @@ const useRootStyles = makeStyles({
       borderColor: 'transparent',
     },
   },
+  disabledFocusable: {
+    ['@media (forced-colors: active)']: {
+      color: 'GrayText',
+      borderColor: 'GrayText',
+    },
+  },
 });
 
 const useRootFocusStyles = makeStyles({
@@ -326,6 +332,7 @@ export const useButtonStyles = (state: ButtonState): ButtonState => {
     (state.disabled || state.disabledFocusable) && state.primary && rootStyles.disabledPrimary,
     (state.disabled || state.disabledFocusable) && state.subtle && rootStyles.disabledSubtle,
     (state.disabled || state.disabledFocusable) && state.transparent && rootStyles.disabledTransparent,
+    state.disabledFocusable && rootStyles.disabledFocusable,
     state.iconOnly && rootIconOnlyStyles[state.size],
     state.className,
   );

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -1,4 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { mergeFallbackCssVariable } from '@fluentui/react-theme';
 import { createFocusIndicatorStyleRule } from '@fluentui/react-tabster';
 import type { ButtonState } from './Button.types';
 
@@ -239,12 +240,12 @@ const useRootStyles = makeStyles({
       borderColor: 'transparent',
     },
   },
-  disabledFocusable: {
+  disabledFocusable: theme => ({
     ['@media (forced-colors: active)']: {
-      color: 'GrayText',
-      borderColor: 'GrayText',
+      color: mergeFallbackCssVariable(theme.alias.color.forced?.foregroundDisabled, 'GrayText'),
+      borderColor: mergeFallbackCssVariable(theme.alias.color.forced?.foregroundDisabled, 'GrayText'),
     },
-  },
+  }),
 });
 
 const useRootFocusStyles = makeStyles({

--- a/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
@@ -115,6 +115,13 @@ const useRootStyles = makeStyles({
       },
     },
   }),
+  disabledFocusable: {
+    ['@media (forced-colors: active)']: {
+      [`& .${CompoundButtonClassNames.secondaryContent}`]: {
+        color: 'GrayText',
+      },
+    },
+  },
 });
 
 const useRootIconOnlyStyles = makeStyles({
@@ -185,6 +192,7 @@ export const useCompoundButtonStyles = (state: CompoundButtonState): CompoundBut
     state.subtle && rootStyles.subtle,
     state.transparent && rootStyles.transparent,
     (state.disabled || state.disabledFocusable) && rootStyles.disabled,
+    state.disabledFocusable && rootStyles.disabledFocusable,
     state.iconOnly && rootIconOnlyStyles[state.size],
     state.className,
   );

--- a/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
@@ -1,6 +1,7 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import { buttonSpacing, useButtonStyles } from '../Button/useButtonStyles';
 import type { CompoundButtonState } from './CompoundButton.types';
+import { mergeFallbackCssVariable } from '@fluentui/react-theme';
 
 const CompoundButtonClassNames = {
   secondaryContent: 'CompoundButton-secondaryContent',
@@ -115,13 +116,13 @@ const useRootStyles = makeStyles({
       },
     },
   }),
-  disabledFocusable: {
+  disabledFocusable: theme => ({
     ['@media (forced-colors: active)']: {
       [`& .${CompoundButtonClassNames.secondaryContent}`]: {
-        color: 'GrayText',
+        color: mergeFallbackCssVariable(theme.alias.color.forced?.foregroundDisabled, 'GrayText'),
       },
     },
-  },
+  }),
 });
 
 const useRootIconOnlyStyles = makeStyles({

--- a/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -1,4 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { mergeFallbackCssVariable } from '@fluentui/react-theme';
 import { useButtonStyles } from '../Button/useButtonStyles';
 import type { ToggleButtonState } from './ToggleButton.types';
 
@@ -20,6 +21,10 @@ const useRootStyles = makeStyles({
       background: theme.alias.color.neutral.neutralBackground1Pressed,
       borderColor: theme.alias.color.neutral.neutralStroke1Pressed,
       color: theme.alias.color.neutral.neutralForeground1,
+    },
+
+    ['@media (forced-colors: active)']: {
+      background: mergeFallbackCssVariable(theme.alias.color.forced?.backgroundHighlight, 'Highlight'),
     },
   }),
   checkedOutline: theme => ({

--- a/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
+++ b/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
@@ -16,6 +16,7 @@ const useStyles = makeStyles({
     backgroundColor: theme.alias.color.neutral.neutralBackground1,
     boxShadow: theme.alias.shadow.shadow16,
     borderRadius: '4px',
+    border: '1px solid transparent',
   }),
 
   inverted: theme => ({
@@ -68,6 +69,8 @@ const useStyles = makeStyles({
       background: 'inherit',
       visibility: 'visible',
       borderBottomRightRadius: theme.global.borderRadius.small,
+      borderBottom: '1px solid transparent',
+      borderRight: '1px solid transparent',
       transform: 'rotate(var(--angle)) translate(0, 50%) rotate(45deg)',
     },
 

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -19,7 +19,7 @@ export const createFocusIndicatorStyleRule = (
   options: CreateFocusIndicatorStyleRuleOptions = defaultOptions,
 ): MakeStylesStyleRule<Theme> => theme => ({
   ':focus-visible': {
-    outline: 'none',
+    outline: '2px solid transparent',
   },
   [`${KEYBOARD_NAV_SELECTOR} :${options.selector || defaultOptions.selector}`]:
     typeof rule === 'function' ? rule(theme) : rule,

--- a/packages/react-theme/etc/react-theme.api.md
+++ b/packages/react-theme/etc/react-theme.api.md
@@ -120,6 +120,24 @@ export type FontWeights = {
 // @public (undocumented)
 export const fontWeights: FontWeights;
 
+// @public
+export type ForcedColorTokens = {
+    background: string;
+    backgroundButton: string;
+    backgroundFormField: string;
+    backgroundHighlight: string;
+    backgroundMark: string;
+    foreground: string;
+    foregroundDisabled: string;
+    foregroundButton: string;
+    foregroundFormField: string;
+    foregroundLink: string;
+    foregroundLinkActive: string;
+    foregroundLinkVisited: string;
+    foregroundHighlight: string;
+    foregroundMark: string;
+};
+
 // @public (undocumented)
 export type GhostColorTokens = {
     ghostBackground: string;
@@ -216,6 +234,9 @@ export type LineHeights = FontSizes;
 
 // @public (undocumented)
 export const lineHeights: LineHeights;
+
+// @public (undocumented)
+export function mergeFallbackCssVariable(cssVariable: string | undefined, fallback: string | undefined): string | undefined;
 
 // @public (undocumented)
 export function mergeThemes(a: Theme | undefined, b: PartialTheme | Theme | undefined): Theme;
@@ -431,6 +452,7 @@ export type Theme = {
     alias: {
         color: Record<keyof GlobalSharedColors, SharedColorTokens> & {
             neutral: NeutralColorTokens;
+            forced?: ForcedColorTokens;
         };
         shadow: ShadowLevelTokens;
     };

--- a/packages/react-theme/src/types.ts
+++ b/packages/react-theme/src/types.ts
@@ -130,6 +130,27 @@ export type SharedColorTokens = {
 };
 
 /**
+ * Design tokens for forced-colors mode override colors
+ * WARNING: should not be used unless forcibly overriding Windows High Contrast colors
+ */
+export type ForcedColorTokens = {
+  background: string;
+  backgroundButton: string;
+  backgroundFormField: string;
+  backgroundHighlight: string;
+  backgroundMark: string;
+  foreground: string;
+  foregroundDisabled: string;
+  foregroundButton: string;
+  foregroundFormField: string;
+  foregroundLink: string;
+  foregroundLinkActive: string;
+  foregroundLinkVisited: string;
+  foregroundHighlight: string;
+  foregroundMark: string;
+};
+
+/**
  * Possible color variant values
  */
 export type ColorVariants = {
@@ -414,6 +435,7 @@ export type Theme = {
   alias: {
     color: Record<keyof GlobalSharedColors, SharedColorTokens> & {
       neutral: NeutralColorTokens;
+      forced?: ForcedColorTokens;
     };
     shadow: ShadowLevelTokens;
   };

--- a/packages/react-theme/src/utils/index.ts
+++ b/packages/react-theme/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './createHighContrastTheme';
 
 export { mergeThemes } from './mergeThemes';
 export * from './themeToCSSVariables';
+export * from './mergeFallbackCssVariable';

--- a/packages/react-theme/src/utils/mergeFallbackCssVariable.test.ts
+++ b/packages/react-theme/src/utils/mergeFallbackCssVariable.test.ts
@@ -1,0 +1,32 @@
+import { mergeFallbackCssVariable } from './mergeFallbackCssVariable';
+
+describe('mergeFallbackCssVariable', () => {
+  it('adds a fallback to a var()', () => {
+    expect(mergeFallbackCssVariable('var(--x)', 'y')).toEqual('var(--x, y)');
+    expect(mergeFallbackCssVariable(' var(something) ', 'else')).toEqual('var(something, else)');
+    expect(mergeFallbackCssVariable('var(--123.xyc-5_final.v2)', '456.$$-oops_final-final.v3')).toEqual(
+      'var(--123.xyc-5_final.v2, 456.$$-oops_final-final.v3)',
+    );
+    expect(mergeFallbackCssVariable('var(--x)', 'var(--y, z)')).toEqual('var(--x, var(--y, z))');
+  });
+  it('replaces an existing fallback', () => {
+    expect(mergeFallbackCssVariable('var(--x, y)', 'z')).toEqual('var(--x, z)');
+  });
+  it('creates a var() with fallback from a css --prop', () => {
+    expect(mergeFallbackCssVariable('--x', 'y')).toEqual('var(--x, y)');
+    expect(mergeFallbackCssVariable('something', 'var(--else)')).toEqual('var(something, var(--else))');
+  });
+  it('returns only the fallback with a missing cssVariable', () => {
+    expect(mergeFallbackCssVariable(undefined, 'fallback')).toEqual('fallback');
+    expect(mergeFallbackCssVariable(null as any, 'fallback')).toEqual('fallback');
+    expect(mergeFallbackCssVariable('', 'fallback')).toEqual('fallback');
+    expect(mergeFallbackCssVariable('var()', 'fallback')).toEqual('fallback');
+    expect(mergeFallbackCssVariable('var( )', 'fallback')).toEqual('fallback');
+    expect(mergeFallbackCssVariable(' ', 'fallback')).toEqual('fallback');
+    expect(mergeFallbackCssVariable({} as any, 'fallback')).toEqual('fallback');
+  });
+  it('returns the original cssVariable with no fallback', () => {
+    expect(mergeFallbackCssVariable('var(--x)', undefined)).toEqual('var(--x)');
+    expect(mergeFallbackCssVariable('#333', undefined)).toEqual('#333');
+  });
+});

--- a/packages/react-theme/src/utils/mergeFallbackCssVariable.ts
+++ b/packages/react-theme/src/utils/mergeFallbackCssVariable.ts
@@ -1,0 +1,32 @@
+/*
+ * Function that accepts either a var(--value) or --value CSS prop, and returns a var()
+ * declaration with a fallback: var(--value, fallback).
+ * If an undefined or non-string cssVariable is passed in, the fallback is returned directly.
+ */
+export function mergeFallbackCssVariable(
+  cssVariable: string | undefined,
+  fallback: string | undefined,
+): string | undefined {
+  if (typeof cssVariable !== 'string') {
+    return fallback ? fallback : cssVariable;
+  }
+
+  const variableParts = cssVariable
+    .split(/[\(\)\,]/)
+    .map(part => part.trim())
+    .filter(part => part.length > 0 && part !== 'var');
+
+  // if both a css variable and fallback were passed in, return a var(value, fallback) declaration
+  if (variableParts.length > 0 && fallback) {
+    return `var(${variableParts[0]}, ${fallback})`;
+  }
+  // if the original cssVariable couldn't be processed, return the fallback
+  else if (fallback) {
+    return fallback;
+  }
+
+  // otherwise return the original value unchanged
+  else {
+    return cssVariable;
+  }
+}

--- a/packages/react-theme/src/utils/mergeFallbackCssVariable.ts
+++ b/packages/react-theme/src/utils/mergeFallbackCssVariable.ts
@@ -3,12 +3,9 @@
  * declaration with a fallback: var(--value, fallback).
  * If an undefined or non-string cssVariable is passed in, the fallback is returned directly.
  */
-export function mergeFallbackCssVariable(
-  cssVariable: string | undefined,
-  fallback: string | undefined,
-): string | undefined {
+export function mergeFallbackCssVariable(cssVariable: string | undefined, fallback: string): string {
   if (typeof cssVariable !== 'string') {
-    return fallback ? fallback : cssVariable;
+    return fallback;
   }
 
   const variableParts = cssVariable
@@ -21,12 +18,5 @@ export function mergeFallbackCssVariable(
     return `var(${variableParts[0]}, ${fallback})`;
   }
   // if the original cssVariable couldn't be processed, return the fallback
-  else if (fallback) {
-    return fallback;
-  }
-
-  // otherwise return the original value unchanged
-  else {
-    return cssVariable;
-  }
+  return fallback;
 }

--- a/packages/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
     fontSize: theme.global.type.fontSizes.base[200],
     lineHeight: theme.global.type.lineHeights.base[200],
     borderRadius: theme.global.borderRadius.medium, // Update tooltipBorderRadius in useTooltip.tsx if this changes
+    border: '1px solid transparent',
 
     background: theme.alias.color.neutral.neutralBackground1,
     color: theme.alias.color.neutral.neutralForeground1,
@@ -49,6 +50,8 @@ const useStyles = makeStyles({
       background: 'inherit',
       visibility: 'visible',
       borderBottomRightRadius: theme.global.borderRadius.small,
+      borderBottom: '1px solid transparent',
+      borderRight: '1px solid transparent',
       transform: 'rotate(var(--angle)) translate(0, 50%) rotate(45deg)',
     },
 


### PR DESCRIPTION
Just a proof of concept, there are some details to iron out (I need to check into what's up with SVG fill nowadays, for instance).

I went through all of the current vNext components and checked the high contrast mode behavior and applied fixes as needed per component.

Individual fixes are up for debate (I made some calls around border vs. outline approach that could easily change), this is mostly just an example of what would be needed to take this approach to windows high contrast mode.