### PR TITLE
RFC: no functions in makeStyles()

### DIFF
--- a/rfcs/convergence/make-styles-no-functions.md
+++ b/rfcs/convergence/make-styles-no-functions.md
@@ -1,6 +1,6 @@
 # Problem
 
-Currently `makeStyles()` implements two on how styles can be defined:
+Currently `makeStyles()` can define style rules in two different ways
 
 ```ts
 makeStyles({
@@ -9,13 +9,13 @@ makeStyles({
 });
 ```
 
-`theme` is typed strictly and offers tokens from `@fluentui/react-theme`. This tokens shape is not extensible for customers.
+`theme` is typed and coupled to tokens from `@fluentui/react-theme`. This tokens shape is not extensible for customers.
 
 # Solution
 
 ## Export tokens separately
 
-Tokens are just CSS variables, we should be clear with customers on what they are using. This also removes need in `useTheme()` hook as tokens can be accessed directly.
+Tokens are just CSS variables, we communicate this fact to customers so that they understand clearly what they are using. This also removes need in `useTheme()` hook as tokens can be accessed directly.
 
 ```tsx
 import { tokens } from '@fluentui/react-theme';
@@ -39,7 +39,7 @@ const tokens: Theme = {
 
 ## Remove functions
 
-Once `tokens` are available there is no sense to keep functions in `makeStyles()`:
+Once `tokens` are available there is no more need for functional style rules in `makeStyles()`:
 
 ```diff
 import { makeStyles } from '@fluentui/react-make-styles';
