### PR TITLE
Revert grouped changefile in #20000

### DIFF
--- a/scripts/beachball/index.ts
+++ b/scripts/beachball/index.ts
@@ -7,7 +7,6 @@ export const config: BeachballConfig = {
   disallowedChangeTypes: ['major', 'prerelease'],
   tag: 'latest',
   generateChangelog: true,
-  groupChanges: true,
   scope: getScopes(),
   changelog: {
     customRenderers: {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

@fluentui/react-componnets@9.0.0-alpha.119 was released incorrectly
because beachball did not apply changes that were in the grouped
changefile. The grouped changelog in react-components was also not
updated.

The release did not pick up the changes in #20041 therefore the latest alpha is in a broken state since theme tokens were broken. Here is an example: https://codesandbox.io/s/white-sea-jkjzq?file=/src/App.js

#### Focus areas to test

(optional)
