### PR TITLE
Add missing `.cache/` dir to `.npmignore` for `migrate-converged-pkg` generator

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -806,7 +806,8 @@ describe('migrate-converged-pkg generator', () => {
       npmIgnoreConfig = getNpmIgnoreConfig(projectConfig);
 
       expect(npmIgnoreConfig).toMatchInlineSnapshot(`
-        ".storybook/
+        ".cache/
+        .storybook/
         .vscode/
         bundle-size/
         config/

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -205,6 +205,7 @@ const templates = {
   },
   npmIgnoreConfig:
     stripIndents`
+    .cache/
     .storybook/
     .vscode/
     bundle-size/


### PR DESCRIPTION
#### Pull request checklist

~- Addresses an existing issue: Fixes #0000~
~- Include a change request file using `$ yarn change`~

#### Description of changes

Add missing dir to our .npmignore when running the `migrate-converged-pkg` generator as described here #19066 and as applied here #19441.