### PR TITLE
chore(react-menu): use react-shared-contexts instead of react-provider

### DIFF
--- a/change/@fluentui-react-menu-2094f79e-b1fa-4a56-b806-883848cdd7b9.json
+++ b/change/@fluentui-react-menu-2094f79e-b1fa-4a56-b806-883848cdd7b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use react-shared-contexts instead of react-provider",
+  "packageName": "@fluentui/react-menu",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/package.json
+++ b/packages/react-menu/package.json
@@ -50,7 +50,7 @@
     "@fluentui/react-make-styles": "9.0.0-beta.2",
     "@fluentui/react-portal": "9.0.0-beta.3",
     "@fluentui/react-positioning": "9.0.0-beta.2",
-    "@fluentui/react-provider": "9.0.0-beta.3",
+    "@fluentui/react-shared-contexts": "9.0.0-beta.2",
     "@fluentui/react-tabster": "9.0.0-beta.3",
     "@fluentui/react-utilities": "9.0.0-beta.2",
     "tslib": "^2.1.0"

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { usePopperMouseTarget, usePopper, resolvePositioningShorthand } from '@fluentui/react-positioning';
 import { useControllableState, useId, useOnClickOutside, useEventCallback } from '@fluentui/react-utilities';
-import { useFluent } from '@fluentui/react-provider';
+import { useFluent } from '@fluentui/react-shared-contexts';
 import { elementContains } from '@fluentui/react-portal';
 import { useFocusFinders } from '@fluentui/react-tabster';
 import { MenuTrigger } from '../MenuTrigger/index';


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`@fluentui/react-menu` should not use `@fluentui/react-provider`, this PR switches dependency to `@fluentui/react-shared-contexts`.