### PR TITLE
DO NOT MERGE testing es2019

### DIFF
--- a/apps/a11y-tests/tsconfig.json
+++ b/apps/a11y-tests/tsconfig.json
@@ -13,7 +13,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es2019", "dom"],
     "types": ["jest"],
     "jsx": "react"
   },

--- a/apps/a11y-tests/tsconfig.json
+++ b/apps/a11y-tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,

--- a/apps/perf-test/tsconfig.json
+++ b/apps/perf-test/tsconfig.json
@@ -12,7 +12,7 @@
     "preserveConstEnums": true,
     "strictNullChecks": true,
     "noImplicitAny": true,
-    "lib": ["es6", "dom"],
+    "lib": ["es2019", "dom"],
     "types": ["webpack-env"],
     "skipLibCheck": true
   },

--- a/apps/perf-test/tsconfig.json
+++ b/apps/perf-test/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
     "jsx": "react",

--- a/apps/public-docsite-resources/tsconfig.json
+++ b/apps/public-docsite-resources/tsconfig.json
@@ -17,7 +17,7 @@
     "preserveConstEnums": true,
     "noImplicitThis": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom", "es2015.promise"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["webpack-env", "custom-global"]
   },

--- a/apps/public-docsite-resources/tsconfig.json
+++ b/apps/public-docsite-resources/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/apps/public-docsite/tsconfig.json
+++ b/apps/public-docsite/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "lib",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/apps/public-docsite/tsconfig.json
+++ b/apps/public-docsite/tsconfig.json
@@ -14,7 +14,7 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["webpack-env", "custom-global"]
   },

--- a/apps/server-rendered-app/tsconfig.json
+++ b/apps/server-rendered-app/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es5",
+    "target": "es2019",
     "module": "es6",
     "jsx": "react",
     "declaration": true,

--- a/apps/server-rendered-app/tsconfig.json
+++ b/apps/server-rendered-app/tsconfig.json
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "preserveConstEnums": false,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["custom-global"]
   },

--- a/apps/theming-designer/tsconfig.json
+++ b/apps/theming-designer/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
     "jsx": "react",

--- a/apps/theming-designer/tsconfig.json
+++ b/apps/theming-designer/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "strict": false,
-    "lib": ["es6", "dom"],
+    "lib": ["es2019", "dom"],
     "types": [],
     "noImplicitAny": true
   },

--- a/apps/todo-app/tsconfig.json
+++ b/apps/todo-app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
     "jsx": "react",

--- a/apps/todo-app/tsconfig.json
+++ b/apps/todo-app/tsconfig.json
@@ -12,7 +12,7 @@
     "preserveConstEnums": true,
     "strict": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["custom-global"]
   },

--- a/apps/vr-tests/tsconfig.json
+++ b/apps/vr-tests/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
     "jsx": "react",

