### PR TITLE
fix(Calendar): move gridcell role and focus target from button to td

### DIFF
--- a/change/@fluentui-react-76856034-f760-4269-9692-1dc49b4d7fad.json
+++ b/change/@fluentui-react-76856034-f760-4269-9692-1dc49b4d7fad.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Calendar: move role=\"gridcell\" to the td element and make it the focus target",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -227,12 +227,19 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
         day.setRef(element);
       }}
       aria-hidden={ariaHidden}
+      aria-disabled={!ariaHidden && !day.isInBounds}
       onClick={day.isInBounds && !ariaHidden ? day.onSelected : undefined}
       onMouseOver={!ariaHidden ? onMouseOverDay : undefined}
       onMouseDown={!ariaHidden ? onMouseDownDay : undefined}
       onMouseUp={!ariaHidden ? onMouseUpDay : undefined}
       onMouseOut={!ariaHidden ? onMouseOutDay : undefined}
-      role="presentation" // the child <button> is the gridcell that our parent <tr> contains, so tell ARIA we are not
+      onKeyDown={!ariaHidden ? onDayKeyDown : undefined}
+      role="gridcell"
+      tabIndex={isNavigatedDate ? 0 : undefined}
+      aria-readonly="true"
+      aria-current={day.isSelected ? 'date' : undefined}
+      aria-selected={day.isInBounds ? day.isSelected : undefined}
+      data-is-focusable={!ariaHidden && (allFocusable || (day.isInBounds ? true : undefined))}
     >
       <button
         key={day.key + 'button'}
@@ -242,18 +249,13 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
           day.isToday && classNames.dayIsToday,
           day.isToday && 'ms-CalendarDay-dayIsToday',
         )}
-        onKeyDown={!ariaHidden ? onDayKeyDown : undefined}
         aria-label={ariaLabel}
         id={isNavigatedDate ? activeDescendantId : undefined}
-        aria-current={day.isSelected ? 'date' : undefined}
-        aria-selected={day.isInBounds ? day.isSelected : undefined}
-        data-is-focusable={!ariaHidden && (allFocusable || (day.isInBounds ? true : undefined))}
         ref={isNavigatedDate ? navigatedDayRef : undefined}
-        disabled={!allFocusable && !day.isInBounds}
-        aria-disabled={!ariaHidden && !day.isInBounds}
+        disabled={!ariaHidden && !day.isInBounds}
         type="button"
-        role="gridcell" // create grid structure
-        tabIndex={isNavigatedDate ? 0 : undefined}
+        tabIndex={-1}
+        data-is-focusable="false"
       >
         <span aria-hidden="true">{dateTimeFormatter.formatDay(day.originalDate)}</span>
         {day.isMarked && <div aria-hidden="true" className={classNames.dayMarker} />}

--- a/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
+++ b/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
@@ -591,7 +591,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           role="presentation"
         >
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -644,13 +647,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="21, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -690,9 +692,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -703,7 +705,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -756,13 +761,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="22, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -802,9 +806,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -815,7 +819,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -868,13 +875,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="23, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -914,9 +920,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -927,7 +933,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -980,13 +989,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="24, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -1026,9 +1034,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -1039,7 +1047,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -1092,13 +1103,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="25, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -1138,9 +1148,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -1151,7 +1161,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -1204,13 +1217,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="26, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -1250,9 +1262,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -1263,7 +1275,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -1316,13 +1331,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="27, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -1362,9 +1376,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -1381,6 +1395,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
 
         >
           <td
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -1457,17 +1474,17 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   color: #605e5c;
                   font-weight: 400;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-label="28, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -1507,10 +1524,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
-              onKeyDown={[Function]}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -1521,6 +1537,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -1597,17 +1616,17 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   color: #605e5c;
                   font-weight: 400;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-label="29, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -1647,10 +1666,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
-              onKeyDown={[Function]}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -1661,6 +1679,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -1737,17 +1758,17 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   color: #605e5c;
                   font-weight: 400;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-label="30, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -1787,10 +1808,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
-              onKeyDown={[Function]}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -1801,6 +1821,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -1877,17 +1900,17 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   color: #605e5c;
                   font-weight: 400;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-label="31, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -1927,10 +1950,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
