### PR TITLE
fix(DetailsList): Sufficient Link contrast in selected rows - 12672

### DIFF
--- a/change/@fluentui-react-211dc2fd-9965-4eb5-b08f-57a3b42d0f90.json
+++ b/change/@fluentui-react-211dc2fd-9965-4eb5-b08f-57a3b42d0f90.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(DetailsList): apply hovered link color via parent container",
+  "packageName": "@fluentui/react",
+  "email": "peter.varholak@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react-focus/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/react-examples/src/react-focus/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -73,6 +73,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         &:hover .is-row-header {
           color: #201f1e;
         }
+        &:hover .ms-DetailsRow-cell > .ms-Link {
+          color: #004578;
+        }
         &:hover .ms-DetailsRow-check {
           opacity: 1;
         }
@@ -770,6 +773,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover .is-row-header {
           color: #201f1e;
+        }
+        &:hover .ms-DetailsRow-cell > .ms-Link {
+          color: #004578;
         }
         &:hover .ms-DetailsRow-check {
           opacity: 1;
@@ -1469,6 +1475,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         &:hover .is-row-header {
           color: #201f1e;
         }
+        &:hover .ms-DetailsRow-cell > .ms-Link {
+          color: #004578;
+        }
         &:hover .ms-DetailsRow-check {
           opacity: 1;
         }
@@ -2166,6 +2175,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover .is-row-header {
           color: #201f1e;
+        }
+        &:hover .ms-DetailsRow-cell > .ms-Link {
+          color: #004578;
         }
         &:hover .ms-DetailsRow-check {
           opacity: 1;
@@ -2865,6 +2877,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         &:hover .is-row-header {
           color: #201f1e;
         }
+        &:hover .ms-DetailsRow-cell > .ms-Link {
+          color: #004578;
+        }
         &:hover .ms-DetailsRow-check {
           opacity: 1;
         }
@@ -3562,6 +3577,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover .is-row-header {
           color: #201f1e;
+        }
+        &:hover .ms-DetailsRow-cell > .ms-Link {
+          color: #004578;
         }
         &:hover .ms-DetailsRow-check {
           opacity: 1;
@@ -4261,6 +4279,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         &:hover .is-row-header {
           color: #201f1e;
         }
+        &:hover .ms-DetailsRow-cell > .ms-Link {
+          color: #004578;
+        }
         &:hover .ms-DetailsRow-check {
           opacity: 1;
         }
@@ -4958,6 +4979,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover .is-row-header {
           color: #201f1e;
+        }
+        &:hover .ms-DetailsRow-cell > .ms-Link {
+          color: #004578;
         }
         &:hover .ms-DetailsRow-check {
           opacity: 1;
@@ -5657,6 +5681,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         &:hover .is-row-header {
           color: #201f1e;
         }
+        &:hover .ms-DetailsRow-cell > .ms-Link {
+          color: #004578;
+        }
         &:hover .ms-DetailsRow-check {
           opacity: 1;
         }
@@ -6354,6 +6381,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover .is-row-header {
           color: #201f1e;
+        }
+        &:hover .ms-DetailsRow-cell > .ms-Link {
+          color: #004578;
         }
         &:hover .ms-DetailsRow-check {
           opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -812,6 +812,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -1229,6 +1232,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
@@ -1648,6 +1654,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -2065,6 +2074,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
@@ -2484,6 +2496,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -2901,6 +2916,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
@@ -3320,6 +3338,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -3737,6 +3758,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
@@ -4156,6 +4180,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -4573,6 +4600,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -608,6 +608,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -1160,6 +1163,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -1714,6 +1720,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -2266,6 +2275,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -2820,6 +2832,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -3372,6 +3387,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -3926,6 +3944,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -4478,6 +4499,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -5032,6 +5056,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -5584,6 +5611,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -3334,6 +3334,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -4365,6 +4368,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
@@ -5398,6 +5404,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -6429,6 +6438,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
@@ -7462,6 +7474,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -8493,6 +8508,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
@@ -9526,6 +9544,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -10557,6 +10578,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
@@ -11590,6 +11614,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -12621,6 +12648,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -853,6 +853,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -1327,6 +1330,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -1803,6 +1809,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -2277,6 +2286,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -2753,6 +2765,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -3227,6 +3242,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -3703,6 +3721,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -4177,6 +4198,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -4653,6 +4677,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -5127,6 +5154,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -1081,6 +1081,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               &:hover .is-row-header {
                                 color: #201f1e;
                               }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
+                              }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
                               }
@@ -1555,6 +1558,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               }
                               &:hover .is-row-header {
                                 color: #201f1e;
+                              }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
                               }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
@@ -2031,6 +2037,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               &:hover .is-row-header {
                                 color: #201f1e;
                               }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
+                              }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
                               }
