### PR TITLE
Breaking(Colors): Removing Red Foreground 3 color token

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,6 +18,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- Remove Red Foreground 3 from color scheme tokens  @codepretty ([#19761](https://github.com/microsoft/fluentui/pull/19761))
+
 ### Documentation
 - Add Chat Playground @Hirse ([#19702](https://github.com/microsoft/fluentui/pull/19702))
 

--- a/packages/fluentui/react-northstar/src/themes/teams-dark/colors.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark/colors.ts
@@ -256,7 +256,6 @@ export const colorScheme: ColorSchemeMapping = {
     foreground: colors.red[200],
     foreground1: colors.white,
     foreground2: colors.grey[800],
-    foreground3: colors.red[200],
 
     background: colors.red[300],
     background1: colors.red[800],

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/colors.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/colors.ts
@@ -254,7 +254,6 @@ export const colorScheme: ColorSchemeMapping = {
     foreground: colors.white,
     foreground1: colors.black,
     foreground2: colors.black,
-    foreground3: colors.white,
 
     background: colors.white,
     background1: colors.black,

--- a/packages/fluentui/react-northstar/src/themes/teams/colors.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/colors.ts
@@ -464,7 +464,6 @@ export const colorScheme: ColorSchemeMapping<ColorScheme, TeamsColorNames> = {
     foreground: colors.red[400],
     foreground1: colors.white,
     foreground2: colors.white,
-    foreground3: colors.red[300],
     background: colors.red[400],
     background1: colors.red[50],
     background2: colors.ruby[500],


### PR DESCRIPTION
I recently added Red Foreground 3 color token in [this PR](https://github.com/microsoft/fluentui/pull/18827)

Design recently found out this color doesn't meet accessibility guidelines for its intended use and are going with a different solution for the banners/alerts
