### PR TITLE
TimePicker Default Value and Update onChange

### DIFF
--- a/change/@fluentui-date-time-utilities-f5190288-ce6e-4607-8bad-7f8cd56f08af.json
+++ b/change/@fluentui-date-time-utilities-f5190288-ce6e-4607-8bad-7f8cd56f08af.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Updated examples to use new props",
+  "comment": "Added getDateFromTimeSelection function, TimeConstant values OffsetTo24HourFormat and TimeFormatRegex",
   "packageName": "@fluentui/date-time-utilities",
   "email": "jamwu@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-date-time-utilities-f5190288-ce6e-4607-8bad-7f8cd56f08af.json
+++ b/change/@fluentui-date-time-utilities-f5190288-ce6e-4607-8bad-7f8cd56f08af.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated examples to use new props",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "jamwu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-b5938547-532d-41fa-b34e-d8d702171623.json
+++ b/change/@fluentui-react-b5938547-532d-41fa-b34e-d8d702171623.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Updated onChange prop, added initial date, use new getDateFromTimeSelection function",
+  "comment": "TimePicker: Updated onChange prop, added initial date, use new getDateFromTimeSelection function",
   "packageName": "@fluentui/react",
   "email": "jamwu@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-b5938547-532d-41fa-b34e-d8d702171623.json
+++ b/change/@fluentui-react-b5938547-532d-41fa-b34e-d8d702171623.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated examples to use new props",
+  "packageName": "@fluentui/react",
+  "email": "jamwu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-b5938547-532d-41fa-b34e-d8d702171623.json
+++ b/change/@fluentui-react-b5938547-532d-41fa-b34e-d8d702171623.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Updated examples to use new props",
+  "comment": "Updated onChange prop, added initial date, use new getDateFromTimeSelection function",
   "packageName": "@fluentui/react",
   "email": "jamwu@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/date-time-utilities/etc/date-time-utilities.api.md
+++ b/packages/date-time-utilities/etc/date-time-utilities.api.md
@@ -105,7 +105,7 @@ export const formatYear: (date: Date) => string;
 export const getBoundedDateRange: (dateRange: Date[], minDate?: Date | undefined, maxDate?: Date | undefined) => Date[];
 
 // @public
-export const getDateFromTimeSelection: (showSeconds: boolean, useHour12: boolean, baseDate: Date, selectedTime: string) => Date;
+export const getDateFromTimeSelection: (useHour12: boolean, baseDate: Date, selectedTime: string) => Date;
 
 // @public
 export function getDatePartHashValue(date: Date): number;

--- a/packages/date-time-utilities/etc/date-time-utilities.api.md
+++ b/packages/date-time-utilities/etc/date-time-utilities.api.md
@@ -279,6 +279,7 @@ export const TimeConstants: {
     HoursInOneDay: number;
     SecondsInOneMinute: number;
     OffsetTo24HourFormat: number;
+    TimeFormatRegex: RegExp;
 };
 
 // (No @packageDocumentation comment for this package)

--- a/packages/date-time-utilities/etc/date-time-utilities.api.md
+++ b/packages/date-time-utilities/etc/date-time-utilities.api.md
@@ -105,6 +105,9 @@ export const formatYear: (date: Date) => string;
 export const getBoundedDateRange: (dateRange: Date[], minDate?: Date | undefined, maxDate?: Date | undefined) => Date[];
 
 // @public
+export const getDateFromTimeSelection: (showSeconds: boolean, useHour12: boolean, baseDate: Date, selectedTime: string) => Date;
+
+// @public
 export function getDatePartHashValue(date: Date): number;
 
 // @public

--- a/packages/date-time-utilities/etc/date-time-utilities.api.md
+++ b/packages/date-time-utilities/etc/date-time-utilities.api.md
@@ -274,7 +274,7 @@ export const TimeConstants: {
     DaysInOneWeek: number;
     MonthInOneYear: number;
     HoursInOneDay: number;
-    SecondsInOneHour: number;
+    SecondsInOneMinute: number;
     OffsetTo24HourFormat: number;
 };
 

