### PR TITLE
Positioning: Allow swapping anchor edge when on boundary and won't cause visual differences

### DIFF
--- a/change/@fluentui-react-94e9e9c3-4144-45ac-85d9-242011b8a27e.json
+++ b/change/@fluentui-react-94e9e9c3-4144-45ac-85d9-242011b8a27e.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "patch",
   "comment": "Swap edge if on boundary",
   "packageName": "@fluentui/react",
   "email": "owcampbe@microsoft.com",

--- a/change/@fluentui-react-94e9e9c3-4144-45ac-85d9-242011b8a27e.json
+++ b/change/@fluentui-react-94e9e9c3-4144-45ac-85d9-242011b8a27e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Swap edge if on boundary",
+  "packageName": "@fluentui/react",
+  "email": "owcampbe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/utilities/positioning/positioning.test.ts
+++ b/packages/react/src/utilities/positioning/positioning.test.ts
@@ -308,6 +308,45 @@ describe('Callout Positioning', () => {
     expect(finalizedBeakPosition.elementPosition.bottom).toBeDefined();
     expect(finalizedBeakPosition.elementPosition.left).toBeUndefined();
   });
+
+  it('Correctly determines the correct edges to return when against bounds', () => {
+    // Create a dummy host, this isn't the part that we care about for this test
+    const host = {
+      getBoundingClientRect: () => {
+        return {
+          bottom: 0,
+          top: 0,
+          left: 0,
+          right: 0,
+          width: 0,
+          height: 0,
+        };
+      },
+    };
+    // create a dummy beak
+    const pos: IElementPosition = {
+      elementRectangle: new Rectangle(400, 500, 400, 500),
+      targetEdge: RectangleEdge.top,
+      alignmentEdge: RectangleEdge.left,
+    };
+    const bounds = new Rectangle(0, 500, 0, 500);
+
+    // When we allow finalizing the return edge, we should specify the bottom such that the host grows away from
+    // the edge of the bounds
+    // In this case, that's the bottom (opposite of target) and right (closer to edge of bounds)
+    let finalizedPosition = __positioningTestPackage._finalizePositionData(pos, host as any, bounds, false, false);
+    expect(finalizedPosition.elementPosition.right).toBeDefined();
+    expect(finalizedPosition.elementPosition.bottom).toBeDefined();
+    expect(finalizedPosition.elementPosition.top).toBeUndefined();
+
+    // When we don't allow finalizing the return edge, but the host is flush against the edge of the bounds,
+    // we should have the same result as before
+    // In this case, that's the bottom (opposite of target) and right (closer to edge of bounds)
+    finalizedPosition = __positioningTestPackage._finalizePositionData(pos, host as any, bounds, false, true);
+    expect(finalizedPosition.elementPosition.right).toBeDefined();
+    expect(finalizedPosition.elementPosition.bottom).toBeDefined();
+    expect(finalizedPosition.elementPosition.top).toBeUndefined();
+  });
 });
 
 describe('getBoundingRectangle', () => {

--- a/packages/react/src/utilities/positioning/positioning.test.ts
+++ b/packages/react/src/utilities/positioning/positioning.test.ts
@@ -254,7 +254,8 @@ describe('Callout Positioning', () => {
       targetEdge: RectangleEdge.top,
       alignmentEdge: RectangleEdge.left,
     };
-    const bounds = new Rectangle(0, 500, 0, 500);
+    const bounds = new Rectangle(0, 501, 0, 501);
+    const flushBounds = new Rectangle(0, 500, 0, 500);
     const target = new Rectangle(0, 100, 0, 100);
 
     // Normal positioning should target the alignment edge and the opposite of the target edge.
@@ -286,6 +287,14 @@ describe('Callout Positioning', () => {
     expect(finalizedPosition.elementPosition.left).toBeDefined();
     expect(finalizedPosition.elementPosition.bottom).toBeDefined();
     expect(finalizedPosition.elementPosition.right).toBeUndefined();
+
+    // With bounds flush against the edge of the elementRectangle, change the edge such that the elementRectangle
+    // will grow correctly but will not visually change
+    // In this case, that's bottom (opposite of target) and right (flush against the bounds)
+    finalizedPosition = __positioningTestPackage._finalizePositionData(pos, host as any, flushBounds, false, true);
+    expect(finalizedPosition.elementPosition.left).toBeUndefined();
+    expect(finalizedPosition.elementPosition.bottom).toBeDefined();
+    expect(finalizedPosition.elementPosition.right).toBeDefined();
 
     // With bounds introduced, the alignment should apply to the beak as well, aligning it to
     // the edge closest to bounds

--- a/packages/react/src/utilities/positioning/positioning.ts
+++ b/packages/react/src/utilities/positioning/positioning.ts
@@ -513,7 +513,14 @@ function _finalizeElementPosition(
   const hostRect: Rectangle = _getRectangleFromElement(hostElement);
   const elementEdge = coverTarget ? targetEdge : targetEdge * -1;
   let returnEdge = alignmentEdge ? alignmentEdge : _getFlankingEdges(targetEdge).positiveEdge;
-  if (!doNotFinalizeReturnEdge) {
+
+  // If the opposite edge is flush against the bounds,
+  // choose that as the anchor edge so the element rect can grow away from the bounds' edge
+  const oppositeReturnEdge = getOppositeEdge(returnEdge);
+  const oppositeEdgeOnBounds =
+    bounds && _getEdgeValue(elementRectangle, oppositeReturnEdge) === _getEdgeValue(bounds, oppositeReturnEdge);
+
+  if (!doNotFinalizeReturnEdge || oppositeEdgeOnBounds) {
     returnEdge = _finalizeReturnEdge(elementRectangle, returnEdge, bounds);
   }
 

--- a/packages/react/src/utilities/positioning/positioning.ts
+++ b/packages/react/src/utilities/positioning/positioning.ts
@@ -492,6 +492,17 @@ function _finalizeReturnEdge(
 }
 
 /**
+ * Whether or not the considered edge of the elementRectangle is lying on the edge of the bounds
+ * @param elementRectangle The rectangle whose edge we are considering
+ * @param bounds The rectangle marking the bounds
+ * @param edge The target edge we're considering
+ * @returns If the target edge of the elementRectangle is in the same location as that edge of the bounds
+ */
+function _isEdgeOnBounds(elementRectangle: Rectangle, edge: RectangleEdge, bounds?: Rectangle): boolean {
+  return bounds !== undefined && _getEdgeValue(elementRectangle, edge) === _getEdgeValue(bounds, edge);
+}
+
+/**
  * Finalizes the element position based on the hostElement. Only returns the
  * rectangle values to position such that they are anchored to the target.
  * This helps prevent resizing from looking very strange.
@@ -514,13 +525,12 @@ function _finalizeElementPosition(
   const elementEdge = coverTarget ? targetEdge : targetEdge * -1;
   let returnEdge = alignmentEdge ? alignmentEdge : _getFlankingEdges(targetEdge).positiveEdge;
 
-  // If the opposite edge is flush against the bounds,
+  // If we are finalizing the return edge, choose the edge such that we grow away from the bounds
+  // If we are not finalizing the return edge but the opposite edge is flush against the bounds,
   // choose that as the anchor edge so the element rect can grow away from the bounds' edge
-  const oppositeReturnEdge = getOppositeEdge(returnEdge);
-  const oppositeEdgeOnBounds =
-    bounds && _getEdgeValue(elementRectangle, oppositeReturnEdge) === _getEdgeValue(bounds, oppositeReturnEdge);
-
-  if (!doNotFinalizeReturnEdge || oppositeEdgeOnBounds) {
+  // In this case there will not be a visual difference because there is no more room for the elementRectangle to grow
+  // in the usual direction
+  if (!doNotFinalizeReturnEdge || _isEdgeOnBounds(elementRectangle, getOppositeEdge(returnEdge), bounds)) {
     returnEdge = _finalizeReturnEdge(elementRectangle, returnEdge, bounds);
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20768 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When the element is flush against the bounds on the opposite side of its anchor edge, allow finalizing the return edge. Changing the edge in this scenario doesn't change the positioning or visuals of the element but does allow the element to grow away from the bounds if necessary.

#### Focus areas to test
Any other use cases of `finalHeight` which is how we get in the scenario of not finalizing the return edge usually.
