### PR TITLE
feat(tools): enable multiple package migration via --name option

### DIFF
--- a/tools/generators/migrate-converged-pkg/README.md
+++ b/tools/generators/migrate-converged-pkg/README.md
@@ -14,8 +14,6 @@ Workspace Generator for migrating converged packages to new DX (stage 1)[https:/
 
 <!-- tocstop -->
 
-## NOTES
-
 ## Usage
 
 ```sh
@@ -59,6 +57,18 @@ Type: `string`
 Package/library name (needs to be full name of the package, scope included - e.g. `@fluentui/<package-name>`)
 
 > NOTE: will trigger CLI prompt if you didn't provide this option
+
+**Run migration on subset of packages:**
+
+To run migration on multiple packages you can specify a comma separated list of project names.
+
+```sh
+# run migration on:
+# - @fluentui/lib-zero
+# - @fluentui/lib-one
+# - @fluentui/lib-two
+yarn nx workspace-generator migrate-converged-pkg --name='@fluentui/lib-zero,@fluentui/lib-one,@fluentui/lib-two'
+```
 
 #### `all`
 

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -1144,6 +1144,29 @@ describe('migrate-converged-pkg generator', () => {
       expect(configs['@proj/react-old'].sourceRoot).not.toBeDefined();
     });
   });
+
+  describe(`--name`, () => {
+    it(`should accept comma separated string to exec on multiple projects`, async () => {
+      const projects = [options.name, '@proj/react-one', '@proj/react-two', '@proj/react-old'] as const;
+
+      setupDummyPackage(tree, { name: projects[1], version: '9.0.22' });
+      setupDummyPackage(tree, { name: projects[2], version: '9.0.31' });
+      setupDummyPackage(tree, { name: projects[3], version: '8.0.1' });
+
+      await generator(tree, { name: `${projects[0]},${projects[1]}` });
+
+      const configs = projects.reduce((acc, projectName) => {
+        acc[projectName] = readProjectConfiguration(tree, projectName);
+
+        return acc;
+      }, {} as Record<typeof projects[number], ReadProjectConfiguration>);
+
+      expect(configs[projects[0]].sourceRoot).toBeDefined();
+      expect(configs[projects[1]].sourceRoot).toBeDefined();
+      expect(configs[projects[2]].sourceRoot).not.toBeDefined();
+      expect(configs[projects[3]].sourceRoot).not.toBeDefined();
+    });
+  });
 });
 
 // ==== helpers ====

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -6,7 +6,6 @@ import {
   readWorkspaceConfiguration,
   joinPathFragments,
   readJson,
-  getProjects,
   stripIndents,
   visitNotIgnoredFiles,
   logger,
@@ -18,7 +17,15 @@ import * as path from 'path';
 import * as os from 'os';
 
 import { PackageJson, TsConfig } from '../../types';
-import { arePromptsEnabled, getProjectConfig, printUserLogs, prompt, updateJestConfig, UserLog } from '../../utils';
+import {
+  arePromptsEnabled,
+  getProjectConfig,
+  getProjects,
+  printUserLogs,
+  prompt,
+  updateJestConfig,
+  UserLog,
+} from '../../utils';
 
 import { MigrateConvergedPkgGeneratorSchema } from './schema';
 
@@ -63,11 +70,9 @@ export default async function (tree: Tree, schema: MigrateConvergedPkgGeneratorS
 }
 
 function runBatchMigration(tree: Tree, userLog: UserLog, projectNames?: string[]) {
-  const projects = Array.from(getProjects(tree)).filter(([projectName]) => {
-    return projectNames ? projectNames.includes(projectName) : true;
-  });
+  const projects = getProjects(tree, projectNames);
 
-  projects.forEach(([projectName, projectConfig]) => {
+  projects.forEach((projectConfig, projectName) => {
     if (!isPackageConverged(tree, projectConfig)) {
       userLog.push({ type: 'error', message: `${projectName} is not converged package. Skipping migration...` });
       return;

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -394,7 +394,7 @@ async function triggerDynamicPrompts() {
 
   return prompt<PromptResponse>([
     {
-      message: 'Which converged package/s would you like migrate to new DX? (ex: @fluentui/react-menu)',
+      message: 'Which converged package(s) would you like migrate to new DX? (ex: @fluentui/react-menu)',
       type: 'input',
       name: 'name',
     },

--- a/tools/generators/migrate-converged-pkg/schema.json
+++ b/tools/generators/migrate-converged-pkg/schema.json
@@ -6,7 +6,7 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Library name or comma delimited library names to execute migration on multiple libraries",
+      "description": "Library name or comma delimited library names to execute migration on multiple libraries.",
       "$default": {
         "$source": "argv",
         "index": 0

--- a/tools/generators/migrate-converged-pkg/schema.json
+++ b/tools/generators/migrate-converged-pkg/schema.json
@@ -6,7 +6,7 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Package name",
+      "description": "Library name or comma delimited library names to execute migration on multiple libraries",
       "$default": {
         "$source": "argv",
         "index": 0

--- a/tools/generators/migrate-converged-pkg/schema.ts
+++ b/tools/generators/migrate-converged-pkg/schema.ts
@@ -1,6 +1,6 @@
 export interface MigrateConvergedPkgGeneratorSchema {
   /**
-   * Library name
+   * Library name or comma delimited library names to execute migration on multiple libraries
    */
   name?: string;
   /**

--- a/tools/generators/migrate-converged-pkg/schema.ts
+++ b/tools/generators/migrate-converged-pkg/schema.ts
@@ -1,6 +1,6 @@
 export interface MigrateConvergedPkgGeneratorSchema {
   /**
-   * Library name or comma delimited library names to execute migration on multiple libraries
+   * Library name or comma delimited library names to execute migration on multiple libraries.
    */
   name?: string;
   /**

--- a/tools/tsconfig.tools.json
+++ b/tools/tsconfig.tools.json
@@ -6,7 +6,8 @@
     "module": "commonjs",
     "target": "es5",
     "types": ["node"],
-    "importHelpers": false
+    "importHelpers": false,
+    "downlevelIteration": true
   },
   "exclude": ["**/*.spec.ts"],
   "include": ["**/*.ts"]

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -1,6 +1,13 @@
 import * as yargsParser from 'yargs-parser';
 import type * as Enquirer from 'enquirer';
-import { joinPathFragments, logger, readProjectConfiguration, readWorkspaceConfiguration, Tree } from '@nrwl/devkit';
+import {
+  joinPathFragments,
+  logger,
+  readProjectConfiguration,
+  readWorkspaceConfiguration,
+  Tree,
+  getProjects as getAllProjects,
+} from '@nrwl/devkit';
 
 /**
  * CLI prompts abstraction to trigger dynamic prompts within a generator
@@ -118,4 +125,29 @@ export function printUserLogs(logs: UserLog) {
   logs.forEach(log => logger[log.type](log.message));
 
   logger.log(`${'='.repeat(80)}\n`);
+}
+
+/**
+ * Overridden `@nrwl/devkit#getProjects` function
+ * Get all workspace projects or only subset, if projectNames array is specified
+ *
+ * @param tree
+ * @param projectNames - array of project names. Use this to return only subset of projects
+ */
+export function getProjects(tree: Tree, projectNames?: string[]) {
+  const allProjects = getAllProjects(tree);
+
+  if (Array.isArray(projectNames) && projectNames.length > 0) {
+    const pickedProjects: ReturnType<typeof getAllProjects> = new Map();
+
+    for (const [projectName, projectConfig] of allProjects.entries()) {
+      if (projectNames.includes(projectName)) {
+        pickedProjects.set(projectName, projectConfig);
+      }
+    }
+
+    return pickedProjects;
+  }
+
+  return allProjects;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: implements partially #19866 
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

Adds support to run migration on multiple packages 

**Before:**

```sh
# run migration on react-text 
yarn nx workspace-generator migrate-converged-pkg --name=@fluentui/react-text

# run migration on react-image
yarn nx workspace-generator migrate-converged-pkg --name=@fluentui/react-image
```


**After:**

```sh
# run migration on react-text and react-image in one run
yarn nx workspace-generator migrate-converged-pkg --name=@fluentui/react-text,@fluentui/react-image
```

![2021-11-11 at 17 26](https://user-images.githubusercontent.com/1223799/141333340-b4500dd4-04b2-4003-8667-821271429fa0.png)


#### Focus areas to test

(optional)
