### PR TITLE
feat(react-theme): update shadow design tokens

### DIFF
--- a/change/@fluentui-react-theme-c199e306-7453-49a4-b630-972843705364.json
+++ b/change/@fluentui-react-theme-c199e306-7453-49a4-b630-972843705364.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat(react-theme): update shadow design tokens",
+  "packageName": "@fluentui/react-theme",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-theme/etc/react-theme.api.md
+++ b/packages/react-theme/etc/react-theme.api.md
@@ -273,6 +273,16 @@ export function mergeThemes(a: Theme | undefined, b: PartialTheme | Theme | unde
 // @public (undocumented)
 export type PartialTheme = Partial<Theme>;
 
+// @public (undocumented)
+export type ShadowBrandTokens = {
+    shadow2Brand: string;
+    shadow4Brand: string;
+    shadow8Brand: string;
+    shadow16Brand: string;
+    shadow28Brand: string;
+    shadow64Brand: string;
+};
+
 // @public
 export type ShadowTokens = {
     shadow2: string;
@@ -301,7 +311,7 @@ export const teamsHighContrastTheme: Theme;
 export const teamsLightTheme: Theme;
 
 // @public (undocumented)
-export type Theme = FontSizeTokens & LineHeightTokens & BorderRadiusTokens & StrokeWidthTokens & ShadowTokens & FontFamilyTokens & FontWeightTokens & ColorPaletteTokens & ColorTokens;
+export type Theme = FontSizeTokens & LineHeightTokens & BorderRadiusTokens & StrokeWidthTokens & ShadowTokens & ShadowBrandTokens & FontFamilyTokens & FontWeightTokens & ColorPaletteTokens & ColorTokens;
 
 // @public (undocumented)
 export function themeToCSSVariables(theme: Theme): Record<string, string | number>;

--- a/packages/react-theme/src/index.ts
+++ b/packages/react-theme/src/index.ts
@@ -9,6 +9,7 @@ export type {
   BorderRadiusTokens,
   StrokeWidthTokens,
   ShadowTokens,
+  ShadowBrandTokens,
   FontFamilyTokens,
   ColorPaletteTokens,
   ColorTokens,

--- a/packages/react-theme/src/themes/ThemeShadows.stories.tsx
+++ b/packages/react-theme/src/themes/ThemeShadows.stories.tsx
@@ -16,6 +16,7 @@ const theme = {
 const ShadowBox: React.FunctionComponent<
   React.HTMLAttributes<HTMLDivElement> & {
     shadow: string;
+    isBrand: boolean;
   }
 > = props => (
   <div
@@ -29,6 +30,10 @@ const ShadowBox: React.FunctionComponent<
       minHeight: '2rem',
       fontFamily: 'monospace',
       fontSize: 10,
+      ...(props.isBrand && {
+        backgroundColor: theme.light.colorBrandBackground,
+        color: theme.light.colorNeutralForegroundOnBrand,
+      }),
     }}
   >
     {props.shadow.split('),').map((line, index, arr) => {
@@ -57,12 +62,15 @@ export const Shadows = () => {
       <h3 key="shadow-title-light">Light</h3>
       <h3 key="shadow-title-dark">Dark</h3>
       <h3 key="shadow-title-hc">High Contrast</h3>
-      {shadowTokens.map(shadow => [
-        <div key={shadow}>{shadow}</div>,
-        <ShadowBox key={`${shadow}-light`} shadow={theme.light[shadow]} />,
-        <ShadowBox key={`${shadow}-dark`} shadow={theme.dark[shadow]} />,
-        <ShadowBox key={`${shadow}-hc`} shadow={theme.highContrast[shadow]} />,
-      ])}
+      {shadowTokens.map(shadow => {
+        const isBrand = shadow.indexOf('Brand') >= 0;
+        return [
+          <div key={shadow}>{shadow}</div>,
+          <ShadowBox key={`${shadow}-light`} shadow={theme.light[shadow]} isBrand={isBrand} />,
+          <ShadowBox key={`${shadow}-dark`} shadow={theme.dark[shadow]} isBrand={isBrand} />,
+          <ShadowBox key={`${shadow}-hc`} shadow={theme.highContrast[shadow]} isBrand={isBrand} />,
+        ];
+      })}
     </div>
   );
 };

--- a/packages/react-theme/src/types.ts
+++ b/packages/react-theme/src/types.ts
@@ -845,6 +845,15 @@ export type ShadowTokens = {
   shadow64: string;
 };
 
+export type ShadowBrandTokens = {
+  shadow2Brand: string;
+  shadow4Brand: string;
+  shadow8Brand: string;
+  shadow16Brand: string;
+  shadow28Brand: string;
+  shadow64Brand: string;
+};
+
 export type GhostColorTokens = {
   ghostBackground: string;
   ghostBackgroundHover: string;
@@ -937,6 +946,7 @@ export type Theme = FontSizeTokens &
   BorderRadiusTokens &
   StrokeWidthTokens &
   ShadowTokens &
+  ShadowBrandTokens &
   FontFamilyTokens &
   FontWeightTokens &
   ColorPaletteTokens &

--- a/packages/react-theme/src/utils/createDarkTheme.ts
+++ b/packages/react-theme/src/utils/createDarkTheme.ts
@@ -18,5 +18,6 @@ export const createDarkTheme: (brand: BrandVariants) => Theme = brand => {
     ...colorPaletteTokens,
 
     ...createShadowTokens(colorTokens.colorNeutralShadowAmbient, colorTokens.colorNeutralShadowKey),
+    ...createShadowTokens(colorTokens.colorBrandShadowAmbient, colorTokens.colorBrandShadowKey, 'Brand'),
   };
 };

--- a/packages/react-theme/src/utils/createHighContrastTheme.ts
+++ b/packages/react-theme/src/utils/createHighContrastTheme.ts
@@ -18,5 +18,6 @@ export const createHighContrastTheme = (): Theme => {
     ...colorPaletteTokens,
 
     ...createShadowTokens(colorTokens.colorNeutralShadowAmbient, colorTokens.colorNeutralShadowKey),
+    ...createShadowTokens(colorTokens.colorBrandShadowAmbient, colorTokens.colorBrandShadowKey, 'Brand'),
   };
 };

--- a/packages/react-theme/src/utils/createLightTheme.ts
+++ b/packages/react-theme/src/utils/createLightTheme.ts
@@ -18,5 +18,6 @@ export const createLightTheme: (brand: BrandVariants) => Theme = brand => {
     ...colorPaletteTokens,
 
     ...createShadowTokens(colorTokens.colorNeutralShadowAmbient, colorTokens.colorNeutralShadowKey),
+    ...createShadowTokens(colorTokens.colorBrandShadowAmbient, colorTokens.colorBrandShadowKey, 'Brand'),
   };
 };

--- a/packages/react-theme/src/utils/createTeamsDarkTheme.ts
+++ b/packages/react-theme/src/utils/createTeamsDarkTheme.ts
@@ -18,5 +18,6 @@ export const createTeamsDarkTheme: (brand: BrandVariants) => Theme = brand => {
     ...colorPaletteTokens,
 
     ...createShadowTokens(colorTokens.colorNeutralShadowAmbient, colorTokens.colorNeutralShadowKey),
+    ...createShadowTokens(colorTokens.colorBrandShadowAmbient, colorTokens.colorBrandShadowKey, 'Brand'),
   };
 };

--- a/packages/react-theme/src/utils/shadows.ts
+++ b/packages/react-theme/src/utils/shadows.ts
@@ -1,12 +1,15 @@
-import type { ShadowTokens } from '../types';
+import type { ShadowBrandTokens, ShadowTokens } from '../types';
 
-export function createShadowTokens(ambientColor: string, keyColor: string): ShadowTokens {
+export function createShadowTokens(ambientColor: string, keyColor: string, tokenSuffix: 'Brand'): ShadowBrandTokens;
+export function createShadowTokens(ambientColor: string, keyColor: string): ShadowTokens;
+
+export function createShadowTokens(ambientColor: string, keyColor: string, tokenSuffix: 'Brand' | '' = '') {
   return {
-    shadow2: `0 0 2px ${ambientColor}, 0 1px 2px ${keyColor}`,
-    shadow4: `0 0 2px ${ambientColor}, 0 2px 4px ${keyColor}`,
-    shadow8: `0 0 2px ${ambientColor}, 0 4px 8px ${keyColor}`,
-    shadow16: `0 0 2px ${ambientColor}, 0 6px 16px ${keyColor}`,
-    shadow28: `0 0 8px ${ambientColor}, 0 14px 28px ${keyColor}`,
-    shadow64: `0 0 8px ${ambientColor}, 0 32px 64px ${keyColor}`,
+    [`shadow2${tokenSuffix}`]: `0 0 2px ${ambientColor}, 0 1px 2px ${keyColor}`,
+    [`shadow4${tokenSuffix}`]: `0 0 2px ${ambientColor}, 0 2px 4px ${keyColor}`,
+    [`shadow8${tokenSuffix}`]: `0 0 2px ${ambientColor}, 0 4px 8px ${keyColor}`,
+    [`shadow16${tokenSuffix}`]: `0 0 2px ${ambientColor}, 0 8px 16px ${keyColor}`,
+    [`shadow28${tokenSuffix}`]: `0 0 8px ${ambientColor}, 0 14px 28px ${keyColor}`,
+    [`shadow64${tokenSuffix}`]: `0 0 8px ${ambientColor}, 0 32px 64px ${keyColor}`,
   };
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20181
- [x] Include a change request file using `$ yarn change`

#### Description of changes

1. Updates y-value for **shadow16** to 8px
![image](https://user-images.githubusercontent.com/9615899/141515159-e84cbb22-33e3-4d0b-a1cc-6122d82d782a.png)

2. Add **shadowNNBrand** tokens
![image](https://user-images.githubusercontent.com/9615899/141515455-303736db-d6cc-4108-9a82-e57bc57c2a98.png)

