### PR TITLE
Charting: CherryPick #20427: D3 xAxis number localization #20427

### DIFF
--- a/change/@uifabric-charting-5bce18ec-0c4e-4843-8c49-2ea7e97b93e1.json
+++ b/change/@uifabric-charting-5bce18ec-0c4e-4843-8c49-2ea7e97b93e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "xAxis number localization",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -107,7 +107,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
   }
 
   public render(): JSX.Element {
-    const { calloutProps, points, chartType, chartHoverProps, svgFocusZoneProps, svgProps } = this.props;
+    const { calloutProps, points, chartType, chartHoverProps, svgFocusZoneProps, svgProps, culture } = this.props;
     if (this.props.parentRef) {
       this._fitParentContainer();
     }
@@ -158,16 +158,16 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
     let xScale: any;
     switch (this.props.xAxisType!) {
       case XAxisTypes.NumericAxis:
-        xScale = createNumericXAxis(XAxisParams);
+        xScale = createNumericXAxis(XAxisParams, culture);
         break;
       case XAxisTypes.DateAxis:
         xScale = createDateXAxis(XAxisParams, this.props.tickParams!);
         break;
       case XAxisTypes.StringAxis:
-        xScale = createStringXAxis(XAxisParams, this.props.tickParams!, this.props.datasetForXAxisDomain!);
+        xScale = createStringXAxis(XAxisParams, this.props.tickParams!, this.props.datasetForXAxisDomain!, culture);
         break;
       default:
-        xScale = createNumericXAxis(XAxisParams);
+        xScale = createNumericXAxis(XAxisParams, culture);
     }
 
     /*

--- a/packages/charting/src/utilities/utilities.ts
+++ b/packages/charting/src/utilities/utilities.ts
@@ -114,7 +114,7 @@ export interface IYAxisParams {
  * @export
  * @param {IXAxisParams} xAxisParams
  */
-export function createNumericXAxis(xAxisParams: IXAxisParams) {
+export function createNumericXAxis(xAxisParams: IXAxisParams, culture?: string) {
   const {
     domainNRangeValues,
     showRoundOffXTickValues = false,
@@ -132,7 +132,11 @@ export function createNumericXAxis(xAxisParams: IXAxisParams) {
     .tickSize(xAxistickSize)
     .tickPadding(tickPadding)
     .ticks(xAxisCount)
-    .tickSizeOuter(0);
+    .tickSizeOuter(0)
+    .tickFormat((domainValue, index) => {
+      const xAxisValue = typeof domainValue === 'number' ? domainValue : domainValue.valueOf();
+      return convertToLocaleString(xAxisValue, culture) as string;
+    });
   if (xAxisElement) {
     d3Select(xAxisElement)
       .call(xAxis)
@@ -177,7 +181,12 @@ export function createDateXAxis(xAxisParams: IXAxisParams, tickParams: ITickPara
  * @param {string[]} dataset
  * @returns
  */
-export function createStringXAxis(xAxisParams: IXAxisParams, tickParams: ITickParams, dataset: string[]) {
+export function createStringXAxis(
+  xAxisParams: IXAxisParams,
+  tickParams: ITickParams,
+  dataset: string[],
+  culture?: string,
+) {
   const { domainNRangeValues, xAxisCount = 6, xAxistickSize = 6, tickPadding = 10, xAxisPadding = 0.1 } = xAxisParams;
   const xAxisScale = d3ScaleBand()
     .domain(dataset!)
@@ -187,7 +196,9 @@ export function createStringXAxis(xAxisParams: IXAxisParams, tickParams: ITickPa
     .tickSize(xAxistickSize)
     .tickPadding(tickPadding)
     .ticks(xAxisCount)
-    .tickFormat((x: string, index: number) => dataset[index] as string);
+    .tickFormat((x: string, index: number) => {
+      return convertToLocaleString(dataset[index], culture) as string;
+    });
 
   if (xAxisParams.xAxisElement) {
     d3Select(xAxisParams.xAxisElement)


### PR DESCRIPTION
### Original description
Cherry pick of [#20427](https://github.com/microsoft/fluentui/pull/20427)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Now xAxis number will also be localized as per the culture pass.

#### Focus areas to test

All charts 


**Before Change:**

![image](https://user-images.githubusercontent.com/29042635/139671184-751fc68b-59fb-4cbf-95b5-234e3f1d521f.png)

![image](https://user-images.githubusercontent.com/29042635/139671470-ac82511a-d767-4bb5-a29f-dcf7b52e16a8.png)

**After Change:**

Showing result for Culture="pt-br"

![image](https://user-images.githubusercontent.com/29042635/139671343-7cb325e8-37a7-43be-a4bc-bc2821cda0be.png)

![image](https://user-images.githubusercontent.com/29042635/139671504-e0fae1eb-23f7-4324-8dd2-154ea6d01a15.png)


