### PR TITLE
Allow Attachment to have children

### DIFF
--- a/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
+++ b/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
@@ -100,6 +100,11 @@ const prototypesTreeItems: TreeProps['items'] = [
     public: false,
   },
   {
+    id: 'attachments',
+    title: { content: 'Attachments', as: NavLink, to: '/prototype-attachments' },
+    public: true,
+  },
+  {
     id: 'asyncshorthand',
     title: { content: 'Async Shorthand', as: NavLink, to: '/prototype-async-shorthand' },
     public: false,

--- a/packages/fluentui/docs/src/routes.tsx
+++ b/packages/fluentui/docs/src/routes.tsx
@@ -37,6 +37,7 @@ import { LazyWithBabel } from './components/ComponentDoc/LazyWithBabel';
 import {
   AlertsPrototype,
   AsyncShorthandPrototype,
+  AttachmentsPrototype,
   ChatMessagesPrototype,
   ChatPanePrototype,
   CompactChatPrototype,
@@ -106,27 +107,28 @@ const Routes = () => (
                 </Route>
                 <Route exact path="/quick-start" component={QuickStart} />
                 <Route exact path="/perf-tests" component={PerformanceTests} />
-                <Route exact path="/prototype-roster" component={RosterPrototype} />
-                <Route exact path="/prototype-chat-pane" component={ChatPanePrototype} />
+                <Route exact path="/prototype-alerts" component={AlertsPrototype} />
+                <Route exact path="/prototype-async-shorthand" component={AsyncShorthandPrototype} />
+                <Route exact path="/prototype-attachments" component={AttachmentsPrototype} />
                 <Route exact path="/prototype-chat-messages" component={ChatMessagesPrototype} />
+                <Route exact path="/prototype-chat-pane" component={ChatPanePrototype} />
                 <Route exact path="/prototype-compact-chat" component={CompactChatPrototype} />
                 <Route exact path="/prototype-custom-scrollbar" component={CustomScrollbarPrototype} />
                 <Route exact path="/prototype-custom-toolbar" component={CustomToolbarPrototype} />
-                <Route exact path="/prototype-async-shorthand" component={AsyncShorthandPrototype} />
-                <Route exact path="/prototype-employee-card" component={EmployeeCardPrototype} />
-                <Route exact path="/prototype-meeting-options" component={MeetingOptionsPrototype} />
-                <Route exact path="/prototype-participants-list" component={ParticipantsListPrototype} />
-                <Route exact path="/prototype-search-page" component={SearchPagePrototype} />
-                <Route exact path="/prototype-mentions" component={MentionsPrototype} />
                 <Route exact path="/prototype-dropdowns" component={DropdownsPrototype} />
-                <Route exact path="/prototype-popups" component={PopupsPrototype} />
-                <Route exact path="/prototype-alerts" component={AlertsPrototype} />
                 <Route exact path="/prototype-editor-toolbar" component={EditorToolbarPrototype} />
-                <Route exact path="/prototype-hexagonal-avatar" component={HexagonalAvatarPrototype} />
-                <Route exact path="/prototype-text-area-autosize" component={TextAreaAutoSize} />
-                <Route exact path="/prototype-table" component={TablePrototype} />
-                <Route exact path="/prototype-nested-popups-and-dialogs" component={NestedPopupsAndDialogsPrototype} />
+                <Route exact path="/prototype-employee-card" component={EmployeeCardPrototype} />
                 <Route exact path="/prototype-form-validation" component={FormValidationPrototype} />
+                <Route exact path="/prototype-hexagonal-avatar" component={HexagonalAvatarPrototype} />
+                <Route exact path="/prototype-meeting-options" component={MeetingOptionsPrototype} />
+                <Route exact path="/prototype-mentions" component={MentionsPrototype} />
+                <Route exact path="/prototype-nested-popups-and-dialogs" component={NestedPopupsAndDialogsPrototype} />
+                <Route exact path="/prototype-participants-list" component={ParticipantsListPrototype} />
+                <Route exact path="/prototype-popups" component={PopupsPrototype} />
+                <Route exact path="/prototype-roster" component={RosterPrototype} />
+                <Route exact path="/prototype-search-page" component={SearchPagePrototype} />
+                <Route exact path="/prototype-table" component={TablePrototype} />
+                <Route exact path="/prototype-text-area-autosize" component={TextAreaAutoSize} />
                 <Route exact path="/virtualized-tree" component={VirtualizedTreePrototype} />
                 <Route exact path="/virtualized-sticky-tree" component={VirtualizedStickyTreePrototype} />
                 <Route exact path="/virtualized-table" component={VirtualizedTablePrototype} />

--- a/packages/fluentui/react-northstar-prototypes/src/index.ts
+++ b/packages/fluentui/react-northstar-prototypes/src/index.ts
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+export const AttachmentsPrototype = React.lazy(
+  () => import(/* webpackChunkName: "prototypes" */ './prototypes/attachment'),
+);
 export const CustomToolbarPrototype = React.lazy(
   () => import(/* webpackChunkName: "prototypes" */ './prototypes/customToolbar'),
 );

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/attachment/AttachmentLinkPreview.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/attachment/AttachmentLinkPreview.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+import { Attachment, Flex, Image, Text } from '@fluentui/react-northstar';
+
+export const AttachmentLinkPreview = () => (
+  <Attachment
+    actionable
+    children={
+      <>
+        <Image
+          src="https://fabricweb.azureedge.net/fabric-website/assets/images/fluent-ui-logo.png"
+          width="90"
+          design={{ padding: '4px 9px' }}
+        />
+        <Flex column style={{ minWidth: 0, alignSelf: 'stretch' }} design={{ padding: '8px' }}>
+          <Text weight="bold">Fluent UI</Text>
+          <Text truncated>
+            Fluent UI provides extensible vanilla JavaScript solutions to component state, styling, and accessibility.
+          </Text>
+          <Flex.Item push>
+            <Text size="small">https://fluentsite.z22.web.core.windows.net</Text>
+          </Flex.Item>
+        </Flex>
+      </>
+    }
+    onClick={() => {
+      alert('AttachmentLinkPreview was clicked!');
+    }}
+    style={{
+      padding: 0,
+      maxWidth: 'unset',
+    }}
+  />
+);

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/attachment/AttachmentQuotedReply.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/attachment/AttachmentQuotedReply.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+
+import { Attachment, Box, Flex, Text } from '@fluentui/react-northstar';
+
+export const AttachmentQuotedReply = () => (
+  <Attachment
+    actionable
+    children={
+      <>
+        <Box
+          style={{
+            alignSelf: 'stretch',
+            background: '#c7c7c7',
+            borderRadius: '4px',
+            marginRight: '8px',
+            width: '4px',
+          }}
+        />
+        <Flex column>
+          <Text timestamp size="small">
+            Cecil Folk
+          </Text>
+          <Text>Would you like to grab lunch there?</Text>
+        </Flex>
+      </>
+    }
+    onClick={() => {
+      alert('AttachmentQuotedReply was clicked!');
+    }}
+    style={{
+      padding: '8px',
+      maxWidth: 'unset',
+    }}
+  />
+);

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/attachment/index.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/attachment/index.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+import { ComponentPrototype, PrototypeSection } from '../Prototypes';
+import { AttachmentLinkPreview } from './AttachmentLinkPreview';
+import { AttachmentQuotedReply } from './AttachmentQuotedReply';
+
+export default () => (
+  <PrototypeSection title="Attachment">
+    <ComponentPrototype title="Quoted Reply Attachment" description="Using Attachment as chiclet for quoted replies.">
+      <AttachmentQuotedReply />
+    </ComponentPrototype>
+    <ComponentPrototype title="Link Preview Attachment" description="Using Attachment as chiclet for link previews.">
+      <AttachmentLinkPreview />
+    </ComponentPrototype>
+  </PrototypeSection>
+);

--- a/packages/fluentui/react-northstar/src/components/Attachment/Attachment.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/Attachment.tsx
@@ -17,12 +17,13 @@ import * as React from 'react';
 
 import { ComponentEventHandler, ShorthandValue } from '../../types';
 import {
-  createShorthandFactory,
-  commonPropTypes,
-  UIComponentProps,
   ChildrenComponentProps,
+  childrenExist,
+  commonPropTypes,
   createShorthand,
+  createShorthandFactory,
   ShorthandFactory,
+  UIComponentProps,
 } from '../../utils';
 import { AttachmentAction, AttachmentActionProps } from './AttachmentAction';
 import { AttachmentBody, AttachmentBodyProps } from './AttachmentBody';
@@ -83,6 +84,7 @@ export const Attachment = compose<'div', AttachmentProps, AttachmentStylesProps,
       action,
       actionable,
       body,
+      children,
       className,
       description,
       design,
@@ -140,8 +142,8 @@ export const Attachment = compose<'div', AttachmentProps, AttachmentStylesProps,
       _.invoke(props, 'onClick', e, props);
     };
 
-    const element = getA11Props.unstable_wrapWithFocusZone(
-      <ElementType {...getA11Props('root', { className: classes.root, onClick: handleClick, ref, ...unhandledProps })}>
+    const elements = () => (
+      <>
         {createShorthand(composeOptions.slots.icon, icon, {
           defaultProps: () => slotProps.icon,
           overrideProps: predefinedProps => ({
@@ -150,7 +152,7 @@ export const Attachment = compose<'div', AttachmentProps, AttachmentStylesProps,
         })}
 
         {(header || description) &&
-          createShorthand(composeOptions.slots.body, body, {
+          createShorthand(composeOptions.slots.body, body ?? {}, {
             defaultProps: () => slotProps.body,
             overrideProps: predefinedProps => ({
               content: (
@@ -180,6 +182,12 @@ export const Attachment = compose<'div', AttachmentProps, AttachmentStylesProps,
           }),
         })}
         {!_.isNil(progress) && <div className="ui-attachment__progress" style={{ width: `${progress}%` }} />}
+      </>
+    );
+
+    const element = getA11Props.unstable_wrapWithFocusZone(
+      <ElementType {...getA11Props('root', { className: classes.root, onClick: handleClick, ref, ...unhandledProps })}>
+        {childrenExist(children) ? children : elements()}
       </ElementType>,
     );
     setEnd();
@@ -240,7 +248,6 @@ Attachment.propTypes = {
 };
 Attachment.defaultProps = {
   accessibility: attachmentBehavior,
-  body: {},
 };
 
 Attachment.Action = AttachmentAction;


### PR DESCRIPTION
Use the Attachment's `children` prop to skip all slots to allow Attachment to be used as a generic chiclet.
This would make it easier for Teams to have a consistent style for chat message chiclets.

New prototypes:
![image](https://user-images.githubusercontent.com/2564094/133369156-a6aa8deb-fd37-47e3-a5e7-f823110f2650.png)
