### PR TITLE
(web-components) Increased contrast for small input controls

### DIFF
--- a/change/@fluentui-web-components-a35ba4d4-7670-4467-993c-98a0c728e0c3.json
+++ b/change/@fluentui-web-components-a35ba4d4-7670-4467-993c-98a0c728e0c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Increased contrast for small input controls",
+  "packageName": "@fluentui/web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -1049,6 +1049,30 @@ export const neutralStrokeRest: CSSDesignToken<Swatch>;
 // @public (undocumented)
 export const neutralStrokeRestDelta: CSSDesignToken<number>;
 
+// @public (undocumented)
+export const neutralStrokeStrongActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeStrongActiveDelta: CSSDesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeStrongFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeStrongFocusDelta: CSSDesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeStrongHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeStrongHoverDelta: CSSDesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeStrongRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const neutralStrokeStrongRest: CSSDesignToken<Swatch>;
+
 // Warning: (ae-internal-missing-underscore) The name "NumberField" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal
@@ -1201,7 +1225,7 @@ export const SwatchRGB: Readonly<{
 export { Switch }
 
 // @public
-export const switchStyles: (context: ElementDefinitionContext, defintiion: SwitchOptions) => ElementStyles;
+export const switchStyles: (context: ElementDefinitionContext, definition: SwitchOptions) => ElementStyles;
 
 export { Tab }
 

--- a/packages/web-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/src/checkbox/checkbox.styles.ts
@@ -20,9 +20,9 @@ import {
   neutralFillInputHover,
   neutralFillInputRest,
   neutralForegroundRest,
-  neutralStrokeActive,
-  neutralStrokeHover,
-  neutralStrokeRest,
+  neutralStrokeStrongActive,
+  neutralStrokeStrongHover,
+  neutralStrokeStrongRest,
   strokeWidth,
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
@@ -51,7 +51,7 @@ export const checkboxStyles: (context: ElementDefinitionContext, definition: Che
       height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
       box-sizing: border-box;
       border-radius: calc(${controlCornerRadius} * 1px);
-      border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+      border: calc(${strokeWidth} * 1px) solid ${neutralStrokeStrongRest};
       background: ${neutralFillInputRest};
       outline: none;
       cursor: pointer;
@@ -97,12 +97,12 @@ export const checkboxStyles: (context: ElementDefinitionContext, definition: Che
 
     :host(:enabled) .control:hover {
       background: ${neutralFillInputHover};
-      border-color: ${neutralStrokeHover};
+      border-color: ${neutralStrokeStrongHover};
     }
 
     :host(:enabled) .control:active {
       background: ${neutralFillInputActive};
-      border-color: ${neutralStrokeActive};
+      border-color: ${neutralStrokeStrongActive};
     }
 
     :host(:${focusVisible}) .control {

--- a/packages/web-components/src/color/recipes/neutral-stroke-strong.ts
+++ b/packages/web-components/src/color/recipes/neutral-stroke-strong.ts
@@ -1,0 +1,27 @@
+import { Palette } from '../palette';
+import { InteractiveSwatchSet } from '../recipe';
+import { Swatch } from '../swatch';
+import { directionByIsDark } from '../utilities/direction-by-is-dark';
+
+/**
+ * @internal
+ */
+export function neutralStrokeStrong(
+  palette: Palette,
+  reference: Swatch,
+  restContrast: number,
+  hoverDelta: number,
+  activeDelta: number,
+  focusDelta: number,
+): InteractiveSwatchSet {
+  const direction = directionByIsDark(reference);
+  const restSwatch = palette.colorContrast(reference, restContrast);
+  const restIndex = palette.closestIndexOf(restSwatch);
+
+  return {
+    rest: restSwatch,
+    hover: palette.get(restIndex + direction * hoverDelta),
+    active: palette.get(restIndex + direction * activeDelta),
+    focus: palette.get(restIndex + direction * focusDelta),
+  };
+}

--- a/packages/web-components/src/design-tokens.ts
+++ b/packages/web-components/src/design-tokens.ts
@@ -25,6 +25,7 @@ import { neutralLayer2 as neutralLayer2Algorithm } from './color/recipes/neutral
 import { neutralLayer3 as neutralLayer3Algorithm } from './color/recipes/neutral-layer-3';
 import { neutralLayer4 as neutralLayer4Algorithm } from './color/recipes/neutral-layer-4';
 import { neutralStroke as neutralStrokeAlgorithm } from './color/recipes/neutral-stroke';
+import { neutralStrokeStrong as neutralStrokeStrongAlgorithm } from './color/recipes/neutral-stroke-strong';
 import { accentBase, middleGrey } from './color/utilities/color-constants';
 import { StandardLuminance } from './color/utilities/base-layer-luminance';
 import { InteractiveSwatchSet } from './color/recipe';
@@ -168,6 +169,13 @@ export const neutralStrokeFocusDelta = create<number>('neutral-stroke-focus-delt
 export const neutralStrokeHoverDelta = create<number>('neutral-stroke-hover-delta').withDefault(40);
 /** @public */
 export const neutralStrokeRestDelta = create<number>('neutral-stroke-rest-delta').withDefault(25);
+
+/** @public */
+export const neutralStrokeStrongHoverDelta = create<number>('neutral-stroke-strong-hover-delta').withDefault(40);
+/** @public */
+export const neutralStrokeStrongActiveDelta = create<number>('neutral-stroke-strong-active-delta').withDefault(16);
+/** @public */
+export const neutralStrokeStrongFocusDelta = create<number>('neutral-stroke-strong-focus-delta').withDefault(25);
 
 /** @public */
 export const strokeWidth = create<number>('stroke-width').withDefault(1);
@@ -717,6 +725,41 @@ export const neutralOutlineHover = neutralStrokeHover;
 export const neutralOutlineActive = neutralStrokeActive;
 /** @public @deprecated Use neutralStrokeFocus */
 export const neutralOutlineFocus = neutralStrokeFocus;
+
+// Neutral Stroke Strong
+/** @public */
+export const neutralStrokeStrongRecipe = create<InteractiveColorRecipe>({
+  name: 'neutral-stroke-strong-recipe',
+  cssCustomPropertyName: null,
+}).withDefault({
+  evaluate: (element: HTMLElement): InteractiveSwatchSet => {
+    return neutralStrokeStrongAlgorithm(
+      neutralPalette.getValueFor(element),
+      fillColor.getValueFor(element),
+      3,
+      neutralStrokeStrongHoverDelta.getValueFor(element),
+      neutralStrokeStrongActiveDelta.getValueFor(element),
+      neutralStrokeStrongFocusDelta.getValueFor(element),
+    );
+  },
+});
+
+/** @public */
+export const neutralStrokeStrongRest = create<Swatch>('neutral-stroke-strong-rest').withDefault(
+  (element: HTMLElement) => neutralStrokeStrongRecipe.getValueFor(element).evaluate(element).rest,
+);
+/** @public */
+export const neutralStrokeStrongHover = create<Swatch>('neutral-stroke-strong-hover').withDefault(
+  (element: HTMLElement) => neutralStrokeStrongRecipe.getValueFor(element).evaluate(element).hover,
+);
+/** @public */
+export const neutralStrokeStrongActive = create<Swatch>('neutral-stroke-strong-active').withDefault(
+  (element: HTMLElement) => neutralStrokeStrongRecipe.getValueFor(element).evaluate(element).active,
+);
+/** @public */
+export const neutralStrokeStrongFocus = create<Swatch>('neutral-stroke-strong-focus').withDefault(
+  (element: HTMLElement) => neutralStrokeStrongRecipe.getValueFor(element).evaluate(element).focus,
+);
 
 // Neutral Layer Card Container
 /** @public */

--- a/packages/web-components/src/radio/radio.styles.ts
+++ b/packages/web-components/src/radio/radio.styles.ts
@@ -19,9 +19,9 @@ import {
   neutralFillInputHover,
   neutralFillInputRest,
   neutralForegroundRest,
-  neutralStrokeActive,
-  neutralStrokeHover,
-  neutralStrokeRest,
+  neutralStrokeStrongActive,
+  neutralStrokeStrongHover,
+  neutralStrokeStrongRest,
   strokeWidth,
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
@@ -54,7 +54,7 @@ export const radioStyles: (context: ElementDefinitionContext, definition: RadioO
       height: calc(var(--input-size) * 1px);
       box-sizing: border-box;
       border-radius: 50%;
-      border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+      border: calc(${strokeWidth} * 1px) solid ${neutralStrokeStrongRest};
       background: ${neutralFillInputRest};
       outline: none;
       cursor: pointer;
@@ -98,12 +98,12 @@ export const radioStyles: (context: ElementDefinitionContext, definition: RadioO
 
     :host(:enabled) .control:hover {
       background: ${neutralFillInputHover};
-      border-color: ${neutralStrokeHover};
+      border-color: ${neutralStrokeStrongHover};
     }
 
     :host(:enabled) .control:active {
       background: ${neutralFillInputActive};
-      border-color: ${neutralStrokeActive};
+      border-color: ${neutralStrokeStrongActive};
     }
 
     :host(:${focusVisible}) .control {

--- a/packages/web-components/src/switch/switch.styles.ts
+++ b/packages/web-components/src/switch/switch.styles.ts
@@ -25,17 +25,17 @@ import {
   neutralFillInputHover,
   neutralFillInputRest,
   neutralForegroundRest,
-  neutralStrokeActive,
-  neutralStrokeHover,
-  neutralStrokeRest,
+  neutralStrokeStrongActive,
+  neutralStrokeStrongHover,
+  neutralStrokeStrongRest,
   strokeWidth,
   typeRampBaseFontSize,
   typeRampBaseLineHeight,
 } from '../design-tokens';
 
-export const switchStyles: (context: ElementDefinitionContext, defintiion: SwitchOptions) => ElementStyles = (
+export const switchStyles: (context: ElementDefinitionContext, definition: SwitchOptions) => ElementStyles = (
   context: ElementDefinitionContext,
-  defintiion: SwitchOptions,
+  definition: SwitchOptions,
 ) =>
   css`
     :host([hidden]) {
@@ -74,18 +74,18 @@ export const switchStyles: (context: ElementDefinitionContext, defintiion: Switc
       height: calc(((${heightNumber} / 2) + ${designUnit}) * 1px);
       background: ${neutralFillInputRest};
       border-radius: calc(${heightNumber} * 1px);
-      border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+      border: calc(${strokeWidth} * 1px) solid ${neutralStrokeStrongRest};
     }
 
     :host(:enabled) .switch:hover {
       background: ${neutralFillInputHover};
-      border-color: ${neutralStrokeHover};
+      border-color: ${neutralStrokeStrongHover};
       cursor: pointer;
     }
 
     :host(:enabled) .switch:active {
       background: ${neutralFillInputActive};
-      border-color: ${neutralStrokeActive};
+      border-color: ${neutralStrokeStrongActive};
     }
 
     :host(:${focusVisible}) .switch {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The smaller input controls like checkbox and radio need to meet 3:1 contrast, but the current neutral stroke recipe wasn't designed for that. Added a "strong" recipe to meet contrast.

#### Focus areas to test

(optional)
