### PR TITLE
feat(react-tabster): Use uncontrolled tabbing by default

### DIFF
--- a/change/@fluentui-react-tabster-71025b3b-cee3-4063-9189-cbec3a3cbe5f.json
+++ b/change/@fluentui-react-tabster-71025b3b-cee3-4063-9189-cbec3a3cbe5f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use uncontrolled tabbing by default",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tabster/package.json
+++ b/packages/react-tabster/package.json
@@ -39,7 +39,7 @@
     "@fluentui/react-shared-contexts": "9.0.0-beta.2",
     "@fluentui/react-utilities": "9.0.0-beta.2",
     "keyborg": "^1.0.0",
-    "tabster": "^1.0.4",
+    "tabster": "^1.0.5",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-tabster/package.json
+++ b/packages/react-tabster/package.json
@@ -39,7 +39,7 @@
     "@fluentui/react-shared-contexts": "9.0.0-beta.2",
     "@fluentui/react-utilities": "9.0.0-beta.2",
     "keyborg": "^1.0.0",
-    "tabster": "^1.0.0",
+    "tabster": "^1.0.4",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-tabster/package.json
+++ b/packages/react-tabster/package.json
@@ -39,7 +39,7 @@
     "@fluentui/react-shared-contexts": "9.0.0-beta.2",
     "@fluentui/react-utilities": "9.0.0-beta.2",
     "keyborg": "^1.0.0",
-    "tabster": "^1.0.5",
+    "tabster": "^1.0.6",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-tabster/src/hooks/useTabster.ts
+++ b/packages/react-tabster/src/hooks/useTabster.ts
@@ -12,7 +12,7 @@ export const useTabster = (): TabsterTypes.TabsterCore | null => {
   const { targetDocument } = useFluent();
 
   const defaultView = targetDocument?.defaultView || undefined;
-  const tabsterOptions = { autoRoot: {} };
+  const tabsterOptions: TabsterTypes.TabsterCoreProps = { autoRoot: {}, controlTab: false };
 
   if (!defaultView) {
     return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -23961,10 +23961,10 @@ table@^6.0.4:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
 
-tabster@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-1.0.0.tgz#ba71943d0cabaa743ac028604a90284bb2e82b68"
-  integrity sha512-k6g6jVi4gXT/zFKomyeM8B6Cdsdv2eYQgdnaLI0b7N7JKKF5TMoN2hoXuMKEIc9Swt5JKV2eVJHe+C7U4h07nw==
+tabster@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-1.0.4.tgz#1e5f0e1f0c92459b239e72f6c21f72003da51420"
+  integrity sha512-N/XQVfIYB4GIxFxK1VOftCxh6Jvojce36tgV7nDAQ2P+WXYpL8sTn4uUoQ13Urf+knCOnoKmreKwteqa+m5OTw==
   dependencies:
     keyborg "^1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23961,10 +23961,10 @@ table@^6.0.4:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
 
-tabster@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-1.0.4.tgz#1e5f0e1f0c92459b239e72f6c21f72003da51420"
-  integrity sha512-N/XQVfIYB4GIxFxK1VOftCxh6Jvojce36tgV7nDAQ2P+WXYpL8sTn4uUoQ13Urf+knCOnoKmreKwteqa+m5OTw==
+tabster@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-1.0.5.tgz#5165a31f60e47518fe549f02a2ca4e8756568250"
+  integrity sha512-94MI6wSv+7Dkf8K4YSe/UsMPvD+ZeyqT4iNp31RF8njopHWz28Cm38ep+u7nrqX+6glTxfFDvSZkqHL8ZKbfkA==
   dependencies:
     keyborg "^1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23961,10 +23961,10 @@ table@^6.0.4:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
 
-tabster@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-1.0.5.tgz#5165a31f60e47518fe549f02a2ca4e8756568250"
-  integrity sha512-94MI6wSv+7Dkf8K4YSe/UsMPvD+ZeyqT4iNp31RF8njopHWz28Cm38ep+u7nrqX+6glTxfFDvSZkqHL8ZKbfkA==
+tabster@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-1.0.6.tgz#6f0519583e22526863eeeab04743e42128f23f7d"
+  integrity sha512-vokH9X2FWT9nB+4Qn4Pt/UNtlgQzxcD0TuG82ZYupSFEhxLUPfkuoB0Jcr00S9YXq4IsEkej/9PdDkwatf71lA==
   dependencies:
     keyborg "^1.0.0"
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Pulls the latest tabster version to use the changes in microsoft/tabster#64 So that focus sentinels are not used in all components that use tabster.

This will result in partners no longer having focus being stolen unless it's being used in a tabster API

#### Focus areas to test

(optional)
