### PR TITLE
Dialog/Modal/Panel: Popup component now correctly finds and adds aria-hidden attribute to sibling nodes.

### DIFF
--- a/change/@fluentui-react-bc5f8123-f2d6-4aea-90bb-d91f6667d51a.json
+++ b/change/@fluentui-react-bc5f8123-f2d6-4aea-90bb-d91f6667d51a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Dialog/Modal/Panel: Popup component now correctly finds and adds aria-hidden attribute to sibling nodes.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -126,11 +126,13 @@ function useHideSiblingNodes(props: IPopupProps) {
   React.useEffect(() => {
     const targetDocument = getDocument();
     if (isModalOrPanel && targetDocument) {
-      const children = targetDocument.body.children;
+      const bodyChildren = targetDocument.body.children;
+      const popupNode = bodyChildren[bodyChildren.length - 1];
+      const popupNodeParentChildren = popupNode.parentElement ? popupNode.parentElement.children : [];
       let nodesToHide: Element[] = [];
 
-      for (let i = 0; i < children.length - 1; i++) {
-        nodesToHide.push(children[i]);
+      for (let i = 0; i < popupNodeParentChildren.length - 1; i++) {
+        nodesToHide.push(popupNodeParentChildren[i]);
       }
 
       nodesToHide = nodesToHide.filter(


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [bug-12844](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12844)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- The change made in #17925 assumed that `body.children` are all siblings of the popup portal node which caused the issue of a parent node being hidden from the a11y tree. This change takes a bottom up approach and explicitly looks for the popup node's parent; then uses that to find and hide all sibling nodes.