### PR TITLE
(web-components): remove lodash-es dependency and add missing fast-web-utilities package

### DIFF
--- a/change/@fluentui-web-components-8446d16f-369a-433b-ae7a-b97dc37698c3.json
+++ b/change/@fluentui-web-components-8446d16f-369a-433b-ae7a-b97dc37698c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove dependency on lodash-es with fast-web-utilities",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -91,7 +91,7 @@
   "dependencies": {
     "@microsoft/fast-colors": "^5.1.0",
     "@microsoft/fast-element": "^1.6.0",
-    "@microsoft/fast-foundation": "^2.19.0",
+    "@microsoft/fast-foundation": "^2.20.0",
     "@microsoft/fast-web-utilities": "^5.0.0",
     "tslib": "^1.13.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2655,17 +2655,17 @@
   resolved "https://registry.yarnpkg.com/@microsoft/fast-colors/-/fast-colors-5.1.3.tgz#5c46147401a823835a3833e3e18dae7f06016966"
   integrity sha512-XDEnRYxPO5P3Jsizm4TCxLu1osS/uV3Lym6SfRhq2PxfXPTgEcdvOYDUXyV2drqebs3U5VQnOcYcJiSp73xhng==
 
-"@microsoft/fast-element@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.6.0.tgz#6079c72cf147737a3fdc6373becdaa230b2859fe"
-  integrity sha512-ePTcBuCA99n7He0BYLIzFr5YOHYPSiBLJeDbDsyyQ5JUs4oXaZD0v54Pq0GAtSZuagnCGTDqcxEcBPUhTqLmQw==
+"@microsoft/fast-element@^1.6.0", "@microsoft/fast-element@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.6.1.tgz#53cf476fc4cf3ea5ac90a51c1032b782f4ee9611"
+  integrity sha512-6wCL1yj5SSfqEq/GAkWeKdcE50NTx3VLINpSYG9cpxckgNGXHErsjDwbqwX3399e/O04BVwyIjILip11DFJP9w==
 
-"@microsoft/fast-foundation@^2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-2.19.0.tgz#2e13421620719a359001b0bf693fb7fa07376b9a"
-  integrity sha512-6c/qp+s3Ju8M6V7mJ8C6d90QtOD7E9EhiA9jQR7emZmy/TBq7rVlr7w/8u+6o4u/s6rbEhoEMwLxCsZmxcyZVA==
+"@microsoft/fast-foundation@^2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-2.20.0.tgz#6d62406ef05a5aa563dc80767e565467da8fe452"
+  integrity sha512-GlnToP2pAfyyiYVwX39nXe+OIfok+SH2VjMxllL5fIVf/rp3gVb6a7eISJv6S4ijR7fi6lz//jvS0UlYOHWgPA==
   dependencies:
-    "@microsoft/fast-element" "^1.6.0"
+    "@microsoft/fast-element" "^1.6.1"
     "@microsoft/fast-web-utilities" "^5.0.1"
     "@microsoft/tsdoc-config" "^0.13.4"
     tabbable "^5.2.0"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Earlier today the FAST team merged a contribution which removed lodash-es as a necessary peer dependency in favor of smaller local functions. This PR resolves removing lodash-es as a dependency of the Fluent UI Web Components. The PR also _adds_ an existing but undeclared dependency for the fast-web-utilities package.

#### Focus areas to test
N/A