### PR TITLE
Charting: CherryPick #20652: For Grouped Vertical Bar chart, bars will be grouped near to each other for barwidth value. #20652

### DIFF
--- a/change/@uifabric-charting-f7bb3167-4a4d-4bd0-b961-d34f5d07cac2.json
+++ b/change/@uifabric-charting-f7bb3167-4a4d-4bd0-b961-d34f5d07cac2.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Grouped Vertical Bar chart, Barwidth issue solved",
+  "comment": "Grouped Vertical Bar chart, Bar width issue solved",
   "packageName": "@uifabric/charting",
   "email": "v-scharde@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@uifabric-charting-f7bb3167-4a4d-4bd0-b961-d34f5d07cac2.json
+++ b/change/@uifabric-charting-f7bb3167-4a4d-4bd0-b961-d34f5d07cac2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Grouped Vertical Bar chart, Barwidth issue solved",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -36,7 +36,7 @@ import {
 } from '../../index';
 
 const COMPONENT_NAME = 'GROUPED VERTICAL BAR CHART';
-const GROUP_PADDING = 16;
+const BAR_SPACE = 2.5;
 const getClassNames = classNamesFunction<IGroupedVerticalBarChartStyleProps, IGroupedVerticalBarChartStyles>();
 type StringAxis = D3Axis<string>;
 type NumericAxis = D3Axis<number | { valueOf(): number }>;
@@ -78,6 +78,8 @@ export class GroupedVerticalBarChartBase extends React.Component<
   private _tooltipId: string;
   private _isNumeric: XAxisTypes;
   private _isRtl: boolean = getRTL();
+  private _isCustomBarWidth: boolean;
+  private _x1TotalBandWidth: number;
 
   public constructor(props: IGroupedVerticalBarChartProps) {
     super(props);
@@ -336,8 +338,10 @@ export class GroupedVerticalBarChartBase extends React.Component<
       };
       xAxisElement && tooltipOfXAxislabels(tooltipProps);
     }
+
+    const customXScale = this._isCustomBarWidth ? (xScale0.bandwidth() - this._x1TotalBandWidth) / 2 : 0;
     return (
-      <g key={singleSet.indexNum} transform={`translate(${xScale0(singleSet.xAxisPoint)}, 0)`}>
+      <g key={singleSet.indexNum} transform={`translate(${xScale0(singleSet.xAxisPoint) + customXScale}, 0)`}>
         {singleGroup}
       </g>
     );
@@ -380,15 +384,24 @@ export class GroupedVerticalBarChartBase extends React.Component<
           ? [containerWidth! - this.margins.right!, this.margins.left!]
           : [this.margins.left!, containerWidth! - this.margins.right!],
       )
-      .padding(GROUP_PADDING / 100);
+      .padding(0.1);
     return x0Axis;
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _createX1Scale = (xScale0: any): any => {
+    let bandWidth = xScale0.bandwidth();
+    if (this.props.barwidth) {
+      const tempDataSet = Object.keys(this._datasetForBars[0]).splice(0, this._keys.length);
+      const totalWidth = (this.props.barwidth! + BAR_SPACE) * tempDataSet.length;
+      this._isCustomBarWidth = totalWidth < xScale0.bandwidth();
+      bandWidth = this._isCustomBarWidth ? totalWidth : xScale0.bandwidth();
+      this._x1TotalBandWidth = bandWidth;
+    }
+
     return d3ScaleBand()
       .domain(this._keys)
-      .range(this._isRtl ? [xScale0.bandwidth(), 0] : [0, xScale0.bandwidth()])
+      .range(this._isRtl ? [bandWidth, 0] : [0, bandWidth])
       .padding(0.05);
   };
 

--- a/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
       />
       <g>
         <g
-          transform="translate(12.222222222222221, 0)"
+          transform="translate(11.42857142857143, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout0"
@@ -117,8 +117,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={5.333333333333329}
           />
           <rect
@@ -138,8 +138,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={0}
           />
           <rect
@@ -159,13 +159,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
         <g
