### PR TITLE
fix(Toggle): remove on/off state text from label

### DIFF
--- a/change/@fluentui-react-09f97422-25cb-432f-b1d0-190d1863f5d4.json
+++ b/change/@fluentui-react-09f97422-25cb-432f-b1d0-190d1863f5d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Toggle to not append on/off text to label\"",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react-tabs/__snapshots__/Tabs.OverflowMenu.Example.tsx.shot
+++ b/packages/react-examples/src/react-tabs/__snapshots__/Tabs.OverflowMenu.Example.tsx.shot
@@ -1749,7 +1749,7 @@ Array [
       >
         <button
           aria-checked={true}
-          aria-labelledby="Toggle29-label Toggle29-stateText"
+          aria-labelledby="Toggle29-label"
           checked={true}
           className=
               ms-Toggle-background
@@ -1927,7 +1927,7 @@ Array [
       >
         <button
           aria-checked={false}
-          aria-labelledby="Toggle30-label Toggle30-stateText"
+          aria-labelledby="Toggle30-label"
           checked={false}
           className=
               ms-Toggle-background
@@ -2098,7 +2098,7 @@ Array [
       >
         <button
           aria-checked={false}
-          aria-labelledby="Toggle31-label Toggle31-stateText"
+          aria-labelledby="Toggle31-label"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -67,7 +67,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
       >
         <button
           aria-checked={false}
-          aria-labelledby="Toggle0-label Toggle0-stateText"
+          aria-labelledby="Toggle0-label"
           checked={false}
           className=
               ms-Toggle-background
@@ -242,7 +242,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
       >
         <button
           aria-checked={false}
-          aria-labelledby="Toggle1-label Toggle1-stateText"
+          aria-labelledby="Toggle1-label"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/react-examples/src/react/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -76,7 +76,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={false}
-        aria-labelledby="Toggle0-label Toggle0-stateText"
+        aria-labelledby="Toggle0-label"
         checked={false}
         className=
             ms-Toggle-background

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -96,7 +96,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
       >
         <button
           aria-checked={false}
-          aria-labelledby="Toggle1-label Toggle1-stateText"
+          aria-labelledby="Toggle1-label"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -279,7 +279,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
         >
           <button
             aria-checked={false}
-            aria-labelledby="Toggle4-label Toggle4-stateText"
+            aria-labelledby="Toggle4-label"
             checked={false}
             className=
                 ms-Toggle-background

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -279,7 +279,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
         >
           <button
             aria-checked={false}
-            aria-labelledby="Toggle4-label Toggle4-stateText"
+            aria-labelledby="Toggle4-label"
             checked={false}
             className=
                 ms-Toggle-background

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -96,7 +96,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
       >
         <button
           aria-checked={false}
-          aria-labelledby="Toggle1-label Toggle1-stateText"
+          aria-labelledby="Toggle1-label"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -97,7 +97,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         >
           <button
             aria-checked={false}
-            aria-labelledby="Toggle1-label Toggle1-stateText"
+            aria-labelledby="Toggle1-label"
             checked={false}
             className=
                 ms-Toggle-background
@@ -426,7 +426,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             >
               <button
                 aria-checked={false}
-                aria-labelledby="Toggle6-label Toggle6-stateText"
+                aria-labelledby="Toggle6-label"
                 checked={false}
                 className=
                     ms-Toggle-background
@@ -755,7 +755,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                 >
                   <button
                     aria-checked={false}
-                    aria-labelledby="Toggle11-label Toggle11-stateText"
+                    aria-labelledby="Toggle11-label"
                     checked={false}
                     className=
                         ms-Toggle-background
@@ -1097,7 +1097,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                 >
                   <button
                     aria-checked={false}
-                    aria-labelledby="Toggle16-label Toggle16-stateText"
+                    aria-labelledby="Toggle16-label"
                     checked={false}
                     className=
                         ms-Toggle-background
@@ -1451,7 +1451,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             >
               <button
                 aria-checked={false}
-                aria-labelledby="Toggle21-label Toggle21-stateText"
+                aria-labelledby="Toggle21-label"
                 checked={false}
                 className=
                     ms-Toggle-background

--- a/packages/react-examples/src/react/__snapshots__/Pivot.OverflowMenu.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Pivot.OverflowMenu.Example.tsx.shot
@@ -63,7 +63,7 @@ Array [
       >
         <button
           aria-checked={true}
-          aria-labelledby="Toggle0-label Toggle0-stateText"
+          aria-labelledby="Toggle0-label"
           checked={true}
           className=
               ms-Toggle-background
@@ -241,7 +241,7 @@ Array [
       >
         <button
           aria-checked={false}
-          aria-labelledby="Toggle1-label Toggle1-stateText"
+          aria-labelledby="Toggle1-label"
           checked={false}
           className=
               ms-Toggle-background
@@ -412,7 +412,7 @@ Array [
       >
         <button
           aria-checked={false}
-          aria-labelledby="Toggle2-label Toggle2-stateText"
+          aria-labelledby="Toggle2-label"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/react-examples/src/react/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -55,7 +55,7 @@ Array [
     >
       <button
         aria-checked={false}
-        aria-labelledby="Toggle0-label Toggle0-stateText"
+        aria-labelledby="Toggle0-label"
         className=
             ms-Toggle-background
             {

--- a/packages/react-examples/src/react/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -76,7 +76,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
-        aria-labelledby="Toggle0-label Toggle0-stateText"
+        aria-labelledby="Toggle0-label"
         className=
             ms-Toggle-background
             {
@@ -253,7 +253,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={false}
-        aria-labelledby="Toggle1-label Toggle1-stateText"
+        aria-labelledby="Toggle1-label"
         className=
             ms-Toggle-background
             {
@@ -428,7 +428,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={true}
         aria-disabled={true}
-        aria-labelledby="Toggle2-label Toggle2-stateText"
+        aria-labelledby="Toggle2-label"
         className=
             ms-Toggle-background
             {
@@ -597,7 +597,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={false}
         aria-disabled={true}
-        aria-labelledby="Toggle3-label Toggle3-stateText"
+        aria-labelledby="Toggle3-label"
         className=
             ms-Toggle-background
             {
@@ -763,7 +763,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={false}
-        aria-labelledby="Toggle4-label Toggle4-stateText"
+        aria-labelledby="Toggle4-label"
         className=
             ms-Toggle-background
             {
@@ -940,7 +940,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={false}
         aria-disabled={true}
-        aria-labelledby="Toggle5-label Toggle5-stateText"
+        aria-labelledby="Toggle5-label"
         className=
             ms-Toggle-background
             {
@@ -1361,7 +1361,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
-        aria-labelledby="Toggle8-label Toggle8-stateText"
+        aria-labelledby="Toggle8-label"
         className=
             ms-Toggle-background
             {

--- a/packages/react-examples/src/react/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
@@ -110,7 +110,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
     >
       <button
         aria-checked={false}
-        aria-labelledby="Toggle0-label Toggle0-stateText"
+        aria-labelledby="Toggle0-label"
         className=
             ms-Toggle-background
             {
@@ -318,7 +318,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
     >
       <button
         aria-checked={false}
-        aria-labelledby="Toggle2-label Toggle2-stateText"
+        aria-labelledby="Toggle2-label"
         className=
             ms-Toggle-background
             {

--- a/packages/react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/react/src/components/Toggle/Toggle.base.tsx
@@ -66,15 +66,15 @@ export const ToggleBase: React.FunctionComponent<IToggleProps> = React.forwardRe
     // The following properties take priority for what Narrator should read:
     // 1. ariaLabel
     // 2. onAriaLabel (if checked) or offAriaLabel (if not checked)
-    // 3. label AND stateText, if existent
+    // 3. label, if existent
 
     let labelledById: string | undefined = undefined;
     if (!ariaLabel && !badAriaLabel) {
       if (label) {
         labelledById = labelId;
       }
-      if (stateText) {
-        labelledById = labelledById ? `${labelledById} ${stateTextId}` : stateTextId;
+      if (stateText && !labelledById) {
+        labelledById = stateTextId;
       }
     }
 

--- a/packages/react/src/components/Toggle/Toggle.test.tsx
+++ b/packages/react/src/components/Toggle/Toggle.test.tsx
@@ -131,10 +131,10 @@ describe('Toggle', () => {
       expect(component.find('button').first().getDOMNode().getAttribute('aria-labelledby')).toBe('ToggleId-stateText');
     });
 
-    it('is labelled by the state text element if no aria labels are provided and no label is provided', () => {
-      const component = mount(<Toggle onText="On" offText="Off" id="ToggleId" />);
+    it('is labelled by the label element alone if no aria labels are provided, and state text is provided', () => {
+      const component = mount(<Toggle label="Label" onText="On" offText="Off" id="ToggleId" />);
 
-      expect(component.find('button').first().getDOMNode().getAttribute('aria-labelledby')).toBe('ToggleId-stateText');
+      expect(component.find('button').first().getDOMNode().getAttribute('aria-labelledby')).toBe('ToggleId-label');
     });
   });
 });

--- a/packages/react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -558,7 +558,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
   >
     <button
       aria-checked={false}
-      aria-labelledby="Toggle0-label Toggle0-stateText"
+      aria-labelledby="Toggle0-label"
       className=
           ms-Toggle-background
           {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15109
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The on/off state text should not be part of a toggle's accessible name, so I've updated the `ariaLabelledBy` logic to remove it. It's still used as a fallback if no other label is provided, but otherwise not included. More detail in the issue comments: https://github.com/microsoft/fluentui/issues/15109#issuecomment-924184328
