### PR TITLE
Cherrypick tschao/customize picker search for more icon

### DIFF
--- a/change/office-ui-fabric-react-84d914cc-f2ba-48f5-9902-0cdc125df8d5.json
+++ b/change/office-ui-fabric-react-84d914cc-f2ba-48f5-9902-0cdc125df8d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Customize search for more icon for Suggestions",
+  "packageName": "office-ui-fabric-react",
+  "email": "tschao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1814,7 +1814,7 @@ export interface IBasePickerStyles {
 }
 
 // @public
-export interface IBasePickerSuggestionsProps<T = any> extends Pick<ISuggestionsProps<T>, 'onRenderNoResultFound' | 'suggestionsHeaderText' | 'mostRecentlyUsedHeaderText' | 'noResultsFoundText' | 'className' | 'suggestionsClassName' | 'suggestionsItemClassName' | 'searchForMoreText' | 'forceResolveText' | 'loadingText' | 'searchingText' | 'resultsFooterFull' | 'resultsFooter' | 'resultsMaximumNumber' | 'showRemoveButtons' | 'suggestionsAvailableAlertText' | 'suggestionsContainerAriaLabel' | 'showForceResolve'> {
+export interface IBasePickerSuggestionsProps<T = any> extends Pick<ISuggestionsProps<T>, 'onRenderNoResultFound' | 'suggestionsHeaderText' | 'mostRecentlyUsedHeaderText' | 'noResultsFoundText' | 'className' | 'suggestionsClassName' | 'suggestionsItemClassName' | 'searchForMoreIcon' | 'searchForMoreText' | 'forceResolveText' | 'loadingText' | 'searchingText' | 'resultsFooterFull' | 'resultsFooter' | 'resultsMaximumNumber' | 'showRemoveButtons' | 'suggestionsAvailableAlertText' | 'suggestionsContainerAriaLabel' | 'showForceResolve'> {
 }
 
 // @public (undocumented)
@@ -7996,6 +7996,7 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
     resultsMaximumNumber?: number;
     // @deprecated
     searchErrorText?: string;
+    searchForMoreIcon?: IIconProps;
     searchForMoreText?: string;
     searchingText?: string;
     showForceResolve?: () => boolean;

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -239,6 +239,7 @@ export interface IBasePickerSuggestionsProps<T = any>
     | 'className'
     | 'suggestionsClassName'
     | 'suggestionsItemClassName'
+    | 'searchForMoreIcon'
     | 'searchForMoreText'
     | 'forceResolveText'
     | 'loadingText'

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -77,6 +77,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
     const {
       forceResolveText,
       mostRecentlyUsedHeaderText,
+      searchForMoreIcon,
       searchForMoreText,
       className,
       moreSuggestionsAvailable,
@@ -197,7 +198,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
           <CommandButton
             componentRef={this._searchForMoreButton}
             className={this._classNames.searchForMoreButton}
-            iconProps={{ iconName: 'Search' }}
+            iconProps={searchForMoreIcon || { iconName: 'Search' }}
             id={searchForMoreId}
             onClick={this._getMoreResults}
             data-automationid={'sug-searchForMore'}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -5,7 +5,7 @@ import { IPersonaProps } from '../../Persona/Persona.types';
 import { IStyle, ITheme } from '../../../Styling';
 import { ISpinnerStyleProps } from '../../Spinner/Spinner.types';
 import { ISuggestionItemProps } from './SuggestionsItem.types';
-
+import { IIconProps } from '../../Icon/Icon.types';
 /**
  * Suggestions component.
  * {@docCategory Pickers}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -77,6 +77,11 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
   mostRecentlyUsedHeaderText?: string;
 
   /**
+   * The icon that appears indicating to the user that they can search for more results.
+   */
+  searchForMoreIcon?: IIconProps;
+
+  /**
    * The text that appears indicating to the user that they can search for more results.
    */
   searchForMoreText?: string;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Cherrypick of https://github.com/microsoft/fluentui/pull/19671

Suggestions currently allow custom search for more text but not icon. This PR makes it so that the icon is also customizable.


#### Focus areas to test

(optional)
