### PR TITLE
Improve component playground overflow

### DIFF
--- a/packages/fluentui/docs-components/src/knobs/defaultComponents.tsx
+++ b/packages/fluentui/docs-components/src/knobs/defaultComponents.tsx
@@ -83,6 +83,7 @@ const KnobSelect: React.FunctionComponent<KnobComponentProps> = props => (
       props.setValue(e.target.value);
     }}
     value={props.value}
+    style={{ width: '100%' }}
   >
     {props.values &&
       props.values.map(option => (
@@ -115,6 +116,7 @@ const KnobString: React.FunctionComponent<KnobComponentProps> = props => (
       props.setValue(e.target.value);
     }}
     value={props.value}
+    style={{ width: '100%' }}
   />
 );
 

--- a/packages/fluentui/docs/src/components/ComponentPlayground/ComponentPlaygroundTemplate.tsx
+++ b/packages/fluentui/docs/src/components/ComponentPlayground/ComponentPlaygroundTemplate.tsx
@@ -26,6 +26,7 @@ const ComponentPlaygroundTemplate: React.FunctionComponent<ComponentPlaygroundTe
       styles={{
         height: 'auto',
         alignItems: 'stretch',
+        minWidth: 0,
       }}
     >
       <Segment


### PR DESCRIPTION
1. Set fixed width for knob input and selects
  *Before*
  ![image](https://user-images.githubusercontent.com/2564094/132572155-77bec5cd-de2b-43c8-ae3b-bd740f92cd87.png)
  *After*
  ![image](https://user-images.githubusercontent.com/2564094/132572168-416d987e-082f-4c81-84b4-d8856192f9c6.png)
2. Prevent Component Playground from growing past the layout horizontally
  *Before*
  ![image](https://user-images.githubusercontent.com/2564094/132571956-e8530a8e-9d1b-422f-b2ba-2806ef28b030.png)
  *After*
  ![image](https://user-images.githubusercontent.com/2564094/132571982-9268bf6f-9904-4008-9312-853977a56670.png)