### PR TITLE
Panel: fix isFooterAtBottom bug where unnecessary scrollbar is present

### DIFF
--- a/change/@fluentui-react-3dda684b-13d5-4e3d-b808-93a50341503a.json
+++ b/change/@fluentui-react-3dda684b-13d5-4e3d-b808-93a50341503a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Panel: fix isFooterAtBottom bug where unnecessary scrollbar is present.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Panel/Panel.base.tsx
+++ b/packages/react/src/components/Panel/Panel.base.tsx
@@ -24,6 +24,7 @@ import { PanelType } from './Panel.types';
 import { ScreenWidthMinMedium } from '../../Styling';
 import type { IProcessedStyleSet } from '../../Styling';
 import type { IPanel, IPanelProps, IPanelStyleProps, IPanelStyles } from './Panel.types';
+import G = require('glob');
 
 const getClassNames = classNamesFunction<IPanelStyleProps, IPanelStyles>();
 const COMPONENT_NAME = 'Panel';
@@ -190,6 +191,11 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
       return null;
     }
 
+    const doc = getDocument();
+    // const docHeight = doc!.documentElement.scrollHeight
+    const documentHeight = doc!.getElementsByClassName('ms-Panel-content')[0]?.scrollHeight;
+
+    console.log('document height ', documentHeight);
     this._classNames = getClassNames(styles!, {
       theme: theme!,
       className,
@@ -204,6 +210,7 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
       isHiddenOnDismiss,
       type,
       hasCustomNavigation: this._hasCustomNavigation,
+      documentHeight: documentHeight ?? 10,
     });
 
     const { _classNames, _allowTouchBodyScroll } = this;
@@ -220,8 +227,6 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
         />
       );
     }
-
-    const documentHeight = getDocument()!.documentElement.scrollHeight;
 
     return (
       <Layer {...layerProps}>
@@ -253,9 +258,8 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
                   {(this._hasCustomNavigation || !hasCloseButton) &&
                     onRenderHeader(this.props, this._onRenderHeader, this._headerTextId)}
                   {onRenderBody(this.props, this._onRenderBody)}
-                  {documentHeight < ScreenWidthMinMedium && onRenderFooter(this.props, this._onRenderFooter)}
+                  {onRenderFooter(this.props, this._onRenderFooter)}
                 </div>
-                {documentHeight >= ScreenWidthMinMedium && onRenderFooter(this.props, this._onRenderFooter)}
               </div>
             </FocusTrapZone>
           </div>

--- a/packages/react/src/components/Panel/Panel.base.tsx
+++ b/packages/react/src/components/Panel/Panel.base.tsx
@@ -17,14 +17,11 @@ import {
   Async,
   EventGroup,
   initializeComponentRef,
-  getDocument,
 } from '../../Utilities';
 import { FocusTrapZone } from '../FocusTrapZone/index';
 import { PanelType } from './Panel.types';
-import { ScreenWidthMinMedium } from '../../Styling';
 import type { IProcessedStyleSet } from '../../Styling';
 import type { IPanel, IPanelProps, IPanelStyleProps, IPanelStyles } from './Panel.types';
-import G = require('glob');
 
 const getClassNames = classNamesFunction<IPanelStyleProps, IPanelStyles>();
 const COMPONENT_NAME = 'Panel';
@@ -191,11 +188,6 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
       return null;
     }
 
-    const doc = getDocument();
-    // const docHeight = doc!.documentElement.scrollHeight
-    const documentHeight = doc!.getElementsByClassName('ms-Panel-content')[0]?.scrollHeight;
-
-    console.log('document height ', documentHeight);
     this._classNames = getClassNames(styles!, {
       theme: theme!,
       className,
@@ -210,7 +202,6 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
       isHiddenOnDismiss,
       type,
       hasCustomNavigation: this._hasCustomNavigation,
-      documentHeight: documentHeight ?? 10,
     });
 
     const { _classNames, _allowTouchBodyScroll } = this;

--- a/packages/react/src/components/Panel/Panel.base.tsx
+++ b/packages/react/src/components/Panel/Panel.base.tsx
@@ -17,9 +17,11 @@ import {
   Async,
   EventGroup,
   initializeComponentRef,
+  getDocument,
 } from '../../Utilities';
 import { FocusTrapZone } from '../FocusTrapZone/index';
 import { PanelType } from './Panel.types';
