### PR TITLE
feat(card, image, radio): add static classes

### DIFF
--- a/change/@fluentui-react-card-83b7c016-46ba-42b5-a1d9-24aac93ceaf8.json
+++ b/change/@fluentui-react-card-83b7c016-46ba-42b5-a1d9-24aac93ceaf8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "export static classes for components",
+  "packageName": "@fluentui/react-card",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-029983f6-5b54-46f2-abe6-ecfec3464c47.json
+++ b/change/@fluentui-react-image-029983f6-5b54-46f2-abe6-ecfec3464c47.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "export static classes for components",
+  "packageName": "@fluentui/react-image",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-card/etc/react-card.api.md
+++ b/packages/react-card/etc/react-card.api.md
@@ -14,10 +14,16 @@ import * as React_2 from 'react';
 export const Card: ForwardRefComponent<CardProps>;
 
 // @public (undocumented)
+export const cardClassName = "fui-Card";
+
+// @public (undocumented)
 export type CardCommons = {};
 
 // @public
 export const CardFooter: ForwardRefComponent<CardFooterProps>;
+
+// @public (undocumented)
+export const cardFooterClassName = "fui-CardFooter";
 
 // @public
 export type CardFooterProps = ComponentProps<CardFooterSlots>;
@@ -36,6 +42,9 @@ export type CardFooterState = ComponentState<CardFooterSlots>;
 
 // @public
 export const CardHeader: ForwardRefComponent<CardHeaderProps>;
+
+// @public (undocumented)
+export const cardHeaderClassName = "fui-CardHeader";
 
 // @public
 export type CardHeaderProps = ComponentProps<CardHeaderSlots>;
@@ -58,6 +67,9 @@ export type CardHeaderState = ComponentState<CardHeaderSlots>;
 
 // @public
 export const CardPreview: ForwardRefComponent<CardPreviewProps>;
+
+// @public (undocumented)
+export const cardPreviewClassName = "fui-CardPreview";
 
 // @public
 export type CardPreviewProps = ComponentProps<CardPreviewSlots>;

--- a/packages/react-card/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/react-card/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Card renders a default state 1`] = `
 <div>
   <div
-    class=""
+    class="fui-Card"
     data-tabster="{\\"groupper\\":{\\"tabbability\\":2}}"
     role="group"
   >

--- a/packages/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-card/src/components/Card/useCardStyles.ts
@@ -1,5 +1,8 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { cardPreviewClassName } from '../CardPreview/index';
 import type { CardState } from './Card.types';
+
+export const cardClassName = 'fui-Card';
 
 /**
  * Styles for the root slot
@@ -21,7 +24,7 @@ const useStyles = makeStyles({
     gap: '12px',
     borderRadius: theme.borderRadiusMedium,
 
-    '> .fluentui-react-card-preview': {
+    [`> .${cardPreviewClassName}`]: {
       marginLeft: '-12px',
       marginRight: '-12px',
       '&:first-child': {
@@ -47,6 +50,7 @@ const useStyles = makeStyles({
 export const useCardStyles = (state: CardState): CardState => {
   const styles = useStyles();
   state.root.className = mergeClasses(
+    cardClassName,
     styles.root,
     (state.root.onClick ||
       state.root.onMouseUp ||

--- a/packages/react-card/src/components/CardFooter/__snapshots__/CardFooter.test.tsx.snap
+++ b/packages/react-card/src/components/CardFooter/__snapshots__/CardFooter.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CardFooter renders a default state 1`] = `
 <div>
   <div
-    class=""
+    class="fui-CardFooter"
   >
     Default CardFooter
     <div

--- a/packages/react-card/src/components/CardFooter/useCardFooterStyles.ts
+++ b/packages/react-card/src/components/CardFooter/useCardFooterStyles.ts
@@ -1,6 +1,8 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import type { CardFooterState } from './CardFooter.types';
 
+export const cardFooterClassName = 'fui-CardFooter';
+
 /**
  * Styles for the root slot
  */
