### PR TITLE
Suggestions: Fixing issue where you couldn't select focused option after hitting 'get more results' button

### DIFF
--- a/change/@fluentui-react-ccae6604-374f-4fe3-b190-e04874862944.json
+++ b/change/@fluentui-react-ccae6604-374f-4fe3-b190-e04874862944.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Suggestions: Fixing issue where you couldn't select focused option after hitting 'get more results' button.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -221,7 +221,6 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
     let isEventHandled = false;
     let newSelectedActionType = null;
     const currentSelectedAction = this.state.selectedActionType;
-    console.log(currentSelectedAction);
     const suggestionLength = this.props.suggestions.length;
     if (keyCode === KeyCodes.down) {
       switch (currentSelectedAction) {

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -221,6 +221,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
     let isEventHandled = false;
     let newSelectedActionType = null;
     const currentSelectedAction = this.state.selectedActionType;
+    console.log(currentSelectedAction);
     const suggestionLength = this.props.suggestions.length;
     if (keyCode === KeyCodes.down) {
       switch (currentSelectedAction) {
@@ -437,6 +438,9 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
   private _getMoreResults = (): void => {
     if (this.props.onGetMoreResults) {
       this.props.onGetMoreResults();
+
+      // Reset selected action type as it will be of type SuggestionActionType.none after more results are gotten
+      this.setState({ selectedActionType: SuggestionActionType.none });
     }
   };
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12968](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12968)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue with `Suggestions` where after hitting the `load more results` button and the focus going back to the first item of those results you couldn't select it via pressing Enter on the keyboard. This was happening because the state was keeping an outdated value which needed clearing so the `keyDown` handling worked correctly.

This can be most easily tested in the `PeoplePicker with limited search` example

__Before: Had to up or down arrow to be able to select an element__
![PeoplePickerBefore](https://user-images.githubusercontent.com/7798177/140240239-f00a4824-d8e8-48a9-9548-012365fb760e.gif)

__After: Works as you would expect__
![PeoplePickerAfter](https://user-images.githubusercontent.com/7798177/140240322-29f8e8c4-8b88-47c9-b38c-2696fd6fcf1a.gif)