### PR TITLE
Ensure output is preserved when running screener

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -162,7 +162,12 @@ jobs:
         displayName: build Webpack loader
 
       - script: |
-          yarn lage screener --to vr-tests --debug --verbose --no-cache
+          yarn workspace vr-tests screener:build
+        displayName: build vr-tests storybook
+
+      # Don't use lage here because it eats long output for reasons that are hard to debug
+      - script: |
+          yarn workspace vr-tests screener
         displayName: run VR Test
         env:
           SCREENER_API_KEY: $(screener.key)

--- a/lage.config.js
+++ b/lage.config.js
@@ -5,8 +5,6 @@ module.exports = {
     'build:info': [],
     bundle: ['build'],
     'bundle-size': ['build'],
-    'screener:build': [],
-    screener: ['screener:build'],
     lint: ['build'],
     clean: [],
     test: ['build'],


### PR DESCRIPTION
We've had some trouble with [screener failures where the log output is truncated](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=227445&view=logs&j=a8a82d6e-f5e1-5356-31e4-5989f531914b&t=36c8ed5a-d0ff-5b6c-53c8-f9f3a874675c&l=67200), making it impossible to see what went wrong. This is presumably due to some issue with output buffering in `lage`, but my previous investigations into this haven't been successful (it has multiple abstractions for process output handling that make it hard to follow). 

A workaround now that we have Screener and ScreenerNorthstar as separate jobs, we can go back to invoking the commands directly instead of using `lage` for the build orchestration. 