### PR TITLE
(react-slider) - Adding missing theme token for mark background

### DIFF
--- a/change/@fluentui-react-slider-209a5408-82e6-4813-98b8-decc9c9abacb.json
+++ b/change/@fluentui-react-slider-209a5408-82e6-4813-98b8-decc9c9abacb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Adding missing theme token for mark background",
+  "packageName": "@fluentui/react-slider",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-slider/src/components/Slider/useSliderStyles.ts
+++ b/packages/react-slider/src/components/Slider/useSliderStyles.ts
@@ -210,8 +210,7 @@ const useMarksWrapperStyles = makeStyles({
     zIndex: '1',
     whiteSpace: 'nowrap',
     [`& .${markClassName}`]: {
-      // TODO: change to theme neutralStrokeOnBrand once it is added
-      background: 'white',
+      background: theme.alias.color.neutral.neutralBackground1,
     },
 
     '& .ms-Slider-firstMark, .ms-Slider-lastMark': {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #19806
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Adding the missing `mark` background theme token for the converged **Slider**.

