### PR TITLE
feat(menu, popover): add static classes

### DIFF
--- a/change/@fluentui-react-menu-4aae6737-d14b-431b-b989-5195c6c388f3.json
+++ b/change/@fluentui-react-menu-4aae6737-d14b-431b-b989-5195c6c388f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "export static classes for components",
+  "packageName": "@fluentui/react-menu",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-d6f0341b-5357-4977-87db-d2ca82fcc7d2.json
+++ b/change/@fluentui-react-popover-d6f0341b-5357-4977-87db-d2ca82fcc7d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "export static classes for components",
+  "packageName": "@fluentui/react-popover",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -35,6 +35,9 @@ export type MenuContextValues = {
 export const MenuDivider: ForwardRefComponent<MenuDividerProps>;
 
 // @public (undocumented)
+export const menuDividerClassName = "fui-MenuDivider";
+
+// @public (undocumented)
 export type MenuDividerProps = ComponentProps<MenuDividerSlots>;
 
 // @public (undocumented)
@@ -47,6 +50,9 @@ export type MenuDividerState = ComponentState<MenuDividerSlots>;
 
 // @public
 export const MenuGroup: ForwardRefComponent<MenuGroupProps>;
+
+// @public (undocumented)
+export const menuGroupClassName = "fui-MenuGroup";
 
 // @public (undocumented)
 export const MenuGroupContextProvider: React_2.Provider<MenuGroupContextValue>;
@@ -63,6 +69,9 @@ export type MenuGroupContextValues = {
 
 // @public
 export const MenuGroupHeader: ForwardRefComponent<MenuGroupHeaderProps>;
+
+// @public (undocumented)
+export const menuGroupHeaderClassName = "fui-MenuGroupHeader";
 
 // @public (undocumented)
 export type MenuGroupHeaderProps = ComponentProps<MenuGroupHeaderSlots>;
@@ -95,10 +104,16 @@ export const MenuItem: ForwardRefComponent<MenuItemProps>;
 export const MenuItemCheckbox: ForwardRefComponent<MenuItemCheckboxProps>;
 
 // @public (undocumented)
+export const menuItemCheckboxClassName = "fui-MenuItemCheckbox";
+
+// @public (undocumented)
 export type MenuItemCheckboxProps = MenuItemProps & MenuItemSelectableProps;
 
 // @public (undocumented)
 export type MenuItemCheckboxState = MenuItemState & MenuItemSelectableState;
+
+// @public (undocumented)
+export const menuItemClassName = "fui-MenuItem";
 
 // Warning: (ae-forgotten-export) The symbol "MenuItemCommons" needs to be exported by the entry point index.d.ts
 //
@@ -107,6 +122,9 @@ export type MenuItemProps = ComponentProps<Partial<MenuItemSlots>> & MenuItemCom
 
 // @public
 export const MenuItemRadio: ForwardRefComponent<MenuItemRadioProps>;
+
+// @public (undocumented)
+export const menuItemRadioClassName = "fui-MenuItemRadio";
 
 // @public (undocumented)
 export type MenuItemRadioProps = MenuItemProps & MenuItemSelectableProps;
@@ -145,6 +163,9 @@ export type MenuItemState = ComponentState<MenuItemSlots> & MenuItemCommons;
 
 // @public
 export const MenuList: ForwardRefComponent<MenuListProps>;
+
+// @public (undocumented)
+export const menuListClassName = "fui-MenuList";
 
 // @public (undocumented)
 export type MenuListCommons = {
@@ -203,6 +224,9 @@ export type MenuOpenEvents = MouseEvent | TouchEvent | React_2.MouseEvent<HTMLEl
 
 // @public
 export const MenuPopover: ForwardRefComponent<MenuPopoverProps>;
+
+// @public (undocumented)
+export const menuPopoverClassName = "fui-MenuPopover";
 
 // @public
 export type MenuPopoverProps = ComponentProps<MenuPopoverSlots>;
@@ -334,14 +358,23 @@ export function useMenuGroupHeader(props: MenuGroupHeaderProps, ref: React_2.Ref
 // @public (undocumented)
 export const useMenuGroupHeaderStyles: (state: MenuGroupHeaderState) => ComponentState<MenuGroupHeaderSlots>;
 
+// @public (undocumented)
+export const useMenuGroupStyles: (state: MenuGroupState) => MenuGroupState;
+
 // @public
 export const useMenuItem: (props: MenuItemProps, ref: React_2.Ref<HTMLElement>) => MenuItemState;
 
 // @public
 export const useMenuItemCheckbox: (props: MenuItemCheckboxProps, ref: React_2.Ref<HTMLElement>) => MenuItemCheckboxState;
 
+// @public (undocumented)
+export const useMenuItemCheckboxStyles: (state: MenuItemCheckboxState) => void;
+
 // @public
 export const useMenuItemRadio: (props: MenuItemRadioProps, ref: React_2.Ref<HTMLElement>) => MenuItemRadioState;
+
+// @public (undocumented)
+export const useMenuItemRadioStyles: (state: MenuItemRadioState) => void;
 
 // @public
 export const useMenuItemStyles: (state: MenuItemState) => void;

--- a/packages/react-menu/src/components/Menu/Menu.test.tsx
+++ b/packages/react-menu/src/components/Menu/Menu.test.tsx
@@ -19,6 +19,7 @@ describe('Menu', () => {
       'component-handles-ref',
       'component-has-root-ref',
       'component-handles-classname',
+      'component-has-static-classname',
       // Menu does not have own styles
       'make-styles-overrides-win',
     ],

--- a/packages/react-menu/src/components/MenuDivider/__snapshots__/MenuDivider.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuDivider/__snapshots__/MenuDivider.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MenuDivider renders a default state 1`] = `
 <div
   aria-hidden={true}
-  className=""
+  className="fui-MenuDivider"
   role="presentation"
 >
   Default MenuDivider

--- a/packages/react-menu/src/components/MenuDivider/useMenuDividerStyles.ts
+++ b/packages/react-menu/src/components/MenuDivider/useMenuDividerStyles.ts
@@ -1,6 +1,8 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import type { MenuDividerState } from './MenuDivider.types';
 
+export const menuDividerClassName = 'fui-MenuDivider';
+
 const useStyles = makeStyles({
   root: theme => ({
     height: '1px',
@@ -12,7 +14,7 @@ const useStyles = makeStyles({
 
 export const useMenuDividerStyles = (state: MenuDividerState) => {
   const styles = useStyles();
-  state.root.className = mergeClasses(styles.root, state.root.className);
+  state.root.className = mergeClasses(menuDividerClassName, styles.root, state.root.className);
 
   return state;
 };

--- a/packages/react-menu/src/components/MenuGroup/MenuGroup.tsx
+++ b/packages/react-menu/src/components/MenuGroup/MenuGroup.tsx
@@ -4,6 +4,7 @@ import { renderMenuGroup } from './renderMenuGroup';
 import { useMenuGroupContextValues } from './useMenuGroupContextValues';
 import type { MenuGroupProps } from './MenuGroup.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useMenuGroupStyles } from './useMenuGroupStyles';
 
 /**
  * Define a styled MenuGroup, using the `useMenuGroup` hook.
@@ -11,6 +12,8 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 export const MenuGroup: ForwardRefComponent<MenuGroupProps> = React.forwardRef((props, ref) => {
   const state = useMenuGroup(props, ref);
   const contextValues = useMenuGroupContextValues(state);
+
+  useMenuGroupStyles(state);
 
   return renderMenuGroup(state, contextValues);
 });

--- a/packages/react-menu/src/components/MenuGroup/__snapshots__/MenuGroup.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuGroup/__snapshots__/MenuGroup.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`MenuGroup renders a default state 1`] = `
 <div
   aria-labelledby="menu-group1"
+  className="fui-MenuGroup"
   role="group"
 >
   Default MenuGroup

--- a/packages/react-menu/src/components/MenuGroup/index.ts
+++ b/packages/react-menu/src/components/MenuGroup/index.ts
@@ -3,3 +3,4 @@ export * from './MenuGroup';
 export * from './renderMenuGroup';
 export * from './useMenuGroup';
 export * from './useMenuGroupContextValues';
+export * from './useMenuGroupStyles';

--- a/packages/react-menu/src/components/MenuGroup/useMenuGroupStyles.ts
+++ b/packages/react-menu/src/components/MenuGroup/useMenuGroupStyles.ts
@@ -1,0 +1,10 @@
+import { mergeClasses } from '@fluentui/react-make-styles';
+import type { MenuGroupState } from './MenuGroup.types';
+
+export const menuGroupClassName = 'fui-MenuGroup';
+
+export const useMenuGroupStyles = (state: MenuGroupState): MenuGroupState => {
+  state.root.className = mergeClasses(menuGroupClassName, state.root.className);
+
+  return state;
+};

--- a/packages/react-menu/src/components/MenuGroupHeader/__snapshots__/MenuGroupHeader.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuGroupHeader/__snapshots__/MenuGroupHeader.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`MenuGroupHeader renders a default state 1`] = `
 <div
-  className=""
+  className="fui-MenuGroupHeader"
   id=""
 >
   Default MenuGroupHeader

--- a/packages/react-menu/src/components/MenuGroupHeader/useMenuGroupHeaderStyles.ts
+++ b/packages/react-menu/src/components/MenuGroupHeader/useMenuGroupHeaderStyles.ts
@@ -1,6 +1,8 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import type { MenuGroupHeaderState } from './MenuGroupHeader.types';
 
+export const menuGroupHeaderClassName = 'fui-MenuGroupHeader';
+
 const useStyles = makeStyles({
   root: theme => ({
     fontSize: theme.fontSizeBase200,
@@ -16,7 +18,7 @@ const useStyles = makeStyles({
 
 export const useMenuGroupHeaderStyles = (state: MenuGroupHeaderState) => {
   const styles = useStyles();
-  state.root.className = mergeClasses(styles.root, state.root.className);
+  state.root.className = mergeClasses(menuGroupHeaderClassName, styles.root, state.root.className);
 
   return state;
 };

--- a/packages/react-menu/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`MenuItem renders a default state 1`] = `
 <div
-  className=""
+  className="fui-MenuItem"
   onClick={[Function]}
   onKeyDown={[Function]}
   onMouseEnter={[Function]}

--- a/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
+++ b/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
@@ -2,6 +2,8 @@ import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import type { MenuItemState } from './MenuItem.types';
 
+export const menuItemClassName = 'fui-MenuItem';
+
 const useStyles = makeStyles({
   focusIndicator: theme => createFocusOutlineStyle(theme),
   root: theme => ({
@@ -66,6 +68,7 @@ const useStyles = makeStyles({
 export const useMenuItemStyles = (state: MenuItemState) => {
   const styles = useStyles();
   state.root.className = mergeClasses(
+    menuItemClassName,
     styles.root,
     styles.focusIndicator,
     state.disabled && styles.disabled,

--- a/packages/react-menu/src/components/MenuItemCheckbox/MenuItemCheckbox.tsx
+++ b/packages/react-menu/src/components/MenuItemCheckbox/MenuItemCheckbox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useMenuItemCheckbox } from './useMenuItemCheckbox';
 import { renderMenuItemCheckbox } from './renderMenuItemCheckbox';
-import { useMenuItemCheckBoxStyles } from './useMenuItemCheckboxStyles';
+import { useMenuItemCheckboxStyles } from './useMenuItemCheckboxStyles';
 import type { MenuItemCheckboxProps } from './MenuItemCheckbox.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 
@@ -10,7 +10,7 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
  */
 export const MenuItemCheckbox: ForwardRefComponent<MenuItemCheckboxProps> = React.forwardRef((props, ref) => {
   const state = useMenuItemCheckbox(props, ref);
-  useMenuItemCheckBoxStyles(state);
+  useMenuItemCheckboxStyles(state);
 
   return renderMenuItemCheckbox(state);
 });

--- a/packages/react-menu/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MenuItemCheckbox conformance renders a default state 1`] = `
 <div
   aria-checked={false}
-  className=""
+  className="fui-MenuItem fui-MenuItemCheckbox"
   name="checkbox"
   onClick={[Function]}
   onKeyDown={[Function]}

--- a/packages/react-menu/src/components/MenuItemCheckbox/index.ts
+++ b/packages/react-menu/src/components/MenuItemCheckbox/index.ts
@@ -2,3 +2,4 @@ export * from './MenuItemCheckbox.types';
 export * from './MenuItemCheckbox';
 export * from './renderMenuItemCheckbox';
 export * from './useMenuItemCheckbox';
+export * from './useMenuItemCheckboxStyles';

--- a/packages/react-menu/src/components/MenuItemCheckbox/useMenuItemCheckboxStyles.ts
+++ b/packages/react-menu/src/components/MenuItemCheckbox/useMenuItemCheckboxStyles.ts
@@ -1,8 +1,13 @@
+import { mergeClasses } from '@fluentui/react-make-styles';
 import { useCheckmarkStyles } from '../../selectable/index';
 import { useMenuItemStyles } from '../MenuItem/useMenuItemStyles';
 import type { MenuItemCheckboxState } from './MenuItemCheckbox.types';
 
-export const useMenuItemCheckBoxStyles = (state: MenuItemCheckboxState) => {
+export const menuItemCheckboxClassName = 'fui-MenuItemCheckbox';
+
+export const useMenuItemCheckboxStyles = (state: MenuItemCheckboxState) => {
+  state.root.className = mergeClasses(menuItemCheckboxClassName, state.root.className);
+
   useMenuItemStyles(state);
   useCheckmarkStyles(state);
 };

--- a/packages/react-menu/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MenuItemRadio renders a default state 1`] = `
 <div
   aria-checked={false}
-  className=""
+  className="fui-MenuItem fui-MenuItemRadio"
   name="radio"
   onClick={[Function]}
   onKeyDown={[Function]}

--- a/packages/react-menu/src/components/MenuItemRadio/index.ts
+++ b/packages/react-menu/src/components/MenuItemRadio/index.ts
@@ -2,3 +2,4 @@ export * from './MenuItemRadio.types';
 export * from './MenuItemRadio';
 export * from './renderMenuItemRadio';
 export * from './useMenuItemRadio';
+export * from './useMenuItemRadioStyles';

--- a/packages/react-menu/src/components/MenuItemRadio/useMenuItemRadioStyles.ts
+++ b/packages/react-menu/src/components/MenuItemRadio/useMenuItemRadioStyles.ts
@@ -1,8 +1,13 @@
+import { mergeClasses } from '@fluentui/react-make-styles';
 import { useCheckmarkStyles } from '../../selectable/index';
 import { useMenuItemStyles } from '../MenuItem/useMenuItemStyles';
 import type { MenuItemRadioState } from './MenuItemRadio.types';
 
+export const menuItemRadioClassName = 'fui-MenuItemRadio';
+
 export const useMenuItemRadioStyles = (state: MenuItemRadioState) => {
+  state.root.className = mergeClasses(menuItemRadioClassName, state.root.className);
+
   useMenuItemStyles(state);
   useCheckmarkStyles(state);
 };

--- a/packages/react-menu/src/components/MenuList/__snapshots__/MenuList.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuList/__snapshots__/MenuList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MenuList renders a default state 1`] = `
 <div
   aria-labelledby=""
-  className=""
+  className="fui-MenuList"
   data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":1}}"
   role="menu"
 >

--- a/packages/react-menu/src/components/MenuList/useMenuListStyles.ts
+++ b/packages/react-menu/src/components/MenuList/useMenuListStyles.ts
@@ -1,6 +1,8 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import type { MenuListState } from './MenuList.types';
 
+export const menuListClassName = 'fui-MenuList';
+
 const useStyles = makeStyles({
   root: {
     display: 'flex',
@@ -14,6 +16,6 @@ const useStyles = makeStyles({
  */
 export const useMenuListStyles = (state: MenuListState): MenuListState => {
   const styles = useStyles();
-  state.root.className = mergeClasses(styles.root, state.root.className);
+  state.root.className = mergeClasses(menuListClassName, styles.root, state.root.className);
   return state;
 };

--- a/packages/react-menu/src/components/MenuPopover/useMenuPopoverStyles.ts
+++ b/packages/react-menu/src/components/MenuPopover/useMenuPopoverStyles.ts
@@ -1,6 +1,8 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import type { MenuPopoverState } from './MenuPopover.types';
 
+export const menuPopoverClassName = 'fui-MenuPopover';
+
 const useStyles = makeStyles({
   root: theme => ({
     borderRadius: theme.borderRadiusMedium,
@@ -19,6 +21,6 @@ const useStyles = makeStyles({
  */
 export const useMenuPopoverStyles = (state: MenuPopoverState): MenuPopoverState => {
   const styles = useStyles();
-  state.root.className = mergeClasses(styles.root, state.root.className);
+  state.root.className = mergeClasses(menuPopoverClassName, styles.root, state.root.className);
   return state;
 };

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
@@ -11,6 +11,7 @@ describe('MenuTrigger', () => {
       'component-handles-ref',
       'component-has-root-ref',
       'component-handles-classname',
+      'component-has-static-classname',
       // MenuTrigger does not have own styles
       'make-styles-overrides-win',
     ],

--- a/packages/react-popover/etc/react-popover.api.md
+++ b/packages/react-popover/etc/react-popover.api.md
@@ -72,6 +72,9 @@ export type PopoverState = PopoverCommons & Pick<PopoverProps, 'children'> & {
 // @public
 export const PopoverSurface: ForwardRefComponent<PopoverSurfaceProps>;
 
+// @public (undocumented)
+export const popoverSurfaceClassName = "fui-PopoverSurface";
+
 // @public
 export type PopoverSurfaceProps = ComponentProps<PopoverSurfaceSlots>;
 

--- a/packages/react-popover/src/components/Popover/Popover.test.tsx
+++ b/packages/react-popover/src/components/Popover/Popover.test.tsx
@@ -14,6 +14,7 @@ describe('Popover', () => {
       'component-handles-ref',
       'component-has-root-ref',
       'component-handles-classname',
+      'component-has-static-classname',
       // Popover does not have own styles
       'make-styles-overrides-win',
     ],

--- a/packages/react-popover/src/components/PopoverSurface/__snapshots__/PopoverSurface.test.tsx.snap
+++ b/packages/react-popover/src/components/PopoverSurface/__snapshots__/PopoverSurface.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PopoverSurface renders a default state 1`] = `
 <div
-  class=""
+  class="fui-PopoverSurface"
   data-tabster="{\\"deloser\\":{},\\"modalizer\\":{\\"id\\":\\"modal-1\\",\\"isOthersAccessible\\":true}}"
   data-testid="component"
   role="dialog"

--- a/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
+++ b/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
@@ -2,6 +2,8 @@ import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import type { PopoverSize } from '../Popover/Popover.types';
 import type { PopoverSurfaceState } from './PopoverSurface.types';
 
+export const popoverSurfaceClassName = 'fui-PopoverSurface';
+
 export const arrowHeights: Record<PopoverSize, number> = {
   small: 6,
   medium: 8,
@@ -86,6 +88,7 @@ const useStyles = makeStyles({
 export const usePopoverSurfaceStyles = (state: PopoverSurfaceState): PopoverSurfaceState => {
   const styles = useStyles();
   state.root.className = mergeClasses(
+    popoverSurfaceClassName,
     styles.root,
     state.size === 'small' && styles.smallPadding,
     state.size === 'medium' && styles.mediumPadding,

--- a/packages/react-popover/src/components/PopoverTrigger/PopoverTrigger.test.tsx
+++ b/packages/react-popover/src/components/PopoverTrigger/PopoverTrigger.test.tsx
@@ -18,6 +18,7 @@ describe('PopoverTrigger', () => {
       'component-handles-ref',
       'component-has-root-ref',
       'component-handles-classname',
+      'component-has-static-classname',
       // PopoverTrigger does not have own styles
       'make-styles-overrides-win',
     ],


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Related to #19937
- [x] Include a change request file using `$ yarn change`

#### Description of changes

✅ _Extracted from #20383, these changes passed conformance test on that PR_

This PR adds static classes to components `@fluentui/react-menu` & `@fluentui/react-popover`.

- All classes follow `fui-ComponentName`
- All classes are publicly exported as `componentNameClassName`
- Snapshots were updated

Classes that are added to DOM are "chained" if they are composed: