### PR TITLE
Update beachball and enabled grouped change files

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "babel-jest": "24.9.0",
     "babel-loader": "8.2.2",
     "babel-plugin-annotate-pure-calls": "0.4.0",
-    "beachball": "2.15.0",
+    "beachball": "2.16.0",
     "chalk": "4.1.0",
     "ci-info": "3.2.0",
     "clean-webpack-plugin": "3.0.0",

--- a/scripts/beachball/index.ts
+++ b/scripts/beachball/index.ts
@@ -7,6 +7,7 @@ export const config: BeachballConfig = {
   disallowedChangeTypes: ['major', 'prerelease'],
   tag: 'latest',
   generateChangelog: true,
+  groupChanges: true,
   scope: getScopes(),
   changelog: {
     customRenderers: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7219,16 +7219,17 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/beachball/-/beachball-2.15.0.tgz#7549e8077a56d2e7a3ca7c58cc5e153227223113"
-  integrity sha512-vSkN3O5Lq6Uw53kJj7e/GtC8zqeNndIpCKy1G+4M7e1UCk1QSIIHc4msIpCuE+g6V+XCGZETfPY/4ticOkLLxw==
+beachball@2.16.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-2.16.0.tgz#cd8d511782177f55b0b5f9b11071a537b7974346"
+  integrity sha512-8qMuH/ZtusIS9HgSYQ4hrJnpfdIFzxGWpPfCemSrVm/fKMRcjZ6YCNPt6YTnaSDaO0y3tNsOQ+ekMZt3c1fuOw==
   dependencies:
     cosmiconfig "^6.0.0"
     execa "^4.0.3"
     fs-extra "^8.0.1"
     git-url-parse "^11.1.2"
     glob "^7.1.4"
+    human-id "^2.0.1"
     lodash "^4.17.15"
     minimatch "^3.0.4"
     p-limit "^3.0.2"
@@ -14063,6 +14064,11 @@ https-proxy-agent@^5.0.0:
   dependencies:
     agent-base "6"
     debug "4"
+
+human-id@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/human-id/-/human-id-2.0.1.tgz#71aadd0f46d577fd982358133cfd43f2a46f1477"
+  integrity sha512-XWoYbGsEfBB0mtUHiyihsefgf+s1tNQHj7sX1kgDxUM0IEKk8rcZIPTwUpqDdFIQbkViOLejbc0t8jBzz5jL3w==
 
 human-signals@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Enable the new `groupChanges` option added in https://github.com/microsoft/beachball/pull/584 -- this makes a single change file for each `yarn change` run, which will make PRs a bit easy to review. 

Example:
```json
{
  "changes": [
    {
      "type": "prerelease",
      "comment": "fake",
      "packageName": "@fluentui/react-badge",
      "email": "elcraig@microsoft.com",
      "dependentChangeType": "patch"
    },
    {
      "type": "prerelease",
      "comment": "fake",
      "packageName": "@fluentui/react-card",
      "email": "elcraig@microsoft.com",
      "dependentChangeType": "patch"
    },
    {
      "type": "prerelease",
      "comment": "fake",
      "packageName": "@fluentui/react-components",
      "email": "elcraig@microsoft.com",
      "dependentChangeType": "patch"
    }
  ]
}
```

([Current limitation](https://github.com/microsoft/beachball/issues/602) is that if you run `yarn change`, change more packages, and run `yarn change` again, it will create a new file rather than updating the existing one for the branch. But it's still an improvement over the previous state.)