### PR TITLE
eslint-plugin: classify stories as examples not tests

### DIFF
--- a/change/@fluentui-eslint-plugin-5733e325-0c8b-4b50-ad12-d52a70e3d28b.json
+++ b/change/@fluentui-eslint-plugin-5733e325-0c8b-4b50-ad12-d52a70e3d28b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Classify .stories.tsx as examples not tests",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -372,10 +372,20 @@ const getOverrides = () => [
   },
   {
     // Example overrides
-    files: '**/*.Example.tsx',
+    files: '**/*.{Example,stories}.tsx',
     rules: {
       'no-alert': 'off',
       'no-console': 'off',
+    },
+  },
+  {
+    files: '**/*.stories.tsx',
+    rules: {
+      // allow arrow functions in stories for now (may want to change this later since using
+      // constantly-mutating functions can be an anti-pattern which we may not want to demonstrate
+      // in our converged components docs; it happened to be allowed starting out because .stories
+      // files were being linted as tests)
+      'react/jsx-no-bind': 'off',
     },
   },
   {

--- a/packages/eslint-plugin/src/utils/configHelpers.js
+++ b/packages/eslint-plugin/src/utils/configHelpers.js
@@ -5,11 +5,10 @@ const path = require('path');
 const jju = require('jju');
 
 const testFiles = [
-  '**/*{.,-}test.{ts,tsx}',
-  '**/*.stories.tsx',
-  '**/{common,test,tests,stories}/**',
+  '**/*{.,-}{test,spec}.{ts,tsx}',
+  '**/{test,tests}/**',
   '**/testUtilities.{ts,tsx}',
-  '**/common/isConformant.{ts,tsx}',
+  '**/common/{isConformant,snapshotSerializers}.{ts,tsx}',
 ];
 
 const docsFiles = ['**/*Page.tsx', '**/{docs,demo}/**', '**/*.doc.{ts,tsx}'];
@@ -47,8 +46,16 @@ module.exports = {
   /** Files for build configuration */
   configFiles,
 
-  /** Files which may reference devDependencies: tests, docs (excluding examples), config/build */
-  devDependenciesFiles: [...testFiles, ...docsFiles, ...configFiles],
+  /**
+   * Files which may reference `devDependencies`:
+   * - tests
+   * - docs (excluding v8 examples)
+   * - config/build
+   * - stories, for now
+   *   - may need to reconsider for converged components depending on website approach
+   *   - the stories suffix is also used for screener stories in `vr-tests`
+   */
+  devDependenciesFiles: [...testFiles, ...docsFiles, ...configFiles, '**/*.stories.tsx'],
 
   /**
    * Whether linting is running in context of lint-staged (which should disable rules requiring


### PR DESCRIPTION
I noticed that our eslint plugin was classifying anything with `*.stories.tsx` as a test rather than an example, which is an artifact from when this extension was only used for stories in `vr-tests`. Update the classification in the plugin, and separately disable one relevant rule in `vr-tests`.