### PR TITLE
fix(ChoiceGroup): add better guidance for image + text strings, and update the example

### DIFF
--- a/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Image.Example.tsx
+++ b/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Image.Example.tsx
@@ -6,17 +6,18 @@ const options: IChoiceGroupOption[] = [
   {
     key: 'bar',
     imageSrc: TestImages.choiceGroupBarUnselected,
-    imageAlt: 'Bar chart icon',
+    imageAlt: 'Bar chart',
     selectedImageSrc: TestImages.choiceGroupBarSelected,
     imageSize: { width: 32, height: 32 },
-    text: 'Clustered bar chart', // This text is long to show text wrapping.
+    text: 'Bar', // This text is long to show text wrapping.
   },
   {
     key: 'pie',
-    imageSrc: TestImages.choiceGroupBarUnselected,
-    selectedImageSrc: TestImages.choiceGroupBarSelected,
+    imageSrc: TestImages.choiceGroupPieUnselected,
+    imageAlt: 'Pie chart',
+    selectedImageSrc: TestImages.choiceGroupPieSelected,
     imageSize: { width: 32, height: 32 },
-    text: 'Pie chart',
+    text: 'Pie',
   },
 ];
 

--- a/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Image.Example.tsx
+++ b/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Image.Example.tsx
@@ -9,7 +9,7 @@ const options: IChoiceGroupOption[] = [
     imageAlt: 'Bar chart',
     selectedImageSrc: TestImages.choiceGroupBarSelected,
     imageSize: { width: 32, height: 32 },
-    text: 'Bar', // This text is long to show text wrapping.
+    text: 'Bar',
   },
   {
     key: 'pie',

--- a/packages/react-examples/src/react/ChoiceGroup/docs/ChoiceGroupBestPractices.md
+++ b/packages/react-examples/src/react/ChoiceGroup/docs/ChoiceGroupBestPractices.md
@@ -12,3 +12,4 @@
 - Select the safest (to prevent loss of data or system access), most secure, and most private option as the default. If safety and security aren't factors, select the most likely or convenient option.
 - Use a phrase for the label, rather than a full sentence.
 - Make sure to give people the option to not make a choice. For example, include a "None" option.
+- When using ChoiceGroup with images, keep text short (ideally one or two words), since overflowing text will be cut off. Translation to other languages and user-applied text styles can often cause label text to end up longer than the English label with author styles.

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -268,7 +268,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   }
                 >
                   <img
-                    alt="Bar chart icon"
+                    alt="Bar chart"
                     className=
                         ms-Image-image
                         ms-Image-image--portrait
@@ -319,7 +319,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   }
                 >
                   <img
-                    alt="Bar chart icon"
+                    alt="Bar chart"
                     className=
                         ms-Image-image
                         ms-Image-image--portrait
@@ -364,7 +364,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-bar"
               >
-                Clustered bar chart
+                Bar
               </span>
             </div>
           </label>
@@ -552,7 +552,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   }
                 >
                   <img
-                    alt=""
+                    alt="Pie chart"
                     className=
                         ms-Image-image
                         ms-Image-image--portrait
@@ -566,7 +566,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                         }
                     onError={[Function]}
                     onLoad={[Function]}
-                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/choicegroup-bar-unselected.png"
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/choicegroup-pie-unselected.png"
                   />
                 </div>
               </div>
@@ -611,7 +611,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   }
                 >
                   <img
-                    alt=""
+                    alt="Pie chart"
                     className=
                         ms-Image-image
                         ms-Image-image--portrait
@@ -625,7 +625,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                         }
                     onError={[Function]}
                     onLoad={[Function]}
-                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/choicegroup-bar-selected.png"
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/choicegroup-pie-selected.png"
                   />
                 </div>
               </div>
@@ -656,7 +656,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-pie"
               >
-                Pie chart
+                Pie
               </span>
             </div>
           </label>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12468](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12468)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The ChoiceGroup image variant doesn't accommodate longer text strings, so I added guidance to keep text short, since translation or user styles can lengthen it. This was the solution proposed when consulting with design, since the current design doesn't have a way to handle longer text without significant alteration.

I also update the example to use the correct icon for pie chart, because why not :D