### PR TITLE
fix(Popover): use `dialog` as value for `aria-haspopup` for focus trap

### DIFF
--- a/change/@fluentui-react-popover-c7cc5d31-12ed-4abf-99d5-6ae5dfc0a045.json
+++ b/change/@fluentui-react-popover-c7cc5d31-12ed-4abf-99d5-6ae5dfc0a045.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(Popover): use `dialog` as value for `aria-haspopup` for focus trap",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-popover/e2e/Popover.e2e.ts
+++ b/packages/react-popover/e2e/Popover.e2e.ts
@@ -1,4 +1,4 @@
-const popoverTriggerSelector = '[aria-haspopup="true"]';
+const popoverTriggerSelector = '[aria-haspopup]';
 const popoverContentSelector = '[role="dialog"]';
 const popoverStoriesTitle = 'Components/Popover';
 

--- a/packages/react-popover/src/components/PopoverTrigger/PopoverTrigger.test.tsx
+++ b/packages/react-popover/src/components/PopoverTrigger/PopoverTrigger.test.tsx
@@ -139,4 +139,17 @@ describe('PopoverTrigger', () => {
       ]
     `);
   });
+
+  it('should use aria-haspopup="dialog" if focus trapped', () => {
+    // Arrange
+    mockPopoverContext({ trapFocus: true });
+    const { getByRole } = render(
+      <PopoverTrigger>
+        <button>Trigger</button>
+      </PopoverTrigger>,
+    );
+
+    // Assert
+    expect(getByRole('button').getAttribute('aria-haspopup')).toEqual('dialog');
+  });
 });

--- a/packages/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
+++ b/packages/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
@@ -18,6 +18,7 @@ export const usePopoverTrigger = (props: PopoverTriggerProps): PopoverTriggerSta
   const triggerRef = usePopoverContext(context => context.triggerRef);
   const openOnHover = usePopoverContext(context => context.openOnHover);
   const openOnContext = usePopoverContext(context => context.openOnContext);
+  const trapFocus = usePopoverContext(context => context.trapFocus);
   const { triggerAttributes } = useModalAttributes();
 
   const onContextMenu = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
@@ -67,7 +68,7 @@ export const usePopoverTrigger = (props: PopoverTriggerProps): PopoverTriggerSta
   return {
     children: React.cloneElement(child, {
       ...triggerAttributes,
-      'aria-haspopup': 'true',
+      'aria-haspopup': trapFocus ? 'dialog' : 'true',
       ...child.props,
       onClick,
       onMouseEnter,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When `Popover` is being used with a focus trap the `PopoverSurface` uses
`role="dialog"` which should match the value of `aria-haspopup` in the
trigger element

#### Focus areas to test

(optional)
