### PR TITLE
Panel: Content no longer overlaps with header and footer when scrolling.

### DIFF
--- a/change/@fluentui-react-2bc57354-2f2d-448d-b39e-6121f7a1ee42.json
+++ b/change/@fluentui-react-2bc57354-2f2d-448d-b39e-6121f7a1ee42.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Panel: Content no longer overlaps with header and footer when scrolling.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Panel/Panel.Footer.Example.tsx
+++ b/packages/react-examples/src/react/Panel/Panel.Footer.Example.tsx
@@ -21,8 +21,7 @@ export const PanelFooterExample: React.FunctionComponent = () => {
     ),
     [dismissPanel],
   );
-  const [content, setContent] = React.useState('Content goes here.');
-  const [show, setShow] = React.useState(false);
+
   return (
     <div>
       <DefaultButton text="Open panel" onClick={openPanel} />
@@ -36,64 +35,7 @@ export const PanelFooterExample: React.FunctionComponent = () => {
         // at the bottom of the page
         isFooterAtBottom={true}
       >
-        {
-          <DefaultButton
-            text="Lots of content"
-            onClick={
-              !show
-                ? () => {
-                    setContent(
-                      'Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. THE END.',
-                    );
-                    setShow(true);
-                  }
-                : () => {
-                    setContent('');
-                    setShow(false);
-                  }
-            }
-          />
-        }
-        {/* <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" />
-        <DefaultButton text="LOTS OF CONTENT" /> */}
-
-        <p>{content}</p>
+        <p>Content goes here.</p>
       </Panel>
     </div>
   );

--- a/packages/react-examples/src/react/Panel/Panel.Footer.Example.tsx
+++ b/packages/react-examples/src/react/Panel/Panel.Footer.Example.tsx
@@ -21,7 +21,8 @@ export const PanelFooterExample: React.FunctionComponent = () => {
     ),
     [dismissPanel],
   );
-
+  const [content, setContent] = React.useState('Content goes here.');
+  const [show, setShow] = React.useState(false);
   return (
     <div>
       <DefaultButton text="Open panel" onClick={openPanel} />
@@ -35,7 +36,64 @@ export const PanelFooterExample: React.FunctionComponent = () => {
         // at the bottom of the page
         isFooterAtBottom={true}
       >
-        <p>Content goes here.</p>
+        {
+          <DefaultButton
+            text="Lots of content"
+            onClick={
+              !show
+                ? () => {
+                    setContent(
+                      'Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. Content goes here. THE END.',
+                    );
+                    setShow(true);
+                  }
+                : () => {
+                    setContent('');
+                    setShow(false);
+                  }
+            }
+          />
+        }
+        {/* <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" />
+        <DefaultButton text="LOTS OF CONTENT" /> */}
+
+        <p>{content}</p>
       </Panel>
     </div>
   );

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -351,15 +351,16 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         flexShrink: 0,
         borderTop: '1px solid transparent',
         transition: `opacity ${AnimationVariables.durationValue3} ${AnimationVariables.easeFunction2}`,
-        background: semanticColors.bodyBackground,
         selectors: {
           [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
+            background: semanticColors.bodyBackground,
             position: 'sticky',
             bottom: 0,
           },
         },
       },
       isFooterSticky && {
+        background: semanticColors.bodyBackground,
         borderTopColor: semanticColors.variantBorder,
       },
     ],

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -264,6 +264,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
             backgroundColor: semanticColors.bodyBackground,
             position: 'sticky',
             top: 0,
+            zIndex: 1,
           },
         },
       },
@@ -350,6 +351,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         flexShrink: 0,
         borderTop: '1px solid transparent',
         transition: `opacity ${AnimationVariables.durationValue3} ${AnimationVariables.easeFunction2}`,
+        background: semanticColors.bodyBackground,
         selectors: {
           [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
             position: 'sticky',
@@ -358,7 +360,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         },
       },
       isFooterSticky && {
-        background: semanticColors.bodyBackground,
         borderTopColor: semanticColors.variantBorder,
       },
     ],

--- a/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -188,6 +188,7 @@ exports[`Panel allows the consumer to pass through popup props 1`] = `
                       margin-top: 18px;
                     }
                     @media (min-height: 480px){& {
+                      background-color: #ffffff;
                       position: sticky;
                       top: 0px;
                       z-index: 1;
@@ -588,6 +589,7 @@ exports[`Panel renders Panel correctly 1`] = `
                       margin-top: 18px;
                     }
                     @media (min-height: 480px){& {
+                      background-color: #ffffff;
                       position: sticky;
                       top: 0px;
                       z-index: 1;

--- a/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -188,9 +188,9 @@ exports[`Panel allows the consumer to pass through popup props 1`] = `
                       margin-top: 18px;
                     }
                     @media (min-height: 480px){& {
-                      background-color: #ffffff;
                       position: sticky;
                       top: 0px;
+                      z-index: 1;
                     }
                 data-is-visible={true}
               >
@@ -588,9 +588,9 @@ exports[`Panel renders Panel correctly 1`] = `
                       margin-top: 18px;
                     }
                     @media (min-height: 480px){& {
-                      background-color: #ffffff;
                       position: sticky;
                       top: 0px;
+                      z-index: 1;
                     }
                 data-is-visible={true}
               >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20637 and issue in [comment](https://github.com/microsoft/fluentui/issues/20637#issuecomment-972388824)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Adds `z-index: 1` property to header/navigation bar when minimum height is met to ensure that contents with `position: relative`  (like Button) don't overlap with the header when scrolling down.
- There will now be a `footer` background when `footer` is "fixed" at the bottom to ensure that when dynamic content is added, that content does not overlap with the footer when scrolling down. 
- 
![PanelContentOverlap](https://user-images.githubusercontent.com/8649804/143658144-d5749435-f9b9-4a11-b93a-6c6fbe558bd2.gif)


