### PR TITLE
Callout: Specifying that gapSpace prop has pixels as its unit in prop comment

### DIFF
--- a/change/@fluentui-react-9957e130-fd74-4cc0-8e6f-2021ae9d778e.json
+++ b/change/@fluentui-react-9957e130-fd74-4cc0-8e6f-2021ae9d778e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Callout: Specifying that gapSpace prop has pixels as its unit in prop comment.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Callout/Callout.types.ts
+++ b/packages/react/src/components/Callout/Callout.types.ts
@@ -33,7 +33,7 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
   directionalHintForRTL?: DirectionalHint;
 
   /**
-   * The gap between the Callout and the target
+   * The gap between the Callout and the target, specified as number of pixels
    * @defaultvalue 0
    */
   gapSpace?: number;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20549
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Callout: Specifying that gapSpace prop has pixels as its unit in prop comment.