### PR TITLE
chore(eslint, conformance): Use `*` versions for dev dependencies

### DIFF
--- a/apps/a11y-tests/package.json
+++ b/apps/a11y-tests/package.json
@@ -23,7 +23,7 @@
     "react-dom": "16.8.6"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/puppeteer": "1.12.3",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",

--- a/apps/perf-test/package.json
+++ b/apps/perf-test/package.json
@@ -12,7 +12,7 @@
     "code-style": "just-scripts code-style"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1"
+    "@fluentui/eslint-plugin": "*"
   },
   "dependencies": {
     "@fluentui/make-styles": "9.0.0-alpha.31",

--- a/apps/pr-deploy-site/package.json
+++ b/apps/pr-deploy-site/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   }
 }

--- a/apps/public-docsite-resources/package.json
+++ b/apps/public-docsite-resources/package.json
@@ -27,7 +27,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "react-dom": "16.8.6"
   },

--- a/apps/public-docsite/package.json
+++ b/apps/public-docsite/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "@fluentui/common-styles": "^1.0.17",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/react-monaco-editor": "^1.2.11",
     "@fluentui/scripts": "^1.0.0",
     "write-file-webpack-plugin": "^4.1.0"

--- a/apps/server-rendered-app/package.json
+++ b/apps/server-rendered-app/package.json
@@ -14,7 +14,7 @@
     "start": "node ./server/index.js"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",

--- a/apps/test-bundles/package.json
+++ b/apps/test-bundles/package.json
@@ -11,7 +11,7 @@
     "just": "just-scripts"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "parallel-webpack": "^2.6.0"
   }

--- a/apps/theming-designer/package.json
+++ b/apps/theming-designer/package.json
@@ -14,7 +14,7 @@
     "start": "just-scripts dev"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "@fluentui/scripts": "^1.0.0"

--- a/apps/todo-app/package.json
+++ b/apps/todo-app/package.json
@@ -12,7 +12,7 @@
     "start": "just-scripts dev"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/es6-promise": "0.0.32",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",

--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -15,7 +15,7 @@
     "start": "start-storybook --port 5555"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1"
+    "@fluentui/eslint-plugin": "*"
   },
   "dependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",

