### PR TITLE
fix(Colorpicker): High Contrast Mode style fixes

### DIFF
--- a/change/change-1a2fe4f0-bbf0-4942-8775-8667fced9a81.json
+++ b/change/change-1a2fe4f0-bbf0-4942-8775-8667fced9a81.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "High contrast style fixes for ColorPicker",
+      "packageName": "@fluentui/react",
+      "email": "sarah.higley@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -60,6 +60,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             .ms-Fabric--isFocusVisible &:focus {
               outline: 1px solid #605e5c;
             }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+              outline: 2px solid CanvasText;
+            }
         data-is-focusable={true}
         onKeyDown={[Function]}
         onMouseDown={[Function]}
@@ -179,6 +182,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                   border-radius: 2px;
                   border: 1px solid #edebe9;
                   box-sizing: border-box;
+                  forced-color-adjust: none;
                   height: 20px;
                   margin-bottom: 8px;
                   outline: none;
@@ -186,6 +190,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 }
                 .ms-Fabric--isFocusVisible &:focus {
                   outline: 1px solid #605e5c;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                  outline: 2px solid CanvasText;
                 }
             data-is-focusable={true}
             onKeyDown={[Function]}
@@ -202,6 +209,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     border-radius: 50%;
                     border: 1px solid #8a8886;
                     box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                    forced-color-adjust: auto;
                     height: 20px;
                     position: absolute;
                     top: 50%;
@@ -230,6 +238,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                   border-radius: 2px;
                   border: 1px solid #edebe9;
                   box-sizing: border-box;
+                  forced-color-adjust: none;
                   height: 20px;
                   margin-bottom: 8px;
                   outline: none;
@@ -237,6 +246,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 }
                 .ms-Fabric--isFocusVisible &:focus {
                   outline: 1px solid #605e5c;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                  outline: 2px solid CanvasText;
                 }
             data-is-focusable={true}
             onKeyDown={[Function]}
@@ -270,6 +282,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     border-radius: 50%;
                     border: 1px solid #8a8886;
                     box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                    forced-color-adjust: auto;
                     height: 20px;
                     position: absolute;
                     top: 50%;

--- a/packages/react/src/components/ColorPicker/ColorRectangle/ColorRectangle.styles.ts
+++ b/packages/react/src/components/ColorPicker/ColorRectangle/ColorRectangle.styles.ts
@@ -26,6 +26,9 @@ export const getStyles = (props: IColorRectangleStyleProps): IColorRectangleStyl
 
           [`.${IsFocusVisibleClassName} &:focus`]: {
             outline: `1px solid ${palette.neutralSecondary}`,
+            [`${HighContrastSelector}`]: {
+              outline: '2px solid CanvasText',
+            },
           },
         },
       },

--- a/packages/react/src/components/ColorPicker/ColorRectangle/__snapshots__/ColorRectangle.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/ColorRectangle/__snapshots__/ColorRectangle.test.tsx.snap
@@ -26,6 +26,9 @@ exports[`ColorRectangle renders correctly 1`] = `
       .ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid #605e5c;
       }
+      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+        outline: 2px solid CanvasText;
+      }
   data-is-focusable={true}
   onKeyDown={[Function]}
   onMouseDown={[Function]}

--- a/packages/react/src/components/ColorPicker/ColorSlider/ColorSlider.styles.ts
+++ b/packages/react/src/components/ColorPicker/ColorSlider/ColorSlider.styles.ts
@@ -1,4 +1,5 @@
 import { IsFocusVisibleClassName } from '../../../Utilities';
+import { HighContrastSelector } from '../../../Styling';
 import type { IColorSliderStyleProps, IColorSliderStyles } from './ColorSlider.types';
 
 const hueStyle = {
@@ -39,10 +40,14 @@ export const getStyles = (props: IColorSliderStyleProps): IColorSliderStyles => 
         borderRadius: effects.roundedCorner2,
         boxSizing: 'border-box',
         outline: 'none',
+        forcedColorAdjust: 'none',
 
         selectors: {
           [`.${IsFocusVisibleClassName} &:focus`]: {
             outline: `1px solid ${palette.neutralSecondary}`,
+            [`${HighContrastSelector}`]: {
+              outline: '2px solid CanvasText',
+            },
           },
         },
       },
@@ -73,6 +78,7 @@ export const getStyles = (props: IColorSliderStyleProps): IColorSliderStyles => 
         boxShadow: effects.elevation8,
         transform: 'translate(-50%, -50%)',
         top: '50%',
+        forcedColorAdjust: 'auto',
       },
     ],
   };

--- a/packages/react/src/components/ColorPicker/ColorSlider/__snapshots__/ColorSlider.deprecated.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/ColorSlider/__snapshots__/ColorSlider.deprecated.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`ColorSlider renders alpha slider correctly 1`] = `
         border-radius: 2px;
         border: 1px solid #edebe9;
         box-sizing: border-box;