+import { ScreenWidthMinMedium } from '../../Styling';
 import type { IProcessedStyleSet } from '../../Styling';
 import type { IPanel, IPanelProps, IPanelStyleProps, IPanelStyles } from './Panel.types';
 
@@ -219,6 +221,8 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
       );
     }
 
+    const documentHeight = getDocument()!.documentElement.scrollHeight;
+
     return (
       <Layer {...layerProps}>
         <Popup
@@ -249,8 +253,9 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
                   {(this._hasCustomNavigation || !hasCloseButton) &&
                     onRenderHeader(this.props, this._onRenderHeader, this._headerTextId)}
                   {onRenderBody(this.props, this._onRenderBody)}
-                  {onRenderFooter(this.props, this._onRenderFooter)}
+                  {documentHeight < ScreenWidthMinMedium && onRenderFooter(this.props, this._onRenderFooter)}
                 </div>
+                {documentHeight >= ScreenWidthMinMedium && onRenderFooter(this.props, this._onRenderFooter)}
               </div>
             </FocusTrapZone>
           </div>

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -353,6 +353,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         selectors: {
           [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
             position: 'sticky',
+            bottom: 0,
           },
         },
       },

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -170,10 +170,13 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     hasCustomNavigation,
     theme,
     type = PanelType.smallFixedFar,
+    documentHeight,
   } = props;
   const { effects, fonts, semanticColors } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
   const isCustomPanel = type === PanelType.custom || type === PanelType.customNear;
+
+  console.log('document height', documentHeight);
 
   return {
     root: [
@@ -344,7 +347,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         selectors: {
           [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
             position: 'sticky',
-            bottom: 0,
+            top: '100%',
           },
         },
       },

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -325,6 +325,8 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       },
       isFooterAtBottom && {
         flexGrow: 1,
+        display: 'inherit',
+        flexDirection: 'inherit',
       },
     ],
     content: [
@@ -332,6 +334,13 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       sharedPaddingStyles,
       {
         paddingBottom: 20,
+      },
+      isFooterAtBottom && {
+        selectors: {
+          [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
+            flexGrow: 1,
+          },
+        },
       },
     ],
     footer: [
@@ -344,7 +353,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         selectors: {
           [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
             position: 'sticky',
-            top: '100%',
           },
         },
       },

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -170,13 +170,10 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     hasCustomNavigation,
     theme,
     type = PanelType.smallFixedFar,
-    documentHeight,
   } = props;
   const { effects, fonts, semanticColors } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
   const isCustomPanel = type === PanelType.custom || type === PanelType.customNear;
-
-  console.log('document height', documentHeight);
 
   return {
     root: [

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -258,7 +258,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     commands: [
       classNames.commands,
       {
-        paddingTop: 18,
+        marginTop: 18,
         selectors: {
           [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
             backgroundColor: semanticColors.bodyBackground,
@@ -332,13 +332,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       sharedPaddingStyles,
       {
         paddingBottom: 20,
-      },
-      isFooterAtBottom && {
-        selectors: {
-          [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
-            minHeight: '100%',
-          },
-        },
       },
     ],
     footer: [

--- a/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -185,7 +185,7 @@ exports[`Panel allows the consumer to pass through popup props 1`] = `
                 className=
                     ms-Panel-commands
                     {
-                      padding-top: 18px;
+                      margin-top: 18px;
                     }
                     @media (min-height: 480px){& {
                       background-color: #ffffff;
@@ -585,7 +585,7 @@ exports[`Panel renders Panel correctly 1`] = `
                 className=
                     ms-Panel-commands
                     {
-                      padding-top: 18px;
+                      margin-top: 18px;
                     }
                     @media (min-height: 480px){& {
                       background-color: #ffffff;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20416
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Removes styling that manually added height to `content` (added by #20136) to keep footer at the bottom of scrollable div but in turn caused the unnecessary scrollbar from occurring. Added `flex` property to scrollable class instead when `isFooterAtBottom` is passed and added `flexGrow` property to `content` to take up the rest of the space in the scrollable container thus pushing the `footer` to the bottom.
- restores `marginTop` attribute that was replaced by #19547.

#### When all `content` fit in viewport:

![image](https://user-images.githubusercontent.com/8649804/140383293-20bd2101-e4de-4647-8834-c867ec342fed.png)


#### When `content` overflows and requires scroll:
![Panel Scroll Footer (2)](https://user-images.githubusercontent.com/8649804/140790550-930a91d7-56de-4ae0-8bae-52bf43ea7c22.gif)

