### PR TITLE
fix(pickers): use listbox role when picker has no suggestions

### DIFF
--- a/change/@fluentui-react-5d671d2f-6433-4b73-80b6-bb442e1c1aec.json
+++ b/change/@fluentui-react-5d671d2f-6433-4b73-80b6-bb442e1c1aec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Switch from dialog role to listbox role for pickers with no suggestions",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -27,7 +27,9 @@ const StyledSuggestionsItem = styled<ISuggestionItemProps<any>, ISuggestionsItem
   SuggestionsItem,
   suggestionsItemStyles,
   undefined,
-  { scope: 'SuggestionItem' },
+  {
+    scope: 'SuggestionItem',
+  },
 );
 
 /**
@@ -139,7 +141,9 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
     // TODO: cleanup after refactor of pickers to composition pattern and remove SASS support.
     const spinnerClassNameOrStyles = styles
       ? { styles: spinnerStyles }
-      : { className: css('ms-Suggestions-spinner', legacyStyles.suggestionsSpinner) };
+      : {
+          className: css('ms-Suggestions-spinner', legacyStyles.suggestionsSpinner),
+        };
 
     const noResults = () => (
       // This ID can be used by the parent to set aria-activedescendant to this
@@ -165,7 +169,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
 
     const hasNoSuggestions = (!suggestions || !suggestions.length) && !isLoading;
     const divProps: React.HtmlHTMLAttributes<HTMLDivElement> =
-      hasNoSuggestions || isLoading ? { role: 'dialog', id: suggestionsListId } : {};
+      hasNoSuggestions || isLoading ? { role: 'listbox', id: suggestionsListId } : {};
 
     const forceResolveId =
       this.state.selectedActionType === SuggestionActionType.forceResolve ? 'sug-selectedAction' : undefined;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12602](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12602)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Pickers used to switch to the dialog role for the suggestions dropdown when there were no suggestions, but the changes in #19606 require a listbox parent.