### PR TITLE
Cherry-pick fix v8 to v7: fix(DetailsList): add accessible name to group header checkboxes 

### DIFF
--- a/change/@fluentui-react-examples-c619834f-5e4a-4f24-ba5c-dd2c9d16d866.json
+++ b/change/@fluentui-react-examples-c619834f-5e4a-4f24-ba5c-dd2c9d16d866.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "cherry-pick fix(DetailsList): add accessible name to group header checkboxes",
-  "packageName": "@fluentui/react-examples",
-  "email": "imoreira@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-examples-c619834f-5e4a-4f24-ba5c-dd2c9d16d866.json
+++ b/change/@fluentui-react-examples-c619834f-5e4a-4f24-ba5c-dd2c9d16d866.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "cherry-pick fix(DetailsList): add accessible name to group header checkboxes",
+  "packageName": "@fluentui/react-examples",
+  "email": "imoreira@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/office-ui-fabric-react-eedaad9c-e940-42c8-a076-3b80ff71568a.json
+++ b/change/office-ui-fabric-react-eedaad9c-e940-42c8-a076-3b80ff71568a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "cherry-pick fix(DetailsList): add accessible name to group header checkboxes",
+  "packageName": "office-ui-fabric-react",
+  "email": "imoreira@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3789,6 +3789,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
     checkboxCellClassName?: string;
     checkboxVisibility?: CheckboxVisibility;
     checkButtonAriaLabel?: string;
+    checkButtonGroupAriaLabel?: string;
     className?: string;
     columnReorderOptions?: IColumnReorderOptions;
     columns?: IColumn[];

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -171,6 +171,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
     getRowAriaLabel,
     getRowAriaDescribedBy,
     checkButtonAriaLabel,
+    checkButtonGroupAriaLabel,
     checkboxCellClassName,
     useReducedRowRenderer,
     enableUpdateAnimations,
@@ -412,8 +413,14 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
       role: role === defaultRole ? 'rowgroup' : 'presentation',
       onRenderFooter: finalOnRenderDetailsGroupFooter,
       onRenderHeader: finalOnRenderDetailsGroupHeader,
+      // pass through custom group header checkbox label
+      headerProps: {
+        selectAllButtonProps: {
+          'aria-label': checkButtonGroupAriaLabel,
+        },
+      },
     };
