### PR TITLE
feat(make-styles-webpack-loader): support resolve plugins

### DIFF
--- a/change/@fluentui-make-styles-webpack-loader-614a0230-6dd7-4e4c-8bcf-4f0031dc206c.json
+++ b/change/@fluentui-make-styles-webpack-loader-614a0230-6dd7-4e4c-8bcf-4f0031dc206c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Support resolve plugins from webpack config",
+  "packageName": "@fluentui/make-styles-webpack-loader",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/make-styles-webpack-loader/__fixtures__/webpack-resolve-plugins/code.ts
+++ b/packages/make-styles-webpack-loader/__fixtures__/webpack-resolve-plugins/code.ts
@@ -1,0 +1,12 @@
+import { makeStyles } from '@fluentui/react-make-styles';
+// @ts-ignore
+import color from 'non-existing-color-module';
+
+const styles = makeStyles({
+  root: theme => ({
+    backgroundColor: color,
+    color: theme.colorBrandStroke1,
+  }),
+});
+
+console.log(styles);

--- a/packages/make-styles-webpack-loader/__fixtures__/webpack-resolve-plugins/color.ts
+++ b/packages/make-styles-webpack-loader/__fixtures__/webpack-resolve-plugins/color.ts
@@ -1,0 +1,3 @@
+const color = 'blue';
+
+export default color;

--- a/packages/make-styles-webpack-loader/__fixtures__/webpack-resolve-plugins/output.ts
+++ b/packages/make-styles-webpack-loader/__fixtures__/webpack-resolve-plugins/output.ts
@@ -1,0 +1,17 @@
+import { __styles } from '@fluentui/react-make-styles'; // @ts-ignore
+
+import color from 'non-existing-color-module';
+
+const styles = __styles(
+  {
+    root: {
+      De3pzq: 'f1bh81bl',
+      sj55zd: 'fl9q5hc',
+    },
+  },
+  {
+    d: ['.f1bh81bl{background-color:blue;}', '.fl9q5hc{color:var(--colorBrandStroke1);}'],
+  },
+);
+
+console.log(styles);

--- a/packages/make-styles-webpack-loader/src/webpackLoader.test.ts
+++ b/packages/make-styles-webpack-loader/src/webpackLoader.test.ts
@@ -220,6 +220,34 @@ describe('webpackLoader', () => {
     },
   });
 
+  // Asserts that aliases are resolved properly in Babel plugin
+  testFixture('webpack-aliases', {
+    webpackConfig: {
+      resolve: {
+        plugins: [
+          {
+            apply: function (resolver) {
+              const target = resolver.ensureHook('resolve');
+              resolver.getHook('before-resolve').tapAsync('ResolveFallback', (request, resolveContext, callback) => {
+                if (request.request === 'non-existing-color-module') {
+                  const obj = {
+                    directory: request.directory,
+                    path: request.path,
+                    query: request.query,
+                    request: path.resolve(__dirname, '..', '__fixtures__', 'webpack-aliases', 'color.ts'),
+                  };
+                  return resolver.doResolve(target, obj, null, resolveContext, callback);
+                }
+
+                callback();
+              });
+            },
+          },
+        ],
+      },
+    },
+  });
+
   // Asserts handling errors from Babel plugin
   testFixture('error-argument-count');
   // Asserts errors in loader's config

--- a/packages/make-styles-webpack-loader/src/webpackLoader.test.ts
+++ b/packages/make-styles-webpack-loader/src/webpackLoader.test.ts
@@ -220,12 +220,14 @@ describe('webpackLoader', () => {
     },
   });
 
-  // Asserts that aliases are resolved properly in Babel plugin
+  // Asserts that aliases are resolved properly in Babel plugin with resolve plugins
   testFixture('webpack-aliases', {
     webpackConfig: {
       resolve: {
         plugins: [
           {
+            // Simple plugin that will detect the non-existent module we are testing for and replace with
+            // correct path from the fixture
             apply: function (resolver) {
               const target = resolver.ensureHook('resolve');
               resolver.getHook('before-resolve').tapAsync('ResolveFallback', (request, resolveContext, callback) => {
@@ -234,7 +236,7 @@ describe('webpackLoader', () => {
                     directory: request.directory,
                     path: request.path,
                     query: request.query,
-                    request: path.resolve(__dirname, '..', '__fixtures__', 'webpack-aliases', 'color.ts'),
+                    request: path.resolve(__dirname, '..', '__fixtures__', 'webpack-resolve-plugins', 'color.ts'),
                   };
                   return resolver.doResolve(target, obj, null, resolveContext, callback);
                 }

--- a/packages/make-styles-webpack-loader/src/webpackLoader.ts
+++ b/packages/make-styles-webpack-loader/src/webpackLoader.ts
@@ -72,6 +72,7 @@ export function webpackLoader(
     ...resolveOptionsDefaults,
     alias: resolveOptionsFromWebpackConfig.alias,
     modules: resolveOptionsFromWebpackConfig.modules,
+    plugins: resolveOptionsFromWebpackConfig.plugins,
   });
 
   const originalResolveFilename = Module._resolveFilename;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Adds the resolve plugins from the current webpack compliation object to
`enhancedResolve` just like aliases are.

This will support third party resolve plugins like [ts-config-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin)

#### Focus areas to test

(optional)
