### PR TITLE
docs(colors): Adds system colors to the `Colors` guide in the docsite

### DIFF
--- a/packages/fluentui/docs/src/components/ColorBox.tsx
+++ b/packages/fluentui/docs/src/components/ColorBox.tsx
@@ -9,6 +9,7 @@ import { AcceptIcon, ClipboardCopiedToIcon } from '@fluentui/react-icons-northst
 import * as Color from 'color';
 import * as _ from 'lodash';
 import * as React from 'react';
+import { isSystemColor } from '../utils';
 
 type ColorBoxProps = {
   children?: React.ReactNode;
@@ -51,6 +52,33 @@ export const colorBoxVariables = (siteVariables): ColorBoxVariables => ({
   },
 });
 
+const getColorBoxTextColor = (color: string | undefined, variables: ColorBoxVariables): string => {
+  if (color === undefined) {
+    return variables.colorWhite;
+  }
+
+  if (isSystemColor(color)) {
+    switch (color) {
+      case 'ButtonFace':
+      case 'Canvas':
+      case 'HighlightText':
+        return variables.colorBlack;
+      case 'CanvasText':
+      case 'GrayText':
+      case 'Highlight':
+      case 'LinkText':
+      case 'ButtonText':
+        return variables.colorWhite;
+    }
+  }
+
+  try {
+    return Color(color).isDark() ? variables.colorWhite : variables.colorBlack;
+  } catch (err) {}
+
+  return variables.colorBlack;
+};
+
 export const colorBoxStyles: ComponentSlotStylesInput<ColorBoxProps, ColorBoxVariables> = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => ({
     ...(p.showColorValue &&
@@ -64,7 +92,7 @@ export const colorBoxStyles: ComponentSlotStylesInput<ColorBoxProps, ColorBoxVar
         backgroundColor: 'transparent',
       }),
     borderRadius: p.rounded && '.25rem',
-    color: p.value !== undefined && Color(p.value).isDark() ? v.colorWhite : v.colorBlack,
+    color: getColorBoxTextColor(p.value, v),
   }),
   inner: ({ props: p, variables: v }) => ({
     backgroundColor: p.value,

--- a/packages/fluentui/docs/src/components/SystemColors.tsx
+++ b/packages/fluentui/docs/src/components/SystemColors.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { Grid } from '@fluentui/react-northstar';
+import ColorBox from './ColorBox';
+import { systemColors } from '../utils';
+
+const SystemColors: React.FC = () => {
+  return (
+    <Grid columns={2} variables={{ gridGap: '.5rem', padding: '.75rem' }}>
+      {systemColors.map(color => (
+        <div key={color}>
+          <ColorBox name={color} rounded size="small" value={color} copyToClipboardIcon={false} />
+        </div>
+      ))}
+    </Grid>
+  );
+};
+
+export default SystemColors;

--- a/packages/fluentui/docs/src/utils/index.tsx
+++ b/packages/fluentui/docs/src/utils/index.tsx
@@ -7,3 +7,4 @@ export { default as getFormattedHash } from './getFormattedHash';
 export { default as getInfoForSeeTags } from './getInfoForSeeTags';
 export { default as parseExamplePath } from './parseExamplePath';
 export { default as scrollToAnchor } from './scrollToAnchor';
+export { systemColors, isSystemColor } from './systemColors';

--- a/packages/fluentui/docs/src/utils/systemColors.ts
+++ b/packages/fluentui/docs/src/utils/systemColors.ts
@@ -1,0 +1,14 @@
+export const systemColors = [
+  'CanvasText',
+  'Canvas',
+  'LinkText',
+  'GrayText',
+  'HighlightText',
+  'Highlight',
+  'ButtonText',
+  'ButtonFace',
+] as const;
+
+export const isSystemColor = (color: string): color is typeof systemColors[number] => {
+  return systemColors.includes(color as typeof systemColors[number]);
+};

--- a/packages/fluentui/docs/src/views/Colors.tsx
+++ b/packages/fluentui/docs/src/views/Colors.tsx
@@ -18,6 +18,7 @@ import { Link } from 'react-router-dom';
 
 import ColorBox, { colorBoxStyles, colorBoxVariables } from '../components/ColorBox';
 import Fader, { faderStyles } from '../components/Fader';
+import SystemColors from '../components/SystemColors';
 import ColorVariants, { colorVariantsStyles } from '../components/ColorVariants';
 import DocPage from '../components/DocPage/DocPage';
 import ExampleSnippet from '../components/ExampleSnippet';
@@ -182,6 +183,39 @@ const Colors = () => (
             To see all colors variants in the palette, follow this{' '}
             <Text as={Link} weight="bold" content="link" color="brand" to="color-palette" />.
           </p>
+
+          <Header as="h3">System colors</Header>
+          <p>
+            When styling web content for Windows high contrast mode, very little CSS rules should be required. In the
+            case where the color needs to be explicitly set in high contrast mode, there is only a limited set of colors
+            that can be used. The complete set of system colors can be found{' '}
+            <Text
+              as={Link}
+              weight="bold"
+              content="in the new CSS standard"
+              color="brand"
+              to={{ pathname: 'https://www.w3.org/TR/css-color-4/#css-system-colors' }}
+            />
+            .
+          </p>
+
+          <p>
+            You can view this page in on windows in high contrast mode with different themes and see these colors change
+            based on the high contrast theme you pick. You can find the instructions to turn on windows high contrast
+            mode by folow this{' '}
+            <Text
+              as={Link}
+              weight="bold"
+              content="link"
+              color="brand"
+              to={{
+                pathname:
+                  'https://support.microsoft.com/en-us/windows/change-color-contrast-in-windows-fedc744c-90ac-69df-aed5-c8a90125e696',
+              }}
+            />
+          </p>
+
+          <SystemColors />
 
           <Header as="h2" content="Color scheme" />
           <p>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Adds a new section that explains systems colors in the context of
windows high contrast mode. The section contains color boxes for all the
available system colors.

Modifies `ColorBox` component not to crash on sytem colours because the
`color` package does not support them

#### Focus areas to test

(optional)
