### PR TITLE
fix(migrate-fixed-dependencies): Handle dev dependencies and utilities

### DIFF
--- a/tools/generators/migrate-fixed-versions/index.spec.ts
+++ b/tools/generators/migrate-fixed-versions/index.spec.ts
@@ -28,7 +28,7 @@ describe('migrate-fixed-versions generator', () => {
     tree = setupDummyPackage(tree, options);
   });
 
-  it('should run successfully', async () => {
+  it('should successfully migrate depedencies', async () => {
     tree = setupDummyPackage(tree, {
       name: '@proj/react-button',
       version: '9.0.0-alpha.0',
@@ -53,6 +53,32 @@ describe('migrate-fixed-versions generator', () => {
     `);
   });
 
+  it('should successfully migrate dev depedencies', async () => {
+    tree = setupDummyPackage(tree, {
+      name: '@proj/react-button',
+      version: '9.0.0-alpha.0',
+      dependencies: {},
+      devDependencies: {
+        '@proj/make-styles': '^9.0.0-alpha.1',
+      },
+      projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-button/src' },
+    });
+    tree = setupDummyPackage(tree, {
+      name: '@proj/make-styles',
+      version: '9.0.0-alpha.0',
+      projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
+    });
+
+    await generator(tree, { name: '@proj/react-button' });
+
+    const packageJson = readJson(tree, 'packages/react-button/package.json');
+    expect(packageJson.devDependencies).toMatchInlineSnapshot(`
+      Object {
+        "@proj/make-styles": "9.0.0-alpha.1",
+      }
+    `);
+  });
+
   it('should not migrate third party dependencies', async () => {
     tree = setupDummyPackage(tree, {
       name: '@proj/react-positioning',
@@ -66,6 +92,26 @@ describe('migrate-fixed-versions generator', () => {
 
     const packageJson = readJson(tree, 'packages/react-positioning/package.json');
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
+      Object {
+        "popperjs/core": "^1.0.0",
+      }
+    `);
+  });
+
+  it('should not migrate third party dev dependencies', async () => {
+    tree = setupDummyPackage(tree, {
+      name: '@proj/react-positioning',
+      version: '9.0.0-alpha.0',
+      dependencies: {},
+      devDependencies: {
+        'popperjs/core': '^1.0.0',
+      },
+      projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-positioning/src' },
+    });
+    await generator(tree, { name: '@proj/react-positioning' });
+
+    const packageJson = readJson(tree, 'packages/react-positioning/package.json');
+    expect(packageJson.devDependencies).toMatchInlineSnapshot(`
       Object {
         "popperjs/core": "^1.0.0",
       }
@@ -124,7 +170,7 @@ describe('migrate-fixed-versions generator', () => {
       });
     });
 
-    it('should migrate all web packages', async () => {
+    it('should migrate all packages', async () => {
       await generator(tree, { all: true, name: '' });
 
       const reactButtonPackageJson = readJson(tree, 'packages/react-button/package.json');
@@ -141,17 +187,6 @@ describe('migrate-fixed-versions generator', () => {
         }
       `);
     });
-
-    it('should skip all non-web packages', async () => {
-      await generator(tree, { all: true, name: '' });
-
-      const packageJson = readJson(tree, 'packages/babel-make-styles/package.json');
-      expect(packageJson.dependencies).toMatchInlineSnapshot(`
-        Object {
-          "@proj/make-styles": "^9.0.0-alpha.1",
-        }
-      `);
-    });
   });
 });
 
@@ -160,6 +195,7 @@ function setupDummyPackage(
   options: MigrateFixedVersionsGeneratorSchema &
     Partial<{
       version: string;
+      devDependencies: Record<string, string>;
       dependencies: Record<string, string>;
       projectConfiguration: Partial<ReturnType<typeof readProjectConfiguration>>;
     }>,
@@ -188,6 +224,7 @@ function setupDummyPackage(
       name: pkgName,
       version: normalizedOptions.version,
       dependencies: normalizedOptions.dependencies,
+      devDependencies: normalizedOptions.devDependencies,
     },
   };
 

--- a/tools/generators/migrate-fixed-versions/index.ts
+++ b/tools/generators/migrate-fixed-versions/index.ts
@@ -23,16 +23,28 @@ export default async function (host: Tree, schema: MigrateFixedVersionsGenerator
 function runMigrationOnProject(host: Tree, schema: ValidatedSchema, userLog: UserLog) {
   const options = normalizeOptions(host, schema);
   const packageJsonPath = options.paths.packageJson;
+
   updateJson(host, packageJsonPath, (packageJson: PackageJson) => {
     if (packageJson.dependencies) {
       Object.keys(packageJson.dependencies).forEach(dependency => {
-        console.log(dependency);
         if (isPackageConverged(dependency, host) && packageJson.dependencies) {
           userLog.push({
             type: 'info',
             message: `Updating package ${schema.name}`,
           });
           packageJson.dependencies[dependency] = packageJson.dependencies[dependency].replace('^', '');
+        }
+      });
+    }
+
+    if (packageJson.devDependencies) {
+      Object.keys(packageJson.devDependencies).forEach(dependency => {
+        if (isPackageConverged(dependency, host) && packageJson.devDependencies) {
+          userLog.push({
+            type: 'info',
+            message: `Updating package ${schema.name}`,
+          });
+          packageJson.devDependencies[dependency] = packageJson.devDependencies[dependency].replace('^', '');
         }
       });
     }
@@ -45,10 +57,6 @@ function runBatchMigration(host: Tree, userLog: UserLog) {
   const projects = getProjects(host);
 
   projects.forEach((project, projectName) => {
-    if (!isPackageConverged(projectName, host)) {
-      userLog.push({ type: 'error', message: `${projectName} is not a converged web package. Skipping...` });
-      return;
-    }
     runMigrationOnProject(host, { name: projectName, all: false }, userLog);
   });
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
The migration generator for fixed versions needs to handle dev
dependencies because syncpack will fail on those too.

Also converged packages are used in quite a few utilities in the
monorepo such as perf test, vr test etc.... that also need to be
migrated since syncpack will fail

#### Focus areas to test

(optional)
