### PR TITLE
Fix for scrollbar overlapping indicator in Multiple Selection

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/dropdownStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/dropdownStyles.ts
@@ -139,9 +139,7 @@ export const dropdownStyles: ComponentSlotStylesPrepared<DropdownStylesProps, Dr
   selectedItems: ({ props: p, variables: v }): ICSSInJSStyle => ({
     display: 'flex',
     flexWrap: 'wrap',
-    overflowY: 'auto',
-    overflowX: 'hidden',
-    maxHeight: v.selectedItemsMaxHeight,
+    overflow: 'hidden',
     width: '100%',
     ...(p.hasToggleIndicator && { paddingRight: v.toggleIndicatorSize }),
     ...(p.multiple &&


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20166
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Currently, the scrollbar overlaps with the indicator:
![Before](https://user-images.githubusercontent.com/59708190/137601106-b40f2b7a-21d5-4b10-8c4e-9fb9b9d65a37.png)

This PR removes the scrollbar and allows container height to expand with contents:

![After](https://user-images.githubusercontent.com/59708190/137602051-db37a906-4536-47ad-a218-0d72ac0b1ac5.png)

If this is not the preferred style, these were some other ideas I had to fix this issue:
1. Move indicator to the left to prevent overlapping.
2. Hide scrollbar but keep container scrollable.

#### Focus areas to test

(optional)
