### PR TITLE
Charting: CherryPick #19965: Pie chart: Title tag removed because of extra tooltip #19965

### DIFF
--- a/change/@uifabric-charting-7367fe87-44d1-4a39-8407-a36e3351bda3.json
+++ b/change/@uifabric-charting-7367fe87-44d1-4a39-8407-a36e3351bda3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed title tag so that title tooltip should not show",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/PieChart/Pie/Pie.tsx
+++ b/packages/charting/src/components/PieChart/Pie/Pie.tsx
@@ -41,8 +41,7 @@ export class Pie extends React.Component<IPieProps, {}> {
     const translate = `translate(${width / 2}, ${height / 2})`;
 
     return (
-      <svg width={width} height={height}>
-        {chartTitle && <title>{chartTitle}</title>}
+      <svg width={width} height={height} aria-label={chartTitle}>
         <g transform={translate}>{piechart.map((d: IArcData, i: number) => this.arcGenerator(d, i))}</g>
       </svg>
     );


### PR DESCRIPTION
### Original description
Cherry pick of [#19965](https://github.com/microsoft/fluentui/pull/19965)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Title tag was showing an extra tooltip on chart hover, so removed that. and added aria-label with svg tag for chart accessibility
#### Focus areas to test

(optional)

**Before Changes:**

![image](https://user-images.githubusercontent.com/29042635/134703113-2c75b5f8-e43c-4836-aad7-fa987fd38cc4.png)


**After Changes:**

![image](https://user-images.githubusercontent.com/29042635/134703806-3e8c5e62-0c0c-485f-8f96-91200fe9bd72.png)