@@ -2505,6 +2514,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               }
                               &:hover .is-row-header {
                                 color: #201f1e;
+                              }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
                               }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
@@ -2981,6 +2993,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               &:hover .is-row-header {
                                 color: #201f1e;
                               }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
+                              }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
                               }
@@ -3455,6 +3470,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               }
                               &:hover .is-row-header {
                                 color: #201f1e;
+                              }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
                               }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
@@ -3931,6 +3949,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               &:hover .is-row-header {
                                 color: #201f1e;
                               }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
+                              }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
                               }
@@ -4405,6 +4426,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               }
                               &:hover .is-row-header {
                                 color: #201f1e;
+                              }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
                               }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
@@ -4881,6 +4905,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               &:hover .is-row-header {
                                 color: #201f1e;
                               }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
+                              }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
                               }
@@ -5355,6 +5382,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               }
                               &:hover .is-row-header {
                                 color: #201f1e;
+                              }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
                               }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.ColumnResize.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.ColumnResize.Example.tsx.shot
@@ -1845,6 +1845,9 @@ Array [
                               &:hover .is-row-header {
                                 color: #201f1e;
                               }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
+                              }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
                               }
@@ -3152,6 +3155,9 @@ Array [
                               }
                               &:hover .is-row-header {
                                 color: #201f1e;
+                              }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
                               }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -1066,6 +1066,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               &:hover .is-row-header {
                                 color: #201f1e;
                               }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
+                              }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
                               }
@@ -1541,6 +1544,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               }
                               &:hover .is-row-header {
                                 color: #201f1e;
+                              }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
                               }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
@@ -2018,6 +2024,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               &:hover .is-row-header {
                                 color: #201f1e;
                               }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
+                              }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
                               }
@@ -2493,6 +2502,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               }
                               &:hover .is-row-header {
                                 color: #201f1e;
+                              }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
                               }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
@@ -2970,6 +2982,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               &:hover .is-row-header {
                                 color: #201f1e;
                               }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
+                              }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
                               }
@@ -3445,6 +3460,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               }
                               &:hover .is-row-header {
                                 color: #201f1e;
+                              }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
                               }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
@@ -3922,6 +3940,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               &:hover .is-row-header {
                                 color: #201f1e;
                               }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
+                              }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
                               }
@@ -4397,6 +4418,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               }
                               &:hover .is-row-header {
                                 color: #201f1e;
+                              }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
                               }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
@@ -4874,6 +4898,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               &:hover .is-row-header {
                                 color: #201f1e;
                               }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
+                              }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;
                               }
@@ -5349,6 +5376,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               }
                               &:hover .is-row-header {
                                 color: #201f1e;
+                              }
+                              &:hover .ms-DetailsRow-cell > .ms-Link {
+                                color: #004578;
                               }
                               &:hover .ms-DetailsRow-check {
                                 opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -1705,6 +1705,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -2694,6 +2697,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -3685,6 +3691,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -4674,6 +4683,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -5665,6 +5677,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -6654,6 +6669,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -7645,6 +7663,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -8634,6 +8655,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -9625,6 +9649,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -10614,6 +10641,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -852,6 +852,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -1326,6 +1329,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -1802,6 +1808,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -2276,6 +2285,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -2752,6 +2764,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -3223,6 +3238,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             }
             &:hover .is-row-header {
               color: #201f1e;
+            }
+            &:hover .ms-DetailsRow-cell > .ms-Link {
+              color: #004578;
             }
             &:hover .ms-DetailsRow-check {
               opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -2709,6 +2709,9 @@ Array [
                                       &:hover .is-row-header {
                                         color: #201f1e;
                                       }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
+                                      }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
                                       }
@@ -3593,6 +3596,9 @@ Array [
                                       }
                                       &:hover .is-row-header {
                                         color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
                                       }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
@@ -4479,6 +4485,9 @@ Array [
                                       &:hover .is-row-header {
                                         color: #201f1e;
                                       }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
+                                      }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
                                       }
@@ -5363,6 +5372,9 @@ Array [
                                       }
                                       &:hover .is-row-header {
                                         color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
                                       }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
