### PR TITLE
Legend container shifted left by 4 px for keyboard focus border

### DIFF
--- a/change/@fluentui-react-charting-362f2982-3f5a-49c8-abac-e01245712012.json
+++ b/change/@fluentui-react-charting-362f2982-3f5a-49c8-abac-e01245712012.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Legend container shifted left by 4 px for keyboard focus border",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
@@ -57,7 +57,7 @@ export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleP
       },
     },
     legendContainer: {
-      marginTop: '5px',
+      margin: '5px 0px 0px 4px',
     },
     noData: {
       cursor: href ? 'pointer' : 'default',

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.styles.ts
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.styles.ts
@@ -37,7 +37,7 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
       marginBottom: '5px',
     },
     legendContainer: {
-      paddingTop: '4px',
+      margin: '4px 0px 0px 4px',
     },
     opacityChangeOnHover: {
       opacity: shouldHighlight ? '' : '0.1',

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -311,6 +311,9 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
     className=
 
         {
+          margin-bottom: 0px;
+          margin-left: 4px;
+          margin-right: 0px;
           margin-top: 5px;
         }
   >
@@ -670,6 +673,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
     className=
 
         {
+          margin-bottom: 0px;
+          margin-left: 4px;
+          margin-right: 0px;
           margin-top: 5px;
         }
   >
@@ -1338,6 +1344,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
     className=
 
         {
+          margin-bottom: 0px;
+          margin-left: 4px;
+          margin-right: 0px;
           margin-top: 5px;
         }
   >
@@ -1884,6 +1893,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
     className=
 
         {
+          margin-bottom: 0px;
+          margin-left: 4px;
+          margin-right: 0px;
           margin-top: 5px;
         }
   >

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1166,7 +1166,10 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
     className=
 
         {
-          padding-top: 4px;
+          margin-bottom: 0px;
+          margin-left: 4px;
+          margin-right: 0px;
+          margin-top: 4px;
         }
   >
     <div


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

For stacked bar chart and multi-stacked bar chart, legend container shifted left by 4px, so that keyboard focus should visible fully.

#### Focus areas to test

Stacked bar chart and multi-stacked bar chart

**Before Changes:**

![image](https://user-images.githubusercontent.com/29042635/134697939-2b9636c0-ab48-4870-af16-b13b6cc6e06d.png)


**After Changes:**

![image](https://user-images.githubusercontent.com/29042635/134698116-f1e3539e-d0b4-456a-b134-9da81677ef93.png)
