### PR TITLE
react-utilities: `ExtractRef` Typings

### DIFF
--- a/change/@fluentui-react-utilities-5deccccb-84e0-4d5d-9883-ffb340f5ca8c.json
+++ b/change/@fluentui-react-utilities-5deccccb-84e0-4d5d-9883-ffb340f5ca8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds ExtractRef typings to react-utilities to extract reference from props",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -81,6 +81,11 @@ export const defaultSSRContextValue: SSRContextValue;
 // @public
 export const divProperties: Record<string, number>;
 
+// @public (undocumented)
+export type ExtractRef<Props extends {
+    ref?: any;
+}> = Props['ref'] extends ((instance: infer I | null) => void) | React_2.RefObject<infer I> | null | undefined ? I : any;
+
 // @public
 export const formProperties: Record<string, number>;
 
@@ -158,6 +163,11 @@ export type NoLegacyRef<Props extends {
 }> = Omit<Props, 'ref'> & {
     ref?: Exclude<Props['ref'], string>;
 };
+
+// @public (undocumented)
+export type NoRef<Props extends {
+    ref?: unknown;
+}> = Omit<Props, 'ref'>;
 
 // @public
 export const nullRender: () => null;

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -164,11 +164,6 @@ export type NoLegacyRef<Props extends {
     ref?: Exclude<Props['ref'], string>;
 };
 
-// @public (undocumented)
-export type NoRef<Props extends {
-    ref?: unknown;
-}> = Omit<Props, 'ref'>;
-
 // @public
 export const nullRender: () => null;
 

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -75,6 +75,16 @@ export type IsSingleton<T extends string> = { [K in T]: Exclude<T, K> extends ne
  */
 export type NoLegacyRef<Props extends { ref?: unknown }> = Omit<Props, 'ref'> & { ref?: Exclude<Props['ref'], string> };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ExtractRef<Props extends { ref?: any }> = Props['ref'] extends
+  | ((instance: infer I | null) => void)
+  | React.RefObject<infer I>
+  | null
+  | undefined
+  ? I
+  : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any;
+
 export type ComponentProps<
   Shorthands extends ObjectShorthandPropsRecord,
   Primary extends keyof Shorthands = 'root'


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Includes `ExtractRef` typings to `react-utilities` to simplify component declaration:

```tsx
export const Button = React.forwardRef<ExtractRef<ButtonProps>, ButtonProps>((props, ref) => { /* ... */ });
export const useButton = (props: ButtonProps, ref: React.Ref<ExtractRef<ButtonProps>>) => {/* ... */}
```

Without `ExtractRef` there'd be a problem with spreading props from components that have `unions` as their props signature, which is the case for `react-button`, as follows:

```tsx
export const Default = (props: ButtonProps) => <Button {...props}>Button</Button>;
```

Without declaring `Button` signature with `ExtractRef` here, this `Default` component would have a conflict between `Button` reference declaration and the reference declaration provided by `ButtonProps`