### PR TITLE
fix(Menu): Missing submenu indicator slot

### DIFF
--- a/apps/vr-tests/src/stories/Menu.stories.tsx
+++ b/apps/vr-tests/src/stories/Menu.stories.tsx
@@ -176,3 +176,41 @@ storiesOf('react-menu Menu - selection groups', module)
       </MenuPopover>
     </Menu>
   ));
+
+storiesOf('react-menu Menu - nested submenus', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps().click('[role="menuitemcheckbox"]').snapshot('selected').end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addDecorator(FluentProviderDecorator)
+  .addStory('default', () => (
+    <Menu open>
+      <MenuTrigger>
+        <button>Toggle menu</button>
+      </MenuTrigger>
+
+      <MenuPopover>
+        <MenuList>
+          <MenuItem>New </MenuItem>
+          <MenuItem>New Window</MenuItem>
+          <MenuItem>Open Folder</MenuItem>
+          <Menu open>
+            <MenuTrigger>
+              <button>Toggle menu</button>
+            </MenuTrigger>
+
+            <MenuPopover>
+              <MenuList>
+                <MenuItem>New </MenuItem>
+                <MenuItem>New Window</MenuItem>
+                <MenuItem>Open Folder</MenuItem>
+              </MenuList>
+            </MenuPopover>
+          </Menu>
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  ));

--- a/apps/vr-tests/src/stories/Menu.stories.tsx
+++ b/apps/vr-tests/src/stories/Menu.stories.tsx
@@ -193,7 +193,7 @@ storiesOf('react-menu Menu - nested submenus', module)
           <MenuItem>Open Folder</MenuItem>
           <Menu open>
             <MenuTrigger>
-              <button>Toggle menu</button>
+              <MenuItem>Preferences</MenuItem>
             </MenuTrigger>
 
             <MenuPopover>

--- a/apps/vr-tests/src/stories/Menu.stories.tsx
+++ b/apps/vr-tests/src/stories/Menu.stories.tsx
@@ -178,13 +178,7 @@ storiesOf('react-menu Menu - selection groups', module)
   ));
 
 storiesOf('react-menu Menu - nested submenus', module)
-  .addDecorator(story => (
-    <Screener
-      steps={new Screener.Steps().click('[role="menuitemcheckbox"]').snapshot('selected').end()}
-    >
-      {story()}
-    </Screener>
-  ))
+  .addDecorator(story => <Screener>{story()}</Screener>)
   .addDecorator(FluentProviderDecorator)
   .addStory('default', () => (
     <Menu open>

--- a/change/@fluentui-react-menu-7cad6973-e27c-43da-9dc4-8cc51f5d55f1.json
+++ b/change/@fluentui-react-menu-7cad6973-e27c-43da-9dc4-8cc51f5d55f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(Menu): Missing submenu indicator slot",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/src/components/MenuItem/renderMenuItem.tsx
+++ b/packages/react-menu/src/components/MenuItem/renderMenuItem.tsx
@@ -15,7 +15,7 @@ export const renderMenuItem = (state: MenuItemState) => {
       <slots.icon {...slotProps.icon} />
       <slots.content {...slotProps.content} />
       <slots.secondaryContent {...slotProps.secondaryContent} />
-      {state.hasSubmenu && <slots.submenuIndicator {...slotProps.submenuIndicator} />}
+      <slots.submenuIndicator {...slotProps.submenuIndicator} />
     </slots.root>
   );
 };

--- a/packages/react-menu/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-menu/src/components/MenuItem/useMenuItem.tsx
@@ -9,7 +9,10 @@ import {
 import { useFluent } from '@fluentui/react-shared-contexts';
 import { useCharacterSearch } from './useCharacterSearch';
 import { useMenuTriggerContext } from '../../contexts/menuTriggerContext';
-import { ChevronRightIcon, ChevronLeftIcon } from '../../utils/DefaultIcons';
+import {
+  ChevronRight20Regular as ChevronRightIcon,
+  ChevronLeft20Regular as ChevronLeftIcon,
+} from '@fluentui/react-icons';
 import { useMenuListContext } from '../../contexts/menuListContext';
 import { useMenuContext } from '../../contexts/menuContext';
 import type { MenuItemProps, MenuItemSlots, MenuItemState } from './MenuItem.types';
@@ -60,6 +63,7 @@ export const useMenuItem = (props: MenuItemProps, ref: React.Ref<HTMLElement>): 
     icon: resolveShorthand(props.icon, { required: hasIcons }),
     checkmark: resolveShorthand(props.checkmark, { required: hasCheckmarks }),
     submenuIndicator: resolveShorthand(props.submenuIndicator, {
+      required: hasSubmenu,
       defaultProps: {
         children: dir === 'ltr' ? <ChevronRightIcon /> : <ChevronLeftIcon />,
       },


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

During the migration of slots, the `required` prop broke the display of the submenu indicator for cases when the slot was `undefined` as a prop.

#### Focus areas to test

(optional)
