### PR TITLE
Add IOnRender interface as replacement for IRenderFunction

### DIFF
--- a/change/@fluentui-utilities-4455a2b1-f186-44de-b2ea-7b0399f28752.json
+++ b/change/@fluentui-utilities-4455a2b1-f186-44de-b2ea-7b0399f28752.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add new IOnRender flow to fix issues with IRenderFunction",
+  "packageName": "@fluentui/utilities",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/src/IOnRender.ts
+++ b/packages/utilities/src/IOnRender.ts
@@ -1,0 +1,8 @@
+/**
+ * Render function interface for providing overrideable render callbacks.
+ *
+ * @public
+ */
+export interface IOnRender<TProps> {
+  (props: TProps, defaultRender?: (props: TProps) => JSX.Element | null): JSX.Element | null;
+}

--- a/packages/utilities/src/IRenderFunction.ts
+++ b/packages/utilities/src/IRenderFunction.ts
@@ -1,5 +1,5 @@
 /**
- * Render function interface for providing overrideable render callbacks.
+ * Render function interface for providing overrideable render callbacks, where the props are optional.
  *
  * @public
  */

--- a/packages/utilities/src/componentAs/composeComponentAs.tsx
+++ b/packages/utilities/src/componentAs/composeComponentAs.tsx
@@ -12,10 +12,6 @@ function createComposedComponent<TProps>(
   const Outer = outer;
 
   const outerMemoizer = createMemoizer((inner: IComponentAs<TProps>) => {
-    if (outer === inner) {
-      throw new Error('Attempted to compose a component with itself.');
-    }
-
     const Inner = inner;
 
     const innerMemoizer = createMemoizer((defaultRender: IComponentAs<TProps>) => {

--- a/packages/utilities/src/componentAs/composeComponentAs.tsx
+++ b/packages/utilities/src/componentAs/composeComponentAs.tsx
@@ -25,6 +25,16 @@ function createComposedComponent<TProps>(
         return <Inner {...innerProps} defaultRender={defaultRender} />;
       };
 
+      (InnerWithDefaultRender as {
+        composed?: {
+          outer: IComponentAs<TProps>;
+          inner: IComponentAs<TProps>;
+        };
+      }).composed = {
+        outer: inner,
+        inner: defaultRender,
+      };
+
       return InnerWithDefaultRender;
     });
 
@@ -34,6 +44,16 @@ function createComposedComponent<TProps>(
       const { defaultRender } = outerProps;
 
       return <Outer {...outerProps} defaultRender={defaultRender ? innerMemoizer(defaultRender) : Inner} />;
+    };
+
+    (OuterWithDefaultRender as {
+      composed?: {
+        outer: IComponentAs<TProps>;
+        inner: IComponentAs<TProps>;
+      };
+    }).composed = {
+      outer,
+      inner,
     };
 
     return OuterWithDefaultRender;

--- a/packages/utilities/src/onRender/composeOnRender.test.tsx
+++ b/packages/utilities/src/onRender/composeOnRender.test.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { composeOnRender } from './composeOnRender';
+import type { IOnRender } from '../IOnRender';
+
+interface IExampleProps {
+  value: string;
+}
+
+const renderBase = (props: IExampleProps): JSX.Element | null => {
+  return <div data-value={props.value} />;
+};
+
+const renderDecoratorA = (props: IExampleProps, defaultRender?: IOnRender<IExampleProps>): JSX.Element | null => {
+  return <div data-a="a">{defaultRender ? defaultRender(props) : null}</div>;
+};
+
+const renderDecoratorB = (props: IExampleProps, defaultRender?: IOnRender<IExampleProps>): JSX.Element | null => {
+  return <div data-b="b">{defaultRender ? defaultRender(props) : null}</div>;
+};
+
+describe('composeComponentAs', () => {
+  it('passes Base to DecoratorA', () => {
+    const renderDecoratorAWithBase = composeOnRender(renderDecoratorA, renderBase);
+
+    const component = renderer.create(<>{renderDecoratorAWithBase({ value: 'test' })}</>);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('passes Base to DecoratorB through DecoratorA', () => {
+    const renderDecoratorAAndBWithBase = composeOnRender(
+      renderDecoratorA,
+      composeOnRender(renderDecoratorB, renderBase),
+    );
+
+    const component = renderer.create(<>{renderDecoratorAAndBWithBase({ value: 'test' })}</>);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('passes Base as defaultRender to DecoratorB through DecoratorA', () => {
+    const renderDecoratorAAroundB = composeOnRender(renderDecoratorA, renderDecoratorB);
+
+    const component = renderer.create(<>{renderDecoratorAAroundB({ value: 'test' }, renderBase)}</>);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders without defaultRender', () => {
+    const renderDecoratorAAroundB = composeOnRender(renderDecoratorA, renderDecoratorB);
+
+    const component = renderer.create(<>{renderDecoratorAAroundB({ value: 'test' })}</>);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('avoids recomposing already-composed components', () => {
+    const renderDecoratorAAroundB = composeOnRender(renderDecoratorA, renderDecoratorB);
+
+    expect(composeOnRender(renderDecoratorA, renderDecoratorB)).toBe(renderDecoratorAAroundB);
+  });
+});

--- a/packages/utilities/src/onRender/composeOnRender.tsx
+++ b/packages/utilities/src/onRender/composeOnRender.tsx
@@ -1,0 +1,58 @@
+import { createMemoizer } from '../memoize';
+import type { IOnRender } from '../IOnRender';
+
+interface IOnRenderComposer {
+  <TProps>(outer: IOnRender<TProps>): (inner: IOnRender<TProps>) => IOnRender<TProps>;
+}
+
+function createComposedOnRender<TProps>(outer: IOnRender<TProps>): (inner: IOnRender<TProps>) => IOnRender<TProps> {
+  const outerMemoizer = createMemoizer((inner: IOnRender<TProps>) => {
+    const innerMemoizer = createMemoizer((defaultRender: IOnRender<TProps>) => {
+      function innerOnRenderWithDefaultRender(innerProps: TProps): JSX.Element | null {
+        return inner(innerProps, defaultRender);
+      }
+
+      (innerOnRenderWithDefaultRender as {
+        composed?: {
+          outer: IOnRender<TProps>;
+          inner: IOnRender<TProps>;
+        };
+      }).composed = {
+        outer: inner,
+        inner: defaultRender,
+      };
+
+      return innerOnRenderWithDefaultRender;
+    });
+
+    function outerOnRenderWithDefaultRender(outerProps: TProps, defaultRender?: IOnRender<TProps>): JSX.Element | null {
+      return outer(outerProps, defaultRender ? innerMemoizer(defaultRender) : inner);
+    }
+
+    (outerOnRenderWithDefaultRender as {
+      composed?: {
+        outer: IOnRender<TProps>;
+        inner: IOnRender<TProps>;
+      };
+    }).composed = {
+      outer,
+      inner,
+    };
+
+    return outerOnRenderWithDefaultRender;
+  });
+
+  return outerMemoizer;
+}
+
+const memoizer = createMemoizer<IOnRenderComposer>(createComposedOnRender);
+
+/**
+ * Composes two 'onRender___' callbacks to produce a final 'onRender___' callback that renders
+ * the outer function, passing the inner function as 'default render'. The inner function
+ * is then passed the original 'default render' prop.
+ * @public
+ */
+export function composeOnRender<TProps>(outer: IOnRender<TProps>, inner: IOnRender<TProps>): IOnRender<TProps> {
+  return memoizer(outer)(inner);
+}


### PR DESCRIPTION
#### Description of changes

The original `IRenderFunction` interface, used for most `onRender___` props throughout Fluent, has a bug: it declares `props` as optional. This means that every implementation which uses `strictNullChecks` must type-check `props` before returning, in addition to type-checking `defaultRender`. The original reason `props` was made optional was a *mistake*: a misunderstanding of the way that TypeScript handled function covariance.

Rather than 'fix' `IRenderFunction` and cause a massive breaking change to all contracts, this change introduces a replacement `IOnRender` interface, with an associated `composeOnRender` helper. New components and override hooks should leverage this new interface so that subsequent implementations can be cleaner and less brittle.

Also, updated `composeRenderFunction` and `composeComponentAs` to attach their composed pieces as 'metadata' on the output function so that debug tools can trace implementation sources.

#### Focus areas to test

Added unit tests for `composeOnRender`; existing components are not impacted by this change.
