### PR TITLE
Toggle: Fixing issue where id was not changing if a different one was passed after first render

### DIFF
--- a/change/office-ui-fabric-react-36ea4ebd-740d-4c67-9927-43099f3423b0.json
+++ b/change/office-ui-fabric-react-36ea4ebd-740d-4c67-9927-43099f3423b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Toggle: Fixing issue where id was not changing if a different one was passed after first render.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -54,7 +54,7 @@ export class ToggleBase extends React.Component<IToggleProps, IToggleState> impl
     this.state = {
       checked: !!(props.checked || props.defaultChecked),
     };
-    this._id = props.id || getId('Toggle');
+    this._id = getId('Toggle');
   }
 
   /**
@@ -71,6 +71,7 @@ export class ToggleBase extends React.Component<IToggleProps, IToggleState> impl
       theme,
       disabled,
       keytipProps,
+      id,
       label,
       ariaLabel,
       /* eslint-disable deprecation/deprecation */
@@ -95,8 +96,9 @@ export class ToggleBase extends React.Component<IToggleProps, IToggleState> impl
       onOffMissing: !onText && !offText,
     });
 
-    const labelId = `${this._id}-label`;
-    const stateTextId = `${this._id}-stateText`;
+    const toggleId = id || this._id;
+    const labelId = `${toggleId}-label`;
+    const stateTextId = `${toggleId}-stateText`;
 
     // The following properties take priority for what Narrator should read:
     // 1. ariaLabel
@@ -121,7 +123,7 @@ export class ToggleBase extends React.Component<IToggleProps, IToggleState> impl
         {...keytipAttributes}
         className={classNames.pill}
         disabled={disabled}
-        id={this._id}
+        id={toggleId}
         type="button"
         role={ariaRole}
         ref={this._toggleButton}
@@ -152,7 +154,7 @@ export class ToggleBase extends React.Component<IToggleProps, IToggleState> impl
     return (
       <RootType className={classNames.root} hidden={(toggleNativeProps as any).hidden}>
         {label && (
-          <Label htmlFor={this._id} className={classNames.label} id={labelId}>
+          <Label htmlFor={toggleId} className={classNames.label} id={labelId}>
             {label}
           </Label>
         )}
@@ -162,7 +164,7 @@ export class ToggleBase extends React.Component<IToggleProps, IToggleState> impl
           {stateText && (
             // This second "htmlFor" property is needed to allow the
             // toggle's stateText to also trigger a state change when clicked.
-            <Label htmlFor={this._id} className={classNames.text} id={stateTextId}>
+            <Label htmlFor={toggleId} className={classNames.text} id={stateTextId}>
               {stateText}
             </Label>
           )}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
@@ -144,6 +144,29 @@ describe('Toggle', () => {
     expect(onSubmit.called).toEqual(false);
   });
 
+  it('correctly changes id if a different one is passed after first render', () => {
+    const testId1 = 'testId1';
+    const testId2 = 'testId2';
+    const component = mount(<Toggle id={testId1} />);
+
+    const toggleButton = component.find('button');
+    expect(toggleButton.length).toEqual(1);
+    expect(
+      toggleButton
+        .first()
+        .getDOMNode()
+        .getAttribute('id'),
+    ).toEqual(testId1);
+
+    component.setProps({ id: testId2 });
+    expect(
+      toggleButton
+        .first()
+        .getDOMNode()
+        .getAttribute('id'),
+    ).toEqual(testId2);
+  });
+
   describe('aria-labelledby', () => {
     it('has no aria-labelledby attribute if ariaLabel is provided', () => {
       const component = mount(<Toggle label="Label" ariaLabel="AriaLabel" />);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes and issue where, when passing an `id` after the element first rendered the `Toggle` component was not updating the id appropriately. It also adds a test to ensure this functionality does not regress in the future.