### PR TITLE
fix(Combobox): switch up scroll-into-view method to never scroll page+close parent combobox menu

### DIFF
--- a/change/@fluentui-react-7e18ffdf-7154-4a18-9ffa-64d26fa7e78a.json
+++ b/change/@fluentui-react-7e18ffdf-7154-4a18-9ffa-64d26fa7e78a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix Combobox scroll into view method to not scroll + close combo menu",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12887](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12887)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The `HTMLElement.scrollIntoView` method has a side effect of sometimes scrolling the parent of the scrolling element, which for inline Combobox will cause the options menu to close. I switched to the safer `parent.offsetTop` scroll approach, which will never cause the page to scroll.