### PR TITLE
Dialog: Removing tooltip from close button

### DIFF
--- a/change/office-ui-fabric-react-97a09438-28ae-49fa-84f6-ce8e0cc68350.json
+++ b/change/office-ui-fabric-react-97a09438-28ae-49fa-84f6-ce8e0cc68350.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Dialog: Removing tooltip from close button.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
@@ -169,8 +169,8 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
         <DialogContent
           subTextId={this._defaultSubTextId}
           showCloseButton={mergedModalProps.isBlocking}
+          onDismiss={onDismiss}
           {...dialogContentProps}
-          onDismiss={onDismiss ? onDismiss : dialogContentProps.onDismiss}
         >
           {this.props.children}
         </DialogContent>

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
@@ -157,11 +157,8 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
         forceFocusInsideTrap={forceFocusInsideTrap}
         ignoreExternalFocusing={ignoreExternalFocusing}
         isClickableOutsideFocusTrap={isClickableOutsideFocusTrap}
-        onDismissed={mergedModalProps.onDismissed}
         responsiveMode={responsiveMode}
         {...mergedModalProps}
-        isDarkOverlay={mergedModalProps.isDarkOverlay}
-        isBlocking={mergedModalProps.isBlocking}
         isOpen={isOpen !== undefined ? isOpen : !hidden}
         className={classNames.root}
         containerClassName={classNames.main}
@@ -171,14 +168,9 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
       >
         <DialogContent
           subTextId={this._defaultSubTextId}
-          title={dialogContentProps.title}
-          subText={dialogContentProps.subText}
           showCloseButton={mergedModalProps.isBlocking}
-          topButtonsProps={dialogContentProps.topButtonsProps}
-          type={dialogContentProps.type}
-          onDismiss={onDismiss ? onDismiss : dialogContentProps.onDismiss}
-          className={dialogContentProps.className}
           {...dialogContentProps}
+          onDismiss={onDismiss ? onDismiss : dialogContentProps.onDismiss}
         >
           {this.props.children}
         </DialogContent>

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
@@ -112,7 +112,7 @@ export class DialogContentBase extends React.Component<IDialogContentProps, {}> 
       contents: [],
     };
 
-    React.Children.map(this.props.children, (child) => {
+    React.Children.map(this.props.children, child => {
       if (typeof child === 'object' && child !== null && (child as any).type === DialogFooterType) {
         groupings.footers.push(child);
       } else {

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
@@ -88,7 +88,6 @@ export class DialogContentBase extends React.Component<IDialogContentProps, {}> 
                 iconProps={{ iconName: 'Cancel' }}
                 ariaLabel={closeButtonAriaLabel}
                 onClick={onDismiss as any}
-                title={closeButtonAriaLabel}
               />
             )}
           </div>
@@ -113,7 +112,7 @@ export class DialogContentBase extends React.Component<IDialogContentProps, {}> 
       contents: [],
     };
 
-    React.Children.map(this.props.children, child => {
+    React.Children.map(this.props.children, (child) => {
       if (typeof child === 'object' && child !== null && (child as any).type === DialogFooterType) {
         groupings.footers.push(child);
       } else {

--- a/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
@@ -947,7 +947,6 @@ exports[`Dialog deprecated props renders Dialog with isBlocking set to true 1`] 
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
-                    title="Close"
                     type="button"
                   >
                     <span


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20152
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_This PR cherrypicks #20530. Original description follows:_

This PR removes the tooltip from the `Dialog` component's close button as it was covering space without offering any value. This PR also cleans up the code in `Dialog.base.tsx` a little bit by removing places where the same prop was being passed twice, first by passing the prop bespoke and then by spreading an object.