### PR TITLE
feat(react-conformance-make-styles): allow to configure number of mergeClasses() calls

### DIFF
--- a/change/@fluentui-react-conformance-make-styles-14258c44-53f1-4c2b-ab7a-7d1cf2bc203f.json
+++ b/change/@fluentui-react-conformance-make-styles-14258c44-53f1-4c2b-ab7a-7d1cf2bc203f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "make number of calls configurable",
+  "packageName": "@fluentui/react-conformance-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-conformance-make-styles/src/index.ts
+++ b/packages/react-conformance-make-styles/src/index.ts
@@ -1,8 +1,10 @@
 import { TestObject } from '@fluentui/react-conformance';
-import { overridesWin } from './overridesWin';
+import { OVERRIDES_WIN_TEST_NAME, overridesWin } from './overridesWin';
 
 const makeStylesTests: TestObject = {
-  'make-styles-overrides-win': overridesWin,
+  [OVERRIDES_WIN_TEST_NAME]: overridesWin,
 };
 
 export default makeStylesTests;
+
+export type { OverridesWinTestOptions } from './overridesWin';

--- a/packages/react-conformance-make-styles/src/matchers/index.ts
+++ b/packages/react-conformance-make-styles/src/matchers/index.ts
@@ -1,5 +1,7 @@
 import { toContainClassNameLastInCalls } from './toContainClassNameLastInCalls';
+import { toHaveMergeClassesCalledTimesWithClassName } from './toHaveMergeClassesCalledTimesWithClassName';
 
 expect.extend({
   toContainClassNameLastInCalls,
+  toHaveMergeClassesCalledTimesWithClassName,
 });

--- a/packages/react-conformance-make-styles/src/matchers/toContainClassNameLastInCalls.test.ts
+++ b/packages/react-conformance-make-styles/src/matchers/toContainClassNameLastInCalls.test.ts
@@ -22,17 +22,6 @@ describe('toContainClassNameLastInCalls', () => {
     );
   });
 