@@ -6249,6 +6261,9 @@ Array [
                                       &:hover .is-row-header {
                                         color: #201f1e;
                                       }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
+                                      }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
                                       }
@@ -7133,6 +7148,9 @@ Array [
                                       }
                                       &:hover .is-row-header {
                                         color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
                                       }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
@@ -8019,6 +8037,9 @@ Array [
                                       &:hover .is-row-header {
                                         color: #201f1e;
                                       }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
+                                      }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
                                       }
@@ -8903,6 +8924,9 @@ Array [
                                       }
                                       &:hover .is-row-header {
                                         color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
                                       }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
@@ -9789,6 +9813,9 @@ Array [
                                       &:hover .is-row-header {
                                         color: #201f1e;
                                       }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
+                                      }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
                                       }
@@ -10673,6 +10700,9 @@ Array [
                                       }
                                       &:hover .is-row-header {
                                         color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
                                       }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -2151,6 +2151,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -3024,6 +3027,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -3900,6 +3906,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -4773,6 +4782,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -5649,6 +5661,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -6522,6 +6537,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -7398,6 +7416,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -8271,6 +8292,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -9147,6 +9171,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -10020,6 +10047,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -1795,6 +1795,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -2255,6 +2258,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
@@ -2717,6 +2723,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -3177,6 +3186,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
@@ -3639,6 +3651,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -4099,6 +4114,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
@@ -4561,6 +4579,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -5021,6 +5042,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
@@ -5483,6 +5507,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             &:hover .is-row-header {
                               color: #201f1e;
                             }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
+                            }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;
                             }
@@ -5943,6 +5970,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             }
                             &:hover .is-row-header {
                               color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-cell > .ms-Link {
+                              color: #004578;
                             }
                             &:hover .ms-DetailsRow-check {
                               opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1726,6 +1726,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       &:hover .is-row-header {
                                         color: #201f1e;
                                       }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
+                                      }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
                                       }
@@ -2219,6 +2222,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       }
                                       &:hover .is-row-header {
                                         color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
                                       }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
@@ -3582,6 +3588,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       &:hover .is-row-header {
                                         color: #201f1e;
                                       }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
+                                      }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
                                       }
@@ -4076,6 +4085,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       &:hover .is-row-header {
                                         color: #201f1e;
                                       }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
+                                      }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;
                                       }
@@ -4569,6 +4581,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       }
                                       &:hover .is-row-header {
                                         color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-cell > .ms-Link {
+                                        color: #004578;
                                       }
                                       &:hover .ms-DetailsRow-check {
                                         opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -1381,6 +1381,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
+                                      color: #004578;
+                                    }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
@@ -1866,6 +1869,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     }
                                     &:hover .is-row-header {
                                       color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
+                                      color: #004578;
                                     }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
@@ -2353,6 +2359,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
+                                      color: #004578;
+                                    }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
@@ -2838,6 +2847,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     }
                                     &:hover .is-row-header {
                                       color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
+                                      color: #004578;
                                     }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
@@ -3325,6 +3337,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
+                                      color: #004578;
+                                    }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
@@ -3810,6 +3825,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     }
                                     &:hover .is-row-header {
                                       color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
+                                      color: #004578;
                                     }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
@@ -4297,6 +4315,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
+                                      color: #004578;
+                                    }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
@@ -4782,6 +4803,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     }
                                     &:hover .is-row-header {
                                       color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
+                                      color: #004578;
                                     }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
@@ -5269,6 +5293,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
+                                      color: #004578;
+                                    }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
@@ -5754,6 +5781,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     }
                                     &:hover .is-row-header {
                                       color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
+                                      color: #004578;
                                     }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -740,6 +740,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -1288,6 +1291,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -1838,6 +1844,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -2386,6 +2395,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -2936,6 +2948,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -3484,6 +3499,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -4034,6 +4052,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -4583,6 +4604,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -5131,6 +5155,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
@@ -1138,6 +1138,9 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -1669,6 +1672,9 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -2202,6 +2208,9 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -2733,6 +2742,9 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -3266,6 +3278,9 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -3797,6 +3812,9 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -4330,6 +4348,9 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -4861,6 +4882,9 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -5394,6 +5418,9 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -5925,6 +5952,9 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -528,6 +528,9 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 &:hover .is-row-header {
                                   color: #201f1e;
                                 }
+                                &:hover .ms-DetailsRow-cell > .ms-Link {
+                                  color: #004578;
+                                }
                                 &:hover .ms-DetailsRow-check {
                                   opacity: 1;
                                 }