@@ -53,7 +53,7 @@ makeStyles({
 
 ## Simplify types in `FluentProvider`
 
-Currently `FluentProvider` accepts `theme` only as `Theme` type from `@fluentui/react-theme`. If we will simplify it to `Record<string, string | number>` this will allow customers to extend our theme.
+Currently `FluentProvider` only supports the `Theme` type from `@fluentui/react-theme`. If we simplify this to `Record<string, string | number>` , we enable consumers to extend the default theme.
 
 ```tsx
 import { FluentProvider } from '@fluentui/react-provider';
@@ -71,11 +71,11 @@ function App() {
 }
 ```
 
-Usage of `FluentProvider` will inject all customer tokens properly and will make them available on React Portals.
+`FluentProvider` will inject all customer tokens properly. These tokens will also be available on React Portals.
 
 ## Using custom tokens in `makeStyles()`
 
-Once tokens are injected on `FluentProvider` they could be used in `makeStyles()`.
+Once tokens are injected through the `FluentProvider` they can be used in `makeStyles()`.
 
 ```tsx
 import { tokens } from '@fluentui/react-theme';

--- a/rfcs/convergence/make-styles-no-functions.md
+++ b/rfcs/convergence/make-styles-no-functions.md
@@ -1,0 +1,94 @@
+# Problem
+
+Currently `makeStyles()` implements two on how styles can be defined:
+
+```ts
+makeStyles({
+  rootA: { color: 'red' },
+  rootB: theme => ({ color: theme.tokenB }),
+});
+```
+
+`theme` is typed strictly and offers tokens from `@fluentui/react-theme`. This tokens shape is not extensible for customers.
+
+# Solution
+
+## Export tokens separately
+
+Tokens are just CSS variables, we should be clear with customers on what they are using. This also removes need in `useTheme()` hook as tokens can be accessed directly.
+
+```tsx
+import { tokens } from '@fluentui/react-theme';
+
+function CustomComponent() {
+  return <div style={{ color: tokens.tokensA }} />;
+}
+```
+
+`tokens` is just a plain object:
+
+```ts
+import type { Theme } from '@fluentui/react-theme';
+
+const tokens: Theme = {
+  borderRadiusNone: 'var(--borderRadiusNone)',
+  borderRadiusSmall: 'var(--borderRadiusSmall)',
+  /* ... */
+};
+```
+
+## Remove functions
+
+Once `tokens` are available there is no sense to keep functions in `makeStyles()`:
+
+```diff
+import { makeStyles } from '@fluentui/react-make-styles';
++import { tokens } from '@fluentui/react-theme';
+
+makeStyles({
+-  root: theme => ({ color: theme.tokenB }),
++  root: { color: tokens.tokenB },
+});
+```
+
+## Simplify types in `FluentProvider`
+
+Currently `FluentProvider` accepts `theme` only as `Theme` type from `@fluentui/react-theme`. If we will simplify it to `Record<string, string | number>` this will allow customers to extend our theme.
+
+```tsx
+import { FluentProvider } from '@fluentui/react-provider';
+import { mergeThemes, teamsLightTheme, Theme } from '@fluentui/react-theme';
+
+type CustomTokens = {
+  tokenA: string;
+};
+type CustomTheme = CustomTokens & Theme;
+
+const extendedTheme: CustomTheme = mergeThemes(teamsLightTheme, { tokenA: 'red' });
+
+function App() {
+  return <FluentProvider theme={extendedTheme} />;
+}
+```
+
+Usage of `FluentProvider` will inject all customer tokens properly and will make them available on React Portals.
+
+## Using custom tokens in `makeStyles()`
+
+Once tokens are injected on `FluentProvider` they could be used in `makeStyles()`.
+
+```tsx
+import { tokens } from '@fluentui/react-theme';
+import type { CustomTokens } from './custom-theme';
+
+const customTokens: CustomTokens = {
+  tokenA: 'var(--tokenA)',
+};
+
+makeStyles({
+  root: {
+    backgroundColor: customTokens.tokenA,
+    color: tokens.tokenB,
+  },
+});
+```

--- a/rfcs/convergence/make-styles-no-functions.md
+++ b/rfcs/convergence/make-styles-no-functions.md
@@ -26,7 +26,7 @@ makeStyles({
 
 ## Export tokens separately
 
-Initially we planed support IE11 via runtime tricks, but with the deprecation of IE11, we are now able to leverage CSS Variables for tokens and theming purposes. We communicate this fact to customers so that they understand clearly what they are using.
+Initially we planed to support IE11 via runtime tricks, but with the deprecation of IE11, we are now able to leverage CSS Variables for tokens and theming purposes. We communicate this fact to customers so that they understand clearly what they are using.
 
 The proposal is to export `tokens` as a plain object:
 
@@ -40,7 +40,7 @@ const tokens: Theme = {
 };
 ```
 
-This also removes need in `useTheme()` hook for customers as tokens can be accessed directly, for example:
+This also removes the need of using the `useTheme()` hook for customers as tokens can be accessed directly, for example:
 
 ```tsx
 import { tokens } from '@fluentui/react-theme';
@@ -68,7 +68,9 @@ makeStyles({
 
 ## Simplify types in `FluentProvider`
 
-Currently `FluentProvider` only supports the `Theme` type from `@fluentui/react-theme`. If we simplify this to `Record<string, string | number>`, we enable consumers to extend the default theme:
+Currently `FluentProvider` only supports the `Theme` type from `@fluentui/react-theme`.
+
+If we simplify this to `Record<string, string | number>`, we enable consumers to extend the default theme:
 
 ```tsx
 import { FluentProvider } from '@fluentui/react-provider';
@@ -86,7 +88,39 @@ function App() {
 }
 ```
 
-`FluentProvider` will inject all customer tokens properly including scenarios with React Portals.
+We could alternatively make the theme property in `FluentProvider` extend from `PartialTheme` if we want to ensure that the theme that is passed in always has the keys for the default tokens we provide.
+
+The type of `FluentProviderProps` would then be:
+
+```ts
+export interface FluentProviderProps<TTheme extends PartialTheme = PartialTheme>
+  extends Omit<ComponentProps<FluentProviderSlots>, 'dir'>,
+    Partial<FluentProviderCommons> {
+  theme?: TTheme;
+}
+```
+
+And we could then use it as follows:
+
+```tsx
+import { FluentProvider } from '@fluentui/react-provider';
+import { mergeThemes, teamsLightTheme, Theme } from '@fluentui/react-theme';
+
+type CustomTokens = {
+  tokenA: string;
+};
+type CustomTheme = CustomTokens & Theme;
+
+const extendedTheme: CustomTheme = mergeThemes(teamsLightTheme, { tokenA: 'red' });
+
+function App() {
+  return <FluentProvider theme={extendedTheme} />;
+}
+```
+
+In both scenarios above, `FluentProvider` will still inject all customer tokens properly including scenarios with React Portals.
+
+Also, in case there is an ask for it, we can decide to export a primitive component in the future (named for example `TokensProvider`) whose only purpose would be to render variables for `Record<string, string | number>`.
 
 ## Using custom tokens in `makeStyles()`
 


### PR DESCRIPTION
This RFC targets to solve extensibility of theme of customers and simplify `makeStyles()` itself. This was already briefly discussed sometime ago, https://github.com/microsoft/fluentui/pull/19752#discussion_r709513133.

---


[RFC Preview](https://github.com/microsoft/fluentui/blob/rfc/mk-drop-fn/rfcs/convergence/make-styles-no-functions.md)


