### PR TITLE
Show highlight on keyboard-focus only

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -71,6 +71,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Tooltip` appearance in high contrast theme @yuanboxue-amber ([#19559](https://github.com/microsoft/fluentui/pull/19559))
 - Fix `Shadow` colors to match redlines @notandrew ([#19552](https://github.com/microsoft/fluentui/pull/19552))
 - Fix `Checkbox` background issue on zoom above 100% @vitthalr ([#19619](https://github.com/microsoft/fluentui/pull/19619))
+- Fix compact `ChatMessage` focus highlight @Hirse ([#19720])(https://github.com/microsoft/fluentui/pull/19720)
 
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### BREAKING CHANGES
 - Remove Red Foreground 3 from color scheme tokens  @codepretty ([#19761](https://github.com/microsoft/fluentui/pull/19761))
 
+### Fixes
+- Fix compact `ChatMessage` focus highlight @Hirse ([#19720](https://github.com/microsoft/fluentui/pull/19720))
+
 ### Documentation
 - Add Chat Playground @Hirse ([#19702](https://github.com/microsoft/fluentui/pull/19702))
 
@@ -71,7 +74,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Tooltip` appearance in high contrast theme @yuanboxue-amber ([#19559](https://github.com/microsoft/fluentui/pull/19559))
 - Fix `Shadow` colors to match redlines @notandrew ([#19552](https://github.com/microsoft/fluentui/pull/19552))
 - Fix `Checkbox` background issue on zoom above 100% @vitthalr ([#19619](https://github.com/microsoft/fluentui/pull/19619))
-- Fix compact `ChatMessage` focus highlight @Hirse ([#19720](https://github.com/microsoft/fluentui/pull/19720))
 
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -71,7 +71,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Tooltip` appearance in high contrast theme @yuanboxue-amber ([#19559](https://github.com/microsoft/fluentui/pull/19559))
 - Fix `Shadow` colors to match redlines @notandrew ([#19552](https://github.com/microsoft/fluentui/pull/19552))
 - Fix `Checkbox` background issue on zoom above 100% @vitthalr ([#19619](https://github.com/microsoft/fluentui/pull/19619))
-- Fix compact `ChatMessage` focus highlight @Hirse ([#19720])(https://github.com/microsoft/fluentui/pull/19720)
+- Fix compact `ChatMessage` focus highlight @Hirse ([#19720](https://github.com/microsoft/fluentui/pull/19720))
 
 ### Features
 - Add Onyx 600, Silver 100 to color palette and some color tokens @codepretty ([#18827](https://github.com/microsoft/fluentui/pull/18827))

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleCompact.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleCompact.shorthand.steps.ts
@@ -7,7 +7,11 @@ const selectors = {
 
 const config: ScreenerTestsConfig = {
   themes: ['teams', 'teamsDark', 'teamsHighContrast', 'teamsV2', 'teamsDarkV2'],
-  steps: [builder => builder.hover(selectors.message).snapshot('Mouse hover on first message')],
+  steps: [
+    builder => builder.hover(selectors.message).snapshot('Mouse hover on first message'),
+    (builder, keys) =>
+      builder.click(selectors.message).keys(selectors.message, keys.downArrow).snapshot('Focuses second message'),
+  ],
 };
 
 export default config;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesCompact.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesCompact.ts
@@ -3,43 +3,47 @@ import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 import { chatMessageSlotClassNames, ChatMessageStylesProps } from '../../../../components/Chat/ChatMessage';
 import { pxToRem } from '../../../../utils';
 import { screenReaderContainerStyles } from '../../../../utils/accessibility/Styles/accessibilityStyles';
+import { getBorderFocusStyles } from '../../getBorderFocusStyles';
 import { ChatMessageVariables } from './chatMessageVariables';
 
 /** ChatMessage styles specific for the compact density. */
 export const chatMessageStylesCompact: ComponentSlotStylesPrepared<ChatMessageStylesProps, ChatMessageVariables> = {
-  root: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    border: v.compactBorder,
-    padding: v.paddingCompact,
-    width: '100%',
-
-    ...((v.hasMention || v.isImportant) && {
-      [`& .${chatMessageSlotClassNames.bar}`]: {
-        backgroundColor: v.hasMention ? v.hasMentionColor : v.isImportantColor,
-        position: 'absolute',
-        borderRadius: pxToRem(2),
-        height: `calc(100% - ${v.paddingCompact} - ${v.paddingCompact})`,
-        left: pxToRem(-56),
-        top: v.paddingCompact,
-        width: pxToRem(2),
-      },
-    }),
-
-    ...(p.focused && {
+  root: ({ theme: { siteVariables }, variables: v }): ICSSInJSStyle => {
+    const borderFocusStyles = getBorderFocusStyles({ borderRadius: 'inherit', variables: siteVariables });
+    const highlight = {
       backgroundColor: v.compactHoverBackground,
       border: v.compactHoverBorder,
       [`& .${chatMessageSlotClassNames.timestamp}`]: {
         opacity: 1,
       },
-    }),
+    };
 
-    '&:hover': {
-      backgroundColor: v.compactHoverBackground,
-      border: v.compactHoverBorder,
-      [`& .${chatMessageSlotClassNames.timestamp}`]: {
-        opacity: 1,
+    return {
+      border: v.compactBorder,
+      padding: v.paddingCompact,
+      width: '100%',
+
+      ...((v.hasMention || v.isImportant) && {
+        [`& .${chatMessageSlotClassNames.bar}`]: {
+          backgroundColor: v.hasMention ? v.hasMentionColor : v.isImportantColor,
+          position: 'absolute',
+          borderRadius: pxToRem(2),
+          height: `calc(100% - ${v.paddingCompact} - ${v.paddingCompact})`,
+          left: pxToRem(-56),
+          top: v.paddingCompact,
+          width: pxToRem(2),
+        },
+      }),
+
+      ':focus-visible': {
+        // Add focus border styles as they would be replaced otherwise
+        ...borderFocusStyles[':focus-visible'],
+        ...highlight,
       },
-    },
-  }),
+
+      '&:hover': highlight,
+    };
+  },
 
   author: ({ props: p, variables: v }): ICSSInJSStyle => ({
     ...((p.attached === 'bottom' || p.attached === true) && (screenReaderContainerStyles as ICSSInJSStyle)),


### PR DESCRIPTION
Compact chat messages have a highlight effect applied on hover and focus.
![compact-focus-old](https://user-images.githubusercontent.com/2564094/132718101-2b00ddb5-0db0-49f5-a05f-cbf2e33d305d.gif)

This PR restricts the focus condition to keyboard-focus only, as the effect otherwise stays too long on the item.