### PR TITLE
StackCallout implemented in Grouped Vertical Bar chart

### DIFF
--- a/change/@fluentui-react-charting-a1060168-e41d-4848-8b96-92f5715c46d8.json
+++ b/change/@fluentui-react-charting-a1060168-e41d-4848-8b96-92f5715c46d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Stack Callout for Grouped vertical bar chart immplemented",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.types.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.types.tsx
@@ -74,6 +74,12 @@ export interface IGroupedVerticalBarChartProps extends ICartesianChartProps {
    * The prop used to define the culture to localized the numbers
    */
   culture?: string;
+
+  /**
+   * To display multi stack callout or single callout
+   * @default false
+   */
+  isCalloutForStack?: boolean;
 }
 
 export interface IGroupedVerticalBarChartStyleProps extends ICartesianChartStyleProps {}

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { DefaultPalette } from '@fluentui/react/lib/Styling';
 import { GroupedVerticalBarChart, IGroupedVerticalBarChartProps } from '@fluentui/react-charting';
+import { ChoiceGroup, IChoiceGroupOption } from '@fluentui/react/lib/ChoiceGroup';
 interface IGroupedBarChartState {
   width: number;
   height: number;
+  selectedCallout: 'singleCallout' | 'StackCallout';
 }
 
 export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGroupedBarChartState> {
@@ -12,6 +14,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
     this.state = {
       width: 700,
       height: 400,
+      selectedCallout: 'StackCallout',
     };
   }
 
@@ -24,6 +27,10 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
   };
   private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({ height: parseInt(e.target.value, 10) });
+  };
+
+  private _onChange = (ev: React.FormEvent<HTMLInputElement>, option: IChoiceGroupOption): void => {
+    this.setState({ selectedCallout: option.key as IGroupedBarChartState['selectedCallout'] });
   };
 
   private _basicExample(): JSX.Element {
@@ -57,7 +64,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
             data: 33000,
             color: DefaultPalette.blueLight,
             legend: 'MetaData1',
-            xAxisCalloutData: '2020/04/30',
+            xAxisCalloutData: '2020/05/30',
             yAxisCalloutData: '33%',
           },
           {
@@ -65,7 +72,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
             data: 3000,
             color: DefaultPalette.blue,
             legend: 'MetaData4',
-            xAxisCalloutData: '2020/04/30',
+            xAxisCalloutData: '2020/05/30',
             yAxisCalloutData: '3%',
           },
         ],
@@ -79,7 +86,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
             data: 14000,
             color: DefaultPalette.blueLight,
             legend: 'MetaData1',
-            xAxisCalloutData: '2020/04/30',
+            xAxisCalloutData: '2020/06/30',
             yAxisCalloutData: '14%',
           },
           {
@@ -87,7 +94,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
             data: 50000,
             color: DefaultPalette.blue,
             legend: 'MetaData4',
-            xAxisCalloutData: '2020/04/30',
+            xAxisCalloutData: '2020/06/30',
             yAxisCalloutData: '50%',
           },
         ],
@@ -100,7 +107,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
             data: 33000,
             color: DefaultPalette.blueLight,
             legend: 'MetaData1',
-            xAxisCalloutData: '2020/04/30',
+            xAxisCalloutData: '2020/07/30',
             yAxisCalloutData: '33%',
           },
           {
@@ -108,11 +115,16 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
             data: 3000,
             color: DefaultPalette.blue,
             legend: 'MetaData4',
-            xAxisCalloutData: '2020/04/30',
+            xAxisCalloutData: '2020/07/30',
             yAxisCalloutData: '3%',
           },
         ],
       },
+    ];
+
+    const options: IChoiceGroupOption[] = [
+      { key: 'singleCallout', text: 'Single callout' },
+      { key: 'StackCallout', text: 'Stack callout' },
     ];
 
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
@@ -122,6 +134,12 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
         <label>change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <ChoiceGroup
+          options={options}
+          selectedKey={this.state.selectedCallout}
+          onChange={this._onChange}
+          label="Pick one"
+        />
         <div style={rootStyle}>
           <GroupedVerticalBarChart
             culture={window.navigator.language}
@@ -131,6 +149,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
             width={this.state.width}
             showYAxisGridLines
             wrapXAxisLables
+            isCalloutForStack={this.state.selectedCallout === 'StackCallout'}
           />
         </div>
       </>

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
@@ -14,7 +14,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
     this.state = {
       width: 700,
       height: 400,
-      selectedCallout: 'StackCallout',
+      selectedCallout: 'singleCallout',
     };
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

StackCallout functionality is implemented in the Group Vertical Bar chart, so on hover/focus all the Group bars callout content will be shown in the single callout. To do so, "**isCalloutForStack**" prop needs to be set to true. 
Basic example updated with this data.

#### Focus areas to test

(optional)

**Before Change:**

![image](https://user-images.githubusercontent.com/29042635/140717539-24a65c98-6a8f-4a73-8f14-7acd065a68ea.png)


**After Change:**

![image](https://user-images.githubusercontent.com/29042635/140717633-1469e314-02e0-44bf-a1e1-641a0e4b9412.png)
