### PR TITLE
refactor(Button): use `event.key` for keyboard event

### DIFF
--- a/change/@fluentui-react-button-878d6447-5a95-4a52-97b2-e1adc2e496f7.json
+++ b/change/@fluentui-react-button-878d6447-5a95-4a52-97b2-e1adc2e496f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "refactor(Button): use `event.key` for keyboard event",
+  "packageName": "@fluentui/react-button",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -45,7 +45,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/keyboard-key": "^0.3.4",
+    "@fluentui/keyboard-keys": "^9.0.0-alpha.3",
     "@fluentui/react-icons": "^1.1.136",
     "@fluentui/react-make-styles": "^9.0.0-alpha.61",
     "@fluentui/react-tabster": "^9.0.0-alpha.55",

--- a/packages/react-button/src/components/Button/useButtonState.ts
+++ b/packages/react-button/src/components/Button/useButtonState.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getCode, EnterKey, SpacebarKey } from '@fluentui/keyboard-key';
+import { Enter, Space } from '@fluentui/keyboard-keys';
 import type { ButtonState } from './Button.types';
 
 /**
@@ -16,8 +16,8 @@ export const useButtonState = (state: ButtonState): ButtonState => {
   const onNonAnchorOrButtonKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
     onKeyDownCallback?.(ev);
 
-    const keyCode = getCode(ev);
-    if (!ev.defaultPrevented && onClick && (keyCode === EnterKey || keyCode === SpacebarKey)) {
+    const key = ev.key;
+    if (!ev.defaultPrevented && onClick && (key === Enter || key === Space)) {
       // Translate the keydown enter/space to a click.
       ev.preventDefault();
       ev.stopPropagation();
@@ -58,8 +58,8 @@ export const useButtonState = (state: ButtonState): ButtonState => {
   // Disallow keydown event when component is disabled and eat events when disabledFocusable is set to true.
   const { onKeyDown } = state;
   state.onKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
-    const keyCode = getCode(ev);
-    if ((disabled || disabledFocusable) && (keyCode === EnterKey || keyCode === SpacebarKey)) {
+    const key = ev.key;
+    if ((disabled || disabledFocusable) && (key === Enter || key === Space)) {
       ev.preventDefault();
       ev.stopPropagation();
     } else {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Implements #18587 #19106
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Removes dependency from `@fluentui/keyboard-key` and switches to the converged `@fluentui/keyboard-keys` implemeting #18587 and bringing all converged dependencies to `alpha` to be ready to release for lockstep for #19106

#### Focus areas to test

(optional)