### PR TITLE
test: add conformance test for static classes

### DIFF
--- a/change/@fluentui-react-92ffe159-fff9-4f25-880e-7eaba232046d.json
+++ b/change/@fluentui-react-92ffe159-fff9-4f25-880e-7eaba232046d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disable conformance test",
+  "packageName": "@fluentui/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-15daef73-c2fb-426a-a8dc-cf04fb9e45a4.json
+++ b/change/@fluentui-react-conformance-15daef73-c2fb-426a-a8dc-cf04fb9e45a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add new test for classnames",
+  "packageName": "@fluentui/react-conformance",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-focus-78f8d0d4-2547-4758-8f25-03aaf90c346f.json
+++ b/change/@fluentui-react-focus-78f8d0d4-2547-4758-8f25-03aaf90c346f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disable conformance test",
+  "packageName": "@fluentui/react-focus",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
+++ b/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
@@ -76,6 +76,8 @@ export function isConformant(
       'component-handles-ref',
       'component-has-root-ref',
       'consistent-callback-args',
+      // Disabled as v0 has different prefix
+      'component-has-static-classname',
     ],
     helperComponents: [Ref, RefFindNode, FocusZone],
   };

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -586,7 +586,7 @@ export const defaultErrorMessages = {
     });
   },
 
-  'component-has-static-classname-at-root': (
+  'component-has-static-classname': (
     testInfo: IsConformantOptions,
     error: Error,
     componentClassName: string,

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -626,8 +626,8 @@ export const defaultErrorMessages = {
         exportName,
       )}) in: ${EOL}${testErrorPath(indexFile)}.`,
       suggestions: [
-        `Make sure that your component's ${resolveInfo('index.ts')} file`,
-        `or a file with styles hook contains \`${resolveInfo(constantValue)}\``,
+        `Make sure that your component's ${resolveInfo('index.ts')} file` +
+          `or a file with styles hook exports \`${resolveInfo(constantValue)}\``,
         `If the component is internal, consider enabling ${resolveInfo('isInternal')} in your isConformant test.`,
       ],
       error,

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -600,7 +600,7 @@ export const defaultErrorMessages = {
       overview: `does not have default className (${testErrorInfo(componentClassName)}).`,
       details: [`After render it has the following classes:`, `    ${failedError(`className='${classNames}'`)}`],
       suggestions: [
-        `Ensure that your component has default a className and it is ${resolveInfo('merged')} with defaults by calling mergeClassNames.`,
+        `Ensure that your component has default a className and it is ${resolveInfo('merged')} with other classNames.`,
       ],
       error,
     });
