### PR TITLE
feat(tools): update generator to set es2019 and fix pattern json.schema violation

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -193,12 +193,12 @@ describe('migrate-converged-pkg generator', () => {
           experimentalDecorators: true,
           importHelpers: true,
           jsx: 'react',
-          lib: ['ES2020', 'dom'],
+          lib: ['ES2019', 'dom'],
           module: 'CommonJS',
           noUnusedLocals: true,
           outDir: 'dist',
           preserveConstEnums: true,
-          target: 'ES2020',
+          target: 'ES2019',
           types: ['jest', 'custom-global', 'inline-style-expand-shorthand'],
         },
         extends: '../../tsconfig.base.json',
@@ -833,7 +833,8 @@ describe('migrate-converged-pkg generator', () => {
         .editorconfig
         .eslint*
         .git*
-        .prettierignore"
+        .prettierignore
+        "
       `);
     });
   });

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -15,6 +15,7 @@ import {
   serializeJson,
 } from '@nrwl/devkit';
 import * as path from 'path';
+import * as os from 'os';
 
 import { PackageJson, TsConfig } from '../../types';
 import { arePromptsEnabled, prompt, updateJestConfig } from '../../utils';
@@ -123,9 +124,9 @@ const templates = {
     extends: '../../tsconfig.base.json',
     include: ['src'],
     compilerOptions: {
-      target: 'ES2020',
+      target: 'ES2019',
       module: 'CommonJS',
-      lib: ['ES2020', 'dom'],
+      lib: ['ES2019', 'dom'],
       outDir: 'dist',
       jsx: 'react',
       declaration: true,
@@ -203,7 +204,8 @@ const templates = {
       include: ['../src/**/*', '*.js'],
     },
   },
-  npmIgnoreConfig: stripIndents`
+  npmIgnoreConfig:
+    stripIndents`
     .cache/
     .storybook/
     .vscode/
@@ -233,7 +235,7 @@ const templates = {
     .eslint*
     .git*
     .prettierignore
-  `,
+  ` + os.EOL,
 };
 
 function normalizeOptions(host: Tree, options: AssertedSchema) {

--- a/tools/generators/migrate-converged-pkg/schema.json
+++ b/tools/generators/migrate-converged-pkg/schema.json
@@ -11,7 +11,7 @@
         "$source": "argv",
         "index": 0
       },
-      "pattern": "^[a-zA-Z].*$"
+      "pattern": "^[@a-zA-Z].*$"
     },
     "stats": {
       "type": "boolean",


### PR DESCRIPTION
#### Pull request checklist

- ~[ ] Addresses an existing issue: Fixes #0000~
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

- fixes pattern violation in schema.json after nx 12.5 migration
- sets target and lib to ES2019 (current limitation caused by node 12 used in our CI) / #19367 
- adds empty line where prettier doesn't work to introduce less diffs when re-running migration on same package

#### Focus areas to test

(optional)
