### PR TITLE
Revert "Add missing `.cache/` dir to `.npmignore` for `migrate-converged-pkg` generator"

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -806,8 +806,7 @@ describe('migrate-converged-pkg generator', () => {
       npmIgnoreConfig = getNpmIgnoreConfig(projectConfig);
 
       expect(npmIgnoreConfig).toMatchInlineSnapshot(`
-        ".cache/
-        .storybook/
+        ".storybook/
         .vscode/
         bundle-size/
         config/

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -205,7 +205,6 @@ const templates = {
   },
   npmIgnoreConfig:
     stripIndents`
-    .cache/
     .storybook/
     .vscode/
     bundle-size/


### PR DESCRIPTION
Reverts microsoft/fluentui#19859

As mentioned [here](https://github.com/microsoft/fluentui/pull/19859#issuecomment-923252990), this is no longer required and should be reverted.