### PR TITLE
Optimized felaInvokeKeyframesPlugin reduced object creation

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -160,6 +160,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Prevent focusable elements to be selectable @assuncaocharles ([#18738](https://github.com/microsoft/fluentui/pull/18738))
 - Fix `MenuButton` to avoid arrow keys to move to cells inside a table @assuncaocharles ([#18663](https://github.com/microsoft/fluentui/pull/18663))
 - Fix dropdown container overflow-x @assuncaocharles ([#18749](https://github.com/microsoft/fluentui/pull/18749))
+- Optimized `felaInvokeKeyframesPlugin` to not create new objects but reuse existing one in `reduce` @mbman ([#20649](https://github.com/microsoft/fluentui/pull/20649))
 
 ### Features
 - Add Default Border Transparent and Default Foreground9 colors @notandrew ([#17906](https://github.com/microsoft/fluentui/pull/17906))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix color of `Dropdown` checkable indicator on hover in high contrast theme @annabratseiko ([#20621](https://github.com/microsoft/fluentui/pull/20621))
 - Fix `Carousel` comoponents to properly pass ref to root slots @chpalac ([#20645](https://github.com/microsoft/fluentui/pull/20645))
 - Fix `Card` comoponent to properly pass ref to root slots @chpalac ([#20644](https://github.com/microsoft/fluentui/pull/20644))
+- Optimized `felaInvokeKeyframesPlugin` to not create new objects but reuse existing one in `reduce` @mbman ([#20649](https://github.com/microsoft/fluentui/pull/20649))
 
 ### Features
 - Adding `ViewPersonSparkleIcon`, `CartIcon`, and fixing `EmojiAddIcon` and `AccessibilityIcon` - @notandrew ([#20054](https://github.com/microsoft/fluentui/pull/20054))
@@ -160,7 +161,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Prevent focusable elements to be selectable @assuncaocharles ([#18738](https://github.com/microsoft/fluentui/pull/18738))
 - Fix `MenuButton` to avoid arrow keys to move to cells inside a table @assuncaocharles ([#18663](https://github.com/microsoft/fluentui/pull/18663))
 - Fix dropdown container overflow-x @assuncaocharles ([#18749](https://github.com/microsoft/fluentui/pull/18749))
-- Optimized `felaInvokeKeyframesPlugin` to not create new objects but reuse existing one in `reduce` @mbman ([#20649](https://github.com/microsoft/fluentui/pull/20649))
 
 ### Features
 - Add Default Border Transparent and Default Foreground9 colors @notandrew ([#17906](https://github.com/microsoft/fluentui/pull/17906))

--- a/packages/fluentui/react-northstar-fela-renderer/src/felaInvokeKeyframesPlugin.ts
+++ b/packages/fluentui/react-northstar-fela-renderer/src/felaInvokeKeyframesPlugin.ts
@@ -20,18 +20,15 @@ export const felaInvokeKeyframesPlugin = (styles: ICSSInJSStyle): ICSSInJSStyle 
           styles[cssPropertyName] = callable(animationDefinition.keyframe)(animationDefinition.params || {});
         }
 
-        return {
-          ...acc,
-          [cssPropertyName]: styles[cssPropertyName],
-        };
+        acc[cssPropertyName] = styles[cssPropertyName];
+        return acc;
       }
 
-      return {
-        ...acc,
-        [cssPropertyName]: felaInvokeKeyframesPlugin(cssPropertyValue as ICSSInJSStyle),
-      };
+      acc[cssPropertyName] = felaInvokeKeyframesPlugin(cssPropertyValue as ICSSInJSStyle);
+      return acc;
     }
 
-    return { ...acc, [cssPropertyName]: styles[cssPropertyName] };
+    acc[cssPropertyName] = styles[cssPropertyName];
+    return acc;
   }, {});
 };

--- a/packages/fluentui/react-northstar-fela-renderer/src/felaInvokeKeyframesPlugin.ts
+++ b/packages/fluentui/react-northstar-fela-renderer/src/felaInvokeKeyframesPlugin.ts
@@ -24,6 +24,7 @@ export const felaInvokeKeyframesPlugin = (styles: ICSSInJSStyle): ICSSInJSStyle 
         return acc;
       }
 
+      // Without casting to any TSC gives "Expression produces a union type that is too complex to represent" error
       (acc as any)[cssPropertyName] = felaInvokeKeyframesPlugin(cssPropertyValue as ICSSInJSStyle);
       return acc;
     }

--- a/packages/fluentui/react-northstar-fela-renderer/src/felaInvokeKeyframesPlugin.ts
+++ b/packages/fluentui/react-northstar-fela-renderer/src/felaInvokeKeyframesPlugin.ts
@@ -9,7 +9,7 @@ import * as _ from 'lodash';
  * tree.
  */
 export const felaInvokeKeyframesPlugin = (styles: ICSSInJSStyle): ICSSInJSStyle => {
-  return Object.keys(styles).reduce((acc, cssPropertyName: keyof ICSSInJSStyle) => {
+  return Object.keys(styles).reduce((acc: ICSSInJSStyle, cssPropertyName: keyof ICSSInJSStyle) => {
     const cssPropertyValue = styles[cssPropertyName];
 
     if (_.isPlainObject(cssPropertyValue)) {
@@ -24,11 +24,11 @@ export const felaInvokeKeyframesPlugin = (styles: ICSSInJSStyle): ICSSInJSStyle 
         return acc;
       }
 
-      acc[cssPropertyName] = felaInvokeKeyframesPlugin(cssPropertyValue as ICSSInJSStyle);
+      (acc as any)[cssPropertyName] = felaInvokeKeyframesPlugin(cssPropertyValue as ICSSInJSStyle);
       return acc;
     }
 
-    acc[cssPropertyName] = styles[cssPropertyName];
+    (acc as any)[cssPropertyName] = styles[cssPropertyName];
     return acc;
   }, {});
 };


### PR DESCRIPTION
#### Description of changes

Optimized `felaInvokeKeyframesPlugin` to not create new objects but reuse existing one in `reduce`.

In local run in Teams it shows improvement from 3.8 ms to 0.8 ms for rendering a single button:
![image](https://user-images.githubusercontent.com/1536385/142466169-d7bdc2c5-9612-4d8e-b77b-87e633ed8781.png)

In JsBench it shows [~87% improvement](https://jsbench.me/jrkw691j6j/1):
![image](https://user-images.githubusercontent.com/1536385/142609403-d2e3129d-0613-4854-9cf6-6b6ea254cc6b.png)




#### Focus areas to test

Performance testing for cases when  `felaInvokeKeyframesPlugin` is called with many styles.
