### PR TITLE
FluentProvider: Adding ability to auto style correctly when in High Contrast mode

### DIFF
--- a/change/@fluentui-react-button-eb89d7a1-d881-4b03-aad1-4e49448fdcf3.json
+++ b/change/@fluentui-react-button-eb89d7a1-d881-4b03-aad1-4e49448fdcf3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing some High Contrast styles on hover and pressed states.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-fca722f9-df68-4e2a-85bb-ae0eb608a19f.json
+++ b/change/@fluentui-react-provider-fca722f9-df68-4e2a-85bb-ae0eb608a19f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "FluentProvider: Adding ability to auto style correctly when in High Contrast mode.",
+  "packageName": "@fluentui/react-provider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -42,7 +42,7 @@ const useRootStyles = makeStyles({
     ':hover': {
       background: theme.alias.color.neutral.neutralBackground1Hover,
       borderColor: theme.alias.color.neutral.neutralStroke1Hover,
-      color: theme.alias.color.neutral.neutralForeground1,
+      color: theme.alias.color.neutral.neutralForeground2Hover,
 
       cursor: 'pointer',
     },
@@ -50,7 +50,7 @@ const useRootStyles = makeStyles({
     ':active': {
       background: theme.alias.color.neutral.neutralBackground1Pressed,
       borderColor: theme.alias.color.neutral.neutralStroke1Pressed,
-      color: theme.alias.color.neutral.neutralForeground1,
+      color: theme.alias.color.neutral.neutralForeground2Pressed,
 
       outline: 'none',
     },


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR makes changes in the `FluentProvider` to add the ability to auto change the styles to be correct when in High Contrast mode.

Here is an example of how this is working in the `Button` component:

__Before:__
![WithoutAutoHC](https://user-images.githubusercontent.com/7798177/130857521-7afac956-975f-44e0-8ce2-68a9513779f8.gif)

__After:__
![AutoHC](https://user-images.githubusercontent.com/7798177/130857529-ddbd519e-8190-4294-a486-883fe2ad8788.gif)

