### PR TITLE
fix(react-button): update styles to not use CSS shorthands

### DIFF
--- a/change/@fluentui-react-button-791d358e-16fb-46a8-adbd-3e5c3c476632.json
+++ b/change/@fluentui-react-button-791d358e-16fb-46a8-adbd-3e5c3c476632.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update styles to not use CSS shorthands",
+  "packageName": "@fluentui/react-button",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/components/Button/stories/ButtonAppearance.stories.tsx
+++ b/packages/react-button/src/components/Button/stories/ButtonAppearance.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button } from '../../../Button'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { Button } from '../../../Button';
 
 export const Appearance = () => (
   <>

--- a/packages/react-button/src/components/Button/stories/ButtonBlock.stories.tsx
+++ b/packages/react-button/src/components/Button/stories/ButtonBlock.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button } from '../../../Button'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { Button } from '../../../Button';
 
 export const Block = () => (
   <>

--- a/packages/react-button/src/components/Button/stories/ButtonDefault.stories.tsx
+++ b/packages/react-button/src/components/Button/stories/ButtonDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ButtonProps } from '../../../Button'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { Button, ButtonProps } from '../../../Button';
 
 export const Default = (props: ButtonProps) => {
   return <Button {...props}>Button</Button>;

--- a/packages/react-button/src/components/Button/stories/ButtonDisabled.stories.tsx
+++ b/packages/react-button/src/components/Button/stories/ButtonDisabled.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CalendarMonth24Regular } from '@fluentui/react-icons';
-import { Button } from '../../../Button'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { Button } from '../../../Button';
 
 export const Disabled = () => {
   const groupStyles: React.CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: '0.5em' };

