### PR TITLE
Resolved DonutChart valueInsideDonut text does not change to light color font in dark mode theme

### DIFF
--- a/change/@fluentui-react-charting-2394eb4f-42a9-4dc9-93b2-0ddb0fc39be6.json
+++ b/change/@fluentui-react-charting-2394eb4f-42a9-4dc9-93b2-0ddb0fc39be6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Resolved DonutChart valueInsideDonut text does not change to light color font in dark mode theme",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-pkoganti@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/DonutChart/Arc/Arc.styles.ts
+++ b/packages/react-charting/src/components/DonutChart/Arc/Arc.styles.ts
@@ -21,6 +21,7 @@ export const getStyles = (props: IArcProps): IArcStyles => {
     },
     insideDonutString: {
       fontSize: FontSizes.large,
+      fill: theme.semanticColors.bodyText,
     },
   };
 };

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -71,6 +71,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -106,6 +107,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -427,6 +429,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -462,6 +465,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -783,6 +787,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -818,6 +823,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -905,6 +911,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -940,6 +947,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -1261,6 +1269,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -1298,6 +1307,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"


### PR DESCRIPTION
 DonutChart valueInsideDonut text does not change to light color font in dark mode theme

#### Pull request checklist

- [X] Addresses an existing issue: Fixes [#19906](https://github.com/microsoft/fluentui/issues/19906)
- [X] Include a change request file using `$ yarn change`

#### Description of changes

 DonutChart valueInsideDonut text does not change to light color font in dark mode theme

#### Focus areas to test

DonutChart


<img width="963" alt="before_fix" src="https://user-images.githubusercontent.com/40680570/140696888-21c9fb4a-ea09-4553-ac57-d2f03051b045.png">
<img width="960" alt="After Fix" src="https://user-images.githubusercontent.com/40680570/140696911-8fd2ffba-6391-4370-9fc5-3e4163b19d75.png">