-          transform="translate(-15.555555555555554, 0)"
+          transform="translate(-17.14285714285714, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout0"
@@ -184,8 +184,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={0}
           />
           <rect
@@ -205,8 +205,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={20}
           />
           <rect
@@ -226,8 +226,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
@@ -663,7 +663,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
       />
       <g>
         <g
-          transform="translate(12.222222222222221, 0)"
+          transform="translate(11.42857142857143, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout14"
@@ -682,8 +682,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={5.333333333333329}
           />
           <rect
@@ -703,8 +703,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={0}
           />
           <rect
@@ -724,13 +724,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
         <g
-          transform="translate(-15.555555555555554, 0)"
+          transform="translate(-17.14285714285714, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout14"
@@ -749,8 +749,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={0}
           />
           <rect
@@ -770,8 +770,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={20}
           />
           <rect
@@ -791,8 +791,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
@@ -1208,7 +1208,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
       />
       <g>
         <g
-          transform="translate(12.222222222222221, 0)"
+          transform="translate(11.42857142857143, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout5"
@@ -1227,8 +1227,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={5.333333333333329}
           />
           <rect
@@ -1248,8 +1248,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={0}
           />
           <rect
@@ -1269,13 +1269,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
         <g
-          transform="translate(-15.555555555555554, 0)"
+          transform="translate(-17.14285714285714, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout5"
@@ -1294,8 +1294,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={0}
           />
           <rect
@@ -1315,8 +1315,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={20}
           />
           <rect
@@ -1336,8 +1336,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
@@ -1445,7 +1445,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
       />
       <g>
         <g
-          transform="translate(12.222222222222221, 0)"
+          transform="translate(11.42857142857143, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout9"
@@ -1464,8 +1464,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={5.333333333333329}
           />
           <rect
@@ -1485,8 +1485,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={0}
           />
           <rect
@@ -1506,13 +1506,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
         <g
-          transform="translate(-15.555555555555554, 0)"
+          transform="translate(-17.14285714285714, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout9"
@@ -1531,8 +1531,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={0}
           />
           <rect
@@ -1552,8 +1552,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={20}
           />
           <rect
@@ -1573,8 +1573,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
@@ -2010,7 +2010,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
       />
       <g>
         <g
-          transform="translate(12.222222222222221, 0)"
+          transform="translate(11.42857142857143, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout19"
@@ -2029,8 +2029,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={5.333333333333329}
           />
           <rect
@@ -2050,8 +2050,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={0}
           />
           <rect
@@ -2071,13 +2071,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
         <g
-          transform="translate(-15.555555555555554, 0)"
+          transform="translate(-17.14285714285714, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout19"
@@ -2096,8 +2096,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={0}
           />
           <rect
@@ -2117,8 +2117,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={20}
           />
           <rect
@@ -2138,8 +2138,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
@@ -2575,7 +2575,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
       />
       <g>
         <g
-          transform="translate(12.222222222222221, 0)"
+          transform="translate(11.42857142857143, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout24"
@@ -2594,8 +2594,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={5.333333333333329}
           />
           <rect
@@ -2615,8 +2615,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={0}
           />
           <rect
@@ -2636,13 +2636,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
         <g
-          transform="translate(-15.555555555555554, 0)"
+          transform="translate(-17.14285714285714, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout24"
@@ -2661,8 +2661,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={0}
           />
           <rect
@@ -2682,8 +2682,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={20}
           />
           <rect
@@ -2703,8 +2703,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
@@ -3140,7 +3140,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
       />
       <g>
         <g
-          transform="translate(12.222222222222221, 0)"
+          transform="translate(11.42857142857143, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout29"
@@ -3159,8 +3159,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={5.333333333333329}
           />
           <rect
@@ -3180,8 +3180,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={0}
           />
           <rect
@@ -3201,13 +3201,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>
         <g
-          transform="translate(-15.555555555555554, 0)"
+          transform="translate(-17.14285714285714, 0)"
         >
           <rect
             aria-labelledby="toolTipcallout29"
