### PR TITLE
Support ability to set a context menu item's event target to the Menu root

### DIFF
--- a/change/@fluentui-react-ecc8a72e-6b2c-434a-8e2d-4594944b54ad.json
+++ b/change/@fluentui-react-ecc8a72e-6b2c-434a-8e2d-4594944b54ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Support ability to prefer the menu target as an item's click event target",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/package.json
+++ b/packages/react-examples/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@fluentui/azure-themes": "^8.1.111",
     "@fluentui/date-time-utilities": "^8.2.3",
+    "@fluentui/dom-utilities": "^2.1.5",
     "@fluentui/example-data": "^8.3.0",
     "@fluentui/font-icons-mdl2": "^8.1.18",
     "@fluentui/foundation-legacy": "^8.1.17",

--- a/packages/react-examples/src/react/CommandBar/CommandBar.Basic.Example.tsx
+++ b/packages/react-examples/src/react/CommandBar/CommandBar.Basic.Example.tsx
@@ -1,12 +1,24 @@
 import * as React from 'react';
 import { CommandBar, ICommandBarItemProps } from '@fluentui/react/lib/CommandBar';
 import { IButtonProps } from '@fluentui/react/lib/Button';
+import { setVirtualParent } from '@fluentui/dom-utilities/lib/setVirtualParent';
+import { FocusTrapZone } from '@fluentui/react/lib/FocusTrapZone';
+import { Checkbox } from '@fluentui/react/lib/Checkbox';
 
 const overflowProps: IButtonProps = { ariaLabel: 'More commands' };
 
 export const CommandBarBasicExample: React.FunctionComponent = () => {
+  const [enableFocusTrap, setEnableFocusTrap] = React.useState(false);
+
+  const onChangeEnableFocusTrap = (
+    ev?: React.FormEvent<HTMLElement | HTMLInputElement> | undefined,
+    checked?: boolean | undefined,
+  ) => {
+    setEnableFocusTrap(!!checked);
+  };
+
   return (
-    <div>
+    <FocusTrapZone disabled={!enableFocusTrap}>
       <CommandBar
         items={_items}
         overflowItems={_overflowItems}
@@ -16,7 +28,8 @@ export const CommandBarBasicExample: React.FunctionComponent = () => {
         primaryGroupAriaLabel="Email actions"
         farItemsGroupAriaLabel="More actions"
       />
-    </div>
+      <Checkbox label="Trap focus around command bar" checked={enableFocusTrap} onChange={onChangeEnableFocusTrap} />
+    </FocusTrapZone>
   );
 };
 
@@ -46,7 +59,76 @@ const _items: ICommandBarItemProps[] = [
     key: 'upload',
     text: 'Upload',
     iconProps: { iconName: 'Upload' },
-    href: 'https://developer.microsoft.com/en-us/fluentui',
+    subMenuProps: {
+      items: [
+        {
+          key: 'uploadfile',
+          text: 'File',
+          preferMenuTargetAsEventTarget: true,
+          onClick: (ev?: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement> | undefined) => {
+            ev?.persist();
+
+            Promise.resolve().then(() => {
+              const inputElement = document.createElement('input');
+              inputElement.style.visibility = 'hidden';
+              inputElement.setAttribute('type', 'file');
+
+              document.body.appendChild(inputElement);
+
+              const target = ev?.target as HTMLElement | undefined;
+
+              if (target) {
+                setVirtualParent(inputElement, target);
+              }
+
+              inputElement.click();
+
+              if (target) {
+                setVirtualParent(inputElement, null);
+              }
+
+              setTimeout(() => {
+                inputElement.remove();
+              }, 10000);
+            });
+          },
+        },
+        {
+          key: 'uploadfolder',
+          text: 'Folder',
+          preferMenuTargetAsEventTarget: true,
+          onClick: (ev?: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement> | undefined) => {
+            ev?.persist();
+
+            Promise.resolve().then(() => {
+              const inputElement = document.createElement('input');
+              inputElement.style.visibility = 'hidden';
+              inputElement.setAttribute('type', 'file');
+
+              (inputElement as { webkitdirectory?: boolean }).webkitdirectory = true;
+
+              document.body.appendChild(inputElement);
+
+              const target = ev?.target as HTMLElement | undefined;
+
+              if (target) {
+                setVirtualParent(inputElement, target);
+              }
+
+              inputElement.click();
+
+              if (target) {
+                setVirtualParent(inputElement, null);
+              }
+
+              setTimeout(() => {
+                inputElement.remove();
+              }, 10000);
+            });
+          },
+        },
+      ],
+    },
   },
   {
     key: 'share',

--- a/packages/react-examples/src/react/CommandBar/CommandBar.Basic.Example.tsx
+++ b/packages/react-examples/src/react/CommandBar/CommandBar.Basic.Example.tsx
@@ -10,12 +10,12 @@ const overflowProps: IButtonProps = { ariaLabel: 'More commands' };
 export const CommandBarBasicExample: React.FunctionComponent = () => {
   const [enableFocusTrap, setEnableFocusTrap] = React.useState(false);
 
-  const onChangeEnableFocusTrap = (
-    ev?: React.FormEvent<HTMLElement | HTMLInputElement> | undefined,
-    checked?: boolean | undefined,
-  ) => {
-    setEnableFocusTrap(!!checked);
-  };
+  const onChangeEnableFocusTrap = React.useCallback(
+    (ev?: React.FormEvent<HTMLElement | HTMLInputElement> | undefined, checked?: boolean | undefined) => {
+      setEnableFocusTrap(!!checked);
+    },
+    [],
+  );
 
   return (
     <FocusTrapZone disabled={!enableFocusTrap}>

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -1,7 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] = `
-<div>
+<div
+  onBlurCapture={[Function]}
+  onFocusCapture={[Function]}
+>
+  <div
+    aria-hidden={true}
+    data-is-visible={true}
+    style={
+      Object {
+        "pointerEvents": "none",
+        "position": "fixed",
+      }
+    }
+    tabIndex={-1}
+  />
   <div>
     <div
       style={
@@ -41,7 +55,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                 padding-right: 14px;
                 padding-top: 0;
               }
-          data-focuszone-id="FocusZone0"
+          data-focuszone-id="FocusZone1"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -237,7 +251,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                             margin-top: 0;
                             white-space: nowrap;
                           }
-                      id="id__1"
+                      id="id__2"
                     >
                       New
                     </span>
@@ -294,10 +308,14 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                   }
               role="none"
             >
-              <a
+              <button
+                aria-controls={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 className=
                     ms-Button
                     ms-Button--commandBar
+                    ms-Button--hasMenu
                     ms-CommandBarItem-link
                     {
                       -moz-osx-font-smoothing: grayscale;
@@ -378,7 +396,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                       color: #323130;
                     }
                 data-is-focusable={true}
-                href="https://developer.microsoft.com/en-us/fluentui"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 onKeyPress={[Function]}
@@ -386,6 +403,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
                 role="menuitem"
+                type="button"
               >
                 <span
                   className=
@@ -457,13 +475,53 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                             margin-top: 0;
                             white-space: nowrap;
                           }
-                      id="id__4"
+                      id="id__5"
                     >
                       Upload
                     </span>
                   </span>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Button-menuIcon
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          flex-shrink: 0;
+                          font-size: 12px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: GrayText;
+                        }
+                    data-icon-name="ChevronDown"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
                 </span>
-              </a>
+              </button>
             </div>
             <div
               className=
@@ -637,7 +695,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                             margin-top: 0;
                             white-space: nowrap;
                           }
-                      id="id__7"
+                      id="id__8"
                     >
                       Share
                     </span>
@@ -817,7 +875,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                             margin-top: 0;
                             white-space: nowrap;
                           }
-                      id="id__10"
+                      id="id__11"
                     >
                       Download
                     </span>
@@ -1343,5 +1401,171 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
       </div>
     </div>
   </div>
+  <div
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          display: flex;
+          position: relative;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+          border-color: Highlight;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #605e5c;
+          opacity: 1;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+          color: Highlight;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
+        }
+  >
+    <input
+      checked={false}
+      className=
+
+          {
+            background: none;
+            opacity: 0;
+            position: absolute;
+          }
+          .ms-Fabric--isFocusVisible &:focus + label::before {
+            outline-offset: 2px;
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+            outline: 1px solid WindowText;
+          }
+      data-ktp-execute-target={true}
+      id="checkbox-25"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <label
+      className=
+          ms-Checkbox-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: flex-start;
+            cursor: pointer;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            position: relative;
+            user-select: none;
+          }
+          &::before {
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      htmlFor="checkbox-25"
+    >
+      <div
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #323130;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-right: 4px;
+              overflow: hidden;
+              position: relative;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              border-color: WindowText;
+              forced-color-adjust: none;
+            }
+        data-ktp-target={true}
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+                forced-color-adjust: none;
+              }
+          data-icon-name="CheckMark"
+        >
+          
+        </i>
+      </div>
+      <span
+        className=
+            ms-Checkbox-text
+            {
+              color: #323130;
+              font-size: 14px;
+              line-height: 20px;
+              margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              color: WindowText;
+              forced-color-adjust: none;
+            }
+      >
+        Trap focus around command bar
+      </span>
+    </label>
+  </div>
+  <div
+    aria-hidden={true}
+    data-is-visible={true}
+    style={
+      Object {
+        "pointerEvents": "none",
+        "position": "fixed",
+      }
+    }
+    tabIndex={-1}
+  />
 </div>
 `;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -350,7 +350,7 @@ import { styled } from '@fluentui/utilities';
 import { StyleFunction } from '@fluentui/utilities';
 import { Stylesheet } from '@fluentui/style-utilities';
 import { tableProperties } from '@fluentui/utilities';
-import type { Target } from '@fluentui/react-hooks';
+import { Target } from '@fluentui/react-hooks';
 import { tdProperties } from '@fluentui/utilities';
 import { textAreaProperties } from '@fluentui/utilities';
 import { Theme } from '@fluentui/theme';
@@ -1813,7 +1813,9 @@ export const getSplitButtonClassNames: (styles: IButtonStyles, disabled: boolean
 export { getStartDateOfWeek }
 
 // @public (undocumented)
-export function getSubmenuItems(item: IContextualMenuItem): IContextualMenuItem[] | undefined;
+export function getSubmenuItems(item: IContextualMenuItem, options?: {
+    target?: Target;
+}): IContextualMenuItem[] | undefined;
 
 export { getTheme }
 
@@ -3915,6 +3917,8 @@ export interface IContextualMenuItem {
     // @deprecated (undocumented)
     inactive?: boolean;
     itemProps?: Partial<IContextualMenuItemProps>;
+    // @deprecated (undocumented)
+    items?: IContextualMenuItem[];
     // (undocumented)
     itemType?: ContextualMenuItemType;
     key: string;
@@ -3926,6 +3930,7 @@ export interface IContextualMenuItem {
     onRender?: (item: any, dismissMenu: (ev?: any, dismissAll?: boolean) => void) => React_2.ReactNode;
     onRenderContent?: (props: IContextualMenuItemProps, defaultRenders: IContextualMenuItemRenderFunctions) => React_2.ReactNode;
     onRenderIcon?: IRenderFunction<IContextualMenuItemProps>;
+    preferMenuTargetAsEventTarget?: boolean;
     primaryDisabled?: boolean;
     rel?: string;
     role?: string;

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -32,6 +32,7 @@ import type { IButtonProps, IButton } from './Button.types';
 import type { IButtonClassNames } from './BaseButton.classNames';
 import type { ISplitButtonClassNames } from './SplitButton/SplitButton.classNames';
 import type { IKeytipProps } from '../../Keytip';
+import { composeComponentAs } from '../../Utilities';
 
 /**
  * {@docCategory Button}
@@ -337,7 +338,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
           {menuProps &&
             !menuProps.doNotLayer &&
             this._shouldRenderMenu() &&
-            onRenderMenu(menuProps, this._onRenderMenu)}
+            onRenderMenu(this._getMenuProps(menuProps), this._onRenderMenu)}
         </span>
       </Tag>
     );
@@ -359,7 +360,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       return (
         <>
           {Content}
-          {this._shouldRenderMenu() && onRenderMenu(menuProps, this._onRenderMenu)}
+          {this._shouldRenderMenu() && onRenderMenu(this._getMenuProps(menuProps), this._onRenderMenu)}
         </>
       );
     }
@@ -510,10 +511,9 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     return <FontIcon iconName="ChevronDown" {...menuIconProps} className={this._classNames.menuIcon} />;
   };
 
-  private _onRenderMenu = (menuProps: IContextualMenuProps): JSX.Element => {
+  private _getMenuProps(menuProps: IContextualMenuProps): IContextualMenuProps {
     const { persistMenu } = this.props;
     const { menuHidden } = this.state;
-    const MenuType = this.props.menuAs || (ContextualMenu as React.ElementType<IContextualMenuProps>);
 
     // the accessible menu label (accessible name) has a relationship to the button.
     // If the menu props do not specify an explicit value for aria-label or aria-labelledBy,
@@ -522,19 +522,23 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       menuProps = { ...menuProps, labelElementId: this._labelId };
     }
 
-    return (
-      <MenuType
-        id={this._labelId + '-menu'}
-        directionalHint={DirectionalHint.bottomLeftEdge}
-        {...menuProps}
-        shouldFocusOnContainer={this._menuShouldFocusOnContainer}
-        shouldFocusOnMount={this._menuShouldFocusOnMount}
-        hidden={persistMenu ? menuHidden : undefined}
-        className={css('ms-BaseButton-menuhost', menuProps.className)}
-        target={this._isSplitButton ? this._splitButtonContainer.current : this._buttonElement.current}
-        onDismiss={this._onDismissMenu}
-      />
-    );
+    return {
+      id: this._labelId + '-menu',
+      directionalHint: DirectionalHint.bottomLeftEdge,
+      ...menuProps,
+      shouldFocusOnContainer: this._menuShouldFocusOnContainer,
+      shouldFocusOnMount: this._menuShouldFocusOnMount,
+      hidden: persistMenu ? menuHidden : undefined,
+      className: css('ms-BaseButton-menuhost', menuProps.className),
+      target: this._isSplitButton ? this._splitButtonContainer.current : this._buttonElement.current,
+      onDismiss: this._onDismissMenu,
+    };
+  }
+
+  private _onRenderMenu = (menuProps: IContextualMenuProps): JSX.Element => {
+    const MenuType = this.props.menuAs ? composeComponentAs(this.props.menuAs, ContextualMenu) : ContextualMenu;
+
+    return <MenuType {...menuProps} />;
   };
 
   private _onDismissMenu: IContextualMenuProps['onDismiss'] = ev => {

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -31,7 +31,7 @@ import {
 } from './ContextualMenuItemWrapper/index';
 import { concatStyleSetsWithProps } from '../../Styling';
 import { getItemStyles } from './ContextualMenu.classNames';
-import { useTarget, usePrevious, useAsync, useWarnings, useId } from '@fluentui/react-hooks';
+import { useTarget, usePrevious, useAsync, useWarnings, useId, Target } from '@fluentui/react-hooks';
 import { useResponsiveMode, ResponsiveMode } from '../../ResponsiveMode';
 import { MenuContext } from '../../utilities/MenuContext/index';
 import type {
@@ -62,8 +62,35 @@ const DEFAULT_PROPS: Partial<IContextualMenuProps> = {
   beakWidth: 16,
 };
 
-export function getSubmenuItems(item: IContextualMenuItem): IContextualMenuItem[] | undefined {
-  return item.subMenuProps ? item.subMenuProps.items : item.items;
+export function getSubmenuItems(
+  item: IContextualMenuItem,
+  options?: {
+    target?: Target;
+  },
+): IContextualMenuItem[] | undefined {
+  const target = options?.target;
+
+  const items = item.subMenuProps ? item.subMenuProps.items : item.items;
+
+  if (items) {
+    const overrideItems: typeof items = [];
+
+    for (const item of items) {
+      if (item.preferMenuTargetAsEventTarget) {
+        // For sub-items which need an overridden target, intercept `onClick`
+        const { onClick, ...contextItem } = item;
+
+        overrideItems.push({
+          ...contextItem,
+          onClick: getOnClickWithOverrideTarget(onClick, target),
+        });
+      } else {
+        overrideItems.push(item);
+      }
+    }
+
+    return overrideItems;
+  }
 }
 
 /**
@@ -123,7 +150,7 @@ function useVisibility(props: IContextualMenuProps, targetWindow: Window | undef
   React.useEffect(() => () => onMenuClosedRef.current?.(propsRef.current), []);
 }
 
-function useSubMenuState({ hidden, items, theme, className, id }: IContextualMenuProps, dismiss: () => void) {
+function useSubMenuState({ hidden, items, theme, className, id, target }: IContextualMenuProps, dismiss: () => void) {
   const [expandedMenuItemKey, setExpandedMenuItemKey] = React.useState<string>();
   const [submenuTarget, setSubmenuTarget] = React.useState<HTMLElement>();
   /** True if the menu was expanded by mouse click OR hover (as opposed to by keyboard) */
@@ -180,6 +207,12 @@ function useSubMenuState({ hidden, items, theme, className, id }: IContextualMen
 
       if (item.subMenuProps) {
         assign(submenuProps, item.subMenuProps);
+      }
+
+      if (item.preferMenuTargetAsEventTarget) {
+        const { onItemClick } = item;
+
+        submenuProps.onItemClick = getOnClickWithOverrideTarget(onItemClick, target);
       }
     }
     return submenuProps;
@@ -469,6 +502,8 @@ function useMouseHandlers(
   onSubMenuDismiss: (ev?: any, dismissAll?: boolean) => void,
   dismiss: (ev?: any, dismissAll?: boolean) => void,
 ) {
+  const { target } = props;
+
   const onItemMouseEnterBase = (item: any, ev: React.MouseEvent<HTMLElement>, target?: HTMLElement): void => {
     if (shouldIgnoreMouseEvent()) {
       return;
@@ -621,6 +656,10 @@ function useMouseHandlers(
   ): void => {
     if (item.disabled || item.isDisabled) {
       return;
+    }
+
+    if (item.preferMenuTargetAsEventTarget) {
+      overrideTarget(ev, target);
     }
 
     let shouldDismiss = false;
@@ -1287,6 +1326,42 @@ function findItemByKeyFromItems(key: string, items: IContextualMenuItem[]): ICon
       }
     } else if (item.key && item.key === key) {
       return item;
+    }
+  }
+}
+
+function getOnClickWithOverrideTarget(
+  onClick:
+    | ((
+        ev?: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement> | undefined,
+        item?: IContextualMenuItem | undefined,
+      ) => boolean | void)
+    | undefined,
+  target: Target | undefined,
+) {
+  return onClick
+    ? (
+        ev?: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement> | undefined,
+        item?: IContextualMenuItem | undefined,
+      ) => {
+        overrideTarget(ev, target);
+
+        return onClick(ev, item);
+      }
+    : onClick;
+}
+
+function overrideTarget(
+  ev?: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement> | undefined,
+  target?: Target,
+): void {
+  if (ev && target) {
+    ev.persist();
+
+    if (target instanceof Event) {
+      ev.target = target.target as HTMLElement;
+    } else if (target instanceof Element) {
+      ev.target = target;
     }
   }
 }

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -70,22 +70,23 @@ export function getSubmenuItems(
 ): IContextualMenuItem[] | undefined {
   const target = options?.target;
 
+  // eslint-disable-next-line deprecation/deprecation
   const items = item.subMenuProps ? item.subMenuProps.items : item.items;
 
   if (items) {
     const overrideItems: typeof items = [];
 
-    for (const item of items) {
-      if (item.preferMenuTargetAsEventTarget) {
+    for (const subItem of items) {
+      if (subItem.preferMenuTargetAsEventTarget) {
         // For sub-items which need an overridden target, intercept `onClick`
-        const { onClick, ...contextItem } = item;
+        const { onClick, ...contextItem } = subItem;
 
         overrideItems.push({
           ...contextItem,
           onClick: getOnClickWithOverrideTarget(onClick, target),
         });
       } else {
-        overrideItems.push(item);
+        overrideItems.push(subItem);
       }
     }
 
@@ -150,7 +151,10 @@ function useVisibility(props: IContextualMenuProps, targetWindow: Window | undef
   React.useEffect(() => () => onMenuClosedRef.current?.(propsRef.current), []);
 }
 
-function useSubMenuState({ hidden, items, theme, className, id, target }: IContextualMenuProps, dismiss: () => void) {
+function useSubMenuState(
+  { hidden, items, theme, className, id, target: menuTarget }: IContextualMenuProps,
+  dismiss: () => void,
+) {
   const [expandedMenuItemKey, setExpandedMenuItemKey] = React.useState<string>();
   const [submenuTarget, setSubmenuTarget] = React.useState<HTMLElement>();
   /** True if the menu was expanded by mouse click OR hover (as opposed to by keyboard) */
@@ -212,7 +216,7 @@ function useSubMenuState({ hidden, items, theme, className, id, target }: IConte
       if (item.preferMenuTargetAsEventTarget) {
         const { onItemClick } = item;
 
-        submenuProps.onItemClick = getOnClickWithOverrideTarget(onItemClick, target);
+        submenuProps.onItemClick = getOnClickWithOverrideTarget(onItemClick, menuTarget);
       }
     }
     return submenuProps;
@@ -502,7 +506,7 @@ function useMouseHandlers(
   onSubMenuDismiss: (ev?: any, dismissAll?: boolean) => void,
   dismiss: (ev?: any, dismissAll?: boolean) => void,
 ) {
-  const { target } = props;
+  const { target: menuTarget } = props;
 
   const onItemMouseEnterBase = (item: any, ev: React.MouseEvent<HTMLElement>, target?: HTMLElement): void => {
     if (shouldIgnoreMouseEvent()) {
@@ -659,7 +663,7 @@ function useMouseHandlers(
     }
 
     if (item.preferMenuTargetAsEventTarget) {
-      overrideTarget(ev, target);
+      overrideTarget(ev, menuTarget);
     }
 
     let shouldDismiss = false;

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '../../Utilities';
+import { styled, composeRenderFunction } from '../../Utilities';
 import { ContextualMenuBase } from './ContextualMenu.base';
 import { getStyles } from './ContextualMenu.styles';
 import type { IContextualMenuProps, IContextualMenuStyleProps, IContextualMenuStyles } from './ContextualMenu.types';
@@ -13,7 +13,16 @@ const LocalContextualMenu: React.FunctionComponent<IContextualMenuProps> = style
   IContextualMenuProps,
   IContextualMenuStyleProps,
   IContextualMenuStyles
->(ContextualMenuBase, getStyles, () => ({ onRenderSubMenu }), { scope: 'ContextualMenu' });
+>(
+  ContextualMenuBase,
+  getStyles,
+  (props: IContextualMenuProps) => ({
+    onRenderSubMenu: props.onRenderSubMenu
+      ? composeRenderFunction(props.onRenderSubMenu, onRenderSubMenu)
+      : onRenderSubMenu,
+  }),
+  { scope: 'ContextualMenu' },
+);
 
 /**
  * ContextualMenu description

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -543,6 +543,11 @@ export interface IContextualMenuItem {
   keytipProps?: IKeytipProps;
 
   /**
+   * @deprecated Use subMenuProps.items instead.
+   */
+  items?: IContextualMenuItem[];
+
+  /**
    * Any additional properties to use when custom rendering menu items.
    */
   [propertyName: string]: any;
@@ -567,6 +572,14 @@ export interface IContextualMenuItem {
    * @deprecated Use `text` instead.
    */
   name?: string;
+
+  /**
+   * Flag which indicates that, when the item is clicked, the 'target' for the click event should be
+   * overridden to reflect the launch target from the root menu.
+   * This avoids a situation where the 'target' of the event may wind up detached from the DOM
+   * when the menu is dismissed in response to the click.
+   */
+  preferMenuTargetAsEventTarget?: boolean;
 }
 
 /**

--- a/packages/react/src/utilities/contextualMenu/contextualMenuUtility.ts
+++ b/packages/react/src/utilities/contextualMenu/contextualMenuUtility.ts
@@ -26,6 +26,7 @@ export function getIsChecked(item: IContextualMenuItem): boolean | null {
 }
 
 export function hasSubmenu(item: IContextualMenuItem): boolean {
+  // eslint-disable-next-line deprecation/deprecation
   return !!(item.subMenuProps || item.items);
 }
 


### PR DESCRIPTION
#### Description of changes

One common scenario for which `CommandBar` and `ContextualMenu` is used is to trigger the Browser's File System dialog, typically to Upload an item. Common practice is to generate an `input` element on the click, and then invoke `.click()` directly onto it. The browser will recognize that the activity is still within the 'trust period' of the UX event and launch the dialog. Since an Upload is long-lived, the best place to attach the `input` element is to the end of the DOM, as a hidden node, and to clean it up once the upload is complete.

This pattern is pretty easy to implement and fairly common, and works in most cases.

However, when a `CommandBar` is wrapped in a `FocusTrapZone`, the basic implementation of the scenario breaks: the `FocusTrapZone`'s global click handler intercepts the `.click()` on the `input` and suppresses it, so the dialog does not open. This occurs because the `input` is not a descendant of the `FocusTrapZone`, so the `FocusTrapZone` is doing its job.

A clever way to 'work around' the behavior of `FocusTrapZone` is to use `setVirtualParent` to pretend that the `input` belongs to the `CommandBar`. However, in the `onClick` callback for `IContextualMenuItem`, `ev.target` is a short-lived button element that is detached from the DOM when the menu is dismissed after clicking the item. Thus, using it as a virtual parent won't work if there is any asynchronicity between dismissing the menu and clicking the `input`.

A missing piece is the ability to use a 'stable' element as the simulated click-target in the `onClick` callback. This PR introduces a new field for `IContextualMenuItem` called `preferMenuTargetAsEventTarget`. When this field is set to `true`, the `ContextualMenu` will supply its original launch target (the top-level command button) in place of the leaf target (the menu item button), ensuring that the `onClick` callback has a 'stable' element to which to attach longer-lived behaviors.

This PR updates the `CommandBar` example to elaborate on Upload, simulating how a File System dialog is launched, utilizing the new flag to guard against interception by `FocusTrapZone`.

#### Focus areas to test

The behavior is entirely opt-in, but the general `CommandBar` and `ContextualMenu` examples should be checked for issues.
