### PR TITLE
react-utilities: Removes ExtractRef typings

### DIFF
--- a/change/@fluentui-react-utilities-d8107bb6-f0d1-457d-a806-0529a229457d.json
+++ b/change/@fluentui-react-utilities-d8107bb6-f0d1-457d-a806-0529a229457d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removes ExtractRef Typings",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -84,11 +84,6 @@ export const defaultSSRContextValue: SSRContextValue;
 // @public
 export const divProperties: Record<string, number>;
 
-// @public (undocumented)
-export type ExtractRef<Props extends {
-    ref?: any;
-}> = Props['ref'] extends ((instance: infer I | null) => void) | React_2.RefObject<infer I> | null | undefined ? I : any;
-
 // @public
 export const formProperties: Record<string, number>;
 

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -94,16 +94,6 @@ export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) e
  */
 export type PropsWithoutRef<P> = 'ref' extends keyof P ? (P extends unknown ? Omit<P, 'ref'> : P) : P;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ExtractRef<Props extends { ref?: any }> = Props['ref'] extends
-  | ((instance: infer I | null) => void)
-  | React.RefObject<infer I>
-  | null
-  | undefined
-  ? I
-  : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any;
-
 export type ComponentProps<
   Shorthands extends ObjectShorthandPropsRecord,
   Primary extends keyof Shorthands = 'root'


### PR DESCRIPTION
#### Description of changes

Removes `ExtractRef` Typings as it's no longer required after #19793