--- a/change/@fluentui-azure-themes-f7514c3b-f8a3-4de8-a6d7-d41a1c91ee59.json
+++ b/change/@fluentui-azure-themes-f7514c3b-f8a3-4de8-a6d7-d41a1c91ee59.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/azure-themes",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-babel-make-styles-eca71a3b-5a09-43b6-83fb-fa68185bb464.json
+++ b/change/@fluentui-babel-make-styles-eca71a3b-5a09-43b6-83fb-fa68185bb464.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-codemods-2c9e18a6-2ebc-4799-af3a-3e18f89c4bf6.json
+++ b/change/@fluentui-codemods-2c9e18a6-2ebc-4799-af3a-3e18f89c4bf6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/codemods",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-date-time-utilities-4a900018-bd88-4bf7-93f6-2c48d680275f.json
+++ b/change/@fluentui-date-time-utilities-4a900018-bd88-4bf7-93f6-2c48d680275f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-dom-utilities-aab6df8c-3daa-42ff-b9ba-c03207627539.json
+++ b/change/@fluentui-dom-utilities-aab6df8c-3daa-42ff-b9ba-c03207627539.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-example-data-16beaf5f-929c-4757-b779-e027f7e62de8.json
+++ b/change/@fluentui-example-data-16beaf5f-929c-4757-b779-e027f7e62de8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/example-data",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-font-icons-mdl2-6d66c625-8f8b-421e-a729-1db1e5191d58.json
+++ b/change/@fluentui-font-icons-mdl2-6d66c625-8f8b-421e-a729-1db1e5191d58.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-foundation-legacy-ec68809e-7472-48e8-89fe-f25334a8e404.json
+++ b/change/@fluentui-foundation-legacy-ec68809e-7472-48e8-89fe-f25334a8e404.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-jest-serializer-make-styles-dbefa815-1002-43b5-81c8-283151ebdd72.json
+++ b/change/@fluentui-jest-serializer-make-styles-dbefa815-1002-43b5-81c8-283151ebdd72.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/jest-serializer-make-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-jest-serializer-merge-styles-5e10c3c7-d84d-44f6-9636-5eb1a0149066.json
+++ b/change/@fluentui-jest-serializer-merge-styles-5e10c3c7-d84d-44f6-9636-5eb1a0149066.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/jest-serializer-merge-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-keyboard-key-0a2791d1-43ca-4bb5-b7c0-b6ac4cb4ecd0.json
+++ b/change/@fluentui-keyboard-key-0a2791d1-43ca-4bb5-b7c0-b6ac4cb4ecd0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-keyboard-keys-51fd21b9-59fa-4836-943e-293f8cd1f89b.json
+++ b/change/@fluentui-keyboard-keys-51fd21b9-59fa-4836-943e-293f8cd1f89b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/keyboard-keys",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-make-styles-3a9e4cdf-fe08-4c87-885c-cbb89378bdb5.json
+++ b/change/@fluentui-make-styles-3a9e4cdf-fe08-4c87-885c-cbb89378bdb5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/make-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-make-styles-webpack-loader-dae9e908-0121-4b33-9701-7f5be3846fb3.json
+++ b/change/@fluentui-make-styles-webpack-loader-dae9e908-0121-4b33-9701-7f5be3846fb3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/make-styles-webpack-loader",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-merge-styles-c059ec81-b474-457a-accf-ab7b8e929558.json
+++ b/change/@fluentui-merge-styles-c059ec81-b474-457a-accf-ab7b8e929558.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/merge-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-monaco-editor-64550c39-59ce-4d23-885b-f2996c8a7a8c.json
+++ b/change/@fluentui-monaco-editor-64550c39-59ce-4d23-885b-f2996c8a7a8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-public-docsite-setup-d94575be-b901-4ed2-99d5-a057e0d38f29.json
+++ b/change/@fluentui-public-docsite-setup-d94575be-b901-4ed2-99d5-a057e0d38f29.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/public-docsite-setup",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-0f6812a9-4581-4e6f-83f7-949c8df79c6a.json
+++ b/change/@fluentui-react-0f6812a9-4581-4e6f-83f7-949c8df79c6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-ea1cd594-b667-4ed4-b3c2-ad32f5d45c15.json
+++ b/change/@fluentui-react-accordion-ea1cd594-b667-4ed4-b3c2-ad32f5d45c15.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-accordion",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-aria-4426ef1f-2752-401a-b729-f3c8a70d5304.json
+++ b/change/@fluentui-react-aria-4426ef1f-2752-401a-b729-f3c8a70d5304.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-aria",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-145c31ad-c37c-4939-b95a-ab4af9f7dd23.json
+++ b/change/@fluentui-react-avatar-145c31ad-c37c-4939-b95a-ab4af9f7dd23.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-avatar",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-83d9dc8f-d950-4604-be30-bce76b239261.json
+++ b/change/@fluentui-react-badge-83d9dc8f-d950-4604-be30-bce76b239261.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-badge",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-3e29081e-4163-46bf-aa44-871916590c6c.json
+++ b/change/@fluentui-react-button-3e29081e-4163-46bf-aa44-871916590c6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-button",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-card-e4ba5ce3-0528-4d04-8d69-cc0b379a7023.json
+++ b/change/@fluentui-react-card-e4ba5ce3-0528-4d04-8d69-cc0b379a7023.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test changing everything to es2019",
+  "packageName": "@fluentui/react-card",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-cards-b2390e67-8898-4e40-8927-40c54352d63d.json
+++ b/change/@fluentui-react-cards-b2390e67-8898-4e40-8927-40c54352d63d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-cards",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-a6cc3516-cd9f-4307-8968-cca8e318ce14.json
+++ b/change/@fluentui-react-charting-a6cc3516-cd9f-4307-8968-cca8e318ce14.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-charting",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-checkbox-6a2bff89-8488-4f4d-903f-1bda8edb00bd.json
+++ b/change/@fluentui-react-checkbox-6a2bff89-8488-4f4d-903f-1bda8edb00bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-components-a9fff412-6325-423f-b109-23795a5a1772.json
+++ b/change/@fluentui-react-components-a9fff412-6325-423f-b109-23795a5a1772.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-compose-b26b4c58-5d11-4a9a-a7ac-93792d3295bd.json
+++ b/change/@fluentui-react-compose-b26b4c58-5d11-4a9a-a7ac-93792d3295bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-compose",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-a8d8a18d-67c5-4d3c-92d4-701a713ccf6a.json
+++ b/change/@fluentui-react-conformance-a8d8a18d-67c5-4d3c-92d4-701a713ccf6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-conformance",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-make-styles-37d6475c-ade8-493f-b424-893eee40c677.json
+++ b/change/@fluentui-react-conformance-make-styles-37d6475c-ade8-493f-b424-893eee40c677.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-conformance-make-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-3ae2899d-e095-4344-8091-f225619a6784.json
+++ b/change/@fluentui-react-context-selector-3ae2899d-e095-4344-8091-f225619a6784.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-date-time-ea6a898f-a873-45c0-9a6a-43f06976cc3c.json
+++ b/change/@fluentui-react-date-time-ea6a898f-a873-45c0-9a6a-43f06976cc3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-date-time",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-divider-98ecb172-b232-4a6f-a90c-1bd27cdb8792.json
+++ b/change/@fluentui-react-divider-98ecb172-b232-4a6f-a90c-1bd27cdb8792.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-divider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-docsite-components-76d83e75-4f69-4721-bb1a-c5edeab4620b.json
+++ b/change/@fluentui-react-docsite-components-76d83e75-4f69-4721-bb1a-c5edeab4620b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-13a5fa22-80ae-4fee-8f97-813a83fc5132.json
+++ b/change/@fluentui-react-experiments-13a5fa22-80ae-4fee-8f97-813a83fc5132.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-file-type-icons-bb3d57eb-b371-48d6-849a-9a2876c73398.json
+++ b/change/@fluentui-react-file-type-icons-bb3d57eb-b371-48d6-849a-9a2876c73398.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-2bffbf71-1f05-4c68-939e-d7a8b7c36095.json
+++ b/change/@fluentui-react-focus-2bffbf71-1f05-4c68-939e-d7a8b7c36095.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-focus",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-hooks-b91aa0ba-18d8-4e29-a65c-27de0a5b0f20.json
+++ b/change/@fluentui-react-hooks-b91aa0ba-18d8-4e29-a65c-27de0a5b0f20.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icon-provider-c782990d-6049-4a68-a47b-e623ea218429.json
+++ b/change/@fluentui-react-icon-provider-c782990d-6049-4a68-a47b-e623ea218429.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-branded-80c01ad5-04fa-4962-87d0-97a4fda0166f.json
+++ b/change/@fluentui-react-icons-mdl2-branded-80c01ad5-04fa-4962-87d0-97a4fda0166f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-icons-mdl2-branded",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-e4f79130-4699-4874-814a-829b22080160.json
+++ b/change/@fluentui-react-icons-mdl2-e4f79130-4699-4874-814a-829b22080160.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-d6cb67fa-4eef-4d31-95b9-f409d9dcace0.json
+++ b/change/@fluentui-react-image-d6cb67fa-4eef-4d31-95b9-f409d9dcace0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-image",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-26ac94b3-a706-4e97-807a-75de3706114d.json
+++ b/change/@fluentui-react-label-26ac94b3-a706-4e97-807a-75de3706114d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-label",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-c47e0bd3-a46c-4f4b-a2b6-02748b01f6fa.json
+++ b/change/@fluentui-react-link-c47e0bd3-a46c-4f4b-a2b6-02748b01f6fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-link",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-make-styles-75e5d680-5b02-49f4-8efc-94414feee692.json
+++ b/change/@fluentui-react-make-styles-75e5d680-5b02-49f4-8efc-94414feee692.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-make-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-c6dd454d-921d-476f-a7bf-7495612ed54b.json
+++ b/change/@fluentui-react-menu-c6dd454d-921d-476f-a7bf-7495612ed54b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-menu",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-97534e8c-f95f-4d13-a1fa-5f707fb90a65.json
+++ b/change/@fluentui-react-monaco-editor-97534e8c-f95f-4d13-a1fa-5f707fb90a65.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-ab1d037e-10f4-427c-be52-956c59f58dd4.json
+++ b/change/@fluentui-react-popover-ab1d037e-10f4-427c-be52-956c59f58dd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-popover",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-6d9149ee-1597-4263-962a-729c59a26523.json
+++ b/change/@fluentui-react-portal-6d9149ee-1597-4263-962a-729c59a26523.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-portal",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-positioning-00f7d9a5-a2fd-4ed7-ae03-8e8e5171c575.json
+++ b/change/@fluentui-react-positioning-00f7d9a5-a2fd-4ed7-ae03-8e8e5171c575.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-positioning",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-9f3a0e8b-1f10-4149-b6df-40f6f1fa99dd.json
+++ b/change/@fluentui-react-provider-9f3a0e8b-1f10-4149-b6df-40f6f1fa99dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-be2e225c-0bf4-48c2-b69a-7293097c9fff.json
+++ b/change/@fluentui-react-shared-contexts-be2e225c-0bf4-48c2-b69a-7293097c9fff.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-97a8dda6-fa69-4491-a656-501f81ce49b7.json
+++ b/change/@fluentui-react-tabs-97a8dda6-fa69-4491-a656-501f81ce49b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-tabs",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-1d2c3545-60f0-44a4-a673-31d5eeb453d9.json
+++ b/change/@fluentui-react-tabster-1d2c3545-60f0-44a4-a673-31d5eeb453d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-tabster",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-53515240-0c67-4f53-80c8-1ce97e8325a7.json
+++ b/change/@fluentui-react-text-53515240-0c67-4f53-80c8-1ce97e8325a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-text",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-130a013a-d7f0-4dd7-a5cc-86904263ea01.json
+++ b/change/@fluentui-react-theme-130a013a-d7f0-4dd7-a5cc-86904263ea01.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-theme",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-46d6f1a7-01a9-43b5-a5a9-adc4bf5fa512.json
+++ b/change/@fluentui-react-tooltip-46d6f1a7-01a9-43b5-a5a9-adc4bf5fa512.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-fabeeb29-d708-4794-a3be-8ba57ef21194.json
+++ b/change/@fluentui-react-utilities-fabeeb29-d708-4794-a3be-8ba57ef21194.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-window-provider-4d4f6576-a76e-4a76-a887-33128cc1c726.json
+++ b/change/@fluentui-react-window-provider-4d4f6576-a76e-4a76-a887-33128cc1c726.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-scheme-utilities-53d2577c-557f-4e6a-85fa-c6551ec98da5.json
+++ b/change/@fluentui-scheme-utilities-53d2577c-557f-4e6a-85fa-c6551ec98da5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/scheme-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-set-version-e9194ee9-a163-42c0-af4b-da66076f2950.json
+++ b/change/@fluentui-set-version-e9194ee9-a163-42c0-af4b-da66076f2950.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/set-version",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-style-utilities-c1ddaeef-72a1-4374-967e-094274bf920a.json
+++ b/change/@fluentui-style-utilities-c1ddaeef-72a1-4374-967e-094274bf920a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/style-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-test-utilities-f2a1c39e-1281-4a06-ab6b-1ed25b439632.json
+++ b/change/@fluentui-test-utilities-f2a1c39e-1281-4a06-ab6b-1ed25b439632.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/test-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-df8b82e1-c9dc-4fa2-b93b-80daae71ad28.json
+++ b/change/@fluentui-theme-df8b82e1-c9dc-4fa2-b93b-80daae71ad28.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/theme",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-samples-e0dbd797-bad1-4473-be24-46493dbd25ff.json
+++ b/change/@fluentui-theme-samples-e0dbd797-bad1-4473-be24-46493dbd25ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/theme-samples",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-utilities-f9772d17-379d-4c77-a999-12df8812b0bb.json
+++ b/change/@fluentui-utilities-f9772d17-379d-4c77-a999-12df8812b0bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-webpack-utilities-6788c31a-9eb3-43ff-be16-d29a101f33f7.json
+++ b/change/@fluentui-webpack-utilities-6788c31a-9eb3-43ff-be16-d29a101f33f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/webpack-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/a11y-testing/tsconfig.json
+++ b/packages/a11y-testing/tsconfig.json
@@ -3,7 +3,7 @@
     "composite": true,
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es6",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -17,7 +17,7 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es2019", "dom"],
     "types": ["jest"]
   },
   "include": ["src"]