--- a/packages/date-time-utilities/etc/date-time-utilities.api.md
+++ b/packages/date-time-utilities/etc/date-time-utilities.api.md
@@ -274,8 +274,9 @@ export const TimeConstants: {
     DaysInOneWeek: number;
     MonthInOneYear: number;
     HoursInOneDay: number;
+    SecondsInOneHour: number;
+    OffsetTo24HourFormat: number;
 };
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/date-time-utilities/src/dateValues/timeConstants.ts
+++ b/packages/date-time-utilities/src/dateValues/timeConstants.ts
@@ -9,6 +9,6 @@ export const TimeConstants = {
   DaysInOneWeek: 7,
   MonthInOneYear: 12,
   HoursInOneDay: 24,
-  SecondsInOneHour: 60,
+  SecondsInOneMinute: 60,
   OffsetTo24HourFormat: 12,
 };

--- a/packages/date-time-utilities/src/dateValues/timeConstants.ts
+++ b/packages/date-time-utilities/src/dateValues/timeConstants.ts
@@ -11,5 +11,12 @@ export const TimeConstants = {
   HoursInOneDay: 24,
   SecondsInOneMinute: 60,
   OffsetTo24HourFormat: 12,
+  /**
+   * TimeFormatRegex groups
+   * Group 1: hours
+   * Group 2: minutes
+   * Group 3: seconds
+   * Group 4: meridiem (am/pm)
+   */
   TimeFormatRegex: /^(\d\d?):(\d\d):?(\d\d)? ?([ap]m)?/i,
 };

--- a/packages/date-time-utilities/src/dateValues/timeConstants.ts
+++ b/packages/date-time-utilities/src/dateValues/timeConstants.ts
@@ -12,11 +12,11 @@ export const TimeConstants = {
   SecondsInOneMinute: 60,
   OffsetTo24HourFormat: 12,
   /**
-   * TimeFormatRegex groups
-   * Group 1: hours
-   * Group 2: minutes
-   * Group 3: seconds
-   * Group 4: meridiem (am/pm)
+   * Matches a time string. Groups:
+   * 1. hours (with or without leading 0)
+   * 2. minutes
+   * 3. seconds (optional)
+   * 4. meridiem (am/pm, case-insensitive, optional)
    */
   TimeFormatRegex: /^(\d\d?):(\d\d):?(\d\d)? ?([ap]m)?/i,
 };

--- a/packages/date-time-utilities/src/dateValues/timeConstants.ts
+++ b/packages/date-time-utilities/src/dateValues/timeConstants.ts
@@ -11,4 +11,5 @@ export const TimeConstants = {
   HoursInOneDay: 24,
   SecondsInOneMinute: 60,
   OffsetTo24HourFormat: 12,
+  TimeFormatRegex: /^(\d\d?):(\d\d):?(\d\d)? ?([ap]m)?/i,
 };

--- a/packages/date-time-utilities/src/dateValues/timeConstants.ts
+++ b/packages/date-time-utilities/src/dateValues/timeConstants.ts
@@ -9,4 +9,6 @@ export const TimeConstants = {
   DaysInOneWeek: 7,
   MonthInOneYear: 12,
   HoursInOneDay: 24,
+  SecondsInOneHour: 60,
+  OffsetTo24HourFormat: 12,
 };

--- a/packages/date-time-utilities/src/timeMath/timeMath.test.ts
+++ b/packages/date-time-utilities/src/timeMath/timeMath.test.ts
@@ -69,4 +69,74 @@ describe('timeMath', () => {
     result = TimeMath.ceilMinuteToIncrement(date, 60);
     expect(result.getMinutes()).toBe(0);
   });
