### PR TITLE
fix(ContextualMenu): add usage note to ContextualMenu header example

### DIFF
--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Header.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Header.Example.tsx
@@ -48,7 +48,7 @@ export const ContextualMenuHeaderExample: React.FunctionComponent = () => {
     <>
       <p>
         Note: this example demonstrates how to use the Header menu item type as a standalone menu item. For semantically
-        grouped options, refer to the "Contextual Menu with section headers" example.
+        grouped options, refer to the <code>Contextual Menu with section headers</code> example.
       </p>
       <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />
     </>

--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Header.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Header.Example.tsx
@@ -44,5 +44,13 @@ export const ContextualMenuHeaderExample: React.FunctionComponent = () => {
     ],
   }));
 
-  return <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />;
+  return (
+    <>
+      <p>
+        Note: this example demonstrates how to use the Header menu item type as a standalone menu item. For semantically
+        grouped options, refer to the "Contextual Menu with section headers" example.
+      </p>
+      <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />
+    </>
+  );
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12756](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12756)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds a one-sentence note to the ContextualMenu with headers example, since it seems that teams were confused about it vs. section headers, and there are a11y implications to the difference.