### PR TITLE
MenuButton: Removing tight coupling with Menu by replicating type locally

### DIFF
--- a/change/@fluentui-react-button-0f70bf9c-dbf4-4d42-b096-5c4396a59490.json
+++ b/change/@fluentui-react-button-0f70bf9c-dbf4-4d42-b096-5c4396a59490.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "MenuButton: Removing tight coupling with Menu by replicating type locally.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -9,7 +9,6 @@ import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { IntrinsicShorthandProps } from '@fluentui/react-utilities';
-import type { MenuTriggerChildProps } from '@fluentui/react-menu';
 import type { ObjectShorthandProps } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 
@@ -68,6 +67,8 @@ export const MenuButton: ForwardRefComponent<MenuButtonProps>;
 // @public (undocumented)
 export const menuButtonClassName = "fui-MenuButton";
 
+// Warning: (ae-forgotten-export) The symbol "MenuTriggerChildProps" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type MenuButtonProps = ComponentProps<MenuButtonSlots> & Partial<Omit<ButtonCommons, 'iconPosition'>> & Partial<MenuTriggerChildProps>;
 

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -31,7 +31,6 @@
     "@fluentui/jest-serializer-make-styles": "9.0.0-beta.3",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-make-styles": "9.0.0-beta.3",
-    "@fluentui/react-menu": "9.0.0-beta.4",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",

--- a/packages/react-button/src/components/MenuButton/MenuButton.types.ts
+++ b/packages/react-button/src/components/MenuButton/MenuButton.types.ts
@@ -1,6 +1,16 @@
-import type { MenuTriggerChildProps } from '@fluentui/react-menu';
+import * as React from 'react';
 import type { ComponentProps, ComponentState, IntrinsicShorthandProps } from '@fluentui/react-utilities';
 import type { ButtonCommons, ButtonSlots, ButtonState } from '../Button/Button.types';
+
+// This type mimics the interface found in MenuTrigger.types.ts to allow MenuButton and Menu to play correctly with each
+// other without having to tightly couple them.
+// https://github.com/microsoft/fluentui/blob/master/packages/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
+type MenuTriggerChildProps = Pick<
+  React.HTMLAttributes<HTMLElement>,
+  'onClick' | 'onMouseEnter' | 'onMouseLeave' | 'onContextMenu' | 'onKeyDown' | 'aria-haspopup' | 'aria-expanded' | 'id'
+> & {
+  ref?: React.Ref<never>;
+};
 
 export type MenuButtonSlots = ButtonSlots & {
   /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Projects that were using `@fluentui/react-button` but not `@fluentui/react-menu` would resolve the `MenuButtonProps` type to `any` because `@fluentui/react-menu` was listed as a `devDependency`. Since we want types to be usable and we don't want to tightly couple `@fluentui/react-button` and `@fluentui/react-menu` this PR replicates the needed type in `@fluentui/react-button`.