### PR TITLE
Input spec

### DIFF
--- a/packages/react-input/Spec-styling.md
+++ b/packages/react-input/Spec-styling.md
@@ -1,5 +1,7 @@
 # `@fluentui/react-input`: Styling implementation notes
 
+**This is outdated after removal of the bookends from the core component. It will be updated as part of the PR implementing the spec changes.**
+
 Input has multiple size and appearance variants. These tables were created based on the design spec to assist with initial implementation and help ensure everything is handled.
 
 General abbreviations used:
@@ -11,9 +13,11 @@ General abbreviations used:
 ## Sizes
 
 - padding and gap values are from (theoretical) `spacing.horizontal` unless otherwise specified
+- bookend-related sizes are from separate bookends page (everything except L/R padding and spacing within inherits from default)
 - interpretation:
   - "spacing between icon before and content"/"spacing between content and icon after 1" => "spacing start/end to content"
-  - "spacing between icon after 1 and icon after 2" => "spacing within contentBefore/After" because we're not going to have two icon slots
+  - "spacing between icon after 1 and icon after 2" => "spacing within insideEnd" because we're not going to have two icon slots
+  - bookend "spacing between content and icon" => "spacing within bookend"
   - omitted "focus indicator" b/c that's handled elsewhere
 
 | Style         | All                 |
@@ -21,29 +25,33 @@ General abbreviations used:
 | v-align       | vertically centered |
 | border radius | medium              |
 
-| Style                              | medium           | small               | large     |
-| ---------------------------------- | ---------------- | ------------------- | --------- |
-| height                             | 32px             | 24px                | 40px      |
-| left/right padding                 | mNudge           | sNudge              | m         |
-| left/right padding in content      | xxs              | "                   | sNudge    |
-| content size                       | body1 (base.300) | caption1 (base.200) | base.400  |
-| "icon" size                        | 20Regular        | 16Regular           | 24Regular |
-| spacing start/end to content       | xxs              | "                   | sNudge    |
-| spacing within contentBefore/After | xs               | "                   | "         |
+| Style                         | medium           | small               | large     |
+| ----------------------------- | ---------------- | ------------------- | --------- |
+| height                        | 32px             | 24px                | 40px      |
+| left/right padding            | mNudge           | sNudge              | m         |
+| left/right padding in content | xxs              | "                   | sNudge    |
+| bookends left/right padding   | s                | sNudge              | m         |
+| content size                  | body1 (base.300) | caption1 (base.200) | base.400  |
+| "icon" size                   | 20Regular        | 16Regular           | 24Regular |
+| spacing start/end to content  | xxs              | "                   | sNudge    |
+| spacing within insideEnd      | xs               | "                   | "         |
+| spacing within bookend        | xs               | "                   | "         |
 
 ### Sizes application
 
-| Style                              | Slot                | Notes                                                            |
-| ---------------------------------- | ------------------- | ---------------------------------------------------------------- |
-| v-align                            | root                | ???                                                              |
-| height                             | root                | ? as minHeight or height ?                                       |
-| border radius                      | root                | set where borders or shadow are defined; don't use if underlined |
-| left/right padding                 | root                | padding                                                          |
-| left/right padding in content      | input               | padding                                                          |
-| content size                       | root, input         | fontSize; doesn't inherit to input                               |
-| "icon" size                        | n/a                 | no icons built in                                                |
-| spacing start/end to content       | root                | display: flex (also to grow input), flex gap                     |
-| spacing within contentBefore/After | contentBefore/After | display: flex, flex gap                                          |
+| Style                         | Slot                         | Notes                                                            |
+| ----------------------------- | ---------------------------- | ---------------------------------------------------------------- |
+| v-align                       | root, inputWrapper           | ???                                                              |
+| height                        | root                         | ? as minHeight or height ?                                       |
+| border radius                 | bookends, inputWrapper, root | set where borders or shadow are defined; don't use if underlined |
+| left/right padding            | inputWrapper                 | padding                                                          |
+| left/right padding in content | input                        | padding                                                          |
+| bookends left/right padding   | bookends                     | padding                                                          |
+| content size                  | root, input                  | fontSize; doesn't inherit to input                               |
+| "icon" size                   | n/a                          | no icons built in                                                |
+| spacing start/end to content  | inputWrapper                 | display: flex (also to grow input), flex gap                     |
+| spacing within insideEnd      | insideEnd                    | display: flex, flex gap                                          |
+| spacing within bookends       | bookends                     | display: flex, flex gap                                          |
 
 ## Appearance colors and strokes
 
@@ -80,39 +88,26 @@ General abbreviations used:
 
 ### Appearance application
 
