### PR TITLE
refactor(FluentProvider): rework className handling

### DIFF
--- a/change/@fluentui-react-provider-61bad14d-8176-477a-b6c2-b3289f39bae0.json
+++ b/change/@fluentui-react-provider-61bad14d-8176-477a-b6c2-b3289f39bae0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "rework className handling",
+  "packageName": "@fluentui/react-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-7ccfbe52-85d3-4452-91c9-8d54ae5070b2.json
+++ b/change/@fluentui-react-provider-7ccfbe52-85d3-4452-91c9-8d54ae5070b2.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "enable makeStyles conformance tests",
-  "packageName": "@fluentui/react-provider",
-  "email": "olfedias@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@fluentui-react-provider-7ccfbe52-85d3-4452-91c9-8d54ae5070b2.json
+++ b/change/@fluentui-react-provider-7ccfbe52-85d3-4452-91c9-8d54ae5070b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "enable makeStyles conformance tests",
+  "packageName": "@fluentui/react-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-provider/etc/react-provider.api.md
+++ b/packages/react-provider/etc/react-provider.api.md
@@ -25,7 +25,7 @@ export interface FluentProviderContextValues {
     // (undocumented)
     theme: ThemeContextValue;
     // (undocumented)
-    themeClassname: ThemeClassNameContextValue;
+    themeClassName: ThemeClassNameContextValue;
     // (undocumented)
     tooltip: TooltipContextType;
 }
@@ -52,6 +52,8 @@ export interface FluentProviderState extends FluentProviderProps {
     targetDocument: Document | undefined;
     // (undocumented)
     theme: Theme;
+    // (undocumented)
+    themeClassName: string;
 }
 
 // @public

--- a/packages/react-provider/src/components/FluentProvider/FluentProvider.types.ts
+++ b/packages/react-provider/src/components/FluentProvider/FluentProvider.types.ts
@@ -28,11 +28,12 @@ export interface FluentProviderState extends FluentProviderProps {
   dir: 'ltr' | 'rtl';
   targetDocument: Document | undefined;
   theme: Theme;
+  themeClassName: string;
 }
 
 export interface FluentProviderContextValues {
   provider: ProviderContextValue;
   theme: ThemeContextValue;
-  themeClassname: ThemeClassNameContextValue;
+  themeClassName: ThemeClassNameContextValue;
   tooltip: TooltipContextType;
 }

--- a/packages/react-provider/src/components/FluentProvider/renderFluentProvider.tsx
+++ b/packages/react-provider/src/components/FluentProvider/renderFluentProvider.tsx
@@ -12,7 +12,7 @@ export const renderFluentProvider = (state: FluentProviderState, contextValues: 
   return (
     <ProviderContext.Provider value={contextValues.provider}>
       <ThemeContext.Provider value={contextValues.theme}>
-        <ThemeClassNameContext.Provider value={contextValues.themeClassname}>
+        <ThemeClassNameContext.Provider value={contextValues.themeClassName}>
           <TooltipContext.Provider value={contextValues.tooltip}>
             <slots.root {...slotProps.root}>{state.children}</slots.root>
           </TooltipContext.Provider>

--- a/packages/react-provider/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-provider/src/components/FluentProvider/useFluentProvider.ts
@@ -48,12 +48,9 @@ export const useFluentProvider = (
   state.targetDocument = state.targetDocument ?? parentContext.targetDocument;
   state.dir = state.dir ?? parentContext.dir;
 
-  // useThemeStyleTag() should be called after .targetDocument will be defined
-  const themeClassName = useThemeStyleTag({ theme: mergedTheme, targetDocument: state.targetDocument });
-
-  // mergeClasses() is not needed here because `themeClassName` is not from a `makeStyles` call
-  state.className = [state.className || '', themeClassName].filter(Boolean).join(' ');
   state.theme = mergedTheme;
+  // useThemeStyleTag() should be called after .targetDocument will be defined
+  state.themeClassName = useThemeStyleTag({ theme: mergedTheme, targetDocument: state.targetDocument });
 
   return state;
 };

--- a/packages/react-provider/src/components/FluentProvider/useFluentProviderContextValues.test.ts
+++ b/packages/react-provider/src/components/FluentProvider/useFluentProviderContextValues.test.ts
@@ -39,11 +39,11 @@ describe('useFluentProviderContextValues', () => {
 
   it('should return a value for "themeClassname"', () => {
     const { result } = renderHook(() => {
-      const state = useFluentProvider({}, React.createRef());
+      const state = useFluentProvider({ className: 'foo' }, React.createRef());
 
       return useFluentProviderContextValues(state);
     });
 
-    expect(typeof result.current.themeClassname).toBe('string');
+    expect(typeof result.current.themeClassName).toBe('string');
   });
 });

--- a/packages/react-provider/src/components/FluentProvider/useFluentProviderContextValues.ts
+++ b/packages/react-provider/src/components/FluentProvider/useFluentProviderContextValues.ts
@@ -13,6 +13,6 @@ export function useFluentProviderContextValues(state: FluentProviderState): Flue
     provider,
     tooltip,
     theme,
-    themeClassname: className,
+    themeClassName: className,
   };
 }

--- a/packages/react-provider/src/components/FluentProvider/useFluentProviderStyles.ts
+++ b/packages/react-provider/src/components/FluentProvider/useFluentProviderStyles.ts
@@ -13,8 +13,9 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useFluentProviderStyles = (state: FluentProviderState) => {
-  // Theme override is passed here to use a proper theme otherwise it will usa a theme from a parent
   const styles = useStyles();
-  state.className = mergeClasses(styles.root, state.className);
+
+  state.className = mergeClasses(state.themeClassName, styles.root, state.className);
+
   return state;
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_Extracted from #19575._

The goal of this PR is to remove duplicate merging of classes in `useFluentProvider()`:

https://github.com/microsoft/fluentui/blob/37d516e954155f25ca242d5ba051e28446f1692b/packages/react-provider/src/components/FluentProvider/useFluentProvider.ts#L54-L55

When it was implemented `FluentProvider` and `ThemeProvider` where separate components and it had sense, now merging can be done in `useFluentProviderStyles()` as in other components.
