### PR TITLE
Make url optional for INavLink type

### DIFF
--- a/packages/react/src/components/Nav/Nav.types.ts
+++ b/packages/react/src/components/Nav/Nav.types.ts
@@ -182,7 +182,7 @@ export interface INavLink {
   /**
    * URL to navigate to for this link
    */
-  url: string;
+  url?: string;
 
   /**
    * Unique, stable key for the link, used when rendering the list of links and for tracking


### PR DESCRIPTION
#### Pull request checklist

- [*] Addresses an existing issue: Fixes #20211
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Makes the url parameter on INavLink optional. This usecase is supported by the docs itself and the code. But the types still demand the url parameter to be required.