-| Style                      | Slot                | Notes                              |
-| -------------------------- | ------------------- | ---------------------------------- |
-| content color              | input               | other things have their own colors |
-| placeholder color          | input               | `::placeholder`                    |
-| "icon" color               | contentBefore/After |                                    |
-| shadow                     | root                |                                    |
-| background                 | root, input         |                                    |
-| border                     | root                |                                    |
-| border hover               | TODO root           | `:hover`                           |
-| border pressed             | TODO                |                                    |
-| border focused             | TODO root           | `:focus-within`                    |
-| borderBottom               | root                |                                    |
-| borderBottom hover         | TODO root           | `:hover`                           |
-| borderBottom pressed       | TODO                |                                    |
-| borderBottom focused       | n/a                 | handled by focus indicator         |
-| in focus indicator         | TODO                |                                    |
-| in focus indicator pressed | TODO                |                                    |
-| cursor                     | root, input         |                                    |
+| Style                      | Slot                | Notes                                                    |
+| -------------------------- | ------------------- | -------------------------------------------------------- |
+| content color              | input               | other things have their own colors                       |
+| placeholder color          | input               | `::placeholder`                                          |
+| "icon" color               | insideStart/End     |                                                          |
+| shadow                     | root                | encompasses bookends; requires rounding root corners     |
+| background                 | inputWrapper, input | bookends have separate background; input doesn't inherit |
+| border                     | inputWrapper        |                                                          |
+| border hover               | TODO inputWrapper   | `:hover`                                                 |
+| border pressed             | TODO                |                                                          |
+| border focused             | TODO inputWrapper   | `:focus-within`                                          |
+| borderBottom               | inputWrapper        |                                                          |
+| borderBottom hover         | TODO inputWrapper   | `:hover`                                                 |
+| borderBottom pressed       | TODO                |                                                          |
+| borderBottom focused       | n/a                 | handled by focus indicator                               |
+| in focus indicator         | TODO                |                                                          |
+| in focus indicator pressed | TODO                |                                                          |
+| cursor                     | root, input         |                                                          |
 
-## Bookends (deferred)
-
-Bookend implementation has been deferred and will likely be handled in a separate component, but leaving these for reference.
-
-### Sizes
-
-| Style              | medium              | small  | large |
-| ------------------ | ------------------- | ------ | ----- |
-| v-align            | vertically centered | "      | "     |
-| border radius      | medium              | "      | "     |
-| left/right padding | s                   | sNudge | m     |
-| spacing within     | xs                  | "      | "     |
-
-### Appearance
+## Bookend appearance (TODO)
 
 | Style           | filled             | brand                    | transparent           |
 | --------------- | ------------------ | ------------------------ | --------------------- |
@@ -124,8 +119,3 @@ Bookend implementation has been deferred and will likely be handled in a separat
 - Inner border ("border right") color is applied separately to before/after bookends.
 - Others are applied in obvious way to both bookends.
 - All borders are thin (1px).
-
-### Changes to default input appearance
-
-- Remove rounded corners from input
-- For filled inputs with shadow, change the shadow to also encompass the bookends

--- a/packages/react-input/Spec-styling.md
+++ b/packages/react-input/Spec-styling.md
@@ -11,11 +11,9 @@ General abbreviations used:
 ## Sizes
 
 - padding and gap values are from (theoretical) `spacing.horizontal` unless otherwise specified
-- bookend-related sizes are from separate bookends page (everything except L/R padding and spacing within inherits from default)
 - interpretation:
   - "spacing between icon before and content"/"spacing between content and icon after 1" => "spacing start/end to content"
-  - "spacing between icon after 1 and icon after 2" => "spacing within insideEnd" because we're not going to have two icon slots
-  - bookend "spacing between content and icon" => "spacing within bookend"
+  - "spacing between icon after 1 and icon after 2" => "spacing within contentBefore/After" because we're not going to have two icon slots
   - omitted "focus indicator" b/c that's handled elsewhere
 
 | Style         | All                 |
@@ -23,33 +21,29 @@ General abbreviations used:
 | v-align       | vertically centered |
 | border radius | medium              |
 
-| Style                         | medium           | small               | large     |
-| ----------------------------- | ---------------- | ------------------- | --------- |
-| height                        | 32px             | 24px                | 40px      |
-| left/right padding            | mNudge           | sNudge              | m         |
-| left/right padding in content | xxs              | "                   | sNudge    |
-| bookends left/right padding   | s                | sNudge              | m         |
-| content size                  | body1 (base.300) | caption1 (base.200) | base.400  |
-| "icon" size                   | 20Regular        | 16Regular           | 24Regular |
-| spacing start/end to content  | xxs              | "                   | sNudge    |
-| spacing within insideEnd      | xs               | "                   | "         |
-| spacing within bookend        | xs               | "                   | "         |
+| Style                              | medium           | small               | large     |
+| ---------------------------------- | ---------------- | ------------------- | --------- |
+| height                             | 32px             | 24px                | 40px      |
+| left/right padding                 | mNudge           | sNudge              | m         |
+| left/right padding in content      | xxs              | "                   | sNudge    |
+| content size                       | body1 (base.300) | caption1 (base.200) | base.400  |
+| "icon" size                        | 20Regular        | 16Regular           | 24Regular |
+| spacing start/end to content       | xxs              | "                   | sNudge    |
+| spacing within contentBefore/After | xs               | "                   | "         |
 
 ### Sizes application
 
-| Style                         | Slot                         | Notes                                                            |
-| ----------------------------- | ---------------------------- | ---------------------------------------------------------------- |
-| v-align                       | root, inputWrapper           | ???                                                              |
-| height                        | root                         | ? as minHeight or height ?                                       |
-| border radius                 | bookends, inputWrapper, root | set where borders or shadow are defined; don't use if underlined |
-| left/right padding            | inputWrapper                 | padding                                                          |
-| left/right padding in content | input                        | padding                                                          |
-| bookends left/right padding   | bookends                     | padding                                                          |
-| content size                  | root, input                  | fontSize; doesn't inherit to input                               |
-| "icon" size                   | n/a                          | no icons built in                                                |
-| spacing start/end to content  | inputWrapper                 | display: flex (also to grow input), flex gap                     |
-| spacing within insideEnd      | insideEnd                    | display: flex, flex gap                                          |
-| spacing within bookends       | bookends                     | display: flex, flex gap                                          |
+| Style                              | Slot                | Notes                                                            |
+| ---------------------------------- | ------------------- | ---------------------------------------------------------------- |
+| v-align                            | root                | ???                                                              |
+| height                             | root                | ? as minHeight or height ?                                       |
+| border radius                      | root                | set where borders or shadow are defined; don't use if underlined |
+| left/right padding                 | root                | padding                                                          |
+| left/right padding in content      | input               | padding                                                          |
+| content size                       | root, input         | fontSize; doesn't inherit to input                               |
+| "icon" size                        | n/a                 | no icons built in                                                |
+| spacing start/end to content       | root                | display: flex (also to grow input), flex gap                     |
+| spacing within contentBefore/After | contentBefore/After | display: flex, flex gap                                          |
 
 ## Appearance colors and strokes
 
