### PR TITLE
fix(react-card): update styles to not use CSS shorthands

### DIFF
--- a/change/@fluentui-react-card-9c7aabc3-29bc-4b08-b8de-3987c7d51d7f.json
+++ b/change/@fluentui-react-card-9c7aabc3-29bc-4b08-b8de-3987c7d51d7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update styles no not use CSS shorthands",
+  "packageName": "@fluentui/react-card",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-card/src/components/Card/useCardStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import { cardPreviewClassName } from '../CardPreview/index';
 import type { CardState } from './Card.types';
 
@@ -11,7 +11,7 @@ const useStyles = makeStyles({
   root: theme => ({
     display: 'flex',
     flexDirection: 'column',
-    overflow: 'hidden',
+    ...shorthands.overflow('hidden'),
 
     boxShadow: theme.shadow4,
     color: theme.colorNeutralForeground1,
@@ -20,9 +20,9 @@ const useStyles = makeStyles({
     // Size: medium
     // TODO: Validate if we should use a token instead + the unit of said token
     // TODO: Explore alternate way of applying padding
-    padding: '12px',
-    gap: '12px',
-    borderRadius: theme.borderRadiusMedium,
+    ...shorthands.padding('12px'),
+    ...shorthands.gap('12px'),
+    ...shorthands.borderRadius(theme.borderRadiusMedium),
 
     [`> .${cardPreviewClassName}`]: {
       marginLeft: '-12px',

--- a/packages/react-card/src/components/CardFooter/useCardFooterStyles.ts
+++ b/packages/react-card/src/components/CardFooter/useCardFooterStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-make-styles';
 import type { CardFooterState } from './CardFooter.types';
 
 export const cardFooterClassName = 'fui-CardFooter';
@@ -10,7 +10,7 @@ const useStyles = makeStyles({
   root: {
     display: 'flex',
     flexDirection: 'row',
-    gap: '12px',
+    ...shorthands.gap('12px'),
   },
   action: {
     marginLeft: 'auto',

--- a/packages/react-card/src/components/CardHeader/useCardHeaderStyles.ts
+++ b/packages/react-card/src/components/CardHeader/useCardHeaderStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-make-styles';
 import type { CardHeaderState } from './CardHeader.types';
 
 export const cardHeaderClassName = 'fui-CardHeader';
@@ -11,7 +11,7 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
-    gap: '12px',
+    ...shorthands.gap('12px'),
     height: '32px',
   },
   image: {

--- a/packages/react-card/src/components/CardPreview/useCardPreviewStyles.ts
+++ b/packages/react-card/src/components/CardPreview/useCardPreviewStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import type { CardPreviewState } from './CardPreview.types';
 
 export const cardPreviewClassName = 'fui-CardPreview';
@@ -10,7 +10,7 @@ const useStyles = makeStyles({
   root: theme => ({
     position: 'relative',
     // TODO: Explore alternate way of applying padding on parent Card
-    margin: '0 -12px',
+    ...shorthands.margin('0', '-12px'),
 
     '> *': {
       display: 'block',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: extracted from #20539, related to #20573
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR updates styles to not use CSS shorthands.
