### PR TITLE
Improve vr-tests addStory typings

### DIFF
--- a/apps/vr-tests/.storybook/preview.js
+++ b/apps/vr-tests/.storybook/preview.js
@@ -5,14 +5,7 @@ import { setRTL } from '@fluentui/react/lib/Utilities';
 import { webLightTheme, webHighContrastTheme, webDarkTheme } from '@fluentui/react-theme';
 import { FluentProvider } from '@fluentui/react-provider';
 
-const defaultConfig = {
-  includeRtl: false,
-  includeHighContrast: false,
-  includeDarkMode: false,
-};
-
 /**
- *
  * @deprecated https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-setaddon
  *
  * TODO: rework this to be conformant with Component Story Format
@@ -24,41 +17,41 @@ const defaultConfig = {
  *
  * Adds a story with different configuration options.
  * By default, only adds a story in LTR.
- * The config parameter can be used to add the story RTL
- *  in addition to LTR.
- * In future, this can add a story with additional configurations
- *  such as theming.
+ * The config parameter can be used to add the story RTL in addition to LTR.
+ * In future, this can add a story with additional configurations such as theming.
  */
 setAddon({
-  addStory(storyName, storyFn, config = defaultConfig) {
+  /**
+   * @type {import('../src/utilities/types').ExtendedStoryApi['addStory']}
+   * @this {import('../src/utilities/types').ExtendedStoryApi}
+   */
+  addStory(storyName, storyFn, config = {}) {
     // V-Next stories
     if (this.kind.includes('Converged')) {
       this.add(storyName, context => {
-        return <FluentProvider theme={webLightTheme}>{storyFn({ context })}</FluentProvider>;
+        return <FluentProvider theme={webLightTheme}>{storyFn(context)}</FluentProvider>;
       });
       if (config.includeRtl) {
         this.add(storyName + ' - RTL', context => {
           return (
             <FluentProvider theme={webLightTheme} dir="rtl">
-              {storyFn({ context })}
+              {storyFn(context)}
             </FluentProvider>
           );
         });
       }
       if (config.includeDarkMode) {
         this.add(storyName + ' - Dark Mode', context => {
-          return <FluentProvider theme={webDarkTheme}>{storyFn({ context })}</FluentProvider>;
+          return <FluentProvider theme={webDarkTheme}>{storyFn(context)}</FluentProvider>;
         });
       }
       if (config.includeHighContrast) {
         this.add(storyName + ' - High Contrast', context => {
-          return (
-            <FluentProvider theme={webHighContrastTheme}>{storyFn({ context })}</FluentProvider>
-          );
+          return <FluentProvider theme={webHighContrastTheme}>{storyFn(context)}</FluentProvider>;
         });
       }
     }
-    // Other stories
+    // v8 stories
     else {
       this.add(storyName, context => {
         setRTL(false);

--- a/apps/vr-tests/src/stories/ColorPicker.stories.tsx
+++ b/apps/vr-tests/src/stories/ColorPicker.stories.tsx
@@ -29,7 +29,7 @@ storiesOf('ColorPicker', module)
       </Fabric>
     ),
     {
-      rtl: true,
+      includeRtl: true,
     },
   )
   .addStory('Blue', () => (

--- a/apps/vr-tests/src/stories/ComboBox.stories.tsx
+++ b/apps/vr-tests/src/stories/ComboBox.stories.tsx
@@ -64,7 +64,7 @@ storiesOf('ComboBox', module)
       />
     ),
     {
-      rtl: true,
+      includeRtl: true,
     },
   )
   .addStory('Styled', () => (

--- a/apps/vr-tests/src/stories/SwitchConverged.stories.tsx
+++ b/apps/vr-tests/src/stories/SwitchConverged.stories.tsx
@@ -19,12 +19,12 @@ storiesOf('Switch Converged', module)
     </Screener>
   ))
   .addStory('Root (unchecked)', () => <Switch className="test-class" defaultChecked={false} />, {
-    rtl: true,
+    includeRtl: true,
     includeHighContrast: true,
     includeDarkMode: true,
   })
   .addStory('Root (checked)', () => <Switch className="test-class" defaultChecked={true} />, {
-    rtl: true,
+    includeRtl: true,
     includeHighContrast: true,
     includeDarkMode: true,
   })

--- a/apps/vr-tests/src/stories/TextField.stories.tsx
+++ b/apps/vr-tests/src/stories/TextField.stories.tsx
@@ -22,7 +22,7 @@ storiesOf('TextField', module)
   ))
   .addStory('Root', () => <TextField label="Standard" />)
   .addStory('Placeholder', () => <TextField label="Standard" placeholder="Placeholder" />, {
-    rtl: true,
+    includeRtl: true,
   })
   .addStory('Disabled', () => <TextField label="Disabled" disabled />)
   .addStory('Required', () => <TextField label="Required" required />)
@@ -64,16 +64,16 @@ storiesOf('TextField', module)
       />
     ),
     {
-      rtl: true,
+      includeRtl: true,
     },
   )
   .addStory(
     'Prefix with Value, Disabled',
     () => <TextField label="Prefix" prefix="https://" defaultValue="example.com" disabled />,
     {
-      rtl: true,
+      includeRtl: true,
     },
   )
   .addStory('Suffix', () => <TextField label="Suffix" suffix=".com" />, {
-    rtl: true,
+    includeRtl: true,
   });

--- a/apps/vr-tests/src/utilities/TestWrapperDecorator.tsx
+++ b/apps/vr-tests/src/utilities/TestWrapperDecorator.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { DecoratorFunction } from '@storybook/addons';
-import { StoryFnReactReturnType } from '@storybook/react/dist/ts3.9/client/preview/types';
+import { ExtendedStoryFnReturnType } from './types';
 
-export const TestWrapperDecorator: DecoratorFunction<StoryFnReactReturnType> = story => (
+export const TestWrapperDecorator: DecoratorFunction<ExtendedStoryFnReturnType> = story => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px', overflow: 'hidden' }}>
       {story()}
@@ -10,7 +10,7 @@ export const TestWrapperDecorator: DecoratorFunction<StoryFnReactReturnType> = s
   </div>
 );
 
-export const TestWrapperDecoratorTall: DecoratorFunction<StoryFnReactReturnType> = story => (
+export const TestWrapperDecoratorTall: DecoratorFunction<ExtendedStoryFnReturnType> = story => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px 10px 120px' }}>
       {story()}
@@ -18,7 +18,7 @@ export const TestWrapperDecoratorTall: DecoratorFunction<StoryFnReactReturnType>
   </div>
 );
 
-export const TestWrapperDecoratorTallFixedWidth: DecoratorFunction<StoryFnReactReturnType> = story => (
+export const TestWrapperDecoratorTallFixedWidth: DecoratorFunction<ExtendedStoryFnReturnType> = story => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px 10px 120px', width: '300px' }}>
       {story()}
@@ -26,7 +26,7 @@ export const TestWrapperDecoratorTallFixedWidth: DecoratorFunction<StoryFnReactR
   </div>
 );
 
-export const TestWrapperDecoratorFixedWidth: DecoratorFunction<StoryFnReactReturnType> = story => (
+export const TestWrapperDecoratorFixedWidth: DecoratorFunction<ExtendedStoryFnReturnType> = story => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px', width: '300px' }}>
       {story()}
@@ -34,7 +34,7 @@ export const TestWrapperDecoratorFixedWidth: DecoratorFunction<StoryFnReactRetur
   </div>
 );
 
-export const TestWrapperDecoratorFullWidth: DecoratorFunction<StoryFnReactReturnType> = story => (
+export const TestWrapperDecoratorFullWidth: DecoratorFunction<ExtendedStoryFnReturnType> = story => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px', width: '100%', overflow: 'hidden' }}>
       {story()}
@@ -71,7 +71,7 @@ const mapper = { default: '', fixed: '300px', full: '100%' };
  */
 export function modifyDeprecatedDecoratorStyles(options: {
   mode: keyof typeof mapper;
-}): DecoratorFunction<StoryFnReactReturnType> {
+}): DecoratorFunction<ExtendedStoryFnReturnType> {
   const { mode } = options;
   return story => {
     return (

--- a/apps/vr-tests/src/utilities/index.ts
+++ b/apps/vr-tests/src/utilities/index.ts
@@ -1,18 +1,15 @@
 import { initializeIcons } from '@fluentui/react/lib/Icons';
 import { initializeFolderCovers } from '@fluentui/react-experiments/lib/FolderCover';
+import { ExtendedStoryApi } from './types';
 
 initializeIcons();
 initializeFolderCovers();
 
-export interface IStoryConfig {
-  rtl?: boolean;
-}
-
-declare module '@storybook/addons/dist/ts3.9/types' {
+declare module '@storybook/addons' {
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  interface StoryApi<StoryFnReturnType = unknown> {
+  interface StoryApi {
     /** adds a story, but via VR Tests' addon which auto adds variants like RTL */
-    addStory: this['add'];
+    addStory: ExtendedStoryApi['addStory'];
   }
 }
 

--- a/apps/vr-tests/src/utilities/types.ts
+++ b/apps/vr-tests/src/utilities/types.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { StoryApi, StoryName, LegacyStoryFn } from '@storybook/addons';
+
+/** Extra parameters provided by our addon (see `.storybook/preview.js`) */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface AddStoryConfig {
+  /** Whether to include an RTL version of the story */
+  includeRtl?: boolean;
+  /** Whether to include a high contrast *theme* version of the story (converged only) */
+  includeHighContrast?: boolean;
+  /** Whether to include a dark theme version of the story (converged only) */
+  includeDarkMode?: boolean;
+}
+
+export type ExtendedStoryFnReturnType = React.ReactElement<unknown>;
+
+export type ExtendedStoryFn = LegacyStoryFn<ExtendedStoryFnReturnType>;
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface ExtendedStoryApi extends StoryApi<ExtendedStoryFnReturnType> {
+  addStory: (
+    storyName: StoryName,
+    storyFn: ExtendedStoryFn,
+    config?: AddStoryConfig,
+  ) => ExtendedStoryApi;
+
+  add: (storyName: StoryName, storyFn: ExtendedStoryFn) => ExtendedStoryApi;
+}


### PR DESCRIPTION
`vr-tests/.storybook/preview.js` extends `@storybook/addons` with a custom `addStory` API. We had partial type definitions for this, but they weren't entirely complete/correct (types for custom options were missing), and `preview.js` itself didn't reference the types.

To fix, I added the types in a shared file `vr-tests/src/utilities/types.ts` and referenced them in both the `@storybook/addons` module augmentation (in `vr-tests/src/index.ts`) and where the `addStory` API is defined in `vr-tests/.storybook/preview.js`.

(It would also be possible to move the augmentation and types to `typings/storybook__addons`, but I don't think that's desirable in this case since `addStory` is specific to `vr-tests` and we ideally should remove it in the future.)

Adding custom option types revealed that some stories were using an invalid option `rtl`, so I corrected that to `includeRtl`.