### PR TITLE
Fix extra 'a' in comment on Breadcrumb.tsx

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/fluentui/react-northstar/src/components/Breadcrumb/Breadcrumb.tsx
@@ -43,7 +43,7 @@ export type BreadcrumbStylesProps = Required<Pick<BreadcrumbProps, 'size'>>;
 export const breadcrumbClassName = 'ui-breadcrumb';
 
 /**
- * Breadcrumb is a a component that indicates the path of the current page
+ * Breadcrumb is a component that indicates the path of the current page
  *
  * @accessibility
  * Implements [ARIA Breadcrumb](https://www.w3.org/TR/wai-aria-practices-1.1/#breadcrumb) design pattern.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20164 
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

There was an extra 'a' in the comment on line 46 (previously: 'Breadcrumb is a a component'). 
Deleted one 'a'.

#### Focus areas to test

(optional)
