### PR TITLE
fix(Colorpicker): Add error state and tooltip when invalid hex/RGBA values are manually entered

### DIFF
--- a/change/@fluentui-react-3f616257-4ae0-4337-9048-f8c9f9a64aaa.json
+++ b/change/@fluentui-react-3f616257-4ae0-4337-9048-f8c9f9a64aaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add alert tooltip to ColorPicker when invalid hex or RGBA values are entered\"",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -384,155 +384,169 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             <td>
               <div
                 className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    className="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Hex"
-                      autoComplete="off"
+                    <div
                       className=
-                          ms-TextField-field
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField1"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="ffffff"
-                    />
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-label="Hex"
+                        autoComplete="off"
+                        className=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField2"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="ffffff"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -540,155 +554,169 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             <td>
               <div
                 className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    className="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Red"
-                      autoComplete="off"
+                    <div
                       className=
-                          ms-TextField-field
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField4"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="255"
-                    />
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-label="Red"
+                        autoComplete="off"
+                        className=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField6"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="255"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -696,155 +724,169 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             <td>
               <div
                 className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    className="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Green"
-                      autoComplete="off"
+                    <div
                       className=
-                          ms-TextField-field
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField7"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="255"
-                    />
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-label="Green"
+                        autoComplete="off"
+                        className=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField10"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="255"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -852,155 +894,169 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             <td>
               <div
                 className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    className="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Blue"
-                      autoComplete="off"
+                    <div
                       className=
-                          ms-TextField-field
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField10"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="255"
-                    />
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-label="Blue"
+                        autoComplete="off"
+                        className=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField14"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="255"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -1008,155 +1064,169 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             <td>
               <div
                 className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    className="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Alpha"
-                      autoComplete="off"
+                    <div
                       className=
-                          ms-TextField-field
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField13"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="100"
-                    />
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-label="Alpha"
+                        autoComplete="off"
+                        className=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField18"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="100"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -1212,8 +1282,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               padding-top: 5px;
               word-wrap: break-word;
             }
-        htmlFor="Toggle16"
-        id="Toggle16-label"
+        htmlFor="Toggle21"
+        id="Toggle21-label"
       >
         Show preview box
       </label>
@@ -1227,7 +1297,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       >
         <button
           aria-checked={true}
-          aria-labelledby="Toggle16-label"
+          aria-labelledby="Toggle21-label"
           checked={true}
           className=
               ms-Toggle-background
@@ -1281,7 +1351,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               }
           data-is-focusable={true}
           data-ktp-target={true}
-          id="Toggle16"
+          id="Toggle21"
           onChange={[Function]}
           onClick={[Function]}
           role="switch"
@@ -1323,7 +1393,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
           }
     >
       <div
-        aria-labelledby="ChoiceGroupLabel18"
+        aria-labelledby="ChoiceGroupLabel23"
         role="radiogroup"
       >
         <label
@@ -1350,7 +1420,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
-          id="ChoiceGroupLabel18"
+          id="ChoiceGroupLabel23"
         >
           Alpha slider type
         </label>
@@ -1399,8 +1469,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       top: 0px;
                       width: 100%;
                     }
-                id="ChoiceGroup17-alpha"
-                name="ChoiceGroup17"
+                id="ChoiceGroup22-alpha"
+                name="ChoiceGroup22"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1486,11 +1556,11 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       border-color: Highlight;
                       forced-color-adjust: none;
                     }
-                htmlFor="ChoiceGroup17-alpha"
+                htmlFor="ChoiceGroup22-alpha"
               >
                 <span
                   className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel18-alpha"
+                  id="ChoiceGroupLabel23-alpha"
                 >
                   Alpha
                 </span>
@@ -1539,8 +1609,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       top: 0px;
                       width: 100%;
                     }
-                id="ChoiceGroup17-transparency"
-                name="ChoiceGroup17"
+                id="ChoiceGroup22-transparency"
+                name="ChoiceGroup22"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1620,11 +1690,11 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 0px;
                     }
-                htmlFor="ChoiceGroup17-transparency"
+                htmlFor="ChoiceGroup22-transparency"
               >
                 <span
                   className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel18-transparency"
+                  id="ChoiceGroupLabel23-transparency"
                 >
                   Transparency
                 </span>
