### PR TITLE
Updating converged README.md files to mention exporting from react-components

### DIFF
--- a/change/@fluentui-react-avatar-2b7719a5-f1e9-4e44-b076-cd1ab54986d0.json
+++ b/change/@fluentui-react-avatar-2b7719a5-f1e9-4e44-b076-cd1ab54986d0.json
@@ -1,0 +1,6 @@
+{
+  "type": "none",
+  "packageName": "@fluentui/react-avatar",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-2b7719a5-f1e9-4e44-b076-cd1ab54986d0.json
+++ b/change/@fluentui-react-avatar-2b7719a5-f1e9-4e44-b076-cd1ab54986d0.json
@@ -1,5 +1,6 @@
 {
   "type": "none",
+  "comment": "Updating README.md",
   "packageName": "@fluentui/react-avatar",
   "email": "czearing@outlook.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-button-d66ecce2-70f2-4d58-b7be-f7ec1fa2f642.json
+++ b/change/@fluentui-react-button-d66ecce2-70f2-4d58-b7be-f7ec1fa2f642.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Updating README.md files to use react-components instead of react",
+  "comment": "Updating README.md",
   "packageName": "@fluentui/react-button",
   "email": "czearing@outlook.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-button-d66ecce2-70f2-4d58-b7be-f7ec1fa2f642.json
+++ b/change/@fluentui-react-button-d66ecce2-70f2-4d58-b7be-f7ec1fa2f642.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updating README.md files to use react-components instead of react",
+  "packageName": "@fluentui/react-button",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-f1fe2aeb-4e58-4498-a658-54330f6c94ee.json
+++ b/change/@fluentui-react-link-f1fe2aeb-4e58-4498-a658-54330f6c94ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updating README.md files to use react-components instead of react",
+  "packageName": "@fluentui/react-link",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-f1fe2aeb-4e58-4498-a658-54330f6c94ee.json
+++ b/change/@fluentui-react-link-f1fe2aeb-4e58-4498-a658-54330f6c94ee.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Updating README.md files to use react-components instead of react",
+  "comment": "Updating README.md",
   "packageName": "@fluentui/react-link",
   "email": "czearing@outlook.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-slider-68923fec-6673-4d05-a8f8-e6699ed08b35.json
+++ b/change/@fluentui-react-slider-68923fec-6673-4d05-a8f8-e6699ed08b35.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Updating README.md files to use react-components instead of react",
+  "comment": "Updating README.md",
   "packageName": "@fluentui/react-slider",
   "email": "czearing@outlook.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-slider-68923fec-6673-4d05-a8f8-e6699ed08b35.json
+++ b/change/@fluentui-react-slider-68923fec-6673-4d05-a8f8-e6699ed08b35.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updating README.md files to use react-components instead of react",
+  "packageName": "@fluentui/react-slider",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-avatar/README.md
+++ b/packages/react-avatar/README.md
@@ -19,7 +19,7 @@ import { Avatar } from '@fluentui/react-avatar';
 Once the Avatar component graduates to a production release, the component will be available at:
 
 ```js
-import { Avatar } from '@fluentui/react';
+import { Avatar } from '@fluentui/react-components';
 ```
 
 ### Examples

--- a/packages/react-button/README.md
+++ b/packages/react-button/README.md
@@ -19,7 +19,7 @@ import { Button } from '@fluentui/react-button';
 Once the Button component graduates to a production release, the component will be available at:
 
 ```js
-import { Button } from '@fluentui/react';
+import { Button } from '@fluentui/react-components';
 ```
 
 ### Examples

--- a/packages/react-link/README.md
+++ b/packages/react-link/README.md
@@ -19,7 +19,7 @@ import { Link } from '@fluentui/react-link';
 Once the Link component graduates to a production release, the component will be available at:
 
 ```js
-import { Link } from '@fluentui/react';
+import { Link } from '@fluentui/react-components';
 ```
 
 ### Examples

--- a/packages/react-slider/README.md
+++ b/packages/react-slider/README.md
@@ -20,5 +20,5 @@ import { Slider } from '@fluentui/react-slider';
 Once the Slider component graduates to a production release, the component will be available at:
 
 ```js
-import { Slider } from '@fluentui/slider';
+import { Slider } from '@fluentui/react-components';
 ```


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes

Updating converged README.md files to mention exporting from `react-components` instead of `react`

