### PR TITLE
fix(Popover): Add accessible border for HC

### DIFF
--- a/change/@fluentui-react-popover-e3fa4fd2-c615-44bf-aa65-8311dd0f20b3.json
+++ b/change/@fluentui-react-popover-e3fa4fd2-c615-44bf-aa65-8311dd0f20b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(Popover): Add accessible border for HC",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
+++ b/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
@@ -16,6 +16,7 @@ const useStyles = makeStyles({
     backgroundColor: theme.alias.color.neutral.neutralBackground1,
     boxShadow: theme.alias.shadow.shadow16,
     borderRadius: '4px',
+    border: `1px solid ${theme.alias.color.neutral.transparentStroke}`,
   }),
 
   inverted: theme => ({

--- a/packages/react-popover/src/stories/Popover.stories.tsx
+++ b/packages/react-popover/src/stories/Popover.stories.tsx
@@ -14,6 +14,23 @@ export { InternalUpdateContent } from './PopoverInternalUpdateContent.stories';
 export default {
   title: 'Components/Popover',
   component: Popover,
+  argTypes: {
+    positioning: {
+      control: {
+        disable: true,
+      },
+    },
+    defaultOpen: {
+      control: {
+        disable: true,
+      },
+    },
+    mountNode: {
+      control: {
+        disable: true,
+      },
+    },
+  },
   parameters: {
     docs: {
       description: {

--- a/packages/react-popover/src/stories/PopoverDefault.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverDefault.stories.tsx
@@ -40,21 +40,3 @@ export const Default = (props: PopoverProps) => (
     </PopoverSurface>
   </Popover>
 );
-
-Default.argTypes = {
-  positioning: {
-    control: {
-      disable: true,
-    },
-  },
-  defaultOpen: {
-    control: {
-      disable: true,
-    },
-  },
-  mountNode: {
-    control: {
-      disable: true,
-    },
-  },
-};


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Adds HC border around `PopoverSurface`, partially addresses issue #19959 to address arrow styling in HC

![image](https://user-images.githubusercontent.com/20744592/134672428-00fbf16f-619a-450b-aa78-c0337292247c.png)

#### Focus areas to test

(optional)
