### PR TITLE
fix(Accordion): Use divs instead of dd/dt to comply with axe rules [BREAKING]

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,6 +18,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- fix(Accordion) Render divs instead of dd and dt elements for Accordion and AccordionTitle @jurokapsiar ([#20773](https://github.com/microsoft/fluentui/pull/20773))
+
 ### Fixes
 - Fix aria-labelledby passed to `DropdownSearchInput` @chpalac ([#20312](https://github.com/microsoft/fluentui/pull/20312))
 - Fix `preventFocusRestoration` in `FocusZone` @chpalac ([#20328](https://github.com/microsoft/fluentui/pull/20328))

--- a/packages/fluentui/react-northstar/src/components/Accordion/AccordionContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/AccordionContent.tsx
@@ -103,7 +103,7 @@ export const AccordionContent = (React.forwardRef<HTMLDListElement, AccordionCon
   setEnd();
 
   return element;
-}) as unknown) as ForwardRefWithAs<'dd', HTMLDListElement, AccordionContentProps> &
+}) as unknown) as ForwardRefWithAs<'div', HTMLDListElement, AccordionContentProps> &
   FluentComponentStaticProps<AccordionContentProps>;
 
 AccordionContent.displayName = 'AccordionContent';
@@ -121,7 +121,7 @@ AccordionContent.propTypes = {
 
 AccordionContent.defaultProps = {
   accessibility: accordionContentBehavior,
-  as: 'dd',
+  as: 'div',
 };
 
 AccordionContent.handledProps = Object.keys(AccordionContent.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
@@ -219,7 +219,7 @@ export const AccordionTitle = (React.forwardRef<HTMLDListElement, AccordionTitle
     setEnd();
     return element;
   },
-) as unknown) as ForwardRefWithAs<'dt', HTMLDListElement, AccordionTitleProps> &
+) as unknown) as ForwardRefWithAs<'div', HTMLDListElement, AccordionTitleProps> &
   FluentComponentStaticProps<AccordionTitleProps>;
 
 AccordionTitle.displayName = 'AccordionTitle';
@@ -245,7 +245,7 @@ AccordionTitle.handledProps = Object.keys(AccordionTitle.propTypes) as any;
 
 AccordionTitle.defaultProps = {
   accessibility: accordionTitleBehavior,
-  as: 'dt',
+  as: 'div',
   contentRef: _.noop,
   indicator: {},
   contentWrapper: {},

--- a/packages/fluentui/react-northstar/test/specs/components/Accordion/Accordion-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Accordion/Accordion-test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { keyboardKey } from '@fluentui/accessibility';
 
 import { Accordion } from 'src/components/Accordion/Accordion';
-import { handlesAccessibility, isConformant } from 'test/specs/commonTests';
+import { handlesAccessibility, htmlIsAccessibilityCompliant, isConformant } from 'test/specs/commonTests';
 import { mountWithProvider, mountWithProviderAndGetComponent, findIntrinsicElement } from 'test/utils';
 import { accordionTitleSlotClassNames } from 'src/components/Accordion/AccordionTitle';
 import { ReactWrapper, CommonWrapper } from 'enzyme';
@@ -221,5 +221,9 @@ describe('Accordion', () => {
 
   describe('accessibility', () => {
     handlesAccessibility(Accordion, { defaultRootRole: 'presentation' });
+  });
+
+  describe('HTML accessibility rules validation', () => {
+    test('default Accordion', async () => await htmlIsAccessibilityCompliant(<Accordion panels={panels} />));
   });
 });


### PR DESCRIPTION
#### Description of changes

According to axe-core rules, dd/dt cannot have role `heading` assigned.
As dd/dt do not add any functionality, it should be ok to replace them with div.

#### Focus areas to test

screenshot tests