### PR TITLE
(web-components) Updated the default fill color to neutral layer 1

### DIFF
--- a/change/@fluentui-web-components-79361e82-0819-43b5-bb93-6fd3cad41bb0.json
+++ b/change/@fluentui-web-components-79361e82-0819-43b5-bb93-6fd3cad41bb0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated the default fill color to neutral layer 1",
+  "packageName": "@fluentui/web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -6,4 +6,14 @@
     height: 100%;
     background: var(--fill-color);
   }
+  #root > h1,
+  #root > h2,
+  #root > h3,
+  #root > h4,
+  #root > h5,
+  #root > h6,
+  #root > p,
+  #root > span {
+    color: var(--neutral-foreground-rest);
+  }
 </style>

--- a/packages/web-components/src/design-tokens.ts
+++ b/packages/web-components/src/design-tokens.ts
@@ -228,11 +228,135 @@ export const accentPalette = create<Palette>({ name: 'accent-palette', cssCustom
   PaletteRGB.create(accentBase),
 );
 
+// Neutral Layer Card Container
 /** @public */
-export const fillColor = create<Swatch>('fill-color').withDefault(element => {
-  const palette = neutralPalette.getValueFor(element);
-  return palette.get(0);
+export const neutralLayerCardContainerRecipe = create<ColorRecipe>({
+  name: 'neutral-layer-card-container-recipe',
+  cssCustomPropertyName: null,
+}).withDefault({
+  evaluate: (element: HTMLElement): Swatch =>
+    neutralLayerCardContainerAlgorithm(
+      neutralPalette.getValueFor(element),
+      baseLayerLuminance.getValueFor(element),
+      neutralFillLayerRestDelta.getValueFor(element),
+    ),
 });
+
+/** @public */
+export const neutralLayerCardContainer = create<Swatch>(
+  'neutral-layer-card-container',
+).withDefault((element: HTMLElement) => neutralLayerCardContainerRecipe.getValueFor(element).evaluate(element));
+
+// Neutral Layer Floating
+/** @public */
+export const neutralLayerFloatingRecipe = create<ColorRecipe>({
+  name: 'neutral-layer-floating-recipe',
+  cssCustomPropertyName: null,
+}).withDefault({
+  evaluate: (element: HTMLElement): Swatch =>
+    neutralLayerFloatingAlgorithm(
+      neutralPalette.getValueFor(element),
+      baseLayerLuminance.getValueFor(element),
+      neutralFillLayerRestDelta.getValueFor(element),
+    ),
+});
+
+/** @public */
+export const neutralLayerFloating = create<Swatch>('neutral-layer-floating').withDefault((element: HTMLElement) =>
+  neutralLayerFloatingRecipe.getValueFor(element).evaluate(element),
+);
+
+// Neutral Layer 1
+/** @public */
+export const neutralLayer1Recipe = create<ColorRecipe>({
+  name: 'neutral-layer-1-recipe',
+  cssCustomPropertyName: null,
+}).withDefault({
+  evaluate: (element: HTMLElement): Swatch =>
+    neutralLayer1Algorithm(neutralPalette.getValueFor(element), baseLayerLuminance.getValueFor(element)),
+});
+
+/** @public */
+export const neutralLayer1 = create<Swatch>('neutral-layer-1').withDefault((element: HTMLElement) =>
+  neutralLayer1Recipe.getValueFor(element).evaluate(element),
+);
+/** @public @deprecated Use neutralLayer1 */
+export const neutralLayerL1 = neutralLayer1;
+
+// Neutral Layer 2
+/** @public */
+export const neutralLayer2Recipe = create<ColorRecipe>({
+  name: 'neutral-layer-2-recipe',
+  cssCustomPropertyName: null,
+}).withDefault({
+  evaluate: (element: HTMLElement): Swatch =>
+    neutralLayer2Algorithm(
+      neutralPalette.getValueFor(element),
+      baseLayerLuminance.getValueFor(element),
+      neutralFillLayerRestDelta.getValueFor(element),
+      neutralFillRestDelta.getValueFor(element),
+      neutralFillHoverDelta.getValueFor(element),
+      neutralFillActiveDelta.getValueFor(element),
+    ),
+});
+
+/** @public */
+export const neutralLayer2 = create<Swatch>('neutral-layer-2').withDefault((element: HTMLElement) =>
+  neutralLayer2Recipe.getValueFor(element).evaluate(element),
+);
+/** @public @deprecated Use neutralLayer2 */
+export const neutralLayerL2 = neutralLayer2;
+
+// Neutral Layer 3
+/** @public */
+export const neutralLayer3Recipe = create<ColorRecipe>({
+  name: 'neutral-layer-3-recipe',
+  cssCustomPropertyName: null,
+}).withDefault({
+  evaluate: (element: HTMLElement): Swatch =>
+    neutralLayer3Algorithm(
+      neutralPalette.getValueFor(element),
+      baseLayerLuminance.getValueFor(element),
+      neutralFillLayerRestDelta.getValueFor(element),
+      neutralFillRestDelta.getValueFor(element),
+      neutralFillHoverDelta.getValueFor(element),
+      neutralFillActiveDelta.getValueFor(element),
+    ),
+});
+
+/** @public */
+export const neutralLayer3 = create<Swatch>('neutral-layer-3').withDefault((element: HTMLElement) =>
+  neutralLayer3Recipe.getValueFor(element).evaluate(element),
+);
+/** @public @deprecated Use neutralLayer3 */
+export const neutralLayerL3 = neutralLayer3;
+
+// Neutral Layer 4
+/** @public */
+export const neutralLayer4Recipe = create<ColorRecipe>({
+  name: 'neutral-layer-4-recipe',
+  cssCustomPropertyName: null,
+}).withDefault({
+  evaluate: (element: HTMLElement): Swatch =>
+    neutralLayer4Algorithm(
+      neutralPalette.getValueFor(element),
+      baseLayerLuminance.getValueFor(element),
+      neutralFillLayerRestDelta.getValueFor(element),
+      neutralFillRestDelta.getValueFor(element),
+      neutralFillHoverDelta.getValueFor(element),
+      neutralFillActiveDelta.getValueFor(element),
+    ),
+});
+
+/** @public */
+export const neutralLayer4 = create<Swatch>('neutral-layer-4').withDefault((element: HTMLElement) =>
+  neutralLayer4Recipe.getValueFor(element).evaluate(element),
+);
+/** @public @deprecated Use neutralLayer4 */
+export const neutralLayerL4 = neutralLayer4;
+
+/** @public */
+export const fillColor = create<Swatch>('fill-color').withDefault(element => neutralLayer1.getValueFor(element));
 
 enum ContrastTarget {
   normal = 4.5,
@@ -760,130 +884,3 @@ export const neutralStrokeStrongActive = create<Swatch>('neutral-stroke-strong-a
 export const neutralStrokeStrongFocus = create<Swatch>('neutral-stroke-strong-focus').withDefault(
   (element: HTMLElement) => neutralStrokeStrongRecipe.getValueFor(element).evaluate(element).focus,
 );
-
-// Neutral Layer Card Container
-/** @public */
-export const neutralLayerCardContainerRecipe = create<ColorRecipe>({
-  name: 'neutral-layer-card-container-recipe',
-  cssCustomPropertyName: null,
-}).withDefault({
-  evaluate: (element: HTMLElement): Swatch =>
-    neutralLayerCardContainerAlgorithm(
-      neutralPalette.getValueFor(element),
-      baseLayerLuminance.getValueFor(element),
-      neutralFillLayerRestDelta.getValueFor(element),
-    ),
-});
-
-/** @public */
-export const neutralLayerCardContainer = create<Swatch>(
-  'neutral-layer-card-container',
-).withDefault((element: HTMLElement) => neutralLayerCardContainerRecipe.getValueFor(element).evaluate(element));
-
-// Neutral Layer Floating
-/** @public */
-export const neutralLayerFloatingRecipe = create<ColorRecipe>({
-  name: 'neutral-layer-floating-recipe',
-  cssCustomPropertyName: null,
-}).withDefault({
-  evaluate: (element: HTMLElement): Swatch =>
-    neutralLayerFloatingAlgorithm(
-      neutralPalette.getValueFor(element),
-      baseLayerLuminance.getValueFor(element),
-      neutralFillLayerRestDelta.getValueFor(element),
-    ),
-});
-
-/** @public */
-export const neutralLayerFloating = create<Swatch>('neutral-layer-floating').withDefault((element: HTMLElement) =>
-  neutralLayerFloatingRecipe.getValueFor(element).evaluate(element),
-);
-
-// Neutral Layer 1
-/** @public */
-export const neutralLayer1Recipe = create<ColorRecipe>({
-  name: 'neutral-layer-1-recipe',
-  cssCustomPropertyName: null,
-}).withDefault({
-  evaluate: (element: HTMLElement): Swatch =>
-    neutralLayer1Algorithm(neutralPalette.getValueFor(element), baseLayerLuminance.getValueFor(element)),
-});
-
-/** @public */
-export const neutralLayer1 = create<Swatch>('neutral-layer-1').withDefault((element: HTMLElement) =>
-  neutralLayer1Recipe.getValueFor(element).evaluate(element),
-);
-/** @public @deprecated Use neutralLayer1 */
-export const neutralLayerL1 = neutralLayer1;
-
-// Neutral Layer 2
-/** @public */
-export const neutralLayer2Recipe = create<ColorRecipe>({
-  name: 'neutral-layer-2-recipe',
-  cssCustomPropertyName: null,
-}).withDefault({
-  evaluate: (element: HTMLElement): Swatch =>
-    neutralLayer2Algorithm(
-      neutralPalette.getValueFor(element),
-      baseLayerLuminance.getValueFor(element),
-      neutralFillLayerRestDelta.getValueFor(element),
-      neutralFillRestDelta.getValueFor(element),
-      neutralFillHoverDelta.getValueFor(element),
-      neutralFillActiveDelta.getValueFor(element),
-    ),
-});
-
-/** @public */
-export const neutralLayer2 = create<Swatch>('neutral-layer-2').withDefault((element: HTMLElement) =>
-  neutralLayer2Recipe.getValueFor(element).evaluate(element),
-);
-/** @public @deprecated Use neutralLayer2 */
-export const neutralLayerL2 = neutralLayer2;
-
-// Neutral Layer 3
-/** @public */
-export const neutralLayer3Recipe = create<ColorRecipe>({
-  name: 'neutral-layer-3-recipe',
-  cssCustomPropertyName: null,
-}).withDefault({
-  evaluate: (element: HTMLElement): Swatch =>
-    neutralLayer3Algorithm(
-      neutralPalette.getValueFor(element),
-      baseLayerLuminance.getValueFor(element),
-      neutralFillLayerRestDelta.getValueFor(element),
-      neutralFillRestDelta.getValueFor(element),
-      neutralFillHoverDelta.getValueFor(element),
-      neutralFillActiveDelta.getValueFor(element),
-    ),
-});
-
-/** @public */
-export const neutralLayer3 = create<Swatch>('neutral-layer-3').withDefault((element: HTMLElement) =>
-  neutralLayer3Recipe.getValueFor(element).evaluate(element),
-);
-/** @public @deprecated Use neutralLayer3 */
-export const neutralLayerL3 = neutralLayer3;
-
-// Neutral Layer 4
-/** @public */
-export const neutralLayer4Recipe = create<ColorRecipe>({
-  name: 'neutral-layer-4-recipe',
-  cssCustomPropertyName: null,
-}).withDefault({
-  evaluate: (element: HTMLElement): Swatch =>
-    neutralLayer4Algorithm(
-      neutralPalette.getValueFor(element),
-      baseLayerLuminance.getValueFor(element),
-      neutralFillLayerRestDelta.getValueFor(element),
-      neutralFillRestDelta.getValueFor(element),
-      neutralFillHoverDelta.getValueFor(element),
-      neutralFillActiveDelta.getValueFor(element),
-    ),
-});
-
-/** @public */
-export const neutralLayer4 = create<Swatch>('neutral-layer-4').withDefault((element: HTMLElement) =>
-  neutralLayer4Recipe.getValueFor(element).evaluate(element),
-);
-/** @public @deprecated Use neutralLayer4 */
-export const neutralLayerL4 = neutralLayer4;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The fillColor design token was set to a fixed, dark position on the neutral palette. This ignored the baseLayerLuminance design token because it was not possible to only change that and have the design system respond. The ideal flow is that the luminance drives the layer colors and the layer colors are used as backgrounds for fixed sections of the app, even if there is only a single section (layer 1).

Also updated the Storybook wrapper to adjust the navigation text based on the updated fill color.

#### Focus areas to test

Default fillColor.
