### PR TITLE
(react-switch) - Adding switch role to the hidden input

### DIFF
--- a/change/@fluentui-react-switch-b245d71e-439a-4dcf-9f77-69b2d9743e7a.json
+++ b/change/@fluentui-react-switch-b245d71e-439a-4dcf-9f77-69b2d9743e7a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding switch role to the hidden input element.",
+  "packageName": "@fluentui/react-switch",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-switch/src/components/Switch/Switch.test.tsx
+++ b/packages/react-switch/src/components/Switch/Switch.test.tsx
@@ -60,7 +60,7 @@ describe('Switch', () => {
       const eventHandler = jest.fn();
 
       render(<Switch checked={false} onChange={eventHandler} input={{ ref: inputRef }} />);
-      const inputElement = screen.getByRole('checkbox');
+      const inputElement = screen.getByRole('switch');
 
       fireEvent.click(inputElement);
 
@@ -74,7 +74,7 @@ describe('Switch', () => {
 
       render(<Switch onChange={eventHandler} />);
 
-      const input = screen.getByRole('checkbox');
+      const input = screen.getByRole('switch');
       expect(eventHandler).toBeCalledTimes(0);
 
       fireEvent.click(input);

--- a/packages/react-switch/src/components/Switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/react-switch/src/components/Switch/__snapshots__/Switch.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`Switch Snapshot Tests renders a basic Switch checked 1`] = `
     <input
       checked=""
       class=""
+      role="switch"
       type="checkbox"
     />
   </div>
@@ -45,6 +46,7 @@ exports[`Switch Snapshot Tests renders a basic Switch unchecked 1`] = `
     </div>
     <input
       class=""
+      role="switch"
       type="checkbox"
     />
   </div>
@@ -71,6 +73,7 @@ exports[`Switch Snapshot Tests renders a disabled Switch checked 1`] = `
     <input
       checked=""
       class=""
+      role="switch"
       type="checkbox"
     />
   </div>
@@ -96,6 +99,7 @@ exports[`Switch Snapshot Tests renders a disabled Switch unchecked 1`] = `
     </div>
     <input
       class=""
+      role="switch"
       type="checkbox"
     />
   </div>

--- a/packages/react-switch/src/components/Switch/useSwitchState.ts
+++ b/packages/react-switch/src/components/Switch/useSwitchState.ts
@@ -46,6 +46,7 @@ export const useSwitchState = (state: SwitchState) => {
   state.input.checked = internalValue;
   state.input.disabled = disabled;
   state.input.ref = inputRef;
+  state.input.role = 'switch';
 
   // thumbContainer Props
   state.thumbWrapper.style = thumbWrapperStyles;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Adding `role="switch"` to the hidden input element in the converged **Switch**. Instead of representing `unchecked` and `checked` states, it will represent `on` and `off`.