### PR TITLE
Fix attachment progress overflow

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Fixes
+- Fix `Attachment` progress-bar overflow @Hirse ([#19727](https://github.com/microsoft/fluentui/pull/19727))
 - `Popup` should not dismiss when its iframe content is focused @ling1726 ([#19955](https://github.com/microsoft/fluentui/pull/19955))
 - `whatInput` Add typings to what input event listeners @ling1726 ([#20024](https://github.com/microsoft/fluentui/pull/20024))
 - Remove `active` as condition to open submenu on `MenuItem` and active styles for vertical menu @chassunc ([#20062](https://github.com/microsoft/fluentui/pull/20062))

--- a/packages/fluentui/docs/src/examples/components/Attachment/Types/AttachmentProgressExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Attachment/Types/AttachmentProgressExample.shorthand.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
-import { Attachment } from '@fluentui/react-northstar';
-import { CloseIcon } from '@fluentui/react-icons-northstar';
 
-const AttachmentProgressExampleShorthand = () => (
-  <Attachment
-    header="Photo.jpg"
-    actionable
-    action={{ icon: <CloseIcon />, onClick: () => alert("'X' is clicked!"), title: 'Close' }}
-    progress={33}
-  />
-);
+import { Attachment } from '@fluentui/react-northstar';
+
+const AttachmentProgressExampleShorthand = () => <Attachment header="Photo.jpg" progress={33} />;
 
 export default AttachmentProgressExampleShorthand;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentStyles.ts
@@ -1,11 +1,11 @@
-import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 import { svgIconClassName } from '@fluentui/react-icons-northstar';
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 
 import { AttachmentStylesProps } from '../../../../components/Attachment/Attachment';
 import { attachmentActionClassName } from '../../../../components/Attachment/AttachmentAction';
-import { AttachmentVariables } from './attachmentVariables';
 import { pxToRem } from '../../../../utils';
 import { getBorderFocusStyles } from '../../getBorderFocusStyles';
+import { AttachmentVariables } from './attachmentVariables';
 
 export const attachmentStyles: ComponentSlotStylesPrepared<AttachmentStylesProps, AttachmentVariables> = {
   root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => {
@@ -29,6 +29,7 @@ export const attachmentStyles: ComponentSlotStylesPrepared<AttachmentStylesProps
       boxShadow: v.boxShadow,
       border: `${siteVariables.borderWidth} solid ${v.borderColor}`,
       borderRadius: v.borderRadius,
+      overflow: 'hidden',
 
       ...borderFocusStyles,
 


### PR DESCRIPTION
Sets overflow to hidden on Attachment so the progress bar stays within the rounded corners.

*Before*
![overflowing progress bar](https://user-images.githubusercontent.com/2564094/132728668-ecdde61b-2bd2-4ba6-8c31-278aa2c38375.png)

*After*
![rounded progress bar](https://user-images.githubusercontent.com/2564094/132728690-2511bf06-29f3-4841-a8ab-82d37764f0f1.png)


