### PR TITLE
SplitButton: Adding missing verticalAlign=middle style

### DIFF
--- a/change/@fluentui-react-button-fcf52db6-2000-4999-b7b5-8f4e23e762e7.json
+++ b/change/@fluentui-react-button-fcf52db6-2000-4999-b7b5-8f4e23e762e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "SplitButton: Adding missing verticalAlign=middle style.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/components/SplitButton/useSplitButtonStyles.ts
+++ b/packages/react-button/src/components/SplitButton/useSplitButtonStyles.ts
@@ -11,6 +11,7 @@ const useStyles = makeStyles({
     display: 'inline-flex',
     justifyContent: 'stretch',
     position: 'relative',
+    verticalAlign: 'middle',
 
     // Use classnames to increase specificy of styles and avoid collisions.
     [`& .${SplitButtonClassNames.button}`]: {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`SplitButton`: Adding missing verticalAlign=middle style.