### PR TITLE
[WIP] Resolved In Browse mode, NVDA reads the callout content of first focus section multiple times

### DIFF
--- a/change/@fluentui-react-charting-cf701143-9a84-4aa5-a822-415e660bf281.json
+++ b/change/@fluentui-react-charting-cf701143-9a84-4aa5-a822-415e660bf281.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Resolved In Browse mode, NVDA reads the callout content of first focus section multiple times",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-pkoganti@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/DonutChart/Arc/Arc.tsx
+++ b/packages/react-charting/src/components/DonutChart/Arc/Arc.tsx
@@ -55,7 +55,7 @@ export class Arc extends React.Component<IArcProps, IArcState> {
           onBlur={this._onBlur}
           opacity={opacity}
           onClick={href ? this._redirectToUrl.bind(this, href) : this.props.data?.data.onClick}
-          aria-labelledby={this.props.calloutId}
+          aria-labelledby={focusedArcId === id ? this.props.calloutId : undefined}
           role="text"
         />
         <text textAnchor={'middle'} className={classNames.insideDonutString} y={5}>

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -44,7 +44,6 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
         >
           <g>
             <path
-              aria-labelledby="callout0"
               className=
 
                   {
@@ -80,7 +79,6 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
           </g>
           <g>
             <path
-              aria-labelledby="callout0"
               className=
 
                   {
@@ -402,7 +400,6 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
         >
           <g>
             <path
-              aria-labelledby="callout9"
               className=
 
                   {
@@ -438,7 +435,6 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
           </g>
           <g>
             <path
-              aria-labelledby="callout9"
               className=
 
                   {
@@ -760,7 +756,6 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
         >
           <g>
             <path
-              aria-labelledby="callout3"
               className=
 
                   {
@@ -796,7 +791,6 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
           </g>
           <g>
             <path
-              aria-labelledby="callout3"
               className=
 
                   {
@@ -884,7 +878,6 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
         >
           <g>
             <path
-              aria-labelledby="callout6"
               className=
 
                   {
@@ -920,7 +913,6 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
           </g>
           <g>
             <path
-              aria-labelledby="callout6"
               className=
 
                   {
@@ -1242,7 +1234,6 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
         >
           <g>
             <path
-              aria-labelledby="callout12"
               className=
 
                   {
@@ -1280,7 +1271,6 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
           </g>
           <g>
             <path
-              aria-labelledby="callout12"
               className=
 
                   {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [#19174](https://github.com/microsoft/fluentui/issues/19174)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In Browse mode, NVDA reads the callout content of first focus section multiple times

#### Focus areas to test

DonutChart
