### PR TITLE
fix(react-conformance): handle "disabledTests" for "extraTests"

### DIFF
--- a/change/@fluentui-react-conformance-8f2ecf54-500c-487b-825b-cfc7bbadfff6.json
+++ b/change/@fluentui-react-conformance-8f2ecf54-500c-487b-825b-cfc7bbadfff6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "handle \"disabledTests\" for \"extraTests\"",
+  "packageName": "@fluentui/react-conformance",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-conformance/src/isConformant.ts
+++ b/packages/react-conformance/src/isConformant.ts
@@ -29,7 +29,9 @@ export function isConformant<TProps = {}>(...testInfo: Partial<IsConformantOptio
       if (extraTests) {
         describe('extraTests', () => {
           for (const test of Object.keys(extraTests)) {
-            extraTests[test](componentInfo, mergedOptions);
+            if (!disabledTests.includes(test)) {
+              extraTests[test](componentInfo, mergedOptions);
+            }
           }
         });
       }


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_Extracted from #19575._

This PR adds handling of `disabledTests` option for `extraTests`. 

This useful in a case with `react-menu`:
- in `src/common/isConformant.ts` we added extra tests for `makeStyles()`
- but they are not valid for `MenuTrigger` (it's not rendering DOM elements and styles)
- currently there is no way to disable these tests 😥