@@ -20,7 +22,7 @@ const useStyles = makeStyles({
  */
 export const useCardFooterStyles = (state: CardFooterState): CardFooterState => {
   const styles = useStyles();
-  state.root.className = mergeClasses(styles.root, state.root.className);
+  state.root.className = mergeClasses(cardFooterClassName, styles.root, state.root.className);
 
   if (state.action) {
     state.action.className = mergeClasses(styles.action, state.action.className);

--- a/packages/react-card/src/components/CardHeader/__snapshots__/CardHeader.test.tsx.snap
+++ b/packages/react-card/src/components/CardHeader/__snapshots__/CardHeader.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CardHeader renders a default state 1`] = `
 <div>
   <div
-    class=""
+    class="fui-CardHeader"
   >
     <div
       class=""

--- a/packages/react-card/src/components/CardHeader/useCardHeaderStyles.ts
+++ b/packages/react-card/src/components/CardHeader/useCardHeaderStyles.ts
@@ -1,6 +1,8 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import type { CardHeaderState } from './CardHeader.types';
 
+export const cardHeaderClassName = 'fui-CardHeader';
+
 /**
  * Styles for the root slot
  */
@@ -46,7 +48,7 @@ const useStyles = makeStyles({
  */
 export const useCardHeaderStyles = (state: CardHeaderState): CardHeaderState => {
   const styles = useStyles();
-  state.root.className = mergeClasses(styles.root, state.root.className);
+  state.root.className = mergeClasses(cardHeaderClassName, styles.root, state.root.className);
 
   if (state.image) {
     state.image.className = mergeClasses(styles.image, state.image.className);

--- a/packages/react-card/src/components/CardPreview/__snapshots__/CardPreview.test.tsx.snap
+++ b/packages/react-card/src/components/CardPreview/__snapshots__/CardPreview.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CardPreview renders a default state 1`] = `
 <div>
   <div
-    class="fluentui-react-card-preview"
+    class="fui-CardPreview"
   >
     Default CardPreview
     <div

--- a/packages/react-card/src/components/CardPreview/useCardPreviewStyles.ts
+++ b/packages/react-card/src/components/CardPreview/useCardPreviewStyles.ts
@@ -1,6 +1,8 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import type { CardPreviewState } from './CardPreview.types';
 
+export const cardPreviewClassName = 'fui-CardPreview';
+
 /**
  * Styles for the root slot
  */
@@ -30,7 +32,7 @@ const useStyles = makeStyles({
  */
 export const useCardPreviewStyles = (state: CardPreviewState): CardPreviewState => {
   const styles = useStyles();
-  state.root.className = mergeClasses('fluentui-react-card-preview', styles.root, state.root.className);
+  state.root.className = mergeClasses(cardPreviewClassName, styles.root, state.root.className);
 
   if (state.logo) {
     state.logo.className = mergeClasses(styles.logo, state.logo.className);

--- a/packages/react-image/etc/react-image.api.md
+++ b/packages/react-image/etc/react-image.api.md
@@ -15,6 +15,9 @@ const Image_2: ForwardRefComponent<ImageProps>;
 export { Image_2 as Image }
 
 // @public (undocumented)
+export const imageClassName = "fui-Image";
+
+// @public (undocumented)
 export type ImageCommons = {
     bordered?: boolean;
     fit?: 'none' | 'center' | 'contain' | 'cover';

--- a/packages/react-image/src/components/Image/__snapshots__/Image.test.tsx.snap
+++ b/packages/react-image/src/components/Image/__snapshots__/Image.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Image renders a default state 1`] = `
 <div>
   <img
     alt="Non-existent image"
-    class=""
+    class="fui-Image"
     src="image.png"
   />
 </div>

--- a/packages/react-image/src/components/Image/useImageStyles.ts
+++ b/packages/react-image/src/components/Image/useImageStyles.ts
@@ -1,6 +1,8 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import type { ImageState } from './Image.types';
 
+export const imageClassName = 'fui-Image';
+
 const useStyles = makeStyles({
   root: theme => ({
     borderColor: theme.colorNeutralStroke1,
@@ -54,6 +56,7 @@ const useStyles = makeStyles({
 export const useImageStyles = (state: ImageState) => {
   const styles = useStyles();
   state.root.className = mergeClasses(
+    imageClassName,
     styles.root,
     state.bordered && styles.rootBordered,
     state.shape === 'circular' && styles.rootCircular,

--- a/packages/react-radio/etc/react-radio.api.md
+++ b/packages/react-radio/etc/react-radio.api.md
@@ -14,6 +14,9 @@ import * as React_2 from 'react';
 export const Radio: ForwardRefComponent<RadioProps>;
 
 // @public (undocumented)
+export const radioClassName = "fui-Radio";
+
+// @public (undocumented)
 export type RadioCommons = {};
 
 // @public

--- a/packages/react-radio/src/components/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react-radio/src/components/Radio/__snapshots__/Radio.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Radio renders a default state 1`] = `
 <div>
   <span
-    class=""
+    class="fui-Radio"
   >
     Default Radio
   </span>

--- a/packages/react-radio/src/components/Radio/useRadioStyles.ts
+++ b/packages/react-radio/src/components/Radio/useRadioStyles.ts
@@ -1,6 +1,8 @@
 import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import { RadioState } from './Radio.types';
 
+export const radioClassName = 'fui-Radio';
+
 /**
  * Styles for the root slot
  */
@@ -17,7 +19,7 @@ const useStyles = makeStyles({
  */
 export const useRadioStyles = (state: RadioState): RadioState => {
   const styles = useStyles();
-  state.root.className = mergeClasses(styles.root, state.root.className);
+  state.root.className = mergeClasses(radioClassName, styles.root, state.root.className);
 
   // TODO Add class names to slots, for example:
   // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Related to #19937
- [x] Include a change request file using `$ yarn change`

#### Description of changes

✅ _Extracted from #20383, these changes passed conformance test on that PR_ 

This PR adds static classes to components `@fluentui/react-card`, `@fluentui/react-image` & `@fluentui/react-radio`.

- All classes follow `fui-ComponentName`
- All classes are publicly exported as `componentNameClassName`
- Snapshots were updated