### PR TITLE
feat(react-tabster): Update default focus outline styles

### DIFF
--- a/change/@fluentui-react-accordion-32aca648-009d-4f30-b946-9d313d2c8512.json
+++ b/change/@fluentui-react-accordion-32aca648-009d-4f30-b946-9d313d2c8512.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use new default pseudo element focus outline style",
+  "packageName": "@fluentui/react-accordion",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-7eabaa4b-cce6-4e23-933d-f28a827734a2.json
+++ b/change/@fluentui-react-button-7eabaa4b-cce6-4e23-933d-f28a827734a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use new default pseudo element focus outline style",
+  "packageName": "@fluentui/react-button",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-7eabaa4b-cce6-4e23-933d-f28a827734a2.json
+++ b/change/@fluentui-react-button-7eabaa4b-cce6-4e23-933d-f28a827734a2.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Use new default pseudo element focus outline style",
+  "comment": "Use the renamed createCustomFocusIndicatorStyle helper for focus outline style",
   "packageName": "@fluentui/react-button",
   "email": "lingfangao@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-checkbox-cd4216e1-692d-4641-a4e1-36f668a0df13.json
+++ b/change/@fluentui-react-checkbox-cd4216e1-692d-4641-a4e1-36f668a0df13.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use new default pseudo element focus outline style",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-cea407d9-dd47-4cf1-86e1-5fb33434985c.json
+++ b/change/@fluentui-react-link-cea407d9-dd47-4cf1-86e1-5fb33434985c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use the renamed createCustomFocusIndicatorStyle helper for focus outline style",
+  "packageName": "@fluentui/react-link",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-54061d79-fc53-4f87-8238-3b84628e879b.json
+++ b/change/@fluentui-react-menu-54061d79-fc53-4f87-8238-3b84628e879b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use new default pseudo element focus outline style",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-84f87cb9-85b4-4a59-b5fe-cae8fe8a97bb.json
+++ b/change/@fluentui-react-slider-84f87cb9-85b4-4a59-b5fe-cae8fe8a97bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use new default pseudo element focus outline style",
+  "packageName": "@fluentui/react-slider",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-7f2bf0df-639d-409b-843b-66e3896f0dd7.json
+++ b/change/@fluentui-react-switch-7f2bf0df-639d-409b-843b-66e3896f0dd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use new default pseudo element focus outline style",
+  "packageName": "@fluentui/react-switch",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-c78ad5dc-ba5f-4995-a7b5-9189b74a6bab.json
+++ b/change/@fluentui-react-tabster-c78ad5dc-ba5f-4995-a7b5-9189b74a6bab.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore(react-tabster): Update default focus ring styles",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
@@ -16,10 +16,7 @@ const useStyles = makeStyles({
     userSelect: 'none',
     textAlign: 'unset',
   },
-  focusIndicator: createFocusIndicatorStyleRule(theme => ({
-    border: `1px solid ${theme.alias.color.neutral.neutralForeground1}`,
-    borderRadius: '2px',
-  })),
+  focusIndicator: createFocusIndicatorStyleRule(),
   root: theme => ({
     color: theme.alias.color.neutral.neutralForeground1,
     backgroundColor: theme.alias.color.neutral.neutralBackground1,
@@ -33,6 +30,7 @@ const useStyles = makeStyles({
     display: 'inline-block',
   },
   button: {
+    position: 'relative',
     width: 'calc(100% - 22px)',
     border: '1px solid transparent',
     paddingRight: '10px',

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
@@ -1,5 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { createFocusIndicatorStyleRule } from '@fluentui/react-tabster';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import type { AccordionHeaderState } from './AccordionHeader.types';
 
 const useStyles = makeStyles({
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
     userSelect: 'none',
     textAlign: 'unset',
   },
-  focusIndicator: createFocusIndicatorStyleRule(),
+  focusIndicator: theme => createFocusOutlineStyle(theme),
   root: theme => ({
     color: theme.alias.color.neutral.neutralForeground1,
     backgroundColor: theme.alias.color.neutral.neutralBackground1,

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -1,5 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { createFocusIndicatorStyleRule } from '@fluentui/react-tabster';
+import { createFocusIndicatorStyleRule, getDefaultFocusOutlineStyles } from '@fluentui/react-tabster';
 import type { ButtonState } from './Button.types';
 
 // TODO: These are named in design specs but not hoisted to global/alias yet.
@@ -15,6 +15,7 @@ export const buttonSpacing = {
 
 const useRootStyles = makeStyles({
   base: theme => ({
+    position: 'relative',
     alignItems: 'center',
     display: 'inline-flex',
     justifyContent: 'center',
@@ -24,7 +25,7 @@ const useRootStyles = makeStyles({
 
     maxWidth: '280px',
 
-    overflow: 'hidden',
+    // overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
 
@@ -245,23 +246,22 @@ const useRootStyles = makeStyles({
 });
 
 const useRootFocusStyles = makeStyles({
-  base: createFocusIndicatorStyleRule(theme => ({
-    borderColor: 'transparent',
-    boxShadow: `
-      ${theme.alias.shadow.shadow4},
-      0 0 0 2px ${theme.alias.color.neutral.strokeFocus2}
-    `,
-    zIndex: 1,
-  })),
+  base: createFocusIndicatorStyleRule(),
   circular: createFocusIndicatorStyleRule(theme => ({
-    borderRadius: theme.global.borderRadius.circular,
+    ...getDefaultFocusOutlineStyles(theme, {
+      outlineRadius: theme.global.borderRadius.circular,
+    }),
   })),
   primary: createFocusIndicatorStyleRule(theme => ({
+    ...getDefaultFocusOutlineStyles(theme, {
+      outlineOffset: '1px',
+    }),
     borderColor: theme.alias.color.neutral.neutralForegroundOnBrand,
-    boxShadow: `${theme.alias.shadow.shadow2}, 0 0 0 2px ${theme.alias.color.neutral.strokeFocus2}`,
   })),
   square: createFocusIndicatorStyleRule(theme => ({
-    borderRadius: theme.global.borderRadius.none,
+    ...getDefaultFocusOutlineStyles(theme, {
+      outlineRadius: theme.global.borderRadius.none,
+    }),
   })),
 });
 

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -246,11 +246,16 @@ const useRootStyles = makeStyles({
 });
 
 const useRootFocusStyles = makeStyles({
-  //   base: theme => createFocusOutlineStyle(theme),
-  //   circular: theme =>
-  //    createFocusOutlineStyle(theme, { style: { outlineRadius: theme.global.borderRadius.circular } }),
-  //   primary: theme => createFocusOutlineStyle(theme, { style: { outlineOffset: '2px' } }),
-  //   square: theme => createFocusOutlineStyle(theme, { style: { outlineRadius: theme.global.borderRadius.none } }),
+  // TODO: `overflow: 'hidden'` on the root does not pay well with `position: absolute`
+  // used by the outline pseudo-element. Need to introduce a text container for children and set
+  // overflow there so that default focus outline can work
+  //
+  // base: theme => createFocusOutlineStyle(theme),
+  // circular: theme =>
+  //  createFocusOutlineStyle(theme, { style: { outlineRadius: theme.global.borderRadius.circular } }),
+  // primary: theme => createFocusOutlineStyle(theme, { style: { outlineOffset: '2px' } }),
+  // square: theme => createFocusOutlineStyle(theme, { style: { outlineRadius: theme.global.borderRadius.none } }),
+
   base: createCustomFocusIndicatorStyle(theme => ({
     borderColor: 'transparent',
     outline: '2px solid transparent',

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -15,7 +15,6 @@ export const buttonSpacing = {
 
 const useRootStyles = makeStyles({
   base: theme => ({
-    position: 'relative',
     alignItems: 'center',
     display: 'inline-flex',
     justifyContent: 'center',

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -25,7 +25,6 @@ const useRootStyles = makeStyles({
 
     maxWidth: '280px',
 
-    // overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
 

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -1,5 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { createFocusIndicatorStyleRule, getDefaultFocusOutlineStyles } from '@fluentui/react-tabster';
+import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import type { ButtonState } from './Button.types';
 
 // TODO: These are named in design specs but not hoisted to global/alias yet.
@@ -25,6 +25,7 @@ const useRootStyles = makeStyles({
 
     maxWidth: '280px',
 
+    overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
 
@@ -245,22 +246,29 @@ const useRootStyles = makeStyles({
 });
 
 const useRootFocusStyles = makeStyles({
-  base: createFocusIndicatorStyleRule(),
-  circular: createFocusIndicatorStyleRule(theme => ({
-    ...getDefaultFocusOutlineStyles(theme, {
-      outlineRadius: theme.global.borderRadius.circular,
-    }),
+  //   base: theme => createFocusOutlineStyle(theme),
+  //   circular: theme =>
+  //    createFocusOutlineStyle(theme, { style: { outlineRadius: theme.global.borderRadius.circular } }),
+  //   primary: theme => createFocusOutlineStyle(theme, { style: { outlineOffset: '2px' } }),
+  //   square: theme => createFocusOutlineStyle(theme, { style: { outlineRadius: theme.global.borderRadius.none } }),
+  base: createCustomFocusIndicatorStyle(theme => ({
+    borderColor: 'transparent',
+    outline: '2px solid transparent',
+    boxShadow: `
+      ${theme.alias.shadow.shadow4},
+      0 0 0 2px ${theme.alias.color.neutral.strokeFocus2}
+    `,
+    zIndex: 1,
   })),
-  primary: createFocusIndicatorStyleRule(theme => ({
-    ...getDefaultFocusOutlineStyles(theme, {
-      outlineOffset: '1px',
-    }),
+  circular: createCustomFocusIndicatorStyle(theme => ({
+    borderRadius: theme.global.borderRadius.circular,
+  })),
+  primary: createCustomFocusIndicatorStyle(theme => ({
     borderColor: theme.alias.color.neutral.neutralForegroundOnBrand,
+    boxShadow: `${theme.alias.shadow.shadow2}, 0 0 0 2px ${theme.alias.color.neutral.strokeFocus2}`,
   })),
-  square: createFocusIndicatorStyleRule(theme => ({
-    ...getDefaultFocusOutlineStyles(theme, {
-      outlineRadius: theme.global.borderRadius.none,
-    }),
+  square: createCustomFocusIndicatorStyle(theme => ({
+    borderRadius: theme.global.borderRadius.none,
   })),
 });
 

--- a/packages/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -1,5 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { createFocusIndicatorStyleRule, getDefaultFocusOutlineStyles } from '@fluentui/react-tabster';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import { CheckboxState } from './Checkbox.types';
 
 /**
@@ -116,14 +116,8 @@ const useStyles = makeStyles({
     },
   }),
 
-  focusIndicator: createFocusIndicatorStyleRule(
-    theme => ({
-      ...getDefaultFocusOutlineStyles(theme, {
-        outlineOffset: '2px',
-      }),
-    }),
-    { selector: 'focus-within' },
-  ),
+  focusIndicator: theme =>
+    createFocusOutlineStyle(theme, { style: { outlineOffset: '2px' }, selector: 'focus-within' }),
 });
 
 const useContainerStyles = makeStyles({

--- a/packages/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -1,5 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { createFocusIndicatorStyleRule } from '@fluentui/react-tabster';
+import { createFocusIndicatorStyleRule, getDefaultFocusOutlineStyles } from '@fluentui/react-tabster';
 import { CheckboxState } from './Checkbox.types';
 
 /**
@@ -116,17 +116,11 @@ const useStyles = makeStyles({
     },
   }),
 
-  focusIndictor: createFocusIndicatorStyleRule(
+  focusIndicator: createFocusIndicatorStyleRule(
     theme => ({
-      ':after': {
-        content: "''",
-        position: 'absolute',
-        width: '100%',
-        height: '100%',
-        border: `2px solid ${theme.alias.color.neutral.neutralForeground1}`,
-        borderRadius: '4px',
-        margin: '-6px',
-      },
+      ...getDefaultFocusOutlineStyles(theme, {
+        outlineOffset: '2px',
+      }),
     }),
     { selector: 'focus-within' },
   ),
@@ -208,7 +202,7 @@ export const useCheckboxStyles = (state: CheckboxState): CheckboxState => {
 
   state.root.className = mergeClasses(
     styles.root,
-    styles.focusIndictor,
+    styles.focusIndicator,
     styles[checkedState],
     state.input.disabled && styles.disabled,
     state.root.className,

--- a/packages/react-link/src/components/Link/useLinkStyles.ts
+++ b/packages/react-link/src/components/Link/useLinkStyles.ts
@@ -1,9 +1,9 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { createFocusIndicatorStyleRule } from '@fluentui/react-tabster';
+import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import type { LinkState } from './Link.types';
 
 const useStyles = makeStyles({
-  focusIndicator: createFocusIndicatorStyleRule({
+  focusIndicator: createCustomFocusIndicatorStyle({
     textDecorationLine: 'underline',
     textDecorationStyle: 'double',
   }),

--- a/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
+++ b/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
@@ -1,9 +1,9 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
-import { createFocusIndicatorStyleRule } from '@fluentui/react-tabster';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import type { MenuItemState } from './MenuItem.types';
 
 const useStyles = makeStyles({
-  focusIndicator: createFocusIndicatorStyleRule(),
+  focusIndicator: theme => createFocusOutlineStyle(theme),
   root: theme => ({
     position: 'relative',
     color: theme.alias.color.neutral.neutralForeground1,

--- a/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
+++ b/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
@@ -5,6 +5,7 @@ import type { MenuItemState } from './MenuItem.types';
 const useStyles = makeStyles({
   focusIndicator: createFocusIndicatorStyleRule(),
   root: theme => ({
+    position: 'relative',
     color: theme.alias.color.neutral.neutralForeground1,
     backgroundColor: theme.alias.color.neutral.neutralBackground1,
     paddingRight: '10px',

--- a/packages/react-slider/src/components/RangedSlider/useRangedSliderStyles.ts
+++ b/packages/react-slider/src/components/RangedSlider/useRangedSliderStyles.ts
@@ -12,7 +12,7 @@ import {
   useTrackStyles,
   useTrackWrapperStyles,
 } from '../Slider/useSliderStyles';
-import { createFocusIndicatorStyleRule } from '@fluentui/react-tabster';
+import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import type { RangedSliderState } from './RangedSlider.types';
 
 export const lowerThumbClassName = mergeClasses(thumbClassName, `${thumbClassName + '-lower'}`);
@@ -32,7 +32,7 @@ const useInputStyles = makeStyles({
     pointerEvents: 'none',
   },
 
-  lowerInputFocusIndicator: createFocusIndicatorStyleRule(
+  lowerInputFocusIndicator: createCustomFocusIndicatorStyle(
     theme => ({
       // TODO: Update this to [`& + .${lowerThumbClassName}`]
       '& + .ms-Slider-thumb-lower': {
@@ -46,7 +46,7 @@ const useInputStyles = makeStyles({
     { selector: 'focus' },
   ),
 
-  upperInputFocusIndicator: createFocusIndicatorStyleRule(
+  upperInputFocusIndicator: createCustomFocusIndicatorStyle(
     theme => ({
       // TODO: Update this to [`& + .${upperThumbClassName}`]
       '& + .ms-Slider-thumb-upper': {

--- a/packages/react-slider/src/components/Slider/useSliderStyles.ts
+++ b/packages/react-slider/src/components/Slider/useSliderStyles.ts
@@ -76,23 +76,6 @@ export const useRootStyles = makeStyles({
     }),
     { selector: 'focus-within' },
   ),
-
-  // focusIndicator: createFocusIndicatorStyleRule(
-  //   theme => ({
-  //     ':after': {
-  //       content: "''",
-  //       position: 'absolute',
-  //       top: '-6px',
-  //       right: '-6px',
-  //       bottom: '-6px',
-  //       left: '-6px',
-  //       boxSizing: 'border-box',
-  //       border: `1px solid ${theme.alias.color.neutral.neutralForeground1}`,
-  //       borderRadius: theme.global.borderRadius.medium,
-  //     },
-  //   }),
-  //   { selector: 'focus-within' },
-  // ),
 });
 
 /**

--- a/packages/react-slider/src/components/Slider/useSliderStyles.ts
+++ b/packages/react-slider/src/components/Slider/useSliderStyles.ts
@@ -1,5 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { createFocusIndicatorStyleRule, getDefaultFocusOutlineStyles } from '@fluentui/react-tabster';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import type { SliderState } from './Slider.types';
 import { markClassName, markLabelClassName } from '../../utils/renderMarks';
 
@@ -68,14 +68,8 @@ export const useRootStyles = makeStyles({
     cursor: 'not-allowed',
   }),
 
-  focusIndicator: createFocusIndicatorStyleRule(
-    theme => ({
-      ...getDefaultFocusOutlineStyles(theme, {
-        outlineOffset: '6px',
-      }),
-    }),
-    { selector: 'focus-within' },
-  ),
+  focusIndicator: theme =>
+    createFocusOutlineStyle(theme, { selector: 'focus-within', style: { outlineOffset: '6px' } }),
 });
 
 /**

--- a/packages/react-slider/src/components/Slider/useSliderStyles.ts
+++ b/packages/react-slider/src/components/Slider/useSliderStyles.ts
@@ -1,5 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { createFocusIndicatorStyleRule } from '@fluentui/react-tabster';
+import { createFocusIndicatorStyleRule, getDefaultFocusOutlineStyles } from '@fluentui/react-tabster';
 import type { SliderState } from './Slider.types';
 import { markClassName, markLabelClassName } from '../../utils/renderMarks';
 
@@ -70,20 +70,29 @@ export const useRootStyles = makeStyles({
 
   focusIndicator: createFocusIndicatorStyleRule(
     theme => ({
-      ':after': {
-        content: "''",
-        position: 'absolute',
-        top: '-6px',
-        right: '-6px',
-        bottom: '-6px',
-        left: '-6px',
-        boxSizing: 'border-box',
-        border: `1px solid ${theme.alias.color.neutral.neutralForeground1}`,
-        borderRadius: theme.global.borderRadius.medium,
-      },
+      ...getDefaultFocusOutlineStyles(theme, {
+        outlineOffset: '6px',
+      }),
     }),
     { selector: 'focus-within' },
   ),
+
+  // focusIndicator: createFocusIndicatorStyleRule(
+  //   theme => ({
+  //     ':after': {
+  //       content: "''",
+  //       position: 'absolute',
+  //       top: '-6px',
+  //       right: '-6px',
+  //       bottom: '-6px',
+  //       left: '-6px',
+  //       boxSizing: 'border-box',
+  //       border: `1px solid ${theme.alias.color.neutral.neutralForeground1}`,
+  //       borderRadius: theme.global.borderRadius.medium,
+  //     },
+  //   }),
+  //   { selector: 'focus-within' },
+  // ),
 });
 
 /**

--- a/packages/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -1,5 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { createFocusIndicatorStyleRule } from '@fluentui/react-tabster';
+import { createFocusIndicatorStyleRule, getDefaultFocusOutlineStyles } from '@fluentui/react-tabster';
 import type { SwitchState } from './Switch.types';
 
 const rootClassName = 'ms-Switch-root';
@@ -66,17 +66,9 @@ const useRootStyles = makeStyles({
 
   focusIndicator: createFocusIndicatorStyleRule(
     theme => ({
-      ':after': {
-        content: "''",
-        position: 'absolute',
-        top: '-8px',
-        right: '-8px',
-        bottom: '-8px',
-        left: '-8px',
-        boxSizing: 'border-box',
-        border: `1px solid ${theme.alias.color.neutral.neutralForeground1}`,
-        borderRadius: theme.global.borderRadius.medium,
-      },
+      ...getDefaultFocusOutlineStyles(theme, {
+        outlineOffset: '8px',
+      }),
     }),
     { selector: 'focus-within' },
   ),

--- a/packages/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -1,5 +1,5 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
-import { createFocusIndicatorStyleRule, getDefaultFocusOutlineStyles } from '@fluentui/react-tabster';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import type { SwitchState } from './Switch.types';
 
 const rootClassName = 'ms-Switch-root';
@@ -64,14 +64,8 @@ const useRootStyles = makeStyles({
     pointerEvents: 'none',
   },
 
-  focusIndicator: createFocusIndicatorStyleRule(
-    theme => ({
-      ...getDefaultFocusOutlineStyles(theme, {
-        outlineOffset: '8px',
-      }),
-    }),
-    { selector: 'focus-within' },
-  ),
+  focusIndicator: theme =>
+    createFocusOutlineStyle(theme, { selector: 'focus-within', style: { outlineOffset: '8px' } }),
 });
 
 /**

--- a/packages/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-tabster/etc/react-tabster.api.md
@@ -4,19 +4,36 @@
 
 ```ts
 
+import type { MakeStyles } from '@fluentui/make-styles';
 import type { MakeStylesStyleRule } from '@fluentui/make-styles';
 import type { RefObject } from 'react';
 import type { Theme } from '@fluentui/react-theme';
 import { Types } from 'tabster';
 
-// @public (undocumented)
-export const createFocusIndicatorStyleRule: (rule?: MakeStylesStyleRule<Theme>, options?: CreateFocusIndicatorStyleRuleOptions) => MakeStylesStyleRule<Theme>;
+// @public
+export const createCustomFocusIndicatorStyle: (rule: MakeStylesStyleRule<Theme>, options?: CreateFocusIndicatorStyleRuleOptions) => MakeStylesStyleRule<Theme>;
 
 // @public (undocumented)
 export interface CreateFocusIndicatorStyleRuleOptions {
     // (undocumented)
     selector?: 'focus' | 'focus-within';
 }
+
+// @public
+export const createFocusOutlineStyle: (theme: Theme, options?: {
+    style: Partial<FocusOutlineStyleOptions>;
+} & CreateFocusIndicatorStyleRuleOptions) => MakeStyles;
+
+// @public (undocumented)
+export type FocusOutlineOffset = Record<'top' | 'bottom' | 'left' | 'right', string>;
+
+// @public (undocumented)
+export type FocusOutlineStyleOptions = {
+    outlineRadius: string;
+    outlineColor: string;
+    outlineWidth: string;
+    outlineOffset?: string | FocusOutlineOffset;
+};
 
 // @public
 export const useArrowNavigationGroup: (options?: UseArrowNavigationGroupOptions | undefined) => Types.TabsterDOMAttribute;

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -21,7 +21,7 @@ type FocusOutlineStyleOptions = {
  * @param options - Configures the style of the focus outline
  * @returns focus outline styles object
  */
-export const getFocusOutlineStyles = (options: FocusOutlineStyleOptions) => {
+const getFocusOutlineStyles = (options: FocusOutlineStyleOptions) => {
   const { outlineRadius, outlineColor, outlineOffset, outlineWidth } = options;
 
   const outlineOffsetTop = (outlineOffset as FocusOutlineOffset)?.top || outlineOffset;

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -5,7 +5,7 @@ import { KEYBOARD_NAV_SELECTOR } from '../symbols';
 const defaultStyleRule = (theme: Theme) => ({
   borderColor: 'transparent',
   boxShadow: `
-      inset 0 0 0 ${theme.global.strokeWidth.thick} ${theme.alias.color.neutral.strokeFocus2}
+      0 0 0 ${theme.global.strokeWidth.thick} ${theme.alias.color.neutral.strokeFocus2}
     `,
   zIndex: 1,
 });

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -63,9 +63,9 @@ const defaultOptions: CreateFocusIndicatorStyleRuleOptions = {
  * NOTE: The element with the focus outline needs to have `position: relative` so that the
  * pseudo element can be properly positioned.
  *
- * @param theme - Theme used in {@see makeStyles}
+ * @param theme - Theme used in @see makeStyles
  * @param options - Configure the style of the focus outline
- * @returns focus outline styles object for {@see makeStyles}
+ * @returns focus outline styles object for @see makeStyles
  */
 export const createFocusOutlineStyle = (
   theme: Theme,
@@ -86,10 +86,10 @@ export const createFocusOutlineStyle = (
 });
 
 /**
- * Creates a style rule for {@see makeStyles} that includes the necessary selectors for focus.
- * Should be used only when {@see createFocusOutlineStyle} does not fit requirements
+ * Creates a style rule for @see makeStyles that includes the necessary selectors for focus.
+ * Should be used only when @see createFocusOutlineStyle does not fit requirements
  *
- * @param rule - styling applied on focus, defaults to {@see getDefaultFocusOutlineStyes}
+ * @param rule - styling applied on focus, defaults to @see getDefaultFocusOutlineStyes
  */
 export const createCustomFocusIndicatorStyle = (
   rule: MakeStylesStyleRule<Theme>,

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -3,6 +3,7 @@ import type { MakeStylesStyleRule } from '@fluentui/make-styles';
 import { KEYBOARD_NAV_SELECTOR } from '../symbols';
 
 const defaultStyleRule = (theme: Theme) => ({
+  outline: `${theme.global.strokeWidth.thick} transparent`,
   boxShadow: `
       0 0 0 ${theme.global.strokeWidth.thick} ${theme.alias.color.neutral.strokeFocus2}
     `,

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -1,9 +1,9 @@
 import type { Theme } from '@fluentui/react-theme';
-import type { MakeStylesStyleRule } from '@fluentui/make-styles';
+import type { MakeStyles, MakeStylesStyleRule } from '@fluentui/make-styles';
 import { KEYBOARD_NAV_SELECTOR } from '../symbols';
 
-type FocusOutlineOffset = Record<'top' | 'bottom' | 'left' | 'right', string>;
-type FocusOutlineStyleOptions = {
+export type FocusOutlineOffset = Record<'top' | 'bottom' | 'left' | 'right', string>;
+export type FocusOutlineStyleOptions = {
   /**
    * Only property not supported by the native CSS `outline`, if this is no longer needed
    * we can just go native instead
@@ -51,20 +51,6 @@ const getFocusOutlineStyles = (options: FocusOutlineStyleOptions) => {
   };
 };
 
-/**
- *
- * @param theme - Fluent theme
- * @param options - Configures the style of the focus outline
- */
-export const getDefaultFocusOutlineStyles = (theme: Theme, options: Partial<FocusOutlineStyleOptions> = {}) =>
-  getFocusOutlineStyles({
-    outlineColor: theme.alias.color.neutral.strokeFocus2,
-    outlineRadius: theme.global.borderRadius.medium,
-    // FIXME: theme.global.strokeWidth.thick causes some weird bugs
-    outlineWidth: '2px',
-    ...options,
-  });
-
 export interface CreateFocusIndicatorStyleRuleOptions {
   selector?: 'focus' | 'focus-within';
 }
@@ -74,11 +60,39 @@ const defaultOptions: CreateFocusIndicatorStyleRuleOptions = {
 };
 
 /**
- * Creates a style rule for {@see makeStyles} that includes the necessary selectors for focus
+ * NOTE: The element with the focus outline needs to have `position: relative` so that the
+ * pseudo element can be properly positioned.
+ *
+ * @param theme - Theme used in {@see makeStyles}
+ * @param options - Configure the style of the focus outline
+ * @returns focus outline styles object for {@see makeStyles}
+ */
+export const createFocusOutlineStyle = (
+  theme: Theme,
+  options: {
+    style: Partial<FocusOutlineStyleOptions>;
+  } & CreateFocusIndicatorStyleRuleOptions = { style: {}, ...defaultOptions },
+): MakeStyles => ({
+  ':focus-visible': {
+    outline: 'none',
+  },
+  [`${KEYBOARD_NAV_SELECTOR} :${options.selector || defaultOptions.selector}`]: getFocusOutlineStyles({
+    outlineColor: theme.alias.color.neutral.strokeFocus2,
+    outlineRadius: theme.global.borderRadius.medium,
+    // FIXME: theme.global.strokeWidth.thick causes some weird bugs
+    outlineWidth: '2px',
+    ...options.style,
+  }),
+});
+
+/**
+ * Creates a style rule for {@see makeStyles} that includes the necessary selectors for focus.
+ * Should be used only when {@see createFocusOutlineStyle} does not fit requirements
+ *
  * @param rule - styling applied on focus, defaults to {@see getDefaultFocusOutlineStyes}
  */
-export const createFocusIndicatorStyleRule = (
-  rule: MakeStylesStyleRule<Theme> = getDefaultFocusOutlineStyles,
+export const createCustomFocusIndicatorStyle = (
+  rule: MakeStylesStyleRule<Theme>,
   options: CreateFocusIndicatorStyleRuleOptions = defaultOptions,
 ): MakeStylesStyleRule<Theme> => theme => ({
   ':focus-visible': {

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -3,6 +3,7 @@ import type { MakeStylesStyleRule } from '@fluentui/make-styles';
 import { KEYBOARD_NAV_SELECTOR } from '../symbols';
 
 const defaultStyleRule = (theme: Theme) => ({
+  // box shadows are ignored in forced-colors mode, use a transparent outline as fallback
   outline: `${theme.global.strokeWidth.thick} transparent`,
   boxShadow: `
       0 0 0 ${theme.global.strokeWidth.thick} ${theme.alias.color.neutral.strokeFocus2}

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -2,14 +2,68 @@ import type { Theme } from '@fluentui/react-theme';
 import type { MakeStylesStyleRule } from '@fluentui/make-styles';
 import { KEYBOARD_NAV_SELECTOR } from '../symbols';
 
-const defaultStyleRule = (theme: Theme) => ({
-  // box shadows are ignored in forced-colors mode, use a transparent outline as fallback
-  outline: `${theme.global.strokeWidth.thick} transparent`,
-  boxShadow: `
-      0 0 0 ${theme.global.strokeWidth.thick} ${theme.alias.color.neutral.strokeFocus2}
-    `,
-  zIndex: 1,
-});
+type FocusOutlineOffset = Record<'top' | 'bottom' | 'left' | 'right', string>;
+type FocusOutlineStyleOptions = {
+  /**
+   * Only property not supported by the native CSS `outline`, if this is no longer needed
+   * we can just go native instead
+   */
+  outlineRadius: string;
+  outlineColor: string;
+  outlineWidth: string;
+  outlineOffset?: string | FocusOutlineOffset;
+};
+
+/**
+ * NOTE: the element with the focus outline needs to have `position: relative` so that the
+ * pseudo element can be properly positioned.
+ *
+ * @param options - Configures the style of the focus outline
+ * @returns focus outline styles object
+ */
+export const getFocusOutlineStyles = (options: FocusOutlineStyleOptions) => {
+  const { outlineRadius, outlineColor, outlineOffset, outlineWidth } = options;
+
+  const outlineOffsetTop = (outlineOffset as FocusOutlineOffset)?.top || outlineOffset;
+  const outlineOffsetBottom = (outlineOffset as FocusOutlineOffset)?.bottom || outlineOffset;
+  const outlineOffsetLeft = (outlineOffset as FocusOutlineOffset)?.left || outlineOffset;
+  const outlineOffsetRight = (outlineOffset as FocusOutlineOffset)?.right || outlineOffset;
+
+  return {
+    borderColor: 'transparent',
+    ':after': {
+      content: '""',
+      position: 'absolute',
+      pointerEvents: 'none',
+      boxSizing: 'outline-box',
+      zIndex: 1,
+
+      borderStyle: 'solid',
+      borderWidth: outlineWidth,
+      borderRadius: outlineRadius,
+      borderColor: outlineColor,
+
+      top: !outlineOffset ? `-${outlineWidth}` : `calc(0px - ${outlineWidth} - ${outlineOffsetTop})`,
+      bottom: !outlineOffset ? `-${outlineWidth}` : `calc(0px - ${outlineWidth} - ${outlineOffsetBottom})`,
+      left: !outlineOffset ? `-${outlineWidth}` : `calc(0px - ${outlineWidth} - ${outlineOffsetLeft})`,
+      right: !outlineOffset ? `-${outlineWidth}` : `calc(0px - ${outlineWidth} - ${outlineOffsetRight})`,
+    },
+  };
+};
+
+/**
+ *
+ * @param theme - Fluent theme
+ * @param options - Configures the style of the focus outline
+ */
+export const getDefaultFocusOutlineStyles = (theme: Theme, options: Partial<FocusOutlineStyleOptions> = {}) =>
+  getFocusOutlineStyles({
+    outlineColor: theme.alias.color.neutral.strokeFocus2,
+    outlineRadius: theme.global.borderRadius.medium,
+    // FIXME: theme.global.strokeWidth.thick causes some weird bugs
+    outlineWidth: '2px',
+    ...options,
+  });
 
 export interface CreateFocusIndicatorStyleRuleOptions {
   selector?: 'focus' | 'focus-within';
@@ -19,8 +73,12 @@ const defaultOptions: CreateFocusIndicatorStyleRuleOptions = {
   selector: 'focus',
 };
 
+/**
+ * Creates a style rule for {@see makeStyles} that includes the necessary selectors for focus
+ * @param rule - styling applied on focus, defaults to {@see getDefaultFocusOutlineStyes}
+ */
 export const createFocusIndicatorStyleRule = (
-  rule: MakeStylesStyleRule<Theme> = defaultStyleRule,
+  rule: MakeStylesStyleRule<Theme> = getDefaultFocusOutlineStyles,
   options: CreateFocusIndicatorStyleRuleOptions = defaultOptions,
 ): MakeStylesStyleRule<Theme> => theme => ({
   ':focus-visible': {

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -3,7 +3,6 @@ import type { MakeStylesStyleRule } from '@fluentui/make-styles';
 import { KEYBOARD_NAV_SELECTOR } from '../symbols';
 
 const defaultStyleRule = (theme: Theme) => ({
-  borderColor: 'transparent',
   boxShadow: `
       0 0 0 ${theme.global.strokeWidth.thick} ${theme.alias.color.neutral.strokeFocus2}
     `,

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -3,7 +3,11 @@ import type { MakeStylesStyleRule } from '@fluentui/make-styles';
 import { KEYBOARD_NAV_SELECTOR } from '../symbols';
 
 const defaultStyleRule = (theme: Theme) => ({
-  outline: `solid 1px ${theme.alias.color.neutral.neutralForeground1}`,
+  borderColor: 'transparent',
+  boxShadow: `
+      inset 0 0 0 ${theme.global.strokeWidth.thick} ${theme.alias.color.neutral.strokeFocus2}
+    `,
+  zIndex: 1,
 });
 
 export interface CreateFocusIndicatorStyleRuleOptions {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Update the default focus ring styles to match what's in the current
design token superset. 

Tries to unify the focus outline styles since **there are currently 4 different ways in the codebase how focus outlines are styled**

The new default style uses a pseudo element with a border. This seems to be the best way to mimic the native `outline` css prop with an option to configure the border radius, that works both for JS themes and windows high contrast mode.

Introduces the following patterns for usage:

```ts
import { createCustomFocusIndicatorStyle, createFocusOutlineStyle } from '@fluentui/react-tabster';

const useStyles = makeStyles({
  // default focus outline
  defaultOutline: theme => createFocusOutlineStyle(theme);
  
  // configure the default focus outline;
  configureOutline: theme => 
    createFocusOutlineStyle(theme, { style: { outlineOffset, outlineRadius, outlineColor, outlineWidth} })
  
  // custom styles
  custom: createCustomFocusIndicatorStyle(theme => ({
    borderColor: 'transparent',
    outline: '2px solid transparent',
    boxShadow: `
      ${theme.alias.shadow.shadow4},
      0 0 0 2px ${theme.alias.color.neutral.strokeFocus2}
    `,
    zIndex: 1,
  })),
}
```
