### PR TITLE
make teamsV2Theme the default docs theme

### DIFF
--- a/packages/fluentui/docs/src/context/ThemeContext.tsx
+++ b/packages/fluentui/docs/src/context/ThemeContext.tsx
@@ -26,4 +26,11 @@ export const themeContextDefaults: ThemeContextData = {
   changeTheme: () => {},
 };
 
+// Existing screener tests assume that they're running with the v1 theme, so
+// set that as the default theme when inside screener. This check is safe
+// because this context is only used in the documentation website.
+if (location.pathname.includes('/react-northstar-screener')) {
+  themeContextDefaults.themeName = 'teamsTheme';
+}
+
 export const ThemeContext = React.createContext<ThemeContextData>(themeContextDefaults);

--- a/packages/fluentui/docs/src/context/ThemeContext.tsx
+++ b/packages/fluentui/docs/src/context/ThemeContext.tsx
@@ -15,7 +15,7 @@ export type ThemeContextData = {
 };
 
 export const themeContextDefaults: ThemeContextData = {
-  themeName: 'teamsTheme',
+  themeName: 'teamsV2Theme',
   themeOptions: [
     { text: 'Teams', value: 'teamsTheme' },
     { text: 'Teams Dark', value: 'teamsDarkTheme' },

--- a/packages/fluentui/docs/src/views/ColorPalette.tsx
+++ b/packages/fluentui/docs/src/views/ColorPalette.tsx
@@ -28,7 +28,7 @@ const themes = {
 };
 
 const ColorPalette = () => {
-  const [theme, setTheme] = React.useState(themeOptions[0]);
+  const [theme, setTheme] = React.useState(themeOptions[1]);
   const changeTheme: (event: React.SyntheticEvent, data: { value: ThemeOption }) => void = (event, { value }) => {
     setTheme(value);
   };

--- a/packages/fluentui/docs/src/views/ColorSchemes.tsx
+++ b/packages/fluentui/docs/src/views/ColorSchemes.tsx
@@ -30,7 +30,7 @@ const themeOptions: ThemeOption[] = [
 ];
 
 export default () => {
-  const [theme, setTheme] = React.useState(themeOptions[0]);
+  const [theme, setTheme] = React.useState(themeOptions[1]);
   const changeTheme: (event: React.SyntheticEvent, data: { value: ThemeOption }) => void = (event, { value }) => {
     setTheme(value);
   };


### PR DESCRIPTION
As I understand it, teamsTheme is deprecated in favor of teamsV2Theme. I've received some requests to change the documentation website's default theme to the most current version, for example to help designers who are visiting the color scheme/palette pages and don't realize that they're looking at the old set of colors.