### PR TITLE
feat(avatar, badge): add static classes

### DIFF
--- a/change/@fluentui-react-avatar-d04ec1d2-24ed-4000-b6c3-8a24808f0777.json
+++ b/change/@fluentui-react-avatar-d04ec1d2-24ed-4000-b6c3-8a24808f0777.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "export static classes for components",
+  "packageName": "@fluentui/react-avatar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-05f4fecb-a61c-47a3-9214-64f2056a2200.json
+++ b/change/@fluentui-react-badge-05f4fecb-a61c-47a3-9214-64f2056a2200.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "export static classes for components",
+  "packageName": "@fluentui/react-badge",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-avatar/etc/react-avatar.api.md
@@ -17,6 +17,9 @@ import type { ShorthandRenderFunction } from '@fluentui/react-utilities';
 export const Avatar: ForwardRefComponent<AvatarProps>;
 
 // @public (undocumented)
+export const avatarClassName = "fui-Avatar";
+
+// @public (undocumented)
 export type AvatarCommons = Omit<React_2.HTMLAttributes<HTMLElement>, 'children'> & {
     name: string;
     getInitials: (name: string, isRtl: boolean) => string;

--- a/packages/react-avatar/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/react-avatar/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Avatar displays a badge 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
   name="First Last"
 >
   <span
@@ -12,7 +12,7 @@ exports[`Avatar displays a badge 1`] = `
   </span>
   <div
     aria-hidden={true}
-    className=""
+    className="fui-Badge fui-PresenceBadge"
   >
     <span
       className=""
@@ -39,7 +39,7 @@ exports[`Avatar displays a badge 1`] = `
 
 exports[`Avatar displays custom initials via getInitials 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
   name="First Last"
 >
   <span
@@ -52,7 +52,7 @@ exports[`Avatar displays custom initials via getInitials 1`] = `
 
 exports[`Avatar handles customSize 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
   name="First Last"
   style={
     Object {
@@ -71,7 +71,7 @@ exports[`Avatar handles customSize 1`] = `
 
 exports[`Avatar prioritizes image over icon 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
 >
   <span
     className=""
@@ -89,7 +89,7 @@ exports[`Avatar prioritizes image over icon 1`] = `
 
 exports[`Avatar prioritizes image over initials 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
   name="First Last"
 >
   <span
@@ -106,7 +106,7 @@ exports[`Avatar prioritizes image over initials 1`] = `
 
 exports[`Avatar prioritizes image over initials and icon 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
   name="First Last"
 >
   <span
@@ -123,7 +123,7 @@ exports[`Avatar prioritizes image over initials and icon 1`] = `
 
 exports[`Avatar prioritizes initials over icon 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
   name="First Last"
 >
   <span
@@ -136,7 +136,7 @@ exports[`Avatar prioritizes initials over icon 1`] = `
 
 exports[`Avatar renders 1 initial with a 1-word name 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
   name="First"
 >
   <span
@@ -149,7 +149,7 @@ exports[`Avatar renders 1 initial with a 1-word name 1`] = `
 
 exports[`Avatar renders 2 initials with a 2-word name 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
   name="First Last"
 >
   <span
@@ -162,7 +162,7 @@ exports[`Avatar renders 2 initials with a 2-word name 1`] = `
 
 exports[`Avatar renders 2 initials with a 3-word name 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
   name="First M. Last"
 >
   <span
@@ -175,7 +175,7 @@ exports[`Avatar renders 2 initials with a 3-word name 1`] = `
 
 exports[`Avatar renders a default state 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
 >
   <span
     className=""
@@ -206,7 +206,7 @@ exports[`Avatar renders a default state 1`] = `
 
 exports[`Avatar renders an icon 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
 >
   <span
     className=""
@@ -220,7 +220,7 @@ exports[`Avatar renders an icon 1`] = `
 
 exports[`Avatar renders an icon if the name is not alphabetic 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
   name="(111)-555-1234"
 >
   <span
@@ -252,7 +252,7 @@ exports[`Avatar renders an icon if the name is not alphabetic 1`] = `
 
 exports[`Avatar renders an image 1`] = `
 <span
-  className=""
+  className="fui-Avatar"
 >
   <span
     className=""

--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -1,6 +1,8 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import type { AvatarState } from './Avatar.types';
 
+export const avatarClassName = 'fui-Avatar';
+
 //
 // TODO: All animation constants should go to theme or globals?
 // https://github.com/microsoft/fluentui/issues/16372#issuecomment-778240665
@@ -415,7 +417,7 @@ export const useAvatarStyles = (state: AvatarState): AvatarState => {
     }
   }
 
-  state.root.className = mergeClasses(...rootClasses, state.root.className);
+  state.root.className = mergeClasses(avatarClassName, ...rootClasses, state.root.className);
 
   if (state.badge) {
     state.badge.className = mergeClasses(styles.badge, size >= 64 && styles.badgeLarge, state.badge.className);

--- a/packages/react-badge/etc/react-badge.api.md
+++ b/packages/react-badge/etc/react-badge.api.md
@@ -14,6 +14,9 @@ import * as React_2 from 'react';
 export const Badge: ForwardRefComponent<BadgeProps>;
 
 // @public (undocumented)
+export const badgeClassName = "fui-Badge";
+
+// @public (undocumented)
 export type BadgeCommons = {
     appearance: 'filled' | 'ghost' | 'outline' | 'tint';
     color: 'brand' | 'danger' | 'important' | 'informative' | 'severe' | 'subtle' | 'success' | 'warning';
@@ -38,6 +41,9 @@ export type BadgeState = ComponentState<BadgeSlots> & BadgeCommons;
 export const CounterBadge: ForwardRefComponent<CounterBadgeProps>;
 
 // @public (undocumented)
+export const counterBadgeClassName = "fui-CounterBadge";
+
+// @public (undocumented)
 export type CounterBadgeCommons = {
     overflowCount: number;
     count: number;
@@ -55,6 +61,9 @@ export type CounterBadgeState = Omit<BadgeState, 'appearance' | 'shape'> & Count
 
 // @public
 export const PresenceBadge: ForwardRefComponent<PresenceBadgeProps>;
+
+// @public (undocumented)
+export const presenceBadgeClassName = "fui-PresenceBadge";
 
 // @public (undocumented)
 export interface PresenceBadgeCommons {

--- a/packages/react-badge/src/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/packages/react-badge/src/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Badge renders a default state 1`] = `
 <div
   aria-hidden={true}
-  className=""
+  className="fui-Badge"
 >
   Default Badge
 </div>

--- a/packages/react-badge/src/components/Badge/useBadgeStyles.ts
+++ b/packages/react-badge/src/components/Badge/useBadgeStyles.ts
@@ -1,6 +1,8 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import type { BadgeState } from './Badge.types';
 
+export const badgeClassName = 'fui-Badge';
+
 const useStyles = makeStyles({
   root: theme => ({
     display: 'inline-flex',
@@ -223,6 +225,7 @@ export const useBadgeStyles = (state: BadgeState): BadgeState => {
   const isSubtle = state.color === 'subtle';
 
   state.root.className = mergeClasses(
+    badgeClassName,
     styles.root,
     state.size === 'tiny' && styles.rootTiny,
     state.size === 'extra-small' && styles.rootExtraSmall,

--- a/packages/react-badge/src/components/CounterBadge/__snapshots__/CounterBadge.test.tsx.snap
+++ b/packages/react-badge/src/components/CounterBadge/__snapshots__/CounterBadge.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CounterBadge renders a default state 1`] = `
 <div
   aria-hidden={true}
-  className=""
+  className="fui-Badge fui-CounterBadge"
 >
   0
 </div>

--- a/packages/react-badge/src/components/CounterBadge/useCounterBadgeStyles.ts
+++ b/packages/react-badge/src/components/CounterBadge/useCounterBadgeStyles.ts
@@ -2,6 +2,8 @@ import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import { useBadgeStyles } from '../Badge/useBadgeStyles';
 import type { CounterBadgeState } from './CounterBadge.types';
 
+export const counterBadgeClassName = 'fui-CounterBadge';
+
 const useStyles = makeStyles({
   root: {
     minWidth: 'auto',
@@ -40,6 +42,7 @@ const useStyles = makeStyles({
 export const useCounterBadgeStyles = (state: CounterBadgeState): CounterBadgeState => {
   const styles = useStyles();
   state.root.className = mergeClasses(
+    counterBadgeClassName,
     styles.root,
     state.color === 'warning' && styles.warning,
     state.color === 'important' && styles.important,

--- a/packages/react-badge/src/components/PresenceBadge/__snapshots__/PresenceBadge.test.tsx.snap
+++ b/packages/react-badge/src/components/PresenceBadge/__snapshots__/PresenceBadge.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PresenceBadge renders a default state 1`] = `
 <div
   aria-hidden={true}
-  className=""
+  className="fui-Badge fui-PresenceBadge"
 >
   <span
     className=""

--- a/packages/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
+++ b/packages/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
@@ -2,6 +2,8 @@ import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import { useBadgeStyles } from '../../Badge';
 import type { PresenceBadgeState } from './PresenceBadge.types';
 
+export const presenceBadgeClassName = 'fui-PresenceBadge';
+
 const useStyles = makeStyles({
   root: theme => ({
     padding: 0,
@@ -52,6 +54,7 @@ const useStyles = makeStyles({
 export const usePresenceBadgeStyles = (state: PresenceBadgeState): PresenceBadgeState => {
   const styles = useStyles();
   state.root.className = mergeClasses(
+    presenceBadgeClassName,
     styles.root,
     (state.status === 'busy' || state.status === 'doNotDisturb') && styles.statusBusy,
     state.status === 'away' && styles.statusAway,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Related to #19937
- [x] Include a change request file using `$ yarn change`

#### Description of changes

✅ _Extracted from #20383, these changes passed conformance test on that PR_ 

This PR adds static classes to components `@fluentui/react-avatar` & `@fluentui/react-badge`.

- All classes follow `fui-ComponentName`
- All classes are publicly exported as `componentNameClassName`
- Snapshots were updated