### PR TITLE
vr-tests: Rename FabricDecorator to be more generic

### DIFF
--- a/apps/vr-tests/src/stories/ActivityItem.stories.tsx
+++ b/apps/vr-tests/src/stories/ActivityItem.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { ActivityItem, Icon } from '@fluentui/react';
 
 storiesOf('ActivityItem', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Breadcrumb.stories.tsx
+++ b/apps/vr-tests/src/stories/Breadcrumb.stories.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorTall } from '../utilities/index';
+import { TestWrapperDecoratorTall } from '../utilities/index';
 import { Breadcrumb } from '@fluentui/react';
 
 const noOp = () => undefined;
 
 storiesOf('Breadcrumb', module)
-  .addDecorator(FabricDecoratorTall)
+  .addDecorator(TestWrapperDecoratorTall)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/Button.stories.tsx
+++ b/apps/vr-tests/src/stories/Button.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator, FabricDecoratorTall } from '../utilities/index';
+import { TestWrapperDecorator, TestWrapperDecoratorTall } from '../utilities/index';
 import {
   DefaultButton,
   ActionButton,
@@ -45,7 +45,7 @@ const commandProps: IButtonProps = {
 };
 
 storiesOf('Button (compat)', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Steps()
@@ -76,7 +76,7 @@ storiesOf('Button (compat)', module)
   .addStory('Icon Only', () => <DefaultButton iconProps={baseProps.iconProps} />);
 
 storiesOf('Button Action (compat)', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Steps()
@@ -97,7 +97,7 @@ storiesOf('Button Action (compat)', module)
   .addStory('Icon Only', () => <ActionButton iconProps={baseProps.iconProps} />);
 
 storiesOf('Button Compound (compat)', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Steps()
@@ -127,7 +127,7 @@ storiesOf('Button Command (compat)', module)
   .addDecorator(story => (
     <div style={{ display: 'flex', alignItems: 'stretch', height: '40px' }}>{story()}</div>
   ))
-  .addDecorator(FabricDecoratorTall)
+  .addDecorator(TestWrapperDecoratorTall)
   .addDecorator(story => (
     <Screener
       steps={new Steps()
@@ -149,7 +149,7 @@ storiesOf('Button Command (compat)', module)
   .addStory('Checked', () => <CommandBarButton {...commandProps} checked={true} />);
 
 storiesOf('Button Split (compat)', module)
-  .addDecorator(FabricDecoratorTall)
+  .addDecorator(TestWrapperDecoratorTall)
   .addDecorator(story => (
     <Screener
       steps={new Steps()
@@ -191,7 +191,7 @@ storiesOf('Button Split (compat)', module)
   .addStory('Command Split', () => <CommandBarButton {...commandProps} split={true} />);
 
 storiesOf('Button Special Scenarios (compat)', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}
@@ -224,7 +224,7 @@ storiesOf('Button Special Scenarios (compat)', module)
   ));
 
 storiesOf('IconButton Scenarios (compat)', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Steps()

--- a/apps/vr-tests/src/stories/Calendar.stories.tsx
+++ b/apps/vr-tests/src/stories/Calendar.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorFixedWidth } from '../utilities/index';
+import { TestWrapperDecoratorFixedWidth } from '../utilities/index';
 import { Fabric, Calendar, DateRangeType, DayOfWeek } from '@fluentui/react';
 
 const date = new Date(2010, 1, 12);
 storiesOf('Calendar', module)
-  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}
@@ -23,7 +23,7 @@ storiesOf('Calendar', module)
   );
 
 storiesOf('Calendar - No Month Option', module)
-  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}

--- a/apps/vr-tests/src/stories/Checkbox.stories.tsx
+++ b/apps/vr-tests/src/stories/Checkbox.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Checkbox, Persona, PersonaSize } from '@fluentui/react';
 
 storiesOf('Checkbox', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener
@@ -52,7 +52,7 @@ storiesOf('Checkbox', module)
   ));
 
 storiesOf('Checkbox Indeterminate', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/ChoiceGroup.stories.tsx
+++ b/apps/vr-tests/src/stories/ChoiceGroup.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { ChoiceGroup, IChoiceGroupOption } from '@fluentui/react';
 import { TestImages } from '@fluentui/example-data';
 
@@ -12,7 +12,7 @@ const options: IChoiceGroupOption[] = [
 ];
 
 storiesOf('ChoiceGroup', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/Coachmark.stories.tsx
+++ b/apps/vr-tests/src/stories/Coachmark.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Coachmark, DirectionalHint, TeachingBubbleContent, Fabric } from '@fluentui/react';
 import { useId } from '@fluentui/react-hooks';
 import { DefaultButton } from '@fluentui/react/lib/Button';
@@ -47,7 +47,7 @@ const CoachmarkUsage = ({ isCollapsed = true }: { isCollapsed?: boolean }) => {
 };
 
 storiesOf('Coachmark', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/ColorPicker.stories.tsx
+++ b/apps/vr-tests/src/stories/ColorPicker.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { ColorPicker, Fabric } from '@fluentui/react';
 
 storiesOf('ColorPicker', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/ComboBox.stories.tsx
+++ b/apps/vr-tests/src/stories/ComboBox.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorTallFixedWidth } from '../utilities/index';
+import { TestWrapperDecoratorTallFixedWidth } from '../utilities/index';
 import { ComboBox, SelectableOptionMenuItemType, ISelectableOption } from '@fluentui/react';
 
 const testOptions = [
@@ -38,7 +38,7 @@ const onRenderFontOption = (item: ISelectableOption) => {
 };
 
 storiesOf('ComboBox', module)
-  .addDecorator(FabricDecoratorTallFixedWidth)
+  .addDecorator(TestWrapperDecoratorTallFixedWidth)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/CommandBar.stories.tsx
+++ b/apps/vr-tests/src/stories/CommandBar.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorTall } from '../utilities/index';
+import { TestWrapperDecoratorTall } from '../utilities/index';
 import { CommandBar, ICommandBarItemProps } from '@fluentui/react';
 
 const items: ICommandBarItemProps[] = [
@@ -66,7 +66,7 @@ const farItems: ICommandBarItemProps[] = [
 ];
 
 storiesOf('CommandBar', module)
-  .addDecorator(FabricDecoratorTall)
+  .addDecorator(TestWrapperDecoratorTall)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/ContextualMenu.stories.tsx
+++ b/apps/vr-tests/src/stories/ContextualMenu.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { ContextualMenu, ContextualMenuItemType, IContextualMenuItem } from '@fluentui/react';
 import { DefaultButton } from '@fluentui/react/lib/Button';
 
@@ -279,7 +279,7 @@ const itemsWithSubmenuHrefs: IContextualMenuItem[] = [
 ];
 
 storiesOf('ContextualMenu', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/DatePicker.stories.tsx
+++ b/apps/vr-tests/src/stories/DatePicker.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorFixedWidth } from '../utilities/index';
+import { TestWrapperDecoratorFixedWidth } from '../utilities/index';
 import { Fabric, IDatePickerProps, DatePicker } from '@fluentui/react';
 
 const customDayClass = 'test-dayCell';
@@ -27,7 +27,7 @@ const commonProps: Partial<IDatePickerProps> = {
 };
 
 storiesOf('DatePicker', module)
-  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
@@ -82,7 +82,7 @@ storiesOf('DatePicker', module)
   ));
 
 storiesOf('DatePicker - No Month Option', module)
-  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
@@ -106,7 +106,7 @@ storiesOf('DatePicker - No Month Option', module)
   ));
 
 storiesOf('DatePicker - Disabled', module)
-  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/DetailsHeader.stories.tsx
+++ b/apps/vr-tests/src/stories/DetailsHeader.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import {
   IColumn,
   DetailsListLayoutMode,
@@ -114,7 +114,7 @@ const _columnReorderProps = {
 };
 
 storiesOf('DetailsHeader', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/DetailsList.stories.tsx
+++ b/apps/vr-tests/src/stories/DetailsList.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import {
   DetailsList,
   DetailsListLayoutMode,
@@ -117,7 +117,7 @@ const groups = [
 ];
 
 storiesOf('DetailsList', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/Dialog.stories.tsx
+++ b/apps/vr-tests/src/stories/Dialog.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorTall } from '../utilities/index';
+import { TestWrapperDecoratorTall } from '../utilities/index';
 import { Dialog, DialogType, DialogFooter } from '@fluentui/react';
 import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/Button';
 
@@ -19,7 +19,7 @@ const text = {
 };
 
 storiesOf('Dialog', module)
-  .addDecorator(FabricDecoratorTall)
+  .addDecorator(TestWrapperDecoratorTall)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/DocumentCard.stories.tsx
+++ b/apps/vr-tests/src/stories/DocumentCard.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator, modifyDeprecatedDecoratorStyles } from '../utilities/index';
+import { TestWrapperDecorator, modifyDeprecatedDecoratorStyles } from '../utilities/index';
 import {
   DocumentCard,
   DocumentCardPreview,
@@ -84,7 +84,7 @@ const docActivity = (
 );
 
 storiesOf('DocumentCard', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener
@@ -138,7 +138,7 @@ storiesOf('DocumentCard', module)
 storiesOf('DocumentCard', module)
   // FIXME: SB6 duplicates same story ID decorators
   // This is a temporary fix until we migrate to CSF format duplication problem
-  // - previously this used FabricDecoratorFullWidth
+  // - previously this used TestWrapperDecoratorFullWidth
   .addDecorator(modifyDeprecatedDecoratorStyles({ mode: 'full' }))
 
   .addDecorator(story =>

--- a/apps/vr-tests/src/stories/Dropdown.stories.tsx
+++ b/apps/vr-tests/src/stories/Dropdown.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import {
   Dropdown,
   DropdownMenuItemType,
@@ -11,7 +11,7 @@ import {
 } from '@fluentui/react';
 
 storiesOf('Dropdown', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
@@ -179,7 +179,7 @@ storiesOf('Dropdown', module)
   ));
 
 storiesOf('Dropdown Disabled', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/Facepile.stories.tsx
+++ b/apps/vr-tests/src/stories/Facepile.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import {
   Facepile,
   PersonaInitialsColor,
@@ -52,7 +52,7 @@ const facepileProps: IFacepileProps = {
 };
 
 storiesOf('Facepile', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/FocusTrapZone.stories.tsx
+++ b/apps/vr-tests/src/stories/FocusTrapZone.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Panel, PanelType, Dialog, DialogType } from '@fluentui/react';
 
 storiesOf('FocusTrapZones', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/FolderCover.stories.tsx
+++ b/apps/vr-tests/src/stories/FolderCover.stories.tsx
@@ -9,7 +9,7 @@ import {
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { ISize, fitContentToBounds, Fabric } from '@fluentui/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 
 interface IFolderCoverWithImageProps extends IFolderCoverProps {
   originalImageSize: ISize;
@@ -41,7 +41,7 @@ const FolderCoverWithImage: React.FunctionComponent<IFolderCoverWithImageProps> 
 
 storiesOf('FolderCover', module)
   .addDecorator(story => <Fabric>{story()}</Fabric>)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Fonts.stories.tsx
+++ b/apps/vr-tests/src/stories/Fonts.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { createFontStyles } from '@fluentui/react/lib/Styling';
 
 const RepresentativeText = (props: { style: React.CSSProperties }) => (
@@ -33,7 +33,7 @@ function getStyle(lang: string) {
 }
 
 storiesOf('Fonts', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/GroupedList.stories.tsx
+++ b/apps/vr-tests/src/stories/GroupedList.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { GroupedList } from '@fluentui/react';
 
 /* eslint-disable @fluentui/max-len */
@@ -86,7 +86,7 @@ const onRenderCell = (nestingDepth: number, item: any, itemIndex: number) => {
 };
 
 storiesOf('GroupedList', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/HoverCard.stories.tsx
+++ b/apps/vr-tests/src/stories/HoverCard.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { HoverCard } from '@fluentui/react';
 
 const onRenderCardContent = (item: any) => {
@@ -20,7 +20,7 @@ const expandingCardProps = {
 };
 
 storiesOf('HoverCard', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Icon.stories.tsx
+++ b/apps/vr-tests/src/stories/Icon.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Icon, IconType, getIconClassName, Fabric } from '@fluentui/react';
 import * as IconNames from '@fluentui/font-icons-mdl2/src/IconNames';
 
@@ -15,7 +15,7 @@ for (const iconName in (IconNames as any).IconNames) {
 }
 
 storiesOf('Icon', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Image.stories.tsx
+++ b/apps/vr-tests/src/stories/Image.stories.tsx
@@ -2,7 +2,7 @@ import { storiesOf } from '@storybook/react';
 import { Image, ImageFit, Label, Layer, IImageProps } from '@fluentui/react';
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 
 const img350x150 = 'http://via.placeholder.com/350x150';
 
@@ -49,7 +49,7 @@ const imagePropsMaximizeFrame: IImageProps = {
 const border = 'solid 1px black';
 
 storiesOf('Image', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Keytip.stories.tsx
+++ b/apps/vr-tests/src/stories/Keytip.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { DelayedRender, Keytip } from '@fluentui/react';
 
 storiesOf('Keytip', module)
@@ -11,7 +11,7 @@ storiesOf('Keytip', module)
       {story()}
     </div>
   ))
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Label.stories.tsx
+++ b/apps/vr-tests/src/stories/Label.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Label } from '@fluentui/react';
 
 storiesOf('Label', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Layer.stories.tsx
+++ b/apps/vr-tests/src/stories/Layer.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Layer } from '@fluentui/react';
 
 storiesOf('Layer', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Link.stories.tsx
+++ b/apps/vr-tests/src/stories/Link.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Link } from '@fluentui/react';
 
 storiesOf('Link', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Steps()

--- a/apps/vr-tests/src/stories/List.stories.tsx
+++ b/apps/vr-tests/src/stories/List.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { List } from '@fluentui/react';
 
 /* eslint-disable @fluentui/max-len */
@@ -131,7 +131,7 @@ const items = [
 const onRenderCell = (item: any) => <div>{item.name}</div>;
 
 storiesOf('List', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/MessageBar.stories.tsx
+++ b/apps/vr-tests/src/stories/MessageBar.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Link, MessageBar, MessageBarType } from '@fluentui/react';
 import { MessageBarButton } from '@fluentui/react/lib/Button';
 
@@ -12,7 +12,7 @@ const longText =
 const link = <Link href="www.bing.com">Visit our website</Link>;
 
 storiesOf('MessageBar', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Modal.stories.tsx
+++ b/apps/vr-tests/src/stories/Modal.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Modal } from '@fluentui/react/lib/Modal';
 
 storiesOf('Modal', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Nav.stories.tsx
+++ b/apps/vr-tests/src/stories/Nav.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Nav, INavLink } from '@fluentui/react/lib/Nav';
 
 const links: INavLink[] = [
@@ -87,7 +87,7 @@ const disabledLinks: INavLink[] = [
 ];
 
 storiesOf('Nav', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/OverflowSet.stories.tsx
+++ b/apps/vr-tests/src/stories/OverflowSet.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Fabric, OverflowSet, IOverflowSetItemProps } from '@fluentui/react';
 import { IconButton } from '@fluentui/react/lib/Button';
 
@@ -11,7 +11,7 @@ const onRenderOverflowButton = (overflowItems: any[]) => {
 };
 
 storiesOf('OverflowSet', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
@@ -47,7 +47,7 @@ storiesOf('OverflowSet', module)
   );
 
 storiesOf('OverflowSet variant', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Overlay.stories.tsx
+++ b/apps/vr-tests/src/stories/Overlay.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Overlay } from '@fluentui/react';
 
 storiesOf('Overlay', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Panel.stories.tsx
+++ b/apps/vr-tests/src/stories/Panel.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { DefaultButton, Panel, PanelType, PrimaryButton, SearchBox } from '@fluentui/react';
 
 const defaultProps = {
@@ -17,7 +17,7 @@ const onRenderFooterContent = () => (
 );
 
 storiesOf('Panel', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/PeoplePicker.stories.tsx
+++ b/apps/vr-tests/src/stories/PeoplePicker.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import {
   Fabric,
   CompactPeoplePicker,
@@ -133,7 +133,7 @@ const getPeople = () => people;
 // Pickers that are 'disabled' are added before the Screener decorator because css classes for
 // suggestion items won't exist
 storiesOf('PeoplePicker', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addStory('Normal disabled', () => (
     <Fabric>
       <NormalPeoplePicker

--- a/apps/vr-tests/src/stories/Persona.stories.tsx
+++ b/apps/vr-tests/src/stories/Persona.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { IPersonaProps, Persona, PersonaPresence, PersonaSize } from '@fluentui/react';
 import { TestImages } from '@fluentui/example-data';
 
@@ -16,7 +16,7 @@ const examplePersona: IPersonaProps = {
 
 // prettier-ignore
 storiesOf('Persona', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/Pivot.stories.tsx
+++ b/apps/vr-tests/src/stories/Pivot.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Pivot, PivotItem, IPivotItemProps, Icon, Fabric } from '@fluentui/react';
 
 storiesOf('Pivot', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/ProgressIndicator.stories.tsx
+++ b/apps/vr-tests/src/stories/ProgressIndicator.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { ProgressIndicator } from '@fluentui/react';
 
 storiesOf('ProgressIndicator', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Rating.stories.tsx
+++ b/apps/vr-tests/src/stories/Rating.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Rating, RatingSize } from '@fluentui/react';
 
 storiesOf('Rating', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/ResizeGroup.stories.tsx
+++ b/apps/vr-tests/src/stories/ResizeGroup.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { ResizeGroup, OverflowSet } from '@fluentui/react';
 import { DefaultButton } from '@fluentui/react/lib/Button';
 
@@ -26,7 +26,7 @@ const list = {
 const noop = () => null;
 
 storiesOf('ResizeGroup', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/ScrollablePane.DetailsList.stories.tsx
+++ b/apps/vr-tests/src/stories/ScrollablePane.DetailsList.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import {
   DetailsList,
   DetailsListLayoutMode,
@@ -196,7 +196,7 @@ function onRenderDetailsFooter(props: IDetailsFooterProps): JSX.Element {
 }
 
 storiesOf('ScrollablePane Details List', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/ScrollablePane.GroupedDetailsList.stories.tsx
+++ b/apps/vr-tests/src/stories/ScrollablePane.GroupedDetailsList.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import {
   DetailsList,
   DetailsListLayoutMode,
@@ -234,7 +234,7 @@ const getElement = "document.getElementsByClassName('ms-ScrollablePane--contentC
 const cropTo = { cropTo: '.testWrapper' };
 
 storiesOf('ScrollablePane Grouped Details List', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/ScrollablePane.stories.tsx
+++ b/apps/vr-tests/src/stories/ScrollablePane.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Fabric, ScrollablePane, StickyPositionType, Sticky } from '@fluentui/react';
 import { lorem } from '@fluentui/example-data';
 
@@ -42,7 +42,7 @@ function createContentArea(index: number) {
 }
 
 storiesOf('ScrollablePane', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/SearchBox.stories.tsx
+++ b/apps/vr-tests/src/stories/SearchBox.stories.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { SearchBox, Fabric } from '@fluentui/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 
-// FabricDecorator isn't added at the top level so that the full SearchBox can be rendered without a parent div
+// TestWrapperDecorator isn't added at the top level so that the full SearchBox can be rendered without a parent div
 
 storiesOf('SearchBox', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/Separator.stories.tsx
+++ b/apps/vr-tests/src/stories/Separator.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Separator, mergeStyles } from '@fluentui/react';
 
 const verticalStyles = mergeStyles({
@@ -13,7 +13,7 @@ const horizontalStyles = mergeStyles({
 });
 
 storiesOf('Separator', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}

--- a/apps/vr-tests/src/stories/Shimmer.stories.tsx
+++ b/apps/vr-tests/src/stories/Shimmer.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Shimmer, ShimmerElementType as ElemType, ShimmerElementsGroup } from '@fluentui/react';
 import { mergeStyles } from '@fluentui/react/lib/Styling';
 
@@ -22,7 +22,7 @@ storiesOf('Shimmer', module)
     // Shimmer without a specified width needs a container with a fixed width or it's collapsing.
     <div style={{ width: '500px' }}>{story()}</div>
   ))
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Signals.stories.tsx
+++ b/apps/vr-tests/src/stories/Signals.stories.tsx
@@ -23,7 +23,7 @@ import {
 } from '@fluentui/react-experiments';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Fabric } from '@fluentui/react';
 
 interface ISignalExampleProps {
@@ -44,7 +44,7 @@ const SignalExample: React.FunctionComponent<ISignalExampleProps> = (
 };
 
 storiesOf('Signals', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}

--- a/apps/vr-tests/src/stories/Slider.stories.tsx
+++ b/apps/vr-tests/src/stories/Slider.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorTall } from '../utilities/index';
+import { TestWrapperDecoratorTall } from '../utilities/index';
 import { Slider, ThemeProvider } from '@fluentui/react';
 
 storiesOf('Slider', module)
-  .addDecorator(FabricDecoratorTall)
+  .addDecorator(TestWrapperDecoratorTall)
   .addDecorator(story => (
     <ThemeProvider>
       <Screener

--- a/apps/vr-tests/src/stories/SpinButton.stories.tsx
+++ b/apps/vr-tests/src/stories/SpinButton.stories.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorFixedWidth, modifyDeprecatedDecoratorStyles } from '../utilities/index';
+import {
+  TestWrapperDecoratorFixedWidth,
+  modifyDeprecatedDecoratorStyles,
+} from '../utilities/index';
 import {
   Fabric,
   SpinButton,
@@ -26,7 +29,7 @@ const textFieldStyles: Partial<ITextFieldStyles> = {
 const iconProps = { iconName: 'IncreaseIndentLegacy' };
 
 storiesOf('SpinButton', module)
-  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
@@ -69,7 +72,7 @@ storiesOf('SpinButton', module)
 storiesOf('SpinButton', module)
   // FIXME: SB6 duplicates same story ID decorators
   // This is a temporary fix until we migrate to CSF format duplication problem
-  // previously this used FabricDecorator
+  // previously this used TestWrapperDecorator
   .addDecorator(modifyDeprecatedDecoratorStyles({ mode: 'default' }))
   .addDecorator(story => (
     <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>

--- a/apps/vr-tests/src/stories/Spinner.stories.tsx
+++ b/apps/vr-tests/src/stories/Spinner.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Spinner, SpinnerSize } from '@fluentui/react';
 
 storiesOf('Spinner', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}

--- a/apps/vr-tests/src/stories/Stack.stories.tsx
+++ b/apps/vr-tests/src/stories/Stack.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorFullWidth } from '../utilities/index';
+import { TestWrapperDecoratorFullWidth } from '../utilities/index';
 import { Fabric, mergeStyleSets, DefaultPalette, IStyle, Stack } from '@fluentui/react';
 
 const rootStyles = {
@@ -68,7 +68,7 @@ const defaultProps = {
 };
 
 storiesOf('Stack', module)
-  .addDecorator(FabricDecoratorFullWidth)
+  .addDecorator(TestWrapperDecoratorFullWidth)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Sticky.Breadcrumb.stories.tsx
+++ b/apps/vr-tests/src/stories/Sticky.Breadcrumb.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import {
   DetailsList,
   DetailsListLayoutMode,
@@ -220,7 +220,7 @@ const getElement = "document.getElementsByClassName('ms-ScrollablePane--contentC
 const cropTo = { cropTo: '.testWrapper' };
 
 storiesOf('Sticky breadcrumb and sticky details list header', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/Suggestions.stories.tsx
+++ b/apps/vr-tests/src/stories/Suggestions.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { DevOnlyStoryHeader } from '../utilities/index';
 import { Suggestions, ISuggestionsProps } from '@fluentui/react/lib/Pickers';
 import { Fabric } from '@fluentui/react/lib/Fabric';
@@ -128,7 +128,7 @@ export class SimpleSuggestionsExample extends React.Component<{}, { Provinces: P
 }
 
 storiesOf('(Dev-Only) Suggestions', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/SwatchColorPicker.stories.tsx
+++ b/apps/vr-tests/src/stories/SwatchColorPicker.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { SwatchColorPicker, ISwatchColorPickerProps } from '@fluentui/react';
 
 const props: ISwatchColorPickerProps = {
@@ -15,7 +15,7 @@ const props: ISwatchColorPickerProps = {
   ],
 };
 storiesOf('SwatchColorPicker', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/TagPicker.stories.tsx
+++ b/apps/vr-tests/src/stories/TagPicker.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator, modifyDeprecatedDecoratorStyles } from '../utilities/index';
+import { TestWrapperDecorator, modifyDeprecatedDecoratorStyles } from '../utilities/index';
 import { TagPicker, Fabric, ITag } from '@fluentui/react';
 
 const testTags: ITag[] = [
@@ -29,7 +29,7 @@ const getList = () => testTags;
 // Pickers that are 'disabled' are added before the Screener decorator because css classes for
 // suggestion items won't exist
 storiesOf('TagPicker', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addStory('TagPicker disabled', () => <TagPicker onResolveSuggestions={getList} disabled />);
 
 storiesOf('TagPicker', module)
@@ -84,7 +84,7 @@ storiesOf('TagPicker', module)
 storiesOf('TagPicker', module)
   // FIXME: SB6 duplicates same story ID decorators
   // This is a temporary fix until we migrate to CSF format duplication problem
-  // - previously this used FabricDecoratorFixedWidth
+  // - previously this used TestWrapperDecoratorFixedWidth
   .addDecorator(modifyDeprecatedDecoratorStyles({ mode: 'fixed' }))
   .addDecorator(story => (
     <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
@@ -107,7 +107,7 @@ storiesOf('TagPicker', module)
   ));
 
 storiesOf('TagItem', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/TeachingBubble.stories.tsx
+++ b/apps/vr-tests/src/stories/TeachingBubble.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorTall } from '../utilities/index';
+import { TestWrapperDecoratorTall } from '../utilities/index';
 import { TeachingBubble } from '@fluentui/react/lib/TeachingBubble';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';
 
 storiesOf('TeachingBubble', module)
-  .addDecorator(FabricDecoratorTall)
+  .addDecorator(TestWrapperDecoratorTall)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps().snapshot('default', { cropTo: '.ms-TeachingBubble' }).end()}

--- a/apps/vr-tests/src/stories/Text.stories.tsx
+++ b/apps/vr-tests/src/stories/Text.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { Text } from '@fluentui/react';
 
 storiesOf('Text', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}

--- a/apps/vr-tests/src/stories/TextField.stories.tsx
+++ b/apps/vr-tests/src/stories/TextField.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorFixedWidth } from '../utilities/index';
+import { TestWrapperDecoratorFixedWidth } from '../utilities/index';
 import { TextField } from '@fluentui/react';
 
 storiesOf('TextField', module)
-  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/stories/ThemeProvider.stories.tsx
+++ b/apps/vr-tests/src/stories/ThemeProvider.stories.tsx
@@ -4,10 +4,10 @@ import { storiesOf } from '@storybook/react';
 import { loadTheme, createTheme, Customizer } from '@fluentui/react';
 import { PrimaryButton } from '@fluentui/react/lib/Button';
 import { ThemeProvider } from '@fluentui/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 
 storiesOf('ThemeProvider', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}
@@ -85,7 +85,7 @@ const LoadThemeTestButton: React.FunctionComponent<{
 };
 
 storiesOf('ThemeProvider with loadTheme', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
@@ -117,7 +117,7 @@ storiesOf('ThemeProvider with loadTheme', module)
   ));
 
 storiesOf('ThemeProvider with Customizer', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}

--- a/apps/vr-tests/src/stories/Tile.stories.tsx
+++ b/apps/vr-tests/src/stories/Tile.stories.tsx
@@ -11,7 +11,7 @@ import {
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { ISize, fitContentToBounds, Fabric } from '@fluentui/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 
 interface IDocumentItem {
   name: JSX.Element;
@@ -129,7 +129,7 @@ const MediaTileWithThumbnail: React.FunctionComponent<IMediaTileWithThumbnailPro
 
 storiesOf('Tile', module)
   .addDecorator(story => <Fabric>{story()}</Fabric>)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener
@@ -214,7 +214,7 @@ storiesOf('Tile', module)
 
 storiesOf('MediaTile', module)
   .addDecorator(story => <Fabric>{story()}</Fabric>)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story =>
     // prettier-ignore
     <Screener

--- a/apps/vr-tests/src/stories/Toggle.stories.tsx
+++ b/apps/vr-tests/src/stories/Toggle.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities/index';
+import { TestWrapperDecorator } from '../utilities/index';
 import { IToggleProps, Toggle } from '@fluentui/react';
 
 const baseProps: IToggleProps = {
@@ -11,7 +11,7 @@ const baseProps: IToggleProps = {
 };
 
 storiesOf('Toggle', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}

--- a/apps/vr-tests/src/stories/Tooltip.stories.tsx
+++ b/apps/vr-tests/src/stories/Tooltip.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator, FabricDecoratorFixedWidth } from '../utilities/index';
+import { TestWrapperDecorator, TestWrapperDecoratorFixedWidth } from '../utilities/index';
 import { TooltipHost } from '@fluentui/react';
 
 storiesOf('Tooltip', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps().hover('.ms-TooltipHost').wait(200).snapshot('default').end()}
@@ -20,7 +20,7 @@ storiesOf('Tooltip', module)
   ));
 
 storiesOf('Tooltip - Multiple', module)
-  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests/src/utilities/TestWrapperDecorator.tsx
+++ b/apps/vr-tests/src/utilities/TestWrapperDecorator.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { DecoratorFunction } from '@storybook/addons';
 import { StoryFnReactReturnType } from '@storybook/react/dist/ts3.9/client/preview/types';
 
-export const FabricDecorator: DecoratorFunction<StoryFnReactReturnType> = story => (
+export const TestWrapperDecorator: DecoratorFunction<StoryFnReactReturnType> = story => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px', overflow: 'hidden' }}>
       {story()}
@@ -10,7 +10,7 @@ export const FabricDecorator: DecoratorFunction<StoryFnReactReturnType> = story 
   </div>
 );
 
-export const FabricDecoratorTall: DecoratorFunction<StoryFnReactReturnType> = story => (
+export const TestWrapperDecoratorTall: DecoratorFunction<StoryFnReactReturnType> = story => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px 10px 120px' }}>
       {story()}
@@ -18,7 +18,7 @@ export const FabricDecoratorTall: DecoratorFunction<StoryFnReactReturnType> = st
   </div>
 );
 
-export const FabricDecoratorTallFixedWidth: DecoratorFunction<StoryFnReactReturnType> = story => (
+export const TestWrapperDecoratorTallFixedWidth: DecoratorFunction<StoryFnReactReturnType> = story => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px 10px 120px', width: '300px' }}>
       {story()}
@@ -26,7 +26,7 @@ export const FabricDecoratorTallFixedWidth: DecoratorFunction<StoryFnReactReturn
   </div>
 );
 
-export const FabricDecoratorFixedWidth: DecoratorFunction<StoryFnReactReturnType> = story => (
+export const TestWrapperDecoratorFixedWidth: DecoratorFunction<StoryFnReactReturnType> = story => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px', width: '300px' }}>
       {story()}
@@ -34,7 +34,7 @@ export const FabricDecoratorFixedWidth: DecoratorFunction<StoryFnReactReturnType
   </div>
 );
 
-export const FabricDecoratorFullWidth: DecoratorFunction<StoryFnReactReturnType> = story => (
+export const TestWrapperDecoratorFullWidth: DecoratorFunction<StoryFnReactReturnType> = story => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px', width: '100%', overflow: 'hidden' }}>
       {story()}
@@ -45,7 +45,6 @@ export const FabricDecoratorFullWidth: DecoratorFunction<StoryFnReactReturnType>
 const mapper = { default: '', fixed: '300px', full: '100%' };
 
 /**
- *
  * Temporary helper to modify already decorated stories for screener DOM container
  * This should be used for all stories that use same story ID multiple times and need different decorator
  *
@@ -56,18 +55,18 @@ const mapper = { default: '', fixed: '300px', full: '100%' };
  * @example
  * ```
  // this adds first decorator
- storiesOf('SpinButton', module).addDecorator(FabricDecorator)...
+ storiesOf('SpinButton', module).addDecorator(TestWrapperDecorator)...
 
  // this adds another decorator to same DOM tree
- storiesOf('SpinButton', module).addDecorator(FabricDecoratorFullWidth)...
+ storiesOf('SpinButton', module).addDecorator(TestWrapperDecoratorFullWidth)...
 
  // this results having following DOM tree
  // ↓ ↓ ↓
-   <FabricDecoratorFullWidth>
-     <FabricDecorator>
+   <TestWrapperDecoratorFullWidth>
+     <TestWrapperDecorator>
        <Story/>
-    </FabricDecorator>
-  </FabricDecoratorFullWidth>
+    </TestWrapperDecorator>
+  </TestWrapperDecoratorFullWidth>
 ```
  */
 export function modifyDeprecatedDecoratorStyles(options: {

--- a/apps/vr-tests/src/utilities/index.ts
+++ b/apps/vr-tests/src/utilities/index.ts
@@ -16,5 +16,5 @@ declare module '@storybook/addons/dist/ts3.9/types' {
   }
 }
 
-export * from './FabricDecorator';
+export * from './TestWrapperDecorator';
 export * from './DevOnlyStoryHeader';


### PR DESCRIPTION
The decorators used to help with snapshot cropping in vr-tests are called `FabricDecorator*` for historical reasons (at some point they included a `<Fabric>` element), but there's no reason to keep that name now. Switch to a more generic name.

Currently I have the new name as `TestWrapperDecorator`, but open to better suggestions.