### PR TITLE
StackCalloutAccessibility implemented in Group Vertical Bar chart

### DIFF
--- a/change/@fluentui-react-charting-4b9ed43d-b2ea-43b7-ad60-d6cd173388c8.json
+++ b/change/@fluentui-react-charting-4b9ed43d-b2ea-43b7-ad60-d6cd173388c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Stack callout accessibility prop added in Grouped Bar chart for Stack callout",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-4b9ed43d-b2ea-43b7-ad60-d6cd173388c8.json
+++ b/change/@fluentui-react-charting-4b9ed43d-b2ea-43b7-ad60-d6cd173388c8.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Stack callout accessibility prop added in Grouped Bar chart for Stack callout",
   "packageName": "@fluentui/react-charting",
   "email": "v-scharde@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "minor"
 }

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -216,7 +216,8 @@ export class GroupedVerticalBarChartBase extends React.Component<
 
   private _onBarHover = (
     pointData: IGVBarChartSeriesPoint,
-    groupSeries: IGVBarChartSeriesPoint[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    groupData: any,
     mouseEvent: React.MouseEvent<SVGElement>,
   ): void => {
     mouseEvent.persist();
@@ -233,8 +234,10 @@ export class GroupedVerticalBarChartBase extends React.Component<
         xCalloutValue: pointData.xAxisCalloutData,
         yCalloutValue: pointData.yAxisCalloutData,
         dataPointCalloutProps: pointData,
-        callOutAccessibilityData: pointData.callOutAccessibilityData,
-        YValueHover: groupSeries,
+        callOutAccessibilityData: this.props.isCalloutForStack
+          ? groupData.stackCallOutAccessibilityData
+          : pointData.callOutAccessibilityData,
+        YValueHover: groupData.groupSeries,
         hoverXValue: pointData.xAxisCalloutData,
       });
     }
@@ -244,7 +247,8 @@ export class GroupedVerticalBarChartBase extends React.Component<
 
   private _onBarFocus = (
     pointData: IGVBarChartSeriesPoint,
-    groupSeries: IGVBarChartSeriesPoint[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    groupData: any,
     refArrayIndexNumber: number,
   ): void => {
     if (
@@ -262,8 +266,10 @@ export class GroupedVerticalBarChartBase extends React.Component<
             xCalloutValue: pointData.xAxisCalloutData,
             yCalloutValue: pointData.yAxisCalloutData,
             dataPointCalloutProps: pointData,
-            callOutAccessibilityData: pointData.callOutAccessibilityData,
-            YValueHover: groupSeries,
+            callOutAccessibilityData: this.props.isCalloutForStack
+              ? groupData.stackCallOutAccessibilityData
+              : pointData.callOutAccessibilityData,
+            YValueHover: groupData.groupSeries,
             hoverXValue: pointData.xAxisCalloutData,
           });
         }
@@ -321,10 +327,10 @@ export class GroupedVerticalBarChartBase extends React.Component<
               this._refCallback(e!, pointData.legend, refIndexNumber);
             }}
             fill={pointData.color}
-            onMouseOver={this._onBarHover.bind(this, pointData, singleSet.groupSeries)}
-            onMouseMove={this._onBarHover.bind(this, pointData, singleSet.groupSeries)}
+            onMouseOver={this._onBarHover.bind(this, pointData, singleSet)}
+            onMouseMove={this._onBarHover.bind(this, pointData, singleSet)}
             onMouseOut={this._onBarLeave}
-            onFocus={this._onBarFocus.bind(this, pointData, singleSet.groupSeries, refIndexNumber)}
+            onFocus={this._onBarFocus.bind(this, pointData, singleSet, refIndexNumber)}
             onBlur={this._onBarLeave}
             onClick={this.props.href ? this._redirectToUrl.bind(this, this.props.href!) : pointData.onClick}
             aria-labelledby={`toolTip${this._calloutId}`}
