### PR TITLE
Adjust TimePicker regex and error message

### DIFF
--- a/change/@fluentui-react-abd666f3-e56b-460d-bd34-16b402508058.json
+++ b/change/@fluentui-react-abd666f3-e56b-460d-bd34-16b402508058.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adjust TimePicker regex and error message",
+  "packageName": "@fluentui/react",
+  "email": "tinakt3@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.test.tsx
@@ -4,6 +4,7 @@ import { TimePicker } from './TimePicker';
 // import { create } from '@fluentui/utilities/lib/test';
 import { mount } from 'enzyme';
 import type { IComboBox } from '../ComboBox/ComboBox.types';
+import { KeyCodes } from '../../Utilities';
 
 describe('TimePicker', () => {
   // TODO: times in this snapshot test changed and failed builds
@@ -25,5 +26,79 @@ describe('TimePicker', () => {
 
     mount(<TimePicker label="I am a TimePicker" onFormatDate={onFormatDate} componentRef={timePicker} />);
     expect(timePicker!.current!.selectedOptions[0].text).toBe('custom date option');
+  });
+
+  describe('validates entered text when', () => {
+    it('receives an invalid hour input for 24-hour-no-seconds format', () => {
+      const wrapper = mount(<TimePicker id="test" allowFreeform useHour12={false} showSeconds={false} />);
+      const input = wrapper.find('input');
+      input.simulate('input', { target: { value: '95:22' } });
+
+      // Trigger validation
+      input.simulate('keydown', { which: KeyCodes.enter });
+
+      // ComboBox sets the error element's ID to `id` from props plus "-error"
+      expect(wrapper.find('#test-error').text()).toMatch('24-hour format: hh:mm');
+    });
+
+    it('receives an invalid hour input for 24-hour-with-seconds format', () => {
+      const wrapper = mount(<TimePicker id="test" allowFreeform useHour12={false} showSeconds={true} />);
+      const input = wrapper.find('input');
+      input.simulate('input', { target: { value: '24:22:42' } });
+
+      // Trigger validation
+      input.simulate('keydown', { which: KeyCodes.enter });
+
+      // ComboBox sets the error element's ID to `id` from props plus "-error"
+      expect(wrapper.find('#test-error').text()).toMatch('24-hour format: hh:mm:ss');
+    });
+
+    it('receives an invalid hour input for 12-hour-no-seconds format', () => {
+      const wrapper = mount(<TimePicker id="test" allowFreeform useHour12={true} showSeconds={false} />);
+      const input = wrapper.find('input');
+      input.simulate('input', { target: { value: '13:26 PM' } });
+
+      // Trigger validation
+      input.simulate('keydown', { which: KeyCodes.enter });
+
+      // ComboBox sets the error element's ID to `id` from props plus "-error"
+      expect(wrapper.find('#test-error').text()).toMatch('12-hour format: hh:mm AP');
+    });
+
+    it('does not receive a complete time input for 12-hour-no-seconds format', () => {
+      const wrapper = mount(<TimePicker id="test" allowFreeform useHour12={true} showSeconds={false} />);
+      const input = wrapper.find('input');
+      input.simulate('input', { target: { value: '3:26' } });
+
+      // Trigger validation
+      input.simulate('keydown', { which: KeyCodes.enter });
+
+      // ComboBox sets the error element's ID to `id` from props plus "-error"
+      expect(wrapper.find('#test-error').text()).toMatch('12-hour format: hh:mm AP');
+    });
+
+    it('receives an invalid hour input for 12-hour-with-seconds format', () => {
+      const wrapper = mount(<TimePicker id="test" allowFreeform useHour12={true} showSeconds={true} />);
+      const input = wrapper.find('input');
+      input.simulate('input', { target: { value: '15:26:37 AM' } });
+
+      // Trigger validation
+      input.simulate('keydown', { which: KeyCodes.enter });
+
+      // ComboBox sets the error element's ID to `id` from props plus "-error"
+      expect(wrapper.find('#test-error').text()).toMatch('12-hour format: hh:mm:ss AP');
+    });
+
+    it('does not receive a complete time input for 12-hour-with-seconds format', () => {
+      const wrapper = mount(<TimePicker id="test" allowFreeform useHour12={true} showSeconds={true} />);
+      const input = wrapper.find('input');
+      input.simulate('input', { target: { value: '5:26:37' } });
+
+      // Trigger validation
+      input.simulate('keydown', { which: KeyCodes.enter });
+
+      // ComboBox sets the error element's ID to `id` from props plus "-error"
+      expect(wrapper.find('#test-error').text()).toMatch('12-hour format: hh:mm:ss AP');
+    });
   });
 });

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -14,16 +14,9 @@ const TIME_LOWER_BOUND = 0;
 const TIME_UPPER_BOUND = 23;
 
 const getDefaultStrings = (useHour12: boolean, showSeconds: boolean): ITimePickerStrings => {
-  let errorMessageToDisplay = '';
   const hourUnits = useHour12 ? '12-hour' : '24-hour';
-
-  errorMessageToDisplay = useHour12
-    ? showSeconds
-      ? `TimePicker format must be valid and in the ${hourUnits} ` + `format hh:mm:ss AP`
-      : `TimePicker format must be valid and in the ${hourUnits} ` + `format hh:mm AP`
-    : showSeconds
-    ? `TimePicker format must be valid and in the ${hourUnits} ` + `format hh:mm:ss`
-    : `TimePicker format must be valid and in the ${hourUnits} ` + `format hh:mm`;
+  const timeFormat = `hh:mm${showSeconds ? ':ss' : ''}${useHour12 ? ' AP' : ''}`;
+  const errorMessageToDisplay = `TimePicker format must be valid and in the ${hourUnits} format ${timeFormat}.`;
 
   return {
     invalidInputErrorMessage: errorMessageToDisplay,

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -16,7 +16,7 @@ const TIME_UPPER_BOUND = 23;
 const getDefaultStrings = (useHour12: boolean, showSeconds: boolean): ITimePickerStrings => {
   const hourUnits = useHour12 ? '12-hour' : '24-hour';
   const timeFormat = `hh:mm${showSeconds ? ':ss' : ''}${useHour12 ? ' AP' : ''}`;
-  const errorMessageToDisplay = `TimePicker format must be valid and in the ${hourUnits} format ${timeFormat}.`;
+  const errorMessageToDisplay = `Enter a valid time in the ${hourUnits} format: ${timeFormat}`;
 
   return {
     invalidInputErrorMessage: errorMessageToDisplay,

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -5,10 +5,10 @@ import { ComboBox } from '../../ComboBox';
 import type { IComboBox, IComboBoxOption } from '../../ComboBox';
 import type { ITimePickerProps, ITimeRange, ITimePickerStrings } from './TimePicker.types';
 
-const REGEX_SHOW_SECONDS_HOUR_12 = /((1[0-2]|0?[1-9]):([0-5][0-9]):(?:[0-5]\d) ?([AaPp][Mm]))$/;
-const REGEX_HIDE_SECONDS_HOUR_12 = /((1[0-2]|0?[1-9]):([0-5][0-9]) ?([AaPp][Mm]))$/;
-const REGEX_SHOW_SECONDS_HOUR_24 = /([0-9]|0[0-9]|1[0-9]|2[0-3]):(?:[0-5]\d):(?:[0-5]\d)$/;
-const REGEX_HIDE_SECONDS_HOUR_24 = /([0-9]|0[0-9]|1[0-9]|2[0-3]):(?:[0-5]\d)$/;
+const REGEX_SHOW_SECONDS_HOUR_12 = /^((1[0-2]|0?[1-9]):([0-5][0-9]):([0-5][0-9])\s([AaPp][Mm]))$/;
+const REGEX_HIDE_SECONDS_HOUR_12 = /^((1[0-2]|0?[1-9]):[0-5][0-9]\s([AaPp][Mm]))$/;
+const REGEX_SHOW_SECONDS_HOUR_24 = /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$/;
+const REGEX_HIDE_SECONDS_HOUR_24 = /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/;
 
 const TIME_LOWER_BOUND = 0;
 const TIME_UPPER_BOUND = 23;
@@ -16,9 +16,14 @@ const TIME_UPPER_BOUND = 23;
 const getDefaultStrings = (useHour12: boolean, showSeconds: boolean): ITimePickerStrings => {
   let errorMessageToDisplay = '';
   const hourUnits = useHour12 ? '12-hour' : '24-hour';
-  showSeconds
-    ? (errorMessageToDisplay = `TimePicker format must be valid and in the ${hourUnits} ` + `format hh:mm:ss A.`)
-    : (errorMessageToDisplay = `TimePicker format must be valid and in the ${hourUnits} ` + `format hh:mm A.`);
+
+  errorMessageToDisplay = useHour12
+    ? showSeconds
+      ? `TimePicker format must be valid and in the ${hourUnits} ` + `format hh:mm:ss AP`
+      : `TimePicker format must be valid and in the ${hourUnits} ` + `format hh:mm AP`
+    : showSeconds
+    ? `TimePicker format must be valid and in the ${hourUnits} ` + `format hh:mm:ss`
+    : `TimePicker format must be valid and in the ${hourUnits} ` + `format hh:mm`;
 
   return {
     invalidInputErrorMessage: errorMessageToDisplay,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20099 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

TimePicker did not have functioning validation for hour inputs (e.g. 95:59:59 would not prompt an error message).
I think the original validation was not triggering because the RegExp was matching the 5:59:59 portion of 95:59:59 and was returning true.
I rewrote the RegExp and added more specific error messages to help with input formatting. Hopefully they work.

#### Focus areas to test

I'm not sure if this needs tests. I think I read for fluentui that it just needs a visual test? Anyhow these seem to render the correct error message. But please check as well. Or let me know if I should write tests :)
Thank you!
10.28.21 update: added tests :)
