### PR TITLE
remove aria attributes from DetailsRowCheck

### DIFF
--- a/change/@fluentui-react-examples-76b4b323-5cf0-4ab6-9fc9-eeb55a7e79e2.json
+++ b/change/@fluentui-react-examples-76b4b323-5cf0-4ab6-9fc9-eeb55a7e79e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove aria-describedby",
+  "packageName": "@fluentui/react-examples",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/office-ui-fabric-react-0f391bc5-3a99-4f6f-8dd7-291ac6463b0d.json
+++ b/change/office-ui-fabric-react-0f391bc5-3a99-4f6f-8dd7-291ac6463b0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove aria attributes from DetailsRowCheck",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -245,15 +245,6 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
                             ? ariaLabelForSelectAllCheckbox
                             : ariaLabelForSelectionColumn
                         }
-                        aria-describedby={
-                          !isCheckboxHidden
-                            ? ariaLabelForSelectAllCheckbox && !this.props.onRenderColumnHeaderTooltip
-                              ? `${this._id}-checkTooltip`
-                              : undefined
-                            : ariaLabelForSelectionColumn && !this.props.onRenderColumnHeaderTooltip
-                            ? `${this._id}-checkTooltip`
-                            : undefined
-                        }
                         data-is-focusable={!isCheckboxHidden || undefined}
                         isHeader={true}
                         selected={isAllSelected}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -324,8 +324,7 @@ describe('DetailsHeader', () => {
     expect(component.toJSON()).toMatchSnapshot();
   });
 
-  // if ariaLabelForSelectAllCheckbox is not provided, the select all checkbox label should not
-  // be rendered and therefore aria-describedby should not exist on the select all checkbox
+  // if ariaLabelForSelectAllCheckbox is not provided, the select all checkbox label should not be rendered
   it('does not accessible label for select all checkbox or aria-describedby', () => {
     const component = mount(
       <DetailsHeader
@@ -341,21 +340,12 @@ describe('DetailsHeader', () => {
       .getDOMNode()
       .getAttribute('aria-labelledby');
 
-    expect(
-      component
-        .find(`#${selectAllCheckBoxAriaLabelledBy}`)
-        .first()
-        .getDOMNode()
-        .hasAttribute('aria-describedby'),
-    ).toBe(false);
-
     expect(component.find(`#${selectAllCheckBoxAriaLabelledBy}Tooltip`).length).toEqual(0);
   });
 
   // if ariaLabelForSelectAllCheckbox is passed in and onRenderColumnHeaderTooltip is not,
-  // the select all checkbox label should be rendered and aria-describedby on select all
-  // checkbox should exist with a valid id
-  it('renders accessible label for select all checkbox and valid aria-describedby', () => {
+  // the select all checkbox label should be rendered and with a valid id
+  it('renders accessible label for select all checkbox', () => {
     const component = mount(
       <DetailsHeader
         selection={_selection}
@@ -370,14 +360,6 @@ describe('DetailsHeader', () => {
       .find('[aria-colindex=1]')
       .getDOMNode()
       .getAttribute('aria-labelledby');
-
-    expect(
-      component
-        .find(`#${selectAllCheckBoxAriaLabelledBy}`)
-        .first()
-        .getDOMNode()
-        .getAttribute('aria-describedby')!,
-    ).toEqual(`${selectAllCheckBoxAriaLabelledBy}Tooltip`);
 
     expect(component.find(`#${selectAllCheckBoxAriaLabelledBy}Tooltip`).length).toEqual(1);
   });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -5,7 +5,7 @@ import {
   IDetailsRowCheckStyleProps,
   IDetailsRowCheckStyles,
 } from './DetailsRowCheck.types';
-import { css, styled, classNamesFunction } from '../../Utilities';
+import { css, styled, classNamesFunction, getNativeElementProps } from '../../Utilities';
 import { Check } from '../../Check';
 import { getStyles } from './DetailsRowCheck.styles';
 import { composeRenderFunction } from '@uifabric/utilities';
@@ -51,6 +51,8 @@ const DetailsRowCheckBase: React.FunctionComponent<IDetailsRowCheckProps> = prop
     theme,
   };
 
+  const divProps = getNativeElementProps('div', buttonProps, ['aria-label', 'aria-labelledby', 'aria-describedby']);
+
   return canSelect ? (
     <div
       {...buttonProps}
@@ -66,7 +68,7 @@ const DetailsRowCheckBase: React.FunctionComponent<IDetailsRowCheckProps> = prop
     </div>
   ) : (
     // eslint-disable-next-line deprecation/deprecation
-    <div {...buttonProps} className={css(classNames.root, classNames.check)} />
+    <div {...divProps} className={css(classNames.root, classNames.check)} />
   );
 };
 

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -340,7 +340,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
               >
                 <div
                   aria-checked={false}
-                  aria-describedby="header4-checkTooltip"
                   aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -138,7 +138,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -950,7 +950,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               >
                 <div
                   aria-checked={false}
-                  aria-describedby="header14-checkTooltip"
                   aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -159,7 +159,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
               >
                 <div
                   aria-checked={false}
-                  aria-describedby="header1-checkTooltip"
                   aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -385,7 +385,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 >
                   <div
                     aria-checked={false}
-                    aria-describedby="header4-checkTooltip"
                     aria-label="Toggle selection for all items"
                     className=
                         ms-DetailsRow-check

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -370,7 +370,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 >
                   <div
                     aria-checked={false}
-                    aria-describedby="header4-checkTooltip"
                     aria-label="Toggle selection for all items"
                     className=
                         ms-DetailsRow-check

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -481,6 +481,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                   id="header1-thumbnail-name"
                 >
+
                 </span>
               </span>
             </span>

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -137,7 +137,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check
@@ -482,7 +481,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                   id="header1-thumbnail-name"
                 >
-                  
+
                 </span>
               </span>
             </span>

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -481,7 +481,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                   id="header1-thumbnail-name"
                 >
-
+                  
                 </span>
               </span>
             </span>

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -481,7 +481,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                   id="header1-thumbnail-name"
                 >
-
                 </span>
               </span>
             </span>

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -137,7 +137,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -137,7 +137,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -536,7 +536,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               >
                 <div
                   aria-checked={false}
-                  aria-describedby="header6-checkTooltip"
                   aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -137,7 +137,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -137,7 +137,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
@@ -138,7 +138,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
             >
               <div
                 aria-checked={false}
-                aria-describedby="header1-checkTooltip"
                 aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check


### PR DESCRIPTION
#### Pull request checklist

- [Y] Addresses an existing issue: Fixes #0000
- [Y] Include a change request file using `$ yarn change`

#### Description of changes
On a single select, the DetailList header section has a check box that is not selectable. This checkbox has aria attibutes but does not have a role attribute causing an accessibility issue [aria-allowed-attr](https://accessibilityinsights.io/info-examples/web/aria-allowed-attr/). The current fix is to remove those aria attributes and resolve the accessibility issue.

(give an overview)

#### Focus areas to test

(optional)
