### PR TITLE
Input: add interaction styling and vr-tests

### DIFF
--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -34,6 +34,7 @@
     "@fluentui/react-icons": "^2.0.152-beta.3",
     "@fluentui/react-icons-mdl2": "^1.2.9",
     "@fluentui/react-image": "9.0.0-beta.4",
+    "@fluentui/react-input": "9.0.0-beta.0",
     "@fluentui/react-label": "9.0.0-beta.4",
     "@fluentui/react-link": "9.0.0-beta.5",
     "@fluentui/react-make-styles": "9.0.0-beta.4",

--- a/apps/vr-tests/src/stories/InputConverged.stories.tsx
+++ b/apps/vr-tests/src/stories/InputConverged.stories.tsx
@@ -1,23 +1,14 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { DecoratorFunction } from '@storybook/addons';
 import { Input } from '@fluentui/react-input';
 import { Search20Regular, Dismiss20Regular } from '@fluentui/react-icons';
-import { StoryFnReactReturnType } from '@storybook/react/dist/ts3.9/client/preview/types';
-
-const InputDecorator: DecoratorFunction<StoryFnReactReturnType> = story => (
-  <div style={{ display: 'flex' }}>
-    <div className="testWrapper" style={{ padding: '10px', width: '300px' }}>
-      {story()}
-    </div>
-  </div>
-);
+import { TestWrapperDecoratorFixedWidth } from '../utilities/TestWrapperDecorator';
 
 // TODO move input.* props to root once primary slot helper is integrated
 
 storiesOf('Input Converged', module)
-  .addDecorator(InputDecorator)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener
       steps={new Steps()
@@ -40,8 +31,8 @@ storiesOf('Input Converged', module)
     <Input appearance="filledDarker" input={{ placeholder: 'Placeholder' }} />
   ))
   .addStory('Appearance: filledLighter', () => (
-    // filledLighter requires a background to show up (this is colorNeutralBackground3)
-    <div style={{ background: '#141414', padding: '10px' }}>
+    // filledLighter requires a background to show up (this is colorNeutralBackground3 in web light theme)
+    <div style={{ background: '#f5f5f5', padding: '10px' }}>
       <Input appearance="filledLighter" input={{ placeholder: 'Placeholder' }} />
     </div>
   ))
@@ -49,8 +40,9 @@ storiesOf('Input Converged', module)
   // TODO move defaultValue prop to root
   .addStory('With value', () => <Input input={{ defaultValue: 'Value!' }} />);
 
