### PR TITLE
fix(Menu): Manually open nested menu in vr-test

### DIFF
--- a/apps/vr-tests/src/stories/Menu.stories.tsx
+++ b/apps/vr-tests/src/stories/Menu.stories.tsx
@@ -178,7 +178,11 @@ storiesOf('react-menu Menu - selection groups', module)
   ));
 
 storiesOf('react-menu Menu - nested submenus', module)
-  .addDecorator(story => <Screener>{story()}</Screener>)
+  .addDecorator(story => (
+    <Screener steps={new Screener.Steps().click('#nestedTrigger').snapshot('all open').end()}>
+      {story()}
+    </Screener>
+  ))
   .addDecorator(FluentProviderDecorator)
   .addStory('default', () => (
     <Menu open>
@@ -191,9 +195,9 @@ storiesOf('react-menu Menu - nested submenus', module)
           <MenuItem>New </MenuItem>
           <MenuItem>New Window</MenuItem>
           <MenuItem>Open Folder</MenuItem>
-          <Menu open>
+          <Menu>
             <MenuTrigger>
-              <MenuItem>Preferences</MenuItem>
+              <MenuItem id="nestedTrigger">Preferences</MenuItem>
             </MenuTrigger>
 
             <MenuPopover>

--- a/apps/vr-tests/src/stories/Menu.stories.tsx
+++ b/apps/vr-tests/src/stories/Menu.stories.tsx
@@ -179,6 +179,7 @@ storiesOf('react-menu Menu - selection groups', module)
 
 storiesOf('react-menu Menu - nested submenus', module)
   .addDecorator(story => (
+    // https://github.com/microsoft/fluentui/issues/19782
     <Screener steps={new Screener.Steps().click('#nestedTrigger').snapshot('all open').end()}>
       {story()}
     </Screener>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes partially #19754 #19782
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Setting the ` open ` prop of both menus can result in race conditions in the positioning of the second menu with respect to the first

#### Focus areas to test

(optional)
