### PR TITLE
Reorder fabric.min.css insertion in Fluent docsite

### DIFF
--- a/apps/public-docsite/src/utilities/createSite.tsx
+++ b/apps/public-docsite/src/utilities/createSite.tsx
@@ -33,13 +33,6 @@ if (window.__siteConfig?.baseCDNUrl) {
 
 initializeIcons();
 
-const corePackageVersion: string = require<any>('office-ui-fabric-core/package.json').version;
-addCSSToHeader(
-  'https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/' +
-    corePackageVersion +
-    '/css/fabric.min.css',
-);
-
 let rootElement: HTMLElement;
 
 export function createSite<TPlatforms extends string>(
@@ -125,14 +118,4 @@ export function createSite<TPlatforms extends string>(
       ReactDOM.unmountComponentAtNode(rootElement);
     }
   }
-}
-
-function addCSSToHeader(fileName: string): void {
-  const headEl = document.head;
-  const linkEl = document.createElement('link');
-
-  linkEl.type = 'text/css';
-  linkEl.rel = 'stylesheet';
-  linkEl.href = fileName;
-  headEl.appendChild(linkEl);
 }

--- a/apps/public-docsite/src/utilities/createSite.tsx
+++ b/apps/public-docsite/src/utilities/createSite.tsx
@@ -33,6 +33,13 @@ if (window.__siteConfig?.baseCDNUrl) {
 
 initializeIcons();
 
+const corePackageVersion: string = require<any>('office-ui-fabric-core/package.json').version;
+addCSSToHeader(
+  'https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/' +
+    corePackageVersion +
+    '/css/fabric.min.css',
+);
+
 let rootElement: HTMLElement;
 
 export function createSite<TPlatforms extends string>(
@@ -117,5 +124,22 @@ export function createSite<TPlatforms extends string>(
     if (rootElement) {
       ReactDOM.unmountComponentAtNode(rootElement);
     }
+  }
+}
+
+function addCSSToHeader(fileName: string): void {
+  const headEl = document.head;
+  const linkEl = document.createElement('link');
+  const styleTags = headEl.getElementsByTagName('style');
+
+  linkEl.type = 'text/css';
+  linkEl.rel = 'stylesheet';
+  linkEl.href = fileName;
+
+  // insert fabric css before other styles so it doesn't override component styles
+  if (styleTags.length) {
+    headEl.insertBefore(linkEl, styleTags[0]);
+  } else {
+    headEl.appendChild(linkEl);
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12694](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12694)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The `fabric.min.css` stylesheet was interfering with component styles, so I updated createSite to order it before any other Fluent styles (which gives it lower priority for the same selector specificity). Fixes text spacing site-only issues for icons, and possibly other components :).
