### PR TITLE
Backspace does not work in BaseExtendedPicker in projection popout windows

### DIFF
--- a/change/@fluentui-react-1fa89b42-50f3-4b05-bbf8-37e4f27e94a4.json
+++ b/change/@fluentui-react-1fa89b42-50f3-4b05-bbf8-37e4f27e94a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Backspace does not work in BaseExtendedpicker in projection popout windows",
+  "packageName": "@fluentui/react",
+  "email": "srangam@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -201,7 +201,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
       if (
         this.input.current &&
         !this.input.current.isValueSelected &&
-        this.input.current.inputElement === document.activeElement &&
+        this.input.current.inputElement === ev.currentTarget.ownerDocument.activeElement &&
         (this.input.current as Autofill).cursorLocation === 0
       ) {
         if (this.floatingPicker.current) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In a popout window, users cannot use backspace to remove recipients. This is similar to [this ](https://github.com/microsoft/fluentui/pull/18428) issue that was fixed a couple of months ago. This is another component that needs this fix

#### Focus areas to test

(optional)
