### PR TITLE
fix: Pass ref for List and ListItem

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Stop `event.view` usage in `whatInput.ts` for tests @ling1726 ([#20492](https://github.com/microsoft/fluentui/pull/20492))
 - chore(ability-attributes): improve schema for aria-controls, aria-haspopup and aria-hidden @jurokapsiar ([#20194](https://github.com/microsoft/fluentui/pull/20194))
 - Remove pointer cursor and prevent navigation on carousel paddle click when `disableClickableNav` @chpalac ([#20521](https://github.com/microsoft/fluentui/pull/20521))
+- Fix `List` and `ListItem` to properly pass ref to root slots @chpalac ([#20557](https://github.com/microsoft/fluentui/pull/20557))
 
 ### Features
 - Adding `ViewPersonSparkleIcon`, `CartIcon`, and fixing `EmojiAddIcon` and `AccessibilityIcon` - @notandrew ([#20054](https://github.com/microsoft/fluentui/pull/20054))

--- a/packages/fluentui/react-northstar/src/components/List/List.tsx
+++ b/packages/fluentui/react-northstar/src/components/List/List.tsx
@@ -1,6 +1,5 @@
 import { Accessibility, listBehavior, ListBehaviorProps } from '@fluentui/accessibility';
 import {
-  ComponentWithAs,
   getElementType,
   useUnhandledProps,
   useAccessibility,
@@ -8,6 +7,7 @@ import {
   useFluentContext,
   useStyles,
   useTelemetry,
+  ForwardRefWithAs,
 } from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as _ from 'lodash';
@@ -89,16 +89,7 @@ export const listClassName = 'ui-list';
  * [JAWS - Listbox options are not reachable in Virtual Cursor PC mode #517](https://github.com/FreedomScientific/VFO-standards-support/issues/517)
  * [JAWS - Aria-selected is not narrated for the single-select listbox, when selection is NOT moved with focus #440](https://github.com/FreedomScientific/VFO-standards-support/issues/440)
  */
-export const List: ComponentWithAs<'ul', ListProps> &
-  FluentComponentStaticProps<ListProps> & {
-    Item: typeof ListItem;
-    ItemContent: typeof ListItemContent;
-    ItemContentMedia: typeof ListItemContentMedia;
-    ItemEndMedia: typeof ListItemEndMedia;
-    ItemHeader: typeof ListItemHeader;
-    ItemHeaderMedia: typeof ListItemHeaderMedia;
-    ItemMedia: typeof ListItemMedia;
-  } = props => {
+export const List = (React.forwardRef<HTMLUListElement, ListProps & { as: React.ReactNode }>((props, ref) => {
   const context = useFluentContext();
   const { setStart, setEnd } = useTelemetry(List.displayName, context.telemetry);
   setStart();
@@ -178,6 +169,7 @@ export const List: ComponentWithAs<'ul', ListProps> &
     <ElementType
       {...getA11Props('root', {
         className: classes.root,
+        ref,
         ...rtlTextContainer.getAttributes({ forElements: [children] }),
         ...unhandledProps,
       })}
@@ -190,7 +182,16 @@ export const List: ComponentWithAs<'ul', ListProps> &
   setEnd();
 
   return element;
-};
+}) as unknown) as ForwardRefWithAs<'ul', HTMLUListElement, ListProps> &
+  FluentComponentStaticProps<ListProps> & {
+    Item: typeof ListItem;
+    ItemContent: typeof ListItemContent;
+    ItemContentMedia: typeof ListItemContentMedia;
+    ItemEndMedia: typeof ListItemEndMedia;
+    ItemHeader: typeof ListItemHeader;
+    ItemHeaderMedia: typeof ListItemHeaderMedia;
+    ItemMedia: typeof ListItemMedia;
+  };
 
 List.displayName = 'List';
 

--- a/packages/fluentui/react-northstar/src/components/List/ListItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/List/ListItem.tsx
@@ -1,6 +1,5 @@
 import { Accessibility, listItemBehavior, ListItemBehaviorProps } from '@fluentui/accessibility';
 import {
-  ComponentWithAs,
   getElementType,
   useUnhandledProps,
   useAccessibility,
@@ -8,6 +7,7 @@ import {
   useStyles,
   useTelemetry,
   useContextSelectors,
+  ForwardRefWithAs,
 } from '@fluentui/react-bindings';
 import cx from 'classnames';
 import * as _ from 'lodash';
@@ -82,8 +82,7 @@ export const listItemSlotClassNames: ListItemSlotClassNames = {
 /**
  * A ListItem contains a single piece of content within a List.
  */
-export const ListItem: ComponentWithAs<'li', ListItemProps & { index: number }> &
-  FluentComponentStaticProps<ListItemProps> = props => {
+export const ListItem = (React.forwardRef<HTMLLIElement, ListItemProps>((props, ref) => {
   const context = useFluentContext();
   const { setStart, setEnd } = useTelemetry(ListItem.displayName, context.telemetry);
 
@@ -195,6 +194,7 @@ export const ListItem: ComponentWithAs<'li', ListItemProps & { index: number }> 
         className: classes.root,
         onClick: handleClick,
         ...unhandledProps,
+        ref,
       })}
     >
       {mediaElement}
@@ -221,7 +221,8 @@ export const ListItem: ComponentWithAs<'li', ListItemProps & { index: number }> 
   setEnd();
 
   return element;
-};
+}) as unknown) as ForwardRefWithAs<'li', HTMLLIElement, ListItemProps & { index: number }> &
+  FluentComponentStaticProps<ListItemProps>;
 
 ListItem.displayName = 'ListItem';
 


### PR DESCRIPTION
#### Description of changes

Make `List` and `ListItem` a `forwardRef` component to properly pass ref to root slots. 
