### PR TITLE
adding total icon

### DIFF
--- a/change/@fluentui-font-icons-mdl2-911bb9d5-e762-44bd-a3e8-dedc5f5dde1e.json
+++ b/change/@fluentui-font-icons-mdl2-911bb9d5-e762-44bd-a3e8-dedc5f5dde1e.json
@@ -1,0 +1,10 @@
+{
+  "type": "minor",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "rpatkar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-font-icons-mdl2-911bb9d5-e762-44bd-a3e8-dedc5f5dde1e.json
+++ b/change/@fluentui-font-icons-mdl2-911bb9d5-e762-44bd-a3e8-dedc5f5dde1e.json
@@ -1,8 +1,8 @@
 {
   "type": "minor",
   "comment": {
-    "title": "",
-    "value": ""
+    "title": "adding font icon",
+    "value": "E9DF"
   },
   "packageName": "@fluentui/font-icons-mdl2",
   "email": "rpatkar@microsoft.com",

--- a/packages/font-icons-mdl2/src/IconNames.ts
+++ b/packages/font-icons-mdl2/src/IconNames.ts
@@ -391,6 +391,7 @@ export const enum IconNames {
   CheckList = 'CheckList',
   Diagnostic = 'Diagnostic',
   Generate = 'Generate',
+  Total = 'Total',
   LineChart = 'LineChart',
   Equalizer = 'Equalizer',
   BarChartHorizontal = 'BarChartHorizontal',

--- a/packages/font-icons-mdl2/src/data/AllIconNames.json
+++ b/packages/font-icons-mdl2/src/data/AllIconNames.json
@@ -389,6 +389,7 @@
   { "name": "CheckList", "unicode": "E9D5" },
   { "name": "Diagnostic", "unicode": "E9D9" },
   { "name": "Generate", "unicode": "E9DA" },
+  { "name": "Total", "unicode": "E9DF" },
   { "name": "LineChart", "unicode": "E9E6" },
   { "name": "Equalizer", "unicode": "E9E9" },
   { "name": "BarChartHorizontal", "unicode": "E9EB" },

--- a/packages/font-icons-mdl2/src/fabric-icons-3.ts
+++ b/packages/font-icons-mdl2/src/fabric-icons-3.ts
@@ -75,6 +75,7 @@ export function initializeIcons(
       'CheckList': '\uE9D5',
       'Diagnostic': '\uE9D9',
       'Generate': '\uE9DA',
+      'Total': '\uE9DF',
       'LineChart': '\uE9E6',
       'Equalizer': '\uE9E9',
       'BarChartHorizontal': '\uE9EB',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20163
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Adds total icon to font-icons-mdl2. Its a commonly used icon that's somehow missing here. Please check https://iconcloud.design/search/filter/Full%20MDL2%20Assets/Fabric%20MDL2%20Assets/total/1fe797eb8-c4094e9ea.

#### Focus areas to test

(optional)
