### PR TITLE
fix(react-popover): update styles to not use CSS shorthands

### DIFF
--- a/change/@fluentui-react-popover-acc8b8e5-c330-42f1-bed9-ddeca5f7ef3c.json
+++ b/change/@fluentui-react-popover-acc8b8e5-c330-42f1-bed9-ddeca5f7ef3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update styles to not use CSS shorthands",
+  "packageName": "@fluentui/react-popover",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
+++ b/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import { createArrowStyles } from '@fluentui/react-positioning';
 import type { PopoverSize } from '../Popover/Popover.types';
 import type { PopoverSurfaceState } from './PopoverSurface.types';
@@ -18,8 +18,8 @@ const useStyles = makeStyles({
   root: theme => ({
     backgroundColor: theme.colorNeutralBackground1,
     boxShadow: theme.shadow16,
-    borderRadius: '4px',
-    border: `1px solid ${theme.colorTransparentStroke}`,
+    ...shorthands.borderRadius('4px'),
+    ...shorthands.border('1px', 'solid', theme.colorTransparentStroke),
   }),
 
   inverted: theme => ({
@@ -35,15 +35,15 @@ const useStyles = makeStyles({
   }),
 
   smallPadding: () => ({
-    padding: '12px',
+    ...shorthands.padding('12px'),
   }),
 
   mediumPadding: () => ({
-    padding: '16px',
+    ...shorthands.padding('16px'),
   }),
 
   largePadding: () => ({
-    padding: '20px',
+    ...shorthands.padding('20px'),
   }),
 
   smallArrow: () => ({

--- a/packages/react-popover/src/stories/PopoverAnchorToCustomTarget.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverAnchorToCustomTarget.stories.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
-
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
-
 import { Button } from '@fluentui/react-button';
+import { makeStyles, shorthands } from '@fluentui/react-make-styles';
 
-import { makeStyles } from '@fluentui/react-make-styles';
+import { Popover, PopoverTrigger, PopoverSurface } from '../index';
 
 const useStyles = makeStyles({
   container: {
     display: 'flex',
-    gap: '10px',
+    ...shorthands.gap('10px'),
   },
 
   contentHeader: {

--- a/packages/react-popover/src/stories/PopoverControllingOpenAndClose.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverControllingOpenAndClose.stories.tsx
@@ -1,18 +1,8 @@
 import * as React from 'react';
-
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
-
 import { Button } from '@fluentui/react-button';
-
 import { makeStyles } from '@fluentui/react-make-styles';
 
-// FIXME need to redeclare types because type imports are under @ts-ignore
-export type OpenPopoverEvents =
-  | MouseEvent
-  | TouchEvent
-  | React.MouseEvent<HTMLElement>
-  | React.KeyboardEvent<HTMLElement>
-  | React.FocusEvent<HTMLElement>;
+import { PopoverProps, Popover, PopoverTrigger, PopoverSurface } from '../index';
 
 const useStyles = makeStyles({
   contentHeader: {
@@ -33,7 +23,7 @@ const ExampleContent = () => {
 
 export const ControllingOpenAndClose = () => {
   const [open, setOpen] = React.useState(false);
-  const handleOpenChange = (e: OpenPopoverEvents, data: { open: boolean }) => setOpen(data.open || false);
+  const handleOpenChange: PopoverProps['onOpenChange'] = (e, data) => setOpen(data.open || false);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setOpen(e.target.checked);

--- a/packages/react-popover/src/stories/PopoverCustomTrigger.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverCustomTrigger.stories.tsx
@@ -1,18 +1,8 @@
 import * as React from 'react';
-
-import { Popover, PopoverSurface } from '@fluentui/react-popover';
-
 import { Button } from '@fluentui/react-button';
-
 import { makeStyles } from '@fluentui/react-make-styles';
 
-// FIXME need to redeclare types because type imports are under @ts-ignore
-export type OpenPopoverEvents =
-  | MouseEvent
-  | TouchEvent
-  | React.MouseEvent<HTMLElement>
-  | React.KeyboardEvent<HTMLElement>
-  | React.FocusEvent<HTMLElement>;
+import { Popover, PopoverProps, PopoverSurface } from '../index';
 
 const useStyles = makeStyles({
   contentHeader: {
@@ -36,7 +26,7 @@ export const CustomTrigger = () => {
   const [target, setTarget] = React.useState<HTMLElement | null>(null);
 
   const onClick = () => setOpen(s => !s);
-  const onOpenChange = (e: OpenPopoverEvents, data: { open: boolean }) => {
+  const onOpenChange: PopoverProps['onOpenChange'] = (e, data) => {
     // handle custom trigger interactions separately
     if (e.target !== target) {
       setOpen(data.open);

--- a/packages/react-popover/src/stories/PopoverDefault.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverDefault.stories.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-
-import { Popover, PopoverTrigger, PopoverSurface, PopoverProps } from '@fluentui/react-popover';
-
 import { Button } from '@fluentui/react-button';
-
 import { makeStyles } from '@fluentui/react-make-styles';
+
+import { Popover, PopoverTrigger, PopoverSurface, PopoverProps } from '../index';
 
 const useStyles = makeStyles({
   contentHeader: {

--- a/packages/react-popover/src/stories/PopoverInternalUpdateContent.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverInternalUpdateContent.stories.tsx
@@ -1,18 +1,8 @@
 import * as React from 'react';
-
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
-
 import { Button } from '@fluentui/react-button';
-
 import { makeStyles } from '@fluentui/react-make-styles';
 
-// FIXME need to redeclare types because type imports are under @ts-ignore
-export type OpenPopoverEvents =
-  | MouseEvent
-  | TouchEvent
-  | React.MouseEvent<HTMLElement>
-  | React.KeyboardEvent<HTMLElement>
-  | React.FocusEvent<HTMLElement>;
+import { Popover, PopoverProps, PopoverTrigger, PopoverSurface } from '../index';
 
 const useStyles = makeStyles({
   contentHeader: {
@@ -35,7 +25,7 @@ export const InternalUpdateContent = () => {
   const [visible, setVisible] = React.useState(false);
 
   const changeContent = () => setVisible(true);
-  const onOpenChange = (e: OpenPopoverEvents, data: { open: boolean }) => {
+  const onOpenChange: PopoverProps['onOpenChange'] = (e, data) => {
     if (data.open === false) {
       setVisible(false);
     }

--- a/packages/react-popover/src/stories/PopoverNestedPopovers.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverNestedPopovers.stories.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
-
 import { Button } from '@fluentui/react-button';
-
 import { makeStyles } from '@fluentui/react-make-styles';
+
+import { Popover, PopoverTrigger, PopoverSurface } from '../index';
 
 const useStyles = makeStyles({
   contentHeader: {

--- a/packages/react-popover/src/stories/PopoverTrappingFocus.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverTrappingFocus.stories.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
-
 import { Button } from '@fluentui/react-button';
-
 import { makeStyles } from '@fluentui/react-make-styles';
+
+import { Popover, PopoverTrigger, PopoverSurface } from '../index';
 
 const useStyles = makeStyles({
   contentHeader: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: extracted from #20539, related to #20573
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR:
- updates styles to not use CSS shorthands
- updates stories to not use CSS shorthands
- cleanups types, removes `codesandbox-dependency` comments