### PR TITLE
DO NOT MERGE testing es2017

### DIFF
--- a/apps/a11y-tests/tsconfig.json
+++ b/apps/a11y-tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,

--- a/apps/perf-test/tsconfig.json
+++ b/apps/perf-test/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib",
     "module": "commonjs",
     "jsx": "react",
@@ -12,7 +12,7 @@
     "preserveConstEnums": true,
     "strictNullChecks": true,
     "noImplicitAny": true,
-    "lib": ["es6", "dom"],
+    "lib": ["es2017", "dom"],
     "types": ["webpack-env"],
     "skipLibCheck": true
   },

--- a/apps/public-docsite-resources/tsconfig.json
+++ b/apps/public-docsite-resources/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/apps/public-docsite/tsconfig.json
+++ b/apps/public-docsite/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "lib",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -14,7 +14,7 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["webpack-env", "custom-global"]
   },

--- a/apps/server-rendered-app/tsconfig.json
+++ b/apps/server-rendered-app/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es5",
+    "target": "es2017",
     "module": "es6",
     "jsx": "react",
     "declaration": true,
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "preserveConstEnums": false,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["custom-global"]
   },

--- a/apps/theming-designer/tsconfig.json
+++ b/apps/theming-designer/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib",
     "module": "commonjs",
     "jsx": "react",
@@ -11,7 +11,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "strict": false,
-    "lib": ["es6", "dom"],
+    "lib": ["es2017", "dom"],
     "types": [],
     "noImplicitAny": true
   },

--- a/apps/todo-app/tsconfig.json
+++ b/apps/todo-app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib",
     "module": "commonjs",
     "jsx": "react",
@@ -12,7 +12,7 @@
     "preserveConstEnums": true,
     "strict": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["custom-global"]
   },

--- a/apps/vr-tests/tsconfig.json
+++ b/apps/vr-tests/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib",
     "module": "commonjs",
     "jsx": "react",

