### PR TITLE
react-utilities - ComponentState fix on custom props

### DIFF
--- a/change/@fluentui-react-utilities-e9f87825-e984-4418-b49e-3f07402f1609.json
+++ b/change/@fluentui-react-utilities-e9f87825-e984-4418-b49e-3f07402f1609.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updates ComponentState on custom props",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -65,7 +65,7 @@ export type ComponentPropsCompat = {
 // @public (undocumented)
 export type ComponentState<Shorthands extends ObjectShorthandPropsRecord> = {
     components?: {
-        [Key in keyof Shorthands]-?: React_2.ComponentType<NonNullable<Shorthands[Key]>> | (NonNullable<Shorthands[Key]> extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
+        [Key in keyof Shorthands]-?: React_2.ComponentType<NonNullable<Shorthands[Key]> extends ObjectShorthandProps<infer P> ? P : NonNullable<Shorthands[Key]>> | (NonNullable<Shorthands[Key]> extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
     };
 } & Shorthands;
 

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -108,7 +108,9 @@ export type ComponentProps<
 export type ComponentState<Shorthands extends ObjectShorthandPropsRecord> = {
   components?: {
     [Key in keyof Shorthands]-?:
-      | React.ComponentType<NonNullable<Shorthands[Key]>>
+      | React.ComponentType<
+          NonNullable<Shorthands[Key]> extends ObjectShorthandProps<infer P> ? P : NonNullable<Shorthands[Key]>
+        >
       | (NonNullable<Shorthands[Key]> extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
   };
 } & Shorthands;


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Updates `ComponentState` typings by adding case for when props extends `ObjectShorthandProps`

There's a case for this in `react-checkbox` when a slot expects a custom property instead of an intrinsic one,

```tsx
export type CheckboxSlots = {
  root: ObjectShorthandProps<LabelProps> | IntrinsicShorthandProps<'span'>;
};
```

`ObjectShorthandProps<LabelProps>` is not being properly handled by `ComponentState` as it's expected to unwrap `LabelProps` from `ObjectShorthandProps`