### PR TITLE
fix(react-conformance-make-styles): avoid collisions of mock

### DIFF
--- a/change/@fluentui-react-conformance-make-styles-7ce90afe-8ca6-4fa6-8991-46970cfb2bcf.json
+++ b/change/@fluentui-react-conformance-make-styles-7ce90afe-8ca6-4fa6-8991-46970cfb2bcf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix mergeClasses() mock",
+  "packageName": "@fluentui/react-conformance-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-conformance-make-styles/src/classNameWins.ts
+++ b/packages/react-conformance-make-styles/src/classNameWins.ts
@@ -1,14 +1,6 @@
 import { IsConformantOptions, ConformanceTest } from '@fluentui/react-conformance';
 import './matchers/index';
 
-const mergeClasses = jest.fn();
-
-jest.mock('@fluentui/react-make-styles', () => {
-  const module = jest.requireActual('@fluentui/react-make-styles');
-
-  return { ...module, mergeClasses };
-});
-
 /**
  * Requires a component from a file path, required for proper mocking.
  */
@@ -30,6 +22,13 @@ async function getReactComponent(
  */
 export const classNameWins: ConformanceTest = (componentInfo, testInfo) => {
   let container: HTMLDivElement | null = null;
+  const mergeClasses = jest.fn();
+
+  jest.mock('@fluentui/react-make-styles', () => {
+    const module = jest.requireActual('@fluentui/react-make-styles');
+
+    return { ...module, mergeClasses };
+  });
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/packages/react-conformance-make-styles/src/index.ts
+++ b/packages/react-conformance-make-styles/src/index.ts
@@ -2,7 +2,7 @@ import { TestObject } from '@fluentui/react-conformance';
 import { classNameWins } from './classNameWins';
 
 const makeStylesTests: TestObject = {
-  'classname-wins': classNameWins,
+  'make-styles-classname-wins': classNameWins,
 };
 
 export default makeStylesTests;

--- a/packages/react-conformance-make-styles/src/index.ts
+++ b/packages/react-conformance-make-styles/src/index.ts
@@ -1,8 +1,8 @@
 import { TestObject } from '@fluentui/react-conformance';
-import { classNameWins } from './classNameWins';
+import { overridesWin } from './overridesWin';
 
 const makeStylesTests: TestObject = {
-  'make-styles-classname-wins': classNameWins,
+  'make-styles-overrides-win': overridesWin,
 };
 
 export default makeStylesTests;

--- a/packages/react-conformance-make-styles/src/overridesWin.ts
+++ b/packages/react-conformance-make-styles/src/overridesWin.ts
@@ -18,7 +18,8 @@ async function getReactComponent(
 }
 
 /**
- * A conformance test for mergeClasses() that ensures that a classname from props is passed as a last param, i.e. ensures that user's overrides have higher priority.
+ * A conformance test for mergeClasses() that ensures that a classname from props is passed as a last param,
+ * i.e. ensures that user's overrides have higher priority.
  */
 export const overridesWin: ConformanceTest = (componentInfo, testInfo) => {
   let container: HTMLDivElement | null = null;

--- a/packages/react-conformance-make-styles/src/overridesWin.ts
+++ b/packages/react-conformance-make-styles/src/overridesWin.ts
@@ -18,9 +18,9 @@ async function getReactComponent(
 }
 
 /**
- * A conformance test for mergeClasses() that ensures that a classname from props is passed as a last param.
+ * A conformance test for mergeClasses() that ensures that a classname from props is passed as a last param, i.e. ensures that user's overrides have higher priority.
  */
-export const classNameWins: ConformanceTest = (componentInfo, testInfo) => {
+export const overridesWin: ConformanceTest = (componentInfo, testInfo) => {
   let container: HTMLDivElement | null = null;
   const mergeClasses = jest.fn();
 


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_Extracted from #19575._

- renames `classname-wins` to `make-styles-overrides-win` (previous name was not clear, it's visible when a rule gets disabled, #19591)
- moves mock inside conformance test otherwise it causes strange issues in some tests, for example:

```
  ● MenuItemCheckbox › should merge checkmark slot props

    expect(received).not.toBeNull()

    Received: null

      167 |     // Assert
      168 |     const slot = container.querySelector(`.${className}`);
    > 169 |     expect(slot).not.toBeNull();
          |                      ^
      170 |     expect(slot?.querySelector('svg')).not.toBeNull();
      171 |   });
      172 | });

      at Object.<anonymous> (src/components/MenuItemCheckbox/MenuItemCheckbox.test.tsx:169:22)
```

This solution is temporary, once we will be able to use `jest.isolateModules()` (requires Jest 27, #19595) mocking should simpler.