--- a/packages/api-docs/tsconfig.json
+++ b/packages/api-docs/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/api-docs/tsconfig.json
+++ b/packages/api-docs/tsconfig.json
@@ -18,7 +18,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "downlevelIteration": true,
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "types": []
   },
   "include": ["src"]

--- a/packages/azure-themes/tsconfig.json
+++ b/packages/azure-themes/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/azure-themes/tsconfig.json
+++ b/packages/azure-themes/tsconfig.json
@@ -16,7 +16,7 @@
     "skipLibCheck": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"]
+    "lib": ["es2019", "dom"]
   },
   "include": ["src"]
 }

--- a/packages/babel-make-styles/__fixtures__/arrow-function-no-param/code.ts
+++ b/packages/babel-make-styles/__fixtures__/arrow-function-no-param/code.ts
@@ -1,0 +1,7 @@
+import { makeStyles } from '@fluentui/react-make-styles';
+
+export const useStyles = makeStyles({
+  root: () => ({
+    display: 'flex',
+  }),
+});

--- a/packages/babel-make-styles/__fixtures__/arrow-function-no-param/output.ts
+++ b/packages/babel-make-styles/__fixtures__/arrow-function-no-param/output.ts
@@ -1,0 +1,11 @@
+import { __styles } from '@fluentui/react-make-styles';
+export const useStyles = __styles(
+  {
+    root: {
+      mc9l5x: 'f22iagw',
+    },
+  },
+  {
+    d: ['.f22iagw{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}'],
+  },
+);