--- a/packages/react-button/src/components/Button/stories/ButtonIcon.stories.tsx
+++ b/packages/react-button/src/components/Button/stories/ButtonIcon.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CalendarMonth24Regular } from '@fluentui/react-icons';
-import { Button } from '../../../Button'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { Button } from '../../../Button';
 
 export const Icon = () => (
   <>

--- a/packages/react-button/src/components/Button/stories/ButtonShape.stories.tsx
+++ b/packages/react-button/src/components/Button/stories/ButtonShape.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button } from '../../../Button'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { Button } from '../../../Button';
 
 export const Shape = () => (
   <>

--- a/packages/react-button/src/components/Button/stories/ButtonSize.stories.tsx
+++ b/packages/react-button/src/components/Button/stories/ButtonSize.stories.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { CalendarMonth24Regular } from '@fluentui/react-icons';
-import { Button } from '../../../Button'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { Button } from '../../../Button';
 
 export const Size = () => {
   const groupStyles: React.CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: '0.5em' };
   const headerStyles: React.CSSProperties = { width: '100%', margin: 0 };
+
   return (
     <>
       <div style={groupStyles}>

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import type { ButtonState } from './Button.types';
 
@@ -23,39 +23,36 @@ const useRootStyles = makeStyles({
     justifyContent: 'center',
     verticalAlign: 'middle',
 
-    margin: 0,
+    ...shorthands.margin(0),
 
     maxWidth: '280px',
 
-    overflow: 'hidden',
+    ...shorthands.overflow('hidden'),
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
 
-    background: theme.colorNeutralBackground1,
+    backgroundColor: theme.colorNeutralBackground1,
     color: theme.colorNeutralForeground1,
-
-    borderColor: theme.colorNeutralStroke1,
-    borderStyle: 'solid',
-    borderWidth: theme.strokeWidthThin,
+    ...shorthands.border(theme.strokeWidthThin, 'solid', theme.colorNeutralStroke1),
 
     fontFamily: theme.fontFamilyBase,
 
-    outline: 'none',
+    outlineStyle: 'none',
 
     ':hover': {
-      background: theme.colorNeutralBackground1Hover,
-      borderColor: theme.colorNeutralStroke1Hover,
+      backgroundColor: theme.colorNeutralBackground1Hover,
+      ...shorthands.borderColor(theme.colorNeutralStroke1Hover),
       color: theme.colorNeutralForeground1,
 
       cursor: 'pointer',
     },
 
     ':active': {
-      background: theme.colorNeutralBackground1Pressed,
-      borderColor: theme.colorNeutralStroke1Pressed,
+      backgroundColor: theme.colorNeutralBackground1Pressed,
+      ...shorthands.borderColor(theme.colorNeutralStroke1Pressed),
       color: theme.colorNeutralForeground1,
 
-      outline: 'none',
+      outlineStyle: 'none',
     },
   }),
 
@@ -67,114 +64,114 @@ const useRootStyles = makeStyles({
 
   // Appearance variations
   outline: theme => ({
-    background: theme.colorTransparentBackground,
+    backgroundColor: theme.colorTransparentBackground,
 
     ':hover': {
-      background: theme.colorTransparentBackgroundHover,
+      backgroundColor: theme.colorTransparentBackgroundHover,
     },
 
     ':active': {
-      background: theme.colorTransparentBackgroundPressed,
+      backgroundColor: theme.colorTransparentBackgroundPressed,
     },
   }),
   primary: theme => ({
-    background: theme.colorBrandBackground,
-    borderColor: 'transparent',
+    backgroundColor: theme.colorBrandBackground,
+    ...shorthands.borderColor('transparent'),
     color: theme.colorNeutralForegroundOnBrand,
 
     ':hover': {
-      background: theme.colorBrandBackgroundHover,
-      borderColor: 'transparent',
+      backgroundColor: theme.colorBrandBackgroundHover,
+      ...shorthands.borderColor('transparent'),
       color: theme.colorNeutralForegroundOnBrand,
     },
 
     ':active': {
-      background: theme.colorBrandBackgroundPressed,
-      borderColor: 'transparent',
+      backgroundColor: theme.colorBrandBackgroundPressed,
+      ...shorthands.borderColor('transparent'),
       color: theme.colorNeutralForegroundOnBrand,
     },
   }),
   subtle: theme => ({
-    background: theme.colorSubtleBackground,
-    borderColor: 'transparent',
+    backgroundColor: theme.colorSubtleBackground,
+    ...shorthands.borderColor('transparent'),
     color: theme.colorNeutralForeground2,
 
     ':hover': {
-      background: theme.colorSubtleBackgroundHover,
-      borderColor: 'transparent',
+      backgroundColor: theme.colorSubtleBackgroundHover,
+      ...shorthands.borderColor('transparent'),
       color: theme.colorNeutralForeground2BrandHover,
     },
 
     ':active': {
-      background: theme.colorSubtleBackgroundPressed,
-      borderColor: 'transparent',
+      backgroundColor: theme.colorSubtleBackgroundPressed,
+      ...shorthands.borderColor('transparent'),
       color: theme.colorNeutralForeground2BrandPressed,
     },
   }),
   transparent: theme => ({
-    background: theme.colorTransparentBackground,
-    borderColor: 'transparent',
+    backgroundColor: theme.colorTransparentBackground,
+    ...shorthands.borderColor('transparent'),
     color: theme.colorNeutralForeground2,
 
     ':hover': {
-      background: theme.colorTransparentBackgroundHover,
-      borderColor: 'transparent',
+      backgroundColor: theme.colorTransparentBackgroundHover,
+      ...shorthands.borderColor('transparent'),
       color: theme.colorNeutralForeground2BrandHover,
     },
 
     ':active': {
-      background: theme.colorTransparentBackgroundPressed,
-      borderColor: 'transparent',
+      backgroundColor: theme.colorTransparentBackgroundPressed,
+      ...shorthands.borderColor('transparent'),
       color: theme.colorNeutralForeground2BrandPressed,
     },
   }),
 
   // Shape variations
   circular: theme => ({
-    borderRadius: theme.borderRadiusCircular,
+    ...shorthands.borderRadius(theme.borderRadiusCircular),
   }),
   rounded: {
     /* The borderRadius rounded styles are handled in the size variations */
   },
   square: theme => ({
-    borderRadius: theme.borderRadiusNone,
+    ...shorthands.borderRadius(theme.borderRadiusNone),
   }),
 
   // Size variations
   small: theme => ({
-    gap: buttonSpacing.smaller,
-    padding: `0 ${buttonSpacing.medium}`,
+    ...shorthands.gap(buttonSpacing.smaller),
+    ...shorthands.padding('0', buttonSpacing.medium),
 
     height: '24px',
     minWidth: '64px',
 
-    borderRadius: theme.borderRadiusSmall,
+    ...shorthands.borderRadius(theme.borderRadiusSmall),
 
     fontSize: theme.fontSizeBase200,
     fontWeight: theme.fontWeightRegular,
     lineHeight: theme.lineHeightBase200,
   }),
   medium: theme => ({
-    gap: buttonSpacing.small,
-    padding: `0 ${buttonSpacing.large}`,
+    ...shorthands.gap(buttonSpacing.small),
+    ...shorthands.padding('0', buttonSpacing.large),
 
     height: '32px',
     minWidth: '96px',
 
-    borderRadius: theme.borderRadiusMedium,
+    ...shorthands.borderRadius(theme.borderRadiusMedium),
 
     fontSize: theme.fontSizeBase300,
     fontWeight: theme.fontWeightSemibold,
     lineHeight: theme.lineHeightBase300,
   }),
   large: theme => ({
-    gap: buttonSpacing.small,
-    padding: `0 ${buttonSpacing.larger}`,
+    ...shorthands.gap(buttonSpacing.small),
+    ...shorthands.padding('0', buttonSpacing.larger),
 
     height: '40px',
     minWidth: '96px',
 
-    borderRadius: theme.borderRadiusMedium,
+    ...shorthands.borderRadius(theme.borderRadiusMedium),
 
     fontSize: theme.fontSizeBase400,
     fontWeight: theme.fontWeightSemibold,
@@ -185,23 +182,23 @@ const useRootStyles = makeStyles({
 const useRootDisabledStyles = makeStyles({
   // Base styles
   base: theme => ({
-    background: theme.colorNeutralBackgroundDisabled,
-    borderColor: theme.colorNeutralStrokeDisabled,
+    backgroundColor: theme.colorNeutralBackgroundDisabled,
+    ...shorthands.borderColor(theme.colorNeutralStrokeDisabled),
     color: theme.colorNeutralForegroundDisabled,
 
     cursor: 'not-allowed',
 
     ':hover': {
-      background: theme.colorNeutralBackgroundDisabled,
-      borderColor: theme.colorNeutralStrokeDisabled,
+      backgroundColor: theme.colorNeutralBackgroundDisabled,
+      ...shorthands.borderColor(theme.colorNeutralStrokeDisabled),
       color: theme.colorNeutralForegroundDisabled,
 
       cursor: 'not-allowed',
     },
 
     ':active': {
-      background: theme.colorNeutralBackgroundDisabled,
-      borderColor: theme.colorNeutralStrokeDisabled,
+      backgroundColor: theme.colorNeutralBackgroundDisabled,
+      ...shorthands.borderColor(theme.colorNeutralStrokeDisabled),
       color: theme.colorNeutralForegroundDisabled,
 
       cursor: 'not-allowed',
@@ -210,53 +207,53 @@ const useRootDisabledStyles = makeStyles({
 
   // Appearance variations
   outline: theme => ({
-    background: theme.colorTransparentBackground,
+    backgroundColor: theme.colorTransparentBackground,
 
     ':hover': {
-      background: theme.colorTransparentBackgroundHover,
+      backgroundColor: theme.colorTransparentBackgroundHover,
     },
 
     ':active': {
-      background: theme.colorTransparentBackgroundPressed,
+      backgroundColor: theme.colorTransparentBackgroundPressed,
     },
   }),
   primary: {
-    borderColor: 'transparent',
+    ...shorthands.borderColor('transparent'),
 
     ':hover': {
-      borderColor: 'transparent',
+      ...shorthands.borderColor('transparent'),
     },
 
     ':active': {
-      borderColor: 'transparent',
+      ...shorthands.borderColor('transparent'),
     },
   },
   subtle: {
-    background: 'none',
-    borderColor: 'transparent',
+    backgroundColor: 'transparent',
+    ...shorthands.borderColor('transparent'),
 
     ':hover': {
-      background: 'none',
-      borderColor: 'transparent',
+      backgroundColor: 'transparent',
+      ...shorthands.borderColor('transparent'),
     },
 
     ':active': {
-      background: 'none',
-      borderColor: 'transparent',
+      backgroundColor: 'transparent',
+      ...shorthands.borderColor('transparent'),
     },
   },
   transparent: {
-    background: 'none',
-    borderColor: 'transparent',
+    backgroundColor: 'transparent',
+    ...shorthands.borderColor('transparent'),
 
     ':hover': {
-      background: 'none',
-      borderColor: 'transparent',
+      backgroundColor: 'transparent',
+      ...shorthands.borderColor('transparent'),
     },
 
     ':active': {
-      background: 'none',
-      borderColor: 'transparent',
+      backgroundColor: 'transparent',
+      ...shorthands.borderColor('transparent'),
     },
   },
 });
@@ -273,8 +270,10 @@ const useRootFocusStyles = makeStyles({
   // square: theme => createFocusOutlineStyle(theme, { style: { outlineRadius: theme.global.borderRadius.none } }),
 
   base: createCustomFocusIndicatorStyle(theme => ({
-    borderColor: 'transparent',
-    outline: '2px solid transparent',
+    ...shorthands.borderColor('transparent'),
+    outlineColor: 'transparent',
+    outlineWidth: '2px',
+    outlineStyle: 'solid',
     boxShadow: `
       ${theme.shadow4},
       0 0 0 2px ${theme.colorStrokeFocus2}
@@ -283,46 +282,46 @@ const useRootFocusStyles = makeStyles({
   })),
 
   circular: createCustomFocusIndicatorStyle(theme => ({
-    borderRadius: theme.borderRadiusCircular,
+    ...shorthands.borderRadius(theme.borderRadiusCircular),
   })),
   rounded: {},
   // Primary styles
   primary: createCustomFocusIndicatorStyle(theme => ({
-    borderColor: theme.colorNeutralForegroundOnBrand,
+    ...shorthands.borderColor(theme.colorNeutralForegroundOnBrand),
     boxShadow: `${theme.shadow2}, 0 0 0 2px ${theme.colorStrokeFocus2}`,
   })),
   square: createCustomFocusIndicatorStyle(theme => ({
-    borderRadius: theme.borderRadiusNone,
+    ...shorthands.borderRadius(theme.borderRadiusNone),
   })),
 
   // Size variations
   small: createCustomFocusIndicatorStyle(theme => ({
-    borderRadius: theme.borderRadiusSmall,
+    ...shorthands.borderRadius(theme.borderRadiusSmall),
   })),
   medium: createCustomFocusIndicatorStyle(theme => ({
-    borderRadius: theme.borderRadiusMedium,
+    ...shorthands.borderRadius(theme.borderRadiusMedium),
   })),
   large: createCustomFocusIndicatorStyle(theme => ({
-    borderRadius: theme.borderRadiusLarge,
+    ...shorthands.borderRadius(theme.borderRadiusLarge),
   })),
 });
 
 const useRootIconOnlyStyles = makeStyles({
   // Size variations
   small: {
-    padding: buttonSpacing.smaller,
+    ...shorthands.padding(buttonSpacing.smaller),
 
     minWidth: '28px',
     maxWidth: '28px',
   },
   medium: {
-    padding: buttonSpacing.smaller,
+    ...shorthands.padding(buttonSpacing.smaller),
 
     minWidth: '32px',
     maxWidth: '32px',
   },
   large: {
-    padding: buttonSpacing.small,
+    ...shorthands.padding(buttonSpacing.small),
 
     minWidth: '40px',
     maxWidth: '40px',

--- a/packages/react-button/src/components/CompoundButton/stories/CompoundButtonAppearance.stories.tsx
+++ b/packages/react-button/src/components/CompoundButton/stories/CompoundButtonAppearance.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CompoundButton } from '../../../CompoundButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { CompoundButton } from '../../../CompoundButton';
 
 export const Appearance = () => (
   <>

--- a/packages/react-button/src/components/CompoundButton/stories/CompoundButtonBlock.stories.tsx
+++ b/packages/react-button/src/components/CompoundButton/stories/CompoundButtonBlock.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CompoundButton } from '../../../CompoundButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { CompoundButton } from '../../../CompoundButton';
 
 export const Block = () => (
   <>

--- a/packages/react-button/src/components/CompoundButton/stories/CompoundButtonDefault.stories.tsx
+++ b/packages/react-button/src/components/CompoundButton/stories/CompoundButtonDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CompoundButton, CompoundButtonProps } from '../../../CompoundButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { CompoundButton, CompoundButtonProps } from '../../../CompoundButton';
 
 export const Default = (props: CompoundButtonProps) => {
   return (

--- a/packages/react-button/src/components/CompoundButton/stories/CompoundButtonDisabled.stories.tsx
+++ b/packages/react-button/src/components/CompoundButton/stories/CompoundButtonDisabled.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CalendarMonth24Regular } from '@fluentui/react-icons';
-import { CompoundButton } from '../../../CompoundButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { CompoundButton } from '../../../CompoundButton';
 
 export const Disabled = () => {
   const groupStyles: React.CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: '0.5em' };

--- a/packages/react-button/src/components/CompoundButton/stories/CompoundButtonIcon.stories.tsx
+++ b/packages/react-button/src/components/CompoundButton/stories/CompoundButtonIcon.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CalendarMonth24Regular } from '@fluentui/react-icons';
-import { CompoundButton } from '../../../CompoundButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { CompoundButton } from '../../../CompoundButton';
 
 export const Icon = () => (
   <>

--- a/packages/react-button/src/components/CompoundButton/stories/CompoundButtonShape.stories.tsx
+++ b/packages/react-button/src/components/CompoundButton/stories/CompoundButtonShape.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CompoundButton } from '../../../CompoundButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { CompoundButton } from '../../../CompoundButton';
 
 export const Shape = () => (
   <>

--- a/packages/react-button/src/components/CompoundButton/stories/CompoundButtonSize.stories.tsx
+++ b/packages/react-button/src/components/CompoundButton/stories/CompoundButtonSize.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CompoundButton } from '../../../CompoundButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { CompoundButton } from '../../../CompoundButton';
 
 export const Size = () => {
   return (

--- a/packages/react-button/src/components/CompoundButton/stories/CompoundButtonWithLongText.stories.tsx
+++ b/packages/react-button/src/components/CompoundButton/stories/CompoundButtonWithLongText.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CompoundButton } from '../../../CompoundButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { CompoundButton } from '../../../CompoundButton';
 
 export const WithLongText = () => (
   <>

--- a/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
+import { shorthands, mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import { buttonSpacing, useButtonStyles } from '../Button/useButtonStyles';
 import type { CompoundButtonState } from './CompoundButton.types';
 
@@ -11,7 +11,7 @@ const CompoundButtonClassNames = {
 const useRootStyles = makeStyles({
   // Base styles
   base: theme => ({
-    gap: buttonSpacing.large,
+    ...shorthands.gap(buttonSpacing.large),
 
     height: 'auto',
 
@@ -90,19 +90,19 @@ const useRootStyles = makeStyles({
 
   // Size variations
   small: theme => ({
-    padding: buttonSpacing.medium,
+    ...shorthands.padding(buttonSpacing.medium),
 
     fontSize: theme.fontSizeBase300,
     lineHeight: theme.lineHeightBase300,
   }),
   medium: theme => ({
-    padding: buttonSpacing.large,
+    ...shorthands.padding(buttonSpacing.large),
 
     fontSize: theme.fontSizeBase300,
     lineHeight: theme.lineHeightBase300,
   }),
   large: theme => ({
-    padding: buttonSpacing.larger,
+    ...shorthands.padding(buttonSpacing.larger),
 
     fontSize: theme.fontSizeBase400,
     lineHeight: theme.lineHeightBase400,
@@ -131,19 +131,19 @@ const useRootStyles = makeStyles({
 const useRootIconOnlyStyles = makeStyles({
   // Size variations
   small: {
-    padding: buttonSpacing.smaller,
+    ...shorthands.padding(buttonSpacing.smaller),
 
     maxWidth: '48px',
     minWidth: '48px',
   },
   medium: {
-    padding: buttonSpacing.small,
+    ...shorthands.padding(buttonSpacing.small),
 
     maxWidth: '52px',
     minWidth: '52px',
   },
   large: {
-    padding: buttonSpacing.medium,
+    ...shorthands.padding(buttonSpacing.medium),
 
     maxWidth: '56px',
     minWidth: '56px',

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonAppearance.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonAppearance.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
 
-import { MenuButton } from '../../../MenuButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { MenuButton } from '../../../MenuButton';
 
 export const Appearance = () => (
   <>

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonBlock.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonBlock.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
-import { MenuButton } from '../../../MenuButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { MenuButton } from '../../../MenuButton';
 
 export const Block = () => (
   <Menu>

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonDefault.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonDefault.stories.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
-/* eslint-enable @typescript-eslint/ban-ts-comment */
-import { MenuButton } from '../../../MenuButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { MenuButton } from '../../../MenuButton';
 
 export const Default = () => {
   return (

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonDisabled.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonDisabled.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
-import { MenuButton } from '../../../MenuButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { MenuButton } from '../../../MenuButton';
 
 export const Disabled = () => {
   return (

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonIcon.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonIcon.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
 import { CalendarMonth24Regular, Filter24Regular } from '@fluentui/react-icons';
-import { MenuButton } from '../../../MenuButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { MenuButton } from '../../../MenuButton';
 
 export const Icon = () => (
   <>

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonShape.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonShape.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
-import { MenuButton } from '../../../MenuButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { MenuButton } from '../../../MenuButton';
 
 export const Shape = () => (
   <>

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonSize.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonSize.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-components';
-import { MenuButton } from '../../../MenuButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { MenuButton } from '../../../MenuButton';
 
 export const Size = () => {
   return (

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonSizeLarge.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonSizeLarge.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
 import { CalendarMonth24Regular } from '@fluentui/react-icons';
-import { MenuButton } from '../../../MenuButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { MenuButton } from '../../../MenuButton';
 
 export const SizeLarge = () => {
   return (

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonSizeMedium.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonSizeMedium.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
 import { CalendarMonth24Regular } from '@fluentui/react-icons';
-import { MenuButton } from '../../../MenuButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { MenuButton } from '../../../MenuButton';
 
 export const SizeMedium = () => {
   return (

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonSizeSmall.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonSizeSmall.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
 import { CalendarMonth24Regular } from '@fluentui/react-icons';
-import { MenuButton } from '../../../MenuButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { MenuButton } from '../../../MenuButton';
 
 export const SizeSmall = () => {
   return (

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonWithLongText.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonWithLongText.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
-import { MenuButton } from '../../../MenuButton'; // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta // codesandbox-dependency: @fluentui/react-button ^9.0.0-beta
+import { MenuButton } from '../../../MenuButton';
 
 export const WithLongText = () => (
   <>

--- a/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
+import { shorthands, mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import { useButtonStyles } from '../Button/useButtonStyles';
 import type { ToggleButtonState } from './ToggleButton.types';
 
@@ -7,85 +7,85 @@ export const toggleButtonClassName = 'fui-ToggleButton';
 const useCheckedStyles = makeStyles({
   // Base styles
   base: theme => ({
-    background: theme.colorNeutralBackground1Selected,
-    borderColor: theme.colorNeutralStroke1,
+    backgroundColor: theme.colorNeutralBackground1Selected,
+    ...shorthands.borderColor(theme.colorNeutralStroke1),
     color: theme.colorNeutralForeground1,
 
-    borderWidth: theme.strokeWidthThin,
+    ...shorthands.borderWidth(theme.strokeWidthThin),
 
     ':hover': {
-      background: theme.colorNeutralBackground1Hover,
-      borderColor: theme.colorNeutralStroke1Hover,
+      backgroundColor: theme.colorNeutralBackground1Hover,
+      ...shorthands.borderColor(theme.colorNeutralStroke1Hover),
       color: theme.colorNeutralForeground1,
     },
 
     ':active': {
-      background: theme.colorNeutralBackground1Pressed,
-      borderColor: theme.colorNeutralStroke1Pressed,
+      backgroundColor: theme.colorNeutralBackground1Pressed,
+      ...shorthands.borderColor(theme.colorNeutralStroke1Pressed),
       color: theme.colorNeutralForeground1,
     },
   }),
 
   // Appearance variations
   outline: theme => ({
-    background: theme.colorTransparentBackgroundSelected,
+    backgroundColor: theme.colorTransparentBackgroundSelected,
 
     ':hover': {
-      background: theme.colorTransparentBackgroundHover,
+      backgroundColor: theme.colorTransparentBackgroundHover,
     },
 
     ':active': {
-      background: theme.colorTransparentBackgroundPressed,
+      backgroundColor: theme.colorTransparentBackgroundPressed,
     },
   }),
   primary: theme => ({
-    background: theme.colorBrandBackgroundSelected,
-    borderColor: 'transparent',
+    backgroundColor: theme.colorBrandBackgroundSelected,
+    ...shorthands.borderColor('transparent'),
     color: theme.colorNeutralForegroundOnBrand,
 
     ':hover': {
-      background: theme.colorBrandBackgroundHover,
-      borderColor: 'transparent',
+      backgroundColor: theme.colorBrandBackgroundHover,
+      ...shorthands.borderColor('transparent'),
       color: theme.colorNeutralForegroundOnBrand,
     },
 
     ':active': {
-      background: theme.colorBrandBackgroundPressed,
-      borderColor: 'transparent',
+      backgroundColor: theme.colorBrandBackgroundPressed,
+      ...shorthands.borderColor('transparent'),
       color: theme.colorNeutralForegroundOnBrand,
     },
   }),
   subtle: theme => ({
-    background: theme.colorSubtleBackgroundSelected,
-    borderColor: 'transparent',
+    backgroundColor: theme.colorSubtleBackgroundSelected,
+    ...shorthands.borderColor('transparent'),
     color: theme.colorNeutralForeground2BrandSelected,
 
     ':hover': {
-      background: theme.colorSubtleBackgroundHover,
-      borderColor: 'transparent',
+      backgroundColor: theme.colorSubtleBackgroundHover,
+      ...shorthands.borderColor('transparent'),
       color: theme.colorNeutralForeground2BrandHover,
     },
 
     ':active': {
-      background: theme.colorSubtleBackgroundPressed,
-      borderColor: 'transparent',
+      backgroundColor: theme.colorSubtleBackgroundPressed,
+      ...shorthands.borderColor('transparent'),
       color: theme.colorNeutralForeground2BrandPressed,
     },
   }),
   transparent: theme => ({
-    background: theme.colorTransparentBackgroundSelected,
-    borderColor: 'transparent',
+    backgroundColor: theme.colorTransparentBackgroundSelected,
+    ...shorthands.borderColor('transparent'),
     color: theme.colorNeutralForeground2BrandSelected,
 
     ':hover': {
-      background: theme.colorTransparentBackgroundHover,
-      borderColor: 'transparent',
+      backgroundColor: theme.colorTransparentBackgroundHover,
+      ...shorthands.borderColor('transparent'),
       color: theme.colorNeutralForeground2BrandHover,
     },
 
     ':active': {
-      background: theme.colorTransparentBackgroundPressed,
-      borderColor: 'transparent',
+      backgroundColor: theme.colorTransparentBackgroundPressed,
+      ...shorthands.borderColor('transparent'),
       color: theme.colorNeutralForeground2BrandPressed,
     },
   }),
@@ -94,19 +94,19 @@ const useCheckedStyles = makeStyles({
 const useDisabledStyles = makeStyles({
   // Base styles
   base: theme => ({
-    background: theme.colorNeutralBackgroundDisabled,
-    borderColor: theme.colorNeutralStrokeDisabled,
+    backgroundColor: theme.colorNeutralBackgroundDisabled,
+    ...shorthands.borderColor(theme.colorNeutralStrokeDisabled),
     color: theme.colorNeutralForegroundDisabled,
 
     ':hover': {
-      background: theme.colorNeutralBackgroundDisabled,
-      borderColor: theme.colorNeutralStrokeDisabled,
+      backgroundColor: theme.colorNeutralBackgroundDisabled,
+      ...shorthands.borderColor(theme.colorNeutralStrokeDisabled),
       color: theme.colorNeutralForegroundDisabled,
     },
 
     ':active': {
-      background: theme.colorNeutralBackgroundDisabled,
-      borderColor: theme.colorNeutralStrokeDisabled,
+      backgroundColor: theme.colorNeutralBackgroundDisabled,
+      ...shorthands.borderColor(theme.colorNeutralStrokeDisabled),
       color: theme.colorNeutralForegroundDisabled,
     },
   }),
@@ -116,42 +116,42 @@ const useDisabledStyles = makeStyles({
     /* No styles */
   },
   primary: {
-    borderColor: 'transparent',
+    ...shorthands.borderColor('transparent'),
 
     ':hover': {
-      borderColor: 'transparent',
+      ...shorthands.borderColor('transparent'),
     },
 
     ':active': {
-      borderColor: 'transparent',
+      ...shorthands.borderColor('transparent'),
     },
   },
   subtle: {
-    background: 'none',
-    borderColor: 'transparent',
+    backgroundColor: 'transparent',
+    ...shorthands.borderColor('transparent'),
 
     ':hover': {
-      background: 'none',
-      borderColor: 'transparent',
+      backgroundColor: 'transparent',
+      ...shorthands.borderColor('transparent'),
     },
 
     ':active': {
-      background: 'none',
-      borderColor: 'transparent',
+      backgroundColor: 'transparent',
+      ...shorthands.borderColor('transparent'),
     },
   },
   transparent: {
-    background: 'none',
-    borderColor: 'transparent',
+    backgroundColor: 'transparent',
+    ...shorthands.borderColor('transparent'),
 
     ':hover': {
-      background: 'none',
-      borderColor: 'transparent',
+      backgroundColor: 'transparent',
+      ...shorthands.borderColor('transparent'),
     },
 
     ':active': {
-      background: 'none',
-      borderColor: 'transparent',
+      backgroundColor: 'transparent',
+      ...shorthands.borderColor('transparent'),
     },
   },
 });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: extracted from #20539, related to #20573
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR:
- updates styles to not use CSS shorthands
- removes `codesandbox-dependency` comment from stories