### PR TITLE
fix(Popup): Should not dismiss when an iframe content is focused inside

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,6 +18,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- `Popup` should not dismiss when its iframe content is focused @ling1726 ([#19955](https://github.com/microsoft/fluentui/pull/19955))
+
 
 <!--------------------------------[ v0.59.0 ]------------------------------- -->
 ## [v0.59.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.59.0) (2021-09-20)

--- a/packages/fluentui/e2e/tests/popupIframeInContent-example.tsx
+++ b/packages/fluentui/e2e/tests/popupIframeInContent-example.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { Popup, popupContentClassName, Button } from '@fluentui/react-northstar';
+
+export const selectors = {
+  popupTriggerId: 'trigger',
+  popupContentClass: popupContentClassName,
+  iframe: 'iframe',
+};
+
+const iframeContent = `<div id="iframecontent">
+  <p>Hello World!</p>
+</div>`;
+
+const PopupIframeInContentExample = () => (
+  <>
+    <Popup
+      trigger={<Button id={selectors.popupTriggerId} content="Open popup" style={{ margin: 50 }} />}
+      content={
+        <>
+          <iframe className={selectors.iframe} title="iframe" srcDoc={iframeContent} />
+        </>
+      }
+    />
+  </>
+);
+
+export default PopupIframeInContentExample;

--- a/packages/fluentui/e2e/tests/popupIframeInContent.spec.ts
+++ b/packages/fluentui/e2e/tests/popupIframeInContent.spec.ts
@@ -1,0 +1,23 @@
+import { selectors } from './popupIframeDismiss-example';
+
+describe('Popup - Dismiss on iframe click', () => {
+  const popupTrigger = `#${selectors.popupTriggerId}`;
+  const popupContent = `.${selectors.popupContentClass}`;
+  const iframe = `.${selectors.iframe}`;
+
+  beforeEach(() => {
+    cy.gotoTestCase(__filename, popupTrigger);
+  });
+
+  it('is should close popup on iframe click', () => {
+    cy.clickOn(popupTrigger);
+    cy.visible(popupContent);
+
+    cy.clickOn(iframe);
+    cy.isFocused(iframe);
+
+    cy.wait(1500);
+
+    cy.get(popupContent).should('be.visible');
+  });
+});

--- a/packages/fluentui/e2e/tests/popupIframeInContent.spec.ts
+++ b/packages/fluentui/e2e/tests/popupIframeInContent.spec.ts
@@ -13,7 +13,7 @@ describe('Popup - Dismiss on iframe click', () => {
     cy.clickOn(popupTrigger);
     cy.visible(popupContent);
 
-    cy.clickOn(iframe);
+    cy.get(iframe).click();
     cy.isFocused(iframe);
 
     cy.wait(1500);

--- a/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
@@ -184,12 +184,14 @@ export const Popup: React.FC<PopupProps> &
   const rightClickReferenceObject = React.useRef<PopperJs.VirtualElement | null>();
 
   useOnIFrameFocus(open, context.target, (e: Event) => {
-    if (
+    const iframeInsidePopup =
       elementContains(triggerRef.current, e.target as HTMLElement) ||
-      elementContains(popupContentRef.current, e.target as HTMLElement)
-    ) {
+      elementContains(popupContentRef.current, e.target as HTMLElement);
+
+    if (iframeInsidePopup) {
       return;
     }
+
     setOpen(__ => {
       _.invoke(props, 'onOpenChange', e, { ...props, ...{ open: false } });
       return false;

--- a/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
@@ -184,9 +184,7 @@ export const Popup: React.FC<PopupProps> &
   const rightClickReferenceObject = React.useRef<PopperJs.VirtualElement | null>();
 
   useOnIFrameFocus(open, context.target, (e: Event) => {
-    const iframeInsidePopup =
-      elementContains(triggerRef.current, e.target as HTMLElement) ||
-      elementContains(popupContentRef.current, e.target as HTMLElement);
+    const iframeInsidePopup = elementContains(popupContentRef.current, e.target as HTMLElement);
 
     if (iframeInsidePopup) {
       return;

--- a/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
@@ -184,6 +184,12 @@ export const Popup: React.FC<PopupProps> &
   const rightClickReferenceObject = React.useRef<PopperJs.VirtualElement | null>();
 
   useOnIFrameFocus(open, context.target, (e: Event) => {
+    if (
+      elementContains(triggerRef.current, e.target as HTMLElement) ||
+      elementContains(popupContentRef.current, e.target as HTMLElement)
+    ) {
+      return;
+    }
     setOpen(__ => {
       _.invoke(props, 'onOpenChange', e, { ...props, ...{ open: false } });
       return false;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19956
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds a check inside the `useIFrameFocus` hook callback in `Popup` to check that the iframe is not contained within the `Popup` or the triggger.

Nested popups should be handled by `elementContains` and virtual parents.

#### Focus areas to test

(optional)
