### PR TITLE
fix: remove YarnInstaller task from build pipeline

### DIFF
--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -6,13 +6,6 @@ steps:
       checkLatest: true
     displayName: 'Install Node.js'
 
-  - task: YarnInstaller@0
-    displayName: 'Use Yarn 1.22.x'
-    inputs:
-      versionSpec: 1.22.x
-      checkLatest: false
-      includePrerelease: false
-
   # For multiline scripts, we want the whole task to fail if any line of the script fails.
   # ADO doesn't have bash configured this way by default. To fix we override the SHELLOPTS built-in variable.
   # https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html


### PR DESCRIPTION
#### Pull request checklist

~- [ ] Addresses an existing issue: Fixes #0000~
~- [ ] Include a change request file using `$ yarn change`~

#### Description of changes
- `yarn 1.22.17` is already installed to the VMs when using the Microsoft Ubuntu 1804 image (see complete list [here](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md)) so removing this task shouldn't alter the build pipelines and also fix the current failures due to [this](https://github.com/geeklearningio/gl-vsts-tasks-yarn/issues/103) issue.
