### PR TITLE
feat(tools): remove ts-ignore pragmas from stories during migration

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -641,6 +641,39 @@ describe('migrate-converged-pkg generator', () => {
         ]),
       );
     });
+
+    it(`should remove @ts-ignore pragmas from all stories`, async () => {
+      const { paths } = setup({ createDummyStories: true });
+      append(
+        tree,
+        paths.storyOne,
+        stripIndents`
+        // https://github.com/microsoft/fluentui/pull/18695#issuecomment-868432982
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        import { Button } from '@fluentui/react-button';
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        import { Text } from '@fluentui/react-text';
+      `,
+      );
+
+      await generator(tree, options);
+
+      expect(tree.read(paths.storyOne)?.toString('utf-8')).toMatchInlineSnapshot(`
+        "import * as Implementation from './index';
+        export const Foo = (props: FooProps) => { return <div>Foo</div>; }\\\\n
+
+
+
+        import { Button } from '@fluentui/react-button';
+
+
+
+        import { Text } from '@fluentui/react-text';"
+      `);
+    });
   });
 
   describe(`e2e config`, () => {
@@ -1254,7 +1287,7 @@ function append(tree: Tree, filePath: string, content: string) {
     filePath,
     stripIndents`
         ${tree.read(filePath)?.toString('utf-8')}\n
-        ${content};
+        ${content}
         `,
   );
 

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -587,6 +587,8 @@ function setupStorybook(tree: Tree, options: NormalizedSchema) {
 
       return json;
     });
+
+    removeTsIgnorePragmas();
   }
 
   if (sbAction === 'remove') {
@@ -619,6 +621,37 @@ function setupStorybook(tree: Tree, options: NormalizedSchema) {
 
       return json;
     });
+  }
+
+  function removeTsIgnorePragmas() {
+    const stories: string[] = [];
+    visitNotIgnoredFiles(tree, options.paths.sourceRoot, treePath => {
+      if (treePath.includes('.stories.')) {
+        stories.push(treePath);
+      }
+    });
+
+    stories.forEach(storyPath => {
+      const content = tree.read(storyPath)?.toString('utf-8');
+
+      if (!content) {
+        throw new Error('story file has no code');
+      }
+
+      let updatedContent = content.replace(/\/\/\s+@ts-ignore/g, '');
+      updatedContent = updatedContent.replace(
+        /\/\/\s+eslint-disable-next-line\s+@typescript-eslint\/ban-ts-comment/g,
+        '',
+      );
+      updatedContent = updatedContent.replace(
+        /\/\/\s+https:\/\/github\.com\/microsoft\/fluentui\/pull\/18695#issuecomment-868432982/g,
+        '',
+      );
+
+      tree.write(storyPath, updatedContent);
+    });
+
+    return tree;
   }
 
   return tree;


### PR DESCRIPTION
### Depends on

- [x] https://github.com/microsoft/fluentui/pull/20478

#### Pull request checklist

- [x] Addresses an existing issue: 
  - Implements partially #19866, 
  - implements https://github.com/microsoft/fluentui/issues/20560
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

- when running `migrate-converged-pkg` to migrate package setup to TS solution config files, this will automatically remove `@ts-ignores` pragmas that were need - thus allow proper TS checking and DX

#### Focus areas to test

(optional)
