### PR TITLE
Button: Adding type=button to all button components, removing @docCategory tags from API and fixing some documentation in the comments

### DIFF
--- a/change/@fluentui-react-button-9705570e-994a-4af4-a52c-8c035b902181.json
+++ b/change/@fluentui-react-button-9705570e-994a-4af4-a52c-8c035b902181.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Button: Adding type=button to all button components, removing @docCategory tags from API and fixing some documentation in the comments.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -158,7 +158,7 @@ export const useMenuButtonState: (state: MenuButtonState) => MenuButtonState;
 // @public (undocumented)
 export const useMenuButtonStyles: (state: MenuButtonState) => MenuButtonState;
 
-// @public (undocumented)
+// @public
 export const useToggleButton: (props: ToggleButtonProps, ref: React_2.Ref<HTMLElement>, defaultProps?: ToggleButtonProps | undefined) => ToggleButtonState;
 
 // @public (undocumented)

--- a/packages/react-button/src/components/Button/Button.types.ts
+++ b/packages/react-button/src/components/Button/Button.types.ts
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import type { ComponentPropsCompat, ComponentStateCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
 
-/**
- * {@docCategory Button}
- */
 export type ButtonProps = ComponentPropsCompat &
   React.ButtonHTMLAttributes<HTMLElement> & {
     /**
@@ -94,19 +91,10 @@ export type ButtonProps = ComponentPropsCompat &
     transparent?: boolean;
   };
 
-/**
- * {@docCategory Button}
- */
 export type ButtonShorthandPropsCompat = 'icon';
 
-/**
- * {@docCategory Button}
- */
 export type ButtonDefaultedProps = 'icon' | 'size';
 
-/**
- * {@docCategory Button}
- */
 export interface ButtonState
   extends ComponentStateCompat<ButtonProps, ButtonShorthandPropsCompat, ButtonDefaultedProps> {
   /**

--- a/packages/react-button/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react-button/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Button renders a default button 1`] = `
   className=""
   onClick={[Function]}
   onKeyDown={[Function]}
+  type="button"
 >
   This is a button
 </button>

--- a/packages/react-button/src/components/Button/useButton.ts
+++ b/packages/react-button/src/components/Button/useButton.ts
@@ -11,7 +11,7 @@ export const buttonShorthandPropsCompat: ButtonShorthandPropsCompat[] = ['icon']
 const mergeProps = makeMergeProps<ButtonState>({ deepMerge: buttonShorthandPropsCompat });
 
 /**
- * Given user props, returns state and render function for a Button.
+ * Given user props, returns the final state for a Button.
  */
 export const useButton = (props: ButtonProps, ref: React.Ref<HTMLElement>, defaultProps?: ButtonProps): ButtonState => {
   const state = mergeProps(
@@ -22,6 +22,7 @@ export const useButton = (props: ButtonProps, ref: React.Ref<HTMLElement>, defau
       icon: { as: 'span' },
       // Non-slot props
       size: 'medium',
+      type: 'button',
     },
     defaultProps && resolveShorthandProps(defaultProps, buttonShorthandPropsCompat),
     resolveShorthandProps(props, buttonShorthandPropsCompat),

--- a/packages/react-button/src/components/Button/useButton.ts
+++ b/packages/react-button/src/components/Button/useButton.ts
@@ -22,7 +22,7 @@ export const useButton = (props: ButtonProps, ref: React.Ref<HTMLElement>, defau
       icon: { as: 'span' },
       // Non-slot props
       size: 'medium',
-      type: 'button',
+      type: 'button', // This is added because the default for type is 'submit'
     },
     defaultProps && resolveShorthandProps(defaultProps, buttonShorthandPropsCompat),
     resolveShorthandProps(props, buttonShorthandPropsCompat),

--- a/packages/react-button/src/components/CompoundButton/CompoundButton.tsx
+++ b/packages/react-button/src/components/CompoundButton/CompoundButton.tsx
@@ -5,8 +5,7 @@ import { useCompoundButtonStyles } from './useCompoundButtonStyles';
 import type { CompoundButtonProps } from './CompoundButton.types';
 
 /**
- * Define a styled CompoundButton, using the `useCompoundButton` hook.
- * {@docCategory Button}
+ * CompoundButtons are buttons that can have secondary content that adds extra information to the user.
  */
 export const CompoundButton = React.forwardRef<HTMLElement, CompoundButtonProps>((props, ref) => {
   const state = useCompoundButton(props, ref);

--- a/packages/react-button/src/components/CompoundButton/CompoundButton.types.ts
+++ b/packages/react-button/src/components/CompoundButton/CompoundButton.types.ts
@@ -7,9 +7,6 @@ import type {
   ButtonState,
 } from '../Button/Button.types';
 
-/**
- * {@docCategory Button}
- */
 export interface CompoundButtonProps extends ButtonProps {
   /**
    * Second line of text that describes the action this button takes.
@@ -22,19 +19,10 @@ export interface CompoundButtonProps extends ButtonProps {
   contentContainer?: ShorthandPropsCompat<React.HTMLAttributes<HTMLElement>>;
 }
 
-/**
- * {@docCategory Button}
- */
 export type CompoundButtonShorthandPropsCompat = ButtonShorthandPropsCompat | 'contentContainer' | 'secondaryContent';
 
-/**
- * {@docCategory Button}
- */
 export type CompoundButtonDefaultedProps = ButtonDefaultedProps | 'contentContainer' | 'secondaryContent';
 
-/**
- * {@docCategory Button}
- */
 export interface CompoundButtonState
   extends ButtonState,
     ComponentStateCompat<CompoundButtonProps, CompoundButtonShorthandPropsCompat, CompoundButtonDefaultedProps> {}

--- a/packages/react-button/src/components/CompoundButton/useCompoundButton.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButton.ts
@@ -39,7 +39,7 @@ export const useCompoundButton = (
       secondaryContent: { as: 'span' },
       // Non-slot props
       size: 'medium',
-      type: 'button',
+      type: 'button', // This is added because the default for type is 'submit'
     },
     defaultProps && resolveShorthandProps(defaultProps, compoundButtonShorthandPropsCompat),
     resolveShorthandProps(props, compoundButtonShorthandPropsCompat),

--- a/packages/react-button/src/components/CompoundButton/useCompoundButton.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButton.ts
@@ -21,7 +21,7 @@ const mergeProps = makeMergeProps<CompoundButtonState>({
 });
 
 /**
- * Given user props, returns state and render function for a Button.
+ * Given user props, returns the final state for a CompoundButton.
  */
 export const useCompoundButton = (
   props: CompoundButtonProps,
@@ -39,6 +39,7 @@ export const useCompoundButton = (
       secondaryContent: { as: 'span' },
       // Non-slot props
       size: 'medium',
+      type: 'button',
     },
     defaultProps && resolveShorthandProps(defaultProps, compoundButtonShorthandPropsCompat),
     resolveShorthandProps(props, compoundButtonShorthandPropsCompat),

--- a/packages/react-button/src/components/MenuButton/MenuButton.tsx
+++ b/packages/react-button/src/components/MenuButton/MenuButton.tsx
@@ -6,8 +6,7 @@ import { useMenuButtonStyles } from './useMenuButtonStyles';
 import type { MenuButtonProps } from './MenuButton.types';
 
 /**
- * Define a styled MenuButton, using the `useMenuButton` hook.
- * {@docCategory Button}
+ * MenuButtons are buttons that handle opening and closing a menu when they are triggered.
  */
 export const MenuButton: React.FunctionComponent<MenuButtonProps & React.RefAttributes<HTMLElement>> = React.forwardRef<
   HTMLElement,

--- a/packages/react-button/src/components/MenuButton/MenuButton.types.ts
+++ b/packages/react-button/src/components/MenuButton/MenuButton.types.ts
@@ -7,9 +7,6 @@ import type {
   ButtonState,
 } from '../Button/Button.types';
 
-/**
- * {@docCategory Button}
- */
 export type MenuButtonProps = Omit<ButtonProps, 'iconPosition'> & {
   /**
    * Menu icon that indicates that this button has a menu that can be expanded.
@@ -47,19 +44,10 @@ export type MenuButtonProps = Omit<ButtonProps, 'iconPosition'> & {
   // onMenuDismiss?: (ev?: Event | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void;
 };
 
-/**
- * {@docCategory Button}
- */
 export type MenuButtonShorthandPropsCompat = ButtonShorthandPropsCompat | 'menuIcon';
 
-/**
- * {@docCategory Button}
- */
 export type MenuButtonDefaultedProps = ButtonDefaultedProps | 'menuIcon';
 
-/**
- * {@docCategory Button}
- */
 export interface MenuButtonState
   extends Omit<ButtonState, 'iconPosition'>,
     ComponentStateCompat<MenuButtonProps, MenuButtonShorthandPropsCompat, MenuButtonDefaultedProps> {}

--- a/packages/react-button/src/components/MenuButton/useMenuButton.ts
+++ b/packages/react-button/src/components/MenuButton/useMenuButton.ts
@@ -11,7 +11,7 @@ export const menuButtonShorthandPropsCompat: MenuButtonShorthandPropsCompat[] = 
 const mergeProps = makeMergeProps<MenuButtonState>({ deepMerge: menuButtonShorthandPropsCompat });
 
 /**
- * Redefine the component factory, reusing button factory.
+ * Given user props, returns the final state for a MenuButton.
  */
 export const useMenuButton = (props: MenuButtonProps, ref: React.Ref<HTMLElement>, defaultProps?: MenuButtonProps) => {
   // Note: because menu button's template and slots are different, we can't reuse
@@ -26,6 +26,7 @@ export const useMenuButton = (props: MenuButtonProps, ref: React.Ref<HTMLElement
       menuIcon: { as: 'span' },
       // Non-slot props
       size: 'medium',
+      type: 'button',
     },
     defaultProps && resolveShorthandProps(defaultProps, menuButtonShorthandPropsCompat),
     resolveShorthandProps(props, menuButtonShorthandPropsCompat),

--- a/packages/react-button/src/components/MenuButton/useMenuButton.ts
+++ b/packages/react-button/src/components/MenuButton/useMenuButton.ts
@@ -26,7 +26,7 @@ export const useMenuButton = (props: MenuButtonProps, ref: React.Ref<HTMLElement
       menuIcon: { as: 'span' },
       // Non-slot props
       size: 'medium',
-      type: 'button',
+      type: 'button', // This is added because the default for type is 'submit'
     },
     defaultProps && resolveShorthandProps(defaultProps, menuButtonShorthandPropsCompat),
     resolveShorthandProps(props, menuButtonShorthandPropsCompat),

--- a/packages/react-button/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/react-button/src/components/ToggleButton/ToggleButton.tsx
@@ -5,8 +5,7 @@ import { useToggleButtonStyles } from './useToggleButtonStyles';
 import type { ToggleButtonProps } from './ToggleButton.types';
 
 /**
- * Define a styled ToggleButton, using the `useToggleButton` hook.
- * {@docCategory Button}
+ * ToggleButtons are buttons that toggle between two defined states when triggered.
  */
 export const ToggleButton = React.forwardRef<HTMLElement, ToggleButtonProps>((props, ref) => {
   const state = useToggleButton(props, ref);

--- a/packages/react-button/src/components/ToggleButton/ToggleButton.types.ts
+++ b/packages/react-button/src/components/ToggleButton/ToggleButton.types.ts
@@ -6,9 +6,6 @@ import type {
   ButtonState,
 } from '../Button/Button.types';
 
-/**
- * {@docCategory Button}
- */
 export interface ToggleButtonProps extends ButtonProps {
   /**
    * Defines the controlled checked state of the `ToggleButton`.
@@ -27,19 +24,10 @@ export interface ToggleButtonProps extends ButtonProps {
   defaultChecked?: boolean;
 }
 
-/**
- * {@docCategory Button}
- */
 export type ToggleButtonShorthandPropsCompat = ButtonShorthandPropsCompat;
 
-/**
- * {@docCategory Button}
- */
 export type ToggleButtonDefaultedProps = ButtonDefaultedProps;
 
-/**
- * {@docCategory Button}
- */
 export interface ToggleButtonState
   extends ButtonState,
     ComponentStateCompat<ToggleButtonProps, ToggleButtonShorthandPropsCompat, ToggleButtonDefaultedProps> {}

--- a/packages/react-button/src/components/ToggleButton/useToggleButton.ts
+++ b/packages/react-button/src/components/ToggleButton/useToggleButton.ts
@@ -3,6 +3,9 @@ import { useButton } from '../Button/useButton';
 import { useChecked } from './useChecked';
 import type { ToggleButtonProps, ToggleButtonState } from './ToggleButton.types';
 
+/**
+ * Given user props, returns the final state for a ToggleButton.
+ */
 export const useToggleButton = (
   props: ToggleButtonProps,
   ref: React.Ref<HTMLElement>,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds `type='button'` to all `Button` components, removes the `@docCategory` tags from the `Button` components API since it is not being used in `@fluentui/react-components` components and makes some minor fixes to some documentation existing in comments across the `@fluentui/react-button` package.