### PR TITLE
Functional context menu

### DIFF
--- a/change/@fluentui-react-a09873cb-03fc-4e00-8ab5-f2cae1a3565d.json
+++ b/change/@fluentui-react-a09873cb-03fc-4e00-8ab5-f2cae1a3565d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fully migrated ContextualMenu implementation to be a functional component",
+  "packageName": "@fluentui/react",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -192,15 +192,7 @@ function useSubMenuState({ hidden, items, theme, className, id }: IContextualMen
     return submenuProps;
   };
 
-  return [
-    expandedMenuItemKey,
-    submenuTarget,
-    expandedByMouseClick,
-    openSubMenu,
-    closeSubMenu,
-    getSubmenuProps,
-    onSubMenuDismiss,
-  ] as const;
+  return [expandedMenuItemKey, openSubMenu, getSubmenuProps, onSubMenuDismiss] as const;
 }
 
 function useShouldUpdateFocusOnMouseMove({ delayUpdateFocusOnHover, hidden }: IContextualMenuProps) {
@@ -252,7 +244,7 @@ function usePreviousActiveElement({ hidden, onRestoreFocus }: IContextualMenuPro
       previousActiveElement.current = undefined;
     }
   }, [hidden, targetWindow?.document.activeElement, tryFocusPreviousActiveElement]);
