### PR TITLE
fix(perf-test): Baseline perf test freezes for unknown test

### DIFF
--- a/apps/perf-test/src/index.scenarios.tsx
+++ b/apps/perf-test/src/index.scenarios.tsx
@@ -26,27 +26,32 @@ const scenario = queryParams.scenario ? (queryParams.scenario as string) : defau
 const renderType = queryParams.renderType;
 
 const PerfTestScenario = scenarios[scenario];
-const PerfTestDecorator = PerfTestScenario.decorator || 'div';
+if (PerfTestScenario) {
+  const PerfTestDecorator = PerfTestScenario.decorator || 'div';
 
-if (renderType === 'virtual-rerender') {
-  for (let i = 0; i < iterations - 1; i++) {
-    ReactDOM.render(<PerfTestScenario />, div);
+  if (renderType === 'virtual-rerender') {
+    for (let i = 0; i < iterations - 1; i++) {
+      ReactDOM.render(<PerfTestScenario />, div);
+    }
+    ReactDOM.render(<PerfTestScenario />, div, () => div.appendChild(renderFinishedMarker));
+  } else {
+    // TODO: This seems to increase React (unstable_runWithPriority) render consumption from 4% to 72%!
+    // const ScenarioContent = Array.from({ length: iterations }, () => scenarios[scenario]);
+
+    // TODO: Using React Fragments increases React (unstable_runWithPriority) render consumption from 4% to 26%.
+    // It'd be interesting to root cause why at some point.
+    // ReactDOM.render(<>{Array.from({ length: iterations }, () => (scenarios[scenario]))}</>, div);
+    ReactDOM.render(
+      <PerfTestDecorator>
+        {Array.from({ length: iterations }, () => (
+          <PerfTestScenario />
+        ))}
+      </PerfTestDecorator>,
+      div,
+      () => div.appendChild(renderFinishedMarker),
+    );
   }
-  ReactDOM.render(<PerfTestScenario />, div, () => div.appendChild(renderFinishedMarker));
 } else {
-  // TODO: This seems to increase React (unstable_runWithPriority) render consumption from 4% to 72%!
-  // const ScenarioContent = Array.from({ length: iterations }, () => scenarios[scenario]);
-
-  // TODO: Using React Fragments increases React (unstable_runWithPriority) render consumption from 4% to 26%.
-  // It'd be interesting to root cause why at some point.
-  // ReactDOM.render(<>{Array.from({ length: iterations }, () => (scenarios[scenario]))}</>, div);
-  ReactDOM.render(
-    <PerfTestDecorator>
-      {Array.from({ length: iterations }, () => (
-        <PerfTestScenario />
-      ))}
-    </PerfTestDecorator>,
-    div,
-    () => div.appendChild(renderFinishedMarker),
-  );
+  // No PerfTest scenario to render -> done
+  div.appendChild(renderFinishedMarker);
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The current implementation of perf tests checks that all scenarios exist on the checked branch. But there is no way to check those scenarios also exist on the baseline branch. If that happens, the perf test freezes waiting for the result.
Usual use case when this happens is when a new test is added in a branch.

There had been a timeout protecting us from that but that was removed in #13551.

This is more a workaround than a proper fix as there is no easy way to report an error to flamegrill so we just report a success - there will be wrong results reported by the flamegrill.

#### Focus areas to test

(optional)