@@ -622,9 +622,9 @@ export const defaultErrorMessages = {
 
     return getErrorMessage({
       displayName,
-      overview: `default className constant  is not exported (${testErrorInfo(
-        exportName,
-      )}) in: ${EOL}${testErrorPath(indexFile)}.`,
+      overview: `default className constant  is not exported (${testErrorInfo(exportName)}) in: ${EOL}${testErrorPath(
+        indexFile,
+      )}.`,
       suggestions: [
         `Make sure that your component's ${resolveInfo('index.ts')} file` +
           `or a file with styles hook exports \`${resolveInfo(constantValue)}\``,

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -600,7 +600,7 @@ export const defaultErrorMessages = {
       overview: `does not have default className (${testErrorInfo(componentClassName)}).`,
       details: [`After render it has the following classes:`, `    ${failedError(`className='${classNames}'`)}`],
       suggestions: [
-        `Ensure that your component has default className and it is ${resolveInfo('merged')} with defaults.`,
+        `Ensure that your component has default a className and it is ${resolveInfo('merged')} with defaults by calling mergeClassNames.`,
       ],
       error,
     });

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -598,7 +598,7 @@ export const defaultErrorMessages = {
     return getErrorMessage({
       displayName,
       overview: `does not have default className (${testErrorInfo(componentClassName)}).`,
-      details: [`After render it has following classes:`, `    ${failedError(`className='${classNames}'`)}`],
+      details: [`After render it has the following classes:`, `    ${failedError(`className='${classNames}'`)}`],
       suggestions: [
         `Ensure that your component has default className and it is ${resolveInfo('merged')} with defaults.`,
       ],

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -628,9 +628,7 @@ export const defaultErrorMessages = {
       suggestions: [
         `Make sure that your component's ${resolveInfo('index.ts')} file`,
         `or a file with styles hook contains \`${resolveInfo(constantValue)}\``,
-        `Check if your component is internal and consider enabling ${resolveInfo(
-          'isInternal',
-        )} in your isConformant test.`,
+        `If the component is internal, consider enabling ${resolveInfo('isInternal')} in your isConformant test.`,
       ],
       error,
     });

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -586,6 +586,56 @@ export const defaultErrorMessages = {
     });
   },
 
+  'component-has-static-classname-at-root': (
+    testInfo: IsConformantOptions,
+    error: Error,
+    componentClassName: string,
+    classNames: string,
+  ) => {
+    const { displayName } = testInfo;
+    const { testErrorInfo, resolveInfo, failedError } = errorMessageColors;
+
+    return getErrorMessage({
+      displayName,
+      overview: `does not have default className (${testErrorInfo(componentClassName)}).`,
+      details: [`After render it has following classes:`, `    ${failedError(`className='${classNames}'`)}`],
+      suggestions: [
+        `Ensure that your component has default className and it is ${resolveInfo('merged')} with defaults.`,
+      ],
+      error,
+    });
+  },
+
+  'component-has-static-classname-exported': (
+    testInfo: IsConformantOptions,
+    error: Error,
+    componentClassName: string,
+    exportName: string,
+  ) => {
+    const { componentPath, displayName } = testInfo;
+    const { testErrorInfo, resolveInfo, testErrorPath } = errorMessageColors;
+
+    const rootPath = componentPath.replace(/[\\/]src[\\/].*/, '');
+    const indexFile = path.join(rootPath, 'src', 'index.ts');
+
+    const constantValue = `export const ${exportName} = "${componentClassName}";`;
+
+    return getErrorMessage({
+      displayName,
+      overview: `does not have an export for className constant (${testErrorInfo(
+        exportName,
+      )}) in: ${EOL}${testErrorPath(indexFile)}.`,
+      suggestions: [
+        `Make sure that your component's ${resolveInfo('index.ts')} file`,
+        `or a file with styles hook contains \`${resolveInfo(constantValue)}\``,
+        `Check if your component is internal and consider enabling ${resolveInfo(
+          'isInternal',
+        )} in your isConformant test.`,
+      ],
+      error,
+    });
+  },
+
   'as-renders-html': (testInfo: IsConformantOptions, error: Error) => {
     const { displayName } = testInfo;
     const { resolveInfo } = errorMessageColors;

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -622,7 +622,7 @@ export const defaultErrorMessages = {
 
     return getErrorMessage({
       displayName,
-      overview: `does not have an export for className constant (${testErrorInfo(
+      overview: `default className constant  is not exported (${testErrorInfo(
         exportName,
       )}) in: ${EOL}${testErrorPath(indexFile)}.`,
       suggestions: [

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -224,6 +224,53 @@ export const defaultTests: TestObject = {
     });
   },
 
+  /** Component file has assigned and exported static class */
+  'component-has-static-classname': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
+    const {
+      componentPath,
+      Component,
+      wrapperComponent,
+      helperComponents = [],
+      requiredProps,
+      customMount = mount,
+    } = testInfo;
+    const componentClassName = `fui-${componentInfo.displayName}`;
+
+    it(`has static classname (component-has-static-classname-at-root)`, () => {
+      const defaultEl = customMount(<Component {...requiredProps} />);
+
+      const defaultComponent = getComponent(defaultEl, helperComponents, wrapperComponent);
+      const classNames = defaultComponent.prop<string>('className');
+
+      try {
+        expect(classNames).toContain(componentClassName);
+      } catch (e) {
+        throw new Error(
+          defaultErrorMessages['component-has-static-classname-at-root'](testInfo, e, componentClassName, classNames),
+        );
+      }
+    });
+
+    it(`static classname is exported at top-level (component-has-static-classname-exported)`, () => {
+      if (testInfo.isInternal) {
+        return;
+      }
+
+      const exportName =
+        componentInfo.displayName.slice(0, 1).toLowerCase() + componentInfo.displayName.slice(1) + 'ClassName';
+
+      try {
+        const indexFile = require(path.join(getPackagePath(componentPath), 'src', 'index'));
+
+        expect(indexFile[exportName]).toBe(componentClassName);
+      } catch (e) {
+        throw new Error(
+          defaultErrorMessages['component-has-static-classname-exported'](testInfo, e, componentClassName, exportName),
+        );
+      }
+    });
+  },
+
   /** Constructor/component name matches filename */
   'name-matches-filename': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
     it(`Component/constructor name matches filename (name-matches-filename)`, () => {

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -236,7 +236,7 @@ export const defaultTests: TestObject = {
     } = testInfo;
     const componentClassName = `fui-${componentInfo.displayName}`;
 
-    it(`has static classname (component-has-static-classname-at-root)`, () => {
+    it(`has static classname (component-has-static-classname)`, () => {
       const defaultEl = customMount(<Component {...requiredProps} />);
 
       const defaultComponent = getComponent(defaultEl, helperComponents, wrapperComponent);
@@ -246,7 +246,7 @@ export const defaultTests: TestObject = {
         expect(classNames).toContain(componentClassName);
       } catch (e) {
         throw new Error(
-          defaultErrorMessages['component-has-static-classname-at-root'](testInfo, e, componentClassName, classNames),
+          defaultErrorMessages['component-has-static-classname'](testInfo, e, componentClassName, classNames),
         );
       }
     });

--- a/packages/react-focus/src/common/isConformant.ts
+++ b/packages/react-focus/src/common/isConformant.ts
@@ -5,7 +5,12 @@ export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
 ) {
   const defaultOptions: Partial<IsConformantOptions<TProps>> = {
-    disabledTests: ['has-docblock', 'kebab-aria-attributes'],
+    disabledTests: [
+      'has-docblock',
+      'kebab-aria-attributes',
+      // Focus* components don't have static classes
+      'component-has-static-classname',
+    ],
     componentPath: module!.parent!.filename.replace('.test', ''),
   };
 

--- a/packages/react-input/etc/react-input.api.md
+++ b/packages/react-input/etc/react-input.api.md
@@ -14,6 +14,9 @@ import * as React_2 from 'react';
 export const Input: ForwardRefComponent<InputProps>;
 
 // @public (undocumented)
+export const inputClassName = "fui-Input";
+
+// @public (undocumented)
 export type InputCommons = {
     fieldSize?: 'small' | 'medium' | 'large';
     inline?: boolean;

--- a/packages/react-input/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/packages/react-input/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Input renders a default state 1`] = `
 <div>
   <span
-    class=""
+    class="fui-Input"
   >
     <input
       class=""

--- a/packages/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-input/src/components/Input/useInputStyles.ts
@@ -2,6 +2,8 @@ import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import type { InputState } from './Input.types';
 import type { Theme } from '@fluentui/react-theme';
 
+export const inputClassName = 'fui-Input';
+
 // TODO(sharing) use theme values once available
 const horizontalSpacing = {
   xxs: '2px',
@@ -154,6 +156,7 @@ export const useInputStyles = (state: InputState): InputState => {
   const contentStyles = useContentStyles();
 
   state.root.className = mergeClasses(
+    inputClassName,
     rootStyles.base,
     rootStyles[fieldSize],
     rootStyles[appearance],

--- a/packages/react/src/common/isConformant.ts
+++ b/packages/react/src/common/isConformant.ts
@@ -9,6 +9,8 @@ export function isConformant<TProps = {}>(
       'has-docblock',
       'kebab-aria-attributes',
       'is-static-property-of-parent',
+      // Disabled as v8 has different prefix
+      'component-has-static-classname',
       // Will enable with appropriate overrides separately
       'consistent-callback-names',
       'consistent-callback-args',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19937
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds a new conformance test and asserts for:
- each component has applied `className`, for example `fui-ComponentName`
- matching constants are exported for each component, for example `componentNameClassName`
- tests are applied only for v9 components

I left changes for `Input` component in this PR to be an example. For all other components it was already applied in separate PRs.