### PR TITLE
fix: do not rely on `UIEvent.view`

### DIFF
--- a/packages/fluentui/react-northstar/src/utils/whatInput.ts
+++ b/packages/fluentui/react-northstar/src/utils/whatInput.ts
@@ -106,8 +106,10 @@ const addListeners = (eventTarget: Window) => {
   eventTarget.addEventListener('keyup', eventBuffer, true);
 };
 
+type UIEventOnElement<T> = UIEvent & { currentTarget: T }
+
 // checks conditions before updating new input
-const setInput = event => {
+const setInput = (event: UIEventOnElement<Window>) => {
   // only execute if the event buffer timer isn't running
   if (!isBuffering) {
     const eventKey = event.which;
@@ -122,7 +124,7 @@ const setInput = event => {
 
     if (currentInput !== value && shouldUpdate) {
       currentInput = value;
-      doUpdate(event.view.document);
+      doUpdate(event.currentTarget.document);
     }
   }
 };
@@ -133,7 +135,7 @@ const doUpdate = (target: Document) => {
 };
 
 // buffers events that frequently also fire mouse events
-const eventBuffer = event => {
+const eventBuffer = (event: UIEventOnElement<Window>) => {
   // set the current input
   setInput(event);
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19233
- [N/A] Include a change request file using `$ yarn change`
  `yarn change` says:
  > No change files are needed

#### Description of changes

Replace `UIEvent.view` as it does not exist at least on some events in major browsers.
See https://github.com/testing-library/user-event/issues/709#issuecomment-891970951

The event handlers in the utility are added on `Window`.
Therefore `UIEvent.view` is replaced with `Event.currentTarget`.

#### Focus areas to test

(optional)
