### PR TITLE
fix(Callout): update both maxHeight and positions when positions recalc

### DIFF
--- a/apps/vr-tests/src/stories/z_Callout.stories.tsx
+++ b/apps/vr-tests/src/stories/z_Callout.stories.tsx
@@ -183,8 +183,8 @@ storiesOf('Callout', module)
     const bounds = {
       left: 50,
       top: 50,
-      width: 200,
-      height: 100,
+      width: 150,
+      height: 50,
     };
     return (
       <Callout {...defaultProps} bounds={bounds}>

--- a/apps/vr-tests/src/stories/z_Callout.stories.tsx
+++ b/apps/vr-tests/src/stories/z_Callout.stories.tsx
@@ -178,17 +178,4 @@ storiesOf('Callout', module)
         </Callout>
       </>
     );
-  })
-  .addStory('Callout rendered within small bounds', () => {
-    const bounds = {
-      left: 50,
-      top: 50,
-      width: 150,
-      height: 50,
-    };
-    return (
-      <Callout {...defaultProps} bounds={bounds}>
-        {calloutContent}
-      </Callout>
-    );
   });

--- a/apps/vr-tests/src/stories/z_Callout.stories.tsx
+++ b/apps/vr-tests/src/stories/z_Callout.stories.tsx
@@ -178,4 +178,17 @@ storiesOf('Callout', module)
         </Callout>
       </>
     );
+  })
+  .addStory('Callout rendered within small bounds', () => {
+    const bounds = {
+      left: 50,
+      top: 50,
+      width: 200,
+      height: 100,
+    };
+    return (
+      <Callout {...defaultProps} bounds={bounds}>
+        {calloutContent}
+      </Callout>
+    );
   });

