### PR TITLE
Add wrapped option text examples to Combobox and Dropdown

### DIFF
--- a/packages/react-examples/src/react/ComboBox/ComboBox.CustomStyled.Example.tsx
+++ b/packages/react-examples/src/react/ComboBox/ComboBox.CustomStyled.Example.tsx
@@ -13,6 +13,7 @@ const fontMapping: { [fontName: string]: string } = {
   ['Times New Roman']: '"Times New Roman", "Times New Roman_MSFontService", serif',
   ['Comic Sans MS']: '"Comic Sans MS", "Comic Sans MS_MSFontService", fantasy',
   ['Calibri']: 'Calibri, Calibri_MSFontService, sans-serif',
+  ['Some sort of script font with a really long name that should wrap']: 'script, fantasy, sans-serif',
 };
 
 const fonts = Object.keys(fontMapping);
@@ -26,6 +27,9 @@ const customStyles: Partial<IComboBoxStyles> = {
   input: {
     backgroundColor: '#b4a0ff',
   },
+  optionsContainerWrapper: {
+    maxWidth: '300px',
+  },
 };
 const optionsWithCustomStyling: IComboBoxOption[] = fonts.map((fontName: string) => ({
   key: fontName,
@@ -33,15 +37,25 @@ const optionsWithCustomStyling: IComboBoxOption[] = fonts.map((fontName: string)
   styles: {
     optionText: {
       fontFamily: fontMapping[fontName],
+      overflow: 'visible',
+      whiteSpace: 'normal',
     },
   },
 }));
 
 const optionsForCustomRender: IComboBoxOption[] = [
-  { key: 'header1', text: 'Theme fonts', itemType: SelectableOptionMenuItemType.Header },
+  {
+    key: 'header1',
+    text: 'Theme fonts',
+    itemType: SelectableOptionMenuItemType.Header,
+  },
   ...fonts.map((fontName: string) => ({ key: fontName, text: fontName })),
   { key: 'divider', text: '-', itemType: SelectableOptionMenuItemType.Divider },
-  { key: 'header2', text: 'Other options', itemType: SelectableOptionMenuItemType.Header },
+  {
+    key: 'header2',
+    text: 'Other options',
+    itemType: SelectableOptionMenuItemType.Header,
+  },
 ];
 
 const onRenderOption = (item: IComboBoxOption) => {
@@ -71,7 +85,7 @@ export const ComboBoxCustomStyledExample: React.FunctionComponent = () => {
     <Stack tokens={stackTokens}>
       <ComboBox
         defaultSelectedKey="Calibri"
-        label="Custom styled ComboBox"
+        label="Custom styled ComboBox with wrapping option text"
         options={optionsWithCustomStyling}
         styles={customStyles}
       />

--- a/packages/react-examples/src/react/ComboBox/docs/ComboBoxBestPractices.md
+++ b/packages/react-examples/src/react/ComboBox/docs/ComboBoxBestPractices.md
@@ -9,7 +9,7 @@
 
 ### Accessibility
 
-Combobox dropdowns render in their own layer by default to ensure they are not clipped by containers with `overflow: hidden` or `overflow: scroll`. This causes extra difficulty for people who use touch-based screen readers, so we recommend rendering the Combobox options dropdown inline unless they are in overflow containers. To do so, set the following property on the Combobox, as demonstrated in the ComboBox with inline dropdown example:
+Comboox dropdowns render in their own layer by default to ensure they are not clipped by containers with `overflow: hidden` or `overflow: scroll`. This causes extra difficulty for people who use touch-based screen readers, so we recommend rendering the ComboBox options dropdown inline unless they are in overflow containers. To do so, set the following property on the ComboBox, as demonstrated in the ComboBox with inline dropdown example:
 
 ```js
 calloutProps={{ doNotLayer: true }}
@@ -17,6 +17,7 @@ calloutProps={{ doNotLayer: true }}
 
 #### Truncation
 
-By default, the Combobox truncates option text instead of wrapping to a new line. To avoid losing meaningful information, adjusting styles to wrap the name while keeping additional secondary text short is recommended.
+By default, the ComboBox truncates option text instead of wrapping to a new line.
+Because this can lose meaningful information, it is recommended to adjust styles to wrap the option text.
 
 The `ComboBox with custom styling` example demonstrates how to override truncation styles to support wrapping. The default style will continue to truncate to support existing implementations.

--- a/packages/react-examples/src/react/ComboBox/docs/ComboBoxBestPractices.md
+++ b/packages/react-examples/src/react/ComboBox/docs/ComboBoxBestPractices.md
@@ -14,3 +14,9 @@ Combobox dropdowns render in their own layer by default to ensure they are not c
 ```js
 calloutProps={{ doNotLayer: true }}
 ```
+
+#### Truncation
+
+By default, the Combobox truncates option text instead of wrapping to a new line. To avoid losing meaningful information, adjusting styles to wrap the name while keeping additional secondary text short is recommended.
+
+The `ComboBox with custom styling` example demonstrates how to override truncation styles to support wrapping. The default style will continue to truncate to support existing implementations.

--- a/packages/react-examples/src/react/ComboBox/docs/ComboBoxBestPractices.md
+++ b/packages/react-examples/src/react/ComboBox/docs/ComboBoxBestPractices.md
@@ -9,7 +9,7 @@
 
 ### Accessibility
 
-Comboox dropdowns render in their own layer by default to ensure they are not clipped by containers with `overflow: hidden` or `overflow: scroll`. This causes extra difficulty for people who use touch-based screen readers, so we recommend rendering the ComboBox options dropdown inline unless they are in overflow containers. To do so, set the following property on the ComboBox, as demonstrated in the ComboBox with inline dropdown example:
+ComboBox dropdowns render in their own layer by default to ensure they are not clipped by containers with `overflow: hidden` or `overflow: scroll`. This causes extra difficulty for people who use touch-based screen readers, so we recommend rendering the ComboBox options dropdown inline unless they are in overflow containers. To do so, set the following property on the ComboBox, as demonstrated in the ComboBox with inline dropdown example:
 
 ```js
 calloutProps={{ doNotLayer: true }}

--- a/packages/react-examples/src/react/Dropdown/Dropdown.Wrapping.Example.tsx
+++ b/packages/react-examples/src/react/Dropdown/Dropdown.Wrapping.Example.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { IStackTokens, Stack } from '@fluentui/react/lib/Stack';
+import { Dropdown, DropdownMenuItemType, IDropdownStyles, IDropdownOption } from '@fluentui/react/lib/Dropdown';
+
+const dropdownStyles: Partial<IDropdownStyles> = {
+  dropdown: { width: 300 },
+  dropdownOptionText: { overflow: 'visible', whiteSpace: 'normal' },
+  dropdownItem: { height: 'auto' },
+};
+
+const options: IDropdownOption[] = [
+  {
+    key: 'fruitsHeader',
+    text: 'Fruits',
+    itemType: DropdownMenuItemType.Header,
+  },
+  { key: 'apple', text: 'Apple' },
+  { key: 'banana', text: 'Banana' },
+  { key: 'orange', text: 'Orange', disabled: true },
+  {
+    key: 'grape',
+    text: 'Grape with some super long text, maybe this includes muscat too',
+  },
+  { key: 'divider_1', text: '-', itemType: DropdownMenuItemType.Divider },
+  {
+    key: 'vegetablesHeader',
+    text: 'Vegetables',
+    itemType: DropdownMenuItemType.Header,
+  },
+  { key: 'broccoli', text: 'Broccoli' },
+  { key: 'carrot', text: 'Carrot' },
+  { key: 'lettuce', text: 'Lettuce' },
+];
+
+const stackTokens: IStackTokens = { childrenGap: 20 };
+
+export const DropdownWrappingExample: React.FunctionComponent = () => {
+  return (
+    <Stack tokens={stackTokens}>
+      <Dropdown
+        placeholder="Select an option"
+        label="Basic uncontrolled example"
+        options={options}
+        styles={dropdownStyles}
+      />
+    </Stack>
+  );
+};

--- a/packages/react-examples/src/react/Dropdown/Dropdown.Wrapping.Example.tsx
+++ b/packages/react-examples/src/react/Dropdown/Dropdown.Wrapping.Example.tsx
@@ -39,7 +39,7 @@ export const DropdownWrappingExample: React.FunctionComponent = () => {
     <Stack tokens={stackTokens}>
       <Dropdown
         placeholder="Select an option"
-        label="Basic uncontrolled example"
+        label="Wrapping option text example"
         options={options}
         styles={dropdownStyles}
       />

--- a/packages/react-examples/src/react/Dropdown/Dropdown.doc.tsx
+++ b/packages/react-examples/src/react/Dropdown/Dropdown.doc.tsx
@@ -5,6 +5,7 @@ import { DropdownBasicExample } from './Dropdown.Basic.Example';
 import { DropdownControlledExample } from './Dropdown.Controlled.Example';
 import { DropdownControlledMultiExample } from './Dropdown.ControlledMulti.Example';
 import { DropdownCustomExample } from './Dropdown.Custom.Example';
+import { DropdownWrappingExample } from './Dropdown.Wrapping.Example';
 import { DropdownErrorExample } from './Dropdown.Error.Example';
 import { DropdownRequiredExample } from './Dropdown.Required.Example';
 
@@ -12,6 +13,7 @@ const DropdownBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/r
 const DropdownControlledExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Dropdown/Dropdown.Controlled.Example.tsx') as string;
 const DropdownControlledMultiExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Dropdown/Dropdown.ControlledMulti.Example.tsx') as string;
 const DropdownCustomExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Dropdown/Dropdown.Custom.Example.tsx') as string;
+const DropdownWrappingExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Dropdown/Dropdown.Wrapping.Example.tsx') as string;
 const DropdownErrorExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Dropdown/Dropdown.Error.Example.tsx') as string;
 const DropdownRequiredExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Dropdown/Dropdown.Required.Example.tsx') as string;
 
@@ -39,6 +41,11 @@ export const DropdownPageProps: IDocPageProps = {
       title: 'Customized Dropdown',
       code: DropdownCustomExampleCode,
       view: <DropdownCustomExample />,
+    },
+    {
+      title: 'Dropdown with wrapping option text',
+      code: DropdownWrappingExampleCode,
+      view: <DropdownWrappingExample />,
     },
     {
       title: 'Dropdown with error message',

--- a/packages/react-examples/src/react/Dropdown/docs/DropdownBestPractices.md
+++ b/packages/react-examples/src/react/Dropdown/docs/DropdownBestPractices.md
@@ -11,3 +11,17 @@
 - If there isn't a default option, use "Select an option" as placeholder text.
 - If "None" is an option, include it.
 - Write the choices using parallel construction. For example, start with the same part of speech or verb tense.
+
+### Accessibility
+
+Dropdown popups render in their own layer by default to ensure they are not clipped by containers with overflow: hidden or overflow: scroll. This causes extra difficulty for people who use touch-based screen readers, so we recommend rendering the Dropdown options list inline unless they are in overflow containers. To do so, set the following property on the Dropdown:
+
+```jsx
+calloutProps={{ doNotLayer: true }}
+```
+
+#### Truncation
+
+By default, the Dropdown truncates option text instead of wrapping to a new line. To avoid losing meaningful information, adjusting styles to wrap the name while keeping additional secondary text short is recommended.
+
+The `Dropdown with wrapping option text` example demonstrates how to override truncation styles to support wrapping. The default style will continue to truncate to support existing implementations.

--- a/packages/react-examples/src/react/Dropdown/docs/DropdownBestPractices.md
+++ b/packages/react-examples/src/react/Dropdown/docs/DropdownBestPractices.md
@@ -22,6 +22,7 @@ calloutProps={{ doNotLayer: true }}
 
 #### Truncation
 
-By default, the Dropdown truncates option text instead of wrapping to a new line. To avoid losing meaningful information, adjusting styles to wrap the name while keeping additional secondary text short is recommended.
+By default, the Dropdown truncates option text instead of wrapping to a new line.
+Because this can lose meaningful information, it is recommended to adjust styles to wrap the option text.
 
 The `Dropdown with wrapping option text` example demonstrates how to override truncation styles to support wrapping. The default style will continue to truncate to support existing implementations.

--- a/packages/react-examples/src/react/Dropdown/docs/DropdownBestPractices.md
+++ b/packages/react-examples/src/react/Dropdown/docs/DropdownBestPractices.md
@@ -14,7 +14,7 @@
 
 ### Accessibility
 
-Dropdown popups render in their own layer by default to ensure they are not clipped by containers with overflow: hidden or overflow: scroll. This causes extra difficulty for people who use touch-based screen readers, so we recommend rendering the Dropdown options list inline unless they are in overflow containers. To do so, set the following property on the Dropdown:
+Dropdown popups render in their own layer by default to ensure they are not clipped by containers with `overflow: hidden` or `overflow: scroll`. This causes extra difficulty for people who use touch-based screen readers, so we recommend rendering the Dropdown options list inline unless they are in overflow containers. To do so, set the following property on the Dropdown:
 
 ```jsx
 calloutProps={{ doNotLayer: true }}

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -51,7 +51,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           }
       id="ComboBox0-label"
     >
-      Custom styled ComboBox
+      Custom styled ComboBox with wrapping option text
     </label>
     <div
       className=

--- a/packages/react-examples/src/react/__snapshots__/Dropdown.Wrapping.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Dropdown.Wrapping.Example.tsx.shot
@@ -1,0 +1,233 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Dropdown.Wrapping.Example.tsx correctly 1`] = `
+<div
+  className=
+      ms-Stack
+      {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
+      }
+      & > * {
+        text-overflow: ellipsis;
+      }
+      & > *:not(:first-child) {
+        margin-top: 20px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
+      }
+>
+  <div
+    className="ms-Dropdown-container"
+  >
+    <label
+      className=
+          ms-Label
+          ms-Dropdown-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      id="Dropdown0-label"
+    >
+      Basic uncontrolled example
+    </label>
+    <div
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-labelledby="Dropdown0-label Dropdown0-option"
+      className=
+          ms-Dropdown
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            border-color: #605e5c;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            user-select: none;
+            width: 300px;
+          }
+          &:hover .ms-Dropdown-title {
+            border-color: #323130;
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Dropdown-title {
+            border-color: Highlight;
+          }
+          &:focus .ms-Dropdown-title {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Dropdown-title {
+            color: Highlight;
+          }
+          &:focus:after {
+            border-radius: 2px;
+            border: 2px solid #0078d4;
+            box-sizing: border-box;
+            content: '';
+            height: 100%;
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            top: 0px;
+            width: 100%;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
+            color: Highlight;
+          }
+          &:active .ms-Dropdown-title {
+            border-color: #0078d4;
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Dropdown-title {
+            border-color: Highlight;
+          }
+          &:hover .ms-Dropdown-caretDown {
+            color: #323130;
+          }
+          &:focus .ms-Dropdown-caretDown {
+            color: #323130;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Dropdown-caretDown {
+            color: Highlight;
+          }
+          &:active .ms-Dropdown-caretDown {
+            color: #323130;
+          }
+          &:hover .ms-Dropdown-titleIsPlaceHolder {
+            color: #323130;
+          }
+          &:focus .ms-Dropdown-titleIsPlaceHolder {
+            color: #323130;
+          }
+          &:active .ms-Dropdown-titleIsPlaceHolder {
+            color: #323130;
+          }
+          &:hover .ms-Dropdown-title--hasError {
+            border-color: #a4262c;
+          }
+          &:active .ms-Dropdown-title--hasError {
+            border-color: #a4262c;
+          }
+      data-is-focusable={true}
+      data-ktp-target={true}
+      id="Dropdown0"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      role="combobox"
+      tabIndex={0}
+    >
+      <span
+        aria-atomic={true}
+        aria-invalid={false}
+        aria-live="polite"
+        className=
+            ms-Dropdown-title
+            ms-Dropdown-titleIsPlaceHolder
+            {
+              background-color: #ffffff;
+              border-color: #605e5c;
+              border-radius: 2px;
+              border-style: solid;
+              border-width: 1px;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #605e5c;
+              cursor: pointer;
+              display: block;
+              height: 32px;
+              line-height: 30px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 28px;
+              padding-top: 0;
+              position: relative;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        id="Dropdown0-option"
+      >
+        Select an option
+      </span>
+      <span
+        className=
+            ms-Dropdown-caretDownWrapper
+            {
+              cursor: pointer;
+              height: 32px;
+              line-height: 30px;
+              position: absolute;
+              right: 8px;
+              top: 1px;
+            }
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Dropdown-caretDown
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-size: 12px;
+                font-style: normal;
+                font-weight: normal;
+                pointer-events: none;
+                speak: none;
+              }
+          data-icon-name="ChevronDown"
+        >
+          
+        </i>
+      </span>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react-examples/src/react/__snapshots__/Dropdown.Wrapping.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Dropdown.Wrapping.Example.tsx.shot
@@ -52,7 +52,7 @@ exports[`Component Examples renders Dropdown.Wrapping.Example.tsx correctly 1`] 
           }
       id="Dropdown0-label"
     >
-      Basic uncontrolled example
+      Wrapping option text example
     </label>
     <div
       aria-expanded="false"

--- a/packages/react-examples/src/react/__snapshots__/Dropdown.Wrapping.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Dropdown.Wrapping.Example.tsx.shot
@@ -158,9 +158,7 @@ exports[`Component Examples renders Dropdown.Wrapping.Example.tsx correctly 1`] 
       tabIndex={0}
     >
       <span
-        aria-atomic={true}
         aria-invalid={false}
-        aria-live="polite"
         className=
             ms-Dropdown-title
             ms-Dropdown-titleIsPlaceHolder


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15498
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Wrapping text + tooltips has a bunch of a11y issues, so I added some examples & docs to show how to opt out!

Previously made this change on PeoplePicker, this PR adds it to Combo & Dropdown
