### PR TITLE
Dropdown focus

### DIFF
--- a/change/@fluentui-react-cbc5b1a0-1178-4792-8db6-5db201a5fbed.json
+++ b/change/@fluentui-react-cbc5b1a0-1178-4792-8db6-5db201a5fbed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Dropdown positioning focus management.",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -193,6 +193,11 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
   private _listId: string;
   private _optionId: string;
   private _isScrollIdle: boolean;
+  /** Flag for tracking if the Callout has previously been positioned.
+   *  This is necessary to properly control focus state when the width
+   *  of the Dropdown is dynamic (e.g, "fit-content").
+   */
+  private _hasBeenPositioned: boolean;
   private readonly _scrollIdleDelay: number = 250 /* ms */;
   private _scrollIdleTimeoutId: number | undefined;
   /** True if the most recent keydown event was for alt (option) or meta (command). */
@@ -252,6 +257,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     this._listId = this._id + '-list';
     this._optionId = this._id + '-option';
     this._isScrollIdle = true;
+    this._hasBeenPositioned = false;
 
     this._sizePosCache.updateOptions(options);
 
@@ -281,6 +287,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
   public componentDidUpdate(prevProps: IDropdownProps, prevState: IDropdownState) {
     if (prevState.isOpen === true && this.state.isOpen === false) {
       this._gotMouseMove = false;
+      this._hasBeenPositioned = false;
 
       if (this.props.onDismiss) {
         this.props.onDismiss();
@@ -848,11 +855,17 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       this._requestAnimationFrame(() => {
         const selectedIndices = this.props.hoisted.selectedIndices;
         if (this._focusZone.current) {
-          if (selectedIndices && selectedIndices[0] && !this.props.options[selectedIndices[0]].disabled) {
+          if (
+            !this._hasBeenPositioned &&
+            selectedIndices &&
+            selectedIndices[0] &&
+            !this.props.options[selectedIndices[0]].disabled
+          ) {
             const element: HTMLElement | null = getDocument()!.getElementById(`${this._id}-list${selectedIndices[0]}`);
             if (element) {
               this._focusZone.current.focusElement(element);
             }
+            this._hasBeenPositioned = true;
           } else {
             this._focusZone.current.focus();
           }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

When the Dropdown Callout (the container for the list of Dropdown options) is positioned a callback on Dropdown is invoked to manage the focus state of options in the Dropdown. This callback will maintain focus on the currently selected option or, when the Dropdown is first opened, focus on the first selected option if there is one. There is a bug in this behavior when Dropdown has a dynamic width (e.g., width: "fit-content") that triggers "first opened" focus behavior. This bug causes screen readers like Narrator and keyboard navigation to be confusing and difficult to use because the focus jumps around in unexpected ways.

This commit introduces a new state variable in Dropdown, "_hasBeenPositioned", that tracks whether the Dropdown's Callout has already been positioned so that we can execute the correct positioning behavior on subsequent callbacks.

I've not added new tests as part of this fix as the behavior I observed for focus in Jest/JSDOM did not align with what I observed manually testing in browsers (`document.activeElement` is always the document body in JSDOM while it correctly updates to focused elements in browsers for example).

#### Focus areas to test

1. Open `Dropdown.ControlledMulti.Example.tsx`
2. Change the width style from `300` to `"fit-content"`.
3. Run Storybook.
4. Navigate the multiselect dropdown with the keyboard, selecting and deselecting options. The focus order should be what you expect.
4.1. Close and reopen the dropdown. The first selected item should be focused.
5. Navigate the multiselect dropdown with Narrator, selecting and deselecting options. The focus order should be what you expect.
5.1. Close and reopen the dropdown. The first selected item should be focused.

To observe the previous buggy behavior see: https://codepen.io/nadavrosenthal/pen/ExvmKMo?editors=1010

**NOTE:** There is a related bug where the Dropdown clips content in the Callout when its width is set to  "fit-content". I've filed [a separate issue for it](https://github.com/microsoft/fluentui/issues/20655)