-              onKeyDown={[Function]}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -1941,6 +1963,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-current="date"
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={true}
             className=
                 ms-CalendarDay-daySelected
                 {
@@ -2052,18 +2078,18 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   color: HighlightText!important;
                   forced-color-adjust: none;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
+            tabIndex={0}
           >
             <button
-              aria-current="date"
-              aria-disabled={false}
               aria-label="1, January, 2019"
-              aria-selected={true}
               className=
                   ms-CalendarDay-dayIsToday
                   {
@@ -2116,12 +2142,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     color: Window!important;
                     forced-color-adjust: none;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
               id="id__0"
-              onKeyDown={[Function]}
-              role="gridcell"
-              tabIndex={0}
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -2132,6 +2156,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -2204,17 +2231,17 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &:after {
                   border-right: 1px solid #605e5c;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-label="2, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -2254,10 +2281,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
-              onKeyDown={[Function]}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -2268,6 +2294,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -2340,17 +2369,17 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &:after {
                   border-right: 1px solid #605e5c;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-label="3, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -2390,10 +2419,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
-              onKeyDown={[Function]}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -2419,7 +2447,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           role="presentation"
         >
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -2468,13 +2499,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="4, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -2514,9 +2544,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -2527,7 +2557,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -2576,13 +2609,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="5, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -2622,9 +2654,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -2635,7 +2667,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -2684,13 +2719,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="6, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -2730,9 +2764,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -2743,7 +2777,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -2792,13 +2829,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="7, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -2838,9 +2874,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -2851,7 +2887,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -2900,13 +2939,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="8, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -2946,9 +2984,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -2959,7 +2997,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -3008,13 +3049,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="9, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -3054,9 +3094,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -3067,7 +3107,10 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -3116,13 +3159,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="10, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -3162,9 +3204,9 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -3863,7 +3905,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           role="presentation"
         >
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -3916,13 +3961,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="23, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -3962,9 +4006,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -3975,7 +4019,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -4028,13 +4075,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="24, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -4074,9 +4120,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -4087,7 +4133,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -4140,13 +4189,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="25, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -4186,9 +4234,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -4199,7 +4247,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -4252,13 +4303,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="26, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -4298,9 +4348,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -4311,7 +4361,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -4364,13 +4417,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="27, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -4410,9 +4462,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -4423,7 +4475,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -4476,13 +4531,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="28, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -4522,9 +4576,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -4535,7 +4589,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -4588,13 +4645,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   color: #605e5c;
                   font-weight: 400;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="29, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -4634,9 +4690,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -4653,6 +4709,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
 
         >
           <td
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -4729,17 +4788,17 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   color: #605e5c;
                   font-weight: 400;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-label="30, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -4779,10 +4838,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
-              onKeyDown={[Function]}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -4793,6 +4851,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -4869,17 +4930,17 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   color: #605e5c;
                   font-weight: 400;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-label="31, December, 2018"
-              aria-selected={false}
               className=
 
                   {
@@ -4919,10 +4980,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
-              onKeyDown={[Function]}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -4933,6 +4993,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-current="date"
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={true}
             className=
                 ms-CalendarDay-daySelected
                 {
@@ -5044,18 +5108,18 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   color: HighlightText!important;
                   forced-color-adjust: none;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
+            tabIndex={0}
           >
             <button
-              aria-current="date"
-              aria-disabled={false}
               aria-label="1, January, 2019"
-              aria-selected={true}
               className=
                   ms-CalendarDay-dayIsToday
                   {
@@ -5108,12 +5172,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     color: Window!important;
                     forced-color-adjust: none;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
               id="id__0"
-              onKeyDown={[Function]}
-              role="gridcell"
-              tabIndex={0}
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -5124,6 +5186,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -5196,17 +5261,17 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &:after {
                   border-right: 1px solid #605e5c;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-label="2, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -5246,10 +5311,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
-              onKeyDown={[Function]}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -5260,6 +5324,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -5332,17 +5399,17 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &:after {
                   border-right: 1px solid #605e5c;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-label="3, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -5382,10 +5449,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
-              onKeyDown={[Function]}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -5396,6 +5462,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -5468,17 +5537,17 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &:after {
                   border-right: 1px solid #605e5c;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-label="4, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -5518,10 +5587,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
-              onKeyDown={[Function]}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -5532,6 +5600,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -5604,17 +5675,17 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &:after {
                   border-right: 1px solid #605e5c;
                 }
+            data-is-focusable={true}
             onClick={[Function]}
+            onKeyDown={[Function]}
             onMouseDown={[Function]}
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             onMouseUp={[Function]}
-            role="presentation"
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-label="5, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -5654,10 +5725,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={true}
+              data-is-focusable="false"
               disabled={false}
-              onKeyDown={[Function]}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -5683,7 +5753,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           role="presentation"
         >
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -5732,13 +5805,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="6, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -5778,9 +5850,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -5791,7 +5863,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -5840,13 +5915,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="7, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -5886,9 +5960,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -5899,7 +5973,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -5948,13 +6025,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="8, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -5994,9 +6070,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -6007,7 +6083,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -6056,13 +6135,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="9, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -6102,9 +6180,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -6115,7 +6193,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -6164,13 +6245,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="10, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -6210,9 +6290,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -6223,7 +6303,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -6272,13 +6355,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="11, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -6318,9 +6400,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span
@@ -6331,7 +6413,10 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             </button>
           </td>
           <td
+            aria-disabled={false}
             aria-hidden={true}
+            aria-readonly="true"
+            aria-selected={false}
             className=
 
                 {
@@ -6380,13 +6465,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
-            role="presentation"
+            data-is-focusable={false}
+            role="gridcell"
           >
             <button
-              aria-disabled={false}
               aria-hidden={true}
               aria-label="12, January, 2019"
-              aria-selected={false}
               className=
 
                   {
@@ -6426,9 +6510,9 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     height: inherit;
                     line-height: inherit;
                   }
-              data-is-focusable={false}
+              data-is-focusable="false"
               disabled={false}
-              role="gridcell"
+              tabIndex={-1}
               type="button"
             >
               <span


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12883](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12883)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Both NVDA and VoiceOver have developed recent, severe bugs where they do not read the contents of grid cells when `role="gridcell"` is nested within the `<td>` element. Our Calendar uses that pattern because of a past bug (I believe it was that screen readers read "button" when reaching a cell with a button within it). This PR reverses the change, and puts both `role="gridcell"` and the focuszone target back on the `<td>`.

Tested with NVDA, JAWS, and Narrator -- the experience in each was good with this change. Keyboard and pointer access is unaffected.

Testing with VoiceOver and Talkback as soon as the PR preview link is generated. I'll update the description with the results as soon as that happens. (I already verified on a JS Fiddle that moving the role around fixed the original VoiceOver issue and worked OK in VO and Talkback, just waiting to verify there are no regressions on Fluent)

Test update:
Works fine with VO, Talkback navigates separately to both the cell and the button, but the experience is generally fine, and certainly better the VO/NVDA issue of not reaching cells at all 😄.