### PR TITLE
implement PaletteRGB.closestIndexOf cache

### DIFF
--- a/change/@fluentui-web-components-968fea0d-db58-4d9a-92e5-1f7dc21569f2.json
+++ b/change/@fluentui-web-components-968fea0d-db58-4d9a-92e5-1f7dc21569f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "implement caching mechanism for PaletteRGB.closestIndexOf",
+  "packageName": "@fluentui/web-components",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/color/palette.ts
+++ b/packages/web-components/src/color/palette.ts
@@ -53,6 +53,8 @@ class PaletteRGBImpl implements Palette<SwatchRGB> {
   public readonly swatches: ReadonlyArray<SwatchRGB>;
   private lastIndex: number;
   private reversedSwatches: ReadonlyArray<SwatchRGB>;
+  private closestIndexCache = new Map<number, number>();
+
   /**
    *
    * @param source - The source color for the palette
@@ -108,9 +110,14 @@ class PaletteRGBImpl implements Palette<SwatchRGB> {
    * {@inheritdoc Palette.closestIndexOf}
    */
   public closestIndexOf(reference: Swatch): number {
-    const index = this.swatches.indexOf(reference as SwatchRGB);
+    if (this.closestIndexCache.has(reference.relativeLuminance)) {
+      return this.closestIndexCache.get(reference.relativeLuminance)!;
+    }
+
+    let index = this.swatches.indexOf(reference as SwatchRGB);
 
     if (index !== -1) {
+      this.closestIndexCache.set(reference.relativeLuminance, index);
       return index;
     }
 
@@ -121,7 +128,10 @@ class PaletteRGBImpl implements Palette<SwatchRGB> {
         : previous,
     );
 
-    return this.swatches.indexOf(closest);
+    index = this.swatches.indexOf(closest);
+    this.closestIndexCache.set(reference.relativeLuminance, index);
+
+    return index;
   }
 
   /**


### PR DESCRIPTION
#### Pull request checklist

This PR mirrors a change in FAST: https://github.com/microsoft/fast/pull/5199

#### Description of changes
This PR adds a caching mechanism to PaletteRGB.closestIndexOf(). In cases where the provided swatch is not an index of PaletteRGB.swatches, PaletteRGB.closestIndexOf() goes down a somewhat slow code-path to determine which swatch in the set of palette swatches has the closest relative luminance of the provided swatch. In practice, this is often redundant work by the palette and can be sped up significantly by implementing a table-based cache.

