### PR TITLE
Codeowners updated for ben oof

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,41 +72,45 @@ perf-test/ @microsoft/fluentui-react-build
 # todo-app/
 
 #### Packages
-packages/react-cards/ @microsoft/cxe-red @khmakoto
-packages/react-charting/ @Raghurk
-packages/react-date-time @lorejoh12 @evlevy
+packages/azure-themes/ @hyoshis @Jacqueline-ms @wsmd
+packages/babel-make-styles/ @microsoft/teams-prg
+packages/bundle-size/ @microsoft/teams-prg
 packages/date-time-utilities @lorejoh12 @evlevy
 packages/eslint-plugin/ @microsoft/fluentui-react-build
-packages/react-docsite-components/ @ecraig12345
-packages/react-file-type-icons/ @KatherineThayerMicrosoft @jahnp @bigbadcapers
 packages/foundation-legacy/ @microsoft/cxe-red @khmakoto
 # packages/font-icons-mdl2/
+packages/jest-serializer-make-styles/ @microsoft/teams-prg
 # packages/jest-serializer-merge-styles/
+packages/make-styles/ @microsoft/teams-prg
+
+packages/make-styles-webpack-loader/ @microsoft/teams-prg
 packages/merge-styles/ @dzearing
 packages/monaco-editor/ @ecraig12345
 packages/public-docsite-setup/ @ecraig12345
+packages/react-aria/ @microsoft/teams-prg
+packages/react-cards/ @microsoft/cxe-red @khmakoto
+packages/react-charting/ @Raghurk
+packages/react-conformance-make-styles/ @microsoft/teams-prg
+packages/react-context-selector/ @microsoft/teams-prg
+packages/react-date-time @lorejoh12 @evlevy
+packages/react-docsite-components/ @ecraig12345
+packages/react-file-type-icons/ @KatherineThayerMicrosoft @jahnp @bigbadcapers
 packages/react-hooks/ @microsoft/cxe-red @ecraig12345
+packages/react-make-styles/ @microsoft/teams-prg
+packages/react-monaco-editor/ @ecraig12345
+packages/react-positioning/ @microsoft/teams-prg
+packages/react-shared-contexts/ @microsoft/teams-prg
+packages/react-storybook/ @microsoft/cxe-prg @microsoft/teams-prg
+packages/react-storybook-addon/ @microsoft/cxe-prg
+packages/react-tabster/ @microsoft/teams-prg
+packages/react-theme/ @microsoft/teams-prg
+packages/storybook/ @microsoft/cxe-prg @microsoft/teams-prg
 packages/style-utilities/ @dzearing
 packages/style-utilities/src/interfaces/ @phkuo @dzearing
 packages/style-utilities/src/styles/ @phkuo @dzearing
 packages/theme/ @dzearing
-packages/react-monaco-editor/ @ecraig12345
 # packages/utilities/
 packages/utilities/positioning/ @microsoft/cxe-red
-packages/azure-themes/ @hyoshis @Jacqueline-ms @wsmd
-packages/make-styles/ @microsoft/teams-prg
-packages/react-make-styles/ @microsoft/teams-prg
-packages/react-aria/ @microsoft/teams-prg
-packages/babel-make-styles/ @microsoft/teams-prg
-packages/make-styles-webpack-loader/ @microsoft/teams-prg
-packages/react-conformance-make-styles/ @microsoft/teams-prg
-packages/jest-serializer-make-styles/ @microsoft/teams-prg
-packages/bundle-size/ @microsoft/teams-prg
-packages/react-shared-contexts/ @microsoft/teams-prg
-packages/react-context-selector/ @microsoft/teams-prg
-packages/react-tabster/ @microsoft/teams-prg
-packages/react-positioning/ @microsoft/teams-prg
-packages/react-theme/ @microsoft/teams-prg
 
 ### Fabric
 # common/
@@ -123,24 +127,21 @@ packages/react-button/ @microsoft/cxe-red @dzearing @khmakoto
 packages/react-card/ @microsoft/cxe-prg
 packages/react-checkbox/ @microsoft/cxe-red @khmakoto
 packages/react-components/ @microsoft/teams-prg @microsoft/cxe-prg @microsoft/cxe-red
-packages/react-divider/ @microsoft/cxe-prg
+packages/react-divider/ @microsoft/cxe-red @geoffcoxmsft
 packages/react-focus/ @microsoft/cxe-red @khmakoto
 packages/react-image/ @microsoft/cxe-prg
 packages/react-input/ @microsoft/cxe-red @ecraig12345
 packages/react-label/ @microsoft/cxe-red
 packages/react-link/ @microsoft/cxe-red @khmakoto
 packages/react-menu/ @microsoft/teams-prg
+packages/react-popover/ @microsoft/teams-prg
+packages/react-portal/ @microsoft/teams-prg
+packages/react-provider/ @microsoft/teams-prg
 packages/react-slider/ @microsoft/cxe-red
