### PR TITLE
Charting: CherryPick  #20347: Number localization in charts #20347

### DIFF
--- a/change/@uifabric-charting-1deb827f-f814-4f56-8db3-31d5f37ed5ea.json
+++ b/change/@uifabric-charting-1deb827f-f814-4f56-8db3-31d5f37ed5ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Number localization in chart",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/AreaChart/AreaChart.types.ts
+++ b/packages/charting/src/components/AreaChart/AreaChart.types.ts
@@ -43,6 +43,11 @@ export interface IAreaChartProps extends ICartesianChartProps {
    * Define a custom callout renderer for a stack; default is to render per data point
    */
   onRenderCalloutPerStack?: IRenderFunction<ICustomizedCalloutData>;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 
 export interface IAreaChartStyles extends ICartesianChartStyles {}

--- a/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../index';
 import {
   ChartHoverCard,
+  convertToLocaleString,
   createNumericXAxis,
   createStringXAxis,
   getAccessibleDataObject,
@@ -290,6 +291,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
                 Legend={calloutProps.legend!}
                 YValue={calloutProps.YValue!}
                 color={calloutProps.color!}
+                culture={this.props.culture}
                 {...chartHoverProps}
               />
             )}
@@ -313,7 +315,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
             className={this._classNames.calloutContentX}
             {...getAccessibleDataObject(calloutProps!.xAxisCalloutAccessibilityData)}
           >
-            {calloutProps!.hoverXValue}{' '}
+            {convertToLocaleString(calloutProps!.hoverXValue, this.props.culture)}
           </div>
         </div>
         <div
@@ -389,12 +391,14 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
       toDrawShape,
     });
 
+    const { culture } = this.props;
+    const yValue = convertToLocaleString(xValue.y, culture);
     if (!xValue.yAxisCalloutData || typeof xValue.yAxisCalloutData === 'string') {
       return (
         <div style={yValueHoverSubCountsExists ? marginStyle : {}}>
           {yValueHoverSubCountsExists && (
             <div className="ms-fontWeight-semibold" style={{ fontSize: '12pt' }}>
-              {xValue.legend!} ({xValue.y})
+              {xValue.legend!} ({yValue})
             </div>
           )}
           <div id={`${index}_${xValue.y}`} className={_classNames.calloutBlockContainer}>
@@ -410,7 +414,10 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
             <div>
               <div className={_classNames.calloutlegendText}> {xValue.legend}</div>
               <div className={_classNames.calloutContentY}>
-                {xValue.yAxisCalloutData ? xValue.yAxisCalloutData : xValue.y || xValue.data}
+                {convertToLocaleString(
+                  xValue.yAxisCalloutData ? xValue.yAxisCalloutData : xValue.y || xValue.data,
+                  culture,
+                )}
               </div>
             </div>
           </div>
@@ -421,13 +428,15 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
       return (
         <div style={marginStyle}>
           <div className="ms-fontWeight-semibold" style={{ fontSize: '12pt' }}>
-            {xValue.legend!} ({xValue.y})
+            {xValue.legend!} ({yValue})
           </div>
           {Object.keys(subcounts).map((subcountName: string) => {
             return (
               <div key={subcountName} className={_classNames.calloutBlockContainer}>
-                <div className={_classNames.calloutlegendText}> {subcountName}</div>
-                <div className={_classNames.calloutContentY}>{subcounts[subcountName]}</div>
+                <div className={_classNames.calloutlegendText}> {convertToLocaleString(subcountName, culture)}</div>
+                <div className={_classNames.calloutContentY}>
+                  {convertToLocaleString(subcounts[subcountName], culture)}
+                </div>
               </div>
             );
           })}

--- a/packages/charting/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.types.ts
@@ -475,4 +475,9 @@ export interface IModifiedCartesianChartProps extends ICartesianChartProps {
    * props to send to the focuszone
    */
   svgFocusZoneProps?: IFocusZoneProps;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -7,7 +7,7 @@ import { IProcessedStyleSet, IPalette } from 'office-ui-fabric-react/lib/Styling
 import { Pie } from './Pie/index';
 import { IAccessibilityProps, ChartHoverCard, ILegend, Legends } from '../../index';
 import { IChartDataPoint, IChartProps, IDonutChartProps, IDonutChartStyleProps, IDonutChartStyles } from './index';
-import { getAccessibleDataObject } from '../../utilities/index';
+import { convertToLocaleString, getAccessibleDataObject } from '../../utilities/index';
 
 const getClassNames = classNamesFunction<IDonutChartStyleProps, IDonutChartStyles>();
 
@@ -99,6 +99,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
     const legendBars = this._createLegends(data!, palette);
     const outerRadius = Math.min(this.state._width!, this.state._height!) / 2;
     const chartData = data && data.chartData;
+    const valueInsideDonut = this._valueInsideDonut(this.props.valueInsideDonut!, chartData!);
     return (
       <div className={this._classNames.root} ref={(rootElem: HTMLElement | null) => (this._rootElem = rootElem)}>
         <FocusZone direction={FocusZoneDirection.horizontal} isCircularNavigation={true}>
@@ -123,7 +124,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
                 focusedArcId={this.state.focusedArcId || ''}
                 href={this.props.href!}
                 calloutId={this._calloutId}
-                valueInsideDonut={this._valueInsideDonut(this.props.valueInsideDonut!, chartData!)}
+                valueInsideDonut={this._toLocaleString(valueInsideDonut)}
                 theme={this.props.theme!}
               />
             </svg>
@@ -149,6 +150,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
               Legend={this.state.xCalloutValue ? this.state.xCalloutValue : this.state.legend}
               YValue={this.state.yCalloutValue ? this.state.yCalloutValue : this.state.value}
               color={this.state.color}
+              culture={this.props.culture}
             />
           )}
         </Callout>
@@ -281,5 +283,13 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
     } else {
       return valueInsideDonut;
     }
+  }
+
+  private _toLocaleString(data: string | number | undefined) {
+    const localeString = convertToLocaleString(data, this.props.culture);
+    if (!localeString) {
+      return data;
+    }
+    return localeString?.toString();
   }
 }

