### PR TITLE
cra-template: fix errors when running test using Windows OS

### DIFF
--- a/change/@fluentui-cra-template-40467b48-9fa0-48c0-a783-7a3878481a16.json
+++ b/change/@fluentui-cra-template-40467b48-9fa0-48c0-a783-7a3878481a16.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "CRA-Template: fix errors when running test using Windows\"",
+  "packageName": "@fluentui/cra-template",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-cra-template-40467b48-9fa0-48c0-a783-7a3878481a16.json
+++ b/change/@fluentui-cra-template-40467b48-9fa0-48c0-a783-7a3878481a16.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
-  "comment": "CRA-Template: fix errors when running test using Windows\"",
+  "type": "none",
+  "comment": "CRA-Template: fix errors when running test using Windows",
   "packageName": "@fluentui/cra-template",
   "email": "tristan.watanabe@gmail.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/packages/cra-template/scripts/test.ts
+++ b/packages/cra-template/scripts/test.ts
@@ -78,10 +78,10 @@ async function runE2ETest() {
   logger(`✔️ Test React app is successfully created: ${testAppPath}`);
 
   logger('STEP 3. Build test app');
-  await shEcho(`yarn build`, testAppPath);
+  await shEcho(`npx cross-env CI=1 yarn build`, testAppPath);
 
   logger('STEP 4. Run test app tests');
-  await shEcho(`yarn test --watchAll=false`, testAppPath);
+  await shEcho(`npx cross-env CI=1 yarn test`, testAppPath);
 
   logger('STEP 5. Load the test app in the browser');
   await performBrowserTest(path.join(testAppPath, 'build'));

--- a/packages/cra-template/scripts/test.ts
+++ b/packages/cra-template/scripts/test.ts
@@ -78,10 +78,10 @@ async function runE2ETest() {
   logger(`✔️ Test React app is successfully created: ${testAppPath}`);
 
   logger('STEP 3. Build test app');
-  await shEcho(`CI=1 yarn build`, testAppPath);
+  await shEcho(`yarn build`, testAppPath);
 
   logger('STEP 4. Run test app tests');
-  await shEcho(`CI=1 yarn test`, testAppPath);
+  await shEcho(`yarn test --watchAll=false`, testAppPath);
 
   logger('STEP 5. Load the test app in the browser');
   await performBrowserTest(path.join(testAppPath, 'build'));

--- a/scripts/projects-test/packPackages.ts
+++ b/scripts/projects-test/packPackages.ts
@@ -62,8 +62,7 @@ export async function packProjectPackages(
   const tmpDirectory = createTempDir('project-packed-');
   logger(`✔️ Temporary directory for packed packages was created: ${tmpDirectory}`);
 
-  await shEcho('npm i npm-which', tmpDirectory);
-  await shEcho('npm-which npm', tmpDirectory);
+  await shEcho('npx npm-which npm', tmpDirectory);
   await shEcho('npm --version', tmpDirectory);
 
   await Promise.all(

--- a/scripts/projects-test/packPackages.ts
+++ b/scripts/projects-test/packPackages.ts
@@ -62,7 +62,8 @@ export async function packProjectPackages(
   const tmpDirectory = createTempDir('project-packed-');
   logger(`✔️ Temporary directory for packed packages was created: ${tmpDirectory}`);
 
-  await shEcho('which npm', tmpDirectory);
+  await shEcho('npm i npm-which', tmpDirectory);
+  await shEcho('npm-which npm', tmpDirectory);
   await shEcho('npm --version', tmpDirectory);
 
   await Promise.all(


### PR DESCRIPTION
#### Pull request checklist

~- [ ] Addresses an existing issue: Fixes #0000~
~- [ ] Include a change request file using `$ yarn change`~

#### Issue:
- Running `yarn test` for the `cra-template` package yields an error for Windows users since non-Windows compatible commands are used in the test.

#### Description of changes
- `packPackages` now uses `npm-which` package for cross OS compatibility.
- now using `cross-env` package to set `CI=1` for cross OS compatibility.
