### PR TITLE
Resolved : For vertical bar charts, yAxis height is not proper when highest value is odd number 

### DIFF
--- a/change/@fluentui-react-charting-dff810e5-e702-477a-acf1-479a99716cfa.json
+++ b/change/@fluentui-react-charting-dff810e5-e702-477a-acf1-479a99716cfa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "YAxis issue for bar charts solved, when highest y axis value is odd number",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -14,6 +14,7 @@ import {
   convertToLocaleString,
   createNumericXAxis,
   createStringXAxis,
+  IAxisData,
   getAccessibleDataObject,
   getDomainNRangeValues,
   createDateXAxis,
@@ -198,12 +199,13 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let yScale: any;
+    const axisData: IAxisData = { yAxisDomainValues: [] };
     if (this.props.yAxisType && this.props.yAxisType === YAxisType.StringAxis) {
       yScale = createStringYAxis(YAxisParams, this.props.stringDatasetForYAxisDomain!, this._isRtl);
     } else {
-      yScale = createYAxis(YAxisParams, this._isRtl);
+      yScale = createYAxis(YAxisParams, this._isRtl, axisData);
     }
-
+    this.props.getAxisData && this.props.getAxisData(axisData);
     // Callback function for chart, returns axis
     this._getData(xScale, yScale);
 

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
@@ -480,4 +480,7 @@ export interface IModifiedCartesianChartProps extends ICartesianChartProps {
    * The prop used to define the culture to localized the numbers
    */
   culture?: string;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getAxisData?: any;
 }

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -9,6 +9,7 @@ import { DirectionalHint } from '@fluentui/react/lib/Callout';
 import { FocusZoneDirection } from '@fluentui/react-focus';
 import {
   ChartTypes,
+  IAxisData,
   getAccessibleDataObject,
   tooltipOfXAxislabels,
   XAxisTypes,
@@ -159,6 +160,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
         customizedCallout={this._getCustomizedCallout()}
         getmargins={this._getMargins}
         getGraphData={this._getGraphData}
+        getAxisData={this._getAxisData}
         /* eslint-disable react/jsx-no-bind */
         // eslint-disable-next-line react/no-children-prop
         children={() => {
@@ -487,5 +489,12 @@ export class GroupedVerticalBarChartBase extends React.Component<
         {...this.props.legendProps}
       />
     );
+  };
+
+  private _getAxisData = (yAxisData: IAxisData) => {
+    if (yAxisData && yAxisData.yAxisDomainValues.length) {
+      const { yAxisDomainValues: domainValue } = yAxisData;
+      this._yMax = Math.max(domainValue[domainValue.length - 1], this.props.yMaxValue || 0);
+    }
   };
 }

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
-            y={5.333333333333329}
+            y={4.45652173913043}
           />
           <rect
             aria-labelledby="toolTipcallout0"
@@ -207,7 +207,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             role="text"
             width={7.267759562841528}
             x={8.0327868852459}
-            y={20}
+            y={18.80434782608696}
           />
           <rect
             aria-labelledby="toolTipcallout0"
@@ -679,7 +679,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
-            y={5.333333333333329}
+            y={4.45652173913043}
           />
           <rect
             aria-labelledby="toolTipcallout12"
@@ -767,7 +767,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             role="text"
             width={7.267759562841528}
             x={8.0327868852459}
-            y={20}
+            y={18.80434782608696}
           />
           <rect
             aria-labelledby="toolTipcallout12"
@@ -1219,7 +1219,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
-            y={5.333333333333329}
+            y={4.45652173913043}
           />
           <rect
             aria-labelledby="toolTipcallout4"
@@ -1307,7 +1307,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             role="text"
             width={7.267759562841528}
             x={8.0327868852459}
-            y={20}
+            y={18.80434782608696}
           />
           <rect
             aria-labelledby="toolTipcallout4"
@@ -1456,7 +1456,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
-            y={5.333333333333329}
+            y={4.45652173913043}
           />
           <rect
             aria-labelledby="toolTipcallout8"
@@ -1544,7 +1544,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             role="text"
             width={7.267759562841528}
             x={8.0327868852459}
-            y={20}
+            y={18.80434782608696}
           />
           <rect
             aria-labelledby="toolTipcallout8"
@@ -2016,7 +2016,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
-            y={5.333333333333329}
+            y={4.45652173913043}
           />
           <rect
             aria-labelledby="toolTipcallout16"
@@ -2104,7 +2104,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             role="text"
             width={7.267759562841528}
             x={8.0327868852459}
-            y={20}
+            y={18.80434782608696}
           />
           <rect
             aria-labelledby="toolTipcallout16"
@@ -2576,7 +2576,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
-            y={5.333333333333329}
+            y={4.45652173913043}
           />
           <rect
             aria-labelledby="toolTipcallout20"
@@ -2664,7 +2664,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             role="text"
             width={7.267759562841528}
             x={8.0327868852459}
-            y={20}
+            y={18.80434782608696}
           />
           <rect
             aria-labelledby="toolTipcallout20"
@@ -3136,7 +3136,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             role="text"
             width={7.267759562841528}
             x={0.3825136612021858}
-            y={5.333333333333329}
+            y={4.45652173913043}
           />
           <rect
             aria-labelledby="toolTipcallout24"
@@ -3224,7 +3224,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             role="text"
             width={7.267759562841528}
             x={8.0327868852459}
-            y={20}
+            y={18.80434782608696}
           />
           <rect
             aria-labelledby="toolTipcallout24"

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -25,6 +25,7 @@ import {
 import { FocusZoneDirection } from '@fluentui/react-focus';
 import {
   ChartTypes,
+  IAxisData,
   getAccessibleDataObject,
   XAxisTypes,
   NumericAxis,
@@ -146,6 +147,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
         customizedCallout={this._getCustomizedCallout()}
         getmargins={this._getMargins}
         getGraphData={this._getGraphData}
+        getAxisData={this._getAxisData}
         /* eslint-disable react/jsx-no-bind */
         // eslint-disable-next-line react/no-children-prop
         children={(props: IChildProps) => {
@@ -675,5 +677,12 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
       />
     );
     return legends;
+  };
+
+  private _getAxisData = (yAxisData: IAxisData) => {
+    if (yAxisData && yAxisData.yAxisDomainValues.length) {
+      const { yAxisDomainValues: domainValue } = yAxisData;
+      this._yMax = Math.max(domainValue[domainValue.length - 1], this.props.yMaxValue || 0);
+    }
   };
 }

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -26,6 +26,7 @@ import {
 import { FocusZoneDirection } from '@fluentui/react-focus';
 import {
   ChartTypes,
+  IAxisData,
   getAccessibleDataObject,
   XAxisTypes,
   getTypeOfAxis,
@@ -83,6 +84,7 @@ export class VerticalStackedBarChartBase extends React.Component<
   private _createLegendsForLine: (data: IVerticalStackedChartProps[]) => LineLegends[];
   private _lineObject: LineObject;
   private _tooltipId: string;
+  private _yMax: number;
 
   public constructor(props: IVerticalStackedBarChartProps) {
     super(props);
@@ -177,6 +179,7 @@ export class VerticalStackedBarChartBase extends React.Component<
         }
         getmargins={this._getMargins}
         getGraphData={this._getGraphData}
+        getAxisData={this._getAxisData}
         customizedCallout={this._getCustomizedCallout()}
         /* eslint-disable react/jsx-no-bind */
         // eslint-disable-next-line react/no-children-prop
@@ -631,10 +634,6 @@ export class VerticalStackedBarChartBase extends React.Component<
     this.props.href ? (window.location.href = this.props.href) : '';
   }
 
-  private _getYMax = (dataset: IDataPoint[]) => {
-    return Math.max(d3Max(dataset, (point: IDataPoint) => point.y)!, this.props.yMaxValue || 0);
-  };
-
   private _getBarGapAndScale(
     bars: IVSChartDataPoint[],
     yBarScale: NumericScale,
@@ -811,7 +810,7 @@ export class VerticalStackedBarChartBase extends React.Component<
   };
 
   private _getScales = (containerHeight: number, containerWidth: number, isNumeric: boolean) => {
-    const yMax = this._getYMax(this._dataset);
+    const yMax = this._yMax;
     const yBarScale = d3ScaleLinear()
       .domain([0, yMax])
       .range([0, containerHeight - this.margins.bottom! - this.margins.top!]);
@@ -874,5 +873,12 @@ export class VerticalStackedBarChartBase extends React.Component<
     this.setState({
       isCalloutVisible: false,
     });
+  };
+
+  private _getAxisData = (yAxisData: IAxisData) => {
+    if (yAxisData && yAxisData.yAxisDomainValues.length) {
+      const { yAxisDomainValues: domainValue } = yAxisData;
+      this._yMax = Math.max(domainValue[domainValue.length - 1], this.props.yMaxValue || 0);
+    }
   };
 }

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -44,6 +44,10 @@ export interface IWrapLabelProps {
   showXAxisLablesTooltip: boolean;
 }
 
+export interface IAxisData {
+  yAxisDomainValues: number[];
+}
+
 export interface IMargins {
   /**
    * left margin for the chart.
@@ -220,7 +224,7 @@ export function prepareDatapoints(maxVal: number, minVal: number, splitInto: num
  * @param {IYAxisParams} yAxisParams
  * @param {boolean} isRtl
  */
-export function createYAxis(yAxisParams: IYAxisParams, isRtl: boolean) {
+export function createYAxis(yAxisParams: IYAxisParams, isRtl: boolean, axisData: IAxisData) {
   const {
     yMinMaxValues = { startValue: 0, endValue: 0 },
     yAxisElement = null,
@@ -252,6 +256,7 @@ export function createYAxis(yAxisParams: IYAxisParams, isRtl: boolean) {
     .tickSizeInner(-(containerWidth - margins.left! - margins.right!));
   yAxisTickFormat ? yAxis.tickFormat(yAxisTickFormat) : yAxis.tickFormat(d3Format('.2~s'));
   yAxisElement ? d3Select(yAxisElement).call(yAxis).selectAll('text').attr('aria-hidden', 'true') : '';
+  axisData.yAxisDomainValues = domainValues;
   return yAxisScale;
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes [#20491](https://github.com/microsoft/fluentui/issues/20491)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
The issue is observed when the max y value is an odd number.
But while doing calculations, a decimal number is changed to an integer value, due to which the d3 y-axis scale is not set properly. 

**For example:** 
Suppose, the user passes the data having Y max value is 23, while calculation, it will round off to 24.
Previously all the calculations (like bar height) are done with 23 values, but while showing the y-Axis scale, 24 number was considered.  

With the new change, here the y-axis scale is set with the highest value which will be shown on Y-Axis. 
So all the calculations are done with 24. 

To achieve this, one more prop is added in the cartesian component. Which is used as a callback to set axis data in the individual chart components. And all the calculations are done with the highest y-Axis value which will be shown on the chart.
Here I have considered the existing prop also **yMaxValue**, if the user sets this prop, the chart will work accordingly.  

#### Focus areas to test

 Vertical bar, group bar and Vertical stacked bar chart

### **Before Changes:**

**Vertical Stacked Bar Chart:**
![image](https://user-images.githubusercontent.com/29042635/141339457-12ad824d-23a5-475e-b0b1-0363415cc993.png)

**Grouped Bar Chart:**
![image](https://user-images.githubusercontent.com/29042635/141339213-daa53b1c-2439-46df-8b31-a01b95ab75c6.png)

**Vertical Bar:** 
![image](https://user-images.githubusercontent.com/29042635/141339064-a9316811-195a-4180-bc04-52edbba6d03e.png)


**### After Changes:**
**Vertical Stacked Bar Chart:**
![image](https://user-images.githubusercontent.com/29042635/141339765-f1edbda7-408d-47ae-a7f7-e2f48aa375df.png)

**Grouped Bar Chart:**
![image](https://user-images.githubusercontent.com/29042635/141340103-7c26b56b-b7c2-44be-b146-0fc5fabbe40c.png)

**Vertical Bar:** 
![image](https://user-images.githubusercontent.com/29042635/141340727-aa57faf8-1280-4896-b955-467abc807c24.png)


