### PR TITLE
fix(positioning): handle case when directionalHintFixed and alignTargetEdge are true

### DIFF
--- a/change/@fluentui-react-8db5511b-b2a0-4d51-b419-2663c209a273.json
+++ b/change/@fluentui-react-8db5511b-b2a0-4d51-b419-2663c209a273.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix uncaught positioning logic when both directionalHintFixed and alignTargetEdge are true",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/utilities/positioning/positioning.test.ts
+++ b/packages/react/src/utilities/positioning/positioning.test.ts
@@ -158,6 +158,34 @@ describe('Callout Positioning', () => {
     validateNoBeakTest(basicTestCase, DirectionalHint.topRightEdge, validateTopRight);
   });
 
+  it('Correctly positions the callout when out of bounds and directionalHintFixed is true', () => {
+    const basicTestCase: ITestValues = {
+      callout: new Rectangle(0, 200, 0, 200),
+      target: new Rectangle(150, 160, 150, 160),
+      bounds: new Rectangle(8, 300, 8, 300),
+      beakWidth: 0,
+    };
+
+    // should align at the bottom, even if it doesn't fit
+    // the alignment edge (left) can adjust, but not the bottom position
+    const validateBottomLeft: ITestValidation = {
+      callout: new Rectangle(100, 300, 160, 300),
+      beak: null,
+    };
+
+    // manually call _positionElementWithinBounds to pass in directionalHintFixed value
+    const result: IElementPosition = __positioningTestPackage._positionElementWithinBounds(
+      basicTestCase.callout,
+      basicTestCase.target,
+      basicTestCase.bounds,
+      __positioningTestPackage._getPositionData(DirectionalHint.bottomLeftEdge),
+      basicTestCase.beakWidth,
+      true, // directionalHintFixed value
+    );
+
+    expect(result.elementRectangle).toEqual(validateBottomLeft.callout);
+  });
+
   it('Correctly determines max height', () => {
     const getMaxHeight = __positioningTestPackage._getMaxHeightFromTargetRectangle;
 

--- a/packages/react/src/utilities/positioning/positioning.ts
+++ b/packages/react/src/utilities/positioning/positioning.ts
@@ -339,6 +339,9 @@ function _adjustFitWithinBounds(
     elementEstimate = _flipToFit(element, target, bounding, positionData, gap);
   }
   const outOfBounds = _getOutOfBoundsEdges(elementEstimate.elementRectangle, bounding);
+  // if directionalHintFixed is specified, we need to force the target edge to not change
+  // we need *-1 because targetEdge refers to the target's edge; the callout edge is the opposite
+  const fixedEdge = directionalHintFixed ? elementEstimate.targetEdge * -1 : undefined;
 
   if (outOfBounds.length > 0) {
     if (alignTargetEdge) {
@@ -354,11 +357,14 @@ function _adjustFitWithinBounds(
             _getOutOfBoundsEdges(flippedElementEstimate.elementRectangle, bounding),
             elementEstimate,
             bounding,
+            fixedEdge,
           );
         }
+      } else {
+        elementEstimate = _alignOutOfBoundsEdges(outOfBounds, elementEstimate, bounding, fixedEdge);
       }
     } else {
-      elementEstimate = _alignOutOfBoundsEdges(outOfBounds, elementEstimate, bounding);
+      elementEstimate = _alignOutOfBoundsEdges(outOfBounds, elementEstimate, bounding, fixedEdge);
     }
   }
 
@@ -370,19 +376,30 @@ function _adjustFitWithinBounds(
  * @param outOfBoundsEdges - Array of edges that are out of bounds
  * @param elementEstimate - The current element positioning estimate
  * @param bounding - The current bounds
+ * @param preserveEdge - Specify an edge that should not be modified
  */
 function _alignOutOfBoundsEdges(
   outOfBoundsEdges: RectangleEdge[],
   elementEstimate: IElementPosition,
   bounding: Rectangle,
+  preserveEdge?: RectangleEdge,
 ) {
   for (const direction of outOfBoundsEdges) {
-    let edgeAttempt = _alignEdges(elementEstimate.elementRectangle, bounding, direction);
-    const inBounds = _isEdgeInBounds(edgeAttempt, bounding, direction * -1);
-    // only update estimate if the attempt didn't break out of the opposite bounding edge
-    if (!inBounds) {
-      edgeAttempt = _moveEdge(edgeAttempt, direction * -1, _getEdgeValue(bounding, direction * -1), false);
+    let edgeAttempt;
+
+    // if preserveEdge is specified, do not call _alignEdges, skip directly to _moveEdge
+    // this is because _alignEdges will move the opposite edge
+    if (preserveEdge && preserveEdge === direction * -1) {
+      edgeAttempt = _moveEdge(elementEstimate.elementRectangle, direction, _getEdgeValue(bounding, direction), false);
       elementEstimate.forcedInBounds = true;
+    } else {
+      edgeAttempt = _alignEdges(elementEstimate.elementRectangle, bounding, direction);
+      const inBounds = _isEdgeInBounds(edgeAttempt, bounding, direction * -1);
+      // only update estimate if the attempt didn't break out of the opposite bounding edge
+      if (!inBounds) {
+        edgeAttempt = _moveEdge(edgeAttempt, direction * -1, _getEdgeValue(bounding, direction * -1), false);
+        elementEstimate.forcedInBounds = true;
+      }
     }
 
     elementEstimate.elementRectangle = edgeAttempt;

--- a/packages/react/src/utilities/positioning/positioning.ts
+++ b/packages/react/src/utilities/positioning/positioning.ts
@@ -341,7 +341,7 @@ function _adjustFitWithinBounds(
   const outOfBounds = _getOutOfBoundsEdges(elementEstimate.elementRectangle, bounding);
   // if directionalHintFixed is specified, we need to force the target edge to not change
   // we need *-1 because targetEdge refers to the target's edge; the callout edge is the opposite
-  const fixedEdge = directionalHintFixed ? elementEstimate.targetEdge * -1 : undefined;
+  const fixedEdge = directionalHintFixed ? -elementEstimate.targetEdge : undefined;
 
   if (outOfBounds.length > 0) {
     if (alignTargetEdge) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20460
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There was a missed logic step when both `directionalHintFixed` and `alignTargetEdge` are true, when the callout wasn't forcing itself within bounds. Currently, if both are true, the positioning utility will fully adhere to the passed-in directional hint, and not switch the callout to a different edge, no matter the available space. It will still add the correct dimensions to force the callout on screen, no matter how tiny it needs to be.