@@ -1673,8 +1743,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       top: 0px;
                       width: 100%;
                     }
-                id="ChoiceGroup17-none"
-                name="ChoiceGroup17"
+                id="ChoiceGroup22-none"
+                name="ChoiceGroup22"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1754,11 +1824,11 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 0px;
                     }
-                htmlFor="ChoiceGroup17-none"
+                htmlFor="ChoiceGroup22-none"
               >
                 <span
                   className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel18-none"
+                  id="ChoiceGroupLabel23-none"
                 >
                   None
                 </span>

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2801,6 +2801,7 @@ export interface IColorPickerProps {
     strings?: IColorPickerStrings;
     styles?: IStyleFunctionOrObject<IColorPickerStyleProps, IColorPickerStyles>;
     theme?: ITheme;
+    tooltipProps?: ITooltipHostProps;
 }
 
 // @public (undocumented)

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2816,19 +2816,25 @@ export interface IColorPickerState {
 export interface IColorPickerStrings {
     alpha?: string;
     alphaAriaLabel?: string;
+    alphaError?: string;
     blue?: string;
+    blueError?: string;
     green?: string;
+    greenError?: string;
     hex?: string;
+    hexError?: string;
     // @deprecated
     hue?: string;
     hueAriaLabel?: string;
     red?: string;
+    redError?: string;
     rootAriaLabelFormat?: string;
     svAriaDescription?: string;
     svAriaLabel?: string;
     svAriaValueFormat?: string;
     transparency?: string;
     transparencyAriaLabel?: string;
+    transparencyError?: string;
 }
 
 // @public (undocumented)
@@ -8128,6 +8134,7 @@ export interface ITextFieldProps extends React_2.AllHTMLAttributes<HTMLInputElem
     errorMessage?: string | JSX.Element;
     iconProps?: IIconProps;
     inputClassName?: string;
+    invalid?: boolean;
     label?: string;
     multiline?: boolean;
     onChange?: (event: React_2.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => void;

--- a/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -169,6 +169,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
       alphaType,
       // eslint-disable-next-line deprecation/deprecation
       alphaSliderHidden = alphaType === 'none',
+      tooltipProps,
     } = props;
     const { color } = this.state;
     const useTransparency = alphaType === 'transparency';
@@ -253,7 +254,12 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
                   const tooltipContent = this._getTooltipValue(comp);
                   return (
                     <td key={comp}>
-                      <TooltipHost content={tooltipContent} directionalHint={DirectionalHint.bottomCenter} role="alert">
+                      <TooltipHost
+                        content={tooltipContent}
+                        directionalHint={DirectionalHint.bottomCenter}
+                        role="alert"
+                        {...tooltipProps}
+                      >
                         <TextField
                           className={classNames.input}
                           onChange={this._textChangeHandlers[comp]}

--- a/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -322,7 +322,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
       return undefined;
     }
 
-    let errorKey: ColorErrorKeys = errorKeys[component];
+    const errorKey: ColorErrorKeys = errorKeys[component];
 
     return this._strings[errorKey];
   }

