### PR TITLE
Fix clearing the search box on the website nav

### DIFF
--- a/change/@fluentui-react-docsite-components-a695e8d1-1d24-4570-aff8-501c7a7e3684.json
+++ b/change/@fluentui-react-docsite-components-a695e8d1-1d24-4570-aff8-501c7a7e3684.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove unnecessary NavSortType type not used externally",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-docsite-components/src/components/Nav/Nav.types.ts
+++ b/packages/react-docsite-components/src/components/Nav/Nav.types.ts
@@ -22,6 +22,9 @@ export interface INavProps<TPlatforms extends string = string> {
    */
   onSearchBoxClick?: (ev?: React.MouseEvent<HTMLElement>) => void;
 
+  /**
+   * Category title to show in the search box. If not given, section is not searchable.
+   */
   searchablePageTitle?: string;
 }
 
@@ -96,9 +99,4 @@ export interface INavPage<TPlatform extends string = string> extends Pick<IRoute
    * full width of the page.
    */
   isContentFullBleed?: boolean;
-}
-
-export enum NavSortType {
-  alphabetized = 'alphabetized',
-  categories = 'categories',
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20183
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Clicking the X button on the search box on the v8 website nav sets the search query to undefined, which after another recent change started causing a crash. This PR fixes that issue (in `_onSearchQueryChanged `).

While looking at this I noticed a bunch of unnecessary/overcomplicated stuff in the website nav implementation, which I removed (the overall behavior it was trying to accomplish should be preserved). I also fixed some incorrect aria labels.