### PR TITLE
DetailsList: Making the disabled prop in IDetailsRowStyleProps optional as making it required is a breaking change

### DIFF
--- a/change/office-ui-fabric-react-e76ffbcf-1bf9-484f-8854-4138856297d3.json
+++ b/change/office-ui-fabric-react-e76ffbcf-1bf9-484f-8854-4138856297d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "DetailsList: Making the disabled prop in IDetailsRowStyleProps optional as making it required is a breaking change.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4009,7 +4009,7 @@ export interface IDetailsRowState {
 }
 
 // @public (undocumented)
-export type IDetailsRowStyleProps = Required<Pick<IDetailsRowProps, 'theme' | 'disabled'>> & {
+export type IDetailsRowStyleProps = Required<Pick<IDetailsRowProps, 'theme'>> & Pick<IDetailsRowProps, 'disabled'> & {
     isSelected?: boolean;
     anySelected?: boolean;
     canSelect?: boolean;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -239,39 +239,40 @@ export interface IDetailsRowProps extends IDetailsRowBaseProps {
 /**
  * {@docCategory DetailsList}
  */
-export type IDetailsRowStyleProps = Required<Pick<IDetailsRowProps, 'theme' | 'disabled'>> & {
-  /** Whether the row is selected  */
-  isSelected?: boolean;
+export type IDetailsRowStyleProps = Required<Pick<IDetailsRowProps, 'theme'>> &
+  Pick<IDetailsRowProps, 'disabled'> & {
+    /** Whether the row is selected  */
+    isSelected?: boolean;
 
-  /** Whether there are any rows in the list selected */
-  anySelected?: boolean;
+    /** Whether there are any rows in the list selected */
+    anySelected?: boolean;
 
-  /** Whether this row can be selected */
-  canSelect?: boolean;
+    /** Whether this row can be selected */
+    canSelect?: boolean;
 
-  /** Class name of when this becomes a drop target. */
-  droppingClassName?: string;
+    /** Class name of when this becomes a drop target. */
+    droppingClassName?: string;
 
-  /** Is the checkbox visible */
-  isCheckVisible?: boolean;
+    /** Is the checkbox visible */
+    isCheckVisible?: boolean;
 
-  /** Is this a row header */
-  isRowHeader?: boolean;
+    /** Is this a row header */
+    isRowHeader?: boolean;
 
-  /** A class name from the checkbox cell, so proper styling can be targeted */
-  checkboxCellClassName?: string;
+    /** A class name from the checkbox cell, so proper styling can be targeted */
+    checkboxCellClassName?: string;
 
-  /** CSS class name for the component */
-  className?: string;
+    /** CSS class name for the component */
+    className?: string;
 
-  /** Is list in compact mode */
-  compact?: boolean;
+    /** Is list in compact mode */
+    compact?: boolean;
 
-  cellStyleProps?: ICellStyleProps;
+    cellStyleProps?: ICellStyleProps;
 
-  /** Whether to animate updates */
-  enableUpdateAnimations?: boolean;
-};
+    /** Whether to animate updates */
+    enableUpdateAnimations?: boolean;
+  };
 
 /**
  * {@docCategory DetailsList}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20485
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_Port of #20488. Original description follows:_

This PR makes the `disabled` prop in `IDetailsRowStyleProps` optional as it was introduced as an unintended breaking change by making it required.
