### PR TITLE
Tailor behavior of "Select all" checkbox in single-select mode

### DIFF
--- a/change/@fluentui-react-67073079-ff39-4631-8371-7ac2f94241e7.json
+++ b/change/@fluentui-react-67073079-ff39-4631-8371-7ac2f94241e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ensure \"Select all\" checkbox only applies in multi-select mode",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -203,6 +203,11 @@ export class DetailsHeaderBase
     const classNames = this._classNames;
     const IconComponent = useFastIcons ? FontIcon : Icon;
 
+    const checkboxLabel =
+      selectionMode === SelectionMode.multiple || isAllSelected
+        ? ariaLabelForSelectAllCheckbox
+        : ariaLabelForSelectionColumn;
+
     const isRTL = getRTL(theme);
     return (
       <FocusZone
@@ -230,20 +235,16 @@ export class DetailsHeaderBase
                     hostClassName: classNames.checkTooltip,
                     id: `${this._id}-checkTooltip`,
                     setAriaDescribedBy: false,
-                    content: ariaLabelForSelectAllCheckbox,
+                    content: checkboxLabel,
                     children: (
                       <DetailsRowCheck
                         id={`${this._id}-check`}
-                        aria-label={
-                          selectionMode === SelectionMode.multiple
-                            ? ariaLabelForSelectAllCheckbox
-                            : ariaLabelForSelectionColumn
-                        }
+                        aria-label={checkboxLabel}
                         data-is-focusable={!isCheckboxHidden || undefined}
                         isHeader={true}
                         selected={isAllSelected}
                         anySelected={false}
-                        canSelect={!isCheckboxHidden}
+                        canSelect={selectionMode === SelectionMode.multiple ? !isCheckboxHidden : !!isAllSelected}
                         className={classNames.check}
                         onRenderDetailsCheckbox={onRenderDetailsCheckbox}
                         useFastIcons={useFastIcons}


### PR DESCRIPTION
#### Description of changes

Fixed an accessibility issue/source of confusion around the "Select all" checkbox in DetailsList when in single-select mode.
The purpose of the checkbox being present is to allow a user to force-deselect whatever single item is selected. However, since it appears to confuse users when it is *not* selected, this change removes the checkbox when there are no items currently selected.

#### Focus areas to test

The `DetailsList` in single and multi-select modes.