--- a/change/@fluentui-azure-themes-9810fc27-ca7a-4966-9d50-caf9a6f9ef36.json
+++ b/change/@fluentui-azure-themes-9810fc27-ca7a-4966-9d50-caf9a6f9ef36.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/azure-themes",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-babel-make-styles-6110c5b1-e10e-404c-b59a-eeae4f1d0124.json
+++ b/change/@fluentui-babel-make-styles-6110c5b1-e10e-404c-b59a-eeae4f1d0124.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-codemods-01f277d0-017c-43e9-a7d5-4a0d8c688df8.json
+++ b/change/@fluentui-codemods-01f277d0-017c-43e9-a7d5-4a0d8c688df8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/codemods",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-date-time-utilities-27162f84-4991-4da4-9b44-c7f817bb986c.json
+++ b/change/@fluentui-date-time-utilities-27162f84-4991-4da4-9b44-c7f817bb986c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-dom-utilities-5fd5d80d-7668-4a2f-a972-cacf55a39128.json
+++ b/change/@fluentui-dom-utilities-5fd5d80d-7668-4a2f-a972-cacf55a39128.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-example-data-3babe96b-4a74-4f6c-b0e9-eb918a5e37c6.json
+++ b/change/@fluentui-example-data-3babe96b-4a74-4f6c-b0e9-eb918a5e37c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/example-data",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-font-icons-mdl2-ff47a9f8-ed51-4b2a-8f8f-f1c1715507b1.json
+++ b/change/@fluentui-font-icons-mdl2-ff47a9f8-ed51-4b2a-8f8f-f1c1715507b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-foundation-legacy-4c84dd15-ba06-49d1-9516-7aefdee359f0.json
+++ b/change/@fluentui-foundation-legacy-4c84dd15-ba06-49d1-9516-7aefdee359f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-jest-serializer-make-styles-b03634ea-c222-44d9-a5f3-713969079502.json
+++ b/change/@fluentui-jest-serializer-make-styles-b03634ea-c222-44d9-a5f3-713969079502.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/jest-serializer-make-styles",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-jest-serializer-merge-styles-b633951c-e60d-444b-9651-d87e541a79ce.json
+++ b/change/@fluentui-jest-serializer-merge-styles-b633951c-e60d-444b-9651-d87e541a79ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/jest-serializer-merge-styles",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-keyboard-key-f50c5f36-ce24-46e2-bbbd-31e533e5456f.json
+++ b/change/@fluentui-keyboard-key-f50c5f36-ce24-46e2-bbbd-31e533e5456f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-keyboard-keys-79c6e5bb-1ed6-401e-9146-49184e03c6c6.json
+++ b/change/@fluentui-keyboard-keys-79c6e5bb-1ed6-401e-9146-49184e03c6c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/keyboard-keys",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-make-styles-cb12098c-9ea5-4f22-b19f-f702b99120de.json
+++ b/change/@fluentui-make-styles-cb12098c-9ea5-4f22-b19f-f702b99120de.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/make-styles",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-make-styles-webpack-loader-5f4d8241-8e91-4228-b2ae-bb3eab77e60a.json
+++ b/change/@fluentui-make-styles-webpack-loader-5f4d8241-8e91-4228-b2ae-bb3eab77e60a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/make-styles-webpack-loader",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-merge-styles-9a38ce90-9718-4e0b-bdbf-d240ed352f8a.json
+++ b/change/@fluentui-merge-styles-9a38ce90-9718-4e0b-bdbf-d240ed352f8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/merge-styles",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-monaco-editor-aa854399-e739-4e95-9096-0ef9e905a468.json
+++ b/change/@fluentui-monaco-editor-aa854399-e739-4e95-9096-0ef9e905a468.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/monaco-editor",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-public-docsite-setup-bd39c1c8-7481-4ce5-91c9-e5e06675dc46.json
+++ b/change/@fluentui-public-docsite-setup-bd39c1c8-7481-4ce5-91c9-e5e06675dc46.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/public-docsite-setup",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-8b1b0f5b-d466-432b-8f17-692a2200c7b8.json
+++ b/change/@fluentui-react-8b1b0f5b-d466-432b-8f17-692a2200c7b8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-55486a61-e5c8-4668-8efb-0edb44ec87f7.json
+++ b/change/@fluentui-react-accordion-55486a61-e5c8-4668-8efb-0edb44ec87f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-accordion",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-aria-68d8fbc7-3270-4275-bdd2-5a8b2929f31e.json
+++ b/change/@fluentui-react-aria-68d8fbc7-3270-4275-bdd2-5a8b2929f31e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-aria",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-47532c4b-0777-4871-b721-e99c0d09fb28.json
+++ b/change/@fluentui-react-avatar-47532c4b-0777-4871-b721-e99c0d09fb28.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-avatar",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-08cac785-b7a8-4318-984e-a2edc3b36eb6.json
+++ b/change/@fluentui-react-badge-08cac785-b7a8-4318-984e-a2edc3b36eb6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-badge",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-4b195ea3-5815-46b4-8447-504e4c5ce075.json
+++ b/change/@fluentui-react-button-4b195ea3-5815-46b4-8447-504e4c5ce075.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-button",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-card-d0efef61-bb9c-430d-96d8-ee8478d00462.json
+++ b/change/@fluentui-react-card-d0efef61-bb9c-430d-96d8-ee8478d00462.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-card",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-cards-3bb1ba9d-8383-4cf4-9c53-20757d7ba356.json
+++ b/change/@fluentui-react-cards-3bb1ba9d-8383-4cf4-9c53-20757d7ba356.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-cards",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-861a46cd-7513-43eb-a561-5593f5c74cb1.json
+++ b/change/@fluentui-react-charting-861a46cd-7513-43eb-a561-5593f5c74cb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-charting",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-checkbox-03b292f1-0036-45b0-a706-89da944059ac.json
+++ b/change/@fluentui-react-checkbox-03b292f1-0036-45b0-a706-89da944059ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-components-b471c264-990a-437f-8d9a-42b8be0a6fa4.json
+++ b/change/@fluentui-react-components-b471c264-990a-437f-8d9a-42b8be0a6fa4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-components",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-compose-201dfb1b-ed14-42b1-b8c0-9bac9161b188.json
+++ b/change/@fluentui-react-compose-201dfb1b-ed14-42b1-b8c0-9bac9161b188.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-compose",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-00802e7c-1f15-4bae-83bb-516af9230cdd.json
+++ b/change/@fluentui-react-conformance-00802e7c-1f15-4bae-83bb-516af9230cdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-conformance",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-make-styles-256865ce-6952-4057-83ca-466208ceccaa.json
+++ b/change/@fluentui-react-conformance-make-styles-256865ce-6952-4057-83ca-466208ceccaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-conformance-make-styles",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-434bbf96-3816-4ed4-866a-e87f3f5b9560.json
+++ b/change/@fluentui-react-context-selector-434bbf96-3816-4ed4-866a-e87f3f5b9560.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-date-time-4754bf77-1570-4e3d-85a4-ae1fafa79a09.json
+++ b/change/@fluentui-react-date-time-4754bf77-1570-4e3d-85a4-ae1fafa79a09.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-date-time",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-divider-0fe501d8-daef-4ea2-8783-18bd9f466739.json
+++ b/change/@fluentui-react-divider-0fe501d8-daef-4ea2-8783-18bd9f466739.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-divider",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-docsite-components-7b9fa0a1-77a5-408d-9b7a-fac78611d09b.json
+++ b/change/@fluentui-react-docsite-components-7b9fa0a1-77a5-408d-9b7a-fac78611d09b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-de8ad3f7-50cf-4417-ae36-d4e024c8eb57.json
+++ b/change/@fluentui-react-experiments-de8ad3f7-50cf-4417-ae36-d4e024c8eb57.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-experiments",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-file-type-icons-abbeab25-cc35-4945-809a-5e6ea6538d37.json
+++ b/change/@fluentui-react-file-type-icons-abbeab25-cc35-4945-809a-5e6ea6538d37.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-b35f5ca7-0e24-49f8-93f7-21ce33bd3dbc.json
+++ b/change/@fluentui-react-focus-b35f5ca7-0e24-49f8-93f7-21ce33bd3dbc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-focus",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-hooks-dc6b8367-c854-4a43-a47c-b352215fd961.json
+++ b/change/@fluentui-react-hooks-dc6b8367-c854-4a43-a47c-b352215fd961.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-hooks",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icon-provider-91a4f22f-0235-42e9-8d39-1ee8138e9fab.json
+++ b/change/@fluentui-react-icon-provider-91a4f22f-0235-42e9-8d39-1ee8138e9fab.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-ac717517-87d2-4b6c-a412-853c89f5a04c.json
+++ b/change/@fluentui-react-icons-mdl2-ac717517-87d2-4b6c-a412-853c89f5a04c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-branded-cc3dd5d5-6ccc-46b3-a1e7-3c98b24c5e63.json
+++ b/change/@fluentui-react-icons-mdl2-branded-cc3dd5d5-6ccc-46b3-a1e7-3c98b24c5e63.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-icons-mdl2-branded",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-a1cdb5ad-0117-42bb-9743-d33356685e7b.json
+++ b/change/@fluentui-react-image-a1cdb5ad-0117-42bb-9743-d33356685e7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-image",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-ed3f9a3c-114b-457f-9bbf-237e2833fab2.json
+++ b/change/@fluentui-react-label-ed3f9a3c-114b-457f-9bbf-237e2833fab2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-label",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-2d21e667-0713-4d24-a7ce-a438d9b28586.json
+++ b/change/@fluentui-react-link-2d21e667-0713-4d24-a7ce-a438d9b28586.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-link",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-make-styles-5d09fa23-5088-486e-966b-3cea89b023df.json
+++ b/change/@fluentui-react-make-styles-5d09fa23-5088-486e-966b-3cea89b023df.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-make-styles",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-c4560a64-aeaa-45f2-a986-389581d47a5e.json
+++ b/change/@fluentui-react-menu-c4560a64-aeaa-45f2-a986-389581d47a5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-748a3ac0-32f9-48f6-92e0-bc0c5030102f.json
+++ b/change/@fluentui-react-monaco-editor-748a3ac0-32f9-48f6-92e0-bc0c5030102f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-2d8c78b6-290d-47bb-940c-1c2bd1c08912.json
+++ b/change/@fluentui-react-popover-2d8c78b6-290d-47bb-940c-1c2bd1c08912.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-98c4d493-dd74-40f2-9701-cf82b8b575bd.json
+++ b/change/@fluentui-react-portal-98c4d493-dd74-40f2-9701-cf82b8b575bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-portal",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-positioning-17a850f9-d37f-43c7-80e5-0b663dd073b7.json
+++ b/change/@fluentui-react-positioning-17a850f9-d37f-43c7-80e5-0b663dd073b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-e9cd380a-29c6-418e-97e0-a1dfb9cdc8f8.json
+++ b/change/@fluentui-react-provider-e9cd380a-29c6-418e-97e0-a1dfb9cdc8f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-provider",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-c0eb0359-10be-4add-95a0-04fa23b782b0.json
+++ b/change/@fluentui-react-shared-contexts-c0eb0359-10be-4add-95a0-04fa23b782b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-slider-fb718603-735c-450d-a1e1-d2dbed589497.json
+++ b/change/@fluentui-react-slider-fb718603-735c-450d-a1e1-d2dbed589497.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-slider",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-switch-9f6d8dad-84f3-45da-8a00-5cdaeb3b966e.json
+++ b/change/@fluentui-react-switch-9f6d8dad-84f3-45da-8a00-5cdaeb3b966e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-switch",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-9e87a85e-1561-4ccb-b59c-bfe801ad3f40.json
+++ b/change/@fluentui-react-tabs-9e87a85e-1561-4ccb-b59c-bfe801ad3f40.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-tabs",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-1a0ebc0e-372e-4cfa-ac02-e92bd8c5d257.json
+++ b/change/@fluentui-react-tabster-1a0ebc0e-372e-4cfa-ac02-e92bd8c5d257.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-c92d27be-32a2-461e-a528-5a42d0208a70.json
+++ b/change/@fluentui-react-text-c92d27be-32a2-461e-a528-5a42d0208a70.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-text",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-5870ee89-d65f-421f-9aec-a031052bf7c1.json
+++ b/change/@fluentui-react-theme-5870ee89-d65f-421f-9aec-a031052bf7c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-theme",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-1cd0d9d3-92b1-4b1a-bb10-9892d9e1ca14.json
+++ b/change/@fluentui-react-tooltip-1cd0d9d3-92b1-4b1a-bb10-9892d9e1ca14.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-6f1224cf-510d-4fce-92ac-fbd5955d2a8e.json
+++ b/change/@fluentui-react-utilities-6f1224cf-510d-4fce-92ac-fbd5955d2a8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-utilities",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-window-provider-756e85df-f7cb-43a3-a8fa-7db8c9a9efaa.json
+++ b/change/@fluentui-react-window-provider-756e85df-f7cb-43a3-a8fa-7db8c9a9efaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-scheme-utilities-fc55c7dd-a1eb-4221-99b2-64a43cc4ec67.json
+++ b/change/@fluentui-scheme-utilities-fc55c7dd-a1eb-4221-99b2-64a43cc4ec67.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/scheme-utilities",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-set-version-e9aa06fd-7ae7-4025-827f-8e9d35e4d68c.json
+++ b/change/@fluentui-set-version-e9aa06fd-7ae7-4025-827f-8e9d35e4d68c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/set-version",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-style-utilities-27bebf55-e88f-4df1-a40c-9c2ea2287e74.json
+++ b/change/@fluentui-style-utilities-27bebf55-e88f-4df1-a40c-9c2ea2287e74.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/style-utilities",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-test-utilities-deb077d7-18de-42a5-a5b0-634c8bc1875c.json
+++ b/change/@fluentui-test-utilities-deb077d7-18de-42a5-a5b0-634c8bc1875c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/test-utilities",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-8fcb7cd3-7430-4f9e-80ef-698df93730ea.json
+++ b/change/@fluentui-theme-8fcb7cd3-7430-4f9e-80ef-698df93730ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/theme",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-samples-c30aea99-e138-4cc4-bd5c-feec5f12f110.json
+++ b/change/@fluentui-theme-samples-c30aea99-e138-4cc4-bd5c-feec5f12f110.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/theme-samples",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-utilities-4804217d-8d45-4a96-b3a6-a5c8eca3344b.json
+++ b/change/@fluentui-utilities-4804217d-8d45-4a96-b3a6-a5c8eca3344b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/utilities",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-webpack-utilities-644bf045-dfe6-4377-8235-93d795b6b4a0.json
+++ b/change/@fluentui-webpack-utilities-644bf045-dfe6-4377-8235-93d795b6b4a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use  versioon eslint-plugin and react-conformance in dev dependencies",
+  "packageName": "@fluentui/webpack-utilities",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/a11y-testing/package.json
+++ b/packages/a11y-testing/package.json
@@ -18,7 +18,7 @@
     "lint": "just-scripts lint"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/react": "16.9.42",

