### PR TITLE
Fix converged package check for default case

### DIFF
--- a/scripts/monorepo/isConvergedPackage.js
+++ b/scripts/monorepo/isConvergedPackage.js
@@ -14,7 +14,9 @@ const { readConfig } = require('../read-config');
  */
 function isConvergedPackage(packagePathOrJson) {
   const packageJson =
-    typeof packagePathOrJson === 'string' ? readConfig('package.json', packagePathOrJson) : packagePathOrJson;
+    !packagePathOrJson || typeof packagePathOrJson === 'string'
+      ? readConfig('package.json', /** @type {string|undefined} */ (packagePathOrJson))
+      : packagePathOrJson;
   return !!packageJson && semver.major(packageJson.version) >= 9;
 }
 


### PR DESCRIPTION
In `isConvergedPackage`, restore handling for the case where `pathOrPackageJson` is undefined so that it defaults to `process.cwd()`. (This will fix codesandbox CI.)