### PR TITLE
Layer: extending HostId to accept Node

### DIFF
--- a/change/@fluentui-react-ebe3fdab-c1a0-4f13-bbfd-f625f59c406e.json
+++ b/change/@fluentui-react-ebe3fdab-c1a0-4f13-bbfd-f625f59c406e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "extending layer to accept Node as host in addition to hostId",
+  "packageName": "@fluentui/react",
+  "email": "marion.lepontois@skatteetaten.no",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -5639,7 +5639,7 @@ export interface ILayerProps extends React_2.HTMLAttributes<HTMLDivElement>, Rea
     className?: string;
     componentRef?: IRefObject<ILayer>;
     eventBubblingEnabled?: boolean;
-    hostId?: string;
+    hostId?: string | Node;
     insertFirst?: boolean;
     onLayerDidMount?: () => void;
     // @deprecated

--- a/packages/react/src/components/Layer/Layer.base.tsx
+++ b/packages/react/src/components/Layer/Layer.base.tsx
@@ -49,7 +49,8 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
       }
 
       if (hostId) {
-        return doc.getElementById(hostId) as Node;
+        const hostNode: Node = typeof hostId === 'string' ? (doc.getElementById(hostId) as Node) : hostId;
+        return hostNode;
       } else {
         const defaultHostSelector = getDefaultTarget();
         return defaultHostSelector ? (doc.querySelector(defaultHostSelector) as Node) : doc.body;

--- a/packages/react/src/components/Layer/Layer.notification.ts
+++ b/packages/react/src/components/Layer/Layer.notification.ts
@@ -4,29 +4,31 @@ let _defaultHostSelector: string | undefined;
 
 /**
  * Register a layer for a given host id
- * @param hostId Id of the layer host
+ * @param hostId Id or Node of the layer host
  * @param layer Layer instance
  */
-export function registerLayer(hostId: string, callback: () => void) {
-  if (!_layersByHostId[hostId]) {
-    _layersByHostId[hostId] = [];
+export function registerLayer(hostId: string | Node, callback: () => void) {
+  const nodeName = typeof hostId === 'string' ? hostId : (hostId as Node).nodeName;
+  if (!_layersByHostId[nodeName]) {
+    _layersByHostId[nodeName] = [];
   }
 
-  _layersByHostId[hostId].push(callback);
+  _layersByHostId[nodeName].push(callback);
 }
 
 /**
  * Unregister a layer for a given host id
- * @param hostId Id of the layer host
+ * @param hostId Id or Node of the layer host
  * @param layer Layer instance
  */
-export function unregisterLayer(hostId: string, callback: () => void) {
-  if (_layersByHostId[hostId]) {
-    const idx = _layersByHostId[hostId].indexOf(callback);
+export function unregisterLayer(hostId: string | Node, callback: () => void) {
+  const nodeName = typeof hostId === 'string' ? hostId : (hostId as Node).nodeName;
+  if (_layersByHostId[nodeName]) {
+    const idx = _layersByHostId[nodeName].indexOf(callback);
     if (idx >= 0) {
-      _layersByHostId[hostId].splice(idx, 1);
-      if (_layersByHostId[hostId].length === 0) {
-        delete _layersByHostId[hostId];
+      _layersByHostId[nodeName].splice(idx, 1);
+      if (_layersByHostId[nodeName].length === 0) {
+        delete _layersByHostId[nodeName];
       }
     }
   }

--- a/packages/react/src/components/Layer/Layer.test.tsx
+++ b/packages/react/src/components/Layer/Layer.test.tsx
@@ -110,7 +110,7 @@ describe('Layer', () => {
   });
 
   it('can render within a targeted Node passed as HostId', () => {
-    const original = global.document.body;
+    const original = document.body;
     document.body.innerHTML = '<div id="hostNode"></div>';
 
     const hostNode = document.getElementById('hostNode') as Node;
@@ -126,7 +126,7 @@ describe('Layer', () => {
     expect(childElement).toBeTruthy();
     expect(childElement?.textContent).toEqual('bar');
 
-    global.document.body = original;
+    document.body = original;
   });
 
   it('stops bubbling events', () => {

--- a/packages/react/src/components/Layer/Layer.test.tsx
+++ b/packages/react/src/components/Layer/Layer.test.tsx
@@ -22,7 +22,7 @@ describe('Layer', () => {
     <context.Consumer>{val => <div id="child">{val.foo}</div>}</context.Consumer>
   );
 
-  const Parent: React.FunctionComponent<{ hostId?: string }> = props => (
+  const Parent: React.FunctionComponent<{ hostId?: string | Node }> = props => (
     <context.Provider value={{ foo: 'bar' }}>
       <div id="parent">
         <Layer hostId={props.hostId}>
@@ -107,6 +107,26 @@ describe('Layer', () => {
       ReactDOM.unmountComponentAtNode(appElement);
       appElement.remove();
     }
+  });
+
+  it('can render within a targeted Node passed as HostId', () => {
+    const original = global.document.body;
+    document.body.innerHTML = '<div id="hostNode"></div>';
+
+    const hostNode = document.getElementById('hostNode') as Node;
+
+    mount(
+      <>
+        <TestChild />
+        <Parent hostId={hostNode} />
+      </>,
+    );
+
+    const childElement = document.getElementById('child');
+    expect(childElement).toBeTruthy();
+    expect(childElement?.textContent).toEqual('bar');
+
+    global.document.body = original;
   });
 
   it('stops bubbling events', () => {

--- a/packages/react/src/components/Layer/Layer.types.ts
+++ b/packages/react/src/components/Layer/Layer.types.ts
@@ -50,12 +50,12 @@ export interface ILayerProps extends React.HTMLAttributes<HTMLDivElement>, React
   onLayerWillUnmount?: () => void;
 
   /**
-   * The optional id property provided on a LayerHost that this Layer should render within. The LayerHost does
+   * The optional id property or node provided on a LayerHost that this Layer should render within. The LayerHost does
    * not need to be immediately available but once has been rendered, and if missing, we'll avoid trying
    * to render the Layer content until the host is available. If an id is not provided, we will render the Layer
    * content in a fixed position element rendered at the end of the document.
    */
-  hostId?: string;
+  hostId?: string | Node;
 
   /**
    * When enabled, Layer allows events to bubble up from Layer content.


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #19768
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Layer Base component: extending HostId to accept Node. This opens up for the related components based on Layer Base so send target accross dom's.
I originally thought of a new prop hostNode but concluded that it would "pollute" the LayerProps with a new key, whereas this is a simple extension. hostId could later eventually be renamed to hostIdOrNode or just host

#### Focus areas to test
Similar to hostId. Added relevant test to target Node.