--- a/packages/api-docs/package.json
+++ b/packages/api-docs/package.json
@@ -18,7 +18,7 @@
     "test": "just-scripts test"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/azure-themes/package.json
+++ b/packages/azure-themes/package.json
@@ -23,7 +23,7 @@
     "start": "just-scripts dev:storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "react": "16.8.6"
   },

--- a/packages/babel-make-styles/package.json
+++ b/packages/babel-make-styles/package.json
@@ -20,7 +20,7 @@
     "type-check": "tsc -p ./tsconfig.spec.json"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/react-make-styles": "9.0.0-alpha.67",
     "@fluentui/react-theme": "9.0.0-alpha.22",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -23,7 +23,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/react": "16.9.42"
   },

--- a/packages/date-time-utilities/package.json
+++ b/packages/date-time-utilities/package.json
@@ -23,7 +23,7 @@
     "lint": "just-scripts lint"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/dom-utilities/package.json
+++ b/packages/dom-utilities/package.json
@@ -23,7 +23,7 @@
     "test": "just-scripts test"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/example-data/package.json
+++ b/packages/example-data/package.json
@@ -20,7 +20,7 @@
     "just": "just-scripts"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/font-icons-mdl2/package.json
+++ b/packages/font-icons-mdl2/package.json
@@ -22,7 +22,7 @@
     "test": "just-scripts test"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/foundation-legacy/package.json
