### PR TITLE
Add sway icon to react-file-type-icons

### DIFF
--- a/change/@fluentui-react-file-type-icons-dec3f0e5-ff94-4a2a-80eb-f8111fedd5d5.json
+++ b/change/@fluentui-react-file-type-icons-dec3f0e5-ff94-4a2a-80eb-f8111fedd5d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add sway icon",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "chhoorn@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-file-type-icons/src/FileIconType.ts
+++ b/packages/react-file-type-icons/src/FileIconType.ts
@@ -20,6 +20,7 @@ export enum FileIconType {
   linkedFolder = 12,
   list = 13,
   form = 14,
+  sway = 15,
 }
 
-export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14;
+export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15;

--- a/packages/react-file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/react-file-type-icons/src/getFileTypeIconProps.ts
@@ -18,6 +18,7 @@ const DOCUMENTS_FOLDER = 'documentfolder';
 const PICTURES_FOLDER = 'picturesfolder';
 const LINKED_FOLDER = 'linkedfolder';
 const FORM = 'form';
+const SWAY = 'sway';
 
 export const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 export type FileTypeIconSize = 16 | 20 | 24 | 32 | 40 | 48 | 64 | 96;
@@ -134,6 +135,9 @@ export function getFileTypeIconNameFromExtensionOrType(
         break;
       case FileIconType.form:
         iconBaseName = FORM;
+        break;
+      case FileIconType.sway:
+        iconBaseName = SWAY;
         break;
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ X] Include a change request file using `$ yarn change`

#### Description of changes

Adding sway icon to react-file-type-icons.
Seems there was already an entry in the map file, but it was never hooked up.

#### Focus areas to test

(optional)
