### PR TITLE
fix(Callout): add explicit maxHeight

### DIFF
--- a/change/@fluentui-react-a9ff1007-5e71-4fa7-ada7-384608fb4560.json
+++ b/change/@fluentui-react-a9ff1007-5e71-4fa7-ada7-384608fb4560.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Callout): add explicit maxHeight",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -116,15 +116,15 @@ function useBounds(
  */
 function useMaxHeight(
   { calloutMaxHeight, directionalHint, directionalHintFixed, hidden }: ICalloutProps,
+  getBounds: () => IRectangle | undefined,
   positions?: ICalloutPositionedInfo,
-  getBounds?: () => IRectangle,
 ) {
   const [maxHeight, setMaxHeight] = React.useState<number | undefined>();
   const { top, bottom } = positions?.elementPosition ?? {};
 
   React.useEffect(() => {
     const isForcedInBounds = typeof top === 'number' && typeof bottom === 'number';
-    const { top: topBounds, bottom: bottomBounds } = getBounds ? getBounds() : ({} as IRectangle);
+    const { top: topBounds, bottom: bottomBounds } = getBounds() ?? {};
 
     if (!calloutMaxHeight && !isForcedInBounds && !hidden) {
       if (typeof top === 'number' && bottomBounds) {
@@ -424,7 +424,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
     });
     const getBounds = useBounds(props, targetRef, targetWindow);
     const positions = usePositions(props, hostElement, calloutElement, targetRef, getBounds);
-    const maxHeight = useMaxHeight(props, positions, getBounds);
+    const maxHeight = useMaxHeight(props, getBounds, positions);
     const [mouseDownOnPopup, mouseUpOnPopup] = useDismissHandlers(
       props,
       positions,

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -112,6 +112,37 @@ function useBounds(
 }
 
 /**
+ * (Hook) to return the maximum available height for the Callout to render into.
+ */
+function useMaxHeight(
+  positions: ICalloutPositionedInfo | undefined,
+  { calloutMaxHeight, directionalHint, directionalHintFixed, hidden }: ICalloutProps,
+  getBounds: () => IRectangle | undefined,
+) {
+  const [maxHeight, setMaxHeight] = React.useState<number | undefined>();
+  const { top, bottom } = positions?.elementPosition ?? {};
+
+  React.useEffect(() => {
+    const isForcedInBounds = typeof top === 'number' && typeof bottom === 'number';
+    const { top: topBounds, bottom: bottomBounds } = getBounds() ?? {};
+
+    if (!calloutMaxHeight && !isForcedInBounds && !hidden) {
+      if (typeof top === 'number' && bottomBounds) {
+        setMaxHeight(bottomBounds - top);
+      } else if (typeof bottom === 'number' && typeof topBounds === 'number' && bottomBounds) {
+        setMaxHeight(bottomBounds - topBounds - bottom);
+      }
+    } else if (calloutMaxHeight) {
+      setMaxHeight(calloutMaxHeight);
+    } else {
+      setMaxHeight(undefined);
+    }
+  }, [positions, calloutMaxHeight, getBounds, hidden, directionalHint, directionalHintFixed]);
+
+  return maxHeight;
+}
+
+/**
  * (Hook) to find the current position of Callout. If Callout is resized then a new position is calculated.
  */
 function usePositions(
@@ -393,6 +424,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
     });
     const getBounds = useBounds(props, targetRef, targetWindow);
     const positions = usePositions(props, hostElement, calloutElement, targetRef, getBounds);
+    const maxHeight = useMaxHeight(positions, props, getBounds);
     const [mouseDownOnPopup, mouseUpOnPopup] = useDismissHandlers(
       props,
       positions,
@@ -444,7 +476,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
         <div
           {...getNativeProps(props, divProperties, ARIA_ROLE_ATTRIBUTES)}
           className={css(classNames.root, positions && positions.targetEdge && ANIMATIONS[positions.targetEdge!])}
-          style={positions ? positions.elementPosition : OFF_SCREEN_STYLE}
+          style={positions ? { ...positions.elementPosition, maxHeight } : OFF_SCREEN_STYLE}
           // Safari and Firefox on Mac OS requires this to back-stop click events so focus remains in the Callout.
           // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
           tabIndex={-1}

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -115,16 +115,16 @@ function useBounds(
  * (Hook) to return the maximum available height for the Callout to render into.
  */
 function useMaxHeight(
-  positions: ICalloutPositionedInfo | undefined,
   { calloutMaxHeight, directionalHint, directionalHintFixed, hidden }: ICalloutProps,
-  getBounds: () => IRectangle | undefined,
+  positions?: ICalloutPositionedInfo,
+  getBounds?: () => IRectangle,
 ) {
   const [maxHeight, setMaxHeight] = React.useState<number | undefined>();
   const { top, bottom } = positions?.elementPosition ?? {};
 
   React.useEffect(() => {
     const isForcedInBounds = typeof top === 'number' && typeof bottom === 'number';
-    const { top: topBounds, bottom: bottomBounds } = getBounds() ?? {};
+    const { top: topBounds, bottom: bottomBounds } = getBounds ? getBounds() : ({} as IRectangle);
 
     if (!calloutMaxHeight && !isForcedInBounds && !hidden) {
       if (typeof top === 'number' && bottomBounds) {
@@ -137,7 +137,7 @@ function useMaxHeight(
     } else {
       setMaxHeight(undefined);
     }
-  }, [positions, calloutMaxHeight, getBounds, hidden, directionalHint, directionalHintFixed]);
+  }, [bottom, calloutMaxHeight, directionalHint, directionalHintFixed, getBounds, hidden, positions, top]);
 
   return maxHeight;
 }
@@ -424,7 +424,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
     });
     const getBounds = useBounds(props, targetRef, targetWindow);
     const positions = usePositions(props, hostElement, calloutElement, targetRef, getBounds);
-    const maxHeight = useMaxHeight(positions, props, getBounds);
+    const maxHeight = useMaxHeight(props, positions, getBounds);
     const [mouseDownOnPopup, mouseUpOnPopup] = useDismissHandlers(
       props,
       positions,

--- a/packages/react/src/components/Callout/CalloutContent.styles.ts
+++ b/packages/react/src/components/Callout/CalloutContent.styles.ts
@@ -46,6 +46,7 @@ export const getStyles = (props: ICalloutContentStyleProps): ICalloutContentStyl
       theme.fonts.medium,
       {
         position: 'absolute',
+        display: 'flex',
         zIndex: doNotLayer ? ZIndexes.Layer : undefined,
         boxSizing: 'border-box',
         borderRadius: effects.roundedCorner2,

--- a/packages/react/src/components/Callout/CalloutContent.styles.ts
+++ b/packages/react/src/components/Callout/CalloutContent.styles.ts
@@ -99,6 +99,7 @@ export const getStyles = (props: ICalloutContentStyleProps): ICalloutContentStyl
         overflowX: 'hidden',
         overflowY: 'auto',
         position: 'relative',
+        width: '100%',
         borderRadius: effects.roundedCorner2,
       },
       overflowYHidden && {

--- a/packages/react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
+++ b/packages/react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`Callout renders Callout correctly 1`] = `
             overflow-x: hidden;
             overflow-y: auto;
             position: relative;
+            width: 100%;
           }
       onKeyDown={[Function]}
       onMouseDown={[Function]}

--- a/packages/react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
+++ b/packages/react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Callout renders Callout correctly 1`] = `
           border-radius: 2px;
           box-shadow: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108);
           box-sizing: border-box;
+          display: flex;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -755,6 +755,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                   overflow-x: hidden;
                   overflow-y: auto;
                   position: relative;
+                  width: 100%;
                 }
             style="outline: none; max-height: 100%;"
           >
@@ -1517,6 +1518,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                   overflow-x: hidden;
                   overflow-y: auto;
                   position: relative;
+                  width: 100%;
                 }
             style="outline: none; max-height: 100%;"
           >

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -728,6 +728,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                 border-radius: 2px;
                 box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
                 box-sizing: border-box;
+                display: flex;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -1489,6 +1490,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                 border-radius: 2px;
                 box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
                 box-sizing: border-box;
+                display: flex;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;

--- a/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -242,6 +242,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                     overflow-x: hidden;
                     overflow-y: auto;
                     position: relative;
+                    width: 100%;
                   }
               onKeyDown={[Function]}
               onMouseDown={[Function]}

--- a/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -207,6 +207,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                   border-radius: 2px;
                   box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
                   box-sizing: border-box;
+                  display: flex;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -419,6 +419,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                   overflow-x: hidden;
                   overflow-y: auto;
                   position: relative;
+                  width: 100%;
                 }
             style="outline: none; max-height: 100%;"
           >
@@ -1433,6 +1434,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                   overflow-x: hidden;
                   overflow-y: auto;
                   position: relative;
+                  width: 100%;
                 }
             style="outline: none; max-height: 100%;"
           >

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -388,6 +388,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                 border-radius: 2px 2px 0 0;
                 box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
                 box-sizing: border-box;
+                display: flex;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -1401,6 +1402,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                 border-radius: 2px 2px 0 0;
                 box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
                 box-sizing: border-box;
+                display: flex;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;

--- a/packages/react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -73,6 +73,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
               border-radius: 2px;
               box-shadow: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108);
               box-sizing: border-box;
+              display: flex;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
@@ -240,6 +241,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
               border-radius: 2px;
               box-shadow: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108);
               box-sizing: border-box;
+              display: flex;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;

--- a/packages/react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -106,6 +106,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
                 overflow-x: hidden;
                 overflow-y: hidden;
                 position: relative;
+                width: 100%;
               }
           onKeyDown={[Function]}
           onMouseDown={[Function]}
@@ -274,6 +275,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
                 overflow-x: hidden;
                 overflow-y: auto;
                 position: relative;
+                width: 100%;
               }
           onKeyDown={[Function]}
           onMouseDown={[Function]}

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -61,6 +61,7 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
             overflow-x: hidden;
             overflow-y: hidden;
             position: relative;
+            width: 100%;
           }
       onKeyDown={[Function]}
       onMouseDown={[Function]}

--- a/packages/react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -106,6 +106,7 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
                 overflow-x: hidden;
                 overflow-y: auto;
                 position: relative;
+                width: 100%;
               }
           onKeyDown={[Function]}
           onMouseDown={[Function]}

--- a/packages/react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -73,6 +73,7 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
               border-radius: 2px;
               box-shadow: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108);
               box-sizing: border-box;
+              display: flex;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

If the Callout content changes without re-rendering, a `maxHeight` prevents it from growing offscreen. `maxHeight` is not applied if the positioning utility applies both `top` and `bottom` values, or if `calloutMaxHeight` is specified.
