### PR TITLE
fix(Layer): Put layer mount events after DOM updated

### DIFF
--- a/change/@fluentui-react-f8e8abf7-3b35-40f1-8480-654d2a0fa1e0.json
+++ b/change/@fluentui-react-f8e8abf7-3b35-40f1-8480-654d2a0fa1e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Put layer mount events after DOM updated.",
+  "packageName": "@fluentui/react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Layer/Layer.test.tsx
+++ b/packages/react/src/components/Layer/Layer.test.tsx
@@ -209,4 +209,55 @@ describe('Layer', () => {
 
     expect(stopPropagationCount).toEqual(0);
   });
+
+  it('raises on onLayerDidMount when mounted', () => {
+    const onLayerDidMountSpy = jest.fn();
+
+    // Mock createPortal to capture its component hierarchy in snapshot output.
+    const createPortal = ReactDOM.createPortal;
+
+    ReactDOM.createPortal = jest.fn(element => element);
+
+    safeCreate(<Layer onLayerDidMount={onLayerDidMountSpy}>Content</Layer>, component => {
+      expect(onLayerDidMountSpy).toHaveBeenCalledTimes(1);
+      ReactDOM.createPortal = createPortal;
+    });
+  });
+
+  it('DOM is ready when onLayerDidMount raised', () => {
+    const onLayerDidMountSpy = jest.fn();
+
+    // Mock createPortal to capture its component hierarchy in snapshot output.
+    const createPortal = ReactDOM.createPortal;
+
+    ReactDOM.createPortal = jest.fn(element => element);
+
+    safeCreate(
+      <div>
+        <Layer onLayerDidMount={onLayerDidMountSpy}>
+          <button>Content</button>
+        </Layer>
+      </div>,
+      component => {
+        expect(component.root.findByType('button')).toBeDefined();
+        ReactDOM.createPortal = createPortal;
+      },
+    );
+  });
+
+  it('does not raise onLayerDidMount when unmounted', () => {
+    const onLayerDidMountSpy = jest.fn();
+
+    // Mock createPortal to capture its component hierarchy in snapshot output.
+    const createPortal = ReactDOM.createPortal;
+
+    ReactDOM.createPortal = jest.fn(element => element);
+
+    safeCreate(<Layer onLayerDidMount={onLayerDidMountSpy}>Content</Layer>, component => {
+      ReactDOM.createPortal = createPortal;
+    });
+
+    // The 1 time is for when it was mounted
+    expect(onLayerDidMountSpy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #19077
- [X] Include a change request file using `$ yarn change`

#### Description of changes

In v7, where Layer was a class component, the onLayerDidMount and onLayerMounted (deprecated) events were raised in the callback from setState.  This caused the events to be raised after the DOM was rendered and ready.
In v8, the events were raised immediately after the elements were inserted in the DOM, so the DOM was not rendered and ready.

I updated Layer to track the need to raise the events as state and added a useEffect to cause them to be raised after a render pass.  I also updated to remove the layer as an HTML element state.  I removed the potentially stale ref on that state and replaced it tracking the layer as a ref.  I updated the removeLayerElement to clear the ref when the layer was removed.

I added 3 unit tests to ensure the event is raised correctly:
- raises on onLayerDidMount when mounted
- DOM is ready when onLayerDidMount raised
- does not raise onLayerDidMount when unmounted

I updated the react examples temporarily to manually verify the DOM was ready when the event is raised (per the example in the issue).
