### PR TITLE
Cherry-pick LayoutGroup className handling to 7.0

### DIFF
--- a/change/@uifabric-experiments-6a9d1c4e-ede9-42db-a18e-a7734acbd6d6.json
+++ b/change/@uifabric-experiments-6a9d1c4e-ede9-42db-a18e-a7734acbd6d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Support override className in LayoutGroup",
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experiments/src/components/LayoutGroup/LayoutGroup.tsx
+++ b/packages/experiments/src/components/LayoutGroup/LayoutGroup.tsx
@@ -48,11 +48,15 @@ export class LayoutGroup extends React.Component<ILayoutGroupProps, {}> {
     return (
       <div
         {...divProps}
-        className={mergeStyles('ms-LayoutGroup', {
-          display: 'flex',
-          flexDirection: direction === 'horizontal' ? 'row' : 'column',
-          justifyContent: this._getJustify(justify),
-        } as IRawStyle)}
+        className={mergeStyles(
+          'ms-LayoutGroup',
+          {
+            display: 'flex',
+            flexDirection: direction === 'horizontal' ? 'row' : 'column',
+            justifyContent: this._getJustify(justify),
+          } as IRawStyle,
+          divProps.className,
+        )}
       >
         {group}
       </div>


### PR DESCRIPTION
From #19871.