### PR TITLE
react-avatar: Fix stories `getFilenameFromUrl` implementation

### DIFF
--- a/change/change-a30552b4-069a-4c00-ba6b-dc05bce14ef3.json
+++ b/change/change-a30552b4-069a-4c00-ba6b-dc05bce14ef3.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "prerelease",
+      "comment": "Fix getFilenameFromUrl implementation",
+      "packageName": "@fluentui/react-avatar",
+      "email": "bsunderhus@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/react-avatar/src/Avatar.stories.tsx
+++ b/packages/react-avatar/src/Avatar.stories.tsx
@@ -300,7 +300,7 @@ export const AvatarPlayground = () => {
       'image',
       [{ src: nameAndImage.image }, nextNameAndImage, prevNameAndImage],
       true,
-      getFilenameFromUrl as () => string,
+      getFilenameFromUrl,
     ),
     useValueSelector('color', useValueSelectorState([...examples.color, ...examples.namedColors])),
     useValueSelector('active', useValueSelectorState(['active', 'inactive'] as const)),
@@ -364,7 +364,9 @@ const AvatarExampleList: React.FC<
 
 const badgeToString = (badge: typeof examples.badge[number] | undefined): string =>
   typeof badge === 'object' ? `{ status: '${badge.status}', outOfOffice: ${badge.outOfOffice} }` : `${badge}`;
-const getFilenameFromUrl = (url: string) => url.substring(url.lastIndexOf('/') + 1);
+
+const getFilenameFromUrl = (url: AvatarProps['image'] | undefined) =>
+  url?.src?.substring(url?.src.lastIndexOf('/') + 1) ?? '';
 
 type ValueSelectorState<T> = [/*value:*/ T, /*next:*/ () => void, /*prev:*/ () => void];
 

--- a/packages/react-avatar/src/Avatar.stories.tsx
+++ b/packages/react-avatar/src/Avatar.stories.tsx
@@ -365,8 +365,8 @@ const AvatarExampleList: React.FC<
 const badgeToString = (badge: typeof examples.badge[number] | undefined): string =>
   typeof badge === 'object' ? `{ status: '${badge.status}', outOfOffice: ${badge.outOfOffice} }` : `${badge}`;
 
-const getFilenameFromUrl = (url: AvatarProps['image'] | undefined) =>
-  url?.src?.substring(url?.src.lastIndexOf('/') + 1) ?? '';
+const getFilenameFromUrl = (image: AvatarProps['image']) =>
+  image?.src?.substring(image?.src.lastIndexOf('/') + 1) ?? '';
 
 type ValueSelectorState<T> = [/*value:*/ T, /*next:*/ () => void, /*prev:*/ () => void];
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Reimplements `getFilenameFromUrl` to follow `AvatarProps['image']` signature