--- a/packages/babel-make-styles/src/plugin.ts
+++ b/packages/babel-make-styles/src/plugin.ts
@@ -150,7 +150,7 @@ function processDefinitions(
 
   const styleSlots = definitionsPath.get('properties');
 
-  styleSlots.forEach(styleSlotPath => {
+  styleSlots.forEach((styleSlotPath: NodePath<t.SpreadElement | t.ObjectMethod | t.ObjectProperty>) => {
     if (styleSlotPath.isObjectMethod()) {
       throw styleSlotPath.buildCodeFrameError('Object methods are not supported for defining styles');
     }
@@ -269,6 +269,7 @@ function processDefinitions(
        * @example
        *    // ✔ can be resolved in AST
        *    makeStyles({ root: (t) => ({ color: t.red }) })
+       *    makeStyles({ root: () => ({ padding: '12px' }) })
        *    // ❌ lazy evaluation
        *    makeStyles({ root: (t) => ({ color: SOME_VARIABLE }) })
        *    // ❌ lazy evaluation, the worst case as function contains body
@@ -279,15 +280,15 @@ function processDefinitions(
           throw stylesPath.buildCodeFrameError('A function in makeStyles() can only a single param');
         }
 
-        const paramsPath = stylesPath.get('params.0') as NodePath<t.Node>;
+        const paramsPath = stylesPath.get('params.0') as NodePath<t.Node> | undefined;
 
-        if (!paramsPath.isIdentifier()) {
+        if (paramsPath && !paramsPath.isIdentifier()) {
           throw stylesPath.buildCodeFrameError(
             'A function in makeStyles() can only a single param and it should be a valid identifier',
           );
         }
 
-        const paramsName = paramsPath.node.name;
+        const paramsName = paramsPath?.node.name;
         const bodyPath = stylesPath.get('body');
 
         /**
@@ -296,6 +297,7 @@ function processDefinitions(
          * @example
          *    // ✔ can be resolved in AST
          *    makeStyles({ root: (t) => ({ color: t.red }) })
+         *    makeStyles({ root: () => ({ padding: '12px' }) })
          *    // ❌ lazy evaluation
          *    makeStyles({ root: (t) => ({ color: SOME_VARIABLE }) })
          */

--- a/packages/babel-make-styles/tsconfig.json
+++ b/packages/babel-make-styles/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2017", "DOM"],
+    "lib": ["es2019", "DOM"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/codemods/tsconfig.json
+++ b/packages/codemods/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es6",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -17,7 +17,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "esModuleInterop": true,
-    "lib": ["dom", "es2015.promise", "es2017"],
+    "lib": ["dom", "es2019"],
     "types": ["jest", "node"],
     "resolveJsonModule": true
   },

--- a/packages/date-time-utilities/tsconfig.json
+++ b/packages/date-time-utilities/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
     "lib": ["es5", "es2015.promise", "dom"],

--- a/packages/date-time-utilities/tsconfig.json
+++ b/packages/date-time-utilities/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es5", "es2015.promise", "dom"],
+    "lib": ["es2019", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/dom-utilities/tsconfig.json
+++ b/packages/dom-utilities/tsconfig.json
@@ -14,7 +14,7 @@
     "strict": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/dom-utilities/tsconfig.json
+++ b/packages/dom-utilities/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/example-data/tsconfig.json
+++ b/packages/example-data/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/example-data/tsconfig.json
+++ b/packages/example-data/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "types": []
   },
   "include": ["src"]

--- a/packages/font-icons-mdl2/tsconfig.json
+++ b/packages/font-icons-mdl2/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "commonjs",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/font-icons-mdl2/tsconfig.json
+++ b/packages/font-icons-mdl2/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "lib": ["es5", "dom"],
     "jsx": "react",

--- a/packages/foundation-legacy/tsconfig.json
+++ b/packages/foundation-legacy/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/foundation-legacy/tsconfig.json
+++ b/packages/foundation-legacy/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/jest-serializer-make-styles/tsconfig.json
+++ b/packages/jest-serializer-make-styles/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["ES2017", "DOM"],
     "outDir": "dist",

--- a/packages/jest-serializer-make-styles/tsconfig.json
+++ b/packages/jest-serializer-make-styles/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2017", "DOM"],
+    "lib": ["es2019", "DOM"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/jest-serializer-merge-styles/tsconfig.json
+++ b/packages/jest-serializer-merge-styles/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
     "lib": ["es2017"],

--- a/packages/jest-serializer-merge-styles/tsconfig.json
+++ b/packages/jest-serializer-merge-styles/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/keyboard-key/tsconfig.json
+++ b/packages/keyboard-key/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/keyboard-key/tsconfig.json
+++ b/packages/keyboard-key/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "types": ["jest"]
   },
   "include": ["src"]

--- a/packages/keyboard-keys/tsconfig.json
+++ b/packages/keyboard-keys/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/keyboard-keys/tsconfig.json
+++ b/packages/keyboard-keys/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/make-styles-webpack-loader/tsconfig.json
+++ b/packages/make-styles-webpack-loader/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2017", "DOM"],
+    "lib": ["es2019", "DOM"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/make-styles/tsconfig.json
+++ b/packages/make-styles/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["ES2015", "dom"],
     "outDir": "dist",

--- a/packages/make-styles/tsconfig.json
+++ b/packages/make-styles/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2015", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/merge-styles/tsconfig.json
+++ b/packages/merge-styles/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/merge-styles/tsconfig.json
+++ b/packages/merge-styles/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
     "lib": ["es5", "dom"],

--- a/packages/monaco-editor/tsconfig.json
+++ b/packages/monaco-editor/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/monaco-editor/tsconfig.json
+++ b/packages/monaco-editor/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "types": []
   },
   "include": ["src"]

--- a/packages/public-docsite-setup/tsconfig.json
+++ b/packages/public-docsite-setup/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "lib",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/public-docsite-setup/tsconfig.json
+++ b/packages/public-docsite-setup/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "lib",
-    "target": "es2019",
+    "target": "es5",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/public-docsite-setup/tsconfig.json
+++ b/packages/public-docsite-setup/tsconfig.json
@@ -12,7 +12,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "types": ["webpack-env"]
   },
   "include": ["src"]

--- a/packages/react-accordion/tsconfig.json
+++ b/packages/react-accordion/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "lib": ["ES2015", "DOM"],
     "outDir": "dist",
     "jsx": "react",

--- a/packages/react-accordion/tsconfig.json
+++ b/packages/react-accordion/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es2019",
-    "lib": ["ES2015", "DOM"],
+    "lib": ["es2019", "DOM"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-aria/tsconfig.json
+++ b/packages/react-aria/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "lib": ["ES2015", "DOM"],
     "outDir": "dist",
     "jsx": "react",

--- a/packages/react-aria/tsconfig.json
+++ b/packages/react-aria/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es2019",
-    "lib": ["ES2015", "DOM"],
+    "lib": ["es2019", "DOM"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-avatar/tsconfig.json
+++ b/packages/react-avatar/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["ES2015", "dom"],
     "outDir": "dist",

--- a/packages/react-avatar/tsconfig.json
+++ b/packages/react-avatar/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2015", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-badge/tsconfig.json
+++ b/packages/react-badge/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/react-badge/tsconfig.json
+++ b/packages/react-badge/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-button/tsconfig.json
+++ b/packages/react-button/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/react-button/tsconfig.json
+++ b/packages/react-button/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-card/tsconfig.json
+++ b/packages/react-card/tsconfig.json
@@ -2,10 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES2019",
-    "isolatedModules": true,
+    "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2019", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,
@@ -13,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
+    "isolatedModules": true,
     "types": ["jest", "custom-global", "inline-style-expand-shorthand", "storybook__addons"]
   }
 }

--- a/packages/react-cards/tsconfig.json
+++ b/packages/react-cards/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/react-cards/tsconfig.json
+++ b/packages/react-cards/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-charting/tsconfig.json
+++ b/packages/react-charting/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-charting/tsconfig.json
+++ b/packages/react-charting/tsconfig.json
@@ -17,7 +17,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/react-checkbox/tsconfig.json
+++ b/packages/react-checkbox/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2015", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-components/config/api-extractor.local.json
+++ b/packages/react-components/config/api-extractor.local.json
@@ -12,7 +12,7 @@
       "extends": "../../tsconfig.base.json",
       "include": ["src"],
       "compilerOptions": {
-        "target": "ES5",
+        "target": "es2019",
         "module": "CommonJS",
         "lib": ["ES2016", "dom"],
         "outDir": "dist",

--- a/packages/react-components/tsconfig.json
+++ b/packages/react-components/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2016", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-components/tsconfig.json
+++ b/packages/react-components/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["ES2016", "dom"],
     "outDir": "dist",

--- a/packages/react-compose/tsconfig.json
+++ b/packages/react-compose/tsconfig.json
@@ -13,7 +13,7 @@
     "strict": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/react-compose/tsconfig.json
+++ b/packages/react-compose/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-conformance-make-styles/tsconfig.json
+++ b/packages/react-conformance-make-styles/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2020", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-conformance/tsconfig.json
+++ b/packages/react-conformance/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es6",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -14,7 +14,7 @@
     "strict": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es2019", "dom"],
     "types": ["jest", "node"]
   },
   "include": ["src"]

--- a/packages/react-context-selector/tsconfig.json
+++ b/packages/react-context-selector/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/react-context-selector/tsconfig.json
+++ b/packages/react-context-selector/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-date-time/tsconfig.json
+++ b/packages/react-date-time/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/react-date-time/tsconfig.json
+++ b/packages/react-date-time/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-divider/tsconfig.json
+++ b/packages/react-divider/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/react-divider/tsconfig.json
+++ b/packages/react-divider/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-docsite-components/tsconfig.json
+++ b/packages/react-docsite-components/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-docsite-components/tsconfig.json
+++ b/packages/react-docsite-components/tsconfig.json
@@ -16,7 +16,7 @@
     "skipLibCheck": true,
     "noImplicitThis": true,
     "outDir": "lib",
-    "lib": ["es5", "dom", "es2015.promise"],
+    "lib": ["es2019", "dom"],
     "types": ["webpack-env", "jest"]
   },
   "include": ["src"]

--- a/packages/react-examples/tsconfig.json
+++ b/packages/react-examples/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-examples/tsconfig.json
+++ b/packages/react-examples/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom", "es2015.promise"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "webpack-env", "custom-global", "node"],
     "paths": {

--- a/packages/react-experiments/tsconfig.json
+++ b/packages/react-experiments/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-experiments/tsconfig.json
+++ b/packages/react-experiments/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"],
     "isolatedModules": true

--- a/packages/react-file-type-icons/tsconfig.json
+++ b/packages/react-file-type-icons/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "commonjs",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/react-file-type-icons/tsconfig.json
+++ b/packages/react-file-type-icons/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "lib": ["es5", "dom"],
     "jsx": "react",

--- a/packages/react-focus/tsconfig.json
+++ b/packages/react-focus/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-focus/tsconfig.json
+++ b/packages/react-focus/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2015", "dom", "es2015.promise"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"],
     "isolatedModules": true

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"],
     "isolatedModules": true

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-icon-provider/tsconfig.json
+++ b/packages/react-icon-provider/tsconfig.json
@@ -14,7 +14,7 @@
     "strict": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"],
     "isolatedModules": true

--- a/packages/react-icon-provider/tsconfig.json
+++ b/packages/react-icon-provider/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-icons-mdl2-branded/tsconfig.json
+++ b/packages/react-icons-mdl2-branded/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-icons-mdl2-branded/tsconfig.json
+++ b/packages/react-icons-mdl2-branded/tsconfig.json
@@ -14,7 +14,7 @@
     "strict": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["custom-global"]
   },

--- a/packages/react-icons-mdl2/tsconfig.json
+++ b/packages/react-icons-mdl2/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-icons-mdl2/tsconfig.json
+++ b/packages/react-icons-mdl2/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "types": ["jest"],
     "isolatedModules": true
   },

--- a/packages/react-image/tsconfig.json
+++ b/packages/react-image/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/react-image/tsconfig.json
+++ b/packages/react-image/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-input/tsconfig.json
+++ b/packages/react-input/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/react-input/tsconfig.json
+++ b/packages/react-input/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-label/tsconfig.json
+++ b/packages/react-label/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/react-label/tsconfig.json
+++ b/packages/react-label/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-link/tsconfig.json
+++ b/packages/react-link/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/react-link/tsconfig.json
+++ b/packages/react-link/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-make-styles/tsconfig.json
+++ b/packages/react-make-styles/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["ES2015", "dom"],
     "outDir": "dist",

--- a/packages/react-make-styles/tsconfig.json
+++ b/packages/react-make-styles/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2015", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-menu/e2e/tsconfig.json
+++ b/packages/react-menu/e2e/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "types": ["cypress", "cypress-storybook/cypress"],
-    "lib": ["es2015", "dom"]
+    "lib": ["es2019", "dom"]
   },
   "include": ["."]
 }

--- a/packages/react-menu/tsconfig.json
+++ b/packages/react-menu/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "lib": ["ES2015", "DOM"],
     "outDir": "dist",
     "jsx": "react",

--- a/packages/react-menu/tsconfig.json
+++ b/packages/react-menu/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es2019",
-    "lib": ["ES2015", "DOM"],
+    "lib": ["es2019", "DOM"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-monaco-editor/tsconfig.json
+++ b/packages/react-monaco-editor/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-monaco-editor/tsconfig.json
+++ b/packages/react-monaco-editor/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "preserveConstEnums": true,
-    "lib": ["es5", "dom", "es2015.promise", "es2015.iterable"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "webpack-env", "custom-global", "node"]
   },

--- a/packages/react-popover/tsconfig.json
+++ b/packages/react-popover/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["ES2015", "dom"],
     "outDir": "dist",

--- a/packages/react-popover/tsconfig.json
+++ b/packages/react-popover/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2015", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-portal/tsconfig.json
+++ b/packages/react-portal/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es2019",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-portal/tsconfig.json
+++ b/packages/react-portal/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "lib": ["es5", "dom"],
     "outDir": "dist",
     "jsx": "react",

--- a/packages/react-positioning/tsconfig.json
+++ b/packages/react-positioning/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es2019",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-positioning/tsconfig.json
+++ b/packages/react-positioning/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "lib": ["es5", "dom"],
     "outDir": "dist",
     "jsx": "react",

--- a/packages/react-provider/tsconfig.json
+++ b/packages/react-provider/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/react-provider/tsconfig.json
+++ b/packages/react-provider/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-shared-contexts/tsconfig.json
+++ b/packages/react-shared-contexts/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/react-shared-contexts/tsconfig.json
+++ b/packages/react-shared-contexts/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-storybook-addon/tsconfig.json
+++ b/packages/react-storybook-addon/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2015", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-storybook/tsconfig.json
+++ b/packages/react-storybook/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["ES2015", "dom"],
     "outDir": "dist",

--- a/packages/react-storybook/tsconfig.json
+++ b/packages/react-storybook/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2015", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-tabs/tsconfig.json
+++ b/packages/react-tabs/tsconfig.json
@@ -14,7 +14,7 @@
     "strict": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/react-tabs/tsconfig.json
+++ b/packages/react-tabs/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-tabster/e2e/tsconfig.json
+++ b/packages/react-tabster/e2e/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "types": ["cypress", "cypress-real-events", "cypress-storybook/cypress"],
-    "lib": ["es2015", "dom"]
+    "lib": ["es2019", "dom"]
   },
   "include": ["."]
 }