--- a/change/@fluentui-azure-themes-f2d37638-8276-46f2-b15f-b3175fcdcca0.json
+++ b/change/@fluentui-azure-themes-f2d37638-8276-46f2-b15f-b3175fcdcca0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/azure-themes",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-codemods-451628a4-b175-4313-a225-c3c3eacb26ca.json
+++ b/change/@fluentui-codemods-451628a4-b175-4313-a225-c3c3eacb26ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/codemods",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-date-time-utilities-1d537561-a524-48cd-8715-84ef8fae2e91.json
+++ b/change/@fluentui-date-time-utilities-1d537561-a524-48cd-8715-84ef8fae2e91.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-dom-utilities-77ea6495-9b85-4cb5-b81b-1af7b2068764.json
+++ b/change/@fluentui-dom-utilities-77ea6495-9b85-4cb5-b81b-1af7b2068764.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-example-data-41d5affe-3e4c-4033-90a5-a02aabfb752b.json
+++ b/change/@fluentui-example-data-41d5affe-3e4c-4033-90a5-a02aabfb752b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/example-data",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-font-icons-mdl2-4268f357-2d8b-4002-9180-a87e94b998de.json
+++ b/change/@fluentui-font-icons-mdl2-4268f357-2d8b-4002-9180-a87e94b998de.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-foundation-legacy-ee99b5ea-1c61-4ab2-8dfe-0de1bb261203.json
+++ b/change/@fluentui-foundation-legacy-ee99b5ea-1c61-4ab2-8dfe-0de1bb261203.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-jest-serializer-merge-styles-466e7084-12ca-4ccc-8f03-7c8a06f95831.json
+++ b/change/@fluentui-jest-serializer-merge-styles-466e7084-12ca-4ccc-8f03-7c8a06f95831.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/jest-serializer-merge-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-keyboard-key-70e07315-40bb-4888-9b47-e3cb2a7ef40b.json
+++ b/change/@fluentui-keyboard-key-70e07315-40bb-4888-9b47-e3cb2a7ef40b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-merge-styles-6b31fb3b-ed37-48e5-bc9d-3189c0a36bf0.json
+++ b/change/@fluentui-merge-styles-6b31fb3b-ed37-48e5-bc9d-3189c0a36bf0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/merge-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-monaco-editor-83256587-b67c-4519-abbc-259acf98ce5a.json
+++ b/change/@fluentui-monaco-editor-83256587-b67c-4519-abbc-259acf98ce5a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-5138f6b1-e8e1-45b5-999c-3aa1105e26df.json
+++ b/change/@fluentui-react-5138f6b1-e8e1-45b5-999c-3aa1105e26df.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-cards-ee979396-04fe-4a86-b098-7162be2acdc1.json
+++ b/change/@fluentui-react-cards-ee979396-04fe-4a86-b098-7162be2acdc1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-cards",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-dcd8b0c9-c44a-4e1a-b356-2a2923dc3efe.json
+++ b/change/@fluentui-react-charting-dcd8b0c9-c44a-4e1a-b356-2a2923dc3efe.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-charting",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-compose-ccf76fde-0c49-463f-afee-78d1693707a2.json
+++ b/change/@fluentui-react-compose-ccf76fde-0c49-463f-afee-78d1693707a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-compose",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-9b5e98dc-684d-4476-8ddf-30de487793e5.json
+++ b/change/@fluentui-react-conformance-9b5e98dc-684d-4476-8ddf-30de487793e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-conformance",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-date-time-e1f267ce-af24-4bd0-b7a8-815e5d0e2f5d.json
+++ b/change/@fluentui-react-date-time-e1f267ce-af24-4bd0-b7a8-815e5d0e2f5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-date-time",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-docsite-components-b9a0ab91-71a4-4712-a31d-34ae0a3996a0.json
+++ b/change/@fluentui-react-docsite-components-b9a0ab91-71a4-4712-a31d-34ae0a3996a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-f850bd2d-5268-4d6e-82c5-921b5d110fff.json
+++ b/change/@fluentui-react-experiments-f850bd2d-5268-4d6e-82c5-921b5d110fff.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-file-type-icons-04bd41bb-0229-4512-a871-8f0e41e72c7a.json
+++ b/change/@fluentui-react-file-type-icons-04bd41bb-0229-4512-a871-8f0e41e72c7a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-b35ee2a5-3330-45f8-b2e9-dfd9f0ea7053.json
+++ b/change/@fluentui-react-focus-b35ee2a5-3330-45f8-b2e9-dfd9f0ea7053.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-focus",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-hooks-6f05a792-cec1-47f1-ab85-37bdbbe9c627.json
+++ b/change/@fluentui-react-hooks-6f05a792-cec1-47f1-ab85-37bdbbe9c627.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icon-provider-8affdc3b-0b23-4445-ab38-602c771dec06.json
+++ b/change/@fluentui-react-icon-provider-8affdc3b-0b23-4445-ab38-602c771dec06.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-branded-289f76f8-ee12-4d0f-b2e5-c85e0cd8b11f.json
+++ b/change/@fluentui-react-icons-mdl2-branded-289f76f8-ee12-4d0f-b2e5-c85e0cd8b11f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-icons-mdl2-branded",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-f3273195-538e-4f3e-8c84-37c3b526c05e.json
+++ b/change/@fluentui-react-icons-mdl2-f3273195-538e-4f3e-8c84-37c3b526c05e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-7ab8fa06-d892-49e3-9ca0-e2ddb97b52ab.json
+++ b/change/@fluentui-react-monaco-editor-7ab8fa06-d892-49e3-9ca0-e2ddb97b52ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-scheme-utilities-832c7c0e-5bd4-4a3b-9a85-fccbbf5cbc85.json
+++ b/change/@fluentui-scheme-utilities-832c7c0e-5bd4-4a3b-9a85-fccbbf5cbc85.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/scheme-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-set-version-bd2efbbc-0403-4055-8630-3210b8014028.json
+++ b/change/@fluentui-set-version-bd2efbbc-0403-4055-8630-3210b8014028.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/set-version",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-style-utilities-ad803937-1167-4d36-81e7-6ae71dea2873.json
+++ b/change/@fluentui-style-utilities-ad803937-1167-4d36-81e7-6ae71dea2873.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/style-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-test-utilities-60879896-6222-4ee5-8caa-6fa8994a6728.json
+++ b/change/@fluentui-test-utilities-60879896-6222-4ee5-8caa-6fa8994a6728.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/test-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-df429568-08b7-4404-a6ee-47991c07b5db.json
+++ b/change/@fluentui-theme-df429568-08b7-4404-a6ee-47991c07b5db.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/theme",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-samples-31e40708-1a4b-472d-b202-ee87db447740.json
+++ b/change/@fluentui-theme-samples-31e40708-1a4b-472d-b202-ee87db447740.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/theme-samples",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-utilities-17ec697a-6458-4a5c-94ea-108514338d77.json
+++ b/change/@fluentui-utilities-17ec697a-6458-4a5c-94ea-108514338d77.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-webpack-utilities-f73dbbf2-4de5-4362-845e-7ef9cdd8d34b.json
+++ b/change/@fluentui-webpack-utilities-f73dbbf2-4de5-4362-845e-7ef9cdd8d34b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test",
+  "packageName": "@fluentui/webpack-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/a11y-testing/tsconfig.json
+++ b/packages/a11y-testing/tsconfig.json
@@ -3,7 +3,7 @@
     "composite": true,
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es6",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/api-docs/tsconfig.json
+++ b/packages/api-docs/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/azure-themes/tsconfig.json
+++ b/packages/azure-themes/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -16,7 +16,7 @@
     "skipLibCheck": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"]