+
+  it('can get date from time selection', () => {
+    const baseDate = new Date('November 25, 2021 09:15:00');
+
+    let result: Date;
+    result = TimeMath.getDateFromTimeSelection(false, baseDate, '11:30');
+    expect(result.getMonth()).toBe(10);
+    expect(result.getDate()).toBe(25);
+    expect(result.getHours()).toBe(11);
+    expect(result.getMinutes()).toBe(30);
+
+    result = TimeMath.getDateFromTimeSelection(true, baseDate, '12:00 am');
+    expect(result.getMonth()).toBe(10);
+    expect(result.getDate()).toBe(26);
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+
+    result = TimeMath.getDateFromTimeSelection(false, baseDate, '7:00:00');
+    expect(result.getMonth()).toBe(10);
+    expect(result.getDate()).toBe(26);
+    expect(result.getHours()).toBe(7);
+    expect(result.getMinutes()).toBe(0);
+
+    result = TimeMath.getDateFromTimeSelection(true, baseDate, '4:20 PM');
+    expect(result.getMonth()).toBe(10);
+    expect(result.getDate()).toBe(25);
+    expect(result.getHours()).toBe(16);
+    expect(result.getMinutes()).toBe(20);
+
+    result = TimeMath.getDateFromTimeSelection(false, baseDate, '9:15');
+    expect(result.getMonth()).toBe(10);
+    expect(result.getDate()).toBe(25);
+    expect(result.getHours()).toBe(9);
+    expect(result.getMinutes()).toBe(15);
+
+    result = TimeMath.getDateFromTimeSelection(true, baseDate, '9:00 am');
+    expect(result.getMonth()).toBe(10);
+    expect(result.getDate()).toBe(26);
+    expect(result.getHours()).toBe(9);
+    expect(result.getMinutes()).toBe(0);
+  });
+
+  it('can get date from time selection over New Years', () => {
+    const baseDate = new Date('December 31, 2021 08:00:00');
+
+    let result: Date;
+    result = TimeMath.getDateFromTimeSelection(false, baseDate, '00:00');
+    expect(result.getMonth()).toBe(0);
+    expect(result.getDate()).toBe(1);
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+
+    result = TimeMath.getDateFromTimeSelection(true, baseDate, '11:59 pm');
+    expect(result.getMonth()).toBe(11);
+    expect(result.getDate()).toBe(31);
+    expect(result.getHours()).toBe(23);
+    expect(result.getMinutes()).toBe(59);
+
+    result = TimeMath.getDateFromTimeSelection(false, baseDate, '07:59');
+    expect(result.getMonth()).toBe(0);
+    expect(result.getDate()).toBe(1);
+    expect(result.getHours()).toBe(7);
+    expect(result.getMinutes()).toBe(59);
+
+    result = TimeMath.getDateFromTimeSelection(true, baseDate, '1:30 pm');
+    expect(result.getMonth()).toBe(11);
+    expect(result.getDate()).toBe(31);
+    expect(result.getHours()).toBe(13);
+    expect(result.getMinutes()).toBe(30);
+  });
 });

--- a/packages/date-time-utilities/src/timeMath/timeMath.ts
+++ b/packages/date-time-utilities/src/timeMath/timeMath.ts
@@ -36,3 +36,64 @@ export const ceilMinuteToIncrement = (date: Date, increments: number) => {
   }
   return result;
 };
+
+/**
+ * Returns a date object from the selected time.
+ * @param showSeconds - If the time picker showed seconds
+ * @param useHour12 - If the time picker uses 12 or 24 hour formatting
+ * @param baseDate - The baseline date to calculate the offset of the selected time
+ * @param selectedTime - A string representing the user selected time
+ * @returns A new date object offset from the baseDate using the selected time.
+ */
+export const getDateFromTimeSelection = (
+  showSeconds: boolean,
+  useHour12: boolean,
+  baseDate: Date,
+  selectedTime: string,
+): Date => {
+  const splitValue = selectedTime.split(':');
+  let hours = +splitValue[0];
+  let minutes;
+  let seconds = baseDate.getSeconds();
+  let ap;
+  if (showSeconds) {
+    minutes = +splitValue[1];
+    seconds = +splitValue[2].split(' ')[0];
+    if (useHour12) {
+      ap = splitValue[2].split(' ')[1];
+    }
+  } else {
+    minutes = +splitValue[1].split(' ')[0];
+    if (useHour12) {
+      ap = splitValue[1].split(' ')[1];
+    }
+  }
+
+  if (useHour12 && ap) {
+    if (ap.toLowerCase() === 'pm' && hours !== 12) {
+      hours += TimeConstants.OffsetTo24HourFormat;
+    } else if (ap.toLowerCase() === 'am' && hours === 12) {
+      hours -= TimeConstants.OffsetTo24HourFormat;
+    }
+  }
+
+  let hoursOffset;
+  if (
+    useHour12 &&
+    (baseDate.getHours() > hours || (baseDate.getHours() === hours && baseDate.getMinutes() > minutes))
+  ) {
+    hoursOffset = TimeConstants.HoursInOneDay - baseDate.getHours() + hours;
+  } else {
+    hoursOffset = Math.abs(baseDate.getHours() - hours);
+  }
+
+  const offset =
+    TimeConstants.MillisecondsIn1Sec * TimeConstants.MinutesInOneHour * hoursOffset * TimeConstants.SecondsInOneMinute +
+    seconds * TimeConstants.MillisecondsIn1Sec;
+
+  const date = new Date(baseDate.getTime() + offset);
+  date.setMinutes(minutes);
+  date.setSeconds(seconds);
+
+  return date;
+};