-  return [previousActiveElement, tryFocusPreviousActiveElement] as const;
+  return [tryFocusPreviousActiveElement] as const;
 }
 
 function useKeyHandlers(
@@ -473,16 +465,8 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
 
   const dismiss = (ev?: any, dismissAll?: boolean) => props.onDismiss?.(ev, dismissAll);
   const [targetRef, targetWindow] = useTarget(props.target, hostElement);
-  const [previousActiveElementRef, tryFocusPreviousActiveElement] = usePreviousActiveElement(props, targetWindow);
-  const [
-    expandedMenuItemKey,
-    submenuTarget,
-    expandedByMouseClick,
-    openSubMenu,
-    closeSubMenu,
-    getSubmenuProps,
-    onSubMenuDismiss,
-  ] = useSubMenuState(props, dismiss);
+  const [tryFocusPreviousActiveElement] = usePreviousActiveElement(props, targetWindow);
+  const [expandedMenuItemKey, openSubMenu, getSubmenuProps, onSubMenuDismiss] = useSubMenuState(props, dismiss);
   const [shouldUpdateFocusOnMouseEvent, gotMouseMove, onMenuFocusCapture] = useShouldUpdateFocusOnMouseMove(props);
   const [onScroll, isScrollIdle] = useScrollHandler(asyncTracker);
   const [cancelSubMenuTimer, startSubmenuTimer, enterTimerRef] = useSubmenuEnterTimer(props, asyncTracker);
@@ -502,16 +486,11 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
         targetRef,
         targetWindow,
         expandedMenuItemKey,
-        submenuTarget,
-        expandedByMouseClick,
         openSubMenu,
-        closeSubMenu,
         shouldUpdateFocusOnMouseEvent,
         gotMouseMove,
         onMenuFocusCapture,
-        asyncTracker,
         menuId,
-        previousActiveElementRef,
         dismiss,
         tryFocusPreviousActiveElement,
         onKeyDown,
@@ -538,16 +517,11 @@ interface IContextualMenuInternalProps extends IContextualMenuProps {
     targetRef: React.RefObject<Element | MouseEvent | Point | null>;
     targetWindow: Window | undefined;
     expandedMenuItemKey?: string;
-    submenuTarget?: Element;
-    expandedByMouseClick?: boolean;
     shouldUpdateFocusOnMouseEvent: React.MutableRefObject<boolean>;
     gotMouseMove: React.MutableRefObject<boolean>;
     openSubMenu(submenuItemKey: IContextualMenuItem, target: HTMLElement, openedByMouseClick?: boolean): void;
-    closeSubMenu(): void;
     onMenuFocusCapture(): void;
-    asyncTracker: Async;
     menuId: string;
-    previousActiveElementRef: React.RefObject<HTMLElement | undefined>;
     dismiss: (ev?: any, dismissAll?: boolean) => void;
     tryFocusPreviousActiveElement: (options: IPopupRestoreFocusParams) => void;
     onKeyDown: (ev: React.KeyboardEvent<HTMLElement>) => boolean;

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -847,7 +847,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
   private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>): boolean => {
     // Take note if we are processing an alt (option) or meta (command) keydown.
     // See comment in _shouldHandleKeyUp for reasoning.
-    this._lastKeyDownWasAltOrMeta = this._isAltOrMeta(ev);
+    this._lastKeyDownWasAltOrMeta = _isAltOrMeta(ev);
 
     // On Mac, pressing escape dismisses all levels of native context menus
     // eslint-disable-next-line deprecation/deprecation
@@ -881,18 +881,10 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
    * closing any open context menus. There is not a similar behavior on Macs.
    */
   private _shouldHandleKeyUp = (ev: React.KeyboardEvent<HTMLElement>) => {
-    const keyPressIsAltOrMetaAlone = this._lastKeyDownWasAltOrMeta && this._isAltOrMeta(ev);
+    const keyPressIsAltOrMetaAlone = this._lastKeyDownWasAltOrMeta && _isAltOrMeta(ev);
     this._lastKeyDownWasAltOrMeta = false;
     return !!keyPressIsAltOrMetaAlone && !(isIOS() || isMac());
   };
-
-  /**
-   * Returns true if the key for the event is alt (Mac option) or meta (Mac command).
-   */
-  private _isAltOrMeta(ev: React.KeyboardEvent<HTMLElement>): boolean {
-    // eslint-disable-next-line deprecation/deprecation
-    return ev.which === KeyCodes.alt || ev.key === 'Meta';
-  }
 
   /**
    * Calls `shouldHandleKey` to determine whether the keyboard event should be handled;
@@ -1258,4 +1250,12 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
   private _onPointerAndTouchEvent = (ev: React.TouchEvent<HTMLElement> | PointerEvent) => {
     this._cancelSubMenuTimer();
   };
+}
+
+/**
+ * Returns true if the key for the event is alt (Mac option) or meta (Mac command).
+ */
+function _isAltOrMeta(ev: React.KeyboardEvent<HTMLElement>): boolean {
+  // eslint-disable-next-line deprecation/deprecation
+  return ev.which === KeyCodes.alt || ev.key === 'Meta';
 }

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -534,7 +534,10 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       theme,
       calloutProps,
       onRenderSubMenu = this._onRenderSubMenu,
-      onRenderMenuList = this._onRenderMenuList,
+      onRenderMenuList = (
+        menuListProps: IContextualMenuListProps,
+        defaultRender?: IRenderFunction<IContextualMenuListProps>,
+      ) => this._onRenderMenuList(menuListProps, classNames, defaultRender),
       focusZoneProps,
       // eslint-disable-next-line deprecation/deprecation
       getMenuClassNames,

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -17,7 +17,6 @@ import {
   shouldWrapFocus,
   isIOS,
   isMac,
-  initializeComponentRef,
   memoizeFunction,
   getPropsWithDefaults,
   getDocument,
@@ -259,7 +258,7 @@ interface IContextualMenuInternalProps extends IContextualMenuProps {
 class ContextualMenuInternal extends React.Component<IContextualMenuInternalProps, never> {
   private _previousActiveElement: HTMLElement | undefined;
   private _enterTimerId: number | undefined;
-  private _isScrollIdle: boolean;
+  private _isScrollIdle: boolean = false;
   private _scrollIdleTimeoutId: number | undefined;
   /** True if the most recent keydown event was for alt (option) or meta (command). */
   private _lastKeyDownWasAltOrMeta: boolean | undefined;
@@ -269,14 +268,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
 
   // eslint-disable-next-line deprecation/deprecation
   private _classNames: IProcessedStyleSet<IContextualMenuStyles> | IContextualMenuClassNames;
-
-  constructor(props: IContextualMenuInternalProps) {
-    super(props);
-
-    initializeComponentRef(this);
-
-    this._isScrollIdle = true;
-  }
 
   public dismiss = (ev?: any, dismissAll?: boolean) => {
     const { onDismiss } = this.props;

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -223,6 +223,8 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
 
   useVisibility(props, targetWindow);
 
+  const dismiss = (ev?: any, dismissAll?: boolean) => props.onDismiss?.(ev, dismissAll);
+
   return (
     <ContextualMenuInternal
       {...props}
@@ -243,6 +245,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
         subMenuId,
         menuId,
         previousActiveElementRef,
+        dismiss,
       }}
       responsiveMode={responsiveMode}
     />
@@ -268,6 +271,7 @@ interface IContextualMenuInternalProps extends IContextualMenuProps {
     subMenuId: string;
     menuId: string;
     previousActiveElementRef: React.RefObject<HTMLElement | undefined>;
+    dismiss: (ev?: any, dismissAll?: boolean) => void;
   };
 }
 
@@ -283,14 +287,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
 
   // eslint-disable-next-line deprecation/deprecation
   private _classNames: IProcessedStyleSet<IContextualMenuStyles> | IContextualMenuClassNames;
-
-  public dismiss = (ev?: any, dismissAll?: boolean) => {
-    const { onDismiss } = this.props;
-
-    if (onDismiss) {
-      onDismiss(ev, dismissAll);
-    }
-  };
 
   public shouldComponentUpdate(newProps: IContextualMenuInternalProps, newState: IContextualMenuState): boolean {
     if (!newProps.shouldUpdateWhenHidden && this.props.hidden && newProps.hidden) {
@@ -800,7 +796,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     if (item.onRender) {
       return item.onRender(
         { 'aria-posinset': focusableElementIndex + 1, 'aria-setsize': totalItemCount, ...item },
-        this.dismiss,
+        this.props.hoisted.dismiss,
       );
     }
 
@@ -827,7 +823,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       expandedMenuItemKey,
       openSubMenu,
       dismissSubMenu: this._onSubMenuDismiss,
-      dismissMenu: this.dismiss,
+      dismissMenu: this.props.hoisted.dismiss,
     } as const;
 
     if (item.href) {
@@ -944,7 +940,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     let handled = false;
 
     if (shouldHandleKey(ev)) {
-      this.dismiss(ev, dismissAllMenus);
+      this.props.hoisted.dismiss(ev, dismissAllMenus);
       ev.preventDefault();
       ev.stopPropagation();
       handled = true;
@@ -1198,7 +1194,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     }
 
     if (dismiss || !ev.defaultPrevented) {
-      this.dismiss(ev, true);
+      this.props.hoisted.dismiss(ev, true);
     }
   };
 
@@ -1282,7 +1278,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
    */
   private _onSubMenuDismiss = (ev?: any, dismissAll?: boolean): void => {
     if (dismissAll) {
-      this.dismiss(ev, dismissAll);
+      this.props.hoisted.dismiss(ev, dismissAll);
     } else if (this._mounted) {
       this.props.hoisted.closeSubMenu();
     }

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -495,8 +495,6 @@ interface IContextualMenuInternalProps extends IContextualMenuProps {
 class ContextualMenuInternal extends React.Component<IContextualMenuInternalProps, never> {
   private _enterTimerId: number | undefined;
 
-  private _adjustedFocusZoneProps: IFocusZoneProps;
-
   // eslint-disable-next-line deprecation/deprecation
   private _classNames: IProcessedStyleSet<IContextualMenuStyles> | IContextualMenuClassNames;
 
@@ -571,7 +569,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       return false;
     }
 
-    this._adjustedFocusZoneProps = {
+    const adjustedFocusZoneProps = {
       ...focusZoneProps,
       className: this._classNames.root,
       isCircularNavigation: true,
@@ -673,6 +671,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
                         },
                         this._onRenderMenuList,
                       ),
+                      adjustedFocusZoneProps,
                     )
                   : null}
                 {submenuProps && onRenderSubMenu(submenuProps, this._onRenderSubMenu)}
@@ -722,9 +721,9 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     );
   };
 
-  private _renderFocusZone(children: JSX.Element | null): JSX.Element {
+  private _renderFocusZone(children: JSX.Element | null, adjustedFocusZoneProps: IFocusZoneProps): JSX.Element {
     const { focusZoneAs: ChildrenRenderer = FocusZone } = this.props;
-    return <ChildrenRenderer {...this._adjustedFocusZoneProps}>{children}</ChildrenRenderer>;
+    return <ChildrenRenderer {...adjustedFocusZoneProps}>{children}</ChildrenRenderer>;
   }
 
   /**

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -1267,8 +1267,11 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
   };
 
   private _getSubmenuProps() {
-    const { submenuTarget, expandedMenuItemKey, expandedByMouseClick } = this.props.hoisted;
-    const item = this._findItemByKey(expandedMenuItemKey!);
+    const {
+      hoisted: { submenuTarget, expandedMenuItemKey, expandedByMouseClick },
+      items,
+    } = this.props;
+    const item = findItemByKeyFromItems(expandedMenuItemKey!, items);
     let submenuProps: IContextualMenuProps | null = null;
 
     if (item) {
@@ -1291,11 +1294,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       }
     }
     return submenuProps;
-  }
-
-  private _findItemByKey(key: string): IContextualMenuItem | undefined {
-    const { items } = this.props;
-    return findItemByKeyFromItems(key, items);
   }
 
   private _onPointerAndTouchEvent = (ev: React.TouchEvent<HTMLElement> | PointerEvent) => {

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -816,31 +816,13 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
         this.dismiss,
       );
     }
-    if (item.href) {
-      return this._renderAnchorMenuItem(
-        item,
-        classNames,
-        index,
-        focusableElementIndex,
-        totalItemCount,
-        hasCheckmarks,
-        hasIcons,
-      );
-    }
 
-    if (item.split && hasSubmenu(item)) {
-      return this._renderSplitButton(
-        item,
-        classNames,
-        index,
-        focusableElementIndex,
-        totalItemCount,
-        hasCheckmarks,
-        hasIcons,
-      );
-    }
+    const {
+      contextualMenuItemAs,
+      hoisted: { expandedMenuItemKey, openSubMenu },
+    } = this.props;
 
-    return this._renderButtonItem(
+    const commonProps = {
       item,
       classNames,
       index,
@@ -848,6 +830,36 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       totalItemCount,
       hasCheckmarks,
       hasIcons,
+      contextualMenuItemAs,
+      onItemMouseEnter: this._onItemMouseEnterBase,
+      onItemMouseLeave: this._onMouseItemLeave,
+      onItemMouseMove: this._onItemMouseMoveBase,
+      onItemMouseDown: this._onItemMouseDown,
+      executeItemClick: this._executeItemClick,
+      onItemKeyDown: this._onItemKeyDown,
+      expandedMenuItemKey,
+      openSubMenu,
+      dismissSubMenu: this._onSubMenuDismiss,
+      dismissMenu: this.dismiss,
+    } as const;
+
+    if (item.href) {
+      return <ContextualMenuAnchor {...commonProps} onItemClick={this._onAnchorClick} />;
+    }
+
+    if (item.split && hasSubmenu(item)) {
+      return (
+        <ContextualMenuSplitButton
+          {...commonProps}
+          onItemClick={this._onItemClick}
+          onItemClickBase={this._onItemClickBase}
+          onTap={this._onPointerAndTouchEvent}
+        />
+      );
+    }
+
+    return (
+      <ContextualMenuButton {...commonProps} onItemClick={this._onItemClick} onItemClickBase={this._onItemClickBase} />
     );
   }
 
@@ -875,128 +887,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
           {...itemProps}
         />
       </div>
-    );
-  }
-
-  private _renderAnchorMenuItem(
-    item: IContextualMenuItem,
-    // eslint-disable-next-line deprecation/deprecation
-    classNames: IMenuItemClassNames,
-    index: number,
-    focusableElementIndex: number,
-    totalItemCount: number,
-    hasCheckmarks: boolean,
-    hasIcons: boolean,
-  ): React.ReactNode {
-    const {
-      contextualMenuItemAs,
-      hoisted: { expandedMenuItemKey, openSubMenu },
-    } = this.props;
-    return (
-      <ContextualMenuAnchor
-        item={item}
-        classNames={classNames}
-        index={index}
-        focusableElementIndex={focusableElementIndex}
-        totalItemCount={totalItemCount}
-        hasCheckmarks={hasCheckmarks}
-        hasIcons={hasIcons}
-        contextualMenuItemAs={contextualMenuItemAs}
-        onItemMouseEnter={this._onItemMouseEnterBase}
-        onItemMouseLeave={this._onMouseItemLeave}
-        onItemMouseMove={this._onItemMouseMoveBase}
-        onItemMouseDown={this._onItemMouseDown}
-        executeItemClick={this._executeItemClick}
-        onItemClick={this._onAnchorClick}
-        onItemKeyDown={this._onItemKeyDown}
-        expandedMenuItemKey={expandedMenuItemKey}
-        openSubMenu={openSubMenu}
-        dismissSubMenu={this._onSubMenuDismiss}
-        dismissMenu={this.dismiss}
-      />
-    );
-  }
-
-  private _renderButtonItem(
-    item: IContextualMenuItem,
-    // eslint-disable-next-line deprecation/deprecation
-    classNames: IMenuItemClassNames,
-    index: number,
-    focusableElementIndex: number,
-    totalItemCount: number,
-    hasCheckmarks?: boolean,
-    hasIcons?: boolean,
-  ) {
-    const {
-      contextualMenuItemAs,
-      hoisted: { expandedMenuItemKey, openSubMenu },
-    } = this.props;
-
-    return (
-      <ContextualMenuButton
-        item={item}
-        classNames={classNames}
-        index={index}
-        focusableElementIndex={focusableElementIndex}
-        totalItemCount={totalItemCount}
-        hasCheckmarks={hasCheckmarks}
-        hasIcons={hasIcons}
-        contextualMenuItemAs={contextualMenuItemAs}
-        onItemMouseEnter={this._onItemMouseEnterBase}
-        onItemMouseLeave={this._onMouseItemLeave}
-        onItemMouseMove={this._onItemMouseMoveBase}
-        onItemMouseDown={this._onItemMouseDown}
-        executeItemClick={this._executeItemClick}
-        onItemClick={this._onItemClick}
-        onItemClickBase={this._onItemClickBase}
-        onItemKeyDown={this._onItemKeyDown}
-        expandedMenuItemKey={expandedMenuItemKey}
-        openSubMenu={openSubMenu}
-        dismissSubMenu={this._onSubMenuDismiss}
-        dismissMenu={this.dismiss}
-      />
-    );
-  }
-
-  private _renderSplitButton(
-    item: IContextualMenuItem,
-    // eslint-disable-next-line deprecation/deprecation
-    classNames: IMenuItemClassNames,
-    index: number,
-    focusableElementIndex: number,
-    totalItemCount: number,
-    hasCheckmarks?: boolean,
-    hasIcons?: boolean,
-  ): JSX.Element {
-    const {
-      contextualMenuItemAs,
-      hoisted: { expandedMenuItemKey, openSubMenu },
-    } = this.props;
-
-    return (
-      <ContextualMenuSplitButton
-        item={item}
-        classNames={classNames}
-        index={index}
-        focusableElementIndex={focusableElementIndex}
-        totalItemCount={totalItemCount}
-        hasCheckmarks={hasCheckmarks}
-        hasIcons={hasIcons}
-        contextualMenuItemAs={contextualMenuItemAs}
-        onItemMouseEnter={this._onItemMouseEnterBase}
-        onItemMouseLeave={this._onMouseItemLeave}
-        onItemMouseMove={this._onItemMouseMoveBase}
-        onItemMouseDown={this._onItemMouseDown}
-        executeItemClick={this._executeItemClick}
-        onItemClick={this._onItemClick}
-        onItemClickBase={this._onItemClickBase}
-        onItemKeyDown={this._onItemKeyDown}
-        openSubMenu={openSubMenu}
-        dismissSubMenu={this._onSubMenuDismiss}
-        dismissMenu={this.dismiss}
-        expandedMenuItemKey={expandedMenuItemKey}
-        onTap={this._onPointerAndTouchEvent}
-      />
     );
   }
 

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -706,11 +706,8 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
         hostElement,
         forwardedRef,
         targetRef,
-        targetWindow,
         expandedMenuItemKey,
         openSubMenu,
-        shouldUpdateFocusOnMouseEvent,
-        gotMouseMove,
         onMenuFocusCapture,
         menuId,
         dismiss,
@@ -719,11 +716,8 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
         onKeyUp,
         onMenuKeyDown,
         onScroll,
-        isScrollIdle,
         onSubMenuDismiss,
         cancelSubMenuTimer,
-        startSubmenuTimer,
-        subMenuEntryTimer,
         getSubmenuProps,
         onItemKeyDown,
         onItemMouseEnterBase,
@@ -745,10 +739,7 @@ interface IContextualMenuInternalProps extends IContextualMenuProps {
     hostElement: React.RefObject<HTMLDivElement>;
     forwardedRef: React.Ref<HTMLDivElement>;
     targetRef: React.RefObject<Element | MouseEvent | Point | null>;
-    targetWindow: Window | undefined;
     expandedMenuItemKey?: string;
-    shouldUpdateFocusOnMouseEvent: React.MutableRefObject<boolean>;
-    gotMouseMove: React.MutableRefObject<boolean>;
     openSubMenu(submenuItemKey: IContextualMenuItem, target: HTMLElement, openedByMouseClick?: boolean): void;
     onMenuFocusCapture(): void;
     menuId: string;
@@ -758,11 +749,8 @@ interface IContextualMenuInternalProps extends IContextualMenuProps {
     onKeyUp: (ev: React.KeyboardEvent<HTMLElement>) => boolean;
     onMenuKeyDown: (ev: React.KeyboardEvent<HTMLElement>) => void;
     onScroll: () => void;
-    isScrollIdle: React.RefObject<boolean>;
     onSubMenuDismiss: (ev?: any, dismissAll?: boolean) => void;
     cancelSubMenuTimer: () => void;
-    startSubmenuTimer: (callback: () => void) => void;
-    subMenuEntryTimer: React.RefObject<number | undefined>;
     getSubmenuProps: () => IContextualMenuProps | null;
     onItemKeyDown: (item: any, ev: React.KeyboardEvent<HTMLElement>) => void;
     onItemMouseEnterBase(item: any, ev: React.MouseEvent<HTMLElement>, target?: HTMLElement): void;

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -1015,7 +1015,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       onItemMouseEnter: this._onItemMouseEnterBase,
       onItemMouseLeave: this._onMouseItemLeave,
       onItemMouseMove: this._onItemMouseMoveBase,
-      onItemMouseDown: this._onItemMouseDown,
+      onItemMouseDown: onItemMouseDown,
       executeItemClick: this._executeItemClick,
       onItemKeyDown: this._onItemKeyDown,
       expandedMenuItemKey,
@@ -1183,12 +1183,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     }
   }
 
-  private _onItemMouseDown = (item: IContextualMenuItem, ev: React.MouseEvent<HTMLElement>): void => {
-    if (item.onMouseDown) {
-      item.onMouseDown(item, ev);
-    }
-  };
-
   private _onItemClick = (
     item: IContextualMenuItem,
     ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
@@ -1340,4 +1334,8 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
 function _isAltOrMeta(ev: React.KeyboardEvent<HTMLElement>): boolean {
   // eslint-disable-next-line deprecation/deprecation
   return ev.which === KeyCodes.alt || ev.key === 'Meta';
+}
+
+function onItemMouseDown(item: IContextualMenuItem, ev: React.MouseEvent<HTMLElement>): void {
+  item.onMouseDown?.(item, ev);
 }

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -383,7 +383,7 @@ function useKeyHandlers(
 }
 
 function useScrollHandler(asyncTracker: Async) {
-  const isScrollIdle = React.useRef<boolean>(false);
+  const isScrollIdle = React.useRef<boolean>(true);
   const scrollIdleTimeoutId = React.useRef<number | undefined>();
 
   /**

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -393,7 +393,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       className: this._classNames.root,
       isCircularNavigation: true,
       handleTabKey: FocusZoneTabbableElements.all,
-      direction: this._getFocusZoneDirection(),
+      direction: this.props.focusZoneProps?.direction ?? FocusZoneDirection.vertical,
     };
 
     const hasCheckmarks = canAnyMenuItemsCheck(items);
@@ -501,17 +501,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     } else {
       return null;
     }
-  }
-
-  /**
-   * Gets the focusZoneDirection by using the arrowDirection if specified,
-   * the direction specified in the focusZoneProps, or defaults to FocusZoneDirection.vertical
-   */
-  private _getFocusZoneDirection() {
-    const { focusZoneProps } = this.props;
-    return focusZoneProps && focusZoneProps.direction !== undefined
-      ? focusZoneProps.direction
-      : FocusZoneDirection.vertical;
   }
 
   private _onRenderSubMenu(

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -1275,8 +1275,10 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
 
   private _getSubmenuProps() {
     const {
-      hoisted: { submenuTarget, expandedMenuItemKey, expandedByMouseClick },
+      hoisted: { submenuTarget, expandedMenuItemKey, expandedByMouseClick, onSubMenuDismiss, subMenuId },
       items,
+      theme,
+      className,
     } = this.props;
     const item = findItemByKeyFromItems(expandedMenuItemKey!, items);
     let submenuProps: IContextualMenuProps | null = null;
@@ -1285,13 +1287,13 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       submenuProps = {
         items: getSubmenuItems(item)!,
         target: submenuTarget,
-        onDismiss: this.props.hoisted.onSubMenuDismiss,
+        onDismiss: onSubMenuDismiss,
         isSubMenu: true,
-        id: this.props.hoisted.subMenuId,
+        id: subMenuId,
         shouldFocusOnMount: true,
         shouldFocusOnContainer: expandedByMouseClick,
-        directionalHint: getRTL(this.props.theme) ? DirectionalHint.leftTopEdge : DirectionalHint.rightTopEdge,
-        className: this.props.className,
+        directionalHint: getRTL(theme) ? DirectionalHint.leftTopEdge : DirectionalHint.rightTopEdge,
+        className: className,
         gapSpace: 0,
         isBeakVisible: false,
       };

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -1295,25 +1295,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
 
   private _findItemByKey(key: string): IContextualMenuItem | undefined {
     const { items } = this.props;
-    return this._findItemByKeyFromItems(key, items);
-  }
-
-  /**
-   * Returns the item that matches a given key if any.
-   * @param key - The key of the item to match
-   * @param items - The items to look for the key
-   */
-  private _findItemByKeyFromItems(key: string, items: IContextualMenuItem[]): IContextualMenuItem | undefined {
-    for (const item of items) {
-      if (item.itemType === ContextualMenuItemType.Section && item.sectionProps) {
-        const match = this._findItemByKeyFromItems(key, item.sectionProps.items);
-        if (match) {
-          return match;
-        }
-      } else if (item.key && item.key === key) {
-        return item;
-      }
-    }
+    return findItemByKeyFromItems(key, items);
   }
 
   private _onPointerAndTouchEvent = (ev: React.TouchEvent<HTMLElement> | PointerEvent) => {
@@ -1341,4 +1323,22 @@ function onDefaultRenderSubMenu(
     'ContextualMenuBase: onRenderSubMenu callback is null or undefined. ' +
       'Please ensure to set `onRenderSubMenu` property either manually or with `styled` helper.',
   );
+}
+
+/**
+ * Returns the item that matches a given key if any.
+ * @param key - The key of the item to match
+ * @param items - The items to look for the key
+ */
+function findItemByKeyFromItems(key: string, items: IContextualMenuItem[]): IContextualMenuItem | undefined {
+  for (const item of items) {
+    if (item.itemType === ContextualMenuItemType.Section && item.sectionProps) {
+      const match = findItemByKeyFromItems(key, item.sectionProps.items);
+      if (match) {
+        return match;
+      }
+    } else if (item.key && item.key === key) {
+      return item;
+    }
+  }
 }

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -8,7 +8,6 @@ import {
   shallowCompare,
   warnDeprecations,
   Async,
-  EventGroup,
   assign,
   classNamesFunction,
   css,
@@ -246,7 +245,6 @@ interface IContextualMenuInternalProps extends IContextualMenuProps {
 
 class ContextualMenuInternal extends React.Component<IContextualMenuInternalProps, IContextualMenuState> {
   private _async: Async;
-  private _events: EventGroup;
   private _id: string;
   private _previousActiveElement: HTMLElement | undefined;
   private _enterTimerId: number | undefined;
@@ -265,7 +263,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     super(props);
 
     this._async = new Async(this);
-    this._events = new EventGroup(this);
     initializeComponentRef(this);
 
     warnDeprecations(COMPONENT_NAME, props, {
@@ -328,7 +325,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
 
   // Invoked immediately before a component is unmounted from the DOM.
   public componentWillUnmount() {
-    this._events.dispose();
     this._async.dispose();
     this._mounted = false;
   }

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -533,7 +533,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       styles,
       theme,
       calloutProps,
-      onRenderSubMenu = this._onRenderSubMenu,
+      onRenderSubMenu = onDefaultRenderSubMenu,
       onRenderMenuList = (
         menuListProps: IContextualMenuListProps,
         defaultRender?: IRenderFunction<IContextualMenuListProps>,
@@ -680,7 +680,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
                       adjustedFocusZoneProps,
                     )
                   : null}
-                {submenuProps && onRenderSubMenu(submenuProps, this._onRenderSubMenu)}
+                {submenuProps && onRenderSubMenu(submenuProps, onDefaultRenderSubMenu)}
               </div>
             </Callout>
           )}
@@ -689,16 +689,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     } else {
       return null;
     }
-  }
-
-  private _onRenderSubMenu(
-    subMenuProps: IContextualMenuInternalProps,
-    defaultRender?: IRenderFunction<IContextualMenuProps>,
-  ): JSX.Element {
-    throw Error(
-      'ContextualMenuBase: onRenderSubMenu callback is null or undefined. ' +
-        'Please ensure to set `onRenderSubMenu` property either manually or with `styled` helper.',
-    );
   }
 
   private _onRenderMenuList = (
@@ -1341,4 +1331,14 @@ function _isAltOrMeta(ev: React.KeyboardEvent<HTMLElement>): boolean {
 
 function onItemMouseDown(item: IContextualMenuItem, ev: React.MouseEvent<HTMLElement>): void {
   item.onMouseDown?.(item, ev);
+}
+
+function onDefaultRenderSubMenu(
+  subMenuProps: IContextualMenuInternalProps,
+  defaultRender?: IRenderFunction<IContextualMenuProps>,
+): JSX.Element {
+  throw Error(
+    'ContextualMenuBase: onRenderSubMenu callback is null or undefined. ' +
+      'Please ensure to set `onRenderSubMenu` property either manually or with `styled` helper.',
+  );
 }

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -53,13 +53,6 @@ import type { IPopupRestoreFocusParams } from '../../Popup';
 const getClassNames = classNamesFunction<IContextualMenuStyleProps, IContextualMenuStyles>();
 const getContextualMenuItemClassNames = classNamesFunction<IContextualMenuItemStyleProps, IContextualMenuItemStyles>();
 
-export interface IContextualMenuState {
-  contextualMenuTarget?: Element;
-  positions?: any;
-  slideDirectionalClassName?: string;
-  submenuDirection?: DirectionalHint;
-}
-
 // The default ContextualMenu properties have no items and beak, the default submenu direction is right and top.
 const DEFAULT_PROPS: Partial<IContextualMenuProps> = {
   items: [],
@@ -538,7 +531,7 @@ interface IContextualMenuInternalProps extends IContextualMenuProps {
 }
 
 class ContextualMenuInternal extends React.Component<IContextualMenuInternalProps, never> {
-  public shouldComponentUpdate(newProps: IContextualMenuInternalProps, newState: IContextualMenuState): boolean {
+  public shouldComponentUpdate(newProps: IContextualMenuInternalProps): boolean {
     if (!newProps.shouldUpdateWhenHidden && this.props.hidden && newProps.hidden) {
       // Do not update when hidden.
       return false;

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -55,7 +55,6 @@ const getClassNames = classNamesFunction<IContextualMenuStyleProps, IContextualM
 const getContextualMenuItemClassNames = classNamesFunction<IContextualMenuItemStyleProps, IContextualMenuItemStyles>();
 
 export interface IContextualMenuState {
-  contextualMenuItems?: IContextualMenuItem[];
   contextualMenuTarget?: Element;
   positions?: any;
   slideDirectionalClassName?: string;
@@ -257,7 +256,7 @@ interface IContextualMenuInternalProps extends IContextualMenuProps {
   };
 }
 
-class ContextualMenuInternal extends React.Component<IContextualMenuInternalProps, IContextualMenuState> {
+class ContextualMenuInternal extends React.Component<IContextualMenuInternalProps, never> {
   private _previousActiveElement: HTMLElement | undefined;
   private _enterTimerId: number | undefined;
   private _isScrollIdle: boolean;
@@ -276,10 +275,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
 
     initializeComponentRef(this);
 
-    this.state = {
-      contextualMenuItems: undefined,
-    };
-
     this._isScrollIdle = true;
   }
 
@@ -297,7 +292,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       return false;
     }
 
-    return !shallowCompare(this.props, newProps) || !shallowCompare(this.state, newState);
+    return !shallowCompare(this.props, newProps);
   }
 
   public getSnapshotBeforeUpdate(prevProps: IContextualMenuInternalProps): null {

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -6,7 +6,6 @@ import {
   divProperties,
   getNativeProps,
   shallowCompare,
-  warnDeprecations,
   Async,
   assign,
   classNamesFunction,
@@ -34,7 +33,7 @@ import {
 } from './ContextualMenuItemWrapper/index';
 import { concatStyleSetsWithProps } from '../../Styling';
 import { getItemStyles } from './ContextualMenu.classNames';
-import { useTarget, usePrevious, useAsync } from '@fluentui/react-hooks';
+import { useTarget, usePrevious, useAsync, useWarnings } from '@fluentui/react-hooks';
 import { useResponsiveMode, ResponsiveMode } from '../../ResponsiveMode';
 import { MenuContext } from '../../utilities/MenuContext/index';
 import type {
@@ -196,6 +195,14 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
   const hostElement = React.useRef<HTMLDivElement>(null);
   const asyncTracker = useAsync();
 
+  useWarnings({
+    name: COMPONENT_NAME,
+    props,
+    deprecations: {
+      getMenuClassNames: 'styles',
+    },
+  });
+
   const [targetRef, targetWindow] = useTarget(props.target, hostElement);
   const [expandedMenuItemKey, submenuTarget, expandedByMouseClick, openSubMenu, closeSubMenu] = useSubMenuState(props);
   const [shouldUpdateFocusOnMouseEvent, gotMouseMove, onMenuFocusCapture] = useShouldUpdateFocusOnMouseMove(props);
@@ -265,10 +272,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     super(props);
 
     initializeComponentRef(this);
-
-    warnDeprecations(COMPONENT_NAME, props, {
-      getMenuClassNames: 'styles',
-    });
 
     this.state = {
       contextualMenuItems: undefined,

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -188,7 +188,13 @@ function usePreviousActiveElement({ hidden, onRestoreFocus }: IContextualMenuPro
   React.useLayoutEffect(() => {
     if (!hidden) {
       previousActiveElement.current = targetWindow?.document.activeElement as HTMLElement;
-    } else {
+    } else if (previousActiveElement.current) {
+      tryFocusPreviousActiveElement({
+        originalElement: previousActiveElement.current,
+        containsFocus: true,
+        documentContainsFocus: getDocument()?.hasFocus() || false,
+      });
+
       previousActiveElement.current = undefined;
     }
   }, [hidden]);
@@ -308,15 +314,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     }
 
     return !shallowCompare(this.props, newProps);
-  }
-
-  public getSnapshotBeforeUpdate(prevProps: IContextualMenuInternalProps): null {
-    if (this._isHidden(prevProps) !== this._isHidden(this.props)) {
-      if (this._isHidden(this.props)) {
-        this._onMenuClosed();
-      }
-    }
-    return null;
   }
 
   // Invoked once, only on the client (not on the server), immediately after the initial rendering occurs.
@@ -504,23 +501,6 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
     } else {
       return null;
     }
-  }
-
-  private _onMenuClosed() {
-    this.props.hoisted.tryFocusPreviousActiveElement?.({
-      originalElement: this.props.hoisted.previousActiveElementRef.current,
-      containsFocus: true,
-      documentContainsFocus: getDocument()?.hasFocus() || false,
-    });
-  }
-
-  /**
-   * Return whether the contextual menu is hidden.
-   * Undefined value for hidden is equivalent to hidden being false.
-   * @param props - Props for the component
-   */
-  private _isHidden(props: IContextualMenuProps) {
-    return !!props.hidden;
   }
 
   /**

--- a/packages/react/src/components/Popup/Popup.types.ts
+++ b/packages/react/src/components/Popup/Popup.types.ts
@@ -56,7 +56,7 @@ export interface IPopupProps extends React.HTMLAttributes<HTMLDivElement>, React
  */
 export interface IPopupRestoreFocusParams {
   /** Element the underlying Popup believes focus should go to */
-  originalElement?: HTMLElement | Window;
+  originalElement?: HTMLElement | Window | null;
   /** Whether the popup currently contains focus */
   containsFocus: boolean;
   /** Whether the document the popup belongs to contains focus (or false if unknown) */


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fully migrate `ContextualMenu` to be a functional component. This work is a precursor to work to allow `items` and `subMenuProps` to be async functions, allowing for the data to be lazy-loaded on-demand (see https://github.com/MLoughry/office-ui-fabric-react/pull/1)

#### Focus areas to test

(optional)
