### PR TITLE
fix(isConvergedPackage): Detect 0.0.0 as converged nightly version

### DIFF
--- a/scripts/monorepo/isConvergedPackage.js
+++ b/scripts/monorepo/isConvergedPackage.js
@@ -17,7 +17,15 @@ function isConvergedPackage(packagePathOrJson) {
     !packagePathOrJson || typeof packagePathOrJson === 'string'
       ? readConfig('package.json', /** @type {string|undefined} */ (packagePathOrJson))
       : packagePathOrJson;
-  return !!packageJson && semver.major(packageJson.version) >= 9;
+  return !!packageJson && (semver.major(packageJson.version) >= 9 || isNightlyVersion(packageJson.version));
+}
+
+/**
+ * Determins if a version is the 0.0.0 nightly version used by converged packages
+ * @param {string} version
+ */
+function isNightlyVersion(version) {
+  return semver.major(version) === 0 && semver.minor(version) === 0 && semver.patch(version) === 0;
 }
 
 module.exports = isConvergedPackage;


### PR DESCRIPTION
We'll be releasing nightly package with 0.0.0, so the utility needs to
know that 0.0.0 is a valid version string for converged

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
