### PR TITLE
fix(Menu): export useMenuPopoverStyles

### DIFF
--- a/change/@fluentui-react-menu-9fe80bc5-0f79-4d2b-a7e1-ce4308a97031.json
+++ b/change/@fluentui-react-menu-9fe80bc5-0f79-4d2b-a7e1-ce4308a97031.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(Menu): export useMenuPopoverStyles",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -449,6 +449,9 @@ export function useMenuListContextValues(state: MenuListState): MenuListContextV
 export const useMenuPopover: (props: MenuPopoverProps, ref: React_2.Ref<HTMLElement>) => MenuPopoverState;
 
 // @public
+export const useMenuPopoverStyles: (state: MenuPopoverState) => MenuPopoverState;
+
+// @public
 export const useMenuTrigger: (props: MenuTriggerProps) => MenuTriggerState;
 
 // @public (undocumented)

--- a/packages/react-menu/src/components/MenuPopover/index.ts
+++ b/packages/react-menu/src/components/MenuPopover/index.ts
@@ -2,3 +2,4 @@ export * from './MenuPopover';
 export * from './MenuPopover.types';
 export * from './renderMenuPopover';
 export * from './useMenuPopover';
+export * from './useMenuPopoverStyles';


### PR DESCRIPTION

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The refactor to `MenuPopover` was done, later and it turns out that the
styling hook was never exported

#### Focus areas to test

(optional)