--- a/packages/date-time-utilities/src/timeMath/timeMath.ts
+++ b/packages/date-time-utilities/src/timeMath/timeMath.ts
@@ -49,8 +49,8 @@ export const getDateFromTimeSelection = (useHour12: boolean, baseDate: Date, sel
     TimeConstants.TimeFormatRegex.exec(selectedTime) || [];
 
   let hours = +selectedHours;
-  let minutes = +selectedMinutes;
-  let seconds = selectedSeconds ? +selectedSeconds : 0;
+  const minutes = +selectedMinutes;
+  const seconds = selectedSeconds ? +selectedSeconds : 0;
 
   if (useHour12 && selectedAp) {
     if (selectedAp.toLowerCase() === 'pm' && hours !== TimeConstants.OffsetTo24HourFormat) {

--- a/packages/date-time-utilities/src/timeMath/timeMath.ts
+++ b/packages/date-time-utilities/src/timeMath/timeMath.ts
@@ -39,40 +39,23 @@ export const ceilMinuteToIncrement = (date: Date, increments: number) => {
 
 /**
  * Returns a date object from the selected time.
- * @param showSeconds - If the time picker showed seconds
  * @param useHour12 - If the time picker uses 12 or 24 hour formatting
  * @param baseDate - The baseline date to calculate the offset of the selected time
  * @param selectedTime - A string representing the user selected time
  * @returns A new date object offset from the baseDate using the selected time.
  */
-export const getDateFromTimeSelection = (
-  showSeconds: boolean,
-  useHour12: boolean,
-  baseDate: Date,
-  selectedTime: string,
-): Date => {
-  const splitValue = selectedTime.split(':');
-  let hours = +splitValue[0];
-  let minutes;
-  let seconds = baseDate.getSeconds();
-  let ap;
-  if (showSeconds) {
-    minutes = +splitValue[1];
-    seconds = +splitValue[2].split(' ')[0];
-    if (useHour12) {
-      ap = splitValue[2].split(' ')[1];
-    }
-  } else {
-    minutes = +splitValue[1].split(' ')[0];
-    if (useHour12) {
-      ap = splitValue[1].split(' ')[1];
-    }
-  }
+export const getDateFromTimeSelection = (useHour12: boolean, baseDate: Date, selectedTime: string): Date => {
+  const [, selectedHours, selectedMinutes, selectedSeconds, selectedAp] =
+    TimeConstants.TimeFormatRegex.exec(selectedTime) || [];
 
-  if (useHour12 && ap) {
-    if (ap.toLowerCase() === 'pm' && hours !== 12) {
+  let hours = +selectedHours;
+  let minutes = +selectedMinutes;
+  let seconds = selectedSeconds ? +selectedSeconds : 0;
+
+  if (useHour12 && selectedAp) {
+    if (selectedAp.toLowerCase() === 'pm' && hours !== TimeConstants.OffsetTo24HourFormat) {
       hours += TimeConstants.OffsetTo24HourFormat;
-    } else if (ap.toLowerCase() === 'am' && hours === 12) {
+    } else if (selectedAp.toLowerCase() === 'am' && hours === TimeConstants.OffsetTo24HourFormat) {
       hours -= TimeConstants.OffsetTo24HourFormat;
     }
   }

--- a/packages/date-time-utilities/src/timeMath/timeMath.ts
+++ b/packages/date-time-utilities/src/timeMath/timeMath.ts
@@ -61,10 +61,7 @@ export const getDateFromTimeSelection = (useHour12: boolean, baseDate: Date, sel
   }
 
   let hoursOffset;
-  if (
-    useHour12 &&
-    (baseDate.getHours() > hours || (baseDate.getHours() === hours && baseDate.getMinutes() > minutes))
-  ) {
+  if (baseDate.getHours() > hours || (baseDate.getHours() === hours && baseDate.getMinutes() > minutes)) {
     hoursOffset = TimeConstants.HoursInOneDay - baseDate.getHours() + hours;
   } else {
     hoursOffset = Math.abs(baseDate.getHours() - hours);

--- a/packages/react-examples/src/react/TimePicker/TimePicker.Example.tsx
+++ b/packages/react-examples/src/react/TimePicker/TimePicker.Example.tsx
@@ -14,14 +14,14 @@ const timePickerStyles: Partial<IComboBoxStyles> = {
   },
 };
 
+const onFormatDate = (date: Date) => `Custom prefix + ${date.toLocaleTimeString()}`;
+const onSelectTime = (date: Date) => console.log('SELECTED DATE: ', date);
+
 export const TimePickerBasicExample: React.FC = () => {
   const timeRange: ITimeRange = {
     start: 8,
     end: 14,
   };
-  const onFormatDate = (date: Date) => `Custom prefix + ${date.toLocaleTimeString()}`;
-
-  const onSelectTime = (date: Date) => console.log('SELECTED DATE: ', date);
 
   return (
     <Stack tokens={stackTokens} styles={stackStyles}>

--- a/packages/react-examples/src/react/TimePicker/TimePicker.Example.tsx
+++ b/packages/react-examples/src/react/TimePicker/TimePicker.Example.tsx
@@ -21,6 +21,8 @@ export const TimePickerBasicExample: React.FC = () => {
   };
   const onFormatDate = (date: Date) => `Custom prefix + ${date.toLocaleTimeString()}`;
 
+  const onSelectTime = (date: Date) => console.log('SELECTED DATE: ', date);
+
   return (
     <Stack tokens={stackTokens} styles={stackStyles}>
       <TimePicker
@@ -29,6 +31,8 @@ export const TimePickerBasicExample: React.FC = () => {
         allowFreeform
         autoComplete="on"
         label={'TimePicker basic example'}
+        onSelectTime={onSelectTime}
+        defaultValue={new Date('November 25, 2021 09:15:00')}
         useComboBoxAsMenuWidth
       />
       <TimePicker
@@ -40,6 +44,7 @@ export const TimePickerBasicExample: React.FC = () => {
         label={'TimePicker with non default options'}
         useComboBoxAsMenuWidth
         timeRange={timeRange}
+        onSelectTime={onSelectTime}
       />
       <TimePicker
         styles={timePickerStyles}

--- a/packages/react-examples/src/react/TimePicker/TimePicker.Example.tsx
+++ b/packages/react-examples/src/react/TimePicker/TimePicker.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ITimeRange, TimePicker } from '@fluentui/react/lib/TimePicker';
-import { IStackTokens, Stack, IStackStyles, IComboBoxStyles } from '@fluentui/react';
+import { IStackTokens, Stack, IStackStyles, IComboBoxStyles, IComboBox } from '@fluentui/react';
 
 const stackStyles: Partial<IStackStyles> = { root: { maxWidth: 300 } };
 const stackTokens: IStackTokens = { childrenGap: 20 };
@@ -15,7 +15,7 @@ const timePickerStyles: Partial<IComboBoxStyles> = {
 };
 
 const onFormatDate = (date: Date) => `Custom prefix + ${date.toLocaleTimeString()}`;
-const onSelectTime = (date: Date) => console.log('SELECTED DATE: ', date);
+const onChange = (_: React.FormEvent<IComboBox>, date: Date) => console.log('SELECTED DATE: ', date);
 
 export const TimePickerBasicExample: React.FC = () => {
   const timeRange: ITimeRange = {
@@ -31,7 +31,7 @@ export const TimePickerBasicExample: React.FC = () => {
         allowFreeform
         autoComplete="on"
         label={'TimePicker basic example'}
-        onSelectTime={onSelectTime}
+        onChange={onChange}
         defaultValue={new Date('November 25, 2021 09:15:00')}
         useComboBoxAsMenuWidth
       />
@@ -44,7 +44,7 @@ export const TimePickerBasicExample: React.FC = () => {
         label={'TimePicker with non default options'}
         useComboBoxAsMenuWidth
         timeRange={timeRange}
-        onSelectTime={onSelectTime}
+        onChange={onChange}
       />
       <TimePicker
         styles={timePickerStyles}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -9066,13 +9066,13 @@ export interface IThemeSlotRule {
 }
 
 // @public (undocumented)
-export interface ITimePickerProps extends Omit<IComboBoxProps, 'options' | 'selectedKey' | 'defaultSelectedKey' | 'multiSelect' | 'text' | 'defaultValue'> {
+export interface ITimePickerProps extends Omit<IComboBoxProps, 'options' | 'selectedKey' | 'defaultSelectedKey' | 'multiSelect' | 'text' | 'defaultValue' | 'onChange'> {
     allowFreeform?: boolean;
     defaultValue?: Date;
     increments?: number;
     label?: string;
+    onChange?: (event: React.FormEvent<IComboBox>, time: Date) => void;
     onFormatDate?: (date: Date) => string;
-    onSelectTime?: (time: Date) => void;
     onValidateUserInput?: (userInput: string) => string;
     showSeconds?: boolean;
     strings?: ITimePickerStrings;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -9066,11 +9066,13 @@ export interface IThemeSlotRule {
 }
 
 // @public (undocumented)
-export interface ITimePickerProps extends Omit<IComboBoxProps, 'options' | 'selectedKey' | 'defaultSelectedKey' | 'multiSelect' | 'text'> {
+export interface ITimePickerProps extends Omit<IComboBoxProps, 'options' | 'selectedKey' | 'defaultSelectedKey' | 'multiSelect' | 'text' | 'defaultValue'> {
     allowFreeform?: boolean;
+    defaultValue?: Date;
     increments?: number;
     label?: string;
     onFormatDate?: (date: Date) => string;
+    onSelectTime?: (time: Date) => void;
     onValidateUserInput?: (userInput: string) => string;
     showSeconds?: boolean;
     strings?: ITimePickerStrings;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -9071,7 +9071,7 @@ export interface ITimePickerProps extends Omit<IComboBoxProps, 'options' | 'sele
     defaultValue?: Date;
     increments?: number;
     label?: string;
-    onChange?: (event: React.FormEvent<IComboBox>, time: Date) => void;
+    onChange?: (event: React_2.FormEvent<IComboBox>, time: Date) => void;
     onFormatDate?: (date: Date) => string;
     onValidateUserInput?: (userInput: string) => string;
     showSeconds?: boolean;

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -64,7 +64,7 @@ export const TimePicker: React.FunctionComponent<ITimePickerProps> = ({
         text: optionText,
       };
     });
-  }, [defaultTime, timeRange, increments, optionsCount, showSeconds, onFormatDate, useHour12]);
+  }, [defaultTime, increments, optionsCount, showSeconds, onFormatDate, useHour12]);
 
   const [selectedKey, setSelectedKey] = React.useState<string | number | undefined>(timePickerOptions[0].key);
 

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -64,7 +64,7 @@ export const TimePicker: React.FunctionComponent<ITimePickerProps> = ({
         text: optionText,
       };
     });
-  }, [timeRange, increments, optionsCount, showSeconds, onFormatDate, useHour12]);
+  }, [defaultTime, timeRange, increments, optionsCount, showSeconds, onFormatDate, useHour12]);
 
   const [selectedKey, setSelectedKey] = React.useState<string | number | undefined>(timePickerOptions[0].key);
 
@@ -119,6 +119,7 @@ export const TimePicker: React.FunctionComponent<ITimePickerProps> = ({
       setSelectedKey(key);
     },
     [
+      defaultTime,
       allowFreeform,
       onFormatDate,
       onValidateUserInput,

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -112,7 +112,7 @@ export const TimePicker: React.FunctionComponent<ITimePickerProps> = ({
       }
 
       if (onChange && !errorMessageToDisplay) {
-        const selectedTime = value ? value : option ? option.text : '';
+        const selectedTime = value || option?.text || '';
         const date = getDateFromTimeSelection(useHour12, baseDate, selectedTime);
         onChange(event, date);
       }

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -202,8 +202,8 @@ const getDateFromSelection = (showSeconds: boolean, useHour12: boolean, defaultT
   }
 
   const offset =
-    TimeConstants.MillisecondsIn1Sec * TimeConstants.MinutesInOneHour * hoursOffset * TimeConstants.SecondsInOneHour +
-    seconds;
+    TimeConstants.MillisecondsIn1Sec * TimeConstants.MinutesInOneHour * hoursOffset * TimeConstants.SecondsInOneMinute +
+    seconds * TimeConstants.MillisecondsIn1Sec;
 
   const date = new Date(defaultTime.getTime() + offset);
   date.setMinutes(minutes);

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -49,7 +49,7 @@ export const TimePicker: React.FunctionComponent<ITimePickerProps> = ({
 
   const optionsCount = getDropdownOptionsCount(increments, timeRange);
 
-  const baseDate: Date = React.useMemo(() => generatebaseDate(increments, timeRange, defaultValue), [
+  const baseDate: Date = React.useMemo(() => generateBaseDate(increments, timeRange, defaultValue), [
     increments,
     timeRange,
     defaultValue,
@@ -177,7 +177,7 @@ const clampTimeRange = (timeRange: ITimeRange): ITimeRange => {
   };
 };
 
-const generatebaseDate = (increments: number, timeRange: ITimeRange | undefined, defaultValue?: Date) => {
+const generateBaseDate = (increments: number, timeRange: ITimeRange | undefined, defaultValue?: Date) => {
   const newbaseDate = defaultValue ? defaultValue : new Date();
   if (timeRange) {
     const clampedTimeRange = clampTimeRange(timeRange);

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -175,7 +175,7 @@ const getDateFromSelection = (showSeconds: boolean, useHour12: boolean, defaultT
   const splitValue = selectedTime.split(':');
   let hours = +splitValue[0];
   let minutes;
-  let seconds = 0;
+  let seconds = defaultTime.getSeconds();
   let ap;
   if (showSeconds) {
     minutes = +splitValue[1];
@@ -190,12 +190,19 @@ const getDateFromSelection = (showSeconds: boolean, useHour12: boolean, defaultT
     }
   }
 
-  if (useHour12 && ap && ap.toLowerCase() === 'pm' && hours !== 12) {
-    hours += TimeConstants.OffsetTo24HourFormat;
+  if (useHour12 && ap) {
+    if (ap.toLowerCase() === 'pm' && hours !== 12) {
+      hours += TimeConstants.OffsetTo24HourFormat;
+    } else if (ap.toLowerCase() === 'am' && hours === 12) {
+      hours -= TimeConstants.OffsetTo24HourFormat;
+    }
   }
 
   let hoursOffset;
-  if (useHour12 && defaultTime.getHours() >= hours) {
+  if (
+    useHour12 &&
+    (defaultTime.getHours() > hours || (defaultTime.getHours() === hours && defaultTime.getMinutes() > minutes))
+  ) {
     hoursOffset = TimeConstants.HoursInOneDay - defaultTime.getHours() + hours;
   } else {
     hoursOffset = Math.abs(defaultTime.getHours() - hours);
@@ -207,7 +214,7 @@ const getDateFromSelection = (showSeconds: boolean, useHour12: boolean, defaultT
 
   const date = new Date(defaultTime.getTime() + offset);
   date.setMinutes(minutes);
-  date.setSeconds(defaultTime.getSeconds());
+  date.setSeconds(seconds);
 
   return date;
 };

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -114,9 +114,9 @@ export const TimePicker: React.FunctionComponent<ITimePickerProps> = ({
         updatedUserText = option.text;
       }
 
-      if (onSelectTime) {
+      if (onSelectTime && !errorMessageToDisplay) {
         const selectedTime = value ? value : option ? option.text : '';
-        const date = getDateFromTimeSelection(showSeconds, useHour12, baseDate, selectedTime);
+        const date = getDateFromTimeSelection(useHour12, baseDate, selectedTime);
         onSelectTime(date);
       }
 

--- a/packages/react/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/react/src/components/TimePicker/TimePicker.types.ts
@@ -20,7 +20,10 @@ export interface ITimePickerStrings {
 }
 
 export interface ITimePickerProps
-  extends Omit<IComboBoxProps, 'options' | 'selectedKey' | 'defaultSelectedKey' | 'multiSelect' | 'text'> {
+  extends Omit<
+    IComboBoxProps,
+    'options' | 'selectedKey' | 'defaultSelectedKey' | 'multiSelect' | 'text' | 'defaultValue'
+  > {
   /**
    * Label of the component
    */

--- a/packages/react/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/react/src/components/TimePicker/TimePicker.types.ts
@@ -1,4 +1,4 @@
-import type { IComboBoxProps } from '../../ComboBox';
+import type { IComboBox, IComboBoxProps } from '../../ComboBox';
 
 /**
  * Range of start and end hours to be shown in the TimePicker.
@@ -22,7 +22,7 @@ export interface ITimePickerStrings {
 export interface ITimePickerProps
   extends Omit<
     IComboBoxProps,
-    'options' | 'selectedKey' | 'defaultSelectedKey' | 'multiSelect' | 'text' | 'defaultValue'
+    'options' | 'selectedKey' | 'defaultSelectedKey' | 'multiSelect' | 'text' | 'defaultValue' | 'onChange'
   > {
   /**
    * Label of the component
@@ -69,9 +69,9 @@ export interface ITimePickerProps
   defaultValue?: Date;
 
   /**
-   * Callback issued when a time is selected
+   * Callback issued when the time is changed
    */
-  onSelectTime?: (time: Date) => void;
+  onChange?: (event: React.FormEvent<IComboBox>, time: Date) => void;
 
   /**
    * Callback to localize the date strings displayed for dropdown options

--- a/packages/react/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/react/src/components/TimePicker/TimePicker.types.ts
@@ -6,6 +6,7 @@ import type { IComboBoxProps } from '../../ComboBox';
 export interface ITimeRange {
   /** Start hour (inclusive) for the time range, 0-23 */
   start: number;
+
   /** End hour (exclusive) for the time range, 0-23 */
   end: number;
 }
@@ -24,19 +25,23 @@ export interface ITimePickerProps
    * Label of the component
    */
   label?: string;
+
   /**
    * Time increments, in minutes, of the options in the dropdown
    */
   increments?: number;
+
   /**
    * If true, show seconds in the dropdown options and consider seconds for
    * default validation purposes.
    */
   showSeconds?: boolean;
+
   /**
    * If true, use 12-hour time format. Otherwise, use 24-hour format.
    */
   useHour12?: boolean;
+
   /**
    * If true, the TimePicker allows freeform user input, rather than restricting
    * to the default increments.
@@ -44,18 +49,32 @@ export interface ITimePickerProps
    * The input will still be restricted to valid time values.
    */
   allowFreeform?: boolean;
+
   /**
    * Custom time range to for time options
    */
   timeRange?: ITimeRange;
+
   /**
    * Localized strings to use in the TimePicker
    */
   strings?: ITimePickerStrings;
+
+  /**
+   * Default value of the TimePicker, if any
+   */
+  defaultValue?: Date;
+
+  /**
+   * Callback issued when a time is selected
+   */
+  onSelectTime?: (time: Date) => void;
+
   /**
    * Callback to localize the date strings displayed for dropdown options
    */
   onFormatDate?: (date: Date) => string;
+
   /**
    * Callback to use custom user-input validation
    */

--- a/packages/react/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/react/src/components/TimePicker/TimePicker.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type { IComboBox, IComboBoxProps } from '../../ComboBox';
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19554
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Greetings, reviewer!

This pull request adds a default value prop and updates the onChange prop to the TimePicker control.

Users of this control can now supply the "starting default time" as a Date object. This new prop is `defaultValue?: Date`. If defaultValue is not supplied, the control will select the "starting default time" as `new Date()`.

Additionally, users can also track changes to the TimePicker control via the updated `onChange` callback function. This way, users can avoid the hassle of parsing their selected time and can instead receive an updated Date object on each selection. This updated prop is `onChange?: (event: React.FormEvent<IComboBox>, time: Date) => void`. It is called within the `onInputChange` function.

There PR also adds a new function within the TimePicker control, `getDateFromSelection`, that supplies the updated selected Date object to the `onChange` prop.

#### Additional information

This feature was previously discussed when the TimePicker PR was first made:

##### Original feedback from @ecraig12345:

> Something to consider for the future: right now it looks like the time picker is always completely uncontrolled (and doesn't even support passing a default value), but for some scenarios the consumer may want to pass a default value or manually control the value. 
> 
> In the interest of not complicating this PR even more, I think it's fine to wait on that feature until somebody requests it. But if/when you get around to implementing it, you'll need to ensure it implements the controlled/uncontrolled pattern properly--[here's an explanation I wrote](https://gist.github.com/ecraig12345/1ea4566ce171b844a0af5a3366d3473f), or you can find many other explanations online if that doesn't make sense. We also have a hook `useControllableValue` to help with implementing it properly.

##### Formal request submitted in the form of issue #19554 

Thank you! 😸 