### PR TITLE
chore(usePopper): Document that `align` does not work without `position`

### DIFF
--- a/change/@fluentui-react-positioning-55755323-ee08-4471-83d0-980f830a0009.json
+++ b/change/@fluentui-react-positioning-55755323-ee08-4471-83d0-980f830a0009.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore(usePopper): Document that `align` does not work without `position`",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-positioning/src/types.ts
+++ b/packages/react-positioning/src/types.ts
@@ -23,7 +23,7 @@ export type PopperRefHandle = { updatePosition: () => void };
 export type PopperVirtualElement = PopperJs.VirtualElement;
 
 export interface PositioningProps {
-  /** Alignment for the component. */
+  /** Alignment for the component. Only has an effect if used with the @see position option */
   align?: Alignment;
 
   /** The element which will define the boundaries of the popper position for the flip behavior. */


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Adds documentation to indicate that `align` does not have an effect without the `position` option

#### Focus areas to test

(optional)