--- a/packages/charting/src/components/DonutChart/DonutChart.types.ts
+++ b/packages/charting/src/components/DonutChart/DonutChart.types.ts
@@ -36,6 +36,11 @@ export interface IDonutChartProps extends ICartesianChartProps {
    * props for the callout in the chart
    */
   calloutProps?: Partial<ICalloutProps>;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 
 export interface IDonutChartStyleProps extends ICartesianChartStyleProps {}

--- a/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -1284,7 +1284,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               textAnchor="middle"
               y={5}
             >
-              1000
+              1,000
             </text>
           </g>
           <g>
@@ -1321,7 +1321,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               textAnchor="middle"
               y={5}
             >
-              1000
+              1,000
             </text>
           </g>
         </g>

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -97,7 +97,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
       showYAxisGridLines: 'Dont use this property. Lines are drawn by default',
       showXAxisPath: 'Dont use this property. Axis line removed default.',
       showYAxisPath: 'Dont use this property. No need to display Y axis path. Handling default',
-      showXAxisGridLines: 'Dont use this proprty. Handling with default value.',
+      showXAxisGridLines: 'Dont use this property. Handling with default value.',
       legendColor: 'Dont use this property. colour will pick from given data.',
     });
     this._refArray = [];
@@ -295,7 +295,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
     tempDataSet.forEach((datasetKey: string, index: number) => {
       const refIndexNumber = singleSet.indexNum * tempDataSet.length + index;
       const pointData = singleSet[datasetKey];
-      // Not rendaring data with 0.
+      // Not rendering data with 0.
       pointData.data &&
         singleGroup.push(
           <rect

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.types.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.types.tsx
@@ -69,6 +69,11 @@ export interface IGroupedVerticalBarChartProps extends ICartesianChartProps {
    * Define a custom callout renderer for a stack
    */
   onRenderCalloutPerDataPoint?: IRenderFunction<IGVBarChartSeriesPoint>;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 
 export interface IGroupedVerticalBarChartStyleProps extends ICartesianChartStyleProps {}

--- a/packages/charting/src/components/HeatMapChart/HeatMapChart.base.tsx
+++ b/packages/charting/src/components/HeatMapChart/HeatMapChart.base.tsx
@@ -14,7 +14,14 @@ import { IProcessedStyleSet } from 'office-ui-fabric-react/lib/Styling';
 import * as React from 'react';
 import { IHeatMapChartProps, IHeatMapChartStyleProps, IHeatMapChartStyles } from './HeatMapChart.types';
 import { ILegend, Legends } from '../Legends/index';
-import { ChartTypes, getAccessibleDataObject, XAxisTypes, YAxisType, getTypeOfAxis } from '../../utilities/utilities';
+import {
+  ChartTypes,
+  convertToLocaleString,
+  getAccessibleDataObject,
+  XAxisTypes,
+  YAxisType,
+  getTypeOfAxis,
+} from '../../utilities/utilities';
 import { Target } from 'office-ui-fabric-react';
 import { format as d3Format } from 'd3-format';
 import * as d3TimeFormat from 'd3-time-format';
@@ -328,7 +335,7 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
               className={this._classNames.text}
               transform={`translate(${this._xAxisScale.bandwidth() / 2}, ${this._yAxisScale.bandwidth() / 2})`}
             >
-              {dataPointObject.rectText}
+              {convertToLocaleString(dataPointObject.rectText, this.props.culture)}
             </text>
           </g>
         );

--- a/packages/charting/src/components/HeatMapChart/HeatMapChart.types.ts
+++ b/packages/charting/src/components/HeatMapChart/HeatMapChart.types.ts
@@ -99,6 +99,11 @@ export interface IHeatMapChartProps extends Pick<ICartesianChartProps, Exclude<k
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IHeatMapChartStyleProps, IHeatMapChartStyles>;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 export interface IHeatMapChartStyleProps extends ICartesianChartStyleProps {}
 export interface IHeatMapChartStyles {

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -11,7 +11,7 @@ import {
   IRefArrayData,
 } from './index';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
-import { ChartHoverCard } from '../../utilities/ChartHoverCard/index';
+import { ChartHoverCard, convertToLocaleString } from '../../utilities/index';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
 
 const getClassNames = classNamesFunction<IHorizontalBarChartStyleProps, IHorizontalBarChartStyles>();
@@ -84,6 +84,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
           const chartDataText = this._getChartDataText(points!);
           const bars = this._createBars(points!, palette);
           const keyVal = this._uniqLineText + '_' + index;
+          const xValue = points!.chartData![0].horizontalBarChartdata!.x;
           return (
             <div key={index} className={this._classNames.items}>
               <div className={this._classNames.items}>
@@ -111,20 +112,8 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                         this._refCallback(e, points!.chartData![0].legend);
                       }}
                       className={this._classNames.barWrapper}
-                      onMouseOver={this._hoverOn.bind(
-                        this,
-                        points!
-                          .chartData![0].horizontalBarChartdata!.x.toString()
-                          .replace(/\B(?=(\d{3})+(?!\d))/g, ','),
-                        points!.chartData![0],
-                      )}
-                      onFocus={this._hoverOn.bind(
-                        this,
-                        points!
-                          .chartData![0].horizontalBarChartdata!.x.toString()
-                          .replace(/\B(?=(\d{3})+(?!\d))/g, ','),
-                        points!.chartData![0],
-                      )}
+                      onMouseOver={this._hoverOn.bind(this, xValue, points!.chartData![0])}
+                      onFocus={this._hoverOn.bind(this, xValue, points!.chartData![0])}
                       // NOTE: points.chartData![0] contains current data value
                       onClick={() => {
                         const p = points!.chartData![0];
@@ -168,6 +157,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                 Legend={this.state.xCalloutValue ? this.state.xCalloutValue : this.state.legend!}
                 YValue={this.state.yCalloutValue ? this.state.yCalloutValue : this.state.hoverValue!}
                 color={this.state.lineColor}
+                culture={this.props.culture}
               />
             )}
           </>
@@ -234,6 +224,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
   };
 
   private _getDefaultTextData = (data: IChartProps): JSX.Element => {
+    const { culture } = this.props;
     const chartDataMode = this.props.chartDataMode || 'default';
     const chartData: IChartDataPoint = data!.chartData![0];
     const x = chartData.horizontalBarChartdata!.x;
@@ -242,21 +233,20 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
     const accessibilityData = this._getAccessibleDataObject(data.chartDataAccessibilityData);
     switch (chartDataMode) {
       case 'default':
-        const chartDataText: string = x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
         return (
           <div className={this._classNames.chartDataText} {...accessibilityData}>
-            {chartDataText}
+            {convertToLocaleString(x, culture)}
           </div>
         );
       case 'fraction':
         return (
           <div {...accessibilityData}>
-            <span className={this._classNames.chartDataText}>{x}</span>
-            <span className={this._classNames.chartDataTextDenominator}>{'/' + y}</span>
+            <span className={this._classNames.chartDataText}>{convertToLocaleString(x, culture)}</span>
+            <span className={this._classNames.chartDataTextDenominator}>{'/' + convertToLocaleString(y, culture)}</span>
           </div>
         );
       case 'percentage':
-        const dataRatioPercentage = `${Math.round((x / y) * 100)}%`;
+        const dataRatioPercentage = `${convertToLocaleString(Math.round((x / y) * 100), culture)}%`;
         return (
           <div className={this._classNames.chartDataText} {...accessibilityData}>
             {dataRatioPercentage}

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
@@ -71,6 +71,11 @@ export interface IHorizontalBarChartProps {
    * will be used to display the data/text based on given chartModeData prop.
    */
   barChartCustomData?: IRenderFunction<IChartProps>;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 
 export interface IHorizontalBarChartStyleProps {

--- a/packages/charting/src/components/LineChart/LineChart.types.ts
+++ b/packages/charting/src/components/LineChart/LineChart.types.ts
@@ -64,6 +64,11 @@ export interface ILineChartProps extends ICartesianChartProps {
    * @default false
    */
   allowMultipleShapesForPoints?: boolean;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 export interface IEventsAnnotationProps {
   events: IEventAnnotation[];

--- a/packages/charting/src/components/PieChart/Arc/Arc.tsx
+++ b/packages/charting/src/components/PieChart/Arc/Arc.tsx
@@ -3,7 +3,7 @@ import * as shape from 'd3-shape';
 import { IArcProps, IArcStyles } from './Arc.types';
 import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { getStyles } from './Arc.styles';
-
+import { convertToLocaleString } from '../../../utilities/utilities';
 export class Arc extends React.Component<IArcProps, {}> {
   public static defaultProps: Partial<IArcProps> = {
     arc: shape.arc(),
@@ -30,7 +30,7 @@ export class Arc extends React.Component<IArcProps, {}> {
 
 export class LabeledArc extends Arc {
   public render(): JSX.Element {
-    const { data, arc } = this.props;
+    const { data, arc, culture } = this.props;
     const [labelX, labelY] = arc.centroid(data);
     const labelTranslate = `translate(${labelX}, ${labelY})`;
 
@@ -38,7 +38,7 @@ export class LabeledArc extends Arc {
       <g className="arc">
         {super.render()}
         <text transform={labelTranslate} textAnchor="middle">
-          {data!.data!.x}-{data!.data!.y}
+          {data!.data!.x}-{convertToLocaleString(data!.data!.y, culture)}
         </text>
       </g>
     );

--- a/packages/charting/src/components/PieChart/Arc/Arc.types.ts
+++ b/packages/charting/src/components/PieChart/Arc/Arc.types.ts
@@ -25,6 +25,11 @@ export interface IArcProps {
    * Color for the Arc.
    */
   color: string;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 
 export interface IArcData {

--- a/packages/charting/src/components/PieChart/Pie/Pie.tsx
+++ b/packages/charting/src/components/PieChart/Pie/Pie.tsx
@@ -22,6 +22,7 @@ export class Pie extends React.Component<IPieProps, {}> {
   public arcGenerator = (d: IArcData, i: number): JSX.Element => {
     return (
       <LabeledArc
+        culture={this.props.culture}
         key={i}
         data={d}
         innerRadius={this.props.innerRadius}

--- a/packages/charting/src/components/PieChart/Pie/Pie.types.ts
+++ b/packages/charting/src/components/PieChart/Pie/Pie.types.ts
@@ -35,6 +35,10 @@ export interface IPieProps {
    */
   /* eslint-disable @typescript-eslint/no-explicit-any */
   pie?: any;
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 
 export interface IPieStyles {

--- a/packages/charting/src/components/PieChart/PieChart.base.tsx
+++ b/packages/charting/src/components/PieChart/PieChart.base.tsx
@@ -16,7 +16,7 @@ export class PieChartBase extends React.Component<IPieChartProps, {}> {
   public render(): JSX.Element {
     const { data, width, height, colors, chartTitle } = this.props;
 
-    const { theme, className, styles } = this.props;
+    const { theme, className, styles, culture } = this.props;
     this._classNames = getClassNames(styles!, {
       theme: theme!,
       width: width!,
@@ -30,6 +30,7 @@ export class PieChartBase extends React.Component<IPieChartProps, {}> {
       <div className={this._classNames.root}>
         {this.props.chartTitle && <p className={this._classNames.chartTitle}>{this.props.chartTitle}</p>}
         <Pie
+          culture={culture}
           width={width!}
           height={height!}
           outerRadius={outerRadius}

--- a/packages/charting/src/components/PieChart/PieChart.types.ts
+++ b/packages/charting/src/components/PieChart/PieChart.types.ts
@@ -49,6 +49,11 @@ export interface IPieChartProps {
    * Width of line stroke
    */
   strokeWidth?: number;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 
 export type IPieChartStyleProps = Required<Pick<IPieChartProps, 'theme' | 'width' | 'height'>> &

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -12,7 +12,7 @@ import {
 } from './index';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
-import { ChartHoverCard } from '../../utilities/index';
+import { ChartHoverCard, convertToLocaleString } from '../../utilities/index';
 
 const getClassNames = classNamesFunction<IMultiStackedBarChartStyleProps, IMultiStackedBarChartStyles>();
 
@@ -67,7 +67,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
   }
 
   public render(): JSX.Element {
-    const { data, theme } = this.props;
+    const { data, theme, culture } = this.props;
     this._adjustProps();
     const { palette } = theme!;
     const legends = this._getLegendData(data!, this.props.hideRatio!, palette);
@@ -114,7 +114,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
             {this.props.onRenderCalloutPerDataPoint ? (
               this.props.onRenderCalloutPerDataPoint(this.state.dataPointCalloutProps)
             ) : (
-              <ChartHoverCard Legend={legendName} YValue={calloutYVal} color={this.state.color} />
+              <ChartHoverCard Legend={legendName} YValue={calloutYVal} color={this.state.color} culture={culture} />
             )}
           </>
         </Callout>
@@ -130,6 +130,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     hideDenominator: boolean,
     href?: string,
   ): JSX.Element {
+    const { culture } = this.props;
     const defaultPalette: string[] = [palette.blueLight, palette.blue, palette.blueMid, palette.red, palette.black];
     // calculating starting point of each bar and it's range
     const startingPoint: number[] = [];
@@ -210,25 +211,25 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     const hideNumber = hideRatio === undefined ? false : hideRatio;
     const showRatio = !hideNumber && data!.chartData!.length === 2;
     const showNumber = !hideNumber && data!.chartData!.length === 1;
-
+    const getChartData = () => convertToLocaleString(data!.chartData![0].data ? data!.chartData![0].data : 0, culture);
     return (
       <div className={this._classNames.singleChartRoot}>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div className={this._classNames.chartTitle}>
             {data!.chartTitle && (
-              <div {...this._getAccessibleDataObject(data!.chartTitleAccessibilityData)}>
+              <div {...this._getAccessibleDataObject(data!.chartTitleAccessibilityData, culture)}>
                 <strong>{data!.chartTitle}</strong>
               </div>
             )}
             {showRatio && (
               <div {...this._getAccessibleDataObject(data!.chartDataAccessibilityData)}>
-                <strong>{data!.chartData![0].data ? data!.chartData![0].data : 0}</strong>
-                {!hideDenominator && <span>/{total}</span>}
+                <strong>{getChartData()}</strong>
+                {!hideDenominator && <span>/{convertToLocaleString(total, culture)}</span>}
               </div>
             )}
             {showNumber && (
               <div {...this._getAccessibleDataObject(data!.chartDataAccessibilityData)}>
-                <strong>{data!.chartData![0].data}</strong>
+                <strong>{getChartData()}</strong>
               </div>
             )}
           </div>

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
@@ -96,6 +96,11 @@ export interface IMultiStackedBarChartProps {
    * props for the callout in the chart
    */
   calloutProps?: Partial<ICalloutProps>;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 
 export interface IMultiStackedBarChartStyleProps {

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -6,7 +6,7 @@ import { IAccessibilityProps, IChartDataPoint, IChartProps } from './index';
 import { IRefArrayData, IStackedBarChartProps, IStackedBarChartStyleProps, IStackedBarChartStyles } from '../../index';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
-import { ChartHoverCard } from '../../utilities/index';
+import { ChartHoverCard, convertToLocaleString } from '../../utilities/index';
 
 const getClassNames = classNamesFunction<IStackedBarChartStyleProps, IStackedBarChartStyles>();
 export interface IStackedBarChartState {
@@ -57,7 +57,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
 
   public render(): JSX.Element {
     this._adjustProps();
-    const { data, benchmarkData, targetData, hideNumberDisplay, ignoreFixStyle } = this.props;
+    const { data, benchmarkData, targetData, hideNumberDisplay, ignoreFixStyle, culture } = this.props;
     const { palette } = this.props.theme!;
     const barHeight = ignoreFixStyle || data!.chartData!.length > 2 ? this.props.barHeight : 8;
 
@@ -98,7 +98,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
       targetColor: targetData ? targetData.color : '',
       targetRatio,
     });
-
+    const getChartData = () => convertToLocaleString(data!.chartData![0].data ? data!.chartData![0].data : 0, culture);
     return (
       <div className={this._classNames.root}>
         <FocusZone direction={FocusZoneDirection.horizontal}>
@@ -110,19 +110,17 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
             )}
             {showRatio && (
               <div {...this._getAccessibleDataObject(data!.chartDataAccessibilityData)}>
-                <span className={this._classNames.ratioNumerator}>
-                  {data!.chartData![0].data ? data!.chartData![0].data : 0}
-                </span>
+                <span className={this._classNames.ratioNumerator}>{getChartData()}</span>
                 {!this.props.hideDenominator && (
                   <span>
-                    /<span className={this._classNames.ratioDenominator}>{total}</span>
+                    /<span className={this._classNames.ratioDenominator}>{convertToLocaleString(total, culture)}</span>
                   </span>
                 )}
               </div>
             )}
             {showNumber && (
               <div {...this._getAccessibleDataObject(data!.chartDataAccessibilityData)}>
-                <strong>{data!.chartData![0].data}</strong>
+                <strong>{getChartData()}</strong>
               </div>
             )}
           </div>
@@ -158,6 +156,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
                       Legend={this.state.xCalloutValue ? this.state.xCalloutValue : this.state.selectedLegendTitle}
                       YValue={this.state.yCalloutValue ? this.state.yCalloutValue : this.state.dataForHoverCard}
                       color={this.state.color}
+                      culture={culture}
                     />
                   )}
                 </>

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.types.ts
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.types.ts
@@ -125,6 +125,11 @@ export interface IStackedBarChartProps {
    * props for the callout in the chart
    */
   calloutProps?: Partial<ICalloutProps>;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 
 export interface IStackedBarChartStyleProps {

--- a/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -253,6 +253,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           {...(index === 0 && { XValue: `${hoverXValue || item.data}` })}
           color={item.color}
           YValue={item.data || item.y}
+          culture={this.props.culture}
         />
       );
     });
@@ -267,6 +268,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           Legend={props.legend}
           YValue={props.yAxisCalloutData || props.y}
           color={!useSingleColor && props.color ? props.color : this._createColors()(props.y)}
+          culture={this.props.culture}
         />
       </>
     );

--- a/packages/charting/src/components/VerticalBarChart/VerticalBarChart.types.ts
+++ b/packages/charting/src/components/VerticalBarChart/VerticalBarChart.types.ts
@@ -57,6 +57,11 @@ export interface IVerticalBarChartProps extends ICartesianChartProps {
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IVerticalBarChartStyleProps, IVerticalBarChartStyles>;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 
 export interface IVerticalBarChartStyleProps extends ICartesianChartStyleProps {

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -405,6 +405,7 @@ export class VerticalStackedBarChartBase extends React.Component<
         Legend={props.legend}
         YValue={props.yAxisCalloutData}
         color={props.color}
+        culture={this.props.culture}
       />
     ) : null;
   }

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
@@ -96,6 +96,11 @@ export interface IVerticalStackedBarChartProps extends ICartesianChartProps {
    * Click handler for bars; type of data is dependant on isCalloutForStack
    */
   onBarClick?: (event: React.MouseEvent<SVGElement>, data: IVerticalStackedChartProps | IVSChartDataPoint) => void;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 
 export interface IVerticalStackedBarChartStyleProps extends ICartesianChartStyleProps {}

--- a/packages/charting/src/utilities/ChartHoverCard/ChartHoverCard.base.tsx
+++ b/packages/charting/src/utilities/ChartHoverCard/ChartHoverCard.base.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { IChartHoverCardStyles, IChartHoverCardStyleProps, IChartHoverCardProps } from './ChartHoverCard.types';
 import { classNamesFunction, IProcessedStyleSet } from 'office-ui-fabric-react';
+import { convertToLocaleString } from '../index';
 
 const getClassNames = classNamesFunction<IChartHoverCardStyleProps, IChartHoverCardStyles>();
 export class ChartHoverCardBase extends React.Component<IChartHoverCardProps, {}> {
   private _classNames: IProcessedStyleSet<IChartHoverCardStyles>;
   public render(): React.ReactNode {
-    const { color, Legend, XValue, YValue, styles, theme, ratio, descriptionMessage } = this.props;
+    const { color, Legend, XValue, YValue, styles, theme, ratio, descriptionMessage, culture } = this.props;
     this._classNames = getClassNames(styles!, {
       theme: theme!,
       color: color,
@@ -22,14 +23,14 @@ export class ChartHoverCardBase extends React.Component<IChartHoverCardProps, {}
         </div>
         <div className={this._classNames.calloutInfoContainer}>
           <div className={this._classNames.calloutBlockContainer}>
-            <div className={this._classNames.calloutlegendText}>{Legend}</div>
-            <div className={this._classNames.calloutContentY}>{YValue}</div>
+            <div className={this._classNames.calloutlegendText}>{convertToLocaleString(Legend, culture)}</div>
+            <div className={this._classNames.calloutContentY}>{convertToLocaleString(YValue, culture)}</div>
           </div>
           {!!ratio && (
             <div className={this._classNames.ratio}>
               <>
-                <span className={this._classNames.numerator}>{ratio[0]}</span>/
-                <span className={this._classNames.denominator}>{ratio[1]}</span>
+                <span className={this._classNames.numerator}>{convertToLocaleString(ratio[0], culture)}</span>/
+                <span className={this._classNames.denominator}>{convertToLocaleString(ratio[1], culture)}</span>
               </>
             </div>
           )}

--- a/packages/charting/src/utilities/ChartHoverCard/ChartHoverCard.types.ts
+++ b/packages/charting/src/utilities/ChartHoverCard/ChartHoverCard.types.ts
@@ -37,6 +37,11 @@ export interface IChartHoverCardProps {
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IChartHoverCardStyleProps, IChartHoverCardStyles>;
+
+  /**
+   * The prop used to define the culture to localized the numbers
+   */
+  culture?: string;
 }
 
 export interface IChartHoverCardStyles {

--- a/packages/charting/src/utilities/utilities.ts
+++ b/packages/charting/src/utilities/utilities.ts
@@ -961,3 +961,19 @@ export const getAccessibleDataObject = (
     'aria-describedby': accessibleData!.ariaDescribedBy,
   };
 };
+
+type LocaleStringDataProps = number | string | Date | undefined;
+export const convertToLocaleString = (data: LocaleStringDataProps, culture?: string): LocaleStringDataProps => {
+  if (!data) {
+    return data;
+  }
+  culture = culture || undefined;
+  if (typeof data === 'number') {
+    return data.toLocaleString(culture);
+  }
+  if (typeof data === 'string' && !window.isNaN(Number(data))) {
+    const num = Number(data);
+    return num.toLocaleString(culture);
+  }
+  return data;
+};

--- a/packages/react-examples/src/charting/AreaChart/AreaChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/AreaChart/AreaChart.Basic.Example.tsx
@@ -49,8 +49,6 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
       {
         x: 20,
         y: 7000,
-        xAxisCalloutData: '2018/01/01',
-        yAxisCalloutData: '10%',
       },
       {
         x: 25,
@@ -162,6 +160,7 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
         <ChoiceGroup options={options} defaultSelectedKey="basicExample" onChange={this._onChange} label="Pick one" />
         <div style={rootStyle}>
           <AreaChart
+            culture={window.navigator.language}
             height={this.state.height}
             width={this.state.width}
             data={chartData}

--- a/packages/react-examples/src/charting/DonutChart/DonutChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/DonutChart/DonutChart.Basic.Example.tsx
@@ -18,6 +18,7 @@ export class DonutChartBasicExample extends React.Component<IDonutChartProps, {}
     };
     return (
       <DonutChart
+        culture={window.navigator.language}
         data={data}
         innerRadius={55}
         href={'https://developer.microsoft.com/en-us/'}

--- a/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
@@ -124,6 +124,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <GroupedVerticalBarChart
+            culture={window.navigator.language}
             chartTitle="Grouped Vertical Bar chart basic example"
             data={data}
             height={this.state.height}

--- a/packages/react-examples/src/charting/HeatMapChart/HeatMapChartBasic.Example.tsx
+++ b/packages/react-examples/src/charting/HeatMapChart/HeatMapChartBasic.Example.tsx
@@ -305,6 +305,7 @@ export class HeatMapChartBasicExample extends React.Component<{}, IHeatMapChartB
         <p>Heat map explaining the Air Quality Index</p>
         <div style={rootStyle}>
           <HeatMapChart
+            culture={window.navigator.language}
             chartTitle="Heat map chart basic example"
             data={HeatMapData}
             // eslint-disable-next-line react/jsx-no-bind

--- a/packages/react-examples/src/charting/HorizontalBarChart/HorizontalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/HorizontalBarChart/HorizontalBarChart.Basic.Example.tsx
@@ -104,5 +104,5 @@ export const HorizontalBarChartBasicExample: React.FunctionComponent<{}> = () =>
     },
   ];
 
-  return <HorizontalBarChart data={data} hideRatio={hideRatio} width={600} />;
+  return <HorizontalBarChart culture={window.navigator.language} data={data} hideRatio={hideRatio} width={600} />;
 };

--- a/packages/react-examples/src/charting/LineChart/LineChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/LineChart/LineChart.Basic.Example.tsx
@@ -154,6 +154,7 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
         />
         <div style={rootStyle}>
           <LineChart
+            culture={window.navigator.language}
             data={data}
             legendsOverflowText={'Overflow Items'}
             yMinValue={200}

--- a/packages/react-examples/src/charting/PieChart/PieChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/PieChart/PieChart.Basic.Example.tsx
@@ -14,6 +14,13 @@ export class PieChartBasicExample extends React.Component<IPieChartProps, {}> {
       { y: 25, x: 'C' },
     ];
     const colors = [DefaultPalette.red, DefaultPalette.blue, DefaultPalette.green];
-    return <PieChart data={points} chartTitle="Pie Chart basic example" colors={colors} />;
+    return (
+      <PieChart
+        culture={window.navigator.language}
+        data={points}
+        chartTitle="Pie Chart basic example"
+        colors={colors}
+      />
+    );
   }
 }

--- a/packages/react-examples/src/charting/StackedBarChart/MultiStackedBarChart.Example.tsx
+++ b/packages/react-examples/src/charting/StackedBarChart/MultiStackedBarChart.Example.tsx
@@ -116,6 +116,7 @@ export const MultiStackedBarChartExample: React.FunctionComponent<{}> = () => {
 
   return (
     <MultiStackedBarChart
+      culture={window.navigator.language}
       data={data}
       hideDenominator={hideDenominator}
       hideRatio={hideRatio}

--- a/packages/react-examples/src/charting/StackedBarChart/StackedBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/StackedBarChart/StackedBarChart.Basic.Example.tsx
@@ -27,9 +27,15 @@ export class StackedBarChartBasicExample extends React.Component<{}, {}> {
 
     return (
       <>
-        <StackedBarChart data={data0} href={'https://developer.microsoft.com/en-us/'} ignoreFixStyle={false} />
+        <StackedBarChart
+          culture={window.navigator.language}
+          data={data0}
+          href={'https://developer.microsoft.com/en-us/'}
+          ignoreFixStyle={false}
+        />
         <br />
         <StackedBarChart
+          culture={window.navigator.language}
           data={data1}
           href={'https://developer.microsoft.com/en-us/'}
           ignoreFixStyle={true}

--- a/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
@@ -159,6 +159,7 @@ export class VerticalBarChartBasicExample extends React.Component<IVerticalBarCh
         />
         <div style={rootStyle}>
           <VerticalBarChart
+            culture={window.navigator.language}
             chartTitle="Vertical bar chart basic example "
             data={points}
             width={this.state.width}

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
@@ -211,6 +211,7 @@ export class VerticalStackedBarChartBasicExample extends React.Component<{}, IVe
         />
         <div style={rootStyle}>
           <VerticalStackedBarChart
+            culture={window.navigator.language}
             chartTitle="Vertical stacked bar chart basic example"
             barGapMax={this.state.barGapMax}
             data={data}


### PR DESCRIPTION
### Original description
Cherry pick of [#20347](https://github.com/microsoft/fluentui/pull/20347)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Previously Number was not localized as per culture. 
So now, culture prop added for charts, and according to that culture, chart numbers will be localized. 
If the culture prop is not passed, then the number will be localized as per system language. 

#### Focus areas to test
All charts

**Before changes:**

![image](https://user-images.githubusercontent.com/29042635/138099262-34c6eb24-f306-4bbb-b1c8-ed0e5af4cd40.png)

![image](https://user-images.githubusercontent.com/29042635/138099275-8f034088-5a61-4c41-b9b1-b82135f19d45.png)


**After Changes:**
In these examples, I have used culture="pt-br" brazil, which uses Decimal mark as "," and Digit grouping separator as "."
![image](https://user-images.githubusercontent.com/29042635/138099706-bf4c4fb8-a091-492d-a3ab-69fc80c17288.png)


![image](https://user-images.githubusercontent.com/29042635/138099405-ba560bba-bc67-4b06-abdc-d62b4b8281b6.png)

![image](https://user-images.githubusercontent.com/29042635/138099422-c03061ff-1fa6-4a97-9b5b-ac99cc7c75dd.png)

