### PR TITLE
Added disabled state(style: dimming) for Tile view

### DIFF
--- a/change/@fluentui-react-experiments-238444d4-1823-4b81-9e2d-4890808aacfe.json
+++ b/change/@fluentui-react-experiments-238444d4-1823-4b81-9e2d-4890808aacfe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "added disabled prop for tile view",
+  "packageName": "@fluentui/react-experiments",
+  "email": "surya.ravva@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/Tile/Tile.scss
+++ b/packages/react-experiments/src/components/Tile/Tile.scss
@@ -486,3 +486,7 @@
     }
   }
 }
+
+.disabled {
+  opacity: 0.5;
+}

--- a/packages/react-experiments/src/components/Tile/Tile.tsx
+++ b/packages/react-experiments/src/components/Tile/Tile.tsx
@@ -168,7 +168,7 @@ export class Tile extends React.Component<ITileProps, ITileState> {
 
     const { isSelected = false, isModal = false } = this.state;
 
-    const { isSelectable = !!selection && selectionIndex > -1 } = this.props;
+    const { isSelectable = !disabled && !!selection && selectionIndex > -1 } = this.props;
     const isInvokable = (!!href || !!onClick || !!invokeSelection) && !isModal;
     const ariaLabelWithSelectState = isSelected && ariaLabelSelected ? `${ariaLabel}, ${ariaLabelSelected}` : ariaLabel;
     const content = (
@@ -242,6 +242,7 @@ export class Tile extends React.Component<ITileProps, ITileState> {
           [`ms-Tile--showCheck ${TileStyles.showCheck}`]: isModal,
           [`ms-Tile--isFluentStyling ${TileStyles.isFluentStyling}`]: isFluentStyling,
         })}
+        data-selection-disabled={disabled}
         data-is-focusable={true}
         data-is-sub-focuszone={true}
         data-disable-click-on-enter={true}

--- a/packages/react-experiments/src/components/Tile/Tile.tsx
+++ b/packages/react-experiments/src/components/Tile/Tile.tsx
@@ -162,6 +162,7 @@ export class Tile extends React.Component<ITileProps, ITileState> {
       isFluentStyling,
       ariaLabelSelected,
       nameplateOnlyOnHover,
+      disabled = false,
       ...divProps
     } = this.props;
 
@@ -218,12 +219,15 @@ export class Tile extends React.Component<ITileProps, ITileState> {
       </LinkAs>
     );
 
