### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/bundle-size/package.json
+++ b/packages/bundle-size/package.json
@@ -9,6 +9,11 @@
     "test": "jest",
     "type-check": "tsc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fluentui.git",
+    "directory": "packages/bundle-size"
+  },
   "dependencies": {
     "@babel/core": "^7.10.4",
     "ajv": "^8.4.0",

--- a/packages/fluentui/circulars-test/package.json
+++ b/packages/fluentui/circulars-test/package.json
@@ -6,6 +6,11 @@
   "dependencies": {
     "@fluentui/react-northstar": "^0.59.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fluentui.git",
+    "directory": "packages/fluentui/circulars-test"
+  },
   "devDependencies": {
     "@fluentui/scripts": "^1.0.0",
     "gulp": "^4.0.2"

--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -49,6 +49,11 @@
     "react-window": "^1.8.6",
     "semver": "^6.2.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fluentui.git",
+    "directory": "packages/fluentui/docs"
+  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/fluentui/e2e/package.json
+++ b/packages/fluentui/e2e/package.json
@@ -19,6 +19,11 @@
     "react-dom": "16.8.6",
     "react-router-dom": "^5.2.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fluentui.git",
+    "directory": "packages/fluentui/e2e"
+  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react": "^8.0.0",

--- a/packages/fluentui/local-sandbox/package.json
+++ b/packages/fluentui/local-sandbox/package.json
@@ -12,6 +12,11 @@
   "dependencies": {
     "@fluentui/react-northstar": "^0.59.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fluentui.git",
+    "directory": "packages/fluentui/local-sandbox"
+  },
   "devDependencies": {
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",

--- a/packages/fluentui/perf-test/package.json
+++ b/packages/fluentui/perf-test/package.json
@@ -11,6 +11,11 @@
     "perf:test": "just-scripts perf-test",
     "perf:test:base": "just-scripts perf-test --base"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fluentui.git",
+    "directory": "packages/fluentui/perf-test"
+  },
   "devDependencies": {
     "@fluentui/digest": "^0.59.0",
     "@fluentui/react": "^8.0.0",

--- a/packages/fluentui/perf/package.json
+++ b/packages/fluentui/perf/package.json
@@ -15,6 +15,11 @@
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fluentui.git",
+    "directory": "packages/fluentui/perf"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fluentui/projects-test/package.json
+++ b/packages/fluentui/projects-test/package.json
@@ -9,6 +9,11 @@
   "devDependencies": {
     "@fluentui/scripts": "^1.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fluentui.git",
+    "directory": "packages/fluentui/projects-test"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @fluentui/bundle-size
* @fluentui/circulars-test
* @fluentui/docs
* @fluentui/e2e
* @fluentui/local-sandbox
* @fluentui/perf
* @fluentui/perf-test
* @fluentui/projects-test

