### PR TITLE
fix: Revert to node 12

### DIFF
--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -2,7 +2,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '14.x'
+      versionSpec: '12.x'
       checkLatest: true
     displayName: 'Install Node.js'
 

--- a/change/@fluentui-eslint-plugin-bdc15f5d-ef63-4e26-89c5-6983d11bfd6a.json
+++ b/change/@fluentui-eslint-plugin-bdc15f5d-ef63-4e26-89c5-6983d11bfd6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert usage of @rnx-kit/eslint-plugin",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "andredias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -294,7 +294,6 @@
         "dependencies": [
           "@babel/core",
           "@babel/preset-typescript",
-          "@rnx-kit/eslint-plugin",
           "@types/react-test-renderer",
           "@typescript-eslint/eslint-plugin",
           "@typescript-eslint/experimental-utils",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -12,7 +12,6 @@
     "lint": "tsc --noEmit && eslint --ext .js --cache ."
   },
   "dependencies": {
-    "@rnx-kit/eslint-plugin": "^0.2.5",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/experimental-utils": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -15,7 +15,6 @@ const config = {
   parser: '@typescript-eslint/parser',
   plugins: [
     '@fluentui',
-    '@rnx-kit',
     '@typescript-eslint',
     'deprecation',
     'import',
@@ -73,7 +72,6 @@ const config = {
     '**/*.scss.ts',
   ],
   rules: {
-    '@rnx-kit/no-export-all': ['error', { expand: 'external-only' }],
     '@fluentui/no-global-react': 'error',
     '@fluentui/max-len': [
       'error',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,23 +1607,6 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@fluentui/babel-make-styles@9.0.0-beta.3":
-  version "9.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@fluentui/babel-make-styles/-/babel-make-styles-9.0.0-beta.3.tgz#0ad8263eef5dd47995ff6008be2c2b5c77c8fa6a"
-  integrity sha512-Q4UZ5PirLM/Enc+Tbzi3plDjxy5tQs2vH51bVEBlWbssW35PyWHzFdIRd9qPlti1kir2xz3vUUb72NUNmhliOg==
-  dependencies:
-    "@babel/core" "^7.10.4"
-    "@babel/generator" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/preset-typescript" "^7.10.4"
-    "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.12.13"
-    "@fluentui/make-styles" "9.0.0-beta.2"
-    "@linaria/babel-preset" "^3.0.0-beta.14"
-    "@linaria/shaker" "^3.0.0-beta.14"
-    ajv "^8.4.0"
-    tslib "^2.1.0"
-
 "@fluentui/dom-utilities@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@fluentui/dom-utilities/-/dom-utilities-1.1.1.tgz#b0bbab665fe726f245800bb9e7883b1ceb54248b"
@@ -1631,18 +1614,6 @@
   dependencies:
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
-
-"@fluentui/make-styles@9.0.0-beta.2":
-  version "9.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@fluentui/make-styles/-/make-styles-9.0.0-beta.2.tgz#95d39f8eda655ad87e7500aa3ee54166cfb5c733"
-  integrity sha512-ygAxSE3kiw1i7KTka/WrebT8wlKU/ph29/DibjwgVmWjy1fCx0sJGFo2ltvc4e0W9kerqc+WjTVoL6YPxk0HSw==
-  dependencies:
-    "@emotion/hash" "^0.8.0"
-    csstype "^2.6.7"
-    inline-style-expand-shorthand "^1.2.0"
-    rtl-css-js "^1.14.1"
-    stylis "^4.0.6"
-    tslib "^2.1.0"
 
 "@fluentui/react-icons@^2.0.152-beta.3":
   version "2.0.152-beta.3"
@@ -22229,7 +22200,7 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-rtl-css-js@^1.1.3, rtl-css-js@^1.14.1, rtl-css-js@^1.14.5:
+rtl-css-js@^1.1.3, rtl-css-js@^1.14.5:
   version "1.14.5"
   resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.14.5.tgz#fd92685acd024e688dda899a28c5fb9270b79974"
   integrity sha512-+ng7LWVvPjQUdgDVviR6vKi2X4JiBtlw5rdY0UM5/Cj39c2/KDUsY/VxEzGE25m4KR5g0dvuKfrDq7DaoDooIA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,6 +1607,23 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@fluentui/babel-make-styles@9.0.0-beta.3":
+  version "9.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@fluentui/babel-make-styles/-/babel-make-styles-9.0.0-beta.3.tgz#0ad8263eef5dd47995ff6008be2c2b5c77c8fa6a"
+  integrity sha512-Q4UZ5PirLM/Enc+Tbzi3plDjxy5tQs2vH51bVEBlWbssW35PyWHzFdIRd9qPlti1kir2xz3vUUb72NUNmhliOg==
+  dependencies:
+    "@babel/core" "^7.10.4"
+    "@babel/generator" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/preset-typescript" "^7.10.4"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.12.13"
+    "@fluentui/make-styles" "9.0.0-beta.2"
+    "@linaria/babel-preset" "^3.0.0-beta.14"
+    "@linaria/shaker" "^3.0.0-beta.14"
+    ajv "^8.4.0"
+    tslib "^2.1.0"
+
 "@fluentui/dom-utilities@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@fluentui/dom-utilities/-/dom-utilities-1.1.1.tgz#b0bbab665fe726f245800bb9e7883b1ceb54248b"
@@ -1614,6 +1631,18 @@
   dependencies:
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
+
+"@fluentui/make-styles@9.0.0-beta.2":
+  version "9.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@fluentui/make-styles/-/make-styles-9.0.0-beta.2.tgz#95d39f8eda655ad87e7500aa3ee54166cfb5c733"
+  integrity sha512-ygAxSE3kiw1i7KTka/WrebT8wlKU/ph29/DibjwgVmWjy1fCx0sJGFo2ltvc4e0W9kerqc+WjTVoL6YPxk0HSw==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    csstype "^2.6.7"
+    inline-style-expand-shorthand "^1.2.0"
+    rtl-css-js "^1.14.1"
+    stylis "^4.0.6"
+    tslib "^2.1.0"
 
 "@fluentui/react-icons@^2.0.152-beta.3":
   version "2.0.152-beta.3"
@@ -3136,17 +3165,6 @@
     invariant "^2.2.3"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
-
-"@rnx-kit/eslint-plugin@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/eslint-plugin/-/eslint-plugin-0.2.5.tgz#30b4398e6db4f7a81b301c5e825341c4386f6821"
-  integrity sha512-69Xlsz7fMMAQqLJ9ghglH5fXvU5xXZR09gCkjoK4gephhnQR/i+QDyt0wlqKt2HBo0RUGFbO+EA8aNPcOrJDJg==
-  dependencies:
-    "@typescript-eslint/eslint-plugin" "^5.0.0"
-    "@typescript-eslint/parser" "^5.0.0"
-    enhanced-resolve "^5.8.3"
-    eslint-plugin-jest "^25.0.0"
-    eslint-plugin-react "^7.26.0"
 
 "@rollup/pluginutils@^3.0.8":
   version "3.1.0"
@@ -5257,7 +5275,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@4.22.0", "@typescript-eslint/eslint-plugin@^4.22.0", "@typescript-eslint/eslint-plugin@^5.0.0":
+"@typescript-eslint/eslint-plugin@4.22.0", "@typescript-eslint/eslint-plugin@^4.22.0":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz#3d5f29bb59e61a9dba1513d491b059e536e16dbc"
   integrity sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==
@@ -5271,7 +5289,7 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.22.0", "@typescript-eslint/experimental-utils@^2.19.2 || ^3.0.0", "@typescript-eslint/experimental-utils@^2.5.0", "@typescript-eslint/experimental-utils@^4.22.0", "@typescript-eslint/experimental-utils@^5.0.0":
+"@typescript-eslint/experimental-utils@4.22.0", "@typescript-eslint/experimental-utils@^2.19.2 || ^3.0.0", "@typescript-eslint/experimental-utils@^2.5.0", "@typescript-eslint/experimental-utils@^4.22.0":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz#68765167cca531178e7b650a53456e6e0bef3b1f"
   integrity sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==
@@ -5283,7 +5301,7 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@4.22.0", "@typescript-eslint/parser@^4.22.0", "@typescript-eslint/parser@^5.0.0":
+"@typescript-eslint/parser@4.22.0", "@typescript-eslint/parser@^4.22.0":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.22.0.tgz#e1637327fcf796c641fe55f73530e90b16ac8fe8"
   integrity sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==
@@ -10848,7 +10866,7 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0, enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.7.0, enhanced-resolve@^5.8.0, enhanced-resolve@^5.8.2, enhanced-resolve@^5.8.3:
+enhanced-resolve@^5.7.0, enhanced-resolve@^5.8.0, enhanced-resolve@^5.8.2:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
   integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
@@ -11241,13 +11259,6 @@ eslint-plugin-jest@23.13.2, eslint-plugin-jest@^23.13.2:
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 
-eslint-plugin-jest@^25.0.0:
-  version "25.2.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-25.2.4.tgz#bb9f6a0bd1fd524ffb0b8b7a159cd70a58a1a793"
-  integrity sha512-HRyinpgmEdkVr7pNPaYPHCoGqEzpgk79X8pg/xCeoAdurbyQjntJQ4pTzHl7BiVEBlam/F1Qsn+Dk0HtJO7Aaw==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "^5.0.0"
-
 eslint-plugin-jsdoc@^36.0.7:
   version "36.0.7"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.0.7.tgz#6e6f9897fc2ff3b3934b09c2748b998bc03d2bf6"
@@ -11305,7 +11316,7 @@ eslint-plugin-react@7.26.0:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.5"
 
-eslint-plugin-react@^7.24.0, eslint-plugin-react@^7.26.0:
+eslint-plugin-react@^7.24.0:
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz#f952c76517a3915b81c7788b220b2b4c96703124"
   integrity sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==
@@ -22218,7 +22229,7 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-rtl-css-js@^1.1.3, rtl-css-js@^1.14.5:
+rtl-css-js@^1.1.3, rtl-css-js@^1.14.1, rtl-css-js@^1.14.5:
   version "1.14.5"
   resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.14.5.tgz#fd92685acd024e688dda899a28c5fb9270b79974"
   integrity sha512-+ng7LWVvPjQUdgDVviR6vKi2X4JiBtlw5rdY0UM5/Cj39c2/KDUsY/VxEzGE25m4KR5g0dvuKfrDq7DaoDooIA==


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20774
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Reverted CI node version back to 12. Version 14 errors when building `@fluentui/react-icons-mdl2`.
Removed usage of the plugin @rnx-kit/eslint-plugin as it requires node v14.