### PR TITLE
Focus does not go back to recipient well after clicking on suggestion in dropdown

### DIFF
--- a/change/@fluentui-react-3a86cfed-a9d2-43d3-bb96-2f3b5f6500f7.json
+++ b/change/@fluentui-react-3a86cfed-a9d2-43d3-bb96-2f3b5f6500f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "use correct document and window when in projection popout",
+  "packageName": "@fluentui/react",
+  "email": "litong@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In a popped out or projection window, the document and window are different from the main document and window.  We should pass the popup root element to look up correct document and window. 

#### Focus areas to test

Close pop up and make sure focus goes to original element