--- a/packages/react-tabster/tsconfig.json
+++ b/packages/react-tabster/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["ES2015", "dom"],
     "outDir": "dist",

--- a/packages/react-tabster/tsconfig.json
+++ b/packages/react-tabster/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2015", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-text/tsconfig.json
+++ b/packages/react-text/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2019", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-text/tsconfig.json
+++ b/packages/react-text/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES2019",
-    "isolatedModules": true,
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
@@ -13,6 +12,7 @@
     "importHelpers": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
+    "isolatedModules": true,
     "types": [
       "jest",
       "custom-global",

--- a/packages/react-theme/tsconfig.json
+++ b/packages/react-theme/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/react-theme/tsconfig.json
+++ b/packages/react-theme/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-tooltip/tsconfig.json
+++ b/packages/react-tooltip/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["es5", "dom"],
     "outDir": "dist",

--- a/packages/react-tooltip/tsconfig.json
+++ b/packages/react-tooltip/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-utilities/tsconfig.json
+++ b/packages/react-utilities/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2019",
     "module": "CommonJS",
     "lib": ["ES2015", "DOM"],
     "outDir": "dist",

--- a/packages/react-utilities/tsconfig.json
+++ b/packages/react-utilities/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",
-    "lib": ["ES2015", "DOM"],
+    "lib": ["es2019", "DOM"],
     "outDir": "dist",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-window-provider/tsconfig.json
+++ b/packages/react-window-provider/tsconfig.json
@@ -14,7 +14,7 @@
     "strict": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2015", "dom", "es2015.promise"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/react-window-provider/tsconfig.json
+++ b/packages/react-window-provider/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -16,7 +16,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom", "es2015.promise"],
+    "lib": ["es2019", "dom"],
     "skipLibCheck": true,
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "isolatedModules": true,

--- a/packages/scheme-utilities/tsconfig.json
+++ b/packages/scheme-utilities/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/scheme-utilities/tsconfig.json
+++ b/packages/scheme-utilities/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
     "lib": ["es5", "dom"],

--- a/packages/set-version/tsconfig.json
+++ b/packages/set-version/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
     "lib": ["es5", "dom"],

--- a/packages/set-version/tsconfig.json
+++ b/packages/set-version/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "declaration": true,
     "sourceMap": true,
     "importHelpers": true,

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es6",
+    "target": "es2019",
     "module": "es6",
     "jsx": "react",
     "declaration": true,
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es6", "dom"],
+    "lib": ["es2019", "dom"],
     "types": [],
     "esModuleInterop": true
   },

