### PR TITLE
Charting: CherryPick #19963: Legend container shifted left by 4 px for keyboard focus border #19963

### DIFF
--- a/change/@uifabric-charting-13197f26-ffb0-4077-90c8-cb26dbe1d6d6.json
+++ b/change/@uifabric-charting-13197f26-ffb0-4077-90c8-cb26dbe1d6d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Legend container shifted left by 4 px for keyboard focus border",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
@@ -57,7 +57,7 @@ export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleP
       },
     },
     legendContainer: {
-      marginTop: '5px',
+      margin: '5px 0px 0px 4px',
     },
     noData: {
       cursor: href ? 'pointer' : 'default',

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
@@ -37,7 +37,7 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
       marginBottom: '5px',
     },
     legendContainer: {
-      paddingTop: '4px',
+      margin: '4px 0px 0px 4px',
     },
     opacityChangeOnHover: {
       opacity: shouldHighlight ? '' : '0.1',

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -311,6 +311,9 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
     className=
 
         {
+          margin-bottom: 0px;
+          margin-left: 4px;
+          margin-right: 0px;
           margin-top: 5px;
         }
   >
@@ -678,6 +681,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
     className=
 
         {
+          margin-bottom: 0px;
+          margin-left: 4px;
+          margin-right: 0px;
           margin-top: 5px;
         }
   >
@@ -1354,6 +1360,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
     className=
 
         {
+          margin-bottom: 0px;
+          margin-left: 4px;
+          margin-right: 0px;
           margin-top: 5px;
         }
   >
@@ -1906,6 +1915,9 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
     className=
 
         {
+          margin-bottom: 0px;
+          margin-left: 4px;
+          margin-right: 0px;
           margin-top: 5px;
         }
   >

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1166,7 +1166,10 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
     className=
 
         {
-          padding-top: 4px;
+          margin-bottom: 0px;
+          margin-left: 4px;
+          margin-right: 0px;
+          margin-top: 4px;
         }
   >
     <div


### PR DESCRIPTION
### Original description
Cherry pick of [#19963](https://github.com/microsoft/fluentui/pull/19963)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

For stacked bar chart and multi-stacked bar chart, legend container shifted left by 4px, so that keyboard focus should visible fully.

#### Focus areas to test

Stacked bar chart and multi-stacked bar chart

**Before Changes:**

![image](https://user-images.githubusercontent.com/29042635/134697939-2b9636c0-ab48-4870-af16-b13b6cc6e06d.png)


**After Changes:**

![image](https://user-images.githubusercontent.com/29042635/134698116-f1e3539e-d0b4-456a-b134-9da81677ef93.png)