--- a/change/@fluentui-react-0305a692-42d9-499d-ac5a-9601e4bc626b.json
+++ b/change/@fluentui-react-0305a692-42d9-499d-ac5a-9601e4bc626b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update Callout to update both maxHeight and positions when recalculating",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -115,7 +115,7 @@ function useBounds(
  * (Hook) to return the maximum available height for the Callout to render into.
  */
 function useMaxHeight(
-  { calloutMaxHeight, directionalHint, directionalHintFixed, hidden }: ICalloutProps,
+  { calloutMaxHeight, finalHeight, directionalHint, directionalHintFixed, hidden }: ICalloutProps,
   getBounds: () => IRectangle | undefined,
   positions?: ICalloutPositionedInfo,
 ) {
@@ -123,10 +123,9 @@ function useMaxHeight(
   const { top, bottom } = positions?.elementPosition ?? {};
 
   React.useEffect(() => {
-    const isForcedInBounds = typeof top === 'number' && typeof bottom === 'number';
     const { top: topBounds, bottom: bottomBounds } = getBounds() ?? {};
 
-    if (!calloutMaxHeight && !isForcedInBounds && !hidden) {
+    if (!calloutMaxHeight && !hidden) {
       if (typeof top === 'number' && bottomBounds) {
         setMaxHeight(bottomBounds - top);
       } else if (typeof bottom === 'number' && typeof topBounds === 'number' && bottomBounds) {
@@ -137,7 +136,7 @@ function useMaxHeight(
     } else {
       setMaxHeight(undefined);
     }
-  }, [bottom, calloutMaxHeight, directionalHint, directionalHintFixed, getBounds, hidden, positions, top]);
+  }, [bottom, calloutMaxHeight, finalHeight, directionalHint, directionalHintFixed, getBounds, hidden, positions, top]);
 
   return maxHeight;
 }
@@ -156,7 +155,7 @@ function usePositions(
   const positionAttempts = React.useRef(0);
   const previousTarget = React.useRef<Target>();
   const async = useAsync();
-  const { hidden, target, finalHeight, onPositioned, directionalHint } = props;
+  const { hidden, target, finalHeight, calloutMaxHeight, onPositioned, directionalHint } = props;
 
   React.useEffect(() => {
     if (!hidden) {
@@ -168,15 +167,25 @@ function usePositions(
             bounds: getBounds(),
           };
 
+          // duplicate calloutElement & remove maxHeight for position calc
+          const dupeCalloutElement = calloutElement.cloneNode(true) as HTMLElement;
+          dupeCalloutElement.style.maxHeight = calloutMaxHeight ? `${calloutMaxHeight}` : '';
+          dupeCalloutElement.style.visibility = 'hidden';
+          calloutElement.parentElement?.appendChild(dupeCalloutElement);
+
           const previousPositions = previousTarget.current === target ? positions : undefined;
 
           // If there is a finalHeight given then we assume that the user knows and will handle
           // additional positioning adjustments so we should call positionCard
           const newPositions: ICalloutPositionedInfo = finalHeight
-            ? positionCard(currentProps, hostElement.current, calloutElement, previousPositions)
-            : positionCallout(currentProps, hostElement.current, calloutElement, previousPositions);
-          // Set the new position only when the positions are not exists or one of the new callout positions
-          // are different. The position should not change if the position is within 2 decimal places.
+            ? positionCard(currentProps, hostElement.current, dupeCalloutElement, previousPositions)
+            : positionCallout(currentProps, hostElement.current, dupeCalloutElement, previousPositions);
+
+          // clean up duplicate calloutElement
+          calloutElement.parentElement?.removeChild(dupeCalloutElement);
+
+          // Set the new position only when the positions do not exist or one of the new callout positions
+          // is different. The position should not change if the position is within 2 decimal places.
           if (
             (!positions && newPositions) ||
             (positions && newPositions && !arePositionsEqual(positions, newPositions) && positionAttempts.current < 5)
@@ -433,6 +442,17 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
       targetWindow,
     );
 
+    // do not set both top and bottom css props from positions
+    // instead, use maxHeight
+    const isForcedInBounds = positions?.elementPosition.top && positions.elementPosition.bottom;
+    const cssPositions = {
+      ...positions?.elementPosition,
+      maxHeight,
+    };
+    if (isForcedInBounds) {
+      cssPositions.bottom = undefined;
+    }
+
     useAutoFocus(props, positions, calloutElement);
 
     React.useEffect(() => {
@@ -476,7 +496,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
         <div
           {...getNativeProps(props, divProperties, ARIA_ROLE_ATTRIBUTES)}
           className={css(classNames.root, positions && positions.targetEdge && ANIMATIONS[positions.targetEdge!])}
-          style={positions ? { ...positions.elementPosition, maxHeight } : OFF_SCREEN_STYLE}
+          style={positions ? { ...cssPositions } : OFF_SCREEN_STYLE}
           // Safari and Firefox on Mac OS requires this to back-stop click events so focus remains in the Callout.
           // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
           tabIndex={-1}

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -167,7 +167,7 @@ function usePositions(
             bounds: getBounds(),
           };
 
-          // duplicate calloutElement & remove maxHeight for position calc
+          // duplicate calloutElement & remove useMaxHeight's maxHeight for position calc
           const dupeCalloutElement = calloutElement.cloneNode(true) as HTMLElement;
           dupeCalloutElement.style.maxHeight = calloutMaxHeight ? `${calloutMaxHeight}` : '';
           dupeCalloutElement.style.visibility = 'hidden';

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -444,7 +444,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
 
     // do not set both top and bottom css props from positions
     // instead, use maxHeight
-    const isForcedInBounds = positions?.elementPosition.top && positions.elementPosition.bottom;
+    const isForcedInBounds = positions?.elementPosition.top && positions?.elementPosition.bottom;
     const cssPositions = {
       ...positions?.elementPosition,
       maxHeight,

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -218,6 +218,7 @@ function usePositions(
     directionalHint,
     async,
     calloutElement,
+    calloutMaxHeight,
     hostElement,
     targetRef,
     finalHeight,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20618 and #20619
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Setting the Callout's `maxHeight` to prevent it from overflowing offscreen would then affect the next positioning calculation, if the Callout's position or height changed while open. This change ensures subsequent position recalculations start from scratch, and re-apply maxHeight afterwards.

This is done through duplicating the element + removing the `maxHeight`, then using that element to calculate position. This is so style updates for the position calc do not affect the actual Callout DOM.

cc/ @dotnetjunky 
