### PR TITLE
Dialog: Removing tooltip from close button

### DIFF
--- a/change/@fluentui-react-9d677af6-df36-4950-906a-2dcfb28ee80f.json
+++ b/change/@fluentui-react-9d677af6-df36-4950-906a-2dcfb28ee80f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Dialog: Removing tooltip from close button.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/react/src/components/Dialog/Dialog.base.tsx
@@ -160,11 +160,8 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
         forceFocusInsideTrap={forceFocusInsideTrap}
         ignoreExternalFocusing={ignoreExternalFocusing}
         isClickableOutsideFocusTrap={isClickableOutsideFocusTrap}
-        onDismissed={mergedModalProps.onDismissed}
         responsiveMode={responsiveMode}
         {...mergedModalProps}
-        isDarkOverlay={mergedModalProps.isDarkOverlay}
-        isBlocking={mergedModalProps.isBlocking}
         isOpen={isOpen !== undefined ? isOpen : !hidden}
         className={classNames.root}
         containerClassName={classNames.main}
@@ -174,14 +171,9 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
       >
         <DialogContent
           subTextId={this._defaultSubTextId}
-          title={dialogContentProps.title}
-          subText={dialogContentProps.subText}
           showCloseButton={mergedModalProps.isBlocking}
-          topButtonsProps={dialogContentProps.topButtonsProps}
-          type={dialogContentProps.type}
-          onDismiss={onDismiss ? onDismiss : dialogContentProps.onDismiss}
-          className={dialogContentProps.className}
           {...dialogContentProps}
+          onDismiss={onDismiss ? onDismiss : dialogContentProps.onDismiss}
         >
           {this.props.children}
         </DialogContent>

--- a/packages/react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/react/src/components/Dialog/Dialog.base.tsx
@@ -172,8 +172,8 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
         <DialogContent
           subTextId={this._defaultSubTextId}
           showCloseButton={mergedModalProps.isBlocking}
+          onDismiss={onDismiss}
           {...dialogContentProps}
-          onDismiss={onDismiss ? onDismiss : dialogContentProps.onDismiss}
         >
           {this.props.children}
         </DialogContent>

--- a/packages/react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/react/src/components/Dialog/DialogContent.base.tsx
@@ -90,7 +90,6 @@ export class DialogContentBase extends React.Component<IDialogContentProps, {}> 
                 iconProps={{ iconName: 'Cancel' }}
                 ariaLabel={closeButtonAriaLabel}
                 onClick={onDismiss as any}
-                title={closeButtonAriaLabel}
               />
             )}
           </div>

--- a/packages/react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
+++ b/packages/react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
@@ -942,7 +942,6 @@ exports[`Dialog deprecated props renders Dialog with isBlocking set to true 1`] 
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
-                    title="Close"
                     type="button"
                   >
                     <span


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20152
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR removes the tooltip from the `Dialog` component's close button as it was covering space without offering any value. This PR also cleans up the code in `Dialog.base.tsx` a little bit by removing places where the same prop was being passed twice, first by passing the prop bespoke and then by spreading an object.