### PR TITLE
Remove docCategory tags from converged components

### DIFF
--- a/change/@fluentui-react-badge-e8020102-523c-4446-8fbb-37e8a418e617.json
+++ b/change/@fluentui-react-badge-e8020102-523c-4446-8fbb-37e8a418e617.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unnecessary docCategory tags",
+  "packageName": "@fluentui/react-badge",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-divider-f711bf06-2155-4b57-9188-d28d55a2c9d1.json
+++ b/change/@fluentui-react-divider-f711bf06-2155-4b57-9188-d28d55a2c9d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unnecessary docCategory tags",
+  "packageName": "@fluentui/react-divider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icon-provider-33c12d6a-f621-4ae2-9ac3-46f80e5151fa.json
+++ b/change/@fluentui-react-icon-provider-33c12d6a-f621-4ae2-9ac3-46f80e5151fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unnecessary docCategory tags",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-7ed1d9f3-5c8b-4656-8c00-410e20551399.json
+++ b/change/@fluentui-react-label-7ed1d9f3-5c8b-4656-8c00-410e20551399.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unnecessary docCategory tags",
+  "packageName": "@fluentui/react-label",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-3cf4ed2f-48db-4b10-926a-e5d9fdfac783.json
+++ b/change/@fluentui-react-menu-3cf4ed2f-48db-4b10-926a-e5d9fdfac783.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unnecessary docCategory tags",
+  "packageName": "@fluentui/react-menu",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-81a68f5c-c5e6-4529-a03d-270b15681db1.json
+++ b/change/@fluentui-react-shared-contexts-81a68f5c-c5e6-4529-a03d-270b15681db1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unnecessary docCategory tags",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-8c315c8f-fb77-457c-9849-09e73afe04b6.json
+++ b/change/@fluentui-react-tabs-8c315c8f-fb77-457c-9849-09e73afe04b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unnecessary docCategory tags",
+  "packageName": "@fluentui/react-tabs",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-21b33567-9669-434b-a4d7-7ab630dc34f0.json
+++ b/change/@fluentui-react-tooltip-21b33567-9669-434b-a4d7-7ab630dc34f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unnecessary docCategory tags",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-badge/Spec.md
+++ b/packages/react-badge/Spec.md
@@ -119,14 +119,8 @@ interface BadgeProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {
 A Presence Badge represents someone's availbility or status
 
 ```typescript
-/**
- * {@docCategory PresenceBadge}
- */
 export type PresenceBadgeStatus = 'busy' | 'oof' | 'away' | 'available' | 'offline';
 
-/**
- * {@docCategory PresenceBadge}
- */
 export interface PresenceBadgeProps extends Omit<BadgeProps, 'shape' | 'appearance'> {
   /**
    * A PresenceBadge can represent several status
@@ -140,9 +134,6 @@ export interface PresenceBadgeProps extends Omit<BadgeProps, 'shape' | 'appearan
   inOffice?: boolean;
 }
 
-/**
- * {@docCategory Badge}
- */
 export interface PresenceBadgeState extends BadgeState {
   /**
    * A PresenceBadge can represent several status
@@ -162,14 +153,8 @@ export interface PresenceBadgeState extends BadgeState {
 A Counter Badge is a visual indicator for numeric values such as tallies and scores.
 
 ```typescript
-/**
- * {@docCategory CounterBadge}
- */
 export type CounterBadgeColors = 'accent' | 'warning' | 'important' | 'severe' | 'informative';
 
-/**
- * {@docCategory CounterBadge}
- */
 export interface CounterBadgeProps extends Omit<BadgeProps, 'appearance' | 'shape'> {
   /**
    * A Badge can be circular or rounded

--- a/packages/react-badge/src/components/Badge/Badge.tsx
+++ b/packages/react-badge/src/components/Badge/Badge.tsx
@@ -6,7 +6,6 @@ import type { BadgeProps } from './Badge.types';
 
 /**
  * Define a styled Badge, using the `useBadge` hook.
- * {@docCategory Badge}
  */
 export const Badge: React.FunctionComponent<BadgeProps & React.RefAttributes<HTMLElement>> = React.forwardRef<
   HTMLElement,

--- a/packages/react-badge/src/components/Badge/Badge.types.ts
+++ b/packages/react-badge/src/components/Badge/Badge.types.ts
@@ -1,24 +1,12 @@
 import * as React from 'react';
 import type { ComponentPropsCompat, ShorthandPropsCompat, ObjectShorthandPropsCompat } from '@fluentui/react-utilities';
 
-/**
- * {@docCategory Badge}
- */
 export type BadgeSize = 'smallest' | 'smaller' | 'small' | 'medium' | 'large' | 'larger' | 'largest';
 
-/**
- * {@docCategory Badge}
- */
 export type BadgeAppearance = 'filled' | 'outline' | 'ghost' | 'tint';
 
-/**
- * {@docCategory Badge}
- */
 export type BadgeShape = 'rounded' | 'square' | 'circular';
 
-/**
- * {@docCategory Badge}
- */
 export type BadgeColors =
   | 'brand'
   | 'danger'
@@ -29,9 +17,6 @@ export type BadgeColors =
   | 'informative'
   | 'subtle';
 
-/**
- * {@docCategory Badge}
- */
 export interface BadgeProps extends ComponentPropsCompat, React.HTMLAttributes<HTMLElement> {
   /**
    * A Badge can be sized.
@@ -69,9 +54,6 @@ export interface BadgeProps extends ComponentPropsCompat, React.HTMLAttributes<H
   iconPosition?: 'before' | 'after';
 }
 
-/**
- * {@docCategory Badge}
- */
 export interface BadgeState extends BadgeProps {
   /**
    * Ref to the root slot

--- a/packages/react-badge/src/components/CounterBadge/CounterBadge.tsx
+++ b/packages/react-badge/src/components/CounterBadge/CounterBadge.tsx
@@ -6,7 +6,6 @@ import type { CounterBadgeProps } from './CounterBadge.types';
 
 /**
  * Define a styled CounterBadge, using the `useCounterBadge` hook.
- * {@docCategory CounterBadge}
  */
 export const CounterBadge = React.forwardRef<HTMLElement, CounterBadgeProps>((props, ref) => {
   const state = useCounterBadge(props, ref);

--- a/packages/react-badge/src/components/CounterBadge/CounterBadge.types.ts
+++ b/packages/react-badge/src/components/CounterBadge/CounterBadge.types.ts
@@ -1,8 +1,5 @@
 import type { BadgeProps, BadgeState } from '../Badge/index';
 
-/**
- * {@docCategory CounterBadge}
- */
 export interface CounterBadgeProps extends Omit<BadgeProps, 'appearance' | 'shape'> {
   /**
    * A Badge can be circular or rounded
@@ -41,9 +38,6 @@ export interface CounterBadgeProps extends Omit<BadgeProps, 'appearance' | 'shap
   dot?: boolean;
 }
 
-/**
- * {@docCategory CounterBadge}
- */
 export interface CounterBadgeState extends BadgeState {
   /**
    * Max number to be displayed

--- a/packages/react-badge/src/components/PresenceBadge/PresenceBadge.tsx
+++ b/packages/react-badge/src/components/PresenceBadge/PresenceBadge.tsx
@@ -6,7 +6,6 @@ import type { PresenceBadgeProps } from './PresenceBadge.types';
 
 /**
  * Define a styled Badge, using the `useBadge` hook.
- * {@docCategory Badge}
  */
 export const PresenceBadge = React.forwardRef<HTMLElement, PresenceBadgeProps>((props, ref) => {
   const state = usePresenceBadge(props, ref);

--- a/packages/react-badge/src/components/PresenceBadge/PresenceBadge.types.ts
+++ b/packages/react-badge/src/components/PresenceBadge/PresenceBadge.types.ts
@@ -1,13 +1,7 @@
 import type { BadgeProps, BadgeState } from '../Badge/index';
 
-/**
- * {@docCategory PresenceBadge}
- */
 export type PresenceBadgeStatus = 'busy' | 'outOfOffice' | 'away' | 'available' | 'offline' | 'doNotDisturb';
 
-/**
- * {@docCategory PresenceBadge}
- */
 export interface PresenceBadgeProps extends Omit<BadgeProps, 'shape' | 'appearance'> {
   /**
    * Represents several status
@@ -22,9 +16,6 @@ export interface PresenceBadgeProps extends Omit<BadgeProps, 'shape' | 'appearan
   outOfOffice?: boolean;
 }
 
-/**
- * {@docCategory Badge}
- */
 export interface PresenceBadgeState extends Omit<BadgeState, 'shape' | 'appearance'> {
   /**
    * Represents several status

--- a/packages/react-divider/src/components/Divider/Divider.tsx
+++ b/packages/react-divider/src/components/Divider/Divider.tsx
@@ -6,7 +6,6 @@ import { useDividerStyles } from './useDividerStyles';
 
 /**
  * Define a styled Divider, using the `useDivider` and `useDividerStyles` hooks.
- * {@docCategory Divider}
  */
 export const Divider = React.forwardRef<HTMLElement, DividerProps>((props, ref) => {
   const state = useDivider(props, ref);

--- a/packages/react-divider/src/components/Divider/Divider.types.ts
+++ b/packages/react-divider/src/components/Divider/Divider.types.ts
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import { ComponentPropsCompat, ShorthandPropsCompat } from '@fluentui/react-utilities';
 
-/**
- * {@docCategory Divider}
- */
 export interface DividerProps extends ComponentPropsCompat, React.HTMLAttributes<HTMLElement> {
   /**
    * Determines the alignment of the content within the divider.
@@ -40,9 +37,6 @@ export interface DividerProps extends ComponentPropsCompat, React.HTMLAttributes
   wrapper?: ShorthandPropsCompat<React.HTMLAttributes<HTMLDivElement>>;
 }
 
-/**
- * {@docCategory Divider}
- */
 export interface DividerState extends DividerProps {
   /**
    * Ref to the root slot

--- a/packages/react-icon-provider/src/IconProvider.types.ts
+++ b/packages/react-icon-provider/src/IconProvider.types.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import type { IIconSubset } from '@fluentui/style-utilities';
 
 /**
- * {@docCategory IconProvider}
  * Props for the IconProvider component.
  */
 export interface IconProviderProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/packages/react-label/Spec.md
+++ b/packages/react-label/Spec.md
@@ -77,7 +77,6 @@ The Label component should be simple as shown below. It will just need the text 
 ```ts
 /**
  * Label Props
- * {@docCategory Label}
  */
 export interface LabelProps extends ComponentProps, React.LabelHTMLAttributes<HTMLElement> {
   /**
@@ -107,19 +106,16 @@ export interface LabelProps extends ComponentProps, React.LabelHTMLAttributes<HT
 
 /**
  * Names of the shorthand properties in LabelProps
- * {@docCategory Label}
  */
 export type LabelShorthandProps = 'required';
 
 /**
  * Names of LabelProps that have a default value in useLabel
- * {@docCategory Label}
  */
 export type LabelDefaultedProps = never;
 
 /**
  * State used in rendering Label
- * {@docCategory Label}
  */
 export interface LabelState extends ComponentState<LabelProps, LabelShorthandProps, LabelDefaultedProps> {
   /**

--- a/packages/react-label/src/components/Label/Label.tsx
+++ b/packages/react-label/src/components/Label/Label.tsx
@@ -6,7 +6,6 @@ import type { LabelProps } from './Label.types';
 
 /**
  * A label component provides a title or name to a component.
- * {@docCategory Label}
  */
 export const Label = React.forwardRef<HTMLElement, LabelProps>((props, ref) => {
   const state = useLabel(props, ref);

--- a/packages/react-label/src/components/Label/Label.types.ts
+++ b/packages/react-label/src/components/Label/Label.types.ts
@@ -8,7 +8,6 @@ import type {
 
 /**
  * Label Props
- * {@docCategory Label}
  */
 export interface LabelProps extends ComponentPropsCompat, React.LabelHTMLAttributes<HTMLLabelElement> {
   /**
@@ -39,19 +38,16 @@ export interface LabelProps extends ComponentPropsCompat, React.LabelHTMLAttribu
 
 /**
  * Names of the shorthand properties in LabelProps
- * {@docCategory Label}
  */
 export type LabelShorthandProps = 'required';
 
 /**
  * Names of LabelProps that have a default value in useLabel
- * {@docCategory Label}
  */
 export type LabelDefaultedProps = 'size';
 
 /**
  * State used in rendering Label
- * {@docCategory Label}
  */
 export interface LabelState extends ComponentStateCompat<LabelProps, LabelShorthandProps, LabelDefaultedProps> {
   /**

--- a/packages/react-label/src/components/Label/renderLabel.tsx
+++ b/packages/react-label/src/components/Label/renderLabel.tsx
@@ -5,7 +5,6 @@ import type { LabelState } from './Label.types';
 
 /**
  * Render the final JSX of Label
- * {@docCategory Label}
  */
 export const renderLabel = (state: LabelState) => {
   const { slots, slotProps } = getSlotsCompat(state, labelShorthandProps);

--- a/packages/react-label/src/components/Label/useLabel.tsx
+++ b/packages/react-label/src/components/Label/useLabel.tsx
@@ -19,8 +19,6 @@ const mergeProps = makeMergeProps<LabelState>({ deepMerge: labelShorthandProps }
  * @param props - props from this instance of Label
  * @param ref - reference to root HTMLElement of Label
  * @param defaultProps - (optional) default prop values provided by the implementing type
- *
- * {@docCategory Label}
  */
 export const useLabel = (props: LabelProps, ref: React.Ref<HTMLElement>, defaultProps?: LabelProps): LabelState => {
   const state = mergeProps(

--- a/packages/react-menu/src/components/Menu/Menu.tsx
+++ b/packages/react-menu/src/components/Menu/Menu.tsx
@@ -6,7 +6,6 @@ import type { MenuProps } from './Menu.types';
 
 /**
  * Wrapper component that manages state for a popup MenuList and a MenuTrigger
- * {@docCategory Menu }
  */
 export const Menu: React.FC<MenuProps> = props => {
   const state = useMenu(props);

--- a/packages/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-menu/src/components/Menu/Menu.types.ts
@@ -52,7 +52,6 @@ export type MenuSlots = {};
 
 /**
  * Extends and drills down Menulist props to simplify API
- * {@docCategory Menu }
  */
 export interface MenuProps extends Partial<MenuCommons>, ComponentProps<MenuSlots> {
   /**
@@ -67,9 +66,6 @@ export interface MenuProps extends Partial<MenuCommons>, ComponentProps<MenuSlot
   positioning?: PositioningShorthand;
 }
 
-/**
- * {@docCategory Menu }
- */
 export interface MenuState extends MenuCommons, ComponentState<MenuSlots> {
   /**
    * Callback to open/close the popup

--- a/packages/react-menu/src/components/Menu/renderMenu.tsx
+++ b/packages/react-menu/src/components/Menu/renderMenu.tsx
@@ -4,7 +4,6 @@ import type { MenuContextValues, MenuState } from './Menu.types';
 
 /**
  * Render the final JSX of Menu
- * {@docCategory Menu }
  */
 export const renderMenu = (state: MenuState, contextValues: MenuContextValues) => {
   return (

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -17,8 +17,6 @@ import type { MenuOpenChangeData, MenuOpenEvents, MenuProps, MenuState } from '.
  * before being passed to renderMenu.
  *
  * @param props - props from this instance of Menu
- *
- * {@docCategory Menu }
  */
 export const useMenu = (props: MenuProps): MenuState => {
   const triggerId = useId('menu');

--- a/packages/react-menu/src/components/MenuDivider/MenuDivider.tsx
+++ b/packages/react-menu/src/components/MenuDivider/MenuDivider.tsx
@@ -6,7 +6,6 @@ import type { MenuDividerProps } from './MenuDivider.types';
 
 /**
  * Define a styled MenuDivider, using the `useMenuDivider` hook.
- * {@docCategory MenuDivider }
  */
 export const MenuDivider = React.forwardRef<HTMLDivElement, MenuDividerProps>((props, ref) => {
   const state = useMenuDivider(props, ref);

--- a/packages/react-menu/src/components/MenuDivider/MenuDivider.types.ts
+++ b/packages/react-menu/src/components/MenuDivider/MenuDivider.types.ts
@@ -4,12 +4,6 @@ export type MenuDividerSlots = {
   root: IntrinsicShorthandProps<'div'>;
 };
 
-/**
- * {@docCategory MenuDivider}
- */
 export interface MenuDividerProps extends ComponentProps<MenuDividerSlots> {}
 
-/**
- * {@docCategory MenuDivider}
- */
 export interface MenuDividerState extends ComponentState<MenuDividerSlots> {}

--- a/packages/react-menu/src/components/MenuGroup/MenuGroup.tsx
+++ b/packages/react-menu/src/components/MenuGroup/MenuGroup.tsx
@@ -6,7 +6,6 @@ import type { MenuGroupProps } from './MenuGroup.types';
 
 /**
  * Define a styled MenuGroup, using the `useMenuGroup` hook.
- * {@docCategory MenuGroup }
  */
 export const MenuGroup = React.forwardRef<HTMLDivElement, MenuGroupProps>((props, ref) => {
   const state = useMenuGroup(props, ref);

--- a/packages/react-menu/src/components/MenuGroup/MenuGroup.types.ts
+++ b/packages/react-menu/src/components/MenuGroup/MenuGroup.types.ts
@@ -5,14 +5,8 @@ export type MenuGroupSlots = {
   root: IntrinsicShorthandProps<'div'>;
 };
 
-/**
- * {@docCategory MenuGroup}
- */
 export interface MenuGroupProps extends ComponentProps<MenuGroupSlots> {}
 
-/**
- * {@docCategory MenuGroup}
- */
 export interface MenuGroupState extends ComponentState<MenuGroupSlots> {
   /**
    * id applied to the DOM element of `MenuGroupHeader`

--- a/packages/react-menu/src/components/MenuGroupHeader/MenuGroupHeader.tsx
+++ b/packages/react-menu/src/components/MenuGroupHeader/MenuGroupHeader.tsx
@@ -6,7 +6,6 @@ import type { MenuGroupHeaderProps } from './MenuGroupHeader.types';
 
 /**
  * Define a styled MenuGroupHeader, using the `useMenuGroupHeader` hook.
- * {@docCategory MenuGroupHeader }
  */
 export const MenuGroupHeader = React.forwardRef<HTMLDivElement, MenuGroupHeaderProps>((props, ref) => {
   const state = useMenuGroupHeader(props, ref);

--- a/packages/react-menu/src/components/MenuGroupHeader/MenuGroupHeader.types.ts
+++ b/packages/react-menu/src/components/MenuGroupHeader/MenuGroupHeader.types.ts
@@ -4,12 +4,6 @@ export type MenuGroupHeaderSlots = {
   root: IntrinsicShorthandProps<'div'>;
 };
 
-/**
- * {@docCategory MenuGroupHeader}
- */
 export interface MenuGroupHeaderProps extends ComponentProps<MenuGroupHeaderSlots> {}
 
-/**
- * {@docCategory MenuGroupHeader}
- */
 export interface MenuGroupHeaderState extends ComponentState<MenuGroupHeaderSlots> {}

--- a/packages/react-menu/src/components/MenuItem/MenuItem.tsx
+++ b/packages/react-menu/src/components/MenuItem/MenuItem.tsx
@@ -8,7 +8,6 @@ import type { MenuItemCheckboxState } from '../MenuItemCheckbox/index';
 
 /**
  * Define a styled MenuItem, using the `useMenuItem` and `useMenuItemStyles` hook.
- * {@docCategory MenuItem}
  */
 export const MenuItem = React.forwardRef<HTMLElement, MenuItemProps>((props, ref) => {
   const state = useMenuItem(props, ref);

--- a/packages/react-menu/src/components/MenuItemCheckbox/MenuItemCheckbox.tsx
+++ b/packages/react-menu/src/components/MenuItemCheckbox/MenuItemCheckbox.tsx
@@ -6,7 +6,6 @@ import type { MenuItemCheckboxProps } from './MenuItemCheckbox.types';
 
 /**
  * Define a styled MenuItemCheckbox, using the `useMenuItemCheckbox` hook.
- * {@docCategory MenuItemCheckbox}
  */
 export const MenuItemCheckbox = React.forwardRef<HTMLElement, MenuItemCheckboxProps>((props, ref) => {
   const state = useMenuItemCheckbox(props, ref);

--- a/packages/react-menu/src/components/MenuItemCheckbox/MenuItemCheckbox.types.ts
+++ b/packages/react-menu/src/components/MenuItemCheckbox/MenuItemCheckbox.types.ts
@@ -1,13 +1,6 @@
 import type { MenuItemSelectableProps, MenuItemSelectableState } from '../../selectable/index';
 import type { MenuItemProps, MenuItemState } from '../MenuItem/MenuItem.types';
 
-/**
- * {@docCategory MenuItemCheckbox}
- */
-
 export interface MenuItemCheckboxProps extends MenuItemProps, MenuItemSelectableProps {}
 
-/**
- * {@docCategory MenuItemCheckbox}
- */
 export interface MenuItemCheckboxState extends MenuItemState, MenuItemSelectableState {}

--- a/packages/react-menu/src/components/MenuItemRadio/MenuItemRadio.tsx
+++ b/packages/react-menu/src/components/MenuItemRadio/MenuItemRadio.tsx
@@ -6,7 +6,6 @@ import type { MenuItemRadioProps } from './MenuItemRadio.types';
 
 /**
  * Define a styled MenuItemRadio, using the `useMenuItemRadio` hook.
- * {@docCategory MenuItemRadio}
  */
 export const MenuItemRadio = React.forwardRef<HTMLElement, MenuItemRadioProps>((props, ref) => {
   const state = useMenuItemRadio(props, ref);

--- a/packages/react-menu/src/components/MenuItemRadio/MenuItemRadio.types.ts
+++ b/packages/react-menu/src/components/MenuItemRadio/MenuItemRadio.types.ts
@@ -1,12 +1,6 @@
 import type { MenuItemSelectableProps, MenuItemSelectableState } from '../../selectable/index';
 import type { MenuItemProps, MenuItemState } from '../MenuItem/MenuItem.types';
 
-/**
- * {@docCategory MenuItemRadio}
- */
 export interface MenuItemRadioProps extends MenuItemProps, MenuItemSelectableProps {}
 
-/**
- * {@docCategory MenuItemRadio}
- */
 export interface MenuItemRadioState extends MenuItemState, MenuItemSelectableState {}

--- a/packages/react-menu/src/components/MenuList/MenuList.tsx
+++ b/packages/react-menu/src/components/MenuList/MenuList.tsx
@@ -6,7 +6,6 @@ import type { MenuListProps } from './MenuList.types';
 
 /**
  * Define a styled MenuList, using the `useMenuList` hook.
- * {@docCategory MenuList}
  */
 export const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>((props, ref) => {
   const state = useMenuList(props, ref);

--- a/packages/react-menu/src/components/MenuPopover/useMenuPopoverStyles.ts
+++ b/packages/react-menu/src/components/MenuPopover/useMenuPopoverStyles.ts
@@ -16,7 +16,6 @@ const useStyles = makeStyles({
 
 /**
  * Apply styling to the Menu slots based on the state
- * {@docCategory Menu }
  */
 export const useMenuPopoverStyles = (state: MenuPopoverState): MenuPopoverState => {
   const styles = useStyles();

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.tsx
@@ -6,7 +6,6 @@ import type { MenuTriggerProps } from './MenuTrigger.types';
 /**
  * Wraps a trigger element as an only child
  * and adds the necessary event handling to open a popup menu
- * {@docCategory MenuTrigger }
  */
 export const MenuTrigger: React.FC<MenuTriggerProps> = props => {
   const state = useMenuTrigger(props);

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
@@ -1,8 +1,5 @@
 import * as React from 'react';
 
-/**
- * {@docCategory MenuTrigger }
- */
 export interface MenuTriggerProps {
   /**
    * Explicitly require single child or render function
@@ -30,7 +27,4 @@ export interface MenuTriggerChildProps
   ref?: React.Ref<never>;
 }
 
-/**
- * {@docCategory MenuTrigger }
- */
 export interface MenuTriggerState extends MenuTriggerProps {}

--- a/packages/react-menu/src/components/MenuTrigger/renderMenuTrigger.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/renderMenuTrigger.tsx
@@ -6,7 +6,6 @@ import type { MenuTriggerState } from './MenuTrigger.types';
  * Render the final JSX of MenuTrigger
  *
  * Only renders children
- * {@docCategory MenuTrigger }
  */
 export const renderMenuTrigger = (state: MenuTriggerState) => {
   return <MenuTriggerContextProvider value={true}>{state.children}</MenuTriggerContextProvider>;

--- a/packages/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
@@ -6,8 +6,6 @@ import type { MenuTriggerProps, MenuTriggerState } from './MenuTrigger.types';
  * Clones the only child component and adds necessary event handling behaviours to open a popup menu
  *
  * @param props - props from this instance of MenuTrigger
- *
- * {@docCategory MenuTrigger }
  */
 export const useMenuTrigger = (props: MenuTriggerProps): MenuTriggerState => {
   const state = { ...props };

--- a/packages/react-shared-contexts/src/MenuContext/types.ts
+++ b/packages/react-shared-contexts/src/MenuContext/types.ts
@@ -1,8 +1,5 @@
 import * as React from 'react';
 
-/**
- * {@docCategory MenuContext}
- */
 export type MinimalMenuProps = {
   hidden?: boolean;
   onDismiss?: () => void;

--- a/packages/react-shared-contexts/src/TooltipContext/TooltipContext.ts
+++ b/packages/react-shared-contexts/src/TooltipContext/TooltipContext.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 /**
  * The context provided by TooltipProvider
- * {@docCategory Tooltip}
  */
 export type TooltipContextType = {
   /**
@@ -16,6 +15,5 @@ export type TooltipContextType = {
 
 /**
  * Context shared by all of the tooltips in the app
- * {@docCategory Tooltip}
  */
 export const TooltipContext = React.createContext<TooltipContextType>({});

--- a/packages/react-tabs/src/components/Tabs/TabItem.types.ts
+++ b/packages/react-tabs/src/components/Tabs/TabItem.types.ts
@@ -3,9 +3,6 @@ import type { IKeytipProps } from '@fluentui/react';
 import type { IButtonProps } from '@fluentui/react/lib/Button';
 import type { IRefObject, IRenderFunction } from '@fluentui/utilities';
 
-/**
- * {@docCategory Tabs}
- */
 export interface TabItemProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Gets the component ref.

--- a/packages/react-tabs/src/components/Tabs/Tabs.types.ts
+++ b/packages/react-tabs/src/components/Tabs/Tabs.types.ts
@@ -3,9 +3,6 @@ import { TabItem } from './TabItem';
 import type { IStyle, ITheme } from '@fluentui/style-utilities';
 import type { IStyleFunctionOrObject } from '@fluentui/utilities';
 
-/**
- * {@docCategory Tabs}
- */
 export interface TabsImperativeHandle {
   /**
    * Sets focus to the first tab.
@@ -13,9 +10,6 @@ export interface TabsImperativeHandle {
   focus(): void;
 }
 
-/**
- * {@docCategory Tabs}
- */
 export interface TabsProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the TabsImperativeHandle interface. Use this instead of ref for accessing
@@ -90,18 +84,12 @@ export interface TabsProps extends React.HTMLAttributes<HTMLDivElement>, React.R
   getTabId?: (itemKey: string, index: number) => string;
 }
 
-/**
- * {@docCategory Tabs}
- */
 export type TabsStyleProps = Required<Pick<TabsProps, 'theme'>> &
   Pick<TabsProps, 'className'> & {
     tabSize?: TabSizeType;
     tabFormat?: TabFormatType;
   };
 
-/**
- * {@docCategory Tabs}
- */
 export interface TabsStyles {
   /**
    * Style for the root element.
@@ -119,13 +107,11 @@ export interface TabsStyles {
 }
 
 /**
- * {@docCategory Tabs}
  * Display mode for the tabs
  */
 export type TabFormatType = 'links' | 'tabs';
 
 /**
- * {@docCategory Tabs}
  * Size of the tabs
  */
 export type TabSizeType = 'normal' | 'large';

--- a/packages/react-tooltip/Spec.md
+++ b/packages/react-tooltip/Spec.md
@@ -202,8 +202,6 @@ This imperative interface is implemented by `TooltipProvider`, and used by `Tool
  *
  * This imperative interface is used by TooltipTrigger to show and hide its tooltip
  * based on events on the trigger element.
- *
- * {@docCategory TooltipProvider}
  */
 export interface TooltipManager {
   showTooltip: (args: ShowTooltipArgs, reason: TooltipTriggerReason) => void;
@@ -217,8 +215,6 @@ export interface TooltipManager {
 
 /**
  * The arguments to TooltipManager.showTooltip
- *
- * {@docCategory TooltipProvider}
  */
 export type ShowTooltipArgs = {
   tooltip: TooltipImperativeHandle;
@@ -231,8 +227,6 @@ export type ShowTooltipArgs = {
 
 /**
  * The source of the event that caused the tooltip to be shown or hidden
- *
- * {@docCategory TooltipProvider}
  */
 export type TooltipTriggerReason = 'focus' | 'pointer';
 ```
@@ -263,9 +257,6 @@ export const useTooltipContext = () => React.useContext(internal__TooltipContext
 `TooltipTrigger` allows tooltips to be added to any focusable component that doesn't have its own `tooltip` prop. It supports a single JSX child, and works by cloning the JSX element in order to add the same `onPointerDown`, etc. listeners that are added by `useTooltipSlot`.
 
 ```ts
-/**
- * {@docCategory TooltipTrigger}
- */
 export interface TooltipTriggerProps
   extends Pick<TooltipProps, 'position' | 'align' | 'subtle' | 'noArrow' | 'offset'> {
   /**
@@ -328,19 +319,14 @@ export type TooltipTriggerChildProps = Pick<
 
 /**
  * Names of the shorthand properties in TooltipTriggerProps
- * {@docCategory TooltipTrigger}
  */
 export type TooltipTriggerShorthandProps = typeof tooltipTriggerShorthandProps[number];
 
 /**
  * Names of TooltipTriggerProps that have a default value in useTooltipTrigger
- * {@docCategory TooltipTrigger}
  */
 export type TooltipTriggerDefaultedProps = 'showDelay' | 'hideDelay';
 
-/**
- * {@docCategory TooltipTrigger}
- */
 export type TooltipTriggerState = RequiredProps<
   ResolvedShorthandProps<
     TooltipTriggerProps & {
@@ -370,19 +356,14 @@ export { TooltipProps };
 
 /**
  * Names of the shorthand properties in TooltipProps
- * {@docCategory Tooltip}
  */
 export type TooltipShorthandProps = 'arrow';
 
 /**
  * Names of TooltipProps that have a default value in useTooltip
- * {@docCategory Tooltip}
  */
 export type TooltipDefaultedProps = 'position' | 'align' | 'offset';
 
-/**
- * {@docCategory Tooltip}
- */
 export type TooltipState = ComponentState<
   React.Ref<HTMLElement>,
   TooltipProps & {

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.tsx
@@ -6,8 +6,6 @@ import type { TooltipProps } from './Tooltip.types';
 
 /**
  * A tooltip provides light weight contextual information on top of its target element.
- *
- * {@docCategory Tooltip}
  */
 export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>((props, ref) => {
   const state = useTooltip(props, ref);

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
@@ -4,7 +4,6 @@ import type { ComponentPropsCompat, ComponentStateCompat, ShorthandPropsCompat }
 
 /**
  * Properties for the Tooltip component
- * {@docCategory Tooltip}
  */
 export interface TooltipProps extends ComponentPropsCompat, React.HTMLAttributes<HTMLElement> {
   /**
@@ -88,7 +87,6 @@ export interface TooltipProps extends ComponentPropsCompat, React.HTMLAttributes
 
 /**
  * The properties that are added to the trigger of the Tooltip
- * {@docCategory Tooltip}
  */
 export type TooltipTriggerProps = {
   ref?: React.Ref<never>;
@@ -106,13 +104,11 @@ export interface OnVisibleChangeData {
 
 /**
  * Names of the shorthand properties in TooltipProps
- * {@docCategory Tooltip}
  */
 export type TooltipShorthandProps = 'content';
 
 /**
  * Names of TooltipProps that have a default value in useTooltip
- * {@docCategory Tooltip}
  */
 export type TooltipDefaultedProps = 'showDelay' | 'hideDelay' | 'content' | 'triggerAriaAttribute';
 

--- a/packages/react-tooltip/src/components/Tooltip/renderTooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/renderTooltip.tsx
@@ -6,7 +6,6 @@ import type { TooltipState } from './Tooltip.types';
 
 /**
  * Render the final JSX of Tooltip
- * {@docCategory Tooltip}
  */
 export const renderTooltip = (state: TooltipState) => {
   const { slots, slotProps } = getSlotsCompat(state, tooltipShorthandProps);

--- a/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -16,7 +16,6 @@ import type { TooltipProps, TooltipShorthandProps, TooltipState, TooltipTriggerP
 
 /**
  * Names of the shorthand properties in TooltipProps
- * {@docCategory Tooltip}
  */
 export const tooltipShorthandProps: TooltipShorthandProps[] = ['content'];
 
@@ -35,8 +34,6 @@ const arrowHeight = 6; // Update the arrow's width/height in useTooltipStyles.ts
  * @param props - props from this instance of Tooltip
  * @param ref - reference to root HTMLElement of Tooltip
  * @param defaultProps - (optional) default prop values provided by the implementing type
- *
- * {@docCategory Tooltip}
  */
 export const useTooltip = (
   props: TooltipProps,

--- a/packages/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
@@ -62,7 +62,6 @@ const useStyles = makeStyles({
 
 /**
  * Apply styling to the Tooltip slots based on the state
- * {@docCategory Tooltip}
  */
 export const useTooltipStyles = (state: TooltipState): TooltipState => {
   const styles = useStyles();


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Remove `{@docCategory}` tags since we're probably not using these in converged for the most part. (split out from #19458)