+    "lib": ["es2017", "dom"]
   },
   "include": ["src"]
 }

--- a/packages/codemods/tsconfig.json
+++ b/packages/codemods/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es6",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -17,7 +17,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "esModuleInterop": true,
-    "lib": ["dom", "es2015.promise", "es2017"],
+    "lib": ["dom", "es2017"],
     "types": ["jest", "node"],
     "resolveJsonModule": true
   },

--- a/packages/date-time-utilities/tsconfig.json
+++ b/packages/date-time-utilities/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es5", "es2015.promise", "dom"],
+    "lib": ["es2017", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/dom-utilities/tsconfig.json
+++ b/packages/dom-utilities/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -14,7 +14,7 @@
     "strict": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/example-data/tsconfig.json
+++ b/packages/example-data/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "types": []
   },
   "include": ["src"]

--- a/packages/font-icons-mdl2/tsconfig.json
+++ b/packages/font-icons-mdl2/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/foundation-legacy/tsconfig.json
+++ b/packages/foundation-legacy/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/jest-serializer-merge-styles/tsconfig.json
+++ b/packages/jest-serializer-merge-styles/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib",
     "module": "commonjs",
     "lib": ["es2017"],

--- a/packages/keyboard-key/tsconfig.json
+++ b/packages/keyboard-key/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "types": ["jest"]
   },
   "include": ["src"]

--- a/packages/merge-styles/tsconfig.json
+++ b/packages/merge-styles/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/monaco-editor/tsconfig.json
+++ b/packages/monaco-editor/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "types": []
   },
   "include": ["src"]

--- a/packages/react-cards/tsconfig.json
+++ b/packages/react-cards/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/react-charting/tsconfig.json
+++ b/packages/react-charting/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -17,7 +17,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/react-compose/tsconfig.json
+++ b/packages/react-compose/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -13,7 +13,7 @@
     "strict": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/react-conformance/tsconfig.json
