### PR TITLE
Add `as` prop to allowed props from `getNativeElementProps`

### DIFF
--- a/change/@fluentui-react-label-59bd42ce-de09-4e78-a509-37d30b17f238.json
+++ b/change/@fluentui-react-label-59bd42ce-de09-4e78-a509-37d30b17f238.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update label snapshots",
+  "packageName": "@fluentui/react-label",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-59bd42ce-de09-4e78-a509-37d30b17f238.json
+++ b/change/@fluentui-react-label-59bd42ce-de09-4e78-a509-37d30b17f238.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Update label snapshots",
-  "packageName": "@fluentui/react-label",
-  "email": "andredias@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@fluentui-react-link-7039887a-f2f0-46ef-b40f-9a7291518072.json
+++ b/change/@fluentui-react-link-7039887a-f2f0-46ef-b40f-9a7291518072.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove workaround for as prop with getNativeElementProps",
+  "packageName": "@fluentui/react-link",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-f6bb5423-e14a-42a1-86c9-6eebaf3975d0.json
+++ b/change/@fluentui-react-text-f6bb5423-e14a-42a1-86c9-6eebaf3975d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove workaround for as prop with getNativeElementProps",
+  "packageName": "@fluentui/react-text",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-a2a91420-444b-431c-b389-505dda1173cb.json
+++ b/change/@fluentui-react-utilities-a2a91420-444b-431c-b389-505dda1173cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add as prop to properties allowed with getNativeElementProps",
+  "packageName": "@fluentui/react-utilities",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-link/src/components/Link/useLink.ts
+++ b/packages/react-link/src/components/Link/useLink.ts
@@ -27,11 +27,9 @@ export const useLink = (props: LinkProps, ref: React.Ref<HTMLAnchorElement | HTM
     root: getNativeElementProps(as, {
       ref,
       ...props,
+      as,
     }),
   };
-
-  // TODO: Remove after https://github.com/microsoft/fluentui/issues/19785 is fixed.
-  state.root.as = as;
 
   useLinkState(state);
 

--- a/packages/react-text/src/components/Text/useText.ts
+++ b/packages/react-text/src/components/Text/useText.ts
@@ -32,10 +32,9 @@ export const useText = (props: TextProps, ref: React.Ref<HTMLElement>): TextStat
     root: getNativeElementProps(as, {
       ref,
       ...props,
+      as,
     }),
   };
-  // TODO: Remove after fix to https://github.com/microsoft/fluentui/issues/19785
-  state.root.as = as;
 
   return state;
 };

--- a/packages/react-utilities/src/compose/getSlotsCompat.test.tsx
+++ b/packages/react-utilities/src/compose/getSlotsCompat.test.tsx
@@ -1,0 +1,25 @@
+import { getSlotsCompat } from './getSlotsCompat';
+
+describe('getSlotsCompat', () => {
+  it('does not propagate the `as` prop', () => {
+    const { slots, slotProps } = getSlotsCompat(
+      {
+        as: 'label',
+        className: 'cool-styles',
+        slot: { as: 'h4', className: 'cool-slot-styles', children: 'Cool slot' },
+      },
+      ['slot'],
+    );
+
+    expect(slots.root).toEqual('label');
+    expect(slotProps.root).toEqual({
+      className: 'cool-styles',
+    });
+
+    expect(slots.slot).toEqual('h4');
+    expect(slotProps.slot).toEqual({
+      className: 'cool-slot-styles',
+      children: 'Cool slot',
+    });
+  });
+});

--- a/packages/react-utilities/src/compose/getSlotsCompat.ts
+++ b/packages/react-utilities/src/compose/getSlotsCompat.ts
@@ -28,7 +28,7 @@ export const getSlotsCompat = (state: GenericDictionary, slotNames?: readonly st
   };
 
   const slotProps: GenericDictionary = {
-    root: typeof slots.root === 'string' ? getNativeElementProps(slots.root, state) : omit(state, ['as']),
+    root: typeof slots.root === 'string' ? getNativeElementProps(slots.root, state, ['as']) : omit(state, ['as']),
   };
 
   if (slotNames) {
@@ -47,7 +47,7 @@ export const getSlotsCompat = (state: GenericDictionary, slotNames?: readonly st
         slots[name] = React.Fragment;
       } else if (slots[name] !== nullRender) {
         slotProps[name] = isSlotPrimitive
-          ? getNativeElementProps(slotAs, slotDefinition)
+          ? getNativeElementProps(slotAs, slotDefinition, ['as'])
           : omit(slotDefinition, ['as']);
       }
     }

--- a/packages/react-utilities/src/utils/getNativeElementProps.test.ts
+++ b/packages/react-utilities/src/utils/getNativeElementProps.test.ts
@@ -6,4 +6,12 @@ describe('getNativeElementProps', () => {
     expect(getNativeElementProps('input', { id: '123', checked: true })).toEqual({ id: '123', checked: true });
     expect(getNativeElementProps('input', { id: '123', checked: true }, ['id'])).toEqual({ checked: true });
   });
+
+  it('includes `as` as a native prop', () => {
+    expect(getNativeElementProps('div', { as: 'span' })).toEqual({ as: 'span' });
+  });
+
+  it('excludes props regardless of the allowed', () => {
+    expect(getNativeElementProps('div', { as: 'span' }, ['as'])).toEqual({});
+  });
 });

--- a/packages/react-utilities/src/utils/getNativeElementProps.ts
+++ b/packages/react-utilities/src/utils/getNativeElementProps.ts
@@ -61,6 +61,7 @@ export function getNativeElementProps<TAttributes extends React.HTMLAttributes<a
   excludedPropNames?: string[],
 ): TAttributes {
   const allowedPropNames = (tagName && nativeElementMap[tagName]) || htmlElementProperties;
+  allowedPropNames.as = 1;
 
   return getNativeProps(props, allowedPropNames, excludedPropNames);
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19785
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Added `as` prop to allowed props of `getNativeElementProps`.
- Added `as` prop to the excluded props for `getSlotsCompat` as that would change the API for components that are not using simplified prop merging yet.
- Removed workaround for react-text and react-link.