@@ -1068,6 +1071,9 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 &:hover .is-row-header {
                                   color: #201f1e;
                                 }
+                                &:hover .ms-DetailsRow-cell > .ms-Link {
+                                  color: #004578;
+                                }
                                 &:hover .ms-DetailsRow-check {
                                   opacity: 1;
                                 }
@@ -1607,6 +1613,9 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 }
                                 &:hover .is-row-header {
                                   color: #201f1e;
+                                }
+                                &:hover .ms-DetailsRow-cell > .ms-Link {
+                                  color: #004578;
                                 }
                                 &:hover .ms-DetailsRow-check {
                                   opacity: 1;
@@ -2552,6 +2561,9 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 &:hover .is-row-header {
                                   color: #201f1e;
                                 }
+                                &:hover .ms-DetailsRow-cell > .ms-Link {
+                                  color: #004578;
+                                }
                                 &:hover .ms-DetailsRow-check {
                                   opacity: 1;
                                 }
@@ -3092,6 +3104,9 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 &:hover .is-row-header {
                                   color: #201f1e;
                                 }
+                                &:hover .ms-DetailsRow-cell > .ms-Link {
+                                  color: #004578;
+                                }
                                 &:hover .ms-DetailsRow-check {
                                   opacity: 1;
                                 }
@@ -3631,6 +3646,9 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 }
                                 &:hover .is-row-header {
                                   color: #201f1e;
+                                }
+                                &:hover .ms-DetailsRow-cell > .ms-Link {
+                                  color: #004578;
                                 }
                                 &:hover .ms-DetailsRow-check {
                                   opacity: 1;
@@ -4576,6 +4594,9 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 &:hover .is-row-header {
                                   color: #201f1e;
                                 }
+                                &:hover .ms-DetailsRow-cell > .ms-Link {
+                                  color: #004578;
+                                }
                                 &:hover .ms-DetailsRow-check {
                                   opacity: 1;
                                 }
@@ -5116,6 +5137,9 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 &:hover .is-row-header {
                                   color: #201f1e;
                                 }
+                                &:hover .ms-DetailsRow-cell > .ms-Link {
+                                  color: #004578;
+                                }
                                 &:hover .ms-DetailsRow-check {
                                   opacity: 1;
                                 }
@@ -5655,6 +5679,9 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 }
                                 &:hover .is-row-header {
                                   color: #201f1e;
+                                }
+                                &:hover .ms-DetailsRow-cell > .ms-Link {
+                                  color: #004578;
                                 }
                                 &:hover .ms-DetailsRow-check {
                                   opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -579,6 +579,9 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -831,6 +834,9 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -1085,6 +1091,9 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -1337,6 +1346,9 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -1591,6 +1603,9 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -1843,6 +1858,9 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -2097,6 +2115,9 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -2349,6 +2370,9 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
@@ -2603,6 +2627,9 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -2855,6 +2882,9 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;

--- a/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
@@ -579,6 +579,9 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -834,6 +837,9 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                           &:hover .is-row-header {
                             color: #201f1e;
                           }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
+                          }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;
                           }
@@ -1088,6 +1094,9 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                           }
                           &:hover .is-row-header {
                             color: #201f1e;
+                          }
+                          &:hover .ms-DetailsRow-cell > .ms-Link {
+                            color: #004578;
                           }
                           &:hover .ms-DetailsRow-check {
                             opacity: 1;

--- a/packages/react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/react/src/components/DetailsList/DetailsRow.styles.ts
@@ -8,6 +8,7 @@ import {
   getHighContrastNoAdjustStyle,
 } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
+import { GlobalClassNames as LinkGlobalClassNames } from '../../components/Link/Link.styles';
 import type { IDetailsRowStyleProps, IDetailsRowStyles, ICellStyleProps } from './DetailsRow.types';
 import type { IStyle } from '../../Styling';
 
@@ -73,7 +74,7 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
     neutralDark,
     neutralQuaternaryAlt,
   } = palette;
-  const { focusBorder } = theme.semanticColors;
+  const { focusBorder, linkHovered: focusedLinkColor } = theme.semanticColors;
 
   const classNames = getGlobalClassNames(DetailsRowGlobalClassNames, theme);
 
@@ -136,6 +137,10 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
           right: 0,
           content: '',
           borderTop: `1px solid ${white}`,
+        },
+
+        [`.${LinkGlobalClassNames.root}`]: {
+          color: focusedLinkColor,
         },
 
         // Selected State hover
