### PR TITLE
React utilities interfaces to types

### DIFF
--- a/change/@fluentui-react-utilities-34d09e7a-440e-4cb2-a8ca-5e37f72cfb25.json
+++ b/change/@fluentui-react-utilities-34d09e7a-440e-4cb2-a8ca-5e37f72cfb25.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Moved from interfaces to types per RFC",
+  "packageName": "@fluentui/react-utilities",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -28,10 +28,9 @@ export const baseElementEvents: Record<string, number>;
 export const baseElementProperties: Record<string, number>;
 
 // @public (undocumented)
-export interface BaseSlotsCompat {
-    // (undocumented)
+export type BaseSlotsCompat = {
     root: React_2.ElementType;
-}
+};
 
 // @public
 export const buttonProperties: Record<string, number>;
@@ -54,14 +53,11 @@ export type ComponentProps<Shorthands extends ObjectShorthandPropsRecord, Primar
 }, Primary> & PropsWithoutRef<Shorthands[Primary]>;
 
 // @public (undocumented)
-export interface ComponentPropsCompat {
-    // (undocumented)
+export type ComponentPropsCompat = {
     as?: React_2.ElementType;
-    // (undocumented)
-    children?: React_2.ReactNode;
-    // (undocumented)
     className?: string;
-}
+    children?: React_2.ReactNode;
+};
 
 // @public (undocumented)
 export type ComponentState<Shorthands extends ObjectShorthandPropsRecord> = {
@@ -211,12 +207,10 @@ export type ResolvedShorthandPropsCompat<T, K extends keyof T> = Omit<T, K> & {
 export function resolveShorthand<Props extends DefaultObjectShorthandProps, Required extends boolean = false>(value: ShorthandProps<Props>, options?: ResolveShorthandOptions<Props, Required>): Required extends false ? Props | undefined : Props;
 
 // @public (undocumented)
-export interface ResolveShorthandOptions<Props extends Record<string, any>, Required extends boolean = false> {
-    // (undocumented)
-    defaultProps?: Props;
-    // (undocumented)
+export type ResolveShorthandOptions<Props extends Record<string, any>, Required extends boolean = false> = {
     required?: Required;
-}
+    defaultProps?: Props;
+};
 
 // @public
 export const resolveShorthandProps: <TProps, TShorthandPropNames extends keyof TProps>(props: TProps, shorthandPropNames: readonly TShorthandPropNames[]) => ResolvedShorthandPropsCompat<TProps, TShorthandPropNames>;
@@ -259,10 +253,9 @@ export const SSRContext: React_2.Context<SSRContextValue>;
 // Warning: (ae-internal-missing-underscore) The name "SSRContextValue" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal
-export interface SSRContextValue {
-    // (undocumented)
+export type SSRContextValue = {
     current: number;
-}
+};
 
 // @public
 export const SSRProvider: React_2.FC;
@@ -289,11 +282,11 @@ export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) e
 export function useBoolean(initialState: boolean): [boolean, UseBooleanCallbacks];
 
 // @public
-export interface UseBooleanCallbacks {
-    setFalse: () => void;
+export type UseBooleanCallbacks = {
     setTrue: () => void;
+    setFalse: () => void;
     toggle: () => void;
-}
+};
 
 // @public
 export function useConst<T>(initialValue: T | (() => T)): T;
@@ -341,13 +334,13 @@ export function useMergedRefs<T>(...refs: (React_2.Ref<T> | undefined)[]): RefOb
 export const useMount: (callback: () => void) => void;
 
 // @public (undocumented)
-export interface UseOnClickOrScrollOutsideOptions {
-    callback: (ev: MouseEvent | TouchEvent) => void;
-    contains?(parent: HTMLElement | null, child: HTMLElement): boolean;
-    disabled?: boolean;
+export type UseOnClickOrScrollOutsideOptions = {
     element: Document | undefined;
     refs: React_2.MutableRefObject<HTMLElement | undefined | null>[];
-}
+    contains?(parent: HTMLElement | null, child: HTMLElement): boolean;
+    disabled?: boolean;
+    callback: (ev: MouseEvent | TouchEvent) => void;
+};
 
 // @public
 export const useOnClickOutside: (options: UseOnClickOrScrollOutsideOptions) => void;

--- a/packages/react-utilities/src/compose/makeMergeProps.ts
+++ b/packages/react-utilities/src/compose/makeMergeProps.ts
@@ -12,18 +12,18 @@ type GenericDictionary = Record<string, any>;
  *
  * @internal
  */
-interface Dictionary {
+type Dictionary = {
   [className: string]: boolean;
-}
+};
 
 /**
  * Serializable object.
  *
  * @internal
  */
-interface SerializableObject {
+type SerializableObject = {
   toString?: () => string;
-}
+};
 
 /**
  * css input type.

--- a/packages/react-utilities/src/compose/resolveShorthand.ts
+++ b/packages/react-utilities/src/compose/resolveShorthand.ts
@@ -2,10 +2,10 @@ import { isValidElement } from 'react';
 import type { DefaultObjectShorthandProps, ShorthandProps } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface ResolveShorthandOptions<Props extends Record<string, any>, Required extends boolean = false> {
+export type ResolveShorthandOptions<Props extends Record<string, any>, Required extends boolean = false> = {
   required?: Required;
   defaultProps?: Props;
-}
+};
 
 /**
  * Resolves ShorthandProps into ObjectShorthandProps, to ensure normalization of the signature

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -71,7 +71,7 @@ export type IntrinsicShorthandProps<
 export type IsSingleton<T extends string> = { [K in T]: Exclude<T, K> extends never ? true : false }[T];
 
 /**
- * Helper type for inferring the type of the as prop from a Props interface.
+ * Helper type for inferring the type of the as prop from a Props type.
  *
  * For example:
  * ```
@@ -115,11 +115,11 @@ export type ComponentState<Shorthands extends ObjectShorthandPropsRecord> = {
 
 /////////////////////////// COMPAT /////////////////////////////////////////////////////////////////////
 
-export interface ComponentPropsCompat {
+export type ComponentPropsCompat = {
   as?: React.ElementType;
   className?: string;
   children?: React.ReactNode;
-}
+};
 
 // Shorthand types
 
@@ -142,9 +142,9 @@ export type ObjectShorthandPropsCompat<TProps extends ComponentPropsCompat = {}>
     children?: TProps['children'] | ShorthandRenderFunctionCompat<TProps>;
   };
 
-export interface BaseSlotsCompat {
+export type BaseSlotsCompat = {
   root: React.ElementType;
-}
+};
 
 export type SlotPropsCompat<
   TSlots extends BaseSlotsCompat,

--- a/packages/react-utilities/src/hooks/useBoolean.ts
+++ b/packages/react-utilities/src/hooks/useBoolean.ts
@@ -2,14 +2,14 @@ import * as React from 'react';
 import { useConst } from './useConst';
 
 /** Updater callbacks returned by `useBoolean`. */
-export interface UseBooleanCallbacks {
+export type UseBooleanCallbacks = {
   /** Set the value to true. Always has the same identity. */
   setTrue: () => void;
   /** Set the value to false. Always has the same identity. */
   setFalse: () => void;
   /** Toggle the value. Always has the same identity. */
   toggle: () => void;
-}
+};
 
 /**
  * Hook to store a value and generate callbacks for setting the value to true or false.

--- a/packages/react-utilities/src/hooks/useControllableState.test.ts
+++ b/packages/react-utilities/src/hooks/useControllableState.test.ts
@@ -1,11 +1,11 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useControllableState } from './useControllableState';
 
-interface RenderProps<T> {
+type RenderProps<T> = {
   state: boolean | undefined;
   defaultState?: boolean;
   initialState: boolean;
-}
+};
 
 describe('useControllableState', () => {
   afterEach(jest.resetAllMocks);

--- a/packages/react-utilities/src/hooks/useOnClickOutside.ts
+++ b/packages/react-utilities/src/hooks/useOnClickOutside.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useEventCallback } from './useEventCallback';
 
-export interface UseOnClickOrScrollOutsideOptions {
+export type UseOnClickOrScrollOutsideOptions = {
   /**
    * The element to listen for the click event
    */
@@ -27,7 +27,7 @@ export interface UseOnClickOrScrollOutsideOptions {
    * Called if the click is outside the element refs
    */
   callback: (ev: MouseEvent | TouchEvent) => void;
-}
+};
 
 /**
  * Utility to perform checks where a click/touch event was made outside a component

--- a/packages/react-utilities/src/ssr/SSRContext.tsx
+++ b/packages/react-utilities/src/ssr/SSRContext.tsx
@@ -7,9 +7,9 @@ import { canUseDOM } from './canUseDOM';
  *
  * @internal
  */
-export interface SSRContextValue {
+export type SSRContextValue = {
   current: number;
-}
+};
 
 /**
  * Default context value to use in case there is no SSRProvider. This is fine for client-only apps.


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #19823
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Updates the definitions in react-utilities to use types instead of interfaces.
Per RFC: https://github.com/microsoft/fluentui/pull/19775

#### Focus areas to test

(optional)
