### PR TITLE
fix(Pivot): add prop for overflow button label

### DIFF
--- a/change/@fluentui-react-f13b3b3e-5a7f-49ec-a19b-b514ee5e22f4.json
+++ b/change/@fluentui-react-f13b3b3e-5a7f-49ec-a19b-b514ee5e22f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix(Pivot): add overflow button aria-label prop",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Pivot/Pivot.OverflowMenu.Example.tsx
+++ b/packages/react-examples/src/react/Pivot/Pivot.OverflowMenu.Example.tsx
@@ -20,6 +20,7 @@ export const PivotOverflowMenuExample: React.FunctionComponent = () => {
           aria-label="Pivot Overflow Menu Example"
           linkFormat={tabs ? 'tabs' : 'links'}
           overflowBehavior={overflow ? 'menu' : 'none'}
+          overflowAriaLabel="more items"
         >
           <PivotItem headerText="My Files">
             <Label>Pivot #1</Label>

--- a/packages/react-examples/src/react/__snapshots__/Pivot.OverflowMenu.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Pivot.OverflowMenu.Example.tsx.shot
@@ -1994,6 +1994,7 @@ Array [
           aria-controls={null}
           aria-expanded={false}
           aria-haspopup={true}
+          aria-label="more items"
           className=
               ms-Button
               ms-Button--action

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6664,6 +6664,7 @@ export interface IPivotProps extends React_2.HTMLAttributes<HTMLDivElement>, Rea
     linkFormat?: PivotLinkFormatType;
     linkSize?: PivotLinkSizeType;
     onLinkClick?: (item?: PivotItem, ev?: React_2.MouseEvent<HTMLElement>) => void;
+    overflowAriaLabel?: string;
     overflowBehavior?: 'none' | 'menu';
     selectedKey?: string | null;
     styles?: IStyleFunctionOrObject<IPivotStyleProps, IPivotStyles>;

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -70,7 +70,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
 
     const [selectedKey, setSelectedKey] = useControllableValue(props.selectedKey, props.defaultSelectedKey);
 
-    const { componentRef, theme, linkSize, linkFormat, overflowBehavior, focusZoneProps } = props;
+    const { componentRef, theme, linkSize, linkFormat, overflowBehavior, overflowAriaLabel, focusZoneProps } = props;
 
     let classNames: { [key in keyof IPivotStyles]: string };
     const nameProps = {
@@ -275,6 +275,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
               componentRef={overflowMenuButtonComponentRef}
               menuProps={overflowMenuProps}
               menuIconProps={{ iconName: 'More', style: { color: 'inherit' } }}
+              ariaLabel={overflowAriaLabel}
             />
           )}
         </FocusZone>

--- a/packages/react/src/components/Pivot/Pivot.types.ts
+++ b/packages/react/src/components/Pivot/Pivot.types.ts
@@ -69,6 +69,11 @@ export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement>, React
   linkFormat?: PivotLinkFormatType;
 
   /**
+   * Aria label for the overflow button, used if `overflowBehavior` is "menu".
+   */
+  overflowAriaLabel?: string;
+
+  /**
    * Overflow behavior when there is not enough room to display all of the links/tabs
    * * none: Pivot links will overflow the container and may not be visible
    * * menu: Display an overflow menu that contains the tabs that don't fit


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [13050](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/13050)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Follows the basic pattern of providing an overflow button label prop similar to what exists in components like Breadcrumb and Commandbar.