+        forced-color-adjust: none;
         height: 20px;
         margin-bottom: 8px;
         outline: none;
@@ -22,6 +23,9 @@ exports[`ColorSlider renders alpha slider correctly 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid #605e5c;
+      }
+      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+        outline: 2px solid CanvasText;
       }
   data-is-focusable={true}
   onKeyDown={[Function]}
@@ -55,6 +59,7 @@ exports[`ColorSlider renders alpha slider correctly 1`] = `
           border-radius: 50%;
           border: 1px solid #8a8886;
           box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+          forced-color-adjust: auto;
           height: 20px;
           position: absolute;
           top: 50%;
@@ -84,6 +89,7 @@ exports[`ColorSlider renders hue slider correctly 1`] = `
         border-radius: 2px;
         border: 1px solid #edebe9;
         box-sizing: border-box;
+        forced-color-adjust: none;
         height: 20px;
         margin-bottom: 8px;
         outline: none;
@@ -91,6 +97,9 @@ exports[`ColorSlider renders hue slider correctly 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid #605e5c;
+      }
+      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+        outline: 2px solid CanvasText;
       }
   data-is-focusable={true}
   onKeyDown={[Function]}
@@ -107,6 +116,7 @@ exports[`ColorSlider renders hue slider correctly 1`] = `
           border-radius: 50%;
           border: 1px solid #8a8886;
           box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+          forced-color-adjust: auto;
           height: 20px;
           position: absolute;
           top: 50%;

--- a/packages/react/src/components/ColorPicker/ColorSlider/__snapshots__/ColorSlider.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/ColorSlider/__snapshots__/ColorSlider.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`ColorSlider renders alpha slider correctly 1`] = `
         border-radius: 2px;
         border: 1px solid #edebe9;
         box-sizing: border-box;
+        forced-color-adjust: none;
         height: 20px;
         margin-bottom: 8px;
         outline: none;
@@ -22,6 +23,9 @@ exports[`ColorSlider renders alpha slider correctly 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid #605e5c;
+      }
+      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+        outline: 2px solid CanvasText;
       }
   data-is-focusable={true}
   onKeyDown={[Function]}
@@ -55,6 +59,7 @@ exports[`ColorSlider renders alpha slider correctly 1`] = `
           border-radius: 50%;
           border: 1px solid #8a8886;
           box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+          forced-color-adjust: auto;
           height: 20px;
           position: absolute;
           top: 50%;
@@ -84,6 +89,7 @@ exports[`ColorSlider renders hue slider correctly 1`] = `
         border-radius: 2px;
         border: 1px solid #edebe9;
         box-sizing: border-box;
+        forced-color-adjust: none;
         height: 20px;
         margin-bottom: 8px;
         outline: none;
@@ -91,6 +97,9 @@ exports[`ColorSlider renders hue slider correctly 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid #605e5c;
+      }
+      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+        outline: 2px solid CanvasText;
       }
   data-is-focusable={true}
   onKeyDown={[Function]}
@@ -107,6 +116,7 @@ exports[`ColorSlider renders hue slider correctly 1`] = `
           border-radius: 50%;
           border: 1px solid #8a8886;
           box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+          forced-color-adjust: auto;
           height: 20px;
           position: absolute;
           top: 50%;
@@ -137,6 +147,7 @@ exports[`ColorSlider renders transparency slider correctly 1`] = `
         border-radius: 2px;
         border: 1px solid #edebe9;
         box-sizing: border-box;
+        forced-color-adjust: none;
         height: 20px;
         margin-bottom: 8px;
         outline: none;
