### PR TITLE
ContextualMenu: Allow focusZoneProps to override default values passed to FocusZone

### DIFF
--- a/change/@fluentui-react-9b93e6fa-64a9-4967-a364-6a99b78f43e4.json
+++ b/change/@fluentui-react-9b93e6fa-64a9-4967-a364-6a99b78f43e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: Allow focusZoneProps to override default values passed to FocusZone.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -1121,11 +1121,11 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
     }
 
     const adjustedFocusZoneProps = {
-      ...focusZoneProps,
-      className: classNames.root,
-      isCircularNavigation: true,
+      direction: FocusZoneDirection.vertical,
       handleTabKey: FocusZoneTabbableElements.all,
-      direction: props.focusZoneProps?.direction ?? FocusZoneDirection.vertical,
+      isCircularNavigation: true,
+      ...focusZoneProps,
+      className: css(classNames.root, props.focusZoneProps?.className),
     };
 
     const hasCheckmarks = canAnyMenuItemsCheck(items);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20620
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue where user-provided `focusZoneProps` were not being respected over the default ones used in `ContextualMenu`.