### PR TITLE
(web-components) create unique class for progress and ring

### DIFF
--- a/change/@fluentui-web-components-1fabcf3e-b2c7-40e6-80bf-713c61d5c72e.json
+++ b/change/@fluentui-web-components-1fabcf3e-b2c7-40e6-80bf-713c61d5c72e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "create explicit classes for progress ring and progress to prevent conflicts during tagFor retrieval",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/progress/progress-ring/index.ts
+++ b/packages/web-components/src/progress/progress-ring/index.ts
@@ -1,9 +1,11 @@
-import {
-  BaseProgress as ProgressRing,
-  ProgressRingOptions,
-  progressRingTemplate as template,
-} from '@microsoft/fast-foundation';
+import { BaseProgress, ProgressRingOptions, progressRingTemplate as template } from '@microsoft/fast-foundation';
 import { progressRingStyles as styles } from './progress-ring.styles';
+
+/**
+ * Progress Ring base class
+ * @public
+ */
+export class ProgressRing extends BaseProgress {}
 
 /**
  * The Fluent Progress Ring Element. Implements {@link @microsoft/fast-foundation#BaseProgress},
@@ -43,9 +45,3 @@ export const fluentProgressRing = ProgressRing.compose<ProgressRingOptions>({
  * @public
  */
 export const progressRingStyles = styles;
-
-/**
- * Progress Ring base class
- * @public
- */
-export { ProgressRing };

--- a/packages/web-components/src/progress/progress/index.ts
+++ b/packages/web-components/src/progress/progress/index.ts
@@ -1,5 +1,11 @@
-import { BaseProgress as Progress, ProgressOptions, progressTemplate as template } from '@microsoft/fast-foundation';
+import { BaseProgress, ProgressOptions, progressTemplate as template } from '@microsoft/fast-foundation';
 import { progressStyles as styles } from './progress.styles';
+
+/**
+ * Progress base class
+ * @public
+ */
+export class Progress extends BaseProgress {}
 
 /**
  * The Fluent Progress Element. Implements {@link @microsoft/fast-foundation#BaseProgress},
@@ -27,9 +33,3 @@ export const fluentProgress = Progress.compose<ProgressOptions>({
  * @public
  */
 export const progressStyles = styles;
-
-/**
- * Progress base class
- * @public
- */
-export { Progress };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
This PR creates unique class instances for Progress and Progress Ring to ensure that calls to the `context.tagFor()` API registers unique instances for the element. Currently, both extend the same base class which is *named* differently for each but not actually different. This means that whichever is registered first is what is retrieved during part of this call.

#### Focus areas to test

(optional)
