### PR TITLE
fix(MessageBar): tweak example page styles for reflow

### DIFF
--- a/packages/react-examples/src/react/MessageBar/MessageBar.Basic.Example.tsx
+++ b/packages/react-examples/src/react/MessageBar/MessageBar.Basic.Example.tsx
@@ -18,10 +18,12 @@ interface IExampleProps {
 
 const horizontalStackProps: IStackProps = {
   horizontal: true,
+  wrap: true,
   tokens: { childrenGap: 16 },
 };
 const verticalStackProps: IStackProps = {
-  styles: { root: { overflow: 'hidden', width: '100%' } },
+  grow: true,
+  styles: { root: { overflow: 'hidden', width: '60%' } },
   tokens: { childrenGap: 20 },
 };
 const choiceGroupStyles: Partial<IChoiceGroupStyles> = { label: { maxWidth: 250 } };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12722](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12722)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Updates the Stack flex styles so the messagebars will reflow underneath the ChoiceGroup in the basic example at smaller viewport widths.