--- a/packages/style-utilities/tsconfig.json
+++ b/packages/style-utilities/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "target": "es5",
+    "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
     "lib": ["es5", "dom"],

--- a/packages/style-utilities/tsconfig.json
+++ b/packages/style-utilities/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "jsx": "react",
     "declaration": true,
     "isolatedModules": true,

--- a/packages/test-utilities/tsconfig.json
+++ b/packages/test-utilities/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/test-utilities/tsconfig.json
+++ b/packages/test-utilities/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es2019", "dom"],
     "types": ["jest"]
   },
   "include": ["src"]

--- a/packages/theme-samples/tsconfig.json
+++ b/packages/theme-samples/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "isolatedModules": true
   },
   "include": ["src"]

--- a/packages/theme-samples/tsconfig.json
+++ b/packages/theme-samples/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -14,7 +14,7 @@
     "strict": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/utilities/tsconfig.json
+++ b/packages/utilities/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
     "lib": ["es5", "es2015.promise", "dom"],

--- a/packages/utilities/tsconfig.json
+++ b/packages/utilities/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es5", "es2015.promise", "dom"],
+    "lib": ["es2019", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/webpack-utilities/tsconfig.json
+++ b/packages/webpack-utilities/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
     "lib": ["es2017"],

--- a/packages/webpack-utilities/tsconfig.json
+++ b/packages/webpack-utilities/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2019",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/scripts/create-package/plop-templates-node/tsconfig.json
+++ b/scripts/create-package/plop-templates-node/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es6",
+    "target": "es2019",
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
@@ -13,7 +13,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "esModuleInterop": true,
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "types": ["jest", "node"]
   },
   "include": ["src"]

