### PR TITLE
Housekeeping workflow - Add labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,1 @@
+'Type: RFC': 'rfcs/**/*.md'

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,11 @@
+name: 'Pull Request Labeler'
+on:
+  - pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,9 +1,9 @@
-name: 'Pull Request Labeler'
+name: Pull-Request Houskeeping 🧹
 on:
-  - pull_request
+  - pull_request_target
 
 jobs:
-  triage:
+  label:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v3

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -1,4 +1,4 @@
-name: Pull-Request Houskeeping 🧹
+name: Pull request houskeeping 🧹
 on:
   - pull_request_target
 


### PR DESCRIPTION
### Why

In an effort to start automating monotonous labeling and organizational tasks, I'm introducing a labeler check to automatically add the label `Type: RFC` for any PR that contains an .md file in the root `rfcs` folder.
The plan is to later on extend this to automate all the things 🧹🙋.

### How

This uses [Github's labeler action ](https://github.com/actions/labeler) to add the said label based on a glob defined in the `labeler.yml` on the root of the .github folder.
`pr-housekeeping.yml` defines the Github check to be run when the PR is created.
The `pull_request_target` trigger is a special trigger that allows for actions to have write permission on the issues, without compromising our workflows if changed by a PR. This special trigger always runs the code from the main branch and is therefore the reason the action is not run on this PR but will be for all future ones after merging.
I go a little bit more in depth in [PR #19185](https://github.com/microsoft/fluentui/pull/19185), in case you want to read more about it.