### PR TITLE
TeachingBubble: Provide default aria attributes for TeachingBubble - 12841

### DIFF
--- a/change/@fluentui-react-8882060f-3a9e-4b9e-8a2b-94ddbf850342.json
+++ b/change/@fluentui-react-8882060f-3a9e-4b9e-8a2b-94ddbf850342.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix(TeachingBubble): Provide default aria attributes for dialog",
+  "packageName": "@fluentui/react",
+  "email": "peter.varholak@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/TeachingBubble/TeachingBubble.test.tsx
+++ b/packages/react/src/components/TeachingBubble/TeachingBubble.test.tsx
@@ -45,9 +45,35 @@ describe('TeachingBubble', () => {
     expect(component.find(TeachingBubbleContent).find('p#content').length).toBe(1);
   });
 
+  it('renders TeachingBubble with provided aria-describedby and aria-labelledby', () => {
+    const component = mount(
+      <TeachingBubble headline="Test Title" ariaDescribedBy="content" ariaLabelledBy="title">
+        Test Content
+      </TeachingBubble>,
+    );
+
+    expect(component.find('div[aria-describedby="content"]').length).toBe(1);
+    expect(component.find('div[aria-labelledby="title"]').length).toBe(1);
+    expect(component.find('p[id="content"]').length).toBe(1);
+    expect(component.find('p[id="title"]').length).toBe(1);
+  });
+
+  it('renders TeachingBubbleContent with generated aria-describedby and aria-labelledby', () => {
+    const component = renderer.create(
+      <TeachingBubbleContent headline="Test Title">Test Content</TeachingBubbleContent>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders TeachingBubble correctly', () => {
     const component = renderer.create(
-      <TeachingBubble isWide={true} calloutProps={{ doNotLayer: true, className: 'specialClassName' }}>
+      <TeachingBubble
+        isWide={true}
+        calloutProps={{ doNotLayer: true, className: 'specialClassName' }}
+        ariaDescribedBy="content"
+        ariaLabelledBy="title"
+      >
         Test Content
       </TeachingBubble>,
     );
@@ -57,7 +83,9 @@ describe('TeachingBubble', () => {
 
   it('renders TeachingBubbleContent correctly', () => {
     const componentContent = renderer.create(
-      <TeachingBubbleContent headline="Test Title">Content</TeachingBubbleContent>,
+      <TeachingBubbleContent headline="Test Title" ariaDescribedBy="content" ariaLabelledBy="title">
+        Content
+      </TeachingBubbleContent>,
     );
     const treeContent = componentContent.toJSON();
     expect(treeContent).toMatchSnapshot();
@@ -70,6 +98,8 @@ describe('TeachingBubble', () => {
         hasCloseButton={true}
         primaryButtonProps={{ children: 'Test Primary Button', className: 'primary-className' }}
         secondaryButtonProps={{ children: 'Test Secondary Button', className: 'secondary-className' }}
+        ariaDescribedBy="content"
+        ariaLabelledBy="title"
       >
         Content
       </TeachingBubbleContent>,
@@ -80,7 +110,12 @@ describe('TeachingBubble', () => {
 
   it('renders TeachingBubbleContent with image correctly', () => {
     const componentContent = renderer.create(
-      <TeachingBubbleContent headline="Test Title" illustrationImage={{ src: 'test image url' }}>
+      <TeachingBubbleContent
+        headline="Test Title"
+        illustrationImage={{ src: 'test image url' }}
+        ariaDescribedBy="content"
+        ariaLabelledBy="title"
+      >
         Content
       </TeachingBubbleContent>,
     );
@@ -90,7 +125,12 @@ describe('TeachingBubble', () => {
 
   it('renders TeachingBubbleContent with condensed headline correctly', () => {
     const componentContent = renderer.create(
-      <TeachingBubbleContent hasCondensedHeadline={true} headline="Test Title">
+      <TeachingBubbleContent
+        hasCondensedHeadline={true}
+        headline="Test Title"
+        ariaDescribedBy="content"
+        ariaLabelledBy="title"
+      >
         Content
       </TeachingBubbleContent>,
     );
@@ -100,7 +140,12 @@ describe('TeachingBubble', () => {
 
   it('renders TeachingBubbleContent with small headline correctly', () => {
     const componentContent = renderer.create(
-      <TeachingBubbleContent hasSmallHeadline={true} headline="Test Title">
+      <TeachingBubbleContent
+        hasSmallHeadline={true}
+        headline="Test Title"
+        ariaDescribedBy="content"
+        ariaLabelledBy="title"
+      >
         Content
       </TeachingBubbleContent>,
     );
@@ -110,7 +155,9 @@ describe('TeachingBubble', () => {
 
   it('renders TeachingBubbleContent with custom footer text', () => {
     const componentContent = renderer.create(
-      <TeachingBubbleContent footerContent="1 of 2">Content</TeachingBubbleContent>,
+      <TeachingBubbleContent footerContent="1 of 2" ariaDescribedBy="content" ariaLabelledBy="title">
+        Content
+      </TeachingBubbleContent>,
     );
     const treeContent = componentContent.toJSON();
     expect(treeContent).toMatchSnapshot();
@@ -118,7 +165,13 @@ describe('TeachingBubble', () => {
 
   it('renders TeachingBubbleContent with calloutProps that deal with styles', () => {
     const componentContent = renderer.create(
-      <TeachingBubbleContent calloutProps={{ beakWidth: 50, calloutWidth: 100 }}>Content</TeachingBubbleContent>,
+      <TeachingBubbleContent
+        calloutProps={{ beakWidth: 50, calloutWidth: 100 }}
+        ariaDescribedBy="content"
+        ariaLabelledBy="title"
+      >
+        Content
+      </TeachingBubbleContent>,
     );
     const treeContent = componentContent.toJSON();
     expect(treeContent).toMatchSnapshot();

--- a/packages/react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -36,11 +36,11 @@ export const TeachingBubbleContentBase: React.FunctionComponent<ITeachingBubbleP
   const documentRef = useDocument();
   const mergedRootRef = useMergedRefs(rootElementRef, forwardedRef);
 
-  const ariaDescribedByRef = useId('teaching-bubble-content-');
-  const ariaLabelledByRef = useId('teaching-bubble-title-');
+  const ariaDescribedById = useId('teaching-bubble-content-');
+  const ariaLabelledById = useId('teaching-bubble-title-');
 
-  const ariaDescribedBy = props.ariaDescribedBy ?? ariaDescribedByRef;
-  const ariaLabelledBy = props.ariaLabelledBy ?? ariaLabelledByRef;
+  const ariaDescribedBy = props.ariaDescribedBy ?? ariaDescribedById;
+  const ariaLabelledBy = props.ariaLabelledBy ?? ariaLabelledById;
 
   const {
     illustrationImage,

--- a/packages/react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -4,7 +4,7 @@ import { PrimaryButton, DefaultButton, IconButton } from '../../Button';
 import { Stack } from '../../Stack';
 import { FocusTrapZone } from '../../FocusTrapZone';
 import { Image } from '../../Image';
-import { useOnEvent, useMergedRefs } from '@fluentui/react-hooks';
+import { useOnEvent, useMergedRefs, useId } from '@fluentui/react-hooks';
 import { useDocument } from '../../WindowProvider';
 import type {
   ITeachingBubbleProps,
@@ -36,6 +36,12 @@ export const TeachingBubbleContentBase: React.FunctionComponent<ITeachingBubbleP
   const documentRef = useDocument();
   const mergedRootRef = useMergedRefs(rootElementRef, forwardedRef);
 
+  const ariaDescribedByRef = useId('teaching-bubble-content-');
+  const ariaLabelledByRef = useId('teaching-bubble-title-');
+
+  const ariaDescribedBy = props.ariaDescribedBy ?? ariaDescribedByRef;
+  const ariaLabelledBy = props.ariaLabelledBy ?? ariaLabelledByRef;
+
   const {
     illustrationImage,
     primaryButtonProps,
@@ -50,8 +56,6 @@ export const TeachingBubbleContentBase: React.FunctionComponent<ITeachingBubbleP
     isWide,
     styles,
     theme,
-    ariaDescribedBy,
-    ariaLabelledBy,
     footerContent: customFooterContent,
     focusTrapZoneProps,
   } = props;

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -2,6 +2,8 @@
 
 exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`] = `
 <div
+  aria-describedby="teaching-bubble-content-0"
+  aria-labelledby="teaching-bubble-title-1"
   className=
       ms-TeachingBubble-content
       {
@@ -69,6 +71,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                 margin-top: 0px;
                 overflow-wrap: break-word;
               }
+          id="teaching-bubble-title-1"
           role="heading"
         >
           Test Title
@@ -93,6 +96,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                 margin-right: 0px;
                 margin-top: 0px;
               }
+          id="teaching-bubble-content-0"
         >
           Content
         </p>
@@ -285,7 +289,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                         margin-right: 4px;
                         margin-top: 0;
                       }
-                  id="id__1"
+                  id="id__3"
                 >
                   Test Secondary Button
                 </span>
@@ -438,7 +442,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                         margin-right: 4px;
                         margin-top: 0;
                       }
-                  id="id__4"
+                  id="id__6"
                 >
                   Test Primary Button
                 </span>

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -75,6 +75,8 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
     >
       <div>
         <div
+          aria-describedby="content"
+          aria-labelledby="title"
           className=
               ms-TeachingBubble-content
               {
@@ -136,6 +138,7 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
                         margin-right: 0px;
                         margin-top: 0px;
                       }
+                  id="content"
                 >
                   Test Content
                 </p>
@@ -162,6 +165,8 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
 
 exports[`TeachingBubble renders TeachingBubbleContent correctly 1`] = `
 <div
+  aria-describedby="content"
+  aria-labelledby="title"
   className=
       ms-TeachingBubble-content
       {
@@ -226,6 +231,7 @@ exports[`TeachingBubble renders TeachingBubbleContent correctly 1`] = `
                 margin-top: 0px;
                 overflow-wrap: break-word;
               }
+          id="title"
           role="heading"
         >
           Test Title
@@ -250,6 +256,7 @@ exports[`TeachingBubble renders TeachingBubbleContent correctly 1`] = `
                 margin-right: 0px;
                 margin-top: 0px;
               }
+          id="content"
         >
           Content
         </p>
@@ -272,6 +279,8 @@ exports[`TeachingBubble renders TeachingBubbleContent correctly 1`] = `
 
 exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`] = `
 <div
+  aria-describedby="content"
+  aria-labelledby="title"
   className=
       ms-TeachingBubble-content
       {
@@ -339,6 +348,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                 margin-top: 0px;
                 overflow-wrap: break-word;
               }
+          id="title"
           role="heading"
         >
           Test Title
@@ -363,6 +373,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                 margin-right: 0px;
                 margin-top: 0px;
               }
+          id="content"
         >
           Content
         </p>
@@ -555,7 +566,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                         margin-right: 4px;
                         margin-top: 0;
                       }
-                  id="id__1"
+                  id="id__3"
                 >
                   Test Secondary Button
                 </span>
@@ -708,7 +719,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                         margin-right: 4px;
                         margin-top: 0;
                       }
-                  id="id__4"
+                  id="id__6"
                 >
                   Test Primary Button
                 </span>
@@ -873,6 +884,8 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
 
 exports[`TeachingBubble renders TeachingBubbleContent with calloutProps that deal with styles 1`] = `
 <div
+  aria-describedby="content"
+  aria-labelledby="title"
   className=
       ms-TeachingBubble-content
       {
@@ -934,6 +947,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with calloutProps that dea
                 margin-right: 0px;
                 margin-top: 0px;
               }
+          id="content"
         >
           Content
         </p>
@@ -956,6 +970,8 @@ exports[`TeachingBubble renders TeachingBubbleContent with calloutProps that dea
 
 exports[`TeachingBubble renders TeachingBubbleContent with condensed headline correctly 1`] = `
 <div
+  aria-describedby="content"
+  aria-labelledby="title"
   className=
       ms-TeachingBubble-content
       {
@@ -1024,6 +1040,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with condensed headline co
                 margin-top: 0px;
                 overflow-wrap: break-word;
               }
+          id="title"
           role="heading"
         >
           Test Title
@@ -1048,6 +1065,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with condensed headline co
                 margin-right: 0px;
                 margin-top: 0px;
               }
+          id="content"
         >
           Content
         </p>
@@ -1070,6 +1088,8 @@ exports[`TeachingBubble renders TeachingBubbleContent with condensed headline co
 
 exports[`TeachingBubble renders TeachingBubbleContent with custom footer text 1`] = `
 <div
+  aria-describedby="content"
+  aria-labelledby="title"
   className=
       ms-TeachingBubble-content
       {
@@ -1131,6 +1151,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with custom footer text 1`
                 margin-right: 0px;
                 margin-top: 0px;
               }
+          id="content"
         >
           Content
         </p>
@@ -1214,8 +1235,124 @@ exports[`TeachingBubble renders TeachingBubbleContent with custom footer text 1`
 </div>
 `;
 
+exports[`TeachingBubble renders TeachingBubbleContent with generated aria-describedby and aria-labelledby 1`] = `
+<div
+  aria-describedby="teaching-bubble-content-0"
+  aria-labelledby="teaching-bubble-title-1"
+  className=
+      ms-TeachingBubble-content
+      {
+        animation-duration: 300ms;
+        animation-fill-mode: both;
+        animation-name: keyframes 0%{opacity:0;animation-timing-function:cubic-bezier(.1,.9,.2,1);transform:scale3d(.90,.90,.90);}100%{opacity:1;transform:scale3d(1,1,1);};
+        animation-timing-function: linear;
+        border: 0px;
+        display: block;
+        max-width: 364px;
+        outline: transparent;
+        width: calc(100% + 1px);
+      }
+  data-is-focusable={true}
+  role="dialog"
+  tabIndex={-1}
+>
+  <div
+    onBlurCapture={[Function]}
+    onFocusCapture={[Function]}
+  >
+    <div
+      aria-hidden={true}
+      data-is-visible={true}
+      style={
+        Object {
+          "pointerEvents": "none",
+          "position": "fixed",
+        }
+      }
+      tabIndex={0}
+    />
+    <div
+      className=
+          ms-TeachingBubble-bodycontent
+          {
+            padding-bottom: 20px;
+            padding-left: 24px;
+            padding-right: 24px;
+            padding-top: 20px;
+          }
+    >
+      <div
+        className=
+            ms-TeachingBubble-header
+            ms-TeachingBubble-header--large
+            &:not(:last-child) {
+              margin-bottom: 14px;
+            }
+      >
+        <p
+          aria-level={3}
+          className=
+              ms-TeachingBubble-headline
+              {
+                color: #ffffff;
+                font-size: 20px;
+                font-weight: 600;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+              }
+          id="teaching-bubble-title-1"
+          role="heading"
+        >
+          Test Title
+        </p>
+      </div>
+      <div
+        className=
+            ms-TeachingBubble-body
+            &:not(:last-child) {
+              margin-bottom: 20px;
+            }
+      >
+        <p
+          className=
+              ms-TeachingBubble-subText
+              {
+                color: #ffffff;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+              }
+          id="teaching-bubble-content-0"
+        >
+          Test Content
+        </p>
+      </div>
+    </div>
+    <div
+      aria-hidden={true}
+      data-is-visible={true}
+      style={
+        Object {
+          "pointerEvents": "none",
+          "position": "fixed",
+        }
+      }
+      tabIndex={0}
+    />
+  </div>
+</div>
+`;
+
 exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] = `
 <div
+  aria-describedby="content"
+  aria-labelledby="title"
   className=
       ms-TeachingBubble-content
       {
@@ -1317,6 +1454,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
                 margin-top: 0px;
                 overflow-wrap: break-word;
               }
+          id="title"
           role="heading"
         >
           Test Title
@@ -1341,6 +1479,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
                 margin-right: 0px;
                 margin-top: 0px;
               }
+          id="content"
         >
           Content
         </p>
@@ -1363,6 +1502,8 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
 
 exports[`TeachingBubble renders TeachingBubbleContent with small headline correctly 1`] = `
 <div
+  aria-describedby="content"
+  aria-labelledby="title"
   className=
       ms-TeachingBubble-content
       {
@@ -1433,6 +1574,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with small headline correc
                 margin-top: 0px;
                 overflow-wrap: break-word;
               }
+          id="title"
           role="heading"
         >
           Test Title
@@ -1457,6 +1599,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with small headline correc
                 margin-right: 0px;
                 margin-top: 0px;
               }
+          id="content"
         >
           Content
         </p>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12841
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Using `<TeachingBubble />` without providing `ariaDescribedBy` and `ariaLabelledBy` creates a dialog element without necessary ARIA attributes to conform to [WAI-ARIA 1.1](https://www.w3.org/TR/wai-aria-1.1/#dialog).

Nothing changes for users who already used these properties, but users who did not set them properly get a uniquely generated ID applied to relevant elements as needed.
