### PR TITLE
Updating fontface path type to be optional instead of required 

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - `Popup` should not dismiss when its iframe content is focused @ling1726 ([#19955](https://github.com/microsoft/fluentui/pull/19955))
 - `whatInput` Add typings to what input event listeners @ling1726 ([#20024](https://github.com/microsoft/fluentui/pull/20024))
+- Update fontFace type have optional path defined @notandrew ([#20055](https://github.com/microsoft/fluentui/pull/20055))
 
 
 <!--------------------------------[ v0.59.0 ]------------------------------- -->

--- a/packages/fluentui/styles/src/types.ts
+++ b/packages/fluentui/styles/src/types.ts
@@ -87,7 +87,7 @@ export interface FontFaceProps {
 
 export interface FontFace {
   name: string;
-  paths: string[];
+  paths?: string[];
   props: FontFaceProps;
 }
 


### PR DESCRIPTION
This is for when a system font, like Segoe, needs to have its styles defined but doesn't have a non-local path.
Example, we can define the italic version of Segoe by using `local("Segoe UI Italic")` and not set the url path:

`@font-face {`
  `font-family: "Segoe UI";`
  `src: local("Segoe UI");`
  `font-style: normal;`
  `font-weight: 400;`
`}`

`@font-face {`
`  font-family: "Segoe UI";`
`  src: local("Segoe UI Italic");`
`  font-style: italic;`
`  font-weight: 400;`
`}`
