### PR TITLE
Adding ref to ObjectShorthandProps so we can always pass a ref down in composite components

### DIFF
--- a/change/@fluentui-react-badge-35544d15-33b4-401d-8314-847afdb97a37.json
+++ b/change/@fluentui-react-badge-35544d15-33b4-401d-8314-847afdb97a37.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating types to conform to change in ObjectShorthandProps.",
+  "packageName": "@fluentui/react-badge",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-ec55bfa1-84cf-423b-a84d-c2b811aaf57d.json
+++ b/change/@fluentui-react-button-ec55bfa1-84cf-423b-a84d-c2b811aaf57d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating types to conform to change in ObjectShorthandProps.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-89f6d625-1ca6-4c53-8cda-1e3bc844d21f.json
+++ b/change/@fluentui-react-utilities-89f6d625-1ca6-4c53-8cda-1e3bc844d21f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding ref to ObjectShorthandProps so we can always pass a ref down in composite components.",
+  "packageName": "@fluentui/react-utilities",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-badge/etc/react-badge.api.md
+++ b/packages/react-badge/etc/react-badge.api.md
@@ -30,8 +30,8 @@ export type BadgeProps = ComponentProps<Partial<BadgeSlots>> & Partial<BadgeComm
 
 // @public (undocumented)
 export type BadgeSlots = {
-    root: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>, HTMLElement>;
-    icon?: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>, HTMLElement>;
+    root: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>, React_2.Ref<HTMLElement>>;
+    icon?: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>, React_2.Ref<HTMLElement>>;
 };
 
 // @public (undocumented)

--- a/packages/react-badge/etc/react-badge.api.md
+++ b/packages/react-badge/etc/react-badge.api.md
@@ -30,8 +30,8 @@ export type BadgeProps = ComponentProps<Partial<BadgeSlots>> & Partial<BadgeComm
 
 // @public (undocumented)
 export type BadgeSlots = {
-    root: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
-    icon?: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
+    root: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>, HTMLElement>;
+    icon?: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>, HTMLElement>;
 };
 
 // @public (undocumented)

