### PR TITLE
Add react-components template to codesandbox CI

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "build:codesandbox",
-  "packages": ["packages/react"],
-  "sandboxes": ["x5u3t"],
+  "packages": ["packages/react", "packages/react-components"],
+  "sandboxes": ["x5u3t", "spnyu"],
   "node": "12"
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "scripts": {
     "a11ytest": "cd apps && cd a11y-tests && yarn test",
     "build": "lage build --verbose",
-    "build:codesandbox": "yarn build --to @fluentui/react --min",
+    "build:codesandbox": "yarn build --to @fluentui/react --to @fluentui/react-components --min",
     "build:fluentui:docs": "gulp build:docs",
-    "build:min": "yarn build --to @fluentui/react --to @fluentui/react-northstar --min",
+    "build:min": "yarn build --to @fluentui/react --to @fluentui/react-northstar --to @fluentui/react-components --min",
     "buildci": "yarn prelint && lage build test lint type-check --verbose",
     "builddemo": "yarn build --to public-docsite-resources",
     "buildto": "lage build --verbose --to",

--- a/scripts/beachball/index.ts
+++ b/scripts/beachball/index.ts
@@ -1,11 +1,11 @@
 import { BeachballConfig } from 'beachball';
-import { getAllPackageInfo } from '../monorepo/index';
+import { getAllPackageInfo, isConvergedPackage } from '../monorepo/index';
 import { renderHeader, renderEntry } from './customRenderers';
 
 const allPackageInfo = getAllPackageInfo();
 const fluentConvergedPackagePaths = Object.values(allPackageInfo)
   .map(packageInfo => {
-    if (packageInfo.packageJson.version.startsWith('9.') && !packageInfo.packageJson.private) {
+    if (isConvergedPackage(packageInfo.packageJson) && !packageInfo.packageJson.private) {
       return packageInfo.packagePath;
     }
 

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -21,6 +21,7 @@ import { postprocessTask } from './tasks/postprocess';
 import { postprocessAmdTask } from './tasks/postprocess-amd';
 import { postprocessCommonjsTask } from './tasks/postprocess-commonjs';
 import { startStorybookTask, buildStorybookTask } from './tasks/storybook';
+import { isConvergedPackage } from './monorepo/index';
 
 interface BasicPresetArgs extends Arguments {
   babel: boolean;
@@ -93,7 +94,8 @@ export function preset() {
     return args.commonjs
       ? series('ts:commonjs-only')
       : parallel(
-          condition('ts:commonjs', () => !args.min),
+          // Converged packages must always build commonjs because of babel-make-styles transforms
+          condition('ts:commonjs', () => !args.min || isConvergedPackage()),
           'ts:esm',
           condition('ts:amd', () => !!args.production),
         );

--- a/scripts/monorepo/index.d.ts
+++ b/scripts/monorepo/index.d.ts
@@ -29,3 +29,11 @@ export declare function findGitRoot(cwd?: string): string;
 export declare function findRepoDeps(cwd?: string): PackageInfo[];
 
 export declare function getAllPackageInfo(): AllPackageInfo;
+
+/**
+ * Determines whether a package is converged, based on its version.
+ * @param packagePathOrJson optional different package path to run in OR previously-read package.json
+ * (defaults to reading package.json from `process.cwd()`)
+ * @returns true if it's a converged package (version >= 9)
+ */
+export declare function isConvergedPackage(packagePathOrJson?: string | PackageJson): boolean;

--- a/scripts/monorepo/index.js
+++ b/scripts/monorepo/index.js
@@ -3,4 +3,5 @@ module.exports = {
   findGitRoot: require('./findGitRoot'),
   findRepoDeps: require('./findRepoDeps'),
   getAllPackageInfo: require('./getAllPackageInfo'),
+  isConvergedPackage: require('./isConvergedPackage'),
 };

--- a/scripts/monorepo/isConvergedPackage.js
+++ b/scripts/monorepo/isConvergedPackage.js
@@ -1,0 +1,19 @@
+// @ts-check
+const semver = require('semver');
+const { readConfig } = require('../read-config');
+
+/**
+ * Determines whether a package is converged, based on its version.
+ * @param {string} [packagePathOrJson] optional different package path to run in OR previously-read package.json
+ * (defaults to reading package.json from `process.cwd()`)
+ * @returns {boolean} true if it's a converged package (version >= 9)
+ */
+function isConvergedPackage(packagePathOrJson) {
+  const packageJson =
+    !packagePathOrJson || typeof packagePathOrJson === 'string'
+      ? readConfig('package.json', packagePathOrJson)
+      : packagePathOrJson;
+  return !!packageJson && semver.major(packageJson.version) >= 9;
+}
+
+module.exports = isConvergedPackage;


### PR DESCRIPTION
Start building a codesandbox template for react-components (https://codesandbox.io/s/fluentui-react-components-9-starter-spnyu) in CI.

Minor hiccup is that apparently converged packages always need to build commonjs due to babel-make-styles, and previously that wasn't included in the `--min` build (which `build:codesandbox` uses). So I updated `scripts/just.config.ts` to handle this.

Partial fix of #19863