### PR TITLE
Support override className in LayoutGroup

### DIFF
--- a/change/@fluentui-react-experiments-e6a050a9-2965-443d-9084-dd37f119c281.json
+++ b/change/@fluentui-react-experiments-e6a050a9-2965-443d-9084-dd37f119c281.json
@@ -1,0 +1,10 @@
+{
+  "type": "patch",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "@fluentui/react-experiments",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/LayoutGroup/LayoutGroup.tsx
+++ b/packages/react-experiments/src/components/LayoutGroup/LayoutGroup.tsx
@@ -49,11 +49,15 @@ export class LayoutGroup extends React.Component<ILayoutGroupProps, {}> {
     return (
       <div
         {...divProps}
-        className={mergeStyles('ms-LayoutGroup', {
-          display: 'flex',
-          flexDirection: direction === 'horizontal' ? 'row' : 'column',
-          justifyContent: this._getJustify(justify),
-        } as IRawStyle)}
+        className={mergeStyles(
+          'ms-LayoutGroup',
+          {
+            display: 'flex',
+            flexDirection: direction === 'horizontal' ? 'row' : 'column',
+            justifyContent: this._getJustify(justify),
+          } as IRawStyle,
+          divProps.className,
+        )}
       >
         {group}
       </div>


### PR DESCRIPTION
#### Description of changes

Updated `LayoutGroup` to respect the `className` prop, appending the provided value after the mixins from the defined behavior.

#### Focus areas to test

`LayoutGroup`.