--- a/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -35,6 +35,10 @@ import type {
 import type { IColor, IRGB } from '../../utilities/color/interfaces';
 
 type ColorComponent = keyof Pick<IColor, 'r' | 'g' | 'b' | 'a' | 't' | 'hex'>;
+type ColorErrorKeys = keyof Pick<
+  IColorPickerStrings,
+  'hexError' | 'alphaError' | 'transparencyError' | 'redError' | 'greenError' | 'blueError'
+>;
 
 export interface IColorPickerState {
   /** Most recently selected color */
@@ -51,6 +55,15 @@ export interface IColorPickerState {
 const getClassNames = classNamesFunction<IColorPickerStyleProps, IColorPickerStyles>();
 
 const allColorComponents: ColorComponent[] = ['hex', 'r', 'g', 'b', 'a', 't'];
+
+const errorKeys: { [component in ColorComponent]: ColorErrorKeys } = {
+  hex: 'hexError',
+  r: 'redError',
+  g: 'greenError',
+  b: 'blueError',
+  a: 'alphaError',
+  t: 'transparencyError',
+};
 
 /**
  * {@docCategory ColorPicker}
@@ -309,29 +322,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
       return undefined;
     }
 
-    let errorKey: keyof Pick<
-      IColorPickerStrings,
-      'hexError' | 'alphaError' | 'transparencyError' | 'redError' | 'greenError' | 'blueError'
-    >;
-    switch (component) {
-      case 'hex':
-        errorKey = 'hexError';
-        break;
-      case 'a':
-        errorKey = 'alphaError';
-        break;
-      case 't':
-        errorKey = 'transparencyError';
-        break;
-      case 'r':
-        errorKey = 'redError';
-        break;
-      case 'g':
-        errorKey = 'greenError';
-        break;
-      default:
-        errorKey = 'blueError';
-    }
+    let errorKey: ColorErrorKeys = errorKeys[component];
 
     return this._strings[errorKey];
   }

--- a/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { classNamesFunction, initializeComponentRef, warnDeprecations, warn } from '../../Utilities';
 import { TextField } from '../../TextField';
+import { TooltipHost } from '../../Tooltip';
+import { DirectionalHint } from '../../common/DirectionalHint';
 import { ColorRectangle } from './ColorRectangle/ColorRectangle';
 import { ColorSlider } from './ColorSlider/ColorSlider';
 import {
@@ -68,6 +70,12 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
       svAriaLabel: ColorRectangleBase.defaultProps.ariaLabel!,
       svAriaValueFormat: ColorRectangleBase.defaultProps.ariaValueFormat!,
       svAriaDescription: ColorRectangleBase.defaultProps.ariaDescription!,
+      hexError: 'Hex values must be between 3 and 6 characters long',
+      alphaError: 'Alpha must be between 0 and 100',
+      transparencyError: 'Transparency must be between 0 and 100',
+      redError: 'Red must be between 0 and 255',
+      greenError: 'Green must be between 0 and 255',
+      blueError: 'Blue must be between 0 and 255',
     },
   };
 
@@ -242,17 +250,21 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
                   if ((comp === 'a' || comp === 't') && alphaSliderHidden) {
                     return null;
                   }
+                  const tooltipContent = this._getTooltipValue(comp);
                   return (
                     <td key={comp}>
-                      <TextField
-                        className={classNames.input}
-                        onChange={this._textChangeHandlers[comp]}
-                        onBlur={this._onBlur}
-                        value={this._getDisplayValue(comp)}
-                        spellCheck={false}
-                        ariaLabel={textLabels[comp]}
-                        autoComplete="off"
-                      />
+                      <TooltipHost content={tooltipContent} directionalHint={DirectionalHint.bottomCenter} role="alert">
+                        <TextField
+                          className={classNames.input}
+                          onChange={this._textChangeHandlers[comp]}
+                          onBlur={this._onBlur}
+                          value={this._getDisplayValue(comp)}
+                          spellCheck={false}
+                          ariaLabel={textLabels[comp]}
+                          autoComplete="off"
+                          invalid={!!tooltipContent}
+                        />
+                      </TooltipHost>
                     </td>
                   );
                 })}
@@ -275,6 +287,47 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
       return String(color[component]);
     }
     return '';
+  }
+
+  /* Get the error tooltip value for a component if the component is in an invalid state */
+  private _getTooltipValue(component: ColorComponent): string | undefined {
+    const { editingColor } = this.state;
+    // if the component does not have an interim value, it is valid
+    if (!editingColor || editingColor.component !== component) {
+      return undefined;
+    }
+
+    const { value } = editingColor;
+    // for hex, do not show a tooltip if the value is between 3-6 characters
+    if (component === 'hex' && value.length >= MIN_HEX_LENGTH && value.length <= MAX_HEX_LENGTH) {
+      return undefined;
+    }
+
+    let errorKey: keyof Pick<
+      IColorPickerStrings,
+      'hexError' | 'alphaError' | 'transparencyError' | 'redError' | 'greenError' | 'blueError'
+    >;
+    switch (component) {
+      case 'hex':
+        errorKey = 'hexError';
+        break;
+      case 'a':
+        errorKey = 'alphaError';
+        break;
+      case 't':
+        errorKey = 'transparencyError';
+        break;
+      case 'r':
+        errorKey = 'redError';
+        break;
+      case 'g':
+        errorKey = 'greenError';
+        break;
+      default:
+        errorKey = 'blueError';
+    }
+
+    return this._strings[errorKey];
   }
 
   private _onSVChanged = (ev: React.MouseEvent<HTMLElement>, color: IColor): void => {

--- a/packages/react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -10,6 +10,7 @@ import { getColorFromString } from '../../utilities/color/getColorFromString';
 import { mockEvent } from '../../common/testUtilities';
 import { ColorRectangleBase } from './ColorRectangle/ColorRectangle.base';
 import { ColorSliderBase } from './ColorSlider/ColorSlider.base';
+import { TooltipHost } from '../../Tooltip';
 import { isConformant } from '../../common/isConformant';
 import type { IColorPickerState } from './ColorPicker.base';
 import type { IColorPickerProps, IColorPickerStrings } from './ColorPicker.types';
@@ -445,6 +446,65 @@ describe('ColorPicker', () => {
     // blur => value clamped
     ReactTestUtils.Simulate.blur(alphaInput);
     validateChange({ calls: 2, prop: 'a', value: 100, input: alphaInput });
+  });
+
+  it('shows error state and tooltip for invalid red value', () => {
+    jest.useFakeTimers();
+    wrapper = mount(<ColorPicker color="#000000" componentRef={colorPickerRef} tooltipProps={{ delay: 2 }} />);
+
+    const redInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[1] as HTMLInputElement;
+    const redTooltipWrapper = wrapper.find(TooltipHost).at(1);
+
+    // input should be valid before entering an invalid number
+    expect(redInput.getAttribute('aria-invalid')).toEqual('false');
+
+    // choose a number that can be typed, but is not allowed
+    ReactTestUtils.Simulate.input(redInput, mockEvent('456'));
+    ReactTestUtils.Simulate.mouseEnter(redTooltipWrapper.getDOMNode());
+
+    ReactTestUtils.act(() => {
+      jest.runAllTimers();
+    });
+
+    const redTooltip = document.querySelector('.ms-Tooltip');
+
+    expect(redInput.getAttribute('aria-invalid')).toEqual('true');
+    expect(redTooltip?.textContent).toBe('Red must be between 0 and 255');
+
+    jest.useRealTimers();
+  });
+
+  it('shows error state and tooltip for invalid hex value', () => {
+    jest.useFakeTimers();
+    wrapper = mount(
+      <ColorPicker
+        color="#000000"
+        componentRef={colorPickerRef}
+        tooltipProps={{ delay: 2 }}
+        strings={{ hexError: 'test hex error' }}
+      />,
+    );
+
+    const hexInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[0] as HTMLInputElement;
+    const hexTooltipWrapper = wrapper.find(TooltipHost).at(0);
+
+    // input should be valid before entering an invalid hex
+    expect(hexInput.getAttribute('aria-invalid')).toEqual('false');
+
+    // enter a 2-digit hex
+    ReactTestUtils.Simulate.input(hexInput, mockEvent('ff'));
+    ReactTestUtils.Simulate.mouseEnter(hexTooltipWrapper.getDOMNode());
+
+    ReactTestUtils.act(() => {
+      jest.runAllTimers();
+    });
+
+    const hexTooltip = document.querySelector('.ms-Tooltip');
+
+    expect(hexInput.getAttribute('aria-invalid')).toEqual('true');
+    expect(hexTooltip?.textContent).toBe('test hex error');
+
+    jest.useRealTimers();
   });
 
   it('handles RGBA input too long', () => {

--- a/packages/react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -476,12 +476,13 @@ describe('ColorPicker', () => {
 
   it('shows error state and tooltip for invalid hex value', () => {
     jest.useFakeTimers();
+    const customHexError = 'test hex error';
     wrapper = mount(
       <ColorPicker
         color="#000000"
         componentRef={colorPickerRef}
         tooltipProps={{ delay: 2 }}
-        strings={{ hexError: 'test hex error' }}
+        strings={{ hexError: customHexError }}
       />,
     );
 
@@ -502,7 +503,7 @@ describe('ColorPicker', () => {
     const hexTooltip = document.querySelector('.ms-Tooltip');
 
     expect(hexInput.getAttribute('aria-invalid')).toEqual('true');
-    expect(hexTooltip?.textContent).toBe('test hex error');
+    expect(hexTooltip?.textContent).toBe(customHexError);
 
     jest.useRealTimers();
   });

--- a/packages/react/src/components/ColorPicker/ColorPicker.types.ts
+++ b/packages/react/src/components/ColorPicker/ColorPicker.types.ts
@@ -200,6 +200,42 @@ export interface IColorPickerStrings {
    * @defaultvalue 'Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.'
    */
   svAriaDescription?: string;
+
+  /**
+   * Error message for invalid hex input
+   * @defaultvalue 'Hex values must be between 3 and 6 characters long'
+   */
+  hexError?: string;
+
+  /**
+   * Error message for invalid alpha input
+   * @defaultvalue 'Alpha must be between 0 and 100'
+   */
+  alphaError?: string;
+
+  /**
+   * Error message for invalid transparency input
+   * @defaultvalue 'Transparency must be between 0 and 100'
+   */
+  transparencyError?: string;
+
+  /**
+   * Error message for invalid red input
+   * @defaultvalue 'Red must be between 0 and 255'
+   */
+  redError?: string;
+
+  /**
+   * Error message for invalid green input
+   * @defaultvalue 'Green must be between 0 and 255'
+   */
+  greenError?: string;
+
+  /**
+   * Error message for invalid blue input
+   * @defaultvalue 'Blue must be between 0 and 255'
+   */
+  blueError?: string;
 }
 
 /**

--- a/packages/react/src/components/ColorPicker/ColorPicker.types.ts
+++ b/packages/react/src/components/ColorPicker/ColorPicker.types.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { ITheme, IStyle } from '../../Styling';
 import type { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 import type { IColor } from '../../utilities/color/interfaces';
+import type { ITooltipHostProps } from '../../Tooltip';
 
 /**
  * {@docCategory ColorPicker}
@@ -109,6 +110,11 @@ export interface IColorPickerProps {
    * @defaultvalue false
    */
   showPreview?: boolean;
+
+  /**
+   * Optional props to pass through to the error message tooltips
+   */
+  tooltipProps?: ITooltipHostProps;
 }
 
 export interface IColorPickerStrings {

--- a/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -348,155 +348,169 @@ exports[`ColorPicker renders correctly 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Hex"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField1"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="abcdef"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Hex"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField2"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="abcdef"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -504,155 +518,169 @@ exports[`ColorPicker renders correctly 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Red"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField4"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="171"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Red"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField6"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="171"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -660,155 +688,169 @@ exports[`ColorPicker renders correctly 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Green"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField7"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="205"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Green"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField10"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="205"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -816,155 +858,169 @@ exports[`ColorPicker renders correctly 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Blue"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField10"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="239"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Blue"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField14"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="239"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -972,155 +1028,169 @@ exports[`ColorPicker renders correctly 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Alpha"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField13"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="100"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Alpha"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField18"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="100"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -1507,155 +1577,169 @@ exports[`ColorPicker renders correctly with preview 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Hex"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField1"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="abcdef"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Hex"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField2"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="abcdef"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -1663,155 +1747,169 @@ exports[`ColorPicker renders correctly with preview 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Red"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField4"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="171"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Red"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField6"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="171"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -1819,155 +1917,169 @@ exports[`ColorPicker renders correctly with preview 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Green"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField7"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="205"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Green"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField10"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="205"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -1975,155 +2087,169 @@ exports[`ColorPicker renders correctly with preview 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Blue"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField10"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="239"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Blue"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField14"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="239"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -2131,155 +2257,169 @@ exports[`ColorPicker renders correctly with preview 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Alpha"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField13"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="100"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Alpha"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField18"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="100"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -2643,155 +2783,169 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Hex"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField1"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="abcdef"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Hex"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField2"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="abcdef"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -2799,155 +2953,169 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Red"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField4"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="171"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Red"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField6"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="171"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -2955,155 +3123,169 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Green"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField7"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="205"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Green"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField10"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="205"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -3111,155 +3293,169 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Blue"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField10"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="239"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Blue"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField14"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="239"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -3267,155 +3463,169 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
           <td>
             <div
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+                  ms-TooltipHost
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
+                    display: inline;
                   }
-                  &.ms-TextField {
-                    padding-right: 4px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
+              onBlurCapture={[Function]}
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="none"
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    &.ms-TextField {
+                      padding-right: 4px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
-                  className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border-radius: 2px;
-                        border: 1px solid #605e5c;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        cursor: text;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #323130;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                        -ms-high-contrast-adjust: none;
-                        border-color: Highlight;
-                        forced-color-adjust: none;
-                      }
+                  className="ms-TextField-wrapper"
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Transparency"
-                    autoComplete="off"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border-radius: 2px;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #323130;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
+                          cursor: text;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
-                        }
-                        &:active {
-                          outline: 0px;
-                        }
-                        &:focus {
-                          outline: 0px;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
                         &:hover {
-                          outline: 0px;
+                          border-color: #323130;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                          -ms-high-contrast-adjust: none;
+                          border-color: Highlight;
+                          forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          background: Window;
-                          color: WindowText;
-                        }
-                        &::placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                          color: GrayText;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                        &::-ms-input-placeholder {
-                          color: #605e5c;
-                          opacity: 1;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                          color: GrayText;
-                        }
-                    id="TextField13"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="0"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Transparency"
+                      autoComplete="off"
+                      className=
+                          ms-TextField-field
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #323130;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active {
+                            outline: 0px;
+                          }
+                          &:focus {
+                            outline: 0px;
+                          }
+                          &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                            color: GrayText;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                            color: GrayText;
+                          }
+                      id="TextField18"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="0"
+                    />
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/react/src/components/TextField/TextField.base.tsx
+++ b/packages/react/src/components/TextField/TextField.base.tsx
@@ -195,6 +195,7 @@ export class TextFieldBase
       borderless,
       className,
       disabled,
+      invalid,
       iconProps,
       inputClassName,
       label,
@@ -217,6 +218,7 @@ export class TextFieldBase
     } = this.props;
     const { isFocused, isRevealingPassword } = this.state;
     const errorMessage = this._errorMessage;
+    const isInvalid = typeof invalid === 'boolean' ? invalid : !!errorMessage;
 
     const hasRevealButton = !!canRevealPassword && type === 'password' && _browserNeedsRevealButton();
 
@@ -228,7 +230,7 @@ export class TextFieldBase
       required,
       multiline,
       hasLabel: !!label,
-      hasErrorMessage: !!errorMessage,
+      hasErrorMessage: isInvalid,
       borderless,
       resizable,
       hasIcon: !!iconProps,
@@ -487,12 +489,14 @@ export class TextFieldBase
   }
 
   private _renderTextArea(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
+    const { invalid } = this.props;
     const textAreaProps = getNativeProps<React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
       this.props,
       textAreaProperties,
       ['defaultValue'],
     );
     const ariaLabelledBy = this.props['aria-labelledby'] || (this.props.label ? this._labelId : undefined);
+    const isInvalid = typeof invalid === 'boolean' ? invalid : !!this._errorMessage;
     return (
       <textarea
         id={this._id}
@@ -504,7 +508,7 @@ export class TextFieldBase
         className={this._classNames.field}
         aria-labelledby={ariaLabelledBy}
         aria-describedby={this._isDescriptionAvailable ? this._descriptionId : this.props['aria-describedby']}
-        aria-invalid={!!this._errorMessage}
+        aria-invalid={isInvalid}
         aria-label={this.props.ariaLabel}
         readOnly={this.props.readOnly}
         onFocus={this._onFocus}
@@ -514,19 +518,21 @@ export class TextFieldBase
   }
 
   private _renderInput(): JSX.Element | null {
+    const { ariaLabel, invalid, type = 'text', label } = this.props;
+    const isInvalid = typeof invalid === 'boolean' ? invalid : !!this._errorMessage;
     const inputProps: React.InputHTMLAttributes<HTMLInputElement> & React.RefAttributes<HTMLInputElement> = {
-      type: this.state.isRevealingPassword ? 'text' : this.props.type || 'text',
+      type: this.state.isRevealingPassword ? 'text' : type,
       id: this._id,
       ...getNativeProps(this.props, inputProperties, ['defaultValue', 'type']),
-      'aria-labelledby': this.props['aria-labelledby'] || (this.props.label ? this._labelId : undefined),
+      'aria-labelledby': this.props['aria-labelledby'] || (label ? this._labelId : undefined),
       ref: this._textElement as React.RefObject<HTMLInputElement>,
       value: this.value || '',
       onInput: this._onInputChange,
       onChange: this._onInputChange,
       className: this._classNames.field,
-      'aria-label': this.props.ariaLabel,
+      'aria-label': ariaLabel,
       'aria-describedby': this._isDescriptionAvailable ? this._descriptionId : this.props['aria-describedby'],
-      'aria-invalid': !!this._errorMessage,
+      'aria-invalid': isInvalid,
       onFocus: this._onFocus,
       onBlur: this._onBlur,
     };

--- a/packages/react/src/components/TextField/TextField.base.tsx
+++ b/packages/react/src/components/TextField/TextField.base.tsx
@@ -489,14 +489,13 @@ export class TextFieldBase
   }
 
   private _renderTextArea(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
-    const { invalid } = this.props;
+    const { invalid = !!this._errorMessage } = this.props;
     const textAreaProps = getNativeProps<React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
       this.props,
       textAreaProperties,
       ['defaultValue'],
     );
     const ariaLabelledBy = this.props['aria-labelledby'] || (this.props.label ? this._labelId : undefined);
-    const isInvalid = typeof invalid === 'boolean' ? invalid : !!this._errorMessage;
     return (
       <textarea
         id={this._id}
@@ -508,7 +507,7 @@ export class TextFieldBase
         className={this._classNames.field}
         aria-labelledby={ariaLabelledBy}
         aria-describedby={this._isDescriptionAvailable ? this._descriptionId : this.props['aria-describedby']}
-        aria-invalid={isInvalid}
+        aria-invalid={invalid}
         aria-label={this.props.ariaLabel}
         readOnly={this.props.readOnly}
         onFocus={this._onFocus}
@@ -518,8 +517,7 @@ export class TextFieldBase
   }
 
   private _renderInput(): JSX.Element | null {
-    const { ariaLabel, invalid, type = 'text', label } = this.props;
-    const isInvalid = typeof invalid === 'boolean' ? invalid : !!this._errorMessage;
+    const { ariaLabel, invalid = !!this._errorMessage, type = 'text', label } = this.props;
     const inputProps: React.InputHTMLAttributes<HTMLInputElement> & React.RefAttributes<HTMLInputElement> = {
       type: this.state.isRevealingPassword ? 'text' : type,
       id: this._id,
@@ -532,7 +530,7 @@ export class TextFieldBase
       className: this._classNames.field,
       'aria-label': ariaLabel,
       'aria-describedby': this._isDescriptionAvailable ? this._descriptionId : this.props['aria-describedby'],
-      'aria-invalid': isInvalid,
+      'aria-invalid': invalid,
       onFocus: this._onFocus,
       onBlur: this._onBlur,
     };

--- a/packages/react/src/components/TextField/TextField.types.ts
+++ b/packages/react/src/components/TextField/TextField.types.ts
@@ -169,6 +169,12 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   readOnly?: boolean;
 
   /**
+   * If true, the text field is invalid. Will be auto-determined by errorMessage unless set.
+   * @defaultvalue false
+   */
+  invalid?: boolean;
+
+  /**
    * Static error message displayed below the text field. Use `onGetErrorMessage` to dynamically
    * change the error message displayed (if any) based on the current value. `errorMessage` and
    * `onGetErrorMessage` are mutually exclusive (`errorMessage` takes precedence).

--- a/packages/react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.base.tsx
@@ -57,7 +57,6 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
         <div
           className={this._classNames.content}
           id={id}
-          role="tooltip"
           onMouseEnter={this.props.onMouseEnter}
           onMouseLeave={this.props.onMouseLeave}
         >

--- a/packages/react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -117,9 +117,7 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
             }
           }
         >
-          <div
-            role="tooltip"
-          >
+          <div>
             <div />
           </div>
         </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19911
- [x] Include a change request file using `$ yarn change`

Note: **DO NOT PORT TO v7**
this is a behavior change in the component, and introduces Tooltip (creating a bundle size impact in ColorPicker). For those reasons, it is not a candidate to add to v7.

#### Description of changes

The original issue was the silent auto-change of invalid entries on blur caused accessibility issues -- it was easy to miss, screen readers didn't announce anything, and ZoomText/magnifier users could easily be prevented from noticing it.

This change fixes it by putting the text input in an error state, and showing a tooltip with a brief error message. The tooltip has `role="alert"` so it will be announced, and since this happens while only focus is in the relevant input, pointer/keyboard tooltip access is not an issue.