### PR TITLE
Make withViewport delay opt-in

### DIFF
--- a/change/@fluentui-react-4fef3cbd-9b5c-497c-b5af-b82ee137411c.json
+++ b/change/@fluentui-react-4fef3cbd-9b5c-497c-b5af-b82ee137411c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make withViewport delay opt-in",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -8515,6 +8515,7 @@ export interface IWithResponsiveModeState {
 export interface IWithViewportProps {
     disableResizeObserver?: boolean;
     skipViewportMeasures?: boolean;
+    waitForViewport?: boolean;
 }
 
 // @public (undocumented)


### PR DESCRIPTION
#### Description of changes

Essentially reverts #19774 because it causes major rendering delays in applications which count on an initial synchronous render pass of `DetailsList`. Hosts which do not pass `skipViewportMeasures` were essentially penalized with a 500-ms delay before content would render.

#### Focus areas to test

`DetailsList.