-storiesOf('Input Converged (non-interactive)', module)
-  .addDecorator(InputDecorator)
+// Non-interactive stories
+storiesOf('Input Converged', module)
+  // note: due to reused "Input Converged" story ID, TestWrapperDecoratorFixedWidth is also reused
   .addDecorator(story => (
     <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}

--- a/apps/vr-tests/src/stories/InputConverged.stories.tsx
+++ b/apps/vr-tests/src/stories/InputConverged.stories.tsx
@@ -52,7 +52,8 @@ storiesOf('Input Converged', module)
   .addStory('Size: large', () => <Input size="large" input={{ placeholder: 'Placeholder' }} />)
   .addStory('Inline', () => (
     <p>
-      Some text with <Input inline input={{ placeholder: 'Placeholder' }} /> inline input
+      Some text with <Input inline input={{ placeholder: 'hello', style: { width: '75px' } }} />{' '}
+      inline input
     </p>
   ))
   .addStory(

--- a/apps/vr-tests/src/stories/InputConverged.stories.tsx
+++ b/apps/vr-tests/src/stories/InputConverged.stories.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import Screener, { Steps } from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { DecoratorFunction } from '@storybook/addons';
+import { Input } from '@fluentui/react-input';
+import { Search20Regular, Dismiss20Regular } from '@fluentui/react-icons';
+import { StoryFnReactReturnType } from '@storybook/react/dist/ts3.9/client/preview/types';
+
+const InputDecorator: DecoratorFunction<StoryFnReactReturnType> = story => (
+  <div style={{ display: 'flex' }}>
+    <div className="testWrapper" style={{ padding: '10px', width: '300px' }}>
+      {story()}
+    </div>
+  </div>
+);
+
+// TODO move input.* props to root once primary slot helper is integrated
+
+storiesOf('Input Converged', module)
+  .addDecorator(InputDecorator)
+  .addDecorator(story => (
+    <Screener
+      steps={new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('input')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .click('input')
+        .wait(250) // let focus border animation finish
+        .snapshot('focused', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Appearance: outline (default)', () => <Input input={{ placeholder: 'Placeholder' }} />)
+  .addStory('Appearance: underline', () => (
+    <Input appearance="underline" input={{ placeholder: 'Placeholder' }} />
+  ))
+  .addStory('Appearance: filledDarker', () => (
+    <Input appearance="filledDarker" input={{ placeholder: 'Placeholder' }} />
+  ))
+  .addStory('Appearance: filledLighter', () => (
+    // filledLighter requires a background to show up (this is colorNeutralBackground3)
+    <div style={{ background: '#141414', padding: '10px' }}>
+      <Input appearance="filledLighter" input={{ placeholder: 'Placeholder' }} />
+    </div>
+  ))
+  .addStory('Disabled', () => <Input input={{ disabled: true }} />)
+  // TODO move defaultValue prop to root
+  .addStory('With value', () => <Input input={{ defaultValue: 'Value!' }} />);
+
+storiesOf('Input Converged (non-interactive)', module)
+  .addDecorator(InputDecorator)
+  .addDecorator(story => (
+    <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
+      {story()}
+    </Screener>
+  ))
+  .addStory('Size: small', () => <Input fieldSize="small" input={{ placeholder: 'Placeholder' }} />)
+  .addStory('Size: large', () => <Input fieldSize="large" input={{ placeholder: 'Placeholder' }} />)
+  .addStory('Inline', () => (
+    <p>
+      Some text with <Input inline input={{ placeholder: 'Placeholder' }} /> inline input
+    </p>
+  ))
+  .addStory(
+    'contentBefore',
+    () => <Input contentBefore={<Search20Regular />} input={{ placeholder: 'Placeholder' }} />,
+    { includeRtl: true },
+  )
+  .addStory(
+    'contentAfter',
+    () => <Input contentAfter={<Dismiss20Regular />} input={{ placeholder: 'Placeholder' }} />,
+    { includeRtl: true },
+  );

--- a/apps/vr-tests/src/stories/InputConverged.stories.tsx
+++ b/apps/vr-tests/src/stories/InputConverged.stories.tsx
@@ -48,8 +48,8 @@ storiesOf('Input Converged', module)
       {story()}
     </Screener>
   ))
-  .addStory('Size: small', () => <Input fieldSize="small" input={{ placeholder: 'Placeholder' }} />)
-  .addStory('Size: large', () => <Input fieldSize="large" input={{ placeholder: 'Placeholder' }} />)
+  .addStory('Size: small', () => <Input size="small" input={{ placeholder: 'Placeholder' }} />)
+  .addStory('Size: large', () => <Input size="large" input={{ placeholder: 'Placeholder' }} />)
   .addStory('Inline', () => (
     <p>
       Some text with <Input inline input={{ placeholder: 'Placeholder' }} /> inline input

--- a/packages/react-input/Spec-styling.md
+++ b/packages/react-input/Spec-styling.md
@@ -10,94 +10,88 @@ General abbreviations used:
 
 ## Sizes
 
+Notes:
+
 - padding and gap values are from (theoretical) `spacing.horizontal` unless otherwise specified
 - interpretation:
-  - "spacing between icon before and content"/"spacing between content and icon after 1" => "spacing start/end to content"
+  - "spacing between icon before and content"/"spacing between content and icon after 1" => "spacing within root"
   - "spacing between icon after 1 and icon after 2" => "spacing within contentBefore/After" because we're not going to have two icon slots
   - omitted "focus indicator" b/c that's handled elsewhere
 
-| Style         | All                 |
-| ------------- | ------------------- |
-| v-align       | vertically centered |
-| border radius | medium              |
+### For all field sizes
 
-| Style                              | medium           | small               | large     |
-| ---------------------------------- | ---------------- | ------------------- | --------- |
-| height                             | 32px             | 24px                | 40px      |
-| left/right padding                 | mNudge           | sNudge              | m         |
-| left/right padding in content      | xxs              | "                   | sNudge    |
-| content size                       | body1 (base.300) | caption1 (base.200) | base.400  |
-| "icon" size                        | 20Regular        | 16Regular           | 24Regular |
-| spacing start/end to content       | xxs              | "                   | sNudge    |
-| spacing within contentBefore/After | xs               | "                   | "         |
+| Style                                  | Application               | All                 |
+| -------------------------------------- | ------------------------- | ------------------- |
+| v-align                                | root                      | vertically centered |
+| border radius                          | root (unless underlined)  | medium              |
+| ~~spacing within contentBefore/After~~ | n/a (add later if needed) | xs                  |
 
-### Sizes application
+### Varying by field size
 
-| Style                              | Slot                | Notes                                                            |
-| ---------------------------------- | ------------------- | ---------------------------------------------------------------- |
-| v-align                            | root                | ???                                                              |
-| height                             | root                | ? as minHeight or height ?                                       |
-| border radius                      | root                | set where borders or shadow are defined; don't use if underlined |
-| left/right padding                 | root                | padding                                                          |
-| left/right padding in content      | input               | padding                                                          |
-| content size                       | root, input         | fontSize; doesn't inherit to input                               |
-| "icon" size                        | n/a                 | no icons built in                                                |
-| spacing start/end to content       | root                | display: flex (also to grow input), flex gap                     |
-| spacing within contentBefore/After | contentBefore/After | display: flex, flex gap                                          |
+| Style                         | Application                    | small               | medium           | large         |
+| ----------------------------- | ------------------------------ | ------------------- | ---------------- | ------------- |
+| height                        | root `minHeight`               | 24px                | 32px             | 40px          |
+| left/right padding            | root                           | sNudge              | mNudge           | m             |
+| left/right padding in content | input                          | xxs                 | xxs              | sNudge        |
+| content size                  | root, input (doesn't inherit)  | caption1 (base.200) | body1 (base.300) | base.400      |
+| ~~"icon" size~~               | n/a (icons not built in)       | ~~16Regular~~       | ~~20Regular~~    | ~~24Regular~~ |
+| spacing within root           | root `display: flex`, flex gap | xxs                 | xxs              | sNudge        |
 
 ## Appearance colors and strokes
 
-- italics = thick border
+Notes:
+
+- borders are thin (1px) unless otherwise noted
+- "in focus indicator" means the bottom border (applied to `:after`)
 - interpreting "compound brand stroke 1 pressed" as compoundBrandStrokePressed
-- appears that focus and keyboard focus styles are the same
+- mouse and keyboard focus styles are the same
 
-| Style                                      | All                       |
-| ------------------------------------------ | ------------------------- |
-| content                                    | neutralForeground1        |
-| content disabled                           | neutralForegroundDisabled |
-| placeholder                                | neutralForeground4        |
-| placeholder disabled                       | neutralForegroundDisabled |
-| "icon" color                               | neutralForeground3        |
-| "icon" color disabled                      | neutralForegroundDisabled |
-| background disabled                        | transparentBackground     |
-| border disabled                            | neutralStrokeDisabled     |
-| in focus indicator (bottom border)         | _compoundBrandStroke_     |
-| in focus indicator (bottom border) pressed | _^Pressed_                |
-| cursor disabled                            | not-allowed               |
+TODO Open questions:
 
-| Style                | filledDarker       | filledLighter      | underline                | outline              |
-| -------------------- | ------------------ | ------------------ | ------------------------ | -------------------- |
-| shadow               | shadow2            | "                  | none                     | "                    |
-| background           | neutralBackground3 | neutralBackground1 | transparentBackground    | neutralBackground1   |
-| border               | transparentStroke  | "                  | none                     | neutralStroke1       |
-| border hover         | ^Interactive       | "                  | n/a                      | ^Hover               |
-| border pressed       | ^                  | "                  | n/a                      | ^^Pressed            |
-| border focused       | ^                  | "                  | n/a                      | n/a (neutralStroke1) |
-| borderBottom         | n/a                | n/a                | neutralStrokeAccessible  | "                    |
-| borderBottom hover   | n/a                | n/a                | ^Hover                   | "                    |
-| borderBottom pressed | n/a                | n/a                | _^^Pressed_              | "                    |
-| borderBottom focused | n/a                | n/a                | n/a (in focus indicator) | "                    |
+- What color should the focus indicator be while animating? (pressed or non-pressed color)
+- For borderBottom pressed:
+  - The designs for outline/underline show a thick bottom border in the pressed state as the focus indicator animates in, but this isn't included in the animation demoing the focus border (and I can't tell if Windows 11 uses it).
+  - This wide border could be added on the root (while maintaining the blue focus border) using `:focus-within:before` + setting the bottom border color on `:focus-within`.
 
-### Appearance application
+### For all appearances
 
-| Style                      | Slot                | Notes                              |
-| -------------------------- | ------------------- | ---------------------------------- |
-| content color              | input               | other things have their own colors |
-| placeholder color          | input               | `::placeholder`                    |
-| "icon" color               | contentBefore/After |                                    |
-| shadow                     | root                |                                    |
-| background                 | root, input         |                                    |
-| border                     | root                |                                    |
-| border hover               | TODO root           | `:hover`                           |
-| border pressed             | TODO                |                                    |
-| border focused             | TODO root           | `:focus-within`                    |
-| borderBottom               | root                |                                    |
-| borderBottom hover         | TODO root           | `:hover`                           |
-| borderBottom pressed       | TODO                |                                    |
-| borderBottom focused       | n/a                 | handled by focus indicator         |
-| in focus indicator         | TODO                |                                    |
-| in focus indicator pressed | TODO                |                                    |
-| cursor                     | root, input         |                                    |
+| Style                      | Application                      | All                       |
+| -------------------------- | -------------------------------- | ------------------------- |
+| content color              | input                            | neutralForeground1        |
+| content color disabled     | ^                                | neutralForegroundDisabled |
+| placeholder color          | input `::placeholder`            | neutralForeground4        |
+| placeholder color disabled | ^                                | neutralForegroundDisabled |
+| "icon" color               | contentBefore/After              | neutralForeground3        |
+| "icon" color disabled      | ^                                | neutralForegroundDisabled |
+| background disabled        | root, input                      | transparentBackground     |
+| border disabled            | root                             | neutralStrokeDisabled     |
+| ~~borderBottom focused~~   | n/a (covered by focus indicator) |                           |
+| in focus indicator         | root `:focus-within:after`       | thick compoundBrandStroke |
+| in focus indicator pressed | root `:after`                    | thick ^Pressed            |
+| cursor disabled            | root, input                      | not-allowed               |
+
+### Varying per appearance
+
+| Style                | Application          | outline                 | underline             | filledDarker       | filledLighter      |
+| -------------------- | -------------------- | ----------------------- | --------------------- | ------------------ | ------------------ |
+| shadow               | root                 | none                    | "                     | shadow2            | "                  |
+| background           | root, input          | neutralBackground1      | transparentBackground | neutralBackground3 | neutralBackground1 |
+| border               | root                 | neutralStroke1          | none                  | transparentStroke  | "                  |
+| border hover         | root `:hover`        | ^Hover                  | n/a                   | ^Interactive       | "                  |
+| border pressed       | root `:active`       | ^^Pressed               | n/a                   | ^                  | "                  |
+| border focused       | root `:focus-within` | n/a (neutralStroke1)    | n/a                   | ^                  | "                  |
+| borderBottom         | root                 | neutralStrokeAccessible | "                     | n/a                | n/a                |
+| borderBottom hover   | root `:hover`        | ^Hover                  | "                     | n/a                | n/a                |
+| borderBottom pressed | TODO (see ? above)   | thick ^^Pressed         | "                     | n/a                | n/a                |
+
+### In focus indicator
+
+|           | focus in                   | focus out        |
+| --------- | -------------------------- | ---------------- |
+| apply to  | root `:focus-within:after` | root `:after`    |
+| transform | scaleX 0-1                 | scaleX 1-0       |
+| duration  | normal (200ms)             | ultraFast (50ms) |
+| easing    | decelerateMid              | accelerateMid    |
 
 ## Bookends (deferred)
 
@@ -105,11 +99,11 @@ Bookend implementation has been deferred and will likely be handled in a separat
 
 ### Sizes
 
-| Style              | medium              | small  | large |
+| Style              | small               | medium | large |
 | ------------------ | ------------------- | ------ | ----- |
 | v-align            | vertically centered | "      | "     |
 | border radius      | medium              | "      | "     |
-| left/right padding | s                   | sNudge | m     |
+| left/right padding | sNudge              | s      | m     |
 | spacing within     | xs                  | "      | "     |
 
 ### Appearance

--- a/packages/react-input/Spec.md
+++ b/packages/react-input/Spec.md
@@ -80,7 +80,7 @@ The top-level `ref` prop also points to the `<input>`. This can be used for thin
 Most custom props are defined in `InputCommons` since they're shared with `InputState`.
 
 ```ts
-export type InputCommons = FieldSizeProps & {
+export type InputCommons = {
   /**
    * If true, the field will have inline display, allowing it be used within text content.
    * If false (the default), the field will have block display.

--- a/packages/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-input/src/components/Input/useInputStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-make-styles';
 import type { InputState } from './Input.types';
 import type { Theme } from '@fluentui/react-theme';
 
@@ -48,10 +48,10 @@ const useRootStyles = makeStyles({
   base: theme => ({
     display: 'flex',
     alignItems: 'center',
-    flexWrap: 'no-wrap',
-    gap: horizontalSpacing.xxs,
+    flexWrap: 'nowrap',
+    ...shorthands.gap(horizontalSpacing.xxs),
     fontFamily: theme.fontFamilyBase,
-    borderRadius: theme.borderRadiusMedium, // used for all but underline
+    ...shorthands.borderRadius(theme.borderRadiusMedium), // used for all but underline
     position: 'relative',
     boxSizing: 'border-box',
 
@@ -77,7 +77,9 @@ const useRootStyles = makeStyles({
       // By default borderBottom will cause little "horns" on the ends. The clipPath trims them off.
       // (This could be done without trimming using `background: linear-gradient(...)`, but using
       // borderBottom makes it easier for people to override the color if needed.)
-      borderBottom: `2px solid ${theme.colorCompoundBrandStroke}`,
+      borderBottomWidth: '2px',
+      borderBottomStyle: 'solid',
+      borderBottomColor: theme.colorCompoundBrandStroke,
       clipPath: 'inset(calc(100% - 2px) 0 0 0)',
 
       // Animation for focus OUT
@@ -96,41 +98,43 @@ const useRootStyles = makeStyles({
   }),
   small: theme => ({
     minHeight: fieldHeights.small,
-    padding: `0 ${horizontalSpacing.sNudge}`,
+    ...shorthands.padding(`0 ${horizontalSpacing.sNudge}`),
     ...contentSizes.caption1(theme),
   }),
   medium: theme => ({
     minHeight: fieldHeights.medium,
-    padding: `0 ${horizontalSpacing.mNudge}`,
+    ...shorthands.padding(`0 ${horizontalSpacing.mNudge}`),
     ...contentSizes.body1(theme),
   }),
   large: theme => ({
     minHeight: fieldHeights.large,
-    padding: `0 ${horizontalSpacing.m}`,
+    ...shorthands.padding(`0 ${horizontalSpacing.m}`),
     ...contentSizes[400](theme),
-    gap: horizontalSpacing.sNudge,
+    ...shorthands.gap(horizontalSpacing.sNudge),
   }),
   inline: {
     display: 'inline-flex',
   },
   outline: theme => ({
     background: theme.colorNeutralBackground1,
-    border: `1px solid ${theme.colorNeutralStroke1}`,
+    ...shorthands.border('1px', 'solid', theme.colorNeutralStroke1),
     borderBottomColor: theme.colorNeutralStrokeAccessible,
     ':hover': {
-      borderColor: theme.colorNeutralStroke1Hover,
+      ...shorthands.borderColor(theme.colorNeutralStroke1Hover),
       borderBottomColor: theme.colorNeutralStrokeAccessibleHover,
     },
     // DO NOT add a space between the selectors! It changes the behavior of make-styles.
     ':active,:focus-within': {
-      borderColor: theme.colorNeutralStroke1Pressed,
+      ...shorthands.borderColor(theme.colorNeutralStroke1Pressed),
       borderBottomColor: theme.colorNeutralStrokeAccessiblePressed,
     },
   }),
   underline: theme => ({
     background: theme.colorTransparentBackground,
-    borderRadius: 0, // corners look strange if rounded
-    borderBottom: `1px solid ${theme.colorNeutralStrokeAccessible}`,
+    ...shorthands.borderRadius(0), // corners look strange if rounded
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: theme.colorNeutralStrokeAccessible,
     ':hover': {
       borderBottomColor: theme.colorNeutralStrokeAccessibleHover,
     },
@@ -138,17 +142,15 @@ const useRootStyles = makeStyles({
     ':active,:focus-within': {
       borderBottomColor: theme.colorNeutralStrokeAccessiblePressed,
     },
-    ':after': {
-      borderRadius: 0, // remove rounded corners from focus underline
-    },
+    ':after': shorthands.borderRadius(0), // remove rounded corners from focus underline
   }),
   filled: theme => ({
     boxShadow: theme.shadow2, // optional shadow for filled appearances
-    border: `1px solid ${theme.colorTransparentStroke}`,
+    ...shorthands.border('1px', 'solid', theme.colorTransparentStroke),
     // DO NOT add a space between the selectors! It changes the behavior of make-styles.
     ':hover,:focus-within': {
       // also handles pressed border color (:active)
-      borderColor: theme.colorTransparentStrokeInteractive,
+      ...shorthands.borderColor(theme.colorTransparentStrokeInteractive),
     },
   }),
   filledDarker: theme => ({
@@ -159,8 +161,8 @@ const useRootStyles = makeStyles({
   }),
   disabled: theme => ({
     cursor: 'not-allowed',
-    border: `1px solid ${theme.colorNeutralStrokeDisabled}`,
-    borderRadius: theme.borderRadiusMedium, // because underline doesn't usually have a radius
+    ...shorthands.border('1px', 'solid', theme.colorNeutralStrokeDisabled),
+    ...shorthands.borderRadius(theme.borderRadiusMedium), // because underline doesn't usually have a radius
   }),
 });
 
@@ -168,8 +170,8 @@ const useInputElementStyles = makeStyles({
   base: theme => ({
     boxSizing: 'border-box',
     flexGrow: 1,
-    border: 'none', // input itself never has a border (this is handled by inputWrapper)
-    padding: `0 ${horizontalSpacing.xxs}`,
+    ...shorthands.borderStyle('none'), // input itself never has a border (this is handled by inputWrapper)
+    ...shorthands.padding('0', horizontalSpacing.xxs),
     color: theme.colorNeutralForeground1,
     // Use literal "transparent" (not from the theme) to always let the color from the root show through
     background: 'transparent',
@@ -191,7 +193,7 @@ const useInputElementStyles = makeStyles({
   }),
   large: theme => ({
     ...contentSizes[400](theme),
-    padding: `0 ${horizontalSpacing.sNudge}`,
+    ...shorthands.padding('0', horizontalSpacing.sNudge),
   }),
   disabled: theme => ({
     color: theme.colorNeutralForegroundDisabled,

--- a/packages/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-input/src/components/Input/useInputStyles.ts
@@ -206,7 +206,7 @@ const useContentStyles = makeStyles({
     boxSizing: 'border-box',
     color: theme.colorNeutralForeground3, // "icon color" in design spec
     // special case styling for icons (most common case) to ensure they're centered vertically
-    '> span > svg': { display: 'block' },
+    '> svg': { display: 'block' },
   }),
   disabled: theme => ({
     color: theme.colorNeutralForegroundDisabled,

--- a/packages/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-input/src/components/Input/useInputStyles.ts
@@ -77,9 +77,7 @@ const useRootStyles = makeStyles({
       // By default borderBottom will cause little "horns" on the ends. The clipPath trims them off.
       // (This could be done without trimming using `background: linear-gradient(...)`, but using
       // borderBottom makes it easier for people to override the color if needed.)
-      borderBottomWidth: '2px',
-      borderBottomStyle: 'solid',
-      borderBottomColor: theme.colorCompoundBrandStroke,
+      ...shorthands.borderBottom('2px', 'solid', theme.colorCompoundBrandStroke),
       clipPath: 'inset(calc(100% - 2px) 0 0 0)',
 
       // Animation for focus OUT
@@ -98,17 +96,17 @@ const useRootStyles = makeStyles({
   }),
   small: theme => ({
     minHeight: fieldHeights.small,
-    ...shorthands.padding(`0 ${horizontalSpacing.sNudge}`),
+    ...shorthands.padding('0', horizontalSpacing.sNudge),
     ...contentSizes.caption1(theme),
   }),
   medium: theme => ({
     minHeight: fieldHeights.medium,
-    ...shorthands.padding(`0 ${horizontalSpacing.mNudge}`),
+    ...shorthands.padding('0', horizontalSpacing.mNudge),
     ...contentSizes.body1(theme),
   }),
   large: theme => ({
     minHeight: fieldHeights.large,
-    ...shorthands.padding(`0 ${horizontalSpacing.m}`),
+    ...shorthands.padding('0', horizontalSpacing.m),
     ...contentSizes[400](theme),
     ...shorthands.gap(horizontalSpacing.sNudge),
   }),
@@ -132,9 +130,7 @@ const useRootStyles = makeStyles({
   underline: theme => ({
     background: theme.colorTransparentBackground,
     ...shorthands.borderRadius(0), // corners look strange if rounded
-    borderBottomWidth: '1px',
-    borderBottomStyle: 'solid',
-    borderBottomColor: theme.colorNeutralStrokeAccessible,
+    ...shorthands.borderBottom('1px', 'solid', theme.colorNeutralStrokeAccessible),
     ':hover': {
       borderBottomColor: theme.colorNeutralStrokeAccessibleHover,
     },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: part of #18131, #20159

#### Description of changes

Add hover styles and focus underline for Input, and add visual tests.

Input is supposed to have a very specific bottom focus border style which was a pain to implement. The comments within the styling file explain a lot of the reasoning behind the approach (and hopefully will help prevent accidental changes).

![input focus underline](https://user-images.githubusercontent.com/5864305/142385993-d2d813da-175a-41f0-aa78-61800a658dfd.png)

