### PR TITLE
fixed swatchColorPicker onChange prop which had undefined event parameter

### DIFF
--- a/packages/react/src/components/SwatchColorPicker/ColorPickerGridCell.types.ts
+++ b/packages/react/src/components/SwatchColorPicker/ColorPickerGridCell.types.ts
@@ -80,7 +80,7 @@ export interface IColorPickerGridCellProps {
   /**
    * Handler for when a color cell is clicked.
    */
-  onClick?: (item: IColorCellProps) => void;
+  onClick?: (event: React.FormEvent<HTMLElement>, item: IColorCellProps) => void;
 
   onHover?: (item?: IColorCellProps) => void;
 

--- a/packages/react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -231,7 +231,7 @@ export const SwatchColorPickerBase: React.FunctionComponent<ISwatchColorPickerPr
    * Handle the click on a cell
    */
   const onCellClick = React.useCallback(
-    (item: IColorCellProps): void => {
+    (event: React.FormEvent<HTMLElement>, item: IColorCellProps): void => {
       if (disabled) {
         return;
       }
@@ -241,7 +241,7 @@ export const SwatchColorPickerBase: React.FunctionComponent<ISwatchColorPickerPr
           internalState.cellFocused = false;
           onCellFocused();
         }
-        setSelectedId(item.id);
+        setSelectedId(item.id, event);
       }
     },
     [disabled, internalState, onCellFocused, selectedId, setSelectedId],

--- a/packages/react/src/utilities/ButtonGrid/ButtonGridCell.tsx
+++ b/packages/react/src/utilities/ButtonGrid/ButtonGridCell.tsx
@@ -27,11 +27,14 @@ export const ButtonGridCell = <T, P extends IButtonGridCellProps<T>>(props: IBut
     onFocus,
   } = props;
 
-  const handleClick = React.useCallback((): void => {
-    if (onClick && !disabled) {
-      onClick(item);
-    }
-  }, [disabled, item, onClick]);
+  const handleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>): void => {
+      if (onClick && !disabled) {
+        onClick(event, item);
+      }
+    },
+    [disabled, item, onClick],
+  );
 
   const handleMouseEnter = React.useCallback(
     (ev: React.MouseEvent<HTMLButtonElement>): void => {

--- a/packages/react/src/utilities/ButtonGrid/ButtonGridCell.types.ts
+++ b/packages/react/src/utilities/ButtonGrid/ButtonGridCell.types.ts
@@ -26,7 +26,7 @@ export interface IButtonGridCellProps<T> {
   /**
    * The on click handler
    */
-  onClick?: (item: T) => void;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>, item: T) => void;
 
   /**
    * The render callback to handle rendering the item


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19533 (2nd issue)
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

onChange prop callback function always had event parameter as undefined as the value of event was undefined when it was called inside SwatchColorPicker.base.tsx file. 

#### Focus areas to test
Tested the below example in local and its working correctly. 
https://codepen.io/ecraig12345/pen/ExXyZEz?editors=0011