-packages/react-storybook/ @microsoft/cxe-prg @microsoft/teams-prg
-packages/react-storybook-addon/ @microsoft/cxe-prg
 packages/react-switch/ @microsoft/cxe-red @behowell @khmakoto @czearing
 packages/react-tabs/ @microsoft/cxe-red @behowell @khmakoto
 packages/react-text/ @microsoft/cxe-prg
 packages/react-tooltip/ @microsoft/cxe-red @behowell @khmakoto
-packages/react-popover/ @microsoft/teams-prg
-packages/react-portal/ @microsoft/teams-prg
-packages/react-provider/ @microsoft/teams-prg
-packages/storybook/ @microsoft/cxe-prg @microsoft/teams-prg
 
 ## Components
 packages/react @microsoft/cxe-red

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -116,29 +116,30 @@ common/_themeOverrides.scss @microsoft/cxe-red @phkuo
 common/_common.scss @microsoft/cxe-red @phkuo
 
 ## Component packages
-packages/react-avatar/ @microsoft/cxe-red @behowell
-packages/react-menu/ @microsoft/teams-prg
 packages/react-accordion/ @microsoft/teams-prg
+packages/react-avatar/ @microsoft/cxe-red @behowell @khmakoto
 packages/react-badge/ @ling1726 @layershifter @assuncaocharles @behowell
 packages/react-button/ @microsoft/cxe-red @dzearing @khmakoto
 packages/react-card/ @microsoft/cxe-prg
 packages/react-checkbox/ @microsoft/cxe-red @khmakoto
 packages/react-components/ @microsoft/teams-prg @microsoft/cxe-prg @microsoft/cxe-red
+packages/react-divider/ @microsoft/cxe-prg
 packages/react-focus/ @microsoft/cxe-red @khmakoto
 packages/react-image/ @microsoft/cxe-prg
-packages/react-text/ @microsoft/cxe-prg
 packages/react-input/ @microsoft/cxe-red @ecraig12345
+packages/react-label/ @microsoft/cxe-red
+packages/react-link/ @microsoft/cxe-red @khmakoto
+packages/react-menu/ @microsoft/teams-prg
+packages/react-slider/ @microsoft/cxe-red
 packages/react-storybook/ @microsoft/cxe-prg @microsoft/teams-prg
 packages/react-storybook-addon/ @microsoft/cxe-prg
 packages/storybook/ @microsoft/cxe-prg @microsoft/teams-prg
-packages/react-link/ @microsoft/cxe-red @khmakoto
-packages/react-slider/ @microsoft/cxe-red
-packages/react-tabs/ @microsoft/cxe-red @behowell
-packages/react-tooltip/ @microsoft/cxe-red @behowell
-packages/react-switch/ @microsoft/cxe-red @behowell @czearing
-packages/react-label/ @microsoft/cxe-red
-packages/react-portal/ @microsoft/teams-prg
+packages/react-switch/ @microsoft/cxe-red @behowell @khmakoto @czearing
+packages/react-tabs/ @microsoft/cxe-red @behowell @khmakoto
+packages/react-text/ @microsoft/cxe-prg
+packages/react-tooltip/ @microsoft/cxe-red @behowell @khmakoto
 packages/react-popover/ @microsoft/teams-prg
+packages/react-portal/ @microsoft/teams-prg
 packages/react-provider/ @microsoft/teams-prg
 
 ## Components

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,7 +133,6 @@ packages/react-menu/ @microsoft/teams-prg
 packages/react-slider/ @microsoft/cxe-red
 packages/react-storybook/ @microsoft/cxe-prg @microsoft/teams-prg
 packages/react-storybook-addon/ @microsoft/cxe-prg
-packages/storybook/ @microsoft/cxe-prg @microsoft/teams-prg
 packages/react-switch/ @microsoft/cxe-red @behowell @khmakoto @czearing
 packages/react-tabs/ @microsoft/cxe-red @behowell @khmakoto
 packages/react-text/ @microsoft/cxe-prg
@@ -141,6 +140,7 @@ packages/react-tooltip/ @microsoft/cxe-red @behowell @khmakoto
 packages/react-popover/ @microsoft/teams-prg
 packages/react-portal/ @microsoft/teams-prg
 packages/react-provider/ @microsoft/teams-prg
+packages/storybook/ @microsoft/cxe-prg @microsoft/teams-prg
 
 ## Components
 packages/react @microsoft/cxe-red


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Ben OOF 
- [X] Change file not needed according to yarn change

#### Description of changes

- Updated to add @khmakoto anywhere @behowell is listed as code owner
- Added react-divider ownership to @microsoft/cxe-prg as shipping in react-components with the beta
- Alphabetized based on folder name within the components section for easier maintenance later

#### Focus areas to test

(optional)