+    const isDisabled = (!isSelectable && !isInvokable) || disabled;
+
     return (
       <div
         aria-selected={isSelected}
         {...getNativeProps(divProps, divProperties)}
         aria-labelledby={ariaLabel ? this._labelId : this._nameId}
         aria-describedby={ariaLabelWithSelectState ? this._descriptionId : this._activityId}
+        aria-disabled={isDisabled}
         className={css('ms-Tile', className, TileStyles.tile, {
           [`ms-Tile--isSmall ${TileStyles.isSmall}`]: tileSize === 'small',
           [`ms-Tile--isLarge ${TileStyles.isLarge}`]: tileSize === 'large',
@@ -236,7 +240,7 @@ export class Tile extends React.Component<ITileProps, ITileState> {
           [`ms-Tile--showBackground ${TileStyles.showBackground}`]: !hideBackground,
           [`ms-Tile--invokable ${TileStyles.invokable}`]: isInvokable,
           [`ms-Tile--uninvokable ${TileStyles.uninvokable}`]: !isInvokable,
-          [`ms-Tile--isDisabled ${TileStyles.disabled}`]: !isSelectable && !isInvokable,
+          [`ms-Tile--isDisabled ${TileStyles.disabled}`]: isDisabled,
           [`ms-Tile--showCheck ${TileStyles.showCheck}`]: isModal,
           [`ms-Tile--isFluentStyling ${TileStyles.isFluentStyling}`]: isFluentStyling,
         })}

--- a/packages/react-experiments/src/components/Tile/Tile.tsx
+++ b/packages/react-experiments/src/components/Tile/Tile.tsx
@@ -225,7 +225,7 @@ export class Tile extends React.Component<ITileProps, ITileState> {
         {...getNativeProps(divProps, divProperties)}
         aria-labelledby={ariaLabel ? this._labelId : this._nameId}
         aria-describedby={ariaLabelWithSelectState ? this._descriptionId : this._activityId}
-        aria-disabled={disabled}
+        aria-disabled={disabled || undefined}
         className={css('ms-Tile', className, TileStyles.tile, {
           [`ms-Tile--isSmall ${TileStyles.isSmall}`]: tileSize === 'small',
           [`ms-Tile--isLarge ${TileStyles.isLarge}`]: tileSize === 'large',
@@ -242,7 +242,7 @@ export class Tile extends React.Component<ITileProps, ITileState> {
           [`ms-Tile--showCheck ${TileStyles.showCheck}`]: isModal,
           [`ms-Tile--isFluentStyling ${TileStyles.isFluentStyling}`]: isFluentStyling,
         })}
-        data-selection-disabled={disabled}
+        data-selection-disabled={disabled || undefined}
         data-is-focusable={true}
         data-is-sub-focuszone={true}
         data-disable-click-on-enter={true}

--- a/packages/react-experiments/src/components/Tile/Tile.tsx
+++ b/packages/react-experiments/src/components/Tile/Tile.tsx
@@ -219,15 +219,13 @@ export class Tile extends React.Component<ITileProps, ITileState> {
       </LinkAs>
     );
 
-    const isDisabled = (!isSelectable && !isInvokable) || disabled;
-
     return (
       <div
         aria-selected={isSelected}
         {...getNativeProps(divProps, divProperties)}
         aria-labelledby={ariaLabel ? this._labelId : this._nameId}
         aria-describedby={ariaLabelWithSelectState ? this._descriptionId : this._activityId}
-        aria-disabled={isDisabled}
+        aria-disabled={disabled}
         className={css('ms-Tile', className, TileStyles.tile, {
           [`ms-Tile--isSmall ${TileStyles.isSmall}`]: tileSize === 'small',
           [`ms-Tile--isLarge ${TileStyles.isLarge}`]: tileSize === 'large',
@@ -240,7 +238,7 @@ export class Tile extends React.Component<ITileProps, ITileState> {
           [`ms-Tile--showBackground ${TileStyles.showBackground}`]: !hideBackground,
           [`ms-Tile--invokable ${TileStyles.invokable}`]: isInvokable,
           [`ms-Tile--uninvokable ${TileStyles.uninvokable}`]: !isInvokable,
-          [`ms-Tile--isDisabled ${TileStyles.disabled}`]: isDisabled,
+          [`ms-Tile--isDisabled ${TileStyles.disabled}`]: disabled,
           [`ms-Tile--showCheck ${TileStyles.showCheck}`]: isModal,
           [`ms-Tile--isFluentStyling ${TileStyles.isFluentStyling}`]: isFluentStyling,
         })}

--- a/packages/react-experiments/src/components/Tile/Tile.types.ts
+++ b/packages/react-experiments/src/components/Tile/Tile.types.ts
@@ -106,4 +106,7 @@ export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpan
    * Hide nameplate and activity until the tile is hovered or selected (applies only to media tiles)
    */
   nameplateOnlyOnHover?: boolean;
+
+  /* whether the component should be rendered as disabled */
+  disabled?: boolean;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added disabled state(style) support for a Tile component. so that when one passes the `disabled` prop to this component, its opacity will be reduced by 50%.  This styling is required in order to easily distinguish them from not disabled ones to users. Below is the preview of the change,
![image](https://user-images.githubusercontent.com/75760398/135140361-dcef09f8-8c5e-4096-8175-cf7bd00e11f8.png)
Had similar PR for details row: https://github.com/microsoft/fluentui/pull/19979

#### Focus areas to test
Tile Component.
(optional)
