### PR TITLE
FluentProvider: Adding ability to auto style correctly when in High Contrast mode

### DIFF
--- a/change/@fluentui-react-button-bad653be-e6ad-4de6-9694-031f8d2639fc.json
+++ b/change/@fluentui-react-button-bad653be-e6ad-4de6-9694-031f8d2639fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing some High Contrast styles on hover and pressed states.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-56aed909-ef62-4a21-9417-db6ca41fc9fa.json
+++ b/change/@fluentui-react-provider-56aed909-ef62-4a21-9417-db6ca41fc9fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "FluentProvider: Adding ability to auto style correctly when in High Contrast mode.",
+  "packageName": "@fluentui/react-provider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -42,7 +42,7 @@ const useRootStyles = makeStyles({
     ':hover': {
       background: theme.alias.color.neutral.neutralBackground1Hover,
       borderColor: theme.alias.color.neutral.neutralStroke1Hover,
-      color: theme.alias.color.neutral.neutralForeground1,
+      color: theme.alias.color.neutral.neutralForeground2Hover,
 
       cursor: 'pointer',
     },
@@ -50,7 +50,7 @@ const useRootStyles = makeStyles({
     ':active': {
       background: theme.alias.color.neutral.neutralBackground1Pressed,
       borderColor: theme.alias.color.neutral.neutralStroke1Pressed,
-      color: theme.alias.color.neutral.neutralForeground1,
+      color: theme.alias.color.neutral.neutralForeground2Pressed,
 
       outline: 'none',
     },

--- a/packages/react-provider/src/components/FluentProvider/useThemeStyleTag.ts
+++ b/packages/react-provider/src/components/FluentProvider/useThemeStyleTag.ts
@@ -3,6 +3,114 @@ import { themeToCSSVariables } from '@fluentui/react-theme';
 import * as React from 'react';
 import type { FluentProviderState } from './FluentProvider.types';
 
+const hcMediaQuery =
+  window && window.matchMedia && window.matchMedia('screen and (-ms-high-contrast: active), (forced-colors: active)');
+const colorTokens: { [key: string]: string } = {
+  '--alias-color-neutral-neutralForeground1': 'CanvasText',
+  '--alias-color-neutral-neutralForeground2': 'CanvasText',
+  '--alias-color-neutral-neutralForeground2Hover': 'HighlightText',
+  '--alias-color-neutral-neutralForeground2Pressed': 'HighlightText',
+  '--alias-color-neutral-neutralForeground2Selected': 'HighlightText',
+  '--alias-color-neutral-neutralForeground2BrandHover': 'HighlightText',
+  '--alias-color-neutral-neutralForeground2BrandPressed': 'HighlightText',
+  '--alias-color-neutral-neutralForeground2BrandSelected': 'HighlightText',
+  '--alias-color-neutral-neutralForeground3': 'CanvasText',
+  '--alias-color-neutral-neutralForeground3Hover': 'HighlightText',
+  '--alias-color-neutral-neutralForeground3Pressed': 'HighlightText',
+  '--alias-color-neutral-neutralForeground3Selected': 'HighlightText',
+  '--alias-color-neutral-neutralForeground3BrandHover': 'HighlightText',
+  '--alias-color-neutral-neutralForeground3BrandPressed': 'HighlightText',
+  '--alias-color-neutral-neutralForeground3BrandSelected': 'HighlightText',
+  '--alias-color-neutral-neutralForeground4': 'CanvasText',
+  '--alias-color-neutral-neutralForegroundDisabled': 'GrayText',
+  '--alias-color-neutral-brandForegroundLink': 'LinkText',
+  '--alias-color-neutral-brandForegroundLinkHover': 'LinkText',
+  '--alias-color-neutral-brandForegroundLinkPressed': 'LinkText',
+  '--alias-color-neutral-brandForegroundLinkSelected': 'LinkText',
+  '--alias-color-neutral-compoundBrandForeground1': 'Highlight',
+  '--alias-color-neutral-compoundBrandForeground1Hover': 'Highlight',
+  '--alias-color-neutral-compoundBrandForeground1Pressed': 'Highlight',
+  '--alias-color-neutral-brandForeground1': 'CanvasText',
+  '--alias-color-neutral-brandForeground2': 'ButtonText',
+  '--alias-color-neutral-neutralForegroundInverted': 'Canvas',
+  '--alias-color-neutral-neutralForegroundOnBrand': 'ButtonText',
+  '--alias-color-neutral-neutralForegroundInvertedLink': 'LinkText',
+  '--alias-color-neutral-neutralForegroundInvertedLinkHover': 'LinkText',
+  '--alias-color-neutral-neutralForegroundInvertedLinkPressed': 'LinkText',
+  '--alias-color-neutral-neutralForegroundInvertedLinkSelected': 'LinkText',
+  '--alias-color-neutral-neutralBackground1': 'Canvas',
+  '--alias-color-neutral-neutralBackground1Hover': 'Highlight',
+  '--alias-color-neutral-neutralBackground1Pressed': 'Highlight',
+  '--alias-color-neutral-neutralBackground1Selected': 'Highlight',
+  '--alias-color-neutral-neutralBackground2': 'Canvas',
+  '--alias-color-neutral-neutralBackground2Hover': 'Highlight',
+  '--alias-color-neutral-neutralBackground2Pressed': 'Highlight',
+  '--alias-color-neutral-neutralBackground2Selected': 'Highlight',
+  '--alias-color-neutral-neutralBackground3': 'Canvas',
+  '--alias-color-neutral-neutralBackground3Hover': 'Highlight',
+  '--alias-color-neutral-neutralBackground3Pressed': 'Highlight',
+  '--alias-color-neutral-neutralBackground3Selected': 'Highlight',
+  '--alias-color-neutral-neutralBackground4': 'Canvas',
+  '--alias-color-neutral-neutralBackground4Hover': 'Highlight',
+  '--alias-color-neutral-neutralBackground4Pressed': 'Highlight',
+  '--alias-color-neutral-neutralBackground4Selected': 'Highlight',
+  '--alias-color-neutral-neutralBackground5': 'Canvas',
+  '--alias-color-neutral-neutralBackground5Hover': 'Highlight',
+  '--alias-color-neutral-neutralBackground5Pressed': 'Highlight',
+  '--alias-color-neutral-neutralBackground5Selected': 'Highlight',
+  '--alias-color-neutral-neutralBackground6': 'Canvas',
+  '--alias-color-neutral-neutralBackgroundInverted': 'CanvasText',
+  '--alias-color-neutral-subtleBackground': 'transparent',
+  '--alias-color-neutral-subtleBackgroundHover': 'Highlight',
+  '--alias-color-neutral-subtleBackgroundPressed': 'Highlight',
+  '--alias-color-neutral-subtleBackgroundSelected': 'Highlight',
+  '--alias-color-neutral-transparentBackground': 'transparent',
+  '--alias-color-neutral-transparentBackgroundHover': 'Highlight',
+  '--alias-color-neutral-transparentBackgroundPressed': 'Highlight',
+  '--alias-color-neutral-transparentBackgroundSelected': 'Highlight',
+  '--alias-color-neutral-neutralBackgroundDisabled': 'Canvas',
+  '--alias-color-neutral-neutralStencil1': 'var(--global-palette-grey-8)',
+  '--alias-color-neutral-neutralStencil2': 'var(--global-palette-grey-52)',
+  '--alias-color-neutral-brandBackground': 'ButtonFace',
+  '--alias-color-neutral-brandBackgroundHover': 'Highlight',
+  '--alias-color-neutral-brandBackgroundPressed': 'Highlight',
+  '--alias-color-neutral-brandBackgroundSelected': 'Highlight',
+  '--alias-color-neutral-compoundBrandBackground': 'Highlight',
+  '--alias-color-neutral-compoundBrandBackgroundHover': 'Highlight',
+  '--alias-color-neutral-compoundBrandBackgroundPressed': 'Highlight',
+  '--alias-color-neutral-brandBackgroundStatic': 'Canvas',
+  '--alias-color-neutral-brandBackground2': 'ButtonFace',
+  '--alias-color-neutral-neutralStrokeAccessible': 'CanvasText',
+  '--alias-color-neutral-neutralStrokeAccessibleHover': 'Highlight',
+  '--alias-color-neutral-neutralStrokeAccessiblePressed': 'Highlight',
+  '--alias-color-neutral-neutralStrokeAccessibleSelected': 'Highlight',
+  '--alias-color-neutral-neutralStroke1': 'CanvasText',
+  '--alias-color-neutral-neutralStroke1Hover': 'Highlight',
+  '--alias-color-neutral-neutralStroke1Pressed': 'Highlight',
+  '--alias-color-neutral-neutralStroke1Selected': 'Highlight',
+  '--alias-color-neutral-neutralStroke2': 'CanvasText',
+  '--alias-color-neutral-neutralStroke3': 'CanvasText',
+  '--alias-color-neutral-brandStroke1': 'CanvasText',
+  '--alias-color-neutral-brandStroke2': 'Canvas',
+  '--alias-color-neutral-compoundBrandStroke': 'Highlight',
+  '--alias-color-neutral-compoundBrandStrokeHover': 'Highlight',
+  '--alias-color-neutral-compoundBrandStrokePressed': 'Highlight',
+  '--alias-color-neutral-neutralStrokeDisabled': 'GrayText',
+  '--alias-color-neutral-transparentStroke': 'CanvasText',
+  '--alias-color-neutral-transparentStrokeInteractive': 'Highlight',
+  '--alias-color-neutral-transparentStrokeDisabled': 'GrayText',
+  '--alias-color-neutral-strokeFocus1': 'Canvas',
+  '--alias-color-neutral-strokeFocus2': 'Highlight',
+  '--alias-color-neutral-neutralShadowAmbient': 'rgba(0,0,0,0.24)',
+  '--alias-color-neutral-neutralShadowKey': 'rgba(0,0,0,0.28)',
+  '--alias-color-neutral-neutralShadowAmbientLighter': 'rgba(0,0,0,0.12)',
+  '--alias-color-neutral-neutralShadowKeyLighter': 'rgba(0,0,0,0.14)',
+  '--alias-color-neutral-neutralShadowAmbientDarker': 'rgba(0,0,0,0.40)',
+  '--alias-color-neutral-neutralShadowKeyDarker': 'rgba(0,0,0,0.48)',
+  '--alias-color-neutral-brandShadowAmbient': 'rgba(0,0,0,0.30)',
+  '--alias-color-neutral-brandShadowKey': 'rgba(0,0,0,0.25)',
+};
+
 /**
  * Writes a theme as css variables in a style tag on the provided targetDocument as a rule applied to a CSS class
  *
@@ -25,10 +133,17 @@ export const useThemeStyleTag = (options: Pick<FluentProviderState, 'theme' | 't
 
   const cssRule = React.useMemo(() => {
     const cssVars = themeToCSSVariables(theme);
-    const cssVarsAsString = Object.keys(cssVars).reduce((cssVarRule, cssVar) => {
-      cssVarRule += `${cssVar}: ${cssVars[cssVar]}; `;
-      return cssVarRule;
+    let cssVarsAsString = Object.keys(cssVars).reduce((cssVarRule, cssVar) => {
+      if (hcMediaQuery && hcMediaQuery.matches && colorTokens[cssVar] !== undefined) {
+        return cssVarRule + `${cssVar}: ${colorTokens[cssVar]}; `;
+      }
+
+      return cssVarRule + `${cssVar}: ${cssVars[cssVar]}; `;
     }, '');
+
+    if (hcMediaQuery && hcMediaQuery.matches) {
+      cssVarsAsString += 'forced-color-adjust: none;';
+    }
 
     // result: .fluent-provider1 { --css-var: '#fff' }
     return `.${styleTagId} { ${cssVarsAsString} }`;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR makes changes in the `FluentProvider` to add the ability to auto change the styles to be correct when in High Contrast mode.

Here is an example of how this is working in the `Button` component:

__Before:__
![WithoutAutoHC](https://user-images.githubusercontent.com/7798177/130857521-7afac956-975f-44e0-8ce2-68a9513779f8.gif)

__After:__
![AutoHC](https://user-images.githubusercontent.com/7798177/130857529-ddbd519e-8190-4294-a486-883fe2ad8788.gif)