@@ -144,6 +155,9 @@ exports[`ColorSlider renders transparency slider correctly 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid #605e5c;
+      }
+      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+        outline: 2px solid CanvasText;
       }
   data-is-focusable={true}
   onKeyDown={[Function]}
@@ -177,6 +191,7 @@ exports[`ColorSlider renders transparency slider correctly 1`] = `
           border-radius: 50%;
           border: 1px solid #8a8886;
           box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+          forced-color-adjust: auto;
           height: 20px;
           position: absolute;
           top: 50%;

--- a/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -51,6 +51,9 @@ exports[`ColorPicker renders correctly 1`] = `
           .ms-Fabric--isFocusVisible &:focus {
             outline: 1px solid #605e5c;
           }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+            outline: 2px solid CanvasText;
+          }
       data-is-focusable={true}
       onKeyDown={[Function]}
       onMouseDown={[Function]}
@@ -170,6 +173,7 @@ exports[`ColorPicker renders correctly 1`] = `
                 border-radius: 2px;
                 border: 1px solid #edebe9;
                 box-sizing: border-box;
+                forced-color-adjust: none;
                 height: 20px;
                 margin-bottom: 8px;
                 outline: none;
@@ -177,6 +181,9 @@ exports[`ColorPicker renders correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid #605e5c;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                outline: 2px solid CanvasText;
               }
           data-is-focusable={true}
           onKeyDown={[Function]}
@@ -193,6 +200,7 @@ exports[`ColorPicker renders correctly 1`] = `
                   border-radius: 50%;
                   border: 1px solid #8a8886;
                   box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                  forced-color-adjust: auto;
                   height: 20px;
                   position: absolute;
                   top: 50%;
@@ -221,6 +229,7 @@ exports[`ColorPicker renders correctly 1`] = `
                 border-radius: 2px;
                 border: 1px solid #edebe9;
                 box-sizing: border-box;
+                forced-color-adjust: none;
                 height: 20px;
                 margin-bottom: 8px;
                 outline: none;
@@ -228,6 +237,9 @@ exports[`ColorPicker renders correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid #605e5c;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                outline: 2px solid CanvasText;
               }
           data-is-focusable={true}
           onKeyDown={[Function]}
@@ -261,6 +273,7 @@ exports[`ColorPicker renders correctly 1`] = `
                   border-radius: 50%;
                   border: 1px solid #8a8886;
                   box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                  forced-color-adjust: auto;
                   height: 20px;
                   position: absolute;
                   top: 50%;
@@ -1245,6 +1258,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
           .ms-Fabric--isFocusVisible &:focus {
             outline: 1px solid #605e5c;
           }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+            outline: 2px solid CanvasText;
+          }
       data-is-focusable={true}
       onKeyDown={[Function]}
       onMouseDown={[Function]}
@@ -1364,6 +1380,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                 border-radius: 2px;
                 border: 1px solid #edebe9;
                 box-sizing: border-box;
+                forced-color-adjust: none;
                 height: 20px;
                 margin-bottom: 8px;
                 outline: none;
@@ -1371,6 +1388,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid #605e5c;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                outline: 2px solid CanvasText;
               }
           data-is-focusable={true}
           onKeyDown={[Function]}
@@ -1387,6 +1407,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   border-radius: 50%;
                   border: 1px solid #8a8886;
                   box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                  forced-color-adjust: auto;
                   height: 20px;
                   position: absolute;
                   top: 50%;
@@ -1415,6 +1436,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                 border-radius: 2px;
                 border: 1px solid #edebe9;
                 box-sizing: border-box;
+                forced-color-adjust: none;
                 height: 20px;
                 margin-bottom: 8px;
                 outline: none;
@@ -1422,6 +1444,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid #605e5c;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                outline: 2px solid CanvasText;
               }
           data-is-focusable={true}
           onKeyDown={[Function]}
@@ -1455,6 +1480,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   border-radius: 50%;
                   border: 1px solid #8a8886;
                   box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                  forced-color-adjust: auto;
                   height: 20px;
                   position: absolute;
                   top: 50%;
@@ -2466,6 +2492,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
           .ms-Fabric--isFocusVisible &:focus {
             outline: 1px solid #605e5c;
           }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+            outline: 2px solid CanvasText;
+          }
       data-is-focusable={true}
       onKeyDown={[Function]}
       onMouseDown={[Function]}
@@ -2585,6 +2614,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                 border-radius: 2px;
                 border: 1px solid #edebe9;
                 box-sizing: border-box;
+                forced-color-adjust: none;
                 height: 20px;
                 margin-bottom: 8px;
                 outline: none;
@@ -2592,6 +2622,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid #605e5c;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                outline: 2px solid CanvasText;
               }
           data-is-focusable={true}
           onKeyDown={[Function]}
@@ -2608,6 +2641,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   border-radius: 50%;
                   border: 1px solid #8a8886;
                   box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                  forced-color-adjust: auto;
                   height: 20px;
                   position: absolute;
                   top: 50%;
@@ -2636,6 +2670,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                 border-radius: 2px;
                 border: 1px solid #edebe9;
                 box-sizing: border-box;
+                forced-color-adjust: none;
                 height: 20px;
                 margin-bottom: 8px;
                 outline: none;
@@ -2643,6 +2678,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid #605e5c;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                outline: 2px solid CanvasText;
               }
           data-is-focusable={true}
           onKeyDown={[Function]}
@@ -2676,6 +2714,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   border-radius: 50%;
                   border: 1px solid #8a8886;
                   box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                  forced-color-adjust: auto;
                   height: 20px;
                   position: absolute;
                   top: 50%;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20059
- [x] Include a change request file using `$ yarn change`

#### Description of changes

ColorPicker's alpha/transparency and hue sliders weren't showing the needed color bg styles in high contrast mode. After adding `forced-color-adjust: none`, they need specific focus color overrides for the :focus style to show in a consistently visible color.

Before:
![screenshot of Fluent Colorpicker where the hue and alpha slider have a consistent background](https://user-images.githubusercontent.com/3819570/135551125-a4932e25-157c-45db-8911-4e7adfc0979a.png)


After:
![screenshot of Fluent ColorPicker with visible hue gradient and alpha gradient](https://user-images.githubusercontent.com/3819570/135551103-80988159-e603-4dd7-b29f-5fcb46892cd5.png)