-  }, [groupProps, finalOnRenderDetailsGroupFooter, finalOnRenderDetailsGroupHeader, role]);
+  }, [groupProps, finalOnRenderDetailsGroupFooter, finalOnRenderDetailsGroupHeader, checkButtonGroupAriaLabel, role]);
 
   const sumColumnWidths = useConst(() =>
     memoizeFunction((columns: IColumn[]) => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -958,4 +958,35 @@ describe('DetailsList', () => {
 
     expect(checkboxId).toEqual(detailsRowCheckSource[`aria-labelledby`].split(' ')[0]);
   });
+
+  it('names group header checkboxes based on checkButtonGroupAriaLabel', () => {
+    const container = document.createElement('div');
+    ReactDOM.render(
+      <DetailsList
+        items={mockData(5)}
+        groups={[
+          {
+            key: 'group0',
+            name: 'Group 0',
+            startIndex: 0,
+            count: 2,
+          },
+          {
+            key: 'group1',
+            name: 'Group 1',
+            startIndex: 2,
+            count: 3,
+          },
+        ]}
+        checkButtonGroupAriaLabel="select section"
+      />,
+      container,
+    );
+
+    const checkbox = container.querySelector('[role="checkbox"][aria-label="select section"]') as HTMLElement;
+    expect(checkbox).not.toBeNull();
+
+    const groupNameId = checkbox.getAttribute('aria-labelledby')?.split(' ')[1];
+    expect(container.querySelector(`#${groupNameId} span`)!.textContent).toEqual('Group 0');
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -250,8 +250,11 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   /** Accessible label describing or summarizing the list. */
   ariaLabel?: string;
 
-  /** Accessible label for the check button. */
+  /** Accessible label for the row check button, e.g. "select row" */
   checkButtonAriaLabel?: string;
+
+  /** Accessible label for the group header check button, e.g. "select section". */
+  checkButtonGroupAriaLabel?: string;
 
   /** Accessible label for the grid within the list. */
   ariaLabelForGrid?: string;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -136,7 +136,9 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
                 type="button"
                 className={this._classNames.check}
                 role="checkbox"
+                id={`${this._id}-check`}
                 aria-checked={currentlySelected}
+                aria-labelledby={`${this._id}-check ${this._id}`}
                 data-selection-toggle={true}
                 onClick={this._onToggleSelectGroupClick}
                 {...selectAllButtonProps}

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Grouped.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Grouped.Example.tsx
@@ -107,6 +107,7 @@ export class DetailsListGroupedExample extends React.Component<{}, IDetailsListG
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           ariaLabelForSelectionColumn="Toggle selection"
           checkButtonAriaLabel="select row"
+          checkButtonGroupAriaLabel="select section"
           onRenderDetailsHeader={this._onRenderDetailsHeader}
           groupProps={{
             showEmptyGroups: true,

--- a/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Grouped.Large.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/DetailsList/DetailsList.Grouped.Large.Example.tsx
@@ -56,6 +56,7 @@ export class DetailsListGroupedLargeExample extends React.Component<{}, {}> {
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
         ariaLabelForSelectionColumn="Toggle selection"
         checkButtonAriaLabel="select row"
+        checkButtonGroupAriaLabel="select section"
         onRenderDetailsHeader={this._onRenderDetailsHeader}
       />
     );

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1309,6 +1309,8 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                             >
                               <button
                                 aria-checked={false}
+                                aria-label="select section"
+                                aria-labelledby="GroupHeader10-check GroupHeader10"
                                 className=
                                     ms-GroupHeader-check
                                     {
@@ -1349,6 +1351,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     }
                                 data-is-focusable={false}
                                 data-selection-toggle={true}
+                                id="GroupHeader10-check"
                                 onClick={[Function]}
                                 role="checkbox"
                                 type="button"
@@ -2703,6 +2706,8 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                             >
                               <button
                                 aria-checked={false}
+                                aria-label="select section"
+                                aria-labelledby="GroupHeader12-check GroupHeader12"
                                 className=
                                     ms-GroupHeader-check
                                     {
@@ -2743,6 +2748,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     }
                                 data-is-focusable={false}
                                 data-selection-toggle={true}
+                                id="GroupHeader12-check"
                                 onClick={[Function]}
                                 role="checkbox"
                                 type="button"
@@ -3123,6 +3129,8 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                             >
                               <button
                                 aria-checked={false}
+                                aria-label="select section"
+                                aria-labelledby="GroupHeader14-check GroupHeader14"
                                 className=
                                     ms-GroupHeader-check
                                     {
@@ -3163,6 +3171,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     }
                                 data-is-focusable={false}
                                 data-selection-toggle={true}
+                                id="GroupHeader14-check"
                                 onClick={[Function]}
                                 role="checkbox"
                                 type="button"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -966,6 +966,8 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                           >
                             <button
                               aria-checked={false}
+                              aria-label="select section"
+                              aria-labelledby="GroupHeader5-check GroupHeader5"
                               className=
                                   ms-GroupHeader-check
                                   {
@@ -1006,6 +1008,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   }
                               data-is-focusable={false}
                               data-selection-toggle={true}
+                              id="GroupHeader5-check"
                               onClick={[Function]}
                               role="checkbox"
                               type="button"

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -153,6 +153,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                       >
                         <button
                           aria-checked={false}
+                          aria-labelledby="GroupHeader3-check GroupHeader3"
                           className=
                               ms-GroupHeader-check
                               {
@@ -193,6 +194,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               }
                           data-is-focusable={false}
                           data-selection-toggle={true}
+                          id="GroupHeader3-check"
                           onClick={[Function]}
                           role="checkbox"
                           type="button"
@@ -2139,6 +2141,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                       >
                         <button
                           aria-checked={false}
+                          aria-labelledby="GroupHeader6-check GroupHeader6"
                           className=
                               ms-GroupHeader-check
                               {
@@ -2179,6 +2182,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               }
                           data-is-focusable={false}
                           data-selection-toggle={true}
+                          id="GroupHeader6-check"
                           onClick={[Function]}
                           role="checkbox"
                           type="button"
@@ -4125,6 +4129,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                       >
                         <button
                           aria-checked={false}
+                          aria-labelledby="GroupHeader9-check GroupHeader9"
                           className=
                               ms-GroupHeader-check
                               {
@@ -4165,6 +4170,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               }
                           data-is-focusable={false}
                           data-selection-toggle={true}
+                          id="GroupHeader9-check"
                           onClick={[Function]}
                           role="checkbox"
                           type="button"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Cherry-pick bug fix from v8 to v7: [fix(DetailsList): add accessible name to group header checkboxes](https://github.com/microsoft/fluentui/pull/17979)
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Cherry-pick bug fix from v8 to v7: [fix(DetailsList): add accessible name to group header checkboxes](https://github.com/microsoft/fluentui/pull/17979)

Ran:
- “yarn buildto *examples”
- “yarn update-snapshots”
- “yarn change”

#### Focus areas to test
N/A

cc: @smhigley 
