### PR TITLE
fix(makeStyles): fix insertion of keyframes

### DIFF
--- a/change/@fluentui-make-styles-ad78d37d-58a7-46c5-83a2-cac7cce8fcff.json
+++ b/change/@fluentui-make-styles-ad78d37d-58a7-46c5-83a2-cac7cce8fcff.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix insertion of keyframes",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-make-styles-0c89fe8b-4478-430d-a761-fc6ead7c7eae.json
+++ b/change/@fluentui-react-make-styles-0c89fe8b-4478-430d-a761-fc6ead7c7eae.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add section about keyframes to README",
+  "packageName": "@fluentui/react-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/make-styles/src/makeStyles.test.ts
+++ b/packages/make-styles/src/makeStyles.test.ts
@@ -129,6 +129,34 @@ describe('makeStyles', () => {
           transform: rotate(-360deg);
         }
       }
+      @keyframes f1q8eu9e {
+        from {
+          -webkit-transform: rotate(0deg);
+          -moz-transform: rotate(0deg);
+          -ms-transform: rotate(0deg);
+          transform: rotate(0deg);
+        }
+        to {
+          -webkit-transform: rotate(360deg);
+          -moz-transform: rotate(360deg);
+          -ms-transform: rotate(360deg);
+          transform: rotate(360deg);
+        }
+      }
+      @keyframes f55c0se {
+        from {
+          -webkit-transform: rotate(0deg);
+          -moz-transform: rotate(0deg);
+          -ms-transform: rotate(0deg);
+          transform: rotate(0deg);
+        }
+        to {
+          -webkit-transform: rotate(-360deg);
+          -moz-transform: rotate(-360deg);
+          -ms-transform: rotate(-360deg);
+          transform: rotate(-360deg);
+        }
+      }
       .f1g6ul6r {
         -webkit-animation-name: f1q8eu9e;
         animation-name: f1q8eu9e;

--- a/packages/make-styles/src/renderer/rehydrateRendererCache.ts
+++ b/packages/make-styles/src/renderer/rehydrateRendererCache.ts
@@ -3,7 +3,7 @@ import { MakeStylesRenderer, StyleBucketName } from '../types';
 // Regexps to extract names of classes and animations
 // https://github.com/styletron/styletron/blob/e0fcae826744eb00ce679ac613a1b10d44256660/packages/styletron-engine-atomic/src/client/client.js#L8
 // eslint-disable-next-line @fluentui/max-len
-const KEYFRAMES_HYDRATOR = /@-webkit-keyframes ([^{]+){((?:(?:from|to|(?:\d+\.?\d*%))\{(?:[^}])*})*)}@keyframes ([^{]+){((?:(?:from|to|(?:\d+\.?\d*%))\{(?:[^}])*})*)}/g;
+const KEYFRAMES_HYDRATOR = /@(-webkit-)?keyframes ([^{]+){((?:(?:from|to|(?:\d+\.?\d*%))\{(?:[^}])*})*)}/g;
 const AT_RULES_HYDRATOR = /@(media|supports)[^{]+\{([\s\S]+?})\s*}/g;
 const STYLES_HYDRATOR = /\.([^{:]+)(:[^{]+)?{(?:[^}]*;)?([^}]*?)}/g;
 

--- a/packages/make-styles/src/runtime/compileKeyframeCSS.test.ts
+++ b/packages/make-styles/src/runtime/compileKeyframeCSS.test.ts
@@ -1,0 +1,40 @@
+import { compileKeyframeRule, compileKeyframesCSS } from './compileKeyframeCSS';
+import { MakeStyles } from '../types';
+
+describe('compileKeyframeRule', () => {
+  it('stringifies an object with keyframes', () => {
+    const keyframes: MakeStyles = {
+      from: {
+        transform: 'rotate(0deg)',
+      },
+      to: {
+        transform: 'rotate(360deg)',
+      },
+    };
+    const result = compileKeyframeRule(keyframes);
+
+    expect(result).toMatchInlineSnapshot(`"from{transform:rotate(0deg);}to{transform:rotate(360deg);}"`);
+  });
+});
+
+describe('compileKeyframeCSS', () => {
+  it('creates CSS from strings with keyframes', () => {
+    const keyframes: MakeStyles = {
+      from: {
+        height: '10px',
+      },
+      to: {
+        height: '50px',
+      },
+    };
+    const keyframesCSS = compileKeyframeRule(keyframes);
+    const result = compileKeyframesCSS('foo', keyframesCSS);
+
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        "@-webkit-keyframes foo{from{height:10px;}to{height:50px;}}",
+        "@keyframes foo{from{height:10px;}to{height:50px;}}",
+      ]
+    `);
+  });
+});

--- a/packages/make-styles/src/runtime/resolveStyleRules.test.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.test.ts
@@ -682,13 +682,13 @@ describe('resolveStyleRules', () => {
             opacity: 1;
           }
         }
-        .f1al5ov7 {
-          -webkit-animation-name: f1q8eu9e f5j8bii;
-          animation-name: f1q8eu9e f5j8bii;
+        .fng7zue {
+          -webkit-animation-name: f1q8eu9e, f5j8bii;
+          animation-name: f1q8eu9e, f5j8bii;
         }
-        .f1yfduy3 {
-          -webkit-animation-name: f55c0se f5j8bii;
-          animation-name: f55c0se f5j8bii;
+        .f12eevt1 {
+          -webkit-animation-name: f55c0se, f5j8bii;
+          animation-name: f55c0se, f5j8bii;
         }
         .f1cpbl36 {
           -webkit-animation-iteration-count: infinite;

--- a/packages/make-styles/src/runtime/resolveStyleRules.test.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.test.ts
@@ -524,20 +524,6 @@ describe('resolveStyleRules', () => {
             transform: rotate(360deg);
           }
         }
-        @keyframes f1q8eu9e {
-          from {
-            -webkit-transform: rotate(0deg);
-            -moz-transform: rotate(0deg);
-            -ms-transform: rotate(0deg);
-            transform: rotate(0deg);
-          }
-          to {
-            -webkit-transform: rotate(360deg);
-            -moz-transform: rotate(360deg);
-            -ms-transform: rotate(360deg);
-            transform: rotate(360deg);
-          }
-        }
         @-webkit-keyframes f55c0se {
           from {
             -webkit-transform: rotate(0deg);
@@ -550,6 +536,20 @@ describe('resolveStyleRules', () => {
             -moz-transform: rotate(-360deg);
             -ms-transform: rotate(-360deg);
             transform: rotate(-360deg);
+          }
+        }
+        @keyframes f1q8eu9e {
+          from {
+            -webkit-transform: rotate(0deg);
+            -moz-transform: rotate(0deg);
+            -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+          }
+          to {
+            -webkit-transform: rotate(360deg);
+            -moz-transform: rotate(360deg);
+            -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
           }
         }
         @keyframes f55c0se {
@@ -624,6 +624,20 @@ describe('resolveStyleRules', () => {
             transform: rotate(360deg);
           }
         }
+        @-webkit-keyframes f55c0se {
+          from {
+            -webkit-transform: rotate(0deg);
+            -moz-transform: rotate(0deg);
+            -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+          }
+          to {
+            -webkit-transform: rotate(-360deg);
+            -moz-transform: rotate(-360deg);
+            -ms-transform: rotate(-360deg);
+            transform: rotate(-360deg);
+          }
+        }
         @keyframes f1q8eu9e {
           from {
             -webkit-transform: rotate(0deg);
@@ -636,6 +650,20 @@ describe('resolveStyleRules', () => {
             -moz-transform: rotate(360deg);
             -ms-transform: rotate(360deg);
             transform: rotate(360deg);
+          }
+        }
+        @keyframes f55c0se {
+          from {
+            -webkit-transform: rotate(0deg);
+            -moz-transform: rotate(0deg);
+            -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+          }
+          to {
+            -webkit-transform: rotate(-360deg);
+            -moz-transform: rotate(-360deg);
+            -ms-transform: rotate(-360deg);
+            transform: rotate(-360deg);
           }
         }
         @-webkit-keyframes f5j8bii {
@@ -652,34 +680,6 @@ describe('resolveStyleRules', () => {
           }
           to {
             opacity: 1;
-          }
-        }
-        @-webkit-keyframes f55c0se {
-          from {
-            -webkit-transform: rotate(0deg);
-            -moz-transform: rotate(0deg);
-            -ms-transform: rotate(0deg);
-            transform: rotate(0deg);
-          }
-          to {
-            -webkit-transform: rotate(-360deg);
-            -moz-transform: rotate(-360deg);
-            -ms-transform: rotate(-360deg);
-            transform: rotate(-360deg);
-          }
-        }
-        @keyframes f55c0se {
-          from {
-            -webkit-transform: rotate(0deg);
-            -moz-transform: rotate(0deg);
-            -ms-transform: rotate(0deg);
-            transform: rotate(0deg);
-          }
-          to {
-            -webkit-transform: rotate(-360deg);
-            -moz-transform: rotate(-360deg);
-            -ms-transform: rotate(-360deg);
-            transform: rotate(-360deg);
           }
         }
         .f1al5ov7 {

--- a/packages/make-styles/src/runtime/resolveStyleRules.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.ts
@@ -145,14 +145,14 @@ function resolveStyleRulesInner(
       }
 
       resolveStyleRulesInner(
-        { animationName: animationNames.join(' ') },
+        { animationName: animationNames.join(', ') },
         unstable_cssPriority,
         pseudo,
         media,
         support,
         cssClassesMap,
         cssRulesByBucket,
-        rtlAnimationNames.join(' '),
+        rtlAnimationNames.join(', '),
       );
     } else if (isObject(value)) {
       if (isNestedSelector(property)) {

--- a/packages/make-styles/src/runtime/resolveStyleRules.ts
+++ b/packages/make-styles/src/runtime/resolveStyleRules.ts
@@ -107,49 +107,52 @@ function resolveStyleRulesInner(
       pushToClassesMap(cssClassesMap, key, className, rtlClassName);
       pushToCSSRules(cssRulesByBucket, styleBucketName, ltrCSS, rtlCSS);
     } else if (property === 'animationName') {
-      const animationNames = Array.isArray(value) ? value : [value];
-      let keyframeCSS = '';
-      let keyframeRtlCSS = '';
+      const animationNameValue = Array.isArray(value) ? value : [value];
 
-      const names = [];
-      const namesRtl = [];
+      const animationNames: string[] = [];
+      const rtlAnimationNames: string[] = [];
 
-      for (const val of animationNames) {
-        const keyframe = compileKeyframeRule(val);
-        const name = HASH_PREFIX + hashString(keyframe);
+      for (const keyframeObject of animationNameValue) {
+        const keyframeCSS = compileKeyframeRule(keyframeObject);
+        const rtlKeyframeCSS = compileKeyframeRule(convert(keyframeObject));
 
-        keyframeCSS += compileKeyframesCSS(name, keyframe);
-        names.push(name);
+        const animationName = HASH_PREFIX + hashString(keyframeCSS);
+        let rtlAnimationName: string;
 
-        const rtlKeyframe = compileKeyframeRule(convert(val));
+        const keyframeRules = compileKeyframesCSS(animationName, keyframeCSS);
+        let rtlKeyframeRules: string[] = [];
 
-        if (keyframe !== rtlKeyframe) {
-          const nameRtl = HASH_PREFIX + hashString(rtlKeyframe);
-          keyframeRtlCSS += compileKeyframesCSS(nameRtl, rtlKeyframe);
-          namesRtl.push(nameRtl);
+        if (keyframeCSS === rtlKeyframeCSS) {
+          // If CSS for LTR & RTL are same we will re-use animationName from LTR to avoid duplication of rules in output
+          rtlAnimationName = animationName;
         } else {
-          namesRtl.push(name);
+          rtlAnimationName = HASH_PREFIX + hashString(rtlKeyframeCSS);
+          rtlKeyframeRules = compileKeyframesCSS(rtlAnimationName, rtlKeyframeCSS);
         }
+
+        for (let i = 0; i < keyframeRules.length; i++) {
+          pushToCSSRules(
+            cssRulesByBucket,
+            // keyframes styles should be inserted into own bucket
+            'k',
+            keyframeRules[i],
+            rtlKeyframeRules[i],
+          );
+        }
+
+        animationNames.push(animationName);
+        rtlAnimationNames.push(rtlAnimationName);
       }
 
-      const animationName = names.join(' ');
-      const animationNameRtl = namesRtl.join(' ');
-
-      pushToCSSRules(
-        cssRulesByBucket,
-        'k', // keyframes styles should be inserted into own bucket
-        keyframeCSS,
-        keyframeRtlCSS || undefined,
-      );
       resolveStyleRulesInner(
-        { animationName },
+        { animationName: animationNames.join(' ') },
         unstable_cssPriority,
         pseudo,
         media,
         support,
         cssClassesMap,
         cssRulesByBucket,
-        animationNameRtl,
+        rtlAnimationNames.join(' '),
       );
     } else if (isObject(value)) {
       if (isNestedSelector(property)) {

--- a/packages/react-make-styles/README.md
+++ b/packages/react-make-styles/README.md
@@ -141,13 +141,23 @@ const useStyles = makeStyles({
     animationIterationCount: 'infinite',
     animationDuration: '3s',
     animationName: {
-      from: {
-        transform: 'rotate(0deg)',
-      },
-      to: {
-        transform: 'rotate(360deg)',
-      },
+      from: { transform: 'rotate(0deg)' },
+      to: { transform: 'rotate(360deg)' },
     },
+  },
+  array: {
+    animationIterationCount: 'infinite',
+    animationDuration: '3s',
+    animationName: [
+      {
+        from: { transform: 'rotate(0deg)' },
+        to: { transform: 'rotate(360deg)' },
+      },
+      {
+        from: { height: '100px' },
+        to: { height: '200px' },
+      },
+    ],
   },
 });
 ```

--- a/packages/react-make-styles/README.md
+++ b/packages/react-make-styles/README.md
@@ -129,6 +129,29 @@ const useStyles = makeStyles({
 });
 ```
 
+### 🎞 `keyframes` (animations)
+
+`keyframes` are supported via `animationName` property that can be defined as an object or an array of objects:
+
+```tsx
+import { makeStyles } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  root: {
+    animationIterationCount: 'infinite',
+    animationDuration: '3s',
+    animationName: {
+      from: {
+        transform: 'rotate(0deg)',
+      },
+      to: {
+        transform: 'rotate(360deg)',
+      },
+    },
+  },
+});
+```
+
 ## `makeStaticStyles()`
 
 Creates styles attached to a global selector. Styles can be defined via objects:

--- a/packages/react-make-styles/src/createDOMRenderer.test.tsx
+++ b/packages/react-make-styles/src/createDOMRenderer.test.tsx
@@ -20,8 +20,8 @@ describe('createDOMRenderer', () => {
     const useExampleStyles = makeStyles({
       root: {
         animationName: {
-          from: { transform: 'rotate(0deg)' },
-          to: { transform: 'rotate(360deg)' },
+          from: { height: '10px' },
+          to: { height: '20px' },
         },
 
         color: 'red',
@@ -80,6 +80,12 @@ describe('createDOMRenderer', () => {
     // We also would to ensure that new elements have not been inserted
     expect(styleElementsBeforeHydration.length).toBe(styleElementsAfterHydration.length);
 
+    // Following rules are present in cache:
+    // - "animationName"
+    // - "color"
+    // - @keyframes + prefixed
+    // - @media
+    expect(Object.keys(clientRenderer.insertionCache)).toHaveLength(5);
     insertRules.forEach(insertRule => {
       expect(insertRule).not.toHaveBeenCalled();
     });

--- a/packages/react-make-styles/src/renderToStyleElements-node.test.tsx
+++ b/packages/react-make-styles/src/renderToStyleElements-node.test.tsx
@@ -142,20 +142,6 @@ describe('renderToStyleElements', () => {
             transform: rotate(360deg);
           }
         }
-        @keyframes f1q8eu9e {
-          from {
-            -webkit-transform: rotate(0deg);
-            -moz-transform: rotate(0deg);
-            -ms-transform: rotate(0deg);
-            transform: rotate(0deg);
-          }
-          to {
-            -webkit-transform: rotate(360deg);
-            -moz-transform: rotate(360deg);
-            -ms-transform: rotate(360deg);
-            transform: rotate(360deg);
-          }
-        }
         @-webkit-keyframes f55c0se {
           from {
             -webkit-transform: rotate(0deg);
@@ -168,6 +154,20 @@ describe('renderToStyleElements', () => {
             -moz-transform: rotate(-360deg);
             -ms-transform: rotate(-360deg);
             transform: rotate(-360deg);
+          }
+        }
+        @keyframes f1q8eu9e {
+          from {
+            -webkit-transform: rotate(0deg);
+            -moz-transform: rotate(0deg);
+            -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+          }
+          to {
+            -webkit-transform: rotate(360deg);
+            -moz-transform: rotate(360deg);
+            -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
           }
         }
         @keyframes f55c0se {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20050
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes insertion of keyframes to `style`. CSS rules that were generated previously contained multiple rules (due prefixing), that caused failures in `.insertRule()` calls.

This PR updates `compileKeyframesCSS()` to generate atomic rules instead:

```js
// Before
const rules = [
  "@-webkit-keyframes foo{from{height:10px;}to{height:50px;}} @keyframes foo{from{height:10px;}to{height:50px;}}"
];
// After
const rules = [
  "@-webkit-keyframes foo{from{height:10px;}to{height:50px;}}",
  "@keyframes foo{from{height:10px;}to{height:50px;}}"
];
```
