### PR TITLE
Updated DividerProps for consistency

### DIFF
--- a/change/@fluentui-react-divider-a6a812b5-5d5b-4aa0-95a5-e66c6b5cb7d7.json
+++ b/change/@fluentui-react-divider-a6a812b5-5d5b-4aa0-95a5-e66c6b5cb7d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updated DividerProps for consistency",
+  "packageName": "@fluentui/react-divider",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-divider/Spec.md
+++ b/packages/react-divider/Spec.md
@@ -70,12 +70,6 @@ Icon
 <Divider><Icon /></Divider>
 ```
 
-Important
-
-```html
-<Divider important>This is important!</Divider>
-```
-
 Inset
 
 ```html

--- a/packages/react-divider/etc/react-divider.api.md
+++ b/packages/react-divider/etc/react-divider.api.md
@@ -11,8 +11,7 @@ import { ShorthandPropsCompat } from '@fluentui/react-utilities';
 // @public
 export const Divider: React_2.ForwardRefExoticComponent<ComponentPropsCompat & React_2.HTMLAttributes<HTMLElement> & {
     alignContent?: "start" | "end" | "center" | undefined;
-    appearance?: "strong" | "default" | "subtle" | "brand" | undefined;
-    important?: boolean | undefined;
+    appearance?: "strong" | "brand" | "subtle" | undefined;
     inset?: boolean | undefined;
     vertical?: boolean | undefined;
     wrapper?: ShorthandPropsCompat<React_2.HTMLAttributes<HTMLDivElement>>;
@@ -21,8 +20,7 @@ export const Divider: React_2.ForwardRefExoticComponent<ComponentPropsCompat & R
 // @public (undocumented)
 export type DividerProps = ComponentPropsCompat & React_2.HTMLAttributes<HTMLElement> & {
     alignContent?: 'start' | 'end' | 'center';
-    appearance?: 'default' | 'subtle' | 'brand' | 'strong';
-    important?: boolean;
+    appearance?: 'brand' | 'strong' | 'subtle';
     inset?: boolean;
     vertical?: boolean;
     wrapper?: ShorthandPropsCompat<React_2.HTMLAttributes<HTMLDivElement>>;

--- a/packages/react-divider/src/Divider.stories.tsx
+++ b/packages/react-divider/src/Divider.stories.tsx
@@ -104,12 +104,6 @@ const DividerExamples = (props: DividerProps) => {
           </Divider>
         </DividerStory>
 
-        <DividerStory label="Important">
-          <Divider {...props} important={true}>
-            This is important!
-          </Divider>
-        </DividerStory>
-
         <DividerStory label="Alignments">
           <Divider {...props} alignContent="start">
             start
@@ -180,14 +174,6 @@ const DividerExamples = (props: DividerProps) => {
             <Divider {...props} inset vertical />
             <Divider {...props} inset vertical>
               Inset with content
-            </Divider>
-          </div>
-        </DividerStory>
-
-        <DividerStory label="Important">
-          <div className="verticalContent">
-            <Divider {...props} important vertical>
-              Important!
             </Divider>
           </div>
         </DividerStory>

--- a/packages/react-divider/src/Divider.stories.tsx
+++ b/packages/react-divider/src/Divider.stories.tsx
@@ -123,9 +123,7 @@ const DividerExamples = (props: DividerProps) => {
         </DividerStory>
 
         <DividerStory label="Appearance">
-          <Divider {...props} appearance="default">
-            default
-          </Divider>
+          <Divider {...props}>default</Divider>
           <Divider {...props} appearance="subtle">
             subtle
           </Divider>
@@ -210,7 +208,7 @@ const DividerExamples = (props: DividerProps) => {
 
         <DividerStory label="Appearance" className="vertical">
           <div className="verticalContent">
-            <Divider {...props} appearance="default" vertical>
+            <Divider {...props} vertical>
               default
             </Divider>
             <Divider {...props} appearance="subtle" vertical>

--- a/packages/react-divider/src/components/Divider/Divider.test.tsx
+++ b/packages/react-divider/src/components/Divider/Divider.test.tsx
@@ -71,12 +71,6 @@ describe('Divider', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a divider with important', () => {
-    const component = renderer.create(<Divider important>Important</Divider>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-
   it('renders a divider with different color', () => {
     const component = renderer.create(<Divider color="#FF00FF" />);
     const tree = component.toJSON();

--- a/packages/react-divider/src/components/Divider/Divider.types.ts
+++ b/packages/react-divider/src/components/Divider/Divider.types.ts
@@ -10,23 +10,20 @@ export type DividerProps = ComponentPropsCompat &
     alignContent?: 'start' | 'end' | 'center';
 
     /**
-     * Predefined visual styles
-     * @defaultvalue 'default'
+     * A divider can have one of the preset appearances.
+     * When not specified, the divider has its default appearance.
      */
-    appearance?: 'default' | 'subtle' | 'brand' | 'strong';
+    appearance?: 'brand' | 'strong' | 'subtle';
 
     /**
-     * A divider can be classified as important to emphasize its content
-     */
-    important?: boolean;
-
-    /**
-     * Adds a 12px padding to the begining and end of the divider
+     * Adds padding to the begining and end of the divider
      */
     inset?: boolean;
 
     /**
-     * A divider can be horizontal (default) or vertical*/
+     * A divider can be horizontal (default) or vertical
+     * @default false
+     */
     vertical?: boolean;
 
     /**

--- a/packages/react-divider/src/components/Divider/__snapshots__/Divider.test.tsx.snap
+++ b/packages/react-divider/src/components/Divider/__snapshots__/Divider.test.tsx.snap
@@ -84,20 +84,6 @@ exports[`Divider renders a divider with different color 1`] = `
 />
 `;
 
-exports[`Divider renders a divider with important 1`] = `
-<div
-  aria-labelledby="divider-1"
-  className=""
-  role="separator"
->
-  <div
-    id="divider-1"
-  >
-    Important
-  </div>
-</div>
-`;
-
 exports[`Divider renders a divider with inset 1`] = `
 <div
   aria-labelledby="divider-1"

--- a/packages/react-divider/src/components/Divider/useDividerStyles.ts
+++ b/packages/react-divider/src/components/Divider/useDividerStyles.ts
@@ -170,9 +170,6 @@ const useStylesOverride = makeStyles({
       marginLeft: 'var(--divider-borderMargin)',
     },
   },
-  important: {
-    '--divider-fontWeight': `700`,
-  },
   verticalColored: {
     ':before': {
       borderRightColor: 'var(--divider-color)',
@@ -223,7 +220,6 @@ export const useDividerStyles = (s: DividerState) => {
     s.alignContent === 'start' && (s.vertical ? styles.verticalStart : styles.horizontalStart),
     s.alignContent === 'end' && (s.vertical ? styles.verticalEnd : styles.horizontalEnd),
     (s.alignContent === 'center' || !s.alignContent) && (s.vertical ? styles.verticalCenter : styles.horizontalCenter),
-    s.important && styles.important,
     s.color && (s.vertical ? styles.verticalColored : styles.horizontalColored),
     s.children === undefined && s.vertical && styles.verticalChildless,
     s.inset && (s.vertical ? styles.verticalInset : styles.inset),


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Updates #19825 Updates #19826
- [X] Include a change request file using `$ yarn change`

#### Description of changes

- Added DividerProps appearance to remove default value as property is optional.
- Removed DividerProps important as not part of figma spec and confusing with appearance=strong.  Confirmed with Daisy.
