### PR TITLE
Azure theme 7.0 placeholder text contrast ratio fix 

### DIFF
--- a/change/@uifabric-azure-themes-12c9408d-21a4-41c3-8114-a0ecd39c89f6.json
+++ b/change/@uifabric-azure-themes-12c9408d-21a4-41c3-8114-a0ecd39c89f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[7.0] dropdown and textfield placeholder contrast theme fix, light theme only ",
+  "packageName": "@uifabric/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -613,7 +613,7 @@ export const LightSemanticColors: IAzureSemanticColors = {
     hyperlinkHovered: BaseColors.BLUE_004578,
     success: BaseColors.GREEN_428000,
     error: BaseColors.RED_A4262C,
-    placeholder: BaseColors.GRAY_8A8886,
+    placeholder: BaseColors.GRAY_605E5C,
   },
   statusBar: {
     link: BaseColors.BLUE_106EBE,

--- a/packages/azure-themes/src/azure/styles/DefaultButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DefaultButton.styles.ts
@@ -14,6 +14,10 @@ export const DefaultButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
       padding: '0px 16px',
       border: `${StyleConstants.borderWidth} solid ${semanticColors.inputBorder}`,
       selectors: {
+        // fix for azure portal bug, text-alignment is off.
+        '.ms-Button-label': {
+          lineHeight: '20px',
+        },
         // standard button
         '&.is-expanded': {
           color: semanticColors.buttonTextHovered,

--- a/packages/azure-themes/src/azure/styles/DropDown.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DropDown.styles.ts
@@ -72,7 +72,7 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
         selectors: {
           ['.ms-Dropdown-title']: {
             color: semanticColors.bodyText,
-            borderColor: semanticColors.inputPlaceholderText,
+            borderColor: semanticColors.inputBorder,
             backgroundColor: extendedSemanticColors.controlBackground,
           },
           ['.ms-Dropdown-titleIsPlaceHolder.ms-Dropdown-title']: {

--- a/packages/azure-themes/src/azure/styles/TextField.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TextField.styles.ts
@@ -13,7 +13,7 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
         height: StyleConstants.inputControlHeight,
       },
       !hasErrorMessage && {
-        borderColor: semanticColors.inputPlaceholderText,
+        borderColor: semanticColors.inputBorder,
         selectors: {
           '::after': {
             borderColor: extendedSemanticColors.controlFocus,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19656 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
PR created in response to #19656 
Per figma: Input border should be #8A8886, placeholder text: #605E5C
![image](https://user-images.githubusercontent.com/30805892/132451820-4b694dc2-171a-403a-9d1b-0ff85cf08f77.png)
![image](https://user-images.githubusercontent.com/30805892/132452014-524974fe-0a9e-45a5-9848-af455ab3c362.png)

No changes made to other themes (dark, high contrast) and they remain the same. 