-  it('fails on multiple occurrences of a class in multiple calls', () => {
-    const callA: MergeClassesParams = ['a', 'className'];
-    const callB: MergeClassesParams = ['b', 'className'];
-
-    expect(() => {
-      expect([callA, callB]).toContainClassNameLastInCalls('className');
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"There multiple calls of mergeClasses() that contain \\"className\\". Last call: b className"`,
-    );
-  });
-
   it('fails on when a class is not last', () => {
     const call: MergeClassesParams = ['className', 'foo'];
 

--- a/packages/react-conformance-make-styles/src/matchers/toContainClassNameLastInCalls.ts
+++ b/packages/react-conformance-make-styles/src/matchers/toContainClassNameLastInCalls.ts
@@ -18,8 +18,6 @@ export const toContainClassNameLastInCalls: jest.CustomMatcher = (
   result: jest.Mock<{}, MergeClassesParams>['mock']['calls'],
   className: string,
 ) => {
-  let hasCallsWithClassName: boolean = false;
-
   let pass = true;
   let message = '';
 
@@ -27,16 +25,6 @@ export const toContainClassNameLastInCalls: jest.CustomMatcher = (
     const indexInClassList = classesList.indexOf(className);
 
     if (indexInClassList >= 0) {
-      if (hasCallsWithClassName) {
-        pass = false;
-        message = [
-          `There multiple calls of mergeClasses() that contain "${className}".`,
-          `Last call: ${classesList.join(' ')}`,
-        ].join(' ');
-
-        return;
-      }
-
       if (classesList.indexOf(className, indexInClassList + 1) !== -1) {
         pass = false;
         message = [
@@ -46,8 +34,6 @@ export const toContainClassNameLastInCalls: jest.CustomMatcher = (
 
         return;
       }
-
-      hasCallsWithClassName = true;
 
       if (indexInClassList !== classesList.length - 1) {
         pass = false;

--- a/packages/react-conformance-make-styles/src/matchers/toHaveMergeClassesCalledTimesWithClassName.test.ts
+++ b/packages/react-conformance-make-styles/src/matchers/toHaveMergeClassesCalledTimesWithClassName.test.ts
@@ -1,0 +1,29 @@
+import { mergeClasses } from '@fluentui/make-styles';
+import './index';
+
+type MergeClassesParams = Parameters<typeof mergeClasses>;
+
+describe('toContainClassNameLastInCalls', () => {
+  it('passes when requirements are met', () => {
+    const callA: MergeClassesParams = ['a', 'className'];
+    const callB: MergeClassesParams = ['b', 'className'];
+
+    expect(() => {
+      expect([callA, callB]).toHaveMergeClassesCalledTimesWithClassName('className', 2);
+    }).not.toThrow();
+  });
+
+  it('fails on multiple occurrences of a class in multiple calls', () => {
+    const callA: MergeClassesParams = ['a', 'className'];
+    const callB: MergeClassesParams = ['b', 'className'];
+
+    expect(() => {
+      expect([callA, callB]).toHaveMergeClassesCalledTimesWithClassName('className', 4);
+    }).toThrowErrorMatchingInlineSnapshot(`
+"There were 2 call(s) of mergeClasses() that contain \\"className\\".
+Expected: 4
+Got: 2
+Last call: b className"
+`);
+  });
+});

--- a/packages/react-conformance-make-styles/src/matchers/toHaveMergeClassesCalledTimesWithClassName.ts
+++ b/packages/react-conformance-make-styles/src/matchers/toHaveMergeClassesCalledTimesWithClassName.ts
@@ -19,18 +19,16 @@ export const toHaveMergeClassesCalledTimesWithClassName: jest.CustomMatcher = (
   className: string,
   expectedTimes: number,
 ) => {
-  let callCount: number = 0;
-
   let pass = true;
   let message = '';
 
-  result.forEach(classesList => {
-    const indexInClassList = classesList.indexOf(className);
-
-    if (indexInClassList >= 0) {
-      callCount += 1;
+  const callCount = result.reduce((callCount, classesList) => {
+    if (classesList.includes(className)) {
+      return callCount + 1;
     }
-  });
+
+    return callCount;
+  }, 0);
 
   if (callCount !== expectedTimes) {
     pass = false;

--- a/packages/react-conformance-make-styles/src/matchers/toHaveMergeClassesCalledTimesWithClassName.ts
+++ b/packages/react-conformance-make-styles/src/matchers/toHaveMergeClassesCalledTimesWithClassName.ts
@@ -22,12 +22,12 @@ export const toHaveMergeClassesCalledTimesWithClassName: jest.CustomMatcher = (
   let pass = true;
   let message = '';
 
-  const callCount = result.reduce((callCount, classesList) => {
+  const callCount = result.reduce((acc, classesList) => {
     if (classesList.includes(className)) {
-      return callCount + 1;
+      return acc + 1;
     }
 
-    return callCount;
+    return acc;
   }, 0);
 
   if (callCount !== expectedTimes) {

--- a/packages/react-conformance-make-styles/src/matchers/toHaveMergeClassesCalledTimesWithClassName.ts
+++ b/packages/react-conformance-make-styles/src/matchers/toHaveMergeClassesCalledTimesWithClassName.ts
@@ -1,0 +1,46 @@
+import { mergeClasses } from '@fluentui/react-make-styles';
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveMergeClassesCalledTimesWithClassName(className: string, times: number): R;
+    }
+  }
+}
+
+type MergeClassesParams = Parameters<typeof mergeClasses>;
+
+/**
+ * Custom Jest matcher that implements a check to ensure that mergeClasses() function with a passes class got called
+ * exact number of times.
+ */
+export const toHaveMergeClassesCalledTimesWithClassName: jest.CustomMatcher = (
+  result: jest.Mock<{}, MergeClassesParams>['mock']['calls'],
+  className: string,
+  expectedTimes: number,
+) => {
+  let callCount: number = 0;
+
+  let pass = true;
+  let message = '';
+
+  result.forEach(classesList => {
+    const indexInClassList = classesList.indexOf(className);
+
+    if (indexInClassList >= 0) {
+      callCount += 1;
+    }
+  });
+
+  if (callCount !== expectedTimes) {
+    pass = false;
+    message = [
+      `There were ${callCount} call(s) of mergeClasses() that contain "${className}".`,
+      `Expected: ${expectedTimes}`,
+      `Got: ${callCount}`,
+      `Last call: ${result[result.length - 1].join(' ')}`,
+    ].join('\n');
+  }
+
+  return { pass, message: () => message };
+};

--- a/packages/react-conformance-make-styles/src/overridesWin.ts
+++ b/packages/react-conformance-make-styles/src/overridesWin.ts
@@ -1,5 +1,12 @@
-import { IsConformantOptions, ConformanceTest } from '@fluentui/react-conformance';
+import type { IsConformantOptions, ConformanceTest, TestOptions } from '@fluentui/react-conformance';
 import './matchers/index';
+
+export const OVERRIDES_WIN_TEST_NAME = 'make-styles-overrides-win';
+
+export type OverridesWinTestOptions = {
+  /** Defines number of allowed mergeClasses() calls per a component render. Defaults to 1. */
+  callCount?: number;
+};
 
 /**
  * Requires a component from a file path, required for proper mocking.
@@ -22,6 +29,10 @@ async function getReactComponent(
  * i.e. ensures that user's overrides have higher priority.
  */
 export const overridesWin: ConformanceTest = (componentInfo, testInfo) => {
+  const testOptions = testInfo.testOptions as
+    | (TestOptions & { [OVERRIDES_WIN_TEST_NAME]?: OverridesWinTestOptions })
+    | undefined;
+
   let container: HTMLDivElement | null = null;
   const mergeClasses = jest.fn();
 
@@ -69,5 +80,9 @@ export const overridesWin: ConformanceTest = (componentInfo, testInfo) => {
 
     expect(mergeClasses.mock.calls.length).toBeGreaterThanOrEqual(1);
     expect(mergeClasses.mock.calls).toContainClassNameLastInCalls(className);
+    expect(mergeClasses.mock.calls).toHaveMergeClassesCalledTimesWithClassName(
+      className,
+      testOptions?.[OVERRIDES_WIN_TEST_NAME]?.callCount || 1,
+    );
   });
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_Extracted from #19575._

Originally #19575 enables new tests for all v9 components, on of edge cases that I met is usage in `react-text` components. There `useTextStyles()` and later a wrapper are calling `mergeClasses()` (that gives us two calls instead of one):

https://github.com/microsoft/fluentui/blob/b9762f72d53452b12d22fd2591fbc57376423048/packages/react-text/src/components/wrapper.tsx#L13-L15

As customers may compose our components in the same way - it's an expected usage.

#### Why not allow random number all calls?

The test itself counts calls of `mergeClasses()` **with** passed `className`:

```tsx
mergeClasses(styles.root, 'className') // callCount: 1
mergeClasses(styles.icon) // callCount: 1
mergeClasses(styles.image, 'className') // callCount: 2
```

This prevents us from scenarios when `className` could be passed to multiple slots by a mistake like in an example above.
