### PR TITLE
Add window.FabricConfig.legacyTheme, which actually calls loadTheme()…

### DIFF
--- a/change/@fluentui-style-utilities-9070a69a-77b6-42cb-9289-b6bfca792ad1.json
+++ b/change/@fluentui-style-utilities-9070a69a-77b6-42cb-9289-b6bfca792ad1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add window.FabricConfig.legacyTheme, which actually calls loadTheme() which will invoke legacy theming",
+  "packageName": "@fluentui/style-utilities",
+  "email": "phkuo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/style-utilities/src/styles/theme.ts
+++ b/packages/style-utilities/src/styles/theme.ts
@@ -12,10 +12,13 @@ let _onThemeChangeCallbacks: Array<(theme: ITheme) => void> = [];
 export const ThemeSettingName = 'theme';
 
 export function initializeThemeInCustomizations(): void {
-  if (!Customizations.getSettings([ThemeSettingName]).theme) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const win: any = getWindow();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const win: any = getWindow();
 
+  if (win?.FabricConfig?.legacyTheme) {
+    // does everything the `else` clause does and more, such as invoke legacy theming
+    loadTheme(win.FabricConfig.legacyTheme);
+  } else if (!Customizations.getSettings([ThemeSettingName]).theme) {
     if (win?.FabricConfig?.theme) {
       _theme = createTheme(win.FabricConfig.theme);
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20155
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds window.FabricConfig.legacyTheme, which invokes loadTheme() which invokes legacy theming (via CSS and string-based variables).