@@ -375,6 +381,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
       singleDatasetPointForBars.xAxisPoint = point.name;
       singleDatasetPointForBars.indexNum = index;
       singleDatasetPointForBars.groupSeries = singleDataSeries;
+      singleDatasetPointForBars.stackCallOutAccessibilityData = point.stackCallOutAccessibilityData;
       datasetForBars.push(singleDatasetPointForBars);
       dataset.push(singleDatasetPoint);
     });

--- a/packages/react-charting/src/types/IDataPoint.ts
+++ b/packages/react-charting/src/types/IDataPoint.ts
@@ -526,6 +526,11 @@ export interface IGroupedVerticalBarChartData {
    * Data points for Grouped vertical bar chart
    */
   series: IGVBarChartSeriesPoint[];
+
+  /**
+   * Accessibility data for Group Bars Stack Callout
+   */
+  stackCallOutAccessibilityData?: IAccessibilityProps;
 }
 
 export interface IGVDataPoint {

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
@@ -5,9 +5,12 @@ import {
   IGroupedVerticalBarChartProps,
   IGroupedVerticalBarChartData,
 } from '@fluentui/react-charting';
+import { ChoiceGroup, IChoiceGroupOption } from '@fluentui/react/lib/ChoiceGroup';
+
 interface IGroupedBarChartState {
   width: number;
   height: number;
+  selectedCallout: 'singleCallout' | 'StackCallout';
 }
 
 export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Component<{}, IGroupedBarChartState> {
@@ -16,6 +19,7 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
     this.state = {
       width: 700,
       height: 400,
+      selectedCallout: 'singleCallout',
     };
   }
 
@@ -28,6 +32,10 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
   };
   private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({ height: parseInt(e.target.value, 10) });
+  };
+
+  private _onChange = (ev: React.FormEvent<HTMLInputElement>, option: IChoiceGroupOption): void => {
+    this.setState({ selectedCallout: option.key as IGroupedBarChartState['selectedCallout'] });
   };
 
   private _basicExample(): JSX.Element {
@@ -43,7 +51,7 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
             xAxisCalloutData: '2020/04/30',
             yAxisCalloutData: '33%',
             callOutAccessibilityData: {
-              ariaLabel: 'Group series 1 of 4, Bar series 1 of 2 2020/04/30 33%',
+              ariaLabel: 'Group series 1 of 4, Bar series 1 of 2 x-Axis 2020/04/30 MetaData1 33%',
             },
           },
           {
@@ -54,10 +62,13 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
             xAxisCalloutData: '2020/04/30',
             yAxisCalloutData: '44%',
             callOutAccessibilityData: {
-              ariaLabel: 'Bar series 2 of 2 2020/04/30 44%',
+              ariaLabel: 'Bar series 2 of 2 x-Axis 2020/04/30 MetaData4 44%',
             },
           },
         ],
+        stackCallOutAccessibilityData: {
+          ariaLabel: 'Group series 1 of 4 x-Axis 2020/04/30 MetaData1 33% MetaData4 44%',
+        },
       },
       {
         name: 'Meta Data2',
@@ -70,7 +81,7 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
             xAxisCalloutData: '2020/04/30',
             yAxisCalloutData: '33%',
             callOutAccessibilityData: {
-              ariaLabel: 'Group series 2 of 4, Bar series 1 of 2 2020/04/30 33%',
+              ariaLabel: 'Group series 2 of 4, Bar series 1 of 2 x-Axis 2020/04/30 MetaData1 33%',
             },
           },
           {
@@ -81,12 +92,14 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
             xAxisCalloutData: '2020/04/30',
             yAxisCalloutData: '3%',
             callOutAccessibilityData: {
-              ariaLabel: 'Bar series 2 of 2 2020/04/30 3%',
+              ariaLabel: 'Bar series 2 of 2 x-Axis 2020/04/30 MetaData4 3%',
             },
           },
         ],
+        stackCallOutAccessibilityData: {
+          ariaLabel: 'Group series 2 of 4 x-Axis 2020/04/30 MetaData1 33% MetaData4 3%',
+        },
       },
