### PR TITLE
chore(release): vNext nightly pipeline

### DIFF
--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -1,0 +1,83 @@
+pr: none
+trigger: none
+
+# Customize build number to include major version
+# Example: v9_20201022.1
+name: 'v9_nightly_$(Date:yyyyMMdd)$(Rev:.r)'
+
+variables:
+  - group: 'Github and NPM secrets'
+  - template: .devops/templates/variables.yml
+    parameters:
+      skipComponentGovernanceDetection: false
+  - name: release.vnext # Used to scope beachball to release only vnext packages
+    value: true
+
+pool: '1ES-Host-Ubuntu'
+
+schedules:
+  # Triggers the nightly release
+  # minute 0, hour 4 in UTC (5am in UTC+1), any day of month, any month, days 1-5 of week (M-F)
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?tabs=yaml&view=azure-devops#supported-cron-syntax
+  - cron: '0 4 * * 1-5'
+    displayName: 'Daily release (M-F at 5am UTC+1)'
+    branches:
+      include:
+        - master
+
+workspace:
+  clean: all
+
+steps:
+  - template: .devops/templates/tools.yml
+
+  - task: Bash@3
+    inputs:
+      filePath: yarn-ci.sh
+    displayName: yarn
+
+    # Bumps all v9 packages to a x.x.x-nightly.commitSha version and checks in change files
+  - script: |
+      commitSha=$(git log -n 1 --pretty=format:"%h")
+      date=$(date +"%Y%m%d")
+      yarn nx workspace-generator version-bump --all --bumpType prerelease --prereleaseTag "nightly.${commitSha}+${date}"
+      git add .
+      git commit -m "bump nightly versions"
+      yarn change --type prerelease --message "Release nightly v9"
+    displayName: 'Bump and commit nightly versions'
+
+  - script: |
+      yarn run:published build --production --no-cache
+    displayName: yarn build
+
+  - script: |
+      yarn run:published test
+    displayName: yarn test
+
+  - script: |
+      yarn run:published lint
+    displayName: yarn lint
+
+  - script: |
+      yarn publish:beachball -n $(npmToken) --no-push --no-tag --tag nightly
+      git reset --hard origin/master
+    displayName: Publish changes and bump versions
+
+  # TODO update release notes script for v9
+  # - script: |
+  #     node -r ./scripts/ts-node-register ./scripts/updateReleaseNotes/index.ts --token=$(githubPAT) --apply --debug
+  #   displayName: 'Update github release notes'
+
+  # This would usually be run automatically (via a pipeline decorator from an extension), but the
+  # thorough cleanup step prevents it from working. So run it manually here.
+  - task: ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    inputs:
+      sourceScanPath: $(Agent.BuildDirectory)
+    condition: succeeded()
+    timeoutInMinutes: 5
+    continueOnError: true
+
+  - template: .devops/templates/cleanup.yml
+    parameters:
+      checkForModifiedFiles: false

--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -57,7 +57,7 @@ steps:
     displayName: yarn lint
 
   - script: |
-      yarn publish:beachball -n $(npmToken) --no-push --no-tag --tag nightly
+      yarn publish:beachball -n $(npmToken) --no-push --tag nightly
       git reset --hard origin/master
     displayName: Publish changes and bump versions
 

--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -38,7 +38,7 @@ steps:
   - script: |
       commitSha=$(git log -n 1 --pretty=format:"%h")
       date=$(date +"%Y%m%d")
-      yarn nx workspace-generator version-bump --all --bumpType prerelease --prereleaseTag "nightly.${commitSha}+${date}"
+      yarn nx workspace-generator version-bump --all --bumpType nightly --prereleaseTag "nightly${commitSha}${date}"
       git add .
       git commit -m "bump nightly versions"
       yarn change --type prerelease --message "Release nightly v9"

--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -8,8 +8,6 @@ name: 'v9_nightly_$(Date:yyyyMMdd)$(Rev:.r)'
 variables:
   - group: 'Github and NPM secrets'
   - template: .devops/templates/variables.yml
-    parameters:
-      skipComponentGovernanceDetection: false
   - name: release.vnext # Used to scope beachball to release only vnext packages
     value: true
 
@@ -62,21 +60,6 @@ steps:
       yarn publish:beachball -n $(npmToken) --no-push --no-tag --tag nightly
       git reset --hard origin/master
     displayName: Publish changes and bump versions
-
-  # TODO update release notes script for v9
-  # - script: |
-  #     node -r ./scripts/ts-node-register ./scripts/updateReleaseNotes/index.ts --token=$(githubPAT) --apply --debug
-  #   displayName: 'Update github release notes'
-
-  # This would usually be run automatically (via a pipeline decorator from an extension), but the
-  # thorough cleanup step prevents it from working. So run it manually here.
-  - task: ComponentGovernanceComponentDetection@0
-    displayName: 'Component Detection'
-    inputs:
-      sourceScanPath: $(Agent.BuildDirectory)
-    condition: succeeded()
-    timeoutInMinutes: 5
-    continueOnError: true
 
   - template: .devops/templates/cleanup.yml
     parameters:


### PR DESCRIPTION

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #19933
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

since #19904 requires more discussion, creating this PR to start
versioning the nightly release pipeline for vNext in the repo.

This pipeline differs from the main release pipeline in the following
ways:

* Bumps packages in the pipeline to nightly versions
* No need for any github related auth or operations

#### Focus areas to test

(optional)
