### PR TITLE
Re-enable typescript pretty option

### DIFF
--- a/scripts/tasks/ts.ts
+++ b/scripts/tasks/ts.ts
@@ -52,6 +52,8 @@ function getExtraTscParams(args: JustArgs) {
     target: 'es5',
     // sourceMap must be true for inlineSources and sourceRoot to work
     ...(args.production && { inlineSources: true, sourceRoot: path.relative(libPath, srcPath), sourceMap: true }),
+    // docs say pretty is on by default, but for some reason this isn't the case when invoked via just-task
+    pretty: true,
   };
 }
 

--- a/scripts/tasks/ts.ts
+++ b/scripts/tasks/ts.ts
@@ -52,7 +52,8 @@ function getExtraTscParams(args: JustArgs) {
     target: 'es5',
     // sourceMap must be true for inlineSources and sourceRoot to work
     ...(args.production && { inlineSources: true, sourceRoot: path.relative(libPath, srcPath), sourceMap: true }),
-    // docs say pretty is on by default, but for some reason this isn't the case when invoked via just-task
+    // docs say pretty is on by default, but it's actually disabled when tsc is run in a
+    // non-TTY context (which is what just-scripts tscTask does)
     pretty: true,
   };
 }


### PR DESCRIPTION
Despite the typescript docs claiming that the `pretty` option is true by default, for some reason this is NOT the case when `tsc` is invoked via `just-task`. (You can try this by intentionally creating a compiler error in some file in `packages/react` locally, then running `yarn build`.) 

EDIT: This appears to be by design (but undocumented) on typescript's side due to the way the tsc process is created within `just-scripts` `tscTask`, with the child's output captured rather than inherited (which is reasonable enough in general). So using `pretty: true` to force pretty output is probably the "right" solution here.

https://github.com/microsoft/TypeScript/blob/95ef2a503dd0cae9f106948cccee8a041078a472/src/executeCommandLine/executeCommandLine.ts#L70-L72

https://github.com/microsoft/TypeScript/blob/39ff1568e9676d40cf545477e9fd04077eff9b78/src/compiler/sys.ts#L1316-L1318