### PR TITLE
Panel: isFooterAtBottom prop now working as expected

### DIFF
--- a/apps/vr-tests/src/stories/Panel.stories.tsx
+++ b/apps/vr-tests/src/stories/Panel.stories.tsx
@@ -79,7 +79,14 @@ storiesOf('Panel', module)
   .addStory('With no header, close button', () => (
     <Panel {...defaultProps} type={PanelType.smallFixedFar} hasCloseButton={true} />
   ))
-  .addStory('With footer at the bottom', () => <Panel {...defaultProps} isFooterAtBottom={true} />);
+  .addStory('With footer at the bottom', () => (
+    <Panel
+      {...defaultProps}
+      type={PanelType.smallFixedFar}
+      headerText="Footer at bottom"
+      isFooterAtBottom={true}
+    />
+  ));
 
 storiesOf('Panel', module)
   .addDecorator(story => (

--- a/apps/vr-tests/src/stories/Panel.stories.tsx
+++ b/apps/vr-tests/src/stories/Panel.stories.tsx
@@ -78,7 +78,8 @@ storiesOf('Panel', module)
   ))
   .addStory('With no header, close button', () => (
     <Panel {...defaultProps} type={PanelType.smallFixedFar} hasCloseButton={true} />
-  ));
+  ))
+  .addStory('With footer at the bottom', () => <Panel {...defaultProps} isFooterAtBottom={true} />);
 
 storiesOf('Panel', module)
   .addDecorator(story => (

--- a/apps/vr-tests/src/stories/Panel.stories.tsx
+++ b/apps/vr-tests/src/stories/Panel.stories.tsx
@@ -2,12 +2,19 @@ import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities/index';
-import { Panel, PanelType, SearchBox } from '@fluentui/react';
+import { DefaultButton, Panel, PanelType, PrimaryButton, SearchBox } from '@fluentui/react';
 
 const defaultProps = {
   isOpen: true,
   children: 'Content goes here',
 };
+
+const onRenderFooterContent = () => (
+  <div>
+    <PrimaryButton>Save</PrimaryButton>
+    <DefaultButton>Cancel</DefaultButton>
+  </div>
+);
 
 storiesOf('Panel', module)
   .addDecorator(FabricDecorator)
@@ -84,6 +91,7 @@ storiesOf('Panel', module)
       {...defaultProps}
       type={PanelType.smallFixedFar}
       headerText="Footer at bottom"
+      onRenderFooterContent={onRenderFooterContent}
       isFooterAtBottom={true}
     />
   ));

--- a/change/@fluentui-react-7932796b-f453-45d5-b72f-8c3191e35095.json
+++ b/change/@fluentui-react-7932796b-f453-45d5-b72f-8c3191e35095.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Panel: isFooterAtBottom prop now working as expected",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -334,7 +334,11 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         paddingBottom: 20,
       },
       isFooterAtBottom && {
-        height: '100%',
+        selectors: {
+          [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
+            height: `100%`,
+          },
+        },
       },
     ],
     footer: [

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -333,6 +333,9 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       {
         paddingBottom: 20,
       },
+      isFooterAtBottom && {
+        height: '100%',
+      },
     ],
     footer: [
       classNames.footer,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19653
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Expands the Panel `content` when `isFooterAtBottom` is passed as prop and minimum height required is met which then pins the footer at the bottom of the panel, mimicking original behavior.
- Adds VR test for `isFooterAtBottom` case.

![image](https://user-images.githubusercontent.com/8649804/133497988-f1ea6872-7cd4-4574-aea9-698ad8e8b990.png)