### PR TITLE
feat: separate static asset types to separate global package

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -191,7 +191,7 @@ describe('migrate-converged-pkg generator', () => {
           outDir: 'dist',
           preserveConstEnums: true,
           target: 'ES2019',
-          types: ['jest', 'custom-global', 'inline-style-expand-shorthand'],
+          types: ['jest', 'static-assets', 'inline-style-expand-shorthand'],
         },
         extends: '../../tsconfig.base.json',
         include: ['src'],
@@ -212,7 +212,7 @@ describe('migrate-converged-pkg generator', () => {
 
       expect(tsConfig.compilerOptions.types).toEqual([
         'jest',
-        'custom-global',
+        'static-assets',
         'inline-style-expand-shorthand',
         '@testing-library/jest-dom',
         'foo-bar',

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -120,7 +120,7 @@ const templates = {
       importHelpers: true,
       noUnusedLocals: true,
       preserveConstEnums: true,
-      types: ['jest', 'custom-global', 'inline-style-expand-shorthand'],
+      types: ['jest', 'static-assets', 'inline-style-expand-shorthand'],
     } as TsConfig['compilerOptions'],
   },
   babelConfig: (options: { extraPlugins: Array<string> }) => {

--- a/typings/custom-global/index.d.ts
+++ b/typings/custom-global/index.d.ts
@@ -1,3 +1,6 @@
+// @TODO https://github.com/microsoft/fluentui/issues/20544
+/// <reference path="../static-assets/index.d.ts" />
+
 /**
  * Generic typings for sass files.
  */
@@ -5,19 +8,6 @@ declare module '*.scss' {
   const styles: { [className: string]: string };
   export default styles;
 }
-declare module '*.svg' {
-  const svgPath: string;
-  export default svgPath;
-}
-declare module '*.png' {
-  const value: any;
-  export default value;
-}
-
-/**
- * Generic typings for Markdown files.
- */
-declare module '*.md';
 
 // These declarations are meant to represent the parts of Map/WeakMap/Set that exist in IE 11.
 // Therefore, some functionality (such as constructor parameters) is intentionally missing.

--- a/typings/static-assets/README.md
+++ b/typings/static-assets/README.md
@@ -1,0 +1,38 @@
+# static-assets
+
+Enables importing various static assets to JS/TS modules (which is invalid ECMA syntax enabled by various tools like webpack etc).
+
+This definition list is maintained manually and should be extended as needed.
+
+## Usage
+
+```json
+{
+  "compilerOptions": {
+    "types": ["static-assets"]
+  }
+}
+```
+
+Now you can import images and others:
+
+```ts
+// @ExpectType string
+import myImgSrc from './hello-world.png`
+
+```
+
+## Adding new asset types
+
+Add new asset types extension as needed.
+
+**Example:**
+
+```ts
+// Adding .avif image type support
+// ↓↓↓
+declare module '*.avif' {
+  const src: string;
+  export default src;
+}
+```

--- a/typings/static-assets/index.d.ts
+++ b/typings/static-assets/index.d.ts
@@ -1,0 +1,33 @@
+/**
+ * Global ambient declaration of various non javascript assets being imported into JS/TS
+ */
+
+declare module '*.svg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.gif' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpeg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.png' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.md' {
+  const src: string;
+  export default src;
+}

--- a/typings/tsconfig.json
+++ b/typings/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
     "skipLibCheck": false,
     "noEmit": true,
-    "esModuleInterop": true,
-    "types": ["node"]
+    "types": ["node"],
+    "typeRoots": ["node_modules/@types"]
   },
   "include": ["**/*.d.ts"]
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] follow up of https://github.com/microsoft/fluentui/pull/20430
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

- custom-global types mixes legacy browser ECMA overrides and static-assets. V9 no longer needs legacy overrides as it supports only evergreen browsers.
- This PR creates new typings with narrow focus for static assets + accommodates those changes in our migration generator

#### Focus areas to test

(optional)
