### PR TITLE
Charting: CherryPick #19708: Fixed: Reverse focus order is not proper in the line chart. #19708

### DIFF
--- a/change/@uifabric-charting-4d52e727-3d45-4ffd-83cf-843de32420f5.json
+++ b/change/@uifabric-charting-4d52e727-3d45-4ffd-83cf-843de32420f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Dots for all points will render with opacity as 1 or 0.01 depends on line is active or not. This is done becouse reverse focus was not proper in line chart",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -530,7 +530,81 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
         let path = this._getPath(this._xAxisScale(x1), this._yAxisScale(y1), circleId, j, false, this._points[i].index);
         const strokeWidth =
           this._points[i].lineOptions?.strokeWidth || this.props.strokeWidth || DEFAULT_LINE_STROKE_SIZE;
-        if (this.state.activeLegend === legendVal || this.state.activeLegend === '' || this.state.isSelectedLegend) {
+
+        const isLegendSelected: boolean =
+          this.state.activeLegend === legendVal || this.state.activeLegend === '' || this.state.isSelectedLegend;
+
+        const hideNonActiveDots = activePoint !== circleId && this._points[i].hideNonActiveDots;
+        pointsForLine.push(
+          <path
+            id={circleId}
+            key={circleId}
+            d={path}
+            data-is-focusable={i === 0 ? true : false}
+            onMouseOver={this._handleHover.bind(this, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
+            onMouseMove={this._handleHover.bind(this, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
+            onMouseOut={this._handleMouseOut}
+            onFocus={() => this._handleFocus(lineId, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
+            onBlur={this._handleMouseOut}
+            onClick={this._onDataPointClick.bind(this, this._points[i].data[j - 1].onDataPointClick)}
+            visibility={hideNonActiveDots ? 'hidden' : 'visible'}
+            opacity={isLegendSelected ? 1 : 0.01}
+            fill={this._getPointFill(lineColor, circleId, j, false)}
+            stroke={lineColor}
+            strokeWidth={2}
+          />,
+        );
+        if (j + 1 === this._points[i].data.length) {
+          const lastCircleId = `${circleId}${j}L`;
+          path = this._getPath(
+            this._xAxisScale(x2),
+            this._yAxisScale(y2),
+            lastCircleId,
+            j,
+            true,
+            this._points[i].index,
+          );
+          const {
+            xAxisCalloutData: lastCirlceXCallout,
+            xAxisCalloutAccessibilityData: lastCirlceXCalloutAccessibilityData,
+          } = this._points[i].data[j];
+          pointsForLine.push(
+            <path
+              id={lastCircleId}
+              key={lastCircleId}
+              d={path}
+              data-is-focusable={i === 0 ? true : false}
+              onMouseOver={this._handleHover.bind(
+                this,
+                x2,
+                lastCirlceXCallout,
+                lastCircleId,
+                lastCirlceXCalloutAccessibilityData,
+              )}
+              onMouseMove={this._handleHover.bind(
+                this,
+                x2,
+                lastCirlceXCallout,
+                lastCircleId,
+                lastCirlceXCalloutAccessibilityData,
+              )}
+              onMouseOut={this._handleMouseOut}
+              onFocus={() =>
+                this._handleFocus(lineId, x2, lastCirlceXCallout, lastCircleId, lastCirlceXCalloutAccessibilityData)
+              }
+              onBlur={this._handleMouseOut}
+              onClick={this._onDataPointClick.bind(this, this._points[i].data[j].onDataPointClick)}
+              visibility={hideNonActiveDots ? 'hidden' : 'visible'}
+              opacity={isLegendSelected ? 1 : 0.01}
+              fill={this._getPointFill(lineColor, lastCircleId, j, true)}
+              stroke={lineColor}
+              strokeWidth={2}
+            />,
+          );
+          /* eslint-enable react/jsx-no-bind */
+        }
+
+        if (isLegendSelected) {
           // don't draw line if it is in a gap
           if (!isInGap) {
             const lineBorderWidth = this._points[i].lineOptions?.lineBorderWidth
@@ -588,76 +662,6 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
                 onClick={this._onLineClick.bind(this, this._points[i].onLineClick)}
               />,
             );
-          }
-          const hideNonActiveDots = activePoint !== circleId && this._points[i].hideNonActiveDots;
-          pointsForLine.push(
-            <path
-              id={circleId}
-              key={circleId}
-              d={path}
-              data-is-focusable={i === 0 ? true : false}
-              onMouseOver={this._handleHover.bind(this, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
-              onMouseMove={this._handleHover.bind(this, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
-              onMouseOut={this._handleMouseOut}
-              onFocus={() => this._handleFocus(lineId, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
-              onBlur={this._handleMouseOut}
-              onClick={this._onDataPointClick.bind(this, this._points[i].data[j - 1].onDataPointClick)}
-              visibility={hideNonActiveDots ? 'hidden' : 'visible'}
-              opacity={1}
-              fill={this._getPointFill(lineColor, circleId, j, false)}
-              stroke={lineColor}
-              strokeWidth={2}
-            />,
-          );
-
-          if (j + 1 === this._points[i].data.length) {
-            const lastCircleId = `${circleId}${j}L`;
-            path = this._getPath(
-              this._xAxisScale(x2),
-              this._yAxisScale(y2),
-              lastCircleId,
-              j,
-              true,
-              this._points[i].index,
-            );
-            const {
-              xAxisCalloutData: lastCirlceXCallout,
-              xAxisCalloutAccessibilityData: lastCirlceXCalloutAccessibilityData,
-            } = this._points[i].data[j];
-            pointsForLine.push(
-              <path
-                id={lastCircleId}
-                key={lastCircleId}
-                d={path}
-                data-is-focusable={i === 0 ? true : false}
-                onMouseOver={this._handleHover.bind(
-                  this,
-                  x2,
-                  lastCirlceXCallout,
-                  lastCircleId,
-                  lastCirlceXCalloutAccessibilityData,
-                )}
-                onMouseMove={this._handleHover.bind(
-                  this,
-                  x2,
-                  lastCirlceXCallout,
-                  lastCircleId,
-                  lastCirlceXCalloutAccessibilityData,
-                )}
-                onMouseOut={this._handleMouseOut}
-                onFocus={() =>
-                  this._handleFocus(lineId, x2, lastCirlceXCallout, lastCircleId, lastCirlceXCalloutAccessibilityData)
-                }
-                onBlur={this._handleMouseOut}
-                onClick={this._onDataPointClick.bind(this, this._points[i].data[j].onDataPointClick)}
-                visibility={hideNonActiveDots ? 'hidden' : 'visible'}
-                opacity={1}
-                fill={this._getPointFill(lineColor, lastCircleId, j, true)}
-                stroke={lineColor}
-                strokeWidth={2}
-              />,
-            );
-            /* eslint-enable react/jsx-no-bind */
           }
         } else {
           if (!isInGap) {


### PR DESCRIPTION
### Original description
Cherry pick of [#19708](https://github.com/microsoft/fluentui/pull/19708)

#### Description of changes
In the line chart, Reverse focus order from legends will work with these changes.
Previously line dots were not rendered for non-active lines, which was removing the line chart tabIndex value. This causes the issue.

With new changes, line dots for all lines will render. If the line is selected then Opacity will be 1 for the line dots, and for non-active lines dots, it is 0.01. By this change, the focus indicator will be there.  With this opacity change, the visual appearance is the same as previous and the reverse focus is also working as expected. 

#### Focus areas to test

Line chart

**Before Changes:**
https://user-images.githubusercontent.com/29042635/132668438-a802db51-e31f-4854-8347-29967a98e058.mp4

**After Changes:**
https://user-images.githubusercontent.com/29042635/132668852-29cb2049-cdd8-4c74-8538-f22ee2b89542.mp4

