### PR TITLE
Charting:CherryPick#20536:Resolved DonutChart valueInsideDonut text does not change to light color font in dark mode theme

### DIFF
--- a/change/@uifabric-charting-bccbb6a4-833b-41a6-9be6-3dc021ce4a9f.json
+++ b/change/@uifabric-charting-bccbb6a4-833b-41a6-9be6-3dc021ce4a9f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Charting:CherryPick#20536:Resolved DonutChart valueInsideDonut text does not change to light color font in dark mode theme",
+  "packageName": "@uifabric/charting",
+  "email": "v-pkoganti@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/DonutChart/Arc/Arc.styles.ts
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.styles.ts
@@ -21,6 +21,7 @@ export const getStyles = (props: IArcProps): IArcStyles => {
     },
     insideDonutString: {
       fontSize: FontSizes.large,
+      fill: theme.semanticColors.bodyText,
     },
   };
 };

--- a/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -71,6 +71,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -106,6 +107,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -433,6 +435,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -468,6 +471,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -795,6 +799,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -830,6 +835,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -917,6 +923,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -952,6 +959,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -1279,6 +1287,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"
@@ -1316,6 +1325,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               className=
 
                   {
+                    fill: #323130;
                     font-size: 18px;
                   }
               textAnchor="middle"


### PR DESCRIPTION
**Original description**
Cherry Pick #20536 [](https://github.com/microsoft/fluentui/pull/20536)


 DonutChart valueInsideDonut text does not change to light color font in dark mode theme

#### Pull request checklist

- [x] Addresses an existing issue: Fixes [#19906](https://github.com/microsoft/fluentui/issues/19906)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

 DonutChart valueInsideDonut text does not change to light color font in dark mode theme

#### Focus areas to test

DonutChart

<img width="963" alt="before_fix" src="https://user-images.githubusercontent.com/40680570/140696888-21c9fb4a-ea09-4553-ac57-d2f03051b045.png">
<img width="960" alt="After Fix" src="https://user-images.githubusercontent.com/40680570/140696911-8fd2ffba-6391-4370-9fc5-3e4163b19d75.png">
