### PR TITLE
Theme: Updating value of borderRadius global token

### DIFF
--- a/change/@fluentui-react-theme-054eefde-31dc-4278-a07f-c512803787b2.json
+++ b/change/@fluentui-react-theme-054eefde-31dc-4278-a07f-c512803787b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Theme: Updating value of borderRadius global token.",
+  "packageName": "@fluentui/react-theme",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-theme/src/global/borderRadius.ts
+++ b/packages/react-theme/src/global/borderRadius.ts
@@ -6,5 +6,5 @@ export const borderRadius: BorderRadius = {
   medium: '4px',
   large: '6px',
   xLarge: '8px',
-  circular: '50%',
+  circular: '10000px',
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR updates the value of the `circular` border radius token in the global section of our theme from `50%` to `10000px` to reflect changes in the design tokens superset.
