### PR TITLE
fix(runPublished): Filter condition was empty for v8 releases

### DIFF
--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -30,17 +30,16 @@ const websitePackages = [
 const beachballPackageScopes = Object.entries(getAllPackageInfo())
   .filter(([, { packageJson, packagePath }]) => {
     // Ignore northstar and private packages
-    if (/[\\/]fluentui[\\/]/.test(packagePath) || packageJson.private === true) {
+    if (/[\\/]fluentui[\\/]/.test(packagePath)) {
       return false;
     }
 
     if (process.env.RELEASE_VNEXT) {
-      return isConvergedPackage(packageJson);
-    } else if (websitePackages.includes(packageJson.name)) {
-      return true;
+      return isConvergedPackage(packageJson) && packageJson.private !== true;
     }
 
-    return true;
+    // v8 release scope
+    return packageJson.private !== true || websitePackages.includes(packageJson.name);
   })
   .map(([packageName]) => `--to=${packageName}`)
   .filter(Boolean);

--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -31,7 +31,6 @@ const beachballPackageScopes = Object.entries(getAllPackageInfo())
   .filter(([, { packageJson, packagePath }]) => {
     // Ignore northstar and private packages
     if (/[\\/]fluentui[\\/]/.test(packagePath) || packageJson.private === true) {
-      console.log(packagePath);
       return false;
     }
 

--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -31,14 +31,17 @@ const beachballPackageScopes = Object.entries(getAllPackageInfo())
   .filter(([, { packageJson, packagePath }]) => {
     // Ignore northstar and private packages
     if (/[\\/]fluentui[\\/]/.test(packagePath) || packageJson.private === true) {
+      console.log(packagePath);
       return false;
     }
 
     if (process.env.RELEASE_VNEXT) {
       return isConvergedPackage(packageJson);
+    } else if (websitePackages.includes(packageJson.name)) {
+      return true;
     }
 
-    return websitePackages.includes(packageJson.name);
+    return true;
   })
   .map(([packageName]) => `--to=${packageName}`)
   .filter(Boolean);

--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -29,7 +29,7 @@ const websitePackages = [
 // in the root package.json's publishing-related scripts and will need to be updated if --scope changes.
 const beachballPackageScopes = Object.entries(getAllPackageInfo())
   .filter(([, { packageJson, packagePath }]) => {
-    // Ignore northstar and private packages
+    // Ignore northstar
     if (/[\\/]fluentui[\\/]/.test(packagePath)) {
       return false;
     }
@@ -41,6 +41,7 @@ const beachballPackageScopes = Object.entries(getAllPackageInfo())
       return packageJson.private !== true || websitePackages.includes(packageJson.name);
     }
 
+    // Ignore v9/converged packages when releasing v8
     return false;
   })
   .map(([packageName]) => `--to=${packageName}`);

--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -36,13 +36,14 @@ const beachballPackageScopes = Object.entries(getAllPackageInfo())
 
     if (process.env.RELEASE_VNEXT) {
       return isConvergedPackage(packageJson) && packageJson.private !== true;
+    } else if (!isConvergedPackage(packageJson)) {
+      // v8 scope
+      return packageJson.private !== true || websitePackages.includes(packageJson.name);
     }
 
-    // v8 release scope
-    return packageJson.private !== true || websitePackages.includes(packageJson.name);
+    return false;
   })
-  .map(([packageName]) => `--to=${packageName}`)
-  .filter(Boolean);
+  .map(([packageName]) => `--to=${packageName}`);
 
 const lageArgs = [
   'run',


### PR DESCRIPTION

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

#19783 added a scope for v9 releases. However the changes to the filter comparator broke the scope generation for v8 releases.

For v8 any package not caught by the previous conditions should just be passed through, even web-components 🤔. Could be optimized more in the future but this should fix v8 releases and use the same scope as previously

#### Focus areas to test

(optional)
