### PR TITLE
(react-slider) - Adding bundle size tool

### DIFF
--- a/packages/react-slider/bundle-size/Slider.fixture.js
+++ b/packages/react-slider/bundle-size/Slider.fixture.js
@@ -1,0 +1,7 @@
+import { Slider } from '@fluentui/react-slider';
+
+console.log(Slider);
+
+export default {
+  name: 'Slider',
+};

--- a/packages/react-slider/package.json
+++ b/packages/react-slider/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #18886

#### Description of changes

Adding a `Slider.fixture.js` file to measure the bundle size
