### PR TITLE
fix(Popover): Remove leftover defaultProps and fix trigger props merge

### DIFF
--- a/change/@fluentui-react-popover-4546d06a-9706-49b4-8a2d-835b5e7aa87f.json
+++ b/change/@fluentui-react-popover-4546d06a-9706-49b4-8a2d-835b5e7aa87f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(Popover): Remove leftover defaultProps and fix trigger props merge",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-popover/etc/react-popover.api.md
+++ b/packages/react-popover/etc/react-popover.api.md
@@ -127,7 +127,7 @@ export const renderPopoverSurface: (state: PopoverSurfaceState) => JSX.Element |
 export const renderPopoverTrigger: (state: PopoverTriggerState) => JSX.Element;
 
 // @public
-export const usePopover: (props: PopoverProps, defaultProps?: PopoverProps | undefined) => PopoverState;
+export const usePopover: (props: PopoverProps) => PopoverState;
 
 // @public (undocumented)
 export const usePopoverContext: <T>(selector: ContextSelector<Pick<PopoverState, "mountNode" | "open" | "setOpen" | "triggerRef" | "contentRef" | "openOnHover" | "openOnContext" | "noArrow" | "arrowRef" | "size" | "brand" | "inverted" | "trapFocus">, T>) => T;
@@ -139,7 +139,7 @@ export const usePopoverSurface: (props: PopoverSurfaceProps, ref: React_2.Ref<HT
 export const usePopoverSurfaceStyles: (state: PopoverSurfaceState) => PopoverSurfaceState;
 
 // @public
-export const usePopoverTrigger: (props: PopoverTriggerProps, defaultProps?: PopoverTriggerProps | undefined) => PopoverTriggerState;
+export const usePopoverTrigger: (props: PopoverTriggerProps) => PopoverTriggerState;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-popover/src/components/Popover/usePopover.ts
@@ -23,9 +23,8 @@ import type { OpenPopoverEvents, PopoverProps, PopoverState } from './Popover.ty
  * before being passed to renderPopover.
  *
  * @param props - props from this instance of Popover
- * @param defaultProps - (optional) default prop values provided by the implementing type
  */
-export const usePopover = (props: PopoverProps, defaultProps?: PopoverProps): PopoverState => {
+export const usePopover = (props: PopoverProps): PopoverState => {
   const [contextTarget, setContextTarget] = usePopperMouseTarget();
   const initialState = {
     size: 'medium',

--- a/packages/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
@@ -14,7 +14,6 @@ export const popoverSurfaceSlots: Array<keyof PopoverSurfaceSlots> = ['root'];
  *
  * @param props - props from this instance of PopoverSurface
  * @param ref - reference to root HTMLDivElement of PopoverSurface
- * @param defaultProps - (optional) default prop values provided by the implementing type
  */
 export const usePopoverSurface = (props: PopoverSurfaceProps, ref: React.Ref<HTMLDivElement>): PopoverSurfaceState => {
   const contentRef = usePopoverContext(context => context.contentRef);
@@ -38,7 +37,6 @@ export const usePopoverSurface = (props: PopoverSurfaceProps, ref: React.Ref<HTM
     arrowRef,
     open,
     mountNode,
-    ...props,
     components: {
       root: 'div',
     },

--- a/packages/react-popover/src/components/PopoverTrigger/PopoverTrigger.test.tsx
+++ b/packages/react-popover/src/components/PopoverTrigger/PopoverTrigger.test.tsx
@@ -74,6 +74,18 @@ describe('PopoverTrigger', () => {
     expect(getByRole('button').getAttribute('aria-haspopup')).toEqual('true');
   });
 
+  it('should allow user to override aria-haspopoup on trigger element', () => {
+    // Arrange
+    const { getByRole } = render(
+      <PopoverTrigger>
+        <button aria-haspopup="false">Trigger</button>
+      </PopoverTrigger>,
+    );
+
+    // Assert
+    expect(getByRole('button').getAttribute('aria-haspopup')).toEqual('false');
+  });
+
   it('should retain original child callback ref', () => {
     // Arrange
     const ref = jest.fn();

--- a/packages/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
+++ b/packages/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
@@ -11,12 +11,8 @@ import type { PopoverTriggerProps, PopoverTriggerState } from './PopoverTrigger.
  * before being passed to renderPopoverTrigger.
  *
  * @param props - props from this instance of PopoverTrigger
- * @param defaultProps - (optional) default prop values provided by the implementing type
  */
-export const usePopoverTrigger = (
-  props: PopoverTriggerProps,
-  defaultProps?: PopoverTriggerProps,
-): PopoverTriggerState => {
+export const usePopoverTrigger = (props: PopoverTriggerProps): PopoverTriggerState => {
   const setOpen = usePopoverContext(context => context.setOpen);
   const open = usePopoverContext(context => context.open);
   const triggerRef = usePopoverContext(context => context.triggerRef);
@@ -70,14 +66,15 @@ export const usePopoverTrigger = (
   const child = React.Children.only(props.children);
   return {
     children: React.cloneElement(child, {
+      ...triggerAttributes,
       'aria-haspopup': 'true',
+      ...child.props,
       onClick,
       onMouseEnter,
       onKeyDown,
       onMouseLeave,
       onContextMenu,
       ref: useMergedRefs(((child as unknown) as React.ReactElement & React.RefAttributes<unknown>).ref, triggerRef),
-      ...triggerAttributes,
     }),
   };
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #19767
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Removes lefover `defaultProps` usages from #19767

Also fixes an issue where user props can never override trigger props

#### Focus areas to test

(optional)