--- a/scripts/create-package/plop-templates-react/tsconfig.json
+++ b/scripts/create-package/plop-templates-react/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2019",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/scripts/create-package/plop-templates-react/tsconfig.json
+++ b/scripts/create-package/plop-templates-react/tsconfig.json
@@ -13,7 +13,7 @@
     "strict": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2019", "dom"],
     "skipLibCheck": true,
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]

--- a/scripts/tasks/ts.ts
+++ b/scripts/tasks/ts.ts
@@ -49,7 +49,6 @@ function prepareTsTaskConfig(options: TscTaskOptions) {
 
 function getExtraTscParams(args: JustArgs) {
   return {
-    target: 'es5',
     // sourceMap must be true for inlineSources and sourceRoot to work
     ...(args.production && { inlineSources: true, sourceRoot: path.relative(libPath, srcPath), sourceMap: true }),
   };

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -3,8 +3,8 @@
   // This config is used for running build scripts through ts-node
   "compilerOptions": {
     "module": "CommonJS",
-    "target": "ES2018", // Node 10 per https://kangax.github.io/compat-table/es2016plus/#node10_9
-    "lib": ["ES2018", "DOM"], // Node 10, occasional test-related stuff that uses DOM
+    "target": "es2019",
+    "lib": ["es2019", "DOM"], // Node 10, occasional test-related stuff that uses DOM
     "esModuleInterop": true,
     "allowJs": true,
     "noImplicitAny": false,

--- a/scripts/typescript/tsconfig.common.json
+++ b/scripts/typescript/tsconfig.common.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "module": "esnext",
     "moduleResolution": "node",
     "lib": ["es2015", "dom"],

--- a/scripts/typescript/tsconfig.fluentui.json
+++ b/scripts/typescript/tsconfig.fluentui.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2019",
     "lib": ["es2015", "dom"],
     "baseUrl": "../../",
     "paths": {

--- a/tools/tsconfig.tools.json
+++ b/tools/tsconfig.tools.json
@@ -4,7 +4,7 @@
     "outDir": "../dist/out-tsc/tools",
     "rootDir": ".",
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2019",
     "types": ["node"],
     "importHelpers": false
   },


### PR DESCRIPTION
Testing impact of es2019 target on bundle size.

WILL NOT be merged for v8/v0 (though we'll be making this change soon for converged)