@@ -86,26 +80,39 @@ General abbreviations used:
 
 ### Appearance application
 
-| Style                      | Slot                | Notes                                                    |
-| -------------------------- | ------------------- | -------------------------------------------------------- |
-| content color              | input               | other things have their own colors                       |
-| placeholder color          | input               | `::placeholder`                                          |
-| "icon" color               | insideStart/End     |                                                          |
-| shadow                     | root                | encompasses bookends; requires rounding root corners     |
-| background                 | inputWrapper, input | bookends have separate background; input doesn't inherit |
-| border                     | inputWrapper        |                                                          |
-| border hover               | TODO inputWrapper   | `:hover`                                                 |
-| border pressed             | TODO                |                                                          |
-| border focused             | TODO inputWrapper   | `:focus-within`                                          |
-| borderBottom               | inputWrapper        |                                                          |
-| borderBottom hover         | TODO inputWrapper   | `:hover`                                                 |
-| borderBottom pressed       | TODO                |                                                          |
-| borderBottom focused       | n/a                 | handled by focus indicator                               |
-| in focus indicator         | TODO                |                                                          |
-| in focus indicator pressed | TODO                |                                                          |
-| cursor                     | root, input         |                                                          |
+| Style                      | Slot                | Notes                              |
+| -------------------------- | ------------------- | ---------------------------------- |
+| content color              | input               | other things have their own colors |
+| placeholder color          | input               | `::placeholder`                    |
+| "icon" color               | contentBefore/After |                                    |
+| shadow                     | root                |                                    |
+| background                 | root, input         |                                    |
+| border                     | root                |                                    |
+| border hover               | TODO root           | `:hover`                           |
+| border pressed             | TODO                |                                    |
+| border focused             | TODO root           | `:focus-within`                    |
+| borderBottom               | root                |                                    |
+| borderBottom hover         | TODO root           | `:hover`                           |
+| borderBottom pressed       | TODO                |                                    |
+| borderBottom focused       | n/a                 | handled by focus indicator         |
+| in focus indicator         | TODO                |                                    |
+| in focus indicator pressed | TODO                |                                    |
+| cursor                     | root, input         |                                    |
 
-## Bookend appearance (TODO)
+## Bookends (deferred)
+
+Bookend implementation has been deferred and will likely be handled in a separate component, but leaving these for reference.
+
+### Sizes
+
+| Style              | medium              | small  | large |
+| ------------------ | ------------------- | ------ | ----- |
+| v-align            | vertically centered | "      | "     |
+| border radius      | medium              | "      | "     |
+| left/right padding | s                   | sNudge | m     |
+| spacing within     | xs                  | "      | "     |
+
+### Appearance
 
 | Style           | filled             | brand                    | transparent           |
 | --------------- | ------------------ | ------------------------ | --------------------- |
@@ -117,3 +124,8 @@ General abbreviations used:
 - Inner border ("border right") color is applied separately to before/after bookends.
 - Others are applied in obvious way to both bookends.
 - All borders are thin (1px).
+
+### Changes to default input appearance
+
+- Remove rounded corners from input
+- For filled inputs with shadow, change the shadow to also encompass the bookends

