### PR TITLE
feat(react-components): Allow deep export of unstable components

### DIFF
--- a/change/@fluentui-react-components-2ff28675-4b35-4a5e-b29a-c81f4fb3d320.json
+++ b/change/@fluentui-react-components-2ff28675-4b35-4a5e-b29a-c81f4fb3d320.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat(react-components): Allow deep export of unstable components",
+  "packageName": "@fluentui/react-components",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/.gitignore
+++ b/packages/react-components/.gitignore
@@ -1,0 +1,2 @@
+# Ignore build output for the react-components unstable export path
+/unstable/

--- a/packages/react-components/config/pre-copy.json
+++ b/packages/react-components/config/pre-copy.json
@@ -1,0 +1,5 @@
+{
+  "copyTo": {
+    "unstable": ["./src/unstable/package.json"]
+  }
+}

--- a/packages/react-components/src/unstable/index.ts
+++ b/packages/react-components/src/unstable/index.ts
@@ -1,3 +1,3 @@
 // Stub for unstable exports
 
-export * from '@fluentui/react-switch';
+// export * from '@fluentui/react-switch';

--- a/packages/react-components/src/unstable/index.ts
+++ b/packages/react-components/src/unstable/index.ts
@@ -1,0 +1,3 @@
+// Stub for unstable exports
+
+export * from '@fluentui/react-switch';

--- a/packages/react-components/src/unstable/package.json
+++ b/packages/react-components/src/unstable/package.json
@@ -1,13 +1,8 @@
 {
-  "name": "@fluentui/react-components",
   "description": "Separate entrypoint for unstable Fluent UI components",
   "main": "../lib-commonjs/unstable/index.js",
   "module": "../lib/unstable/index.js",
-  "typings": "../lib/index.d.ts",
+  "typings": "../lib/unstable/index.d.ts",
   "sideEffects": false,
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/microsoft/fluentui"
-  },
   "license": "MIT"
 }

--- a/packages/react-components/src/unstable/package.json
+++ b/packages/react-components/src/unstable/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@fluentui/react-components",
+  "description": "Separate entrypoint for unstable Fluent UI components",
+  "main": "../lib-commonjs/unstable/index.js",
+  "module": "../lib/unstable/index.js",
+  "typings": "../lib/index.d.ts",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fluentui"
+  },
+  "license": "MIT"
+}

--- a/packages/react-components/src/unstable/tsconfig.json
+++ b/packages/react-components/src/unstable/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes partially #19106
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Allows the following deep export:

```tsx
import { Switch } from '@fluentui/react-components/unstable'
```

Uses the `copy` task configuration to add a separate entrypoint so that both webpack and jest can load the unstable packages correctly.

The code snippet below shows how to export a component as an unstable one:

```tsx
// packages/react-components/src/unstable/index.ts

export * from '@fluentui/react-switch'
```