+++ b/packages/foundation-legacy/package.json
@@ -25,7 +25,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/react": "16.9.42",

--- a/packages/jest-serializer-make-styles/package.json
+++ b/packages/jest-serializer-make-styles/package.json
@@ -20,7 +20,7 @@
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/jest-serializer-make-styles/src && yarn docs"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/react-make-styles": "9.0.0-alpha.67",
     "@fluentui/react-shared-contexts": "9.0.0-alpha.24",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/jest-serializer-merge-styles/package.json
+++ b/packages/jest-serializer-merge-styles/package.json
@@ -19,7 +19,7 @@
     "start-test": "just-scripts jest-watch"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",

--- a/packages/keyboard-key/package.json
+++ b/packages/keyboard-key/package.json
@@ -21,7 +21,7 @@
     "test": "just-scripts test"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/keyboard-keys/package.json
+++ b/packages/keyboard-keys/package.json
@@ -21,7 +21,7 @@
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/keyboard-keys/src && yarn docs"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {},

--- a/packages/make-styles-webpack-loader/package.json
+++ b/packages/make-styles-webpack-loader/package.json
@@ -21,7 +21,7 @@
     "type-check": "tsc -p ./tsconfig.spec.json"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/make-styles/package.json
+++ b/packages/make-styles/package.json
@@ -22,7 +22,7 @@
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/ && yarn docs"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/test-utilities": "^8.0.8",
     "@types/stylis": "4.0.0"

