### PR TITLE
Fix callout window resize

### DIFF
--- a/change/@fluentui-react-b1f79e0f-2c24-481e-9ce7-870a2a3d337b.json
+++ b/change/@fluentui-react-b1f79e0f-2c24-481e-9ce7-870a2a3d337b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated callout bounds to watch for window resize",
+  "packageName": "@fluentui/react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #19728
- [X] Include a change request file using `$ yarn change`

#### Description of changes

- Updated the useBounds hook to watch for the targetWindow resize and invalidate the callback to update the cached measurements
- Fixed an issue with the usePosition hook that it was not clearing state when the callout is hidden.

#### Focus areas to test

Callout
ContextMenu
