### PR TITLE
feat: Forced color support

### DIFF
--- a/change/@fluentui-react-menu-2c74feed-cf75-4700-99b6-b7876ecb1f11.json
+++ b/change/@fluentui-react-menu-2c74feed-cf75-4700-99b6-b7876ecb1f11.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds forced color styling for MenuItem component",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-0f05f8ca-e8d8-4c0b-bba6-ff21a594d06b.json
+++ b/change/@fluentui-react-provider-0f05f8ca-e8d8-4c0b-bba6-ff21a594d06b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds `noForcedColors` flag that applies `forced-color-adjust: none` to provider and managed portals",
+  "packageName": "@fluentui/react-provider",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-shared-contexts-4f85add5-622f-4f64-9026-c3c88e1637ab.json
+++ b/change/@fluentui-react-shared-contexts-4f85add5-622f-4f64-9026-c3c88e1637ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds `noForcedColors` boolean flage to `ProviderContext`",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
+++ b/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
@@ -1,11 +1,13 @@
 import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
+import { useFluent } from '@fluentui/react-shared-contexts';
 import type { MenuItemState } from './MenuItem.types';
 
 export const menuItemClassName = 'fui-MenuItem';
 
 const useStyles = makeStyles({
   focusIndicator: theme => createFocusOutlineStyle(theme),
+  focusIndicatorForced: theme => createFocusOutlineStyle(theme, { style: { outlineColor: 'HighLight' } }),
   root: theme => ({
     borderRadius: theme.borderRadiusMedium,
     position: 'relative',
@@ -62,16 +64,44 @@ const useStyles = makeStyles({
       color: theme.colorNeutralForegroundDisabled,
     },
   }),
+
+  hoverForcedColors: {
+    '@media (forced-colors: active)': {
+      ':hover': {
+        forcedColorAdjust: 'none',
+        backgroundColor: 'HighLight',
+        color: 'HighLightText',
+      },
+    },
+  },
+
+  disabledForcedColors: {
+    '@media (forced-colors: active)': {
+      ':hover': {
+        forcedColorAdjust: 'none',
+        backgroundColor: 'Canvas',
+        color: 'GrayText',
+      },
+      ':focus': {
+        color: 'GrayText',
+      },
+      color: 'GrayText',
+    },
+  },
 });
 
 /** Applies style classnames to slots */
 export const useMenuItemStyles = (state: MenuItemState) => {
+  const { noForcedColors } = useFluent();
   const styles = useStyles();
   state.root.className = mergeClasses(
     menuItemClassName,
     styles.root,
     styles.focusIndicator,
     state.disabled && styles.disabled,
+    !noForcedColors && styles.focusIndicatorForced,
+    !noForcedColors && styles.hoverForcedColors,
+    !noForcedColors && state.disabled && styles.disabledForcedColors,
     state.root.className,
   );
   state.content.className = mergeClasses(styles.content, state.content.className);

--- a/packages/react-provider/etc/react-provider.api.md
+++ b/packages/react-provider/etc/react-provider.api.md
@@ -26,6 +26,7 @@ export const fluentProviderClassName = "fui-FluentProvider";
 // @public (undocumented)
 export interface FluentProviderCommons {
     dir: 'ltr' | 'rtl';
+    noForcedColors?: boolean;
     targetDocument: Document | undefined;
 }
 

--- a/packages/react-provider/src/components/FluentProvider/FluentProvider.types.ts
+++ b/packages/react-provider/src/components/FluentProvider/FluentProvider.types.ts
@@ -17,6 +17,9 @@ export interface FluentProviderCommons {
 
   /** Provides the document, can be undefined during SSR render. */
   targetDocument: Document | undefined;
+
+  /** The provider will use `forced-color-adjust: none` to bail out from system forced colors */
+  noForcedColors?: boolean;
 }
 
 export interface FluentProviderProps

--- a/packages/react-provider/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-provider/src/components/FluentProvider/useFluentProvider.ts
@@ -26,14 +26,20 @@ export const useFluentProvider = (props: FluentProviderProps, ref: React.Ref<HTM
    * nesting providers with the same "dir" should not add additional attributes to DOM
    * see https://github.com/microsoft/fluentui/blob/0dc74a19f3aa5a058224c20505016fbdb84db172/packages/fluentui/react-northstar/src/utils/mergeProviderContexts.ts#L89-L93
    */
-  const { dir = parentContext.dir, targetDocument = parentContext.targetDocument, theme = {} } = props;
+  const {
+    dir = parentContext.dir,
+    targetDocument = parentContext.targetDocument,
+    theme = {},
+    noForcedColors = parentContext.noForcedColors,
+  } = props;
   const mergedTheme = mergeThemes(parentTheme, theme);
 
   return {
     dir,
+    noForcedColors,
     targetDocument,
     theme: mergedTheme,
-    themeClassName: useThemeStyleTag({ theme: mergedTheme, targetDocument }),
+    themeClassName: useThemeStyleTag({ theme: mergedTheme, targetDocument, noForcedColors }),
 
     components: {
       root: 'div',

--- a/packages/react-provider/src/components/FluentProvider/useFluentProviderContextValues.ts
+++ b/packages/react-provider/src/components/FluentProvider/useFluentProviderContextValues.ts
@@ -3,9 +3,13 @@ import * as React from 'react';
 import type { FluentProviderContextValues, FluentProviderState } from './FluentProvider.types';
 
 export function useFluentProviderContextValues(state: FluentProviderState): FluentProviderContextValues {
-  const { root, dir, targetDocument, theme } = state;
+  const { root, dir, targetDocument, theme, noForcedColors } = state;
 
-  const provider = React.useMemo(() => ({ dir, targetDocument }), [dir, targetDocument]);
+  const provider = React.useMemo(() => ({ dir, targetDocument, noForcedColors }), [
+    dir,
+    targetDocument,
+    noForcedColors,
+  ]);
   // "Tooltip" component mutates an object in this context, instance should be stable
   const tooltip = useConst({});
 

--- a/packages/react-provider/src/components/FluentProvider/useThemeStyleTag.ts
+++ b/packages/react-provider/src/components/FluentProvider/useThemeStyleTag.ts
@@ -9,8 +9,8 @@ import { fluentProviderClassName } from './useFluentProviderStyles';
  *
  * @returns CSS class to apply the rule
  */
-export const useThemeStyleTag = (options: Pick<FluentProviderState, 'theme' | 'targetDocument'>) => {
-  const { targetDocument, theme } = options;
+export const useThemeStyleTag = (options: Pick<FluentProviderState, 'theme' | 'targetDocument' | 'noForcedColors'>) => {
+  const { targetDocument, theme, noForcedColors } = options;
 
   const styleTagId = useId(fluentProviderClassName);
   const styleTag = React.useMemo(() => {
@@ -31,9 +31,10 @@ export const useThemeStyleTag = (options: Pick<FluentProviderState, 'theme' | 't
       return cssVarRule;
     }, '');
 
+    const noForcedColorsRule = `forced-color-adjust: none;`;
     // result: .fluent-provider1 { --css-var: '#fff' }
-    return `.${styleTagId} { ${cssVarsAsString} }`;
-  }, [theme, styleTagId]);
+    return `.${styleTagId} { ${cssVarsAsString} ${noForcedColors ? noForcedColorsRule : ''} }`;
+  }, [theme, styleTagId, noForcedColors]);
   const previousCssRule = usePrevious(cssRule);
 
   if (styleTag && previousCssRule !== cssRule) {

--- a/packages/react-shared-contexts/etc/react-shared-contexts.api.md
+++ b/packages/react-shared-contexts/etc/react-shared-contexts.api.md
@@ -23,6 +23,7 @@ export const ProviderContext: React_2.Context<ProviderContextValue>;
 // @public (undocumented)
 export interface ProviderContextValue {
     dir: 'ltr' | 'rtl';
+    noForcedColors?: boolean;
     targetDocument?: Document;
 }
 

--- a/packages/react-shared-contexts/src/ProviderContext/ProviderContext.types.ts
+++ b/packages/react-shared-contexts/src/ProviderContext/ProviderContext.types.ts
@@ -4,4 +4,10 @@ export interface ProviderContextValue {
 
   /** Provides the document, can be undefined during SSR render. */
   targetDocument?: Document;
+
+  /**
+   * The provider will use `forced-color-adjust: none` to bail out from system forced colors.
+   * Setting this flag means the Fluent application will no longer be affected by windows high contrast mode.
+   */
+  noForcedColors?: boolean;
 }

--- a/packages/react-storybook-addon/src/decorators/withFluentProvider.tsx
+++ b/packages/react-storybook-addon/src/decorators/withFluentProvider.tsx
@@ -11,14 +11,14 @@ const getActiveFluentTheme = (globals: FluentGlobals) => {
   const selectedThemeId = globals[THEME_ID];
   const { theme } = themes.find(value => value.id === selectedThemeId) ?? defaultTheme;
 
-  return { theme };
+  return { theme, themeId: selectedThemeId };
 };
 
 export const withFluentProvider = (StoryFn: StoryFunction<React.ReactElement>, context: FluentStoryContext) => {
-  const { theme } = getActiveFluentTheme(context.globals);
+  const { theme, themeId } = getActiveFluentTheme(context.globals);
 
   return (
-    <FluentProvider theme={theme}>
+    <FluentProvider noForcedColors={themeId === 'teams-high-contrast'} theme={theme}>
       <FluentExampleContainer theme={theme}>{StoryFn()}</FluentExampleContainer>
     </FluentProvider>
   );


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19725
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Implements RFC #20672

Adds the `noForcedColors` combined prop and context value for the
`FluentProvider`.

This PR enables users to bail out of forced colors mode by using:

```tsx
<FluentProvider noForcedColors theme={theme}>{children}</FluentProvider>
```

`FluentProvider` will apply `forced-color-adjust: none` to all of its
children **and the portals rendered under its React tree**.

In order to apply forced colors specific styles, we should only apply
them when `noForcedColors` is `false` so that it will not break manual
CSS high contrast themes used by products like Teams.

```ts
const { noForcedColors } = useFluent();

state.root.className = mergeClasses(
  styles.root, 
  !noForcedColors && styles.rootForcedColors,
);
```

The PR uses `MenuItem` as an example to apply forced colors styles

#### Focus areas to test

* Open demo v9 storybook
* Use `Menu` examples
* Turn on windows HC mode
* Use `teamsHighContrastTheme` to enable `noForcedColors` mode automatically
