### PR TITLE
Allow Nav to hide the 'collapse' button and support more style cues

### DIFF
--- a/change/@fluentui-react-b53bdf43-15a9-49f6-8917-ae3f1f404781.json
+++ b/change/@fluentui-react-b53bdf43-15a9-49f6-8917-ae3f1f404781.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Support more Nav overrides and style cues",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Nav/Nav.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.Basic.Example.tsx
@@ -13,6 +13,7 @@ const navStyles: Partial<INavStyles> = {
 
 const navLinkGroups: INavLinkGroup[] = [
   {
+    name: 'Group',
     links: [
       {
         name: 'Home',

--- a/packages/react-examples/src/react/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -35,6 +35,101 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
     <div
       className="ms-Nav-group is-expanded"
     >
+      <button
+        aria-expanded={true}
+        className=
+            ms-Nav-chevronButton
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-bottom: 1px solid #edebe9;
+              border: none;
+              color: #323130;
+              cursor: pointer;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 18px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-bottom: 5px;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 5px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 0px,;
+              padding-left: 28px;
+              padding-right: 20px,;
+              padding-top: 0px,;
+              position: relative;
+              text-align: left;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+              width: 100%;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:visited {
+              color: #323130;
+            }
+        onClick={[Function]}
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Nav-chevron
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                display: inline-flex;
+                font-family: "FabricMDL2Icons";
+                font-size: 12px;
+                font-style: normal;
+                font-weight: normal;
+                height: 44px;
+                left: 8px;
+                line-height: 44px;
+                position: absolute;
+                speak: none;
+                transform: rotate(-180deg);
+                transition: transform .1s linear;
+              }
+          data-icon-name="ChevronDown"
+        >
+          
+        </i>
+        <div
+          className=
+              ms-Nav-linkText
+              {
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                overflow: hidden;
+                text-align: left;
+                text-overflow: ellipsis;
+                vertical-align: middle;
+              }
+        >
+          Group
+        </div>
+      </button>
       <div
         className=
             ms-Nav-groupContent

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6063,7 +6063,7 @@ export interface INav {
 
 // @public (undocumented)
 export interface INavButtonProps extends IButtonProps {
-    link?: INavLink;
+    link?: IRenderNavLinkProps;
 }
 
 // @public (undocumented)
@@ -6080,6 +6080,7 @@ export interface INavLink {
     // @deprecated (undocumented)
     iconClassName?: string;
     iconProps?: IIconProps;
+    isCollapsible?: boolean;
     isExpanded?: boolean;
     key?: string;
     links?: INavLink[];
@@ -6097,6 +6098,7 @@ export interface INavLinkGroup {
     collapseByDefault?: boolean;
     expandAriaLabel?: string;
     groupData?: any;
+    isCollapsible?: boolean;
     links: INavLink[];
     name?: string;
     onHeaderClick?: (ev?: React_2.MouseEvent<HTMLElement>, isCollapsing?: boolean) => void;
@@ -6116,7 +6118,7 @@ export interface INavProps {
     onLinkClick?: (ev?: React_2.MouseEvent<HTMLElement>, item?: INavLink) => void;
     onLinkExpandClick?: (ev?: React_2.MouseEvent<HTMLElement>, item?: INavLink) => void;
     onRenderGroupHeader?: IRenderFunction<IRenderGroupHeaderProps>;
-    onRenderLink?: IRenderFunction<INavLink>;
+    onRenderLink?: IRenderFunction<IRenderNavLinkProps>;
     // @deprecated
     selectedAriaLabel?: string;
     selectedKey?: string;
@@ -6140,7 +6142,9 @@ export interface INavState {
 export interface INavStyleProps {
     className?: string;
     groups: INavLinkGroup[] | null;
+    hasIcon?: boolean;
     isButtonEntry?: boolean;
+    isCollapsible?: boolean;
     isDisabled?: boolean;
     isExpanded?: boolean;
     isGroup?: boolean;
@@ -6150,6 +6154,7 @@ export interface INavStyleProps {
     leftPadding?: number;
     leftPaddingExpanded?: number;
     navHeight?: number;
+    nestingLevel?: number;
     position?: number;
     rightPadding?: number;
     theme: ITheme;
@@ -6958,6 +6963,12 @@ export interface IRelativePositions {
 // @public (undocumented)
 export interface IRenderGroupHeaderProps extends INavLinkGroup {
     isExpanded?: boolean;
+}
+
+// @public (undocumented)
+export interface IRenderNavLinkProps extends INavLink {
+    // (undocumented)
+    nestingLevel?: number;
 }
 
 // @public (undocumented)

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6967,7 +6967,6 @@ export interface IRenderGroupHeaderProps extends INavLinkGroup {
 
 // @public (undocumented)
 export interface IRenderNavLinkProps extends INavLink {
-    // (undocumented)
     nestingLevel?: number;
 }
 

--- a/packages/react/src/components/Nav/Nav.styles.ts
+++ b/packages/react/src/components/Nav/Nav.styles.ts
@@ -9,6 +9,12 @@ import {
 import type { INavStyleProps, INavStyles } from './Nav.types';
 import type { IButtonStyles } from '../../Button';
 
+// The number pixels per indentation level for Nav links.
+const _indentationSize = 14;
+
+// The number of pixels of left margin
+const _baseIndent = 3;
+
 const GlobalClassNames = {
   root: 'ms-Nav',
   linkText: 'ms-Nav-linkText',
@@ -45,11 +51,18 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
     isDisabled,
     isButtonEntry,
     navHeight = 44,
-    position,
-    leftPadding = 20,
+    nestingLevel,
+    hasIcon,
     leftPaddingExpanded = 28,
     rightPadding = 20,
   } = props;
+
+  const basePosition = typeof nestingLevel === 'number' ? _indentationSize * nestingLevel + 1 : undefined;
+
+  const baseLeftPadding =
+    typeof nestingLevel === 'number' ? _indentationSize * nestingLevel + _baseIndent + (hasIcon ? 0 : 24) : undefined;
+
+  const { position = basePosition, leftPadding = baseLeftPadding ?? 20 } = props;
 
   const { palette, semanticColors, fonts } = theme;
 

--- a/packages/react/src/components/Nav/Nav.types.ts
+++ b/packages/react/src/components/Nav/Nav.types.ts
@@ -17,6 +17,16 @@ export interface IRenderGroupHeaderProps extends INavLinkGroup {
 /**
  * {@docCategory Nav}
  */
+export interface IRenderNavLinkProps extends INavLink {
+  /**
+   * The nesting level at which the link will be rendered.
+   */
+  nestingLevel?: number;
+}
+
+/**
+ * {@docCategory Nav}
+ */
 export interface INav {
   /**
    * The meta 'key' property of the currently selected NavItem of the Nav. Can return
@@ -79,7 +89,7 @@ export interface INavProps {
   /**
    * Used to customize how content inside the link tag is rendered
    */
-  onRenderLink?: IRenderFunction<INavLink>;
+  onRenderLink?: IRenderFunction<IRenderNavLinkProps>;
 
   /**
    * Function callback invoked when a link in the navigation is clicked
@@ -148,6 +158,12 @@ export interface INavLinkGroup {
    * If true, the group should render collapsed by default
    */
   collapseByDefault?: boolean;
+
+  /**
+   * Whether not the group may be collapsed.
+   * @defaultvalue true
+   */
+  isCollapsible?: boolean;
 
   /**
    * Callback invoked when a group header is clicked
@@ -269,6 +285,12 @@ export interface INavLink {
   collapseAriaLabel?: string;
 
   /**
+   * Whether not the link's children may be collapsed.
+   * @defaultvalue true
+   */
+  isCollapsible?: boolean;
+
+  /**
    * (Optional) Any additional properties to apply to the rendered links.
    */
   [propertyName: string]: any;
@@ -349,10 +371,24 @@ export interface INavStyleProps {
   position?: number;
 
   /**
+   * The nesting level of the link being rendered. Will only be present for links, not groups.
+   */
+  nestingLevel?: number;
+  /**
+   * Whether or not the link being rendered has an icon. Will only be present for links, not groups.
+   */
+  hasIcon?: boolean;
+
+  /**
    * Inherited from INavProps
    * A collection of link groups to display in the navigation bar
    */
   groups: INavLinkGroup[] | null;
+
+  /**
+   * Whether or not the node being rendered may be collapsed.
+   */
+  isCollapsible?: boolean;
 }
 
 /**
@@ -420,5 +456,5 @@ export interface INavButtonProps extends IButtonProps {
   /**
    * (Optional) Link to be rendered.
    */
-  link?: INavLink;
+  link?: IRenderNavLinkProps;
 }

--- a/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -111,7 +111,22 @@ exports[`Nav render Nav with overrides correctly 1`] = `
           >
             
           </i>
-          Group
+          <div
+            className=
+                ms-Nav-linkText
+                {
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  overflow: hidden;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: middle;
+                }
+          >
+            Group
+          </div>
         </button>
       </div>
       <div


### PR DESCRIPTION
#### Description of changes

Updated the rendering logic for `Nav` so that `INavLink` accepts `isCollapsible` to show/hide the chevron buttons.
Added style props for `nestingLevel`, `hasIcon`, and `isCollapsible` and made `Nav` pass those cues to `getClassNames` instead of directly writing the left-padding. Now the padding can be computed properly by the style function.
Updated the `Nav` demo to include a group header, and fixed the visual alignment of group header text.

#### Focus areas to test

The `Nav` demo pages.
