### PR TITLE
fix(ChoiceGroup): call useFocusRects to show focus outline

### DIFF
--- a/change/@fluentui-react-6272d530-022c-4ca0-b288-c19a3578d2b6.json
+++ b/change/@fluentui-react-6272d530-022c-4ca0-b288-c19a3578d2b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "call useFocusRects within ChoiceGroup",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react';
 import { Label } from '../../Label';
-import { classNamesFunction, find, getNativeProps, divProperties, setFocusVisibility } from '../../Utilities';
+import {
+  classNamesFunction,
+  find,
+  getNativeProps,
+  divProperties,
+  setFocusVisibility,
+  useFocusRects,
+} from '../../Utilities';
 import { ChoiceGroupOption } from './ChoiceGroupOption/index';
-import { useId, useControllableValue, useWarnings } from '@fluentui/react-hooks';
+import { useId, useControllableValue, useMergedRefs, useWarnings } from '@fluentui/react-hooks';
 import type { IRefObject } from '../../Utilities';
 import type {
   IChoiceGroupOption,
@@ -88,8 +95,12 @@ export const ChoiceGroupBase: React.FunctionComponent<IChoiceGroupProps> = React
   const [keyChecked, setKeyChecked] = useControllableValue(props.selectedKey, defaultSelectedKey);
   const [keyFocused, setKeyFocused] = React.useState<string | number>();
 
+  const rootRef = React.useRef<HTMLDivElement | null>(null);
+  const mergedRootRefs: React.Ref<HTMLDivElement> = useMergedRefs(rootRef, forwardedRef);
+
   useDebugWarnings(props);
   useComponentRef(options, keyChecked, id, componentRef);
+  useFocusRects(rootRef);
 
   const onFocus = React.useCallback((ev?: React.FocusEvent<HTMLElement>, option?: IChoiceGroupOptionProps) => {
     if (option) {
@@ -117,7 +128,7 @@ export const ChoiceGroupBase: React.FunctionComponent<IChoiceGroupProps> = React
   );
 
   return (
-    <div className={classNames.root} {...divProps} ref={forwardedRef}>
+    <div className={classNames.root} {...divProps} ref={mergedRootRefs}>
       <div role="radiogroup" {...(ariaLabelledBy && { 'aria-labelledby': ariaLabelledBy })}>
         {label && (
           <Label className={classNames.label} required={required} id={labelId} disabled={disabled}>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [12937](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12937)
- [x] Include a change request file using `$ yarn change`

#### Description of changes

If ChoiceGroup was used entirely on its own, it does not have visible focus because it does not call useFocusRects or otherwise set focus visibility individually. This bug only shows up if it is not used together with ThemeProvider or another component that calls useFocusRects.