--- a/packages/react-badge/src/components/Badge/Badge.types.ts
+++ b/packages/react-badge/src/components/Badge/Badge.types.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 import type { ComponentProps, ComponentState, ObjectShorthandProps } from '@fluentui/react-utilities';
 
 export type BadgeSlots = {
-  root: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
-  icon?: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
+  root: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+  icon?: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
 };
 
 export type BadgeCommons = {

--- a/packages/react-badge/src/components/Badge/Badge.types.ts
+++ b/packages/react-badge/src/components/Badge/Badge.types.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 import type { ComponentProps, ComponentState, ObjectShorthandProps } from '@fluentui/react-utilities';
 
 export type BadgeSlots = {
-  root: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-  icon?: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+  root: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>, React.Ref<HTMLElement>>;
+  icon?: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>, React.Ref<HTMLElement>>;
 };
 
 export type BadgeCommons = {

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -106,8 +106,8 @@ export type SplitButtonProps = ComponentProps<SplitButtonSlots> & Omit<ButtonPro
 // @public (undocumented)
 export type SplitButtonSlots = {
     root: IntrinsicShorthandProps<'div'>;
-    menuButton?: ObjectShorthandProps<MenuButtonProps>;
-    primaryActionButton?: ObjectShorthandProps<ButtonProps>;
+    menuButton?: ObjectShorthandProps<MenuButtonProps, HTMLButtonElement | HTMLAnchorElement>;
+    primaryActionButton?: ObjectShorthandProps<ButtonProps, HTMLButtonElement | HTMLAnchorElement>;
 };
 
 // @public (undocumented)

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -106,8 +106,8 @@ export type SplitButtonProps = ComponentProps<SplitButtonSlots> & Omit<ButtonPro
 // @public (undocumented)
 export type SplitButtonSlots = {
     root: IntrinsicShorthandProps<'div'>;
-    menuButton?: ObjectShorthandProps<MenuButtonProps, HTMLButtonElement | HTMLAnchorElement>;
-    primaryActionButton?: ObjectShorthandProps<ButtonProps, HTMLButtonElement | HTMLAnchorElement>;
+    menuButton?: ObjectShorthandProps<MenuButtonProps, React_2.Ref<HTMLButtonElement | HTMLAnchorElement>>;
+    primaryActionButton?: ObjectShorthandProps<ButtonProps, React_2.Ref<HTMLButtonElement | HTMLAnchorElement>>;
 };
 
 // @public (undocumented)

--- a/packages/react-button/src/components/SplitButton/SplitButton.types.ts
+++ b/packages/react-button/src/components/SplitButton/SplitButton.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type {
   ComponentProps,
   ComponentState,
@@ -16,12 +17,12 @@ export type SplitButtonSlots = {
   /**
    * Button that opens menu with secondary actions in SplitButton.
    */
-  menuButton?: ObjectShorthandProps<MenuButtonProps, HTMLButtonElement | HTMLAnchorElement>;
+  menuButton?: ObjectShorthandProps<MenuButtonProps, React.Ref<HTMLButtonElement | HTMLAnchorElement>>;
 
   /**
    * Button to perform primary action in SplitButton.
    */
-  primaryActionButton?: ObjectShorthandProps<ButtonProps, HTMLButtonElement | HTMLAnchorElement>;
+  primaryActionButton?: ObjectShorthandProps<ButtonProps, React.Ref<HTMLButtonElement | HTMLAnchorElement>>;
 };
 
 export type SplitButtonProps = ComponentProps<SplitButtonSlots> &

--- a/packages/react-button/src/components/SplitButton/SplitButton.types.ts
+++ b/packages/react-button/src/components/SplitButton/SplitButton.types.ts
@@ -16,12 +16,12 @@ export type SplitButtonSlots = {
   /**
    * Button that opens menu with secondary actions in SplitButton.
    */
-  menuButton?: ObjectShorthandProps<MenuButtonProps>;
+  menuButton?: ObjectShorthandProps<MenuButtonProps, HTMLButtonElement | HTMLAnchorElement>;
 
   /**
    * Button to perform primary action in SplitButton.
    */
-  primaryActionButton?: ObjectShorthandProps<ButtonProps>;
+  primaryActionButton?: ObjectShorthandProps<ButtonProps, HTMLButtonElement | HTMLAnchorElement>;
 };
 
 export type SplitButtonProps = ComponentProps<SplitButtonSlots> &

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -135,8 +135,11 @@ export const nullRender: () => null;
 // @public
 export type ObjectShorthandProps<Props extends {
     children?: React_2.ReactNode;
-} = {}> = Props & {
+} = {}, RefElement = Element> = Props & {
     children?: Props['children'] | ShorthandRenderFunction<Props>;
+    ref?: Props extends {
+        ref?: infer R;
+    } ? R : React_2.Ref<RefElement>;
 };
 
 // @public (undocumented)

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -135,11 +135,11 @@ export const nullRender: () => null;
 // @public
 export type ObjectShorthandProps<Props extends {
     children?: React_2.ReactNode;
-} = {}, RefElement = Element> = Props & {
+} = {}, Ref = Props extends {
+    ref?: infer R;
+} ? R : React_2.Ref<Element>> = Props & {
     children?: Props['children'] | ShorthandRenderFunction<Props>;
-    ref?: Props extends {
-        ref?: infer R;
-    } ? R : React_2.Ref<RefElement>;
+    ref?: Ref;
 };
 
 // @public (undocumented)

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -32,9 +32,12 @@ export type DefaultObjectShorthandProps = ObjectShorthandProps<{
  *
  * For intrinsic elements like 'div', use {@link IntrinsicShorthandProps} instead.
  */
-export type ObjectShorthandProps<Props extends { children?: React.ReactNode } = {}, RefElement = Element> = Props & {
+export type ObjectShorthandProps<
+  Props extends { children?: React.ReactNode } = {},
+  Ref = Props extends { ref?: infer R } ? R : React.Ref<Element>
+> = Props & {
   children?: Props['children'] | ShorthandRenderFunction<Props>;
-  ref?: Props extends { ref?: infer R } ? R : React.Ref<RefElement>;
+  ref?: Ref;
 };
 
 /**

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -32,8 +32,9 @@ export type DefaultObjectShorthandProps = ObjectShorthandProps<{
  *
  * For intrinsic elements like 'div', use {@link IntrinsicShorthandProps} instead.
  */
-export type ObjectShorthandProps<Props extends { children?: React.ReactNode } = {}> = Props & {
+export type ObjectShorthandProps<Props extends { children?: React.ReactNode } = {}, RefElement = Element> = Props & {
   children?: Props['children'] | ShorthandRenderFunction<Props>;
+  ref?: Props extends { ref?: infer R } ? R : React.Ref<RefElement>;
 };
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

We recently discovered that in composite components like `SplitButton` there was no way to pass a `ref` by default to an inner component because it was not included as part of the props of the component itself, but instead passed via `forwardRef`. This created a problem when using one of our converged components as a slot because `ObjectShorthandProps` just gets the prop bag as is. This PR solves this issue by having `ObjectShorthandProps` include `ref` by default and makes the necessary updates to those components that make use of this: `Badge` and `SplitButton`.