--- a/packages/react-input/Spec-variants.md
+++ b/packages/react-input/Spec-variants.md
@@ -1,0 +1,85 @@
+# Input Variants
+
+Input has many variants and additional features. We don't plan to implement any of these immediately, but adding notes here for future reference.
+
+## Multi-line (`textarea`)
+
+This will tentatively be a separate component, likely sharing some internals with the basic `Input` using hooks. Scheduling TBD but likely late 2021.
+
+| Prop/concept       | v8                          | v0  | Proposal                                                 |
+| ------------------ | --------------------------- | --- | -------------------------------------------------------- |
+| resizable          | `resizable?: boolean`       |     | via native props                                         |
+| auto-adjust height | `autoAdjustHeight?: boolean |     | TBD (common request but has nasty implementation issues) |
+
+Similar to both v8 and v0, passing other `textarea` native props as top-level component props will be supported.
+
+### Possibility: `useTextInput`
+
+We might want to make a hook and some types to share props and behavior between `Input` and the potential future `TextArea` (which would depend on `react-input` but with some different props and behaviors).
+
+```ts
+type TextInputSlots<
+  TInput extends HTMLInputElement | HTMLTextAreaElement,
+  TInputAttributes = TInput extends HTMLInputElement
+    ? React.InputHTMLAttributes<TInput>
+    : React.TextAreaHTMLAttributes<TInput>
+> = {
+  root: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+  input: ObjectShorthandProps<TInputAttributes, TInput>;
+};
+```
+
+## Validation
+
+Validation features and error messages will not be built into the new `Input`. Possible approaches:
+
+- Hooks and/or a `Field` component to provide visual consistency and proper accessibility behavior across different types of inputs.
+- A `Form` component for more complex scenarios involving validation across multiple fields.
+
+### In v8
+
+```ts
+// relevant props only
+interface ITextFieldProps {
+  // static error message
+  errorMessage?: string | JSX.Element;
+  // called to determine whether input is valid and show error if not
+  // (on all changes by default; modified by validateOnFocusIn/Out)
+  onGetErrorMessage?: (value: string) => string | JSX.Element | PromiseLike<string | JSX.Element> | undefined;
+  // whether to validate when focus moves into input (NOT on change)
+  validateOnFocusIn?: boolean;
+  // whether to validate when focus moves out of input (NOT on change)
+  validateOnFocusOut?: boolean;
+  // whether to validate when input is initially rendered
+  validiateOnLoad?: boolean;
+  // wait to validate until user stops typing by this ms
+  deferredValidationTime?: number;
+  // called after validation completes
+  onNotifyValidationResult?: (errorMessage: string | JSX.Element, value: string | undefined) => void;
+  // ...
+}
+```
+
+### In v0
+
+TBD
+
+## Password
+
+v8 supports a password field with a custom reveal password button:
+
+```tsx
+<TextField type="password" canRevealPassword revealPasswordAriaLabel="Show password" />
+```
+
+v0 does not appear to have a similar feature.
+
+TBD if/how we want to handle this in converged.
+
+## Masking
+
+"Masking" refers to a text input with some pre-specified format that gets filled in as the user types, like `(___) ___-____`.
+
+In v8 it's handled by `MaskedTextField`.
+
+Masking is tricky to implement properly and bad for accessibility, so we don't plan to implement it in converged unless there's a compelling product requirement. At that point we'll also evaluate whether there are any suitable 3rd-party libraries which could handle it.

--- a/packages/react-input/Spec-variants.md
+++ b/packages/react-input/Spec-variants.md
@@ -4,12 +4,12 @@ Input has many variants and additional features. We don't plan to implement any 
 
 ## Multi-line (`textarea`)
 
-This will tentatively be a separate component, likely sharing some internals with the basic `Input` using hooks. Scheduling TBD but likely late 2021.
+This will tentatively be a separate component, likely sharing some internals with the basic `Input` using hooks (scheduling TBD).
 
-| Prop/concept       | v8                          | v0  | Proposal                                                 |
-| ------------------ | --------------------------- | --- | -------------------------------------------------------- |
-| resizable          | `resizable?: boolean`       |     | via native props                                         |
-| auto-adjust height | `autoAdjustHeight?: boolean |     | TBD (common request but has nasty implementation issues) |
+| Prop/concept       | v8                           | v0  | Proposal                                                 |
+| ------------------ | ---------------------------- | --- | -------------------------------------------------------- |
+| resizable          | `resizable?: boolean`        |     | via native props                                         |
+| auto-adjust height | `autoAdjustHeight?: boolean` |     | TBD (common request but has nasty implementation issues) |
 
 Similar to both v8 and v0, passing other `textarea` native props as top-level component props will be supported.
 

--- a/packages/react-input/Spec-variants.md
+++ b/packages/react-input/Spec-variants.md
@@ -2,6 +2,20 @@
 
 Input has many variants and additional features. We don't plan to implement any of these immediately, but adding notes here for future reference.
 
+## Bookends
+
+"Bookends" (the naming comes from the design spec) are bits of text on the left or right outside of the field, surrounded by a border or background color.
+
+Initially, bookends were planned to be included in the main component (as `bookendBefore`/`bookendAfter` slots) but we decided they're not essential and should be split out to simplify the DOM structure and defer some of the related open questions until later.
+
+If/when a partner needs this feature, it will likely go in some kind of wrapper component.
+
+Visual variants for the bookends are as follows (note that specific colors are just examples based on the default theme):
+
+- `filled` (default): bookends have a gray background, black text, and no border
+- `brand`: bookends have a brand color (such as blue or purple) background, white text, and no border
+- `transparent`: bookends have a transparent background, black text, and only a thin inside border to distinguish them from the field
+
 ## Multi-line (`textarea`)
 
 This will tentatively be a separate component, likely sharing some internals with the basic `Input` using hooks (scheduling TBD).

--- a/packages/react-input/Spec.md
+++ b/packages/react-input/Spec.md
@@ -79,7 +79,11 @@ export type InputProps = InputCommons & Omit<ComponentProps<InputSlots, 'input'>
 
 ### Main props
 