@@ -319,6 +324,10 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
             selectors: {
               [`.${classNames.isRowHeader}`]: {
                 color: colors.defaultHoverHeaderText,
+              },
+
+              [`.${LinkGlobalClassNames.root}`]: {
+                color: focusedLinkColor,
               },
             },
           },

--- a/packages/react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/react/src/components/DetailsList/DetailsRow.styles.ts
@@ -139,7 +139,7 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
           borderTop: `1px solid ${white}`,
         },
 
-        [`.${LinkGlobalClassNames.root}`]: {
+        [`.${classNames.cell} > .${LinkGlobalClassNames.root}`]: {
           color: focusedLinkColor,
         },
 
@@ -326,7 +326,7 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
                 color: colors.defaultHoverHeaderText,
               },
 
-              [`.${LinkGlobalClassNames.root}`]: {
+              [`.${classNames.cell} > .${LinkGlobalClassNames.root}`]: {
                 color: focusedLinkColor,
               },
             },

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -8355,7 +8355,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
-                                    &:hover .ms-Link {
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
                                       color: #004578;
                                     }
                                     &:hover .ms-DetailsRow-check {
@@ -8664,7 +8664,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
-                                    &:hover .ms-Link {
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
                                       color: #004578;
                                     }
                                     &:hover .ms-DetailsRow-check {
@@ -9226,7 +9226,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
-                                    &:hover .ms-Link {
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
                                       color: #004578;
                                     }
                                     &:hover .ms-DetailsRow-check {
@@ -9535,7 +9535,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
-                                    &:hover .ms-Link {
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
                                       color: #004578;
                                     }
                                     &:hover .ms-DetailsRow-check {
@@ -9844,7 +9844,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
-                                    &:hover .ms-Link {
+                                    &:hover .ms-DetailsRow-cell > .ms-Link {
                                       color: #004578;
                                     }
                                     &:hover .ms-DetailsRow-check {

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -8355,6 +8355,9 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
+                                    &:hover .ms-Link {
+                                      color: #004578;
+                                    }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
@@ -8660,6 +8663,9 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     }
                                     &:hover .is-row-header {
                                       color: #201f1e;
+                                    }
+                                    &:hover .ms-Link {
+                                      color: #004578;
                                     }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
@@ -9220,6 +9226,9 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
+                                    &:hover .ms-Link {
+                                      color: #004578;
+                                    }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
@@ -9526,6 +9535,9 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     &:hover .is-row-header {
                                       color: #201f1e;
                                     }
+                                    &:hover .ms-Link {
+                                      color: #004578;
+                                    }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;
                                     }
@@ -9831,6 +9843,9 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     }
                                     &:hover .is-row-header {
                                       color: #201f1e;
+                                    }
+                                    &:hover .ms-Link {
+                                      color: #004578;
                                     }
                                     &:hover .ms-DetailsRow-check {
                                       opacity: 1;

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -1741,7 +1741,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
       &:hover .is-row-header {
         color: #201f1e;
       }
-      &:hover .ms-Link {
+      &:hover .ms-DetailsRow-cell > .ms-Link {
         color: #004578;
       }
       &:hover .ms-DetailsRow-check {

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -1741,6 +1741,9 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
       &:hover .is-row-header {
         color: #201f1e;
       }
+      &:hover .ms-Link {
+        color: #004578;
+      }
       &:hover .ms-DetailsRow-check {
         opacity: 1;
       }

--- a/packages/react/src/components/Link/Link.styles.ts
+++ b/packages/react/src/components/Link/Link.styles.ts
@@ -1,7 +1,7 @@
 import { getGlobalClassNames, HighContrastSelector } from '@fluentui/style-utilities';
 import type { ILinkStyleProps, ILinkStyles } from './Link.types';
 
-const GlobalClassNames = {
+export const GlobalClassNames = {
   root: 'ms-Link',
 };
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12672/
- [x] Include a change request file using `$ yarn change`

#### Description of changes

From an accessibility standpoint we cannot ensure that all dynamic content passed into `<DetailsRow />` will have sufficient contrast. Therefore it is up to the end user to ensure their components have proper contrast.

However, for the sake of DX we should provide some sensible defaults, and although a case could be made that `<DetailsRow />` should not posses styles for a component it may not even contain, it makes sense to ensure these styles are provided out of the box.

#### Focus areas to test

- `<Link />` component as a direct child of a row cell should always have sufficient contrast
- `<Link />` component nested as part of another component should not be affected (avoids regression)