--- a/packages/merge-styles/package.json
+++ b/packages/merge-styles/package.json
@@ -24,7 +24,7 @@
     "start-test": "just-scripts jest-watch"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/monaco-editor/package.json
+++ b/packages/monaco-editor/package.json
@@ -16,7 +16,7 @@
     "just": "just-scripts"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "monaco-editor": "0.19.0",
     "monaco-typescript": "3.6.1"

--- a/packages/public-docsite-setup/package.json
+++ b/packages/public-docsite-setup/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "rollup": "^2.7.6",
     "rollup-plugin-terser": "^5.3.0"

--- a/packages/react-accordion/package.json
+++ b/packages/react-accordion/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-aria/package.json
+++ b/packages/react-aria/package.json
@@ -24,9 +24,9 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-badge/package.json
+++ b/packages/react-badge/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -27,9 +27,9 @@
   "devDependencies": {
     "@fluentui/a11y-testing": "^0.1.0",
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/react-menu": "9.0.0-alpha.78",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/react-card/package.json
+++ b/packages/react-card/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/react-text": "^9.0.0-alpha.16",

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -26,7 +26,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-merge-styles": "^8.0.10",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-charting/package.json
+++ b/packages/react-charting/package.json
@@ -27,7 +27,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/react": "^8.34.2",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",

--- a/packages/react-checkbox/package.json
+++ b/packages/react-checkbox/package.json
@@ -24,9 +24,9 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -27,7 +27,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -22,7 +22,7 @@
     "just": "just-scripts"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/react": "16.9.42",

--- a/packages/react-conformance-make-styles/package.json
+++ b/packages/react-conformance-make-styles/package.json
@@ -22,9 +22,9 @@
     "start": "yarn storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
-    "@fluentui/react-conformance": "^0.5.0"
+    "@fluentui/react-conformance": "*"
   },
   "dependencies": {
     "@fluentui/react-make-styles": "9.0.0-alpha.67",

--- a/packages/react-conformance/package.json
+++ b/packages/react-conformance/package.json
@@ -18,7 +18,7 @@
     "lint": "just-scripts lint"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/doctrine": "0.0.3",
     "@types/enzyme": "3.10.3",

--- a/packages/react-context-selector/package.json
+++ b/packages/react-context-selector/package.json
@@ -22,7 +22,7 @@
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-context-selector/src && yarn docs"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/scheduler": "^0.16.1",
     "@types/react": "16.9.42",

--- a/packages/react-date-time/package.json
+++ b/packages/react-date-time/package.json
@@ -22,7 +22,7 @@
     "code-style": "just-scripts code-style"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/react-dom": "16.9.10",
     "@types/react": "16.9.42",

--- a/packages/react-divider/package.json
+++ b/packages/react-divider/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-docsite-components/package.json
+++ b/packages/react-docsite-components/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@fluentui/common-styles": "^1.0.17",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/color-check": "0.0.0",
     "@types/markdown-to-jsx": "6.11.0",

--- a/packages/react-examples/package.json
+++ b/packages/react-examples/package.json
@@ -19,7 +19,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-merge-styles": "^8.0.10",
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/storybook": "^1.0.0",

--- a/packages/react-experiments/package.json
+++ b/packages/react-experiments/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@fluentui/common-styles": "^1.0.17",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/deep-assign": "^0.1.1",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",

--- a/packages/react-file-type-icons/package.json
+++ b/packages/react-file-type-icons/package.json
@@ -22,7 +22,7 @@
     "test": "just-scripts test"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "react": "16.8.6"

--- a/packages/react-focus/package.json
+++ b/packages/react-focus/package.json
@@ -26,8 +26,8 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/eslint-plugin": "*",
+    "@fluentui/react-conformance": "*",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/react": "16.9.42",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -24,7 +24,7 @@
     "just": "just-scripts"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/react": "16.9.42",

--- a/packages/react-icon-provider/package.json
+++ b/packages/react-icon-provider/package.json
@@ -23,7 +23,7 @@
     "test": "just-scripts test"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/react-icons-mdl2-branded/package.json
+++ b/packages/react-icons-mdl2-branded/package.json
@@ -21,7 +21,7 @@
     "lint": "just-scripts lint"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/react-icons-mdl2/package.json
+++ b/packages/react-icons-mdl2/package.json
@@ -25,7 +25,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/react": "16.9.42",

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-input/package.json
+++ b/packages/react-input/package.json
@@ -27,9 +27,9 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-label/package.json
+++ b/packages/react-label/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-link/package.json
+++ b/packages/react-link/package.json
@@ -27,9 +27,9 @@
   "devDependencies": {
     "@fluentui/a11y-testing": "^0.1.0",
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-make-styles/package.json
+++ b/packages/react-make-styles/package.json
@@ -25,7 +25,7 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",

--- a/packages/react-menu/package.json
+++ b/packages/react-menu/package.json
@@ -27,9 +27,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-monaco-editor/package.json
+++ b/packages/react-monaco-editor/package.json
@@ -23,7 +23,7 @@
     "just": "just-scripts"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "@types/react-syntax-highlighter": "^10.2.1",

--- a/packages/react-popover/package.json
+++ b/packages/react-popover/package.json
@@ -27,9 +27,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-portal/package.json
+++ b/packages/react-portal/package.json
@@ -25,9 +25,9 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",

--- a/packages/react-positioning/package.json
+++ b/packages/react-positioning/package.json
@@ -25,7 +25,7 @@
     "start": "yarn storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",

--- a/packages/react-provider/package.json
+++ b/packages/react-provider/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-shared-contexts/package.json
+++ b/packages/react-shared-contexts/package.json
@@ -22,7 +22,7 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/test-utilities": "^8.0.8",
     "@types/enzyme": "3.10.3",

--- a/packages/react-slider/package.json
+++ b/packages/react-slider/package.json
@@ -25,9 +25,9 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/react-label": "9.0.0-alpha.40",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/react-storybook-addon/package.json
+++ b/packages/react-storybook-addon/package.json
@@ -25,7 +25,7 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "react": "16.8.6"

--- a/packages/react-storybook/package.json
+++ b/packages/react-storybook/package.json
@@ -25,7 +25,7 @@
     "storybook": "start-storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "react": "16.8.6",

--- a/packages/react-switch/package.json
+++ b/packages/react-switch/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/react-label": "9.0.0-alpha.40",
     "@fluentui/react-provider": "9.0.0-alpha.78",

--- a/packages/react-tabs/package.json
+++ b/packages/react-tabs/package.json
@@ -23,8 +23,8 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/eslint-plugin": "*",
+    "@fluentui/react-conformance": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",

--- a/packages/react-tabster/package.json
+++ b/packages/react-tabster/package.json
@@ -24,7 +24,7 @@
     "start": "yarn storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",

--- a/packages/react-text/package.json
+++ b/packages/react-text/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-theme/package.json
+++ b/packages/react-theme/package.json
@@ -25,7 +25,7 @@
     "build:local": "tsc -p . --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output dist/react-theme/src && yarn docs"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",

--- a/packages/react-tooltip/package.json
+++ b/packages/react-tooltip/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@fluentui/babel-make-styles": "9.0.0-alpha.49",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-make-styles": "9.0.0-alpha.42",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-alpha.11",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-utilities/package.json
+++ b/packages/react-utilities/package.json
@@ -25,7 +25,7 @@
     "start": "yarn storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",

--- a/packages/react-window-provider/package.json
+++ b/packages/react-window-provider/package.json
@@ -24,7 +24,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/test-utilities": "^8.0.8",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,10 +32,10 @@
   },
   "devDependencies": {
     "@fluentui/common-styles": "^1.0.17",
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/example-data": "^8.2.6",
     "@fluentui/jest-serializer-merge-styles": "^8.0.10",
-    "@fluentui/react-conformance": "^0.5.0",
+    "@fluentui/react-conformance": "*",
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/test-utilities": "^8.0.8",
     "@fluentui/webpack-utilities": "^8.1.5",

--- a/packages/scheme-utilities/package.json
+++ b/packages/scheme-utilities/package.json
@@ -23,7 +23,7 @@
     "start-test": "just-scripts jest-watch"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/set-version/package.json
+++ b/packages/set-version/package.json
@@ -18,7 +18,7 @@
     "test": "just-scripts test"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -18,7 +18,7 @@
     "lint": "just-scripts lint"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/react": "16.9.42",
     "@fluentui/scripts": "^1.0.0",
     "react": "16.8.6"

--- a/packages/style-utilities/package.json
+++ b/packages/style-utilities/package.json
@@ -25,7 +25,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -19,7 +19,7 @@
     "test": "just-scripts test"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/enzyme": "3.10.3",
     "@types/react": "16.9.42",
     "@types/react-test-renderer": "^16.0.0",

--- a/packages/theme-samples/package.json
+++ b/packages/theme-samples/package.json
@@ -22,7 +22,7 @@
     "clean": "just-scripts clean"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -24,7 +24,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/react": "16.9.42",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -24,7 +24,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/react": "16.9.42",

--- a/packages/webpack-utilities/package.json
+++ b/packages/webpack-utilities/package.json
@@ -15,7 +15,7 @@
     "lint": "just-scripts lint"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1",
+    "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -15,7 +15,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "^1.4.1"
+    "@fluentui/eslint-plugin": "*"
   },
   "dependencies": {
     "@mdx-js/loader": "^1.5.5",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes partially #19106 
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Following #19799, runs the generator and migrates all packages in the
monorepo to use `esling-plugin` and `react-conformance` with `*` version in dev dependencies.

This avoids potential version bumping issues when Fluent vNext is released separately to the rest of the repo

