### PR TITLE
fix(mergeClasses): merge classes generated by CSS modules

### DIFF
--- a/change/@fluentui-make-styles-600013d4-087f-46dd-b38c-648534d68e60.json
+++ b/change/@fluentui-make-styles-600013d4-087f-46dd-b38c-648534d68e60.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "handle classes from CSS modules in mergeClasses()",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/make-styles/etc/make-styles.api.md
+++ b/packages/make-styles/etc/make-styles.api.md
@@ -145,7 +145,7 @@ export const SEQUENCE_HASH_LENGTH = 7;
 // Warning: (ae-internal-missing-underscore) The name "SEQUENCE_PREFIX" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export const SEQUENCE_PREFIX = "__";
+export const SEQUENCE_PREFIX = "___";
 
 // @public (undocumented)
 export type SequenceHash = string;

--- a/packages/make-styles/src/constants.ts
+++ b/packages/make-styles/src/constants.ts
@@ -7,7 +7,7 @@ export const HASH_PREFIX = 'f';
 export const SEQUENCE_HASH_LENGTH = 7;
 
 /** @internal */
-export const SEQUENCE_PREFIX = '__';
+export const SEQUENCE_PREFIX = '___';
 
 /** @internal */
 export const DEFINITION_LOOKUP_TABLE: Record<SequenceHash, LookupItem> = {};

--- a/packages/make-styles/src/makeStaticStyles.test.ts
+++ b/packages/make-styles/src/makeStaticStyles.test.ts
@@ -122,7 +122,7 @@ describe('makeStaticStyles', () => {
     });
 
     useStaticStyles({ renderer });
