### PR TITLE
chore: Disable `isolatedModules` for e2e tsconfig

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -762,6 +762,7 @@ describe('migrate-converged-pkg generator', () => {
       expect(e2eTsConfig).toEqual({
         extends: '../tsconfig.json',
         compilerOptions: {
+          isolatedModules: false,
           lib: ['ES2019', 'dom'],
           types: ['node', 'cypress', 'cypress-storybook/cypress', 'cypress-real-events'],
         },

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -276,6 +276,7 @@ const templates = {
     tsconfig: {
       extends: '../tsconfig.json',
       compilerOptions: {
+        isolatedModules: false,
         types: ['node', 'cypress', 'cypress-storybook/cypress', 'cypress-real-events'],
         lib: ['ES2019', 'dom'],
       },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Unblocks #20692
- [x] Include a change request file using `$ yarn change`

#### Description of changes

cypress tests don't necessary need to import anything. They are also not shipped along with the package. We should not fail build if there are no imports in test files

#### Focus areas to test

(optional)
