### PR TITLE
Disable ProgressPlugin in react-components storybook CI build

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -65,6 +65,11 @@ module.exports = /** @type {Omit<StorybookConfig,'typescript'|'babel'>} */ ({
       });
     }
 
+    if ((process.env.CI || process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME) && config.plugins) {
+      // Disable ProgressPlugin in PR/CI builds to reduce log verbosity (warnings and errors are still logged)
+      config.plugins = config.plugins.filter(({ constructor }) => constructor.name !== 'ProgressPlugin');
+    }
+
     return config;
   },
 


### PR DESCRIPTION
Remove unhelpful ProgressPlugin logs from PR/CI build of `@fluentui/react-components` storybook (it's built for the PR deploy site). 

We already had this logic for other webpack configs but it was missing from the converged storybook config, occasionally leading to builds like [this one](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=222339&view=logs&j=be0e6c0b-16d6-5408-4b39-461952619dc9&t=91e838fc-b8f7-564c-c417-9130335111f3&l=7176) where the storybook build failed but it wasn't clear why.