### PR TITLE
FocusTrapCallout: Updating example so that all focusable elements are tabbable

### DIFF
--- a/change/@fluentui-react-15221f83-6f67-4181-83b0-2c9a9e24b3ac.json
+++ b/change/@fluentui-react-15221f83-6f67-4181-83b0-2c9a9e24b3ac.json
@@ -1,5 +1,6 @@
 {
   "type": "patch",
+  "comment": "Small update to comment in FocusTrapZone.",
   "packageName": "@fluentui/react",
   "email": "Humberto.Morimoto@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-b27d2d56-1910-4bff-ae88-a1b025a6a37e.json
+++ b/change/@fluentui-react-b27d2d56-1910-4bff-ae88-a1b025a6a37e.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Callout/Callout.FocusTrap.Example.tsx
+++ b/packages/react-examples/src/react/Callout/Callout.FocusTrap.Example.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { FocusTrapCallout, Stack, FocusZone, mergeStyleSets, FontWeights, Text } from '@fluentui/react';
+import {
+  mergeStyleSets,
+  FocusTrapCallout,
+  FocusZone,
+  FocusZoneTabbableElements,
+  FontWeights,
+  Stack,
+  Text,
+} from '@fluentui/react';
 import { useBoolean, useId } from '@fluentui/react-hooks';
 import { DefaultButton, PrimaryButton } from '@fluentui/react/lib/Button';
 
@@ -28,7 +36,7 @@ export const CalloutFocusTrapExample: React.FunctionComponent = () => {
           </Text>
           {/* This FocusZone allows the user to go between buttons with the arrow keys.
               It's not related to or required for FocusTrapCallout's built-in focus trapping. */}
-          <FocusZone>
+          <FocusZone handleTabKey={FocusZoneTabbableElements.all} isCircularNavigation>
             <Stack className={styles.buttons} gap={8} horizontal>
               <PrimaryButton onClick={toggleIsCalloutVisible}>Done</PrimaryButton>
               <DefaultButton onClick={toggleIsCalloutVisible}>Cancel</DefaultButton>

--- a/packages/react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -170,7 +170,7 @@ export const FocusTrapZone: React.FunctionComponent<IFocusTrapZoneProps> & {
       let relatedTarget = ev.relatedTarget;
       if (ev.relatedTarget === null) {
         // In IE11, due to lack of support, event.relatedTarget is always
-        // null making every onBlur call to be "outside" of the ComboBox
+        // null making every onBlur call to be "outside" of the root
         // even when it's not. Using document.activeElement is another way
         // for us to be able to get what the relatedTarget without relying
         // on the event


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12473](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12473)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR updates a bug in the `FocusTrapCallout` example that was making it impossible for all the buttons inside the callout to be tabbed to. It also makes a small fix in the `FocusTrapZone` comments that referenced `ComboBox` even though that component is unrelated to `FocusTrapZone`.