### PR TITLE
Fix typo: when using yarn the command is "create react-app"

### DIFF
--- a/apps/public-docsite/src/pages/Overviews/GetStartedPage/docs/web/GetStartedDevelopSimple.md
+++ b/apps/public-docsite/src/pages/Overviews/GetStartedPage/docs/web/GetStartedDevelopSimple.md
@@ -9,7 +9,7 @@ cd my-app
 npm start
 
 # Option 2: using yarn
-yarn create-react-app my-app --template @fluentui/cra-template
+yarn create react-app my-app --template @fluentui/cra-template
 cd my-app
 yarn start
 ```


### PR DESCRIPTION

#### Description of changes
Fix typo: when using yarn the command is "create react-app", not "create-react-app"