@@ -3226,8 +3226,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={0.3825136612021858}
+            width={8.009367681498828}
+            x={0.42154566744730637}
             y={0}
           />
           <rect
@@ -3247,8 +3247,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={8.0327868852459}
+            width={8.009367681498828}
+            x={8.852459016393441}
             y={20}
           />
           <rect
@@ -3268,8 +3268,8 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOver={[Function]}
             opacity=""
             role="text"
-            width={7.267759562841528}
-            x={15.683060109289613}
+            width={8.009367681498828}
+            x={17.283372365339574}
             y={0}
           />
         </g>

--- a/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
@@ -4,6 +4,7 @@ import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
 interface IGroupedBarChartState {
   width: number;
   height: number;
+  barwidth: number;
 }
 
 export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGroupedBarChartState> {
@@ -12,6 +13,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
     this.state = {
       width: 700,
       height: 400,
+      barwidth: 10,
     };
   }
 
@@ -25,7 +27,9 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
   private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({ height: parseInt(e.target.value, 10) });
   };
-
+  private _onBarwidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ barwidth: parseInt(e.target.value, 10) });
+  };
   private _basicExample(): JSX.Element {
     const data = [
       {
@@ -122,6 +126,10 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
         <label>change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <br />
+        <label>change Barwidth:</label>
+        <input type="range" value={this.state.barwidth} min={10} max={70} onChange={this._onBarwidthChange} />
+        <label>{this.state.barwidth}</label>
         <div style={rootStyle}>
           <GroupedVerticalBarChart
             culture={window.navigator.language}
@@ -131,6 +139,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
             width={this.state.width}
             showYAxisGridLines
             wrapXAxisLables
+            barwidth={this.state.barwidth}
           />
         </div>
       </>


### PR DESCRIPTION
### Original description
Cherry pick of [#20652](https://github.com/microsoft/fluentui/pull/20652)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
1. On passing barwidth value to the Group Vertical bar, previously all the bars of a single group were placed too far from each other.
Now With this change, all the bars will be only 2.5px distance from each other. 

This is achieved by setting the Single Group range bandwidth with the below calculation
Suppose, Barwidth is 10, and in single Group, 3 bars are there, and each bar required padding which sets as 2.5
So, total bandwidth = ( Barwidth + Padding ) * Total Bars in a single group
                                = ( 10 + 2.5 ) * 3
This is how the Inner group range is defined,  with this change bars are close to each other with 2.5Px padding.
And Single Group's X-Axis position is calculated as (to make Bar's in center of the Group x-axis name)
= Previous Position + ( Bandwidth without custom barwidth calculation - New Bandwidth ) / 2
This completely solved the issue.
If bar width is not set, it will work as previous flow.

### **Before Changes:**
![image](https://user-images.githubusercontent.com/29042635/142445369-5e519a00-6947-4534-963d-abdfe1a74252.png)

### **After Changes:**
For barwidth=10

![image](https://user-images.githubusercontent.com/29042635/142447024-9c3185f9-3d82-479d-90a9-c25c443bbbb1.png)

https://user-images.githubusercontent.com/29042635/142447930-70631189-0747-4c9e-974f-15221e252e48.mp4

### **-----------------------------------------------------------------------------------------------------------------**

2. Also corrected the x-Axis tick size issue, tick was not in the center of the bars.

### **Before Changes:**
![image](https://user-images.githubusercontent.com/29042635/142446790-a5d4b8f6-5d24-49ef-80c5-e8241ecbd3bb.png)

### **After Changes:**
![image](https://user-images.githubusercontent.com/29042635/142447284-65696b2c-8cdc-40f4-89d7-04fa9c66686b.png)

### **-----------------------------------------------------------------------------------------------------------------**

3. Basic example updated, added the Bar Width range to modifying bar width from example page directly. 

![image](https://user-images.githubusercontent.com/29042635/142446129-e4ba0003-f721-4dab-9f24-cb4473538167.png)


(give an overview)

#### Focus areas to test

Grouped Vertical Bar Chart
