### PR TITLE
Rename "check for changed files" to "check for modified files"

### DIFF
--- a/.devops/templates/cleanup.yml
+++ b/.devops/templates/cleanup.yml
@@ -1,13 +1,13 @@
 parameters:
-  - name: checkForChangedFiles
+  - name: checkForModifiedFiles
     type: boolean
     default: true
 
 steps:
   - script: |
-      npm run check-for-changed-files
-    condition: ${{ parameters.checkForChangedFiles }}
-    displayName: check for changed files
+      npm run check-for-modified-files
+    condition: ${{ parameters.checkForModifiedFiles }}
+    displayName: check for modified files
 
   # In theory the "workspace: clean: all" setting should handle this, but it doesn't always seem to work.
   # ReallyClean is a custom task from our internal UI Fabric azure-devops-tasks repo which attempts to

--- a/azure-pipelines.hotfix.yml
+++ b/azure-pipelines.hotfix.yml
@@ -52,4 +52,4 @@ steps:
 
   - template: .devops/templates/cleanup.yml
     parameters:
-      checkForChangedFiles: false
+      checkForModifiedFiles: false

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -202,4 +202,4 @@ steps:
 
   - template: .devops/templates/cleanup.yml
     parameters:
-      checkForChangedFiles: false
+      checkForModifiedFiles: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
 
       - script: |
           yarn checkchange
-        displayName: check change
+        displayName: verify change files
 
       - script: |
           yarn nx workspace-lint

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bundlesize": "cd scripts && yarn bundlesize",
     "bundlesizecollect": "node ./scripts/bundle-size-collect",
     "change": "beachball change --scope \"!packages/fluentui/*\"",
-    "check-for-changed-files": "cd scripts && just-scripts check-for-modified-files",
+    "check-for-modified-files": "cd scripts && just-scripts check-for-modified-files",
     "checkchange": "beachball check  --scope \"!packages/fluentui/*\" --changehint \"Run 'yarn change' to generate a change file\"",
     "clean": "lage clean --verbose",
     "code-style": "lage code-style --verbose",


### PR DESCRIPTION
Rename the "check for changed files" step to "check for **modified** files" to reduce confusion with the unrelated "check change" (beachball change files) step.

Also rename "check change" to "verify change files" to be a bit clearer (open to better suggestions).