### PR TITLE
docs(storybook): hide editors in ArgsTable

### DIFF
--- a/.storybook/preview-head-template.html
+++ b/.storybook/preview-head-template.html
@@ -150,6 +150,14 @@
     border-bottom: 1px solid #edebe9;
   }
 
+  #docs-root .docblock-argstable-body > tr > td:nth-child(4) {
+    display: none;
+  }
+
+  #docs-root .docblock-argstable-head > tr > th:nth-child(4) {
+    display: none;
+  }
+
   #docs-root .docblock-argstable tbody tr {
     border: none;
   }

--- a/change/@fluentui-react-components-49ec8f54-7c30-4c2d-a8a4-7a29909b42fd.json
+++ b/change/@fluentui-react-components-49ec8f54-7c30-4c2d-a8a4-7a29909b42fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs(storybook): hide editors in ArgsTable",
+  "packageName": "@fluentui/react-components",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/DocsComponents/FluentDocsPage.stories.tsx
+++ b/packages/react-components/src/DocsComponents/FluentDocsPage.stories.tsx
@@ -30,6 +30,15 @@ const useStyles = makeStyles({
     flexBasis: '700px',
     flexGrow: 1,
   },
+  argsTable: {
+    // hide editors in ArgsTable
+    '& .docblock-argstable-body>tr>td:nth-child(4)': {
+      display: 'none',
+    },
+    '& .docblock-argstable-head>tr>th:nth-child(4)': {
+      display: 'none',
+    },
+  },
 });
 
 export const FluentDocsPage = () => {
@@ -64,8 +73,9 @@ export const FluentDocsPage = () => {
             {primaryStory.name}
           </HeaderMdx>
           <Primary />
-          <ArgsTable story={PRIMARY_STORY} />
-
+          <div className={styles.argsTable}>
+            <ArgsTable story={PRIMARY_STORY} />
+          </div>
           <Stories />
         </div>
       </div>

--- a/packages/react-components/src/DocsComponents/FluentDocsPage.stories.tsx
+++ b/packages/react-components/src/DocsComponents/FluentDocsPage.stories.tsx
@@ -30,15 +30,6 @@ const useStyles = makeStyles({
     flexBasis: '700px',
     flexGrow: 1,
   },
-  argsTable: {
-    // hide editors in ArgsTable
-    '& .docblock-argstable-body>tr>td:nth-child(4)': {
-      display: 'none',
-    },
-    '& .docblock-argstable-head>tr>th:nth-child(4)': {
-      display: 'none',
-    },
-  },
 });
 
 export const FluentDocsPage = () => {
@@ -73,9 +64,7 @@ export const FluentDocsPage = () => {
             {primaryStory.name}
           </HeaderMdx>
           <Primary />
-          <div className={styles.argsTable}>
-            <ArgsTable story={PRIMARY_STORY} />
-          </div>
+          <ArgsTable story={PRIMARY_STORY} />
           <Stories />
         </div>
       </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Remove edit controls from ArgsTable in docs.
The editors currently do not work as expected. We have a tracking issue #19309 to improve them, until that happens let's hide them to avoid confusion.
