### PR TITLE
refactor(Link): use `event.key` for keyboard event

### DIFF
--- a/change/@fluentui-react-link-0d19f1a0-0e06-46d2-a260-d03ef2c4ce54.json
+++ b/change/@fluentui-react-link-0d19f1a0-0e06-46d2-a260-d03ef2c4ce54.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "refactor(Link): use `event.key` for keyboard event",
+  "packageName": "@fluentui/react-link",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-link/package.json
+++ b/packages/react-link/package.json
@@ -44,9 +44,9 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-tabster": "^9.0.0-alpha.55",
-    "@fluentui/keyboard-key": "^0.3.4",
+    "@fluentui/keyboard-keys": "^9.0.0-alpha.3",
     "@fluentui/react-make-styles": "^9.0.0-alpha.61",
+    "@fluentui/react-tabster": "^9.0.0-alpha.55",
     "@fluentui/react-utilities": "^9.0.0-alpha.43",
     "tslib": "^2.1.0"
   },

--- a/packages/react-link/src/components/Link/useLinkState.ts
+++ b/packages/react-link/src/components/Link/useLinkState.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getCode, EnterKey, SpacebarKey } from '@fluentui/keyboard-key';
+import { Enter, Space } from '@fluentui/keyboard-keys';
 import type { LinkState } from './Link.types';
 
 /**
@@ -12,8 +12,8 @@ export const useLinkState = (state: LinkState): LinkState => {
   const onNonAnchorOrButtonKeyDown = (ev: React.KeyboardEvent<HTMLAnchorElement | HTMLButtonElement | HTMLElement>) => {
     onKeyDownCallback?.(ev);
 
-    const keyCode = getCode(ev);
-    if (!ev.defaultPrevented && onClick && (keyCode === EnterKey || keyCode === SpacebarKey)) {
+    const key = ev.key;
+    if (!ev.defaultPrevented && onClick && (key === Enter || key === Space)) {
       // Translate the keydown enter/space to a click.
       ev.preventDefault();
       ev.stopPropagation();
@@ -67,8 +67,8 @@ export const useLinkState = (state: LinkState): LinkState => {
   // Disallow keydown event when component is disabled and eat events when disabledFocusable is set to true.
   const { onKeyDown } = state;
   state.onKeyDown = (ev: React.KeyboardEvent<HTMLAnchorElement | HTMLButtonElement | HTMLElement>) => {
-    const keyCode = getCode(ev);
-    if ((disabled || disabledFocusable) && (keyCode === EnterKey || keyCode === SpacebarKey)) {
+    const key = ev.key;
+    if ((disabled || disabledFocusable) && (key === Enter || key === Space)) {
       ev.preventDefault();
       ev.stopPropagation();
     } else {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Implements #18587 #19106
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Removes dependency from `@fluentui/keyboard-key` and switches to the converged `@fluentui/keyboard-keys` implemeting #18587 and bringing all converged dependencies to `alpha` to be ready to release for lockstep for #19106

#### Focus areas to test

(optional)