### PR TITLE
chore(a11y-testing): Remove dependency on `keyboard-keys`

### DIFF
--- a/packages/a11y-testing/package.json
+++ b/packages/a11y-testing/package.json
@@ -26,7 +26,6 @@
     "react": "16.8.6"
   },
   "dependencies": {
-    "@fluentui/keyboard-keys": "9.0.0-alpha.3",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/a11y-testing/src/facades/ComponentTestFacade.tsx
+++ b/packages/a11y-testing/src/facades/ComponentTestFacade.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Props, PropValue, TestFacade } from '../types';
 import { ReactWrapper, mount } from 'enzyme';
-import { Enter, Space, keyCodes } from '@fluentui/keyboard-keys';
 
 export class ComponentTestFacade implements TestFacade {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -84,22 +83,22 @@ export class ComponentTestFacade implements TestFacade {
 
   public pressSpaceKey(selector: string) {
     if (selector === 'root') {
-      this.renderedComponent.simulate('keydown', { keyCode: keyCodes.Space, key: Space });
+      this.renderedComponent.simulate('keydown', { keyCode: 32, key: ' ' });
       // TODO: This is required for space clicking with useARIAButton
-      this.renderedComponent.simulate('keyup', { keyCode: keyCodes.Space, key: Space });
+      this.renderedComponent.simulate('keyup', { keyCode: 32, key: ' ' });
       return;
     }
-    this.renderedComponent.find(selector).simulate('keydown', { keyCode: keyCodes.Space, key: Space });
+    this.renderedComponent.find(selector).simulate('keydown', { keyCode: 32, key: ' ' });
     // TODO: This is required for space clicking with useARIAButton
-    this.renderedComponent.find(selector).simulate('keyup', { keyCode: keyCodes.Space, key: Space });
+    this.renderedComponent.find(selector).simulate('keyup', { keyCode: 32, key: ' ' });
   }
 
   public pressEnterKey(selector: string) {
     if (selector === 'root') {
-      this.renderedComponent.simulate('keydown', { keyCode: keyCodes.Enter, key: Enter });
+      this.renderedComponent.simulate('keydown', { keyCode: 13, key: 'Enter' });
       return;
     }
-    this.renderedComponent.find(selector).simulate('keydown', { keyCode: keyCodes.Enter, key: Enter });
+    this.renderedComponent.find(selector).simulate('keydown', { keyCode: 13, key: 'Enter' });
   }
 
   public forProps = (props: Props): TestFacade => {


### PR DESCRIPTION

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes partially #19106 
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Clean up dependency separation between v9 and non-v9 packages in the
repo.

The usage of the `keyboard-keys` package was fairly limited and the string keys are self explanatory. The `keyboard-keys` package was intended to used in the web platform to reduce bundle size from duplicated strings.
#### Focus areas to test

(optional)
