### PR TITLE
Callout content focusable sets false and Title aria-label added for Donut and Horizontal bar chart SVG tags

### DIFF
--- a/change/@fluentui-react-charting-1a7f0331-e960-45d7-9e3f-f84d09bf27a1.json
+++ b/change/@fluentui-react-charting-1a7f0331-e960-45d7-9e3f-f84d09bf27a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Callout content focusable removed and Title for SVG added",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -315,7 +315,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
         >
           <div
             className={this._classNames.calloutContentX}
-            {...getAccessibleDataObject(calloutProps!.xAxisCalloutAccessibilityData)}
+            {...getAccessibleDataObject(calloutProps!.xAxisCalloutAccessibilityData, 'text', false)}
           >
             {convertToLocaleString(calloutProps!.hoverXValue, this.props.culture)}
           </div>
@@ -330,7 +330,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
               const { shouldDrawBorderBottom = false } = yValue;
               return (
                 <div
-                  {...getAccessibleDataObject(yValue.callOutAccessibilityData)}
+                  {...getAccessibleDataObject(yValue.callOutAccessibilityData, 'text', false)}
                   key={`callout-content-${index}`}
                   style={
                     yValueHoverSubCountsExists

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -100,14 +100,14 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
     const chartData = data && data.chartData;
     const valueInsideDonut = this._valueInsideDonut(this.props.valueInsideDonut!, chartData!);
     return (
-      <div
-        className={this._classNames.root}
-        aria-label={data?.chartTitle}
-        ref={(rootElem: HTMLElement | null) => (this._rootElem = rootElem)}
-      >
+      <div className={this._classNames.root} ref={(rootElem: HTMLElement | null) => (this._rootElem = rootElem)}>
         <FocusZone direction={FocusZoneDirection.horizontal} isCircularNavigation={true}>
           <div>
-            <svg className={this._classNames.chart} ref={(node: SVGElement | null) => this._setViewBox(node)}>
+            <svg
+              className={this._classNames.chart}
+              aria-label={data?.chartTitle}
+              ref={(node: SVGElement | null) => this._setViewBox(node)}
+            >
               <Pie
                 width={this.state._width!}
                 height={this.state._height!}

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
 <div
-  aria-label="Stacked Bar chart example"
   className=
       ms-DonutChart
       {
@@ -31,6 +30,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
   >
     <div>
       <svg
+        aria-label="Stacked Bar chart example"
         className=
 
             {
@@ -360,7 +360,6 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
 
 exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1`] = `
 <div
-  aria-label="Stacked Bar chart example"
   className=
       ms-DonutChart
       {
@@ -389,6 +388,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
   >
     <div>
       <svg
+        aria-label="Stacked Bar chart example"
         className=
 
             {
@@ -718,7 +718,6 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
 
 exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
 <div
-  aria-label="Stacked Bar chart example"
   className=
       ms-DonutChart
       {
@@ -747,6 +746,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
   >
     <div>
       <svg
+        aria-label="Stacked Bar chart example"
         className=
 
             {
@@ -842,7 +842,6 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
 
 exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
 <div
-  aria-label="Stacked Bar chart example"
   className=
       ms-DonutChart
       {
@@ -871,6 +870,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
   >
     <div>
       <svg
+        aria-label="Stacked Bar chart example"
         className=
 
             {
@@ -1200,7 +1200,6 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
 
 exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
 <div
-  aria-label="Stacked Bar chart example"
   className=
       ms-DonutChart
       {
@@ -1229,6 +1228,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
   >
     <div>
       <svg
+        aria-label="Stacked Bar chart example"
         className=
 
             {

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -99,8 +99,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                 </FocusZone>
                 {points!.chartData![0].data && this._createBenchmark(points!)}
                 <FocusZone direction={FocusZoneDirection.horizontal}>
-                  <svg className={this._classNames.chart}>
-                    {points!.chartTitle && <title>{points!.chartTitle}</title>}
+                  <svg className={this._classNames.chart} aria-label={points!.chartTitle}>
                     <g
                       id={keyVal}
                       key={keyVal}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

1. Callout content data focusable attribute sets as false because callout content is not for focus. 
    
2. For the Donut chart and Horizontal chart, the chart title is used with SVG tag, so on the focus of the chart, NVDA will announce the chart title.

#### Focus areas to test

(optional)
