### PR TITLE
fix: open submenu on arrow right for children api

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Ignore `ChatItem` contentPosition in compact density @Hirse ([#19701](https://github.com/microsoft/fluentui/pull/19701))
 - Fix compact `ChatMessage` focus highlight @Hirse ([#19720](https://github.com/microsoft/fluentui/pull/19720))
+- Set active item of `MenuItem` with submenu on focus @chassunc ([#19820](https://github.com/microsoft/fluentui/pull/19820))
 
 ### Documentation
 - Add Chat Playground @Hirse ([#19702](https://github.com/microsoft/fluentui/pull/19702))

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -199,6 +199,7 @@ export const MenuItem = (React.forwardRef<HTMLAnchorElement, MenuItemProps>((inp
     active: parentProps.active,
     variables: parentProps.variables,
     accessibility: parentProps.accessibility,
+    onItemSelect: parentProps.onItemSelect,
     ...inputProps,
   };
 
@@ -224,6 +225,7 @@ export const MenuItem = (React.forwardRef<HTMLAnchorElement, MenuItemProps>((inp
     styles,
     variables,
     on,
+    index,
   } = props;
 
   const [menu, positioningProps] = partitionPopperPropsFromShorthand(props.menu);
@@ -353,8 +355,10 @@ export const MenuItem = (React.forwardRef<HTMLAnchorElement, MenuItemProps>((inp
 
   const handleFocus = (e: React.FocusEvent) => {
     setIsFromKeyboard(isEventFromKeyboard());
-
     _.invoke(props, 'onFocus', e, props);
+    if (menu) {
+      _.invoke(props, 'onItemSelect', e, index);
+    }
   };
 
   const isSubmenuOpen = (): boolean => {
@@ -412,7 +416,7 @@ export const MenuItem = (React.forwardRef<HTMLAnchorElement, MenuItemProps>((inp
           setWhatInputSource(context.target, 'mouse');
           trySetMenuOpen(true, e);
           _.invoke(props, 'onMouseEnter', e, props);
-          _.invoke(parentProps, 'onItemSelect', e, props.index);
+          _.invoke(parentProps, 'onItemSelect', e, index);
         },
         onMouseLeave: e => {
           trySetMenuOpen(false, e);
@@ -505,7 +509,7 @@ export const MenuItem = (React.forwardRef<HTMLAnchorElement, MenuItemProps>((inp
         setWhatInputSource(context.target, 'mouse');
         trySetMenuOpen(true, e);
         _.invoke(predefinedProps, 'onMouseEnter', e, props);
-        _.invoke(parentProps, 'onItemSelect', e, props.index);
+        _.invoke(parentProps, 'onItemSelect', e, index);
       },
       onMouseLeave: e => {
         trySetMenuOpen(false, e);

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -199,7 +199,6 @@ export const MenuItem = (React.forwardRef<HTMLAnchorElement, MenuItemProps>((inp
     active: parentProps.active,
     variables: parentProps.variables,
     accessibility: parentProps.accessibility,
-    onItemSelect: parentProps.onItemSelect,
     ...inputProps,
   };
 
@@ -357,7 +356,7 @@ export const MenuItem = (React.forwardRef<HTMLAnchorElement, MenuItemProps>((inp
     setIsFromKeyboard(isEventFromKeyboard());
     _.invoke(props, 'onFocus', e, props);
     if (menu) {
-      _.invoke(props, 'onItemSelect', e, index);
+      _.invoke(parentProps, 'onItemSelect', e, index);
     }
   };
 

--- a/packages/fluentui/react-northstar/test/specs/components/Menu/Menu-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Menu/Menu-test.tsx
@@ -55,6 +55,24 @@ describe('Menu', () => {
       expect(items[0].onClick).toHaveBeenCalled();
     });
 
+    it('set active index of items with submenu on focus', () => {
+      const mockActiveIndexChange = jest.fn();
+      const menu = mountWithProvider(
+        <Menu onActiveIndexChange={mockActiveIndexChange}>
+          <Menu.Item index={0} menu={['1']}>
+            item 1
+          </Menu.Item>
+        </Menu>,
+      );
+
+      menu.find('MenuItem').first().find('a').first().simulate('focus');
+      expect(mockActiveIndexChange).toHaveBeenCalled();
+      expect(mockActiveIndexChange).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'focus' }),
+        expect.objectContaining({ activeIndex: 0 }),
+      );
+    });
+
     it('should open on hover and keep open on click', () => {
       const items: MenuItemProps[] = getNestedItems();
       items[1].on = 'hover';

--- a/packages/fluentui/react-northstar/test/specs/components/Menu/Menu-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Menu/Menu-test.tsx
@@ -58,11 +58,7 @@ describe('Menu', () => {
     it('set active index of items with submenu on focus', () => {
       const mockActiveIndexChange = jest.fn();
       const menu = mountWithProvider(
-        <Menu onActiveIndexChange={mockActiveIndexChange}>
-          <Menu.Item index={0} menu={['1']}>
-            item 1
-          </Menu.Item>
-        </Menu>,
+        <Menu items={[{ index: 0, key: 0, menu: ['0'] }]} onActiveIndexChange={mockActiveIndexChange} />,
       );
 
       menu.find('MenuItem').first().find('a').first().simulate('focus');


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

When the menu is constructed using children instead of shorthand, right arrow does not initially work to open the submenu. It starts working once menu gets opened and closed.

Repro:
open https://codesandbox.io/s/fluent-ui-example-forked-u54vd
Open the avatar/button menu
Press arrow down to navigate to Available
Press arrow right to open the submenu

Expected: Submenu opens
Actual: nothing happens

#### Focus areas to test

(optional)
