### PR TITLE
Rounded FocusBorder for ToolbarItem

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarCustomItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarCustomItemStyles.ts
@@ -10,6 +10,7 @@ export const toolbarCustomItemStyles: ComponentSlotStylesPrepared<ToolbarCustomI
     const { borderWidth } = siteVariables;
     const borderFocusStyles = getBorderFocusStyles({
       variables: siteVariables,
+      borderRadius: v.focusBorderRadius,
     });
 
     return {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarItemStyles.ts
@@ -11,6 +11,7 @@ export const toolbarItemStyles: ComponentSlotStylesPrepared<ToolbarItemStylesPro
     const { borderWidth } = siteVariables;
     const borderFocusStyles = getBorderFocusStyles({
       variables: siteVariables,
+      borderRadius: v.focusBorderRadius,
     });
 
     return {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarVariables.ts
@@ -27,6 +27,7 @@ export interface ToolbarVariables {
   foreground: string;
   background: string;
   dividerBorder: string;
+  focusBorderRadius: string;
 
   foregroundHover: string;
   backgroundHover: string;
@@ -86,6 +87,7 @@ export const toolbarVariables = (siteVars: any): ToolbarVariables => ({
   foreground: undefined,
   background: 'transparent',
   dividerBorder: undefined,
+  focusBorderRadius: siteVars.borderRadiusMedium,
 
   foregroundHover: undefined,
   backgroundHover: undefined,


### PR DESCRIPTION
Add border radius to the ToolbarItem focus border to align with other button styles.

*Before*
![image](https://user-images.githubusercontent.com/2564094/135002886-c47ea900-3cab-415e-80ce-28807f819029.png)

*After*
![image](https://user-images.githubusercontent.com/2564094/135002866-8cf83be0-8141-4188-a07f-cc7a687acd61.png)