-
       {
         name: 'Single line text ',
         series: [
@@ -98,7 +111,7 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
             xAxisCalloutData: '2020/04/30',
             yAxisCalloutData: '14%',
             callOutAccessibilityData: {
-              ariaLabel: 'Group series 3 of 4, Bar series 1 of 2 2020/04/30 14%',
+              ariaLabel: 'Group series 3 of 4, Bar series 1 of 2 x-Axis 2020/04/30 MetaData1 14%',
             },
           },
           {
@@ -109,10 +122,13 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
             xAxisCalloutData: '2020/04/30',
             yAxisCalloutData: '50%',
             callOutAccessibilityData: {
-              ariaLabel: 'Bar series 2 of 2 2020/04/30 50%',
+              ariaLabel: 'Bar series 2 of 2 x-Axis 2020/04/30 MetaData4 50%',
             },
           },
         ],
+        stackCallOutAccessibilityData: {
+          ariaLabel: 'Group series 3 of 4 x-Axis 2020/04/30 MetaData1 14% MetaData4 50%',
+        },
       },
       {
         name: 'Hello World!!!',
@@ -125,7 +141,7 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
             xAxisCalloutData: '2020/04/30',
             yAxisCalloutData: '33%',
             callOutAccessibilityData: {
-              ariaLabel: 'Group series 4 of 4, Bar series 1 of 2 2020/04/30 33%',
+              ariaLabel: 'Group series 4 of 4, Bar series 1 of 2 x-Axis 2020/04/30 MetaData1 33%',
             },
           },
           {
@@ -136,20 +152,33 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
             xAxisCalloutData: '2020/04/30',
             yAxisCalloutData: '3%',
             callOutAccessibilityData: {
-              ariaLabel: 'Bar series 2 of 2 2020/04/30 3%',
+              ariaLabel: 'Bar series 2 of 2 x-Axis 2020/04/30 MetaData4 3%',
             },
           },
         ],
+        stackCallOutAccessibilityData: {
+          ariaLabel: 'Group series 4 of 4 x-Axis 2020/04/30 MetaData1 33% MetaData4 3%',
+        },
       },
     ];
 
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+    const options: IChoiceGroupOption[] = [
+      { key: 'singleCallout', text: 'Single callout' },
+      { key: 'StackCallout', text: 'Stack callout' },
+    ];
     return (
       <>
         <label>change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
         <label>change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <ChoiceGroup
+          options={options}
+          selectedKey={this.state.selectedCallout}
+          onChange={this._onChange}
+          label="Pick one"
+        />
         <div style={rootStyle}>
           <GroupedVerticalBarChart
             chartTitle="Grouped Vertical Bar chart custom accessibility example"
@@ -158,6 +187,7 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
             width={this.state.width}
             showYAxisGridLines
             wrapXAxisLables
+            isCalloutForStack={this.state.selectedCallout === 'StackCallout'}
           />
         </div>
       </>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
New prop added for GroupedVerticalBar chart series I,e **stackCallOutAccessibilityData**.
Recently Stack Callout is implemented in the GroupedVerticalBar chart, with that implementation, this prop was added.
Users can customize the accessibility data for the whole stack callout. 

#### Focus areas to test

Grouped Vertical Bar chart

### **After Change:**

**For Single Callout** 

![image](https://user-images.githubusercontent.com/29042635/141348842-31be64b9-528e-48b6-ba08-0f83bc2faf9c.png)

![image](https://user-images.githubusercontent.com/29042635/141348529-6b685d64-9834-462b-b64e-ab50cdc6e0bb.png)

**For Stacked Callout:**

![image](https://user-images.githubusercontent.com/29042635/141348866-24e32d62-88e6-43fc-846d-52da7af88a7f.png)

![image](https://user-images.githubusercontent.com/29042635/141348784-cc7511e2-9a2b-4ec6-826b-77a467495c61.png)