-Note: most of these are defined in `InputCommons` since they're shared with `InputState`.
+All native HTML `<input>` props are supported. Since the `input` slot is primary (more on that later), top-level native props except `className` and `style` will go to the input.
+
+The top-level `ref` prop also points to the `<input>`. This can be used for things like getting the current value or manipulating focus or selection (instead of explicitly exposing an imperative API).
+
+Most custom props are defined in `InputCommons` since they're shared with `InputState`.
 
 ```ts
 export type InputCommons = FieldSizeProps & {
@@ -142,9 +146,14 @@ Note that the field **does not** include a label, required indicator, descriptio
 
 ```ts
 export type InputSlots = {
+  /** Wrapper element for all parts of the component. */
   root: IntrinsicShorthandProps<'span'>;
 
-  /** The actual `<input>` element. `type="text"` will be automatically applied unless overridden. */
+  /**
+   * The actual `<input>` element. `type="text"` will be automatically applied unless overridden.
+   * This is the "primary" slot, so top-level native props (except `className` and `style`) and the
+   * top-level `ref` will go here.
+   */
   input: IntrinsicShorthandProps<'input'>;
 
   /**
@@ -311,12 +320,12 @@ type InputBehaviorProps = { disabled?: boolean; required?: boolean; error?: bool
 Native props following standard behavior in both libraries + converged:
 
 - `disabled?: boolean`
-- `readOnly?: boolean` -- VERIFY v0
-- `autoComplete?: string` -- VERIFY v0
-- and any other native props not specified
+- `readOnly?: boolean`
+- `autoComplete?: string`
+- and most other native props not specified
 
 ### Imperative API
 
 In v8 there's an explicit imperative API, which is accessed via `componentRef` following the [`ITextField` interface](https://github.com/microsoft/fluentui/blob/master/packages/react/src/components/TextField/TextField.types.ts#L9). The methods are used for getting the value and manipulating focus and selection.
 
-In v0, all these things can be done by calling methods on the `<input>` element itself, exposed via the top-level `ref`.
+In v0 (and in converged), all these things can be done by calling methods on the `<input>` element itself, exposed via the top-level `ref`.

--- a/packages/react-input/Spec.md
+++ b/packages/react-input/Spec.md
@@ -1,63 +1,322 @@
 # @fluentui/react-input Spec
 
+**Epic issue** - [Input Convergence](https://github.com/microsoft/fluentui/issues/18131)
+
 ## Background
 
-_Description and use cases of this component_
+`Input` in its most basic form is a text input field abstracting `<input type="text" />`.
+
+In some libraries it also abstracts a `textarea` (multi-line text input). It may also have features such as a label and start/end slots built in.
 
 ## Prior Art
 
-_Include background research done for this component_
+### In other frameworks
 
-- _Link to Open UI research_
-- _Link to comparison of v7 and v0_
-- _Link to GitHub epic issue for the converged component_
+| Framework                        | `<input type="text">`                                                                     | `<textarea>`                                                                                     | Notes                                                                                           |
+| -------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| Ant Design                       | [`Input`](https://ant.design/components/input/)                                           | `Input.TextArea`                                                                                 | No label. Has both inner and outer prefix/suffix.                                               |
+| AtlasKit                         | [`Textfield`](https://atlassian.design/components/textfield)                              | [`Textarea`](https://atlassian.design/components/textarea)                                       | No label                                                                                        |
+| Carbon                           | [`TextInput`](https://www.carbondesignsystem.com/components/text-input/usage/)            | `TextArea`                                                                                       | Has label prop                                                                                  |
+| Evergreen                        | [`TextInput`](https://evergreen.segment.com/components/text-input)                        | [`Textarea`](https://evergreen.segment.com/components/textarea)                                  | `TextInputField` and `TextareaField` wrappers provide label etc                                 |
+| Lightning                        | [`input`](https://www.lightningdesignsystem.com/components/input/)                        | [`textarea`](https://www.lightningdesignsystem.com/components/textarea/)                         | Not a React library                                                                             |
+| Material UI React                | [`Input`](https://material-ui.com/components/text-fields/)                                | built in to `TextField`                                                                          | `TextField` is a rollup of functionality: label, appearances, start/end slots, lots of variants |
+| `@fluentui/react` (v8)           | [`TextField`](https://developer.microsoft.com/en-us/fluentui#/controls/web/textfield)     | built in to `TextField`                                                                          | Has label prop                                                                                  |
+| `@fluentui/react-northstar` (v0) | [`Input`](https://fluentsite.z22.web.core.windows.net/0.57.0/components/input/definition) | [`TextArea`](https://fluentsite.z22.web.core.windows.net/0.57.0/components/text-area/definition) | Has label prop                                                                                  |
+
+### Comparison of v8 and v0
+
+Please see the [migration guide](#migration-guide) section.
 
 ## Sample Code
 
-_Provide some representative example code that uses the proposed API for the component_
+See [Structure section](#structure) for the output HTML.
+
+```tsx
+<Label htmlFor="input1">Label</Label> // note that this is not built in
+<Input
+  className="rootClass"
+  input={{ className: 'inputClass' }}
+  id="input1"
+  value="something"
+  onChange={(ev, data) => console.log(data.value)}
+  bookendBefore="bookendBefore"
+  bookendAfter="bookendAfter"
+  insideBefore={<SearchIcon />}
+  insideAfter={<ClearIcon />}
+/>
+```
 
 ## Variants
 
-_Describe visual or functional variants of this control, if applicable. For example, a slider could have a 2D variant._
+### Visual variants
+
+See the design spec for details on the appearance of each of these. Note that the actual colors used will follow the theme; white/gray/black are just examples from the default theme.
+
+Visual variants for the main field are as follows:
+
+- `outline` (default): the field has a full outline, with a slightly darker underline on the bottom
+- `underline`: the field has an underline on the bottom only
+- `filledDarker`: the field has a gray background and no underline/outline
+- `filledLighter`: the field has a white background and no underline/outline (for use on top of gray/colored backgrounds)
+
+Visual variants for the bookend are as follows:
+
+- `filled` (default): bookends have a gray background, black text, and no border
+- `brand`: bookends have a brand color (such as blue or purple) background, white text, and no border
+- `transparent`: bookends have a transparent background, black text, and only a thin inside border to distinguish them from the field
+
+### Behavior variants
+
+In the future we may implement behavior variants, such as a password field with reveal button, but that will be spec'd if/when we need it. See [Spec-variants.md](./Spec-variants.md) for more details.
 
 ## API
 
-_List the **Props** and **Slots** proposed for the component. Ideally this would just be a link to the component's `.types.ts` file_
+In this component, `input` is the primary slot. See notes under [Structure](#structure).
+
+```ts
+export type InputProps = InputCommons & Omit<ComponentProps<InputSlots, 'input'>, 'children'>;
+```
+
+### Main props
+
+Note: most of these are defined in `InputCommons` since they're shared with `InputState`.
+
+```ts
+export type InputCommons = FieldSizeProps & {
+  /**
+   * If true, the field will have inline display, allowing it be used within text content.
+   * If false (the default), the field will have block display.
+   */
+  inline?: boolean;
+
+  /**
+   * Controls the colors and borders of the field.
+   * @default 'outline'
+   */
+  appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
+
+  /**
+   * Controls the colors and borders of the bookends.
+   * @default 'filled'
+   */
+  bookendAppearance?: 'filled' | 'brand' | 'transparent';
+};
+```
+
+### Field sizing
+
+This should be common between most types of fields.
+
+```ts
+export type FieldSize = 'small' | 'medium' | 'large';
+
+export type FieldSizeProps = {
+  /**
+   * Size of the input (changes the font size and spacing).
+   * NOTE: can't use `size` as the name due to overlap with a native input prop :(
+   * @default 'medium'
+   */
+  fieldSize?: FieldSize;
+};
+```
+
+```ts
+export const fieldHeights = {
+  small: '24px',
+  medium: '32px',
+  large: '40px',
+};
+
+export const useFieldSizeStyles = makeStyles({
+  small: theme => ({
+    // font sizes, height
+  }),
+  medium: theme => ({}),
+  large: theme => ({}),
+});
+```
+
+### Slots
+
+Note that the field **does not** include a label, required indicator, description, or error message.
+
+```ts
+export type InputSlots = {
+  root: IntrinsicShorthandProps<'span'>;
+
+  /** The actual `<input>` element. `type="text"` will be automatically applied unless overridden. */
+  input: IntrinsicShorthandProps<'input'>;
+
+  /**
+   * Wrapper element containing `insideBefore`, `input`, and `insideAfter`. This is the element that
+   * visually appears to be the input and is used for borders, focus styling, etc.
+   */
+  inputWrapper: IntrinsicShorthandProps<'span'>;
+
+  /** Element before the input field, visually separated from it */
+  bookendBefore?: IntrinsicShorthandProps<'span'>;
+
+  /** Element after the input field, visually separated from it */
+  bookendAfter?: IntrinsicShorthandProps<'span'>;
+
+  /** Element at the start of the input field, visually appearing to be inside of it */
+  insideBefore?: IntrinsicShorthandProps<'span'>;
+
+  /** Element at the end of the input field, visually appearing to be inside of it */
+  insideAfter?: IntrinsicShorthandProps<'span'>;
+};
+```
 
 ## Structure
 
-- _**Public**_
-- _**Internal**_
-- _**DOM** - how the component will be rendered as HTML elements_
+In this component, `input` is the primary slot. Per the [native element props/primary slot RFC](https://github.com/microsoft/fluentui/blob/master/rfcs/convergence/native-element-props.md), this means that most top-level props will go to `input`, but the top-level `className` and `style` will go to the actual root element.
 
-## Migration
+```tsx
+{
+  /* Out of top-level native props, only `className` and `style` go here */
+}
+<slots.root {...slotProps.root}>
+  <slots.bookendBefore {...slotProps.bookendBefore} />
+  {/* This is visually styled to look like the input */}
+  <slots.inputWrapper {...slotProps.inputWrapper}>
+    <slots.insideBefore {...slotProps.insideBefore} />
+    {/* Primary slot. Top-level native props except `className` and `style` go here. */}
+    <slots.input {...slotProps.input} />
+    <slots.insideAfter {...slotProps.insideAfter} />
+  </slots.inputWrapper>
+  <slots.bookendAfter {...slotProps.bookendAfter} />
+</slots.root>;
+```
 
-_Describe what will need to be done to upgrade from the existing implementations:_
+Notes on the HTML rendering:
 
-- _Migration from v8_
-- _Migration from v0_
+- Using `span` rather than `div` prevents nesting errors if the Input is rendered inline within a `<p>`.
+- There's an extra `inputWrapper` span which is visually styled as the input (with borders etc) so that the `insideBefore`, `insideAfter`, and actual `input` elements can easily be properly positioned inside it.
+
+This example usage:
+
+```tsx
+<Input
+  className="rootClass"
+  style={{ background: 'red' }}
+  input={{ className: 'inputClass', style: { background: 'blue' } }}
+  id="input1"
+  value="something"
+  onChange={(ev, data) => console.log(data.value)}
+  bookendBefore="bookendBefore"
+  bookendAfter="bookendAfter"
+  insideBefore={<SearchIcon />}
+  insideAfter={<ClearIcon />}
+/>
+```
+
+Gives this HTML:
+
+```html
+<span className="rootClass" style="background: red">
+  <span>bookendBefore</span>
+  <!-- inputWrapper -->
+  <span>
+    <span><!-- insideBefore content here --></span>
+    <!-- input: type="text" is applied automatically -->
+    <input
+      type="text"
+      className="inputClass"
+      style="background: blue"
+      id="input1"
+      value="something"
+      onChange="(function)"
+    />
+    <span><!-- insert insideAfter content here --></span>
+  </span>
+  <span>bookendAfter</span>
+</span>
+```
 
 ## Behaviors
 
-_Explain how the component will behave in use, including:_
+Most of the behavior is inherited from the native `<input>` element, and all we add is styling.
 
-- _Component States_
-- _Interaction_
-  - _Keyboard_
-  - _Cursor_
-  - _Touch_
-  - _Screen readers_
+The component has the following interactive states:
+
+- Rest
+- Hover: change stroke color
+- Pressed: apply focus border style as animation
+- Focused: currently indicated by a thick brand color stroke on the bottom border only (regardless of whether focus was by keyboard or mouse)
+
+Keyboard, cursor, touch, and screen reader interaction will be handled automatically by the internal `<input>`.
 
 ## Accessibility
 
-Base accessibility information is included in the design document. After the spec is filled and review, outcomes from it need to be communicated to design and incorporated in the design document.
+- Most interaction and screen reader behavior will be handled automatically by the internal `<input type="text">`.
+- The `<input>` is visible and shows the placeholder or value text.
+- The component doesn't provide a built-in label, so it's important for the user to pass in appropriate attributes such as `id` (associated with a label using `htmlFor`), `aria-label`, or `aria-labelledby`.
+- No features in the initial implementation require manipulation of focus, tab order, or key handling.
+- Visual states for focus and hover will be applied to `inputWrapper` rather than the `<input>` itself (which is rendered without a border and only used to show the text), because the `insideBefore` and `insideAfter` slots need to visually appear to be within the input.
 
-- Decide whether to use **native element** or folow **ARIA** and provide reasons
-- Identify the **[ARIA](https://www.w3.org/TR/wai-aria-practices-1.2/) pattern** and, if the component is listed there, follow its specification as possible.
-- Identify accessibility **variants**, the `role` ([ARIA roles](https://www.w3.org/TR/wai-aria-1.1/#role_definitions)) of the component, its `slots` and `aria-*` props.
-- Describe the **keyboard navigation**: Tab Oder and Arrow Key Navigation. Describe any other keyboard **shortcuts** used
-- Specify texts for **state change announcements** - [ARIA live regions
-  ](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) (number of available items in dropdown, error messages, confirmations, ...)
-- Identify UI parts that appear on **hover or focus** and specify keyboard and screen reader interaction with them
-- List cases when **focus** needs to be **trapped** in sections of the UI (for dialogs and popups or for hierarchical navigation)
-- List cases when **focus** needs to be **moved programatically** (if parts of the UI are appearing/disappearing or other cases)
+## Migration
+
+> **NOTE**: Props related to multiline, reveal password, validation, and masking are not yet supported and likely to be handled in separate components. See [Spec-variants.md](./Spec-variants.md) for more details.
+
+### Props
+
+| Prop/concept                 | v8                                                    | v0                                                          | Proposal                                |
+| ---------------------------- | ----------------------------------------------------- | ----------------------------------------------------------- | --------------------------------------- |
+| imperative API               | `componentRef`                                        | n/a                                                         | n/a                                     |
+| supported native props       | `React.AllHTMLAttributes` (input or textarea)         | `SupportedIntrinsicInputProps` (see below)                  | `React.InputHTMLAttributes`             |
+| setting native props on root |                                                       | ?                                                           | `root` slot (mostly, see below)         |
+| root element access          | `elementRef`                                          | ?                                                           | `ref` on `root` slot                    |
+| primary element access       | not possible                                          | `ref`                                                       | top-level `ref`                         |
+| multiline mode               | `multiline?: boolean`                                 | separate component (`TextArea`)                             | separate component                      |
+| underlined                   | `underlined?: boolean`                                |                                                             | `appearance`                            |
+| borderless                   | `borderless?: boolean`                                |                                                             | not supported?                          |
+| fluid (full width)           | default behavior                                      | `fluid?: boolean`                                           | default behavior                        |
+| inline                       | n/a (use styling)                                     | `inline?: boolean`                                          | `inline?: boolean`                      |
+| label                        | `label?: string`, `onRenderLabel`                     | `label?: ShorthandValue<InputLabelProps>`,                  | handled by Field                        |
+| label position               | n/a (use styling)                                     | `labelPosition?: 'above' \| 'inline' \| 'inside'`           | handled by Field                        |
+| description                  | `description?: string`, `onRenderDescription`         | use FormField                                               | handled by Field                        |
+| error message                | see [Spec-variants.md](./Spec-variants.md#validation) | use FormField                                               | handled by Field                        |
+| content outside before field | `prefix?: string`, `onRenderPrefix`                   |                                                             | `bookendBefore` slot                    |
+| content outside after field  | `suffix?: string`, `onRenderSuffix`                   |                                                             | `bookendAfter` slot                     |
+| icon at start of field       | n/a                                                   | `icon?: ShorthandValue<BoxProps>` + `iconPosition: 'start'` | `insideBefore` slot                     |
+| icon at end of field         | `iconProps?: IIconProps`                              | `icon?: ShorthandValue<BoxProps>` + `iconPosition: 'end'`   | `insideAfter` slot                      |
+| value                        | `value?: string`                                      | `value?: string \| number`                                  | `value?: string`                        |
+| defaultValue                 | `defaultValue?: string`                               | `defaultValue?: string \| string[]`                         | `defaultValue?: string`                 |
+| onChange                     | `(ev, value) => void`                                 | `(ev, data: { ...props, value }) => void`                   | `(ev, data: { value: string }) => void` |
+| container className          | `className?: string`                                  |                                                             | top-level `className`                   |
+| input className              | `inputClassName?: string`                             | `input.className?: `                                        |                                         |
+| aria label                   | `ariaLabel?: string`                                  | `'aria-label'?: string`                                     | `'aria-label'?: string`                 |
+| clearable                    | n/a                                                   | `clearable?: boolean`                                       | TBD (deferred)                          |
+| theme                        | `theme?: ITheme`                                      |                                                             | handled by context                      |
+| style overrides              | `styles?: IStyleFunctionOrObject<...>`                | `styles?: ComponentSlotStyles<...>`                         | className, slot classNames              |
+| accessibility                | individual props                                      | `Accessibility<InputBehaviorProps>` (see below)             | individual props?                       |
+
+```ts
+// packages/fluentui/react-northstar/src/utils/htmlPropsUtils.tsx
+type SupportedIntrinsicInputProps = {
+  [K in HtmlInputProps]?: K extends keyof JSX.IntrinsicElements['input'] ? JSX.IntrinsicElements['input'][K] : any;
+};
+// HtmlInputProps: a subset of React and HTML native props
+
+// packages/fluentui/react-northstar/src/components/Box/Box.tsx
+interface BoxProps extends UIComponentProps<BoxProps>, ContentComponentProps, ChildrenComponentProps {
+  /** Accessibility behavior if overridden by the user. */
+  accessibility?: Accessibility<never>;
+}
+
+// packages/fluentui/accessibility/src/behaviors/Input/inputBehavior.ts
+type InputBehaviorProps = { disabled?: boolean; required?: boolean; error?: boolean };
+```
+
+Native props following standard behavior in both libraries + converged:
+
+- `disabled?: boolean`
+- `readOnly?: boolean` -- VERIFY v0
+- `autoComplete?: string` -- VERIFY v0
+- and any other native props not specified
+
+### Imperative API
+
+In v8 there's an explicit imperative API, which is accessed via `componentRef` following the [`ITextField` interface](https://github.com/microsoft/fluentui/blob/master/packages/react/src/components/TextField/TextField.types.ts#L9). The methods are used for getting the value and manipulating focus and selection.
+
+In v0, all these things can be done by calling methods on the `<input>` element itself, exposed via the top-level `ref`.

--- a/rfcs/convergence/native-element-props.md
+++ b/rfcs/convergence/native-element-props.md
@@ -76,22 +76,22 @@ Third-party styling libraries can assume that `className` applies to the root DO
 
 _For reference, this proposal was labeled **Option D** in discussion on [PR #18983](https://github.com/microsoft/fluentui/pull/18983#issuecomment-910563694)_.
 
-### Introduce the concept of a `primary` slot
+### Introduce the concept of a _primary_ slot
 
-The `primary` slot is the slot that receives the native props that are specified as props of the component itself.
+The _**primary**_ slot is the slot that receives the native props that are specified as props of the component itself.
 
-1. By default, `root` (the outermost DOM element) is the primary slot:
+**By default, `root` (the outermost DOM element) is the primary slot.**
 
-   - This is the _status quo_: all components worked like this prior to this RFC.
-   - `root` gets all of the native props specified as props on the component.
-   - The component does _not_ have a prop called `root`.
+- This is the _status quo_: all components worked like this prior to this RFC.
+- `root` gets all of the native props specified as props on the component.
+- The component does _not_ have a prop called `root`.
 
-2. A component can be designed with a different `primary` slot:
+**In special cases, a component can designate a different primary slot.**
 
-   - All native props are forwarded to the `primary` slot, _except_ `className` and `style`.
-   - The `className` and `style` props are _always_ forwarded to the `root` slot.
-   - Both `root` and the `primary` slot are exposed as props, to allow for props to be explicitly set on those slots.
-   - The `primary` slot is intrinsic to the component, and is part of how it works. Users cannot designate a different slot as primary.
+- All native props are forwarded to the primary slot, _except_ `className` and `style`.
+- The `className` and `style` props are _always_ forwarded to the `root` slot.
+- Both `root` and the primary slot are exposed as props, to allow for props to be explicitly set on those slots.
+- The primary slot is intrinsic to the component, and is part of how it works. Users cannot designate a different slot as primary.
 
 See [Usage examples](#Usage-examples) below for examples of how this works.
 
@@ -107,8 +107,8 @@ To avoid confusion from a user standpoint, if we're going to allow varying where
 
 Examples include:
 
-- Input components like `Input`, `Checkbox`, `Dropdown`, etc. These wrap the actual `<input>` element with styling/layout divs, but the `<input>` should be the primary slot.
-- Example from v8 (not sure if this applies to converged): Modal's actual React root element is usually a Layer, but from a user standpoint it makes a lot more sense to apply top-level props to the modal _content's_ root element.
+- Input components like `Input`, `Checkbox`, `Dropdown`, etc. These wrap the actual `<input>` or `<select>` element with styling/layout elements, but the `<input>` or `<select>` should be the primary slot.
+- Example from v8 (may look different in converged): Modal's actual React root element is usually a Layer, but from a user standpoint it makes a lot more sense to apply top-level props to the modal _content's_ root element.
 
 ### Propsed Implementation
 
@@ -149,6 +149,9 @@ const state = {
 
 - Need to be able to specify which is the primary slot in conformance tests
 - Check that `className` and `style` always go to the root slot
+- Check that slot props take precedence over top-level props (with custom primary slot):
+  - `<Input className="foo" root={{ className: 'bar' }} />` => root element has `className="bar"`
+  - `<Input id="foo" input={{ id: 'bar' }} />` => input has `id="bar"`
 - Check that `<input>` elements are always the primary slot
 
 ## Usage examples


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: part of #18131

#### Description of changes

Add spec for Input.

Secondary things also included in this PR:
- `Spec-variants.md` under `react-input` has tentative notes about input variants we're not implementing right away. It's not intended to be 100% finished in this PR. A detailed spec and full comparison for any of these variants will be filled out once we're closer to implementing them.
- I made some minor updates to to the primary slot (native-element-props) RFC--just minor formatting and wording improvements, and adding a suggested test