-    expect(useStyles({ dir: 'ltr', renderer }).root).toBe('__23yvam0 fy9yzz7 f4ybsrx');
+    expect(useStyles({ dir: 'ltr', renderer }).root).toBe('___23yvam0 fy9yzz7 f4ybsrx');
 
     expect(renderer).toMatchInlineSnapshot(`
       @font-face {

--- a/packages/make-styles/src/makeStyles.test.ts
+++ b/packages/make-styles/src/makeStyles.test.ts
@@ -25,7 +25,7 @@ describe('makeStyles', () => {
         color: 'red',
       },
     });
-    expect(computeClasses({ dir: 'ltr', renderer }).root).toEqual('__afhpfp0 fe3e8s9');
+    expect(computeClasses({ dir: 'ltr', renderer }).root).toEqual('___afhpfp0 fe3e8s9');
 
     expect(renderer).toMatchInlineSnapshot(`
       .fe3e8s9 {
@@ -41,7 +41,7 @@ describe('makeStyles', () => {
         position: 'absolute',
       },
     });
-    expect(computeClasses({ dir: 'ltr', renderer }).root).toEqual('__1jgns8t fe3e8s9 f1euv43f');
+    expect(computeClasses({ dir: 'ltr', renderer }).root).toEqual('___1jgns8t fe3e8s9 f1euv43f');
 
     expect(renderer).toMatchInlineSnapshot(`
       .fe3e8s9 {
@@ -64,8 +64,8 @@ describe('makeStyles', () => {
     const ltrClasses = computeClasses({ dir: 'ltr', renderer }).root;
     const rtlClasses = computeClasses({ dir: 'rtl', renderer }).root;
 
-    expect(ltrClasses).toEqual('__a0zqzs0 frdkuqy f1c8chgj');
-    expect(rtlClasses).toEqual('__7x57i00 f81rol6 f19krssl');
+    expect(ltrClasses).toEqual('___a0zqzs0 frdkuqy f1c8chgj');
+    expect(rtlClasses).toEqual('___7x57i00 f81rol6 f19krssl');
 
     expect(renderer).toMatchInlineSnapshot(`
       .frdkuqy {
@@ -98,7 +98,7 @@ describe('makeStyles', () => {
         animationDuration: '5s',
       },
     });
-    expect(computeClasses({ dir: 'rtl', renderer }).root).toBe('__3kh5ri0 f1fp4ujf f1cpbl36 f1t9cprh');
+    expect(computeClasses({ dir: 'rtl', renderer }).root).toBe('___3kh5ri0 f1fp4ujf f1cpbl36 f1t9cprh');
 
     expect(renderer).toMatchInlineSnapshot(`
       @-webkit-keyframes f1q8eu9e {
@@ -209,7 +209,7 @@ describe('makeStyles', () => {
         color: 'red',
       },
     });
-    expect(computeClasses({ dir: 'ltr', renderer })[42]).toEqual('__afhpfp0 fe3e8s9');
+    expect(computeClasses({ dir: 'ltr', renderer })[42]).toEqual('___afhpfp0 fe3e8s9');
 
     expect(renderer).toMatchInlineSnapshot(`
       .fe3e8s9 {

--- a/packages/make-styles/src/mergeClasses.test.ts
+++ b/packages/make-styles/src/mergeClasses.test.ts
@@ -19,6 +19,15 @@ describe('mergeClasses', () => {
     expect(mergeClasses('ui-button', 'ui-button-content')).toBe('ui-button ui-button-content');
   });
 
+  it('handles classes from CSS modules', () => {
+    expect(mergeClasses('_src_Button_module__primary')).toBe('_src_Button_module__primary');
+    expect(mergeClasses('Button_primary__XXP8s')).toBe('Button_primary__XXP8s');
+
+    expect(mergeClasses('Button_primary__XXP8b Button_primary__XXP8s')).toBe(
+      'Button_primary__XXP8b Button_primary__XXP8s',
+    );
+  });
+
   it('handles empty params', () => {
     expect(mergeClasses('ui-button', undefined)).toBe('ui-button');
     expect(mergeClasses(undefined, false)).toBe('');
@@ -68,8 +77,8 @@ describe('mergeClasses', () => {
     const sequence3 = mergeClasses(sequence1, sequence2, className5);
 
     expect(sequence1).toBe(`ui-button ${className2}`);
-    expect(sequence2).toBe('ui-flex __wz3cad0 f13qh94s f1sbtcvk fwiuce9 fdghr9 f15vdbe4');
-    expect(sequence3).toBe('ui-button ui-flex __gpv7qo0 f13qh94s f1sbtcvk fwiuce9 fdghr9 f15vdbe4 f1rqyxcv');
+    expect(sequence2).toBe('ui-flex ___wz3cad0 f13qh94s f1sbtcvk fwiuce9 fdghr9 f15vdbe4');
+    expect(sequence3).toBe('ui-button ui-flex ___gpv7qo0 f13qh94s f1sbtcvk fwiuce9 fdghr9 f15vdbe4 f1rqyxcv');
   });
 
   it('warns if an unregistered sequence was passed', () => {
@@ -78,7 +87,7 @@ describe('mergeClasses', () => {
     const className = makeStyles({ root: { display: 'block' } })(options).root;
 
     expect(mergeClasses(className, `${SEQUENCE_PREFIX}abcdefg oprsqrt`)).toBe(className);
-    expect(error).toHaveBeenCalledWith(expect.stringMatching(/passed string contains an identifier \(__abcdefg\)/));
+    expect(error).toHaveBeenCalledWith(expect.stringMatching(/passed string contains an identifier \(___abcdefg\)/));
   });
 
   it('warns if strings are not properly merged', () => {
@@ -120,7 +129,7 @@ describe('mergeClasses', () => {
       expect(mergeClasses(rtlClasses1.start, rtlClasses2.start)).toBe(rtlClasses2.start);
 
       expect(mergeClasses(rtlClasses1.start, rtlClasses2.start, rtlClasses1.end, rtlClasses2.end)).toBe(
-        '__1soy3ld f93e62u fo2qazs',
+        '___1soy3ld f93e62u fo2qazs',
       );
     });
 
@@ -137,8 +146,6 @@ describe('mergeClasses', () => {
     });
 
     it('classes for different text directions should not collide', () => {
-      // TODO: add a link to the issue
-
       const computeClasses1 = makeStyles({ root: { color: 'red' } });
       const computeClasses2 = makeStyles({ root: { paddingLeft: '10px' } });
 
@@ -148,8 +155,8 @@ describe('mergeClasses', () => {
       const rtlClassName1 = computeClasses1({ ...options, dir: 'rtl' }).root;
       const rtlClassName2 = computeClasses2({ ...options, dir: 'rtl' }).root;
 
-      expect(mergeClasses(ltrClassName1, ltrClassName2)).toBe('__1t65jhk fe3e8s9 frdkuqy');
-      expect(mergeClasses(rtlClassName1, rtlClassName2)).toBe('__w1tqsn0 fe3e8s9 f81rol6');
+      expect(mergeClasses(ltrClassName1, ltrClassName2)).toBe('___1t65jhk fe3e8s9 frdkuqy');
+      expect(mergeClasses(rtlClassName1, rtlClassName2)).toBe('___w1tqsn0 fe3e8s9 f81rol6');
     });
   });
 

--- a/packages/make-styles/src/mergeClasses.ts
+++ b/packages/make-styles/src/mergeClasses.ts
@@ -84,7 +84,7 @@ export function mergeClasses(): string {
           if (process.env.NODE_ENV !== 'production') {
             // eslint-disable-next-line no-console
             console.error(
-              `mergeClasses(): a passed string contains an identifier (${sequenceId}) that does not match any entry` +
+              `mergeClasses(): a passed string contains an identifier (${sequenceId}) that does not match any entry ` +
                 `in cache. Source string: ${className}`,
             );
           }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19724
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR changes `SEQUENCE_PREFIX` to be `___` instead of `__`, this solves the problem with colliding classes when classes from CSS modules are used as input.