### PR TITLE
Add splitbutton labels to Commandbar example

### DIFF
--- a/packages/react-examples/src/react/CommandBar/CommandBar.SplitDisabled.Example.tsx
+++ b/packages/react-examples/src/react/CommandBar/CommandBar.SplitDisabled.Example.tsx
@@ -23,6 +23,7 @@ const _items: ICommandBarItemProps[] = [
     iconProps: { iconName: 'Add' },
     split: true,
     ariaLabel: 'New',
+    splitButtonAriaLabel: 'More New options',
     subMenuProps: {
       items: [
         { key: 'emailMessage', text: 'Email message', iconProps: { iconName: 'Mail' } },
@@ -35,6 +36,8 @@ const _items: ICommandBarItemProps[] = [
     text: 'Upload',
     iconProps: { iconName: 'Upload' },
     split: true,
+    ariaLabel: 'Upload',
+    splitButtonAriaLabel: 'More Upload options',
     disabled: true,
     href: 'https://developer.microsoft.com/en-us/fluentui',
     subMenuProps: {

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -335,6 +335,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
+                    aria-label="More New options"
                     className=
                         ms-Button
                         {
@@ -497,6 +498,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                 aria-disabled={true}
                 aria-expanded={false}
                 aria-haspopup={true}
+                aria-label="Upload"
                 className=
 
                     {
@@ -576,6 +578,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                 >
                   <button
                     aria-disabled={true}
+                    aria-label="Upload"
                     className=
                         ms-Button
                         ms-Button--commandBar
@@ -751,6 +754,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     aria-disabled={true}
                     aria-expanded={false}
                     aria-haspopup={true}
+                    aria-label="More Upload options"
                     className=
                         ms-Button
                         is-disabled


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [10520](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10520)
#### Description of changes

Adds splitbutton menu button labels to the CommandBar example. Examples-only change.

