### PR TITLE
Update beachball to fix issue with reused commit hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "babel-jest": "24.9.0",
     "babel-loader": "8.2.2",
     "babel-plugin-annotate-pure-calls": "0.4.0",
-    "beachball": "2.16.0",
+    "beachball": "2.18.0",
     "chalk": "4.1.0",
     "ci-info": "3.2.0",
     "clean-webpack-plugin": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7231,10 +7231,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/beachball/-/beachball-2.16.0.tgz#cd8d511782177f55b0b5f9b11071a537b7974346"
-  integrity sha512-8qMuH/ZtusIS9HgSYQ4hrJnpfdIFzxGWpPfCemSrVm/fKMRcjZ6YCNPt6YTnaSDaO0y3tNsOQ+ekMZt3c1fuOw==
+beachball@2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-2.18.0.tgz#429fbe6c546c9db7557d7594cf35f029263bef49"
+  integrity sha512-3Uk4TJfDQoj/zQy1c9vQeVZZ2sKWWDdL/d3zlyCM2pJsZjQSYveLjRRBJjG7fsz+lFtU0uYiUhbMW4oWn9HXSw==
   dependencies:
     cosmiconfig "^6.0.0"
     execa "^4.0.3"


### PR DESCRIPTION
Pick up beachball fix from https://github.com/microsoft/beachball/pull/613 so that each changelog entry will have the correct commit hash.

Fixes #19932.