### PR TITLE
Move jest cache under node_modules/.cache/jest

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,7 +10,6 @@ yarn.lock
 
 # generated folders
 node_modules
-.cache
 lib
 lib-amd
 lib-esm

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -20,7 +20,7 @@ const baseConfig = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   testPathIgnorePatterns: ['/node_modules/', '/lib/', '/lib-commonjs/', '/dist/'],
   moduleNameMapper: { ...tsPathAliases },
-  cacheDirectory: '<rootDir>/.cache/jest',
+  cacheDirectory: '<rootDir>/node_modules/.cache/jest',
   clearMocks: true,
   watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
 };

--- a/rfcs/build-system/03-packaging-for-npm.md
+++ b/rfcs/build-system/03-packaging-for-npm.md
@@ -82,6 +82,8 @@ unpacked size: 263.9 kB
 total files:   518
 ```
 
+> **NOTE:** The issue with `.cache` (Jest cache) was addressed separately by moving the cache under `<package root>/node_modules/.cache/jest`, following the convention used by other tools' caches.
+
 ## Detailed Design or Proposal
 
 > **💡 NOTE:** This proposal/guide applies only for vNext packages and libraries using new DX
@@ -94,12 +96,11 @@ This is a living document that will describe various proposals that all aim to i
 - better security for consumers
 - better tree-shaking capabilities
 
-### 1. `.npmignore` cleanup
+### 1. `.npmignore` cleanup _(implemented)_
 
 **`<package>/.npmignore`**
 
 ```sh
-.cache/
 .storybook/
 .vscode/
 bundle-size/

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -805,7 +805,6 @@ describe('migrate-converged-pkg generator', () => {
       npmIgnoreConfig = getNpmIgnoreConfig(projectConfig);
 
       expect(npmIgnoreConfig).toMatchInlineSnapshot(`
-        ".cache/
         .storybook/
         .vscode/
         bundle-size/

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -805,7 +805,7 @@ describe('migrate-converged-pkg generator', () => {
       npmIgnoreConfig = getNpmIgnoreConfig(projectConfig);
 
       expect(npmIgnoreConfig).toMatchInlineSnapshot(`
-        .storybook/
+        ".storybook/
         .vscode/
         bundle-size/
         config/

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -206,7 +206,6 @@ const templates = {
   },
   npmIgnoreConfig:
     stripIndents`
-    .cache/
     .storybook/
     .vscode/
     bundle-size/


### PR DESCRIPTION
Each converged package's jest cache was being stored under `<package root>/.cache/jest` rather than following the convention of `<package root>/node_modules/.cache/<tool name>` (used by babel, storybook, and others), which required extra ignores/exclusions of the cache folder in various config files.

Moving the jest cache under node_modules with the others increases consistency, allows removing the extra `.cache` directory from `.npmignore`, and potentially helps prevent other future issues. (I'm leaving `.cache` in `.gitignore` and `.vscode/settings.json` for now to prevent contamination from caches which already exist in people's local copies.)