+++ b/packages/react-conformance/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es6",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/react-date-time/tsconfig.json
+++ b/packages/react-date-time/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/react-docsite-components/tsconfig.json
+++ b/packages/react-docsite-components/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -16,7 +16,7 @@
     "skipLibCheck": true,
     "noImplicitThis": true,
     "outDir": "lib",
-    "lib": ["es5", "dom", "es2015.promise"],
+    "lib": ["es2017", "dom"],
     "types": ["webpack-env", "jest"]
   },
   "include": ["src"]

--- a/packages/react-examples/tsconfig.json
+++ b/packages/react-examples/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom", "es2015.promise"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "webpack-env", "custom-global", "node"],
     "paths": {

--- a/packages/react-experiments/tsconfig.json
+++ b/packages/react-experiments/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"],
     "isolatedModules": true

--- a/packages/react-file-type-icons/tsconfig.json
+++ b/packages/react-file-type-icons/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/react-focus/tsconfig.json
+++ b/packages/react-focus/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2015", "dom", "es2015.promise"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"],
     "isolatedModules": true

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"],
     "isolatedModules": true

--- a/packages/react-icon-provider/tsconfig.json
+++ b/packages/react-icon-provider/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -14,7 +14,7 @@
     "strict": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"],
     "isolatedModules": true

--- a/packages/react-icons-mdl2-branded/tsconfig.json
+++ b/packages/react-icons-mdl2-branded/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -14,7 +14,7 @@
     "strict": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["custom-global"]
   },

--- a/packages/react-icons-mdl2/tsconfig.json
+++ b/packages/react-icons-mdl2/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "types": ["jest"],
     "isolatedModules": true
   },

--- a/packages/react-monaco-editor/tsconfig.json
+++ b/packages/react-monaco-editor/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "preserveConstEnums": true,
-    "lib": ["es5", "dom", "es2015.promise", "es2015.iterable"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "webpack-env", "custom-global", "node"]
   },

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "isolatedModules": true,
@@ -16,7 +16,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom", "es2015.promise"],
+    "lib": ["es2017", "dom"],
     "skipLibCheck": true,
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]

--- a/packages/scheme-utilities/tsconfig.json
+++ b/packages/scheme-utilities/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/set-version/tsconfig.json
+++ b/packages/set-version/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "declaration": true,
     "sourceMap": true,
     "importHelpers": true,

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "lib",
-    "target": "es6",
+    "target": "es2017",
     "module": "es6",
     "jsx": "react",
     "declaration": true,
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es6", "dom"],
+    "lib": ["es2017", "dom"],
     "types": [],
     "esModuleInterop": true
   },

--- a/packages/style-utilities/tsconfig.json
+++ b/packages/style-utilities/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "jsx": "react",
     "declaration": true,
     "isolatedModules": true,

--- a/packages/test-utilities/tsconfig.json
+++ b/packages/test-utilities/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,

--- a/packages/theme-samples/tsconfig.json
+++ b/packages/theme-samples/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "isolatedModules": true
   },
   "include": ["src"]

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -14,7 +14,7 @@
     "strict": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/utilities/tsconfig.json
+++ b/packages/utilities/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es5", "es2015.promise", "dom"],
+    "lib": ["es2017", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/webpack-utilities/tsconfig.json
+++ b/packages/webpack-utilities/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib",
     "module": "commonjs",
     "lib": ["es2017"],

--- a/scripts/tasks/ts.ts
+++ b/scripts/tasks/ts.ts
@@ -49,7 +49,6 @@ function prepareTsTaskConfig(options: TscTaskOptions) {
 
 function getExtraTscParams(args: JustArgs) {
   return {
-    target: 'es5',
     // sourceMap must be true for inlineSources and sourceRoot to work
     ...(args.production && { inlineSources: true, sourceRoot: path.relative(libPath, srcPath), sourceMap: true }),
   };


### PR DESCRIPTION
Testing impact of es2017 target on bundle size for v8.

WILL NOT be merged, though it provides an interesting demo of the bundle size benefit we could get once we finally drop IE 11.