### PR TITLE
Adding Teams Messaging as Chat component codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,8 @@
 packages/a11y-rules/ @kolaps33 @assuncaocharles @layershifter @miroslavstastny @pompomon @jurokapsiar @ling1726
 packages/a11y-testing/ @kolaps33 @assuncaocharles @layershifter @miroslavstastny @pompomon @jurokapsiar @ling1726
 packages/fluentui/ @assuncaocharles @layershifter @miroslavstastny @pompomon @jurokapsiar @ling1726
+packages/fluentui/react-northstar/src/components/Chat/ @assuncaocharles @layershifter @miroslavstastny @pompomon @jurokapsiar @ling1726 @Hirse
+packages/fluentui/react-northstar/src/themes/teams/components/Chat/ @assuncaocharles @layershifter @miroslavstastny @pompomon @jurokapsiar @ling1726 @Hirse
 
 #### Web Components
 packages/web-components @chrisdholt @EisenbergEffect @nicholasrice


### PR DESCRIPTION
Adding a representative for Teams Messaging (myself) as co-codeowner for N* Chat-components so we (I) get notified for any changes.