### PR TITLE
Pie chart: Title tag removed because of extra tooltip

### DIFF
--- a/change/@fluentui-react-charting-98dbe053-2d64-4d21-b16c-b3d50c3cb554.json
+++ b/change/@fluentui-react-charting-98dbe053-2d64-4d21-b16c-b3d50c3cb554.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed title tag so that title tooltip should not show",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/PieChart/Pie/Pie.tsx
+++ b/packages/react-charting/src/components/PieChart/Pie/Pie.tsx
@@ -41,8 +41,7 @@ export class Pie extends React.Component<IPieProps, {}> {
     const translate = `translate(${width / 2}, ${height / 2})`;
 
     return (
-      <svg width={width} height={height}>
-        {chartTitle && <title>{chartTitle}</title>}
+      <svg width={width} height={height} aria-label={chartTitle}>
         <g transform={translate}>{piechart.map((d: IArcData, i: number) => this.arcGenerator(d, i))}</g>
       </svg>
     );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Title tag was showing an extra tooltip on chart hover, so removed that. and added aria-label with svg tag for chart accessibility
#### Focus areas to test

(optional)

**Before Changes:**

![image](https://user-images.githubusercontent.com/29042635/134703113-2c75b5f8-e43c-4836-aad7-fa987fd38cc4.png)


**After Changes:**

![image](https://user-images.githubusercontent.com/29042635/134703806-3e8c5e62-0c0c-485f-8f96-91200fe9bd72.png)
