### PR TITLE
fix(storybook): Load custom storybook theme correctly

### DIFF
--- a/change/@fluentui-react-components-80bdc7d7-c235-43dc-bbef-7e97bbe9825e.json
+++ b/change/@fluentui-react-components-80bdc7d7-c235-43dc-bbef-7e97bbe9825e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(storybook): Load custom storybook theme correctly",
+  "packageName": "@fluentui/react-components",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/.storybook/manager.js
+++ b/packages/react-components/.storybook/manager.js
@@ -1,0 +1,6 @@
+import { addons } from '@storybook/addons';
+import fluentStorybookTheme from './theme';
+
+addons.setConfig({
+  theme: fluentStorybookTheme,
+});


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20543
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds `manager.js` to `react-components` storybook configuration and adds
the custom theme correctly according to [storybook docs](https://storybook.js.org/docs/react/configure/theming#create-a-theme-quickstart)

#### Focus areas to test

(optional)
