### PR TITLE
fix(react-image): update styles to not use CSS shorthands

### DIFF
--- a/change/@fluentui-react-image-f564a1b4-7542-42b2-b9aa-fa0421f9be5e.json
+++ b/change/@fluentui-react-image-f564a1b4-7542-42b2-b9aa-fa0421f9be5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update styles to not use CSS shorthands",
+  "packageName": "@fluentui/react-image",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-image/src/components/Image/useImageStyles.ts
+++ b/packages/react-image/src/components/Image/useImageStyles.ts
@@ -1,25 +1,25 @@
-import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
+import { shorthands, mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import type { ImageState } from './Image.types';
 
 export const imageClassName = 'fui-Image';
 
 const useStyles = makeStyles({
   root: theme => ({
-    borderColor: theme.colorNeutralStroke1,
-    borderRadius: theme.borderRadiusNone,
+    ...shorthands.borderColor(theme.colorNeutralStroke1),
+    ...shorthands.borderRadius(theme.borderRadiusNone),
 
     boxSizing: 'border-box',
     display: 'inline-block',
   }),
   rootBordered: theme => ({
-    borderStyle: 'solid',
-    borderWidth: theme.strokeWidthThin,
+    ...shorthands.borderStyle('solid'),
+    ...shorthands.borderWidth(theme.strokeWidthThin),
   }),
   rootCircular: theme => ({
-    borderRadius: theme.borderRadiusCircular,
+    ...shorthands.borderRadius(theme.borderRadiusCircular),
   }),
   rootRounded: theme => ({
-    borderRadius: theme.borderRadiusMedium,
+    ...shorthands.borderRadius(theme.borderRadiusMedium),
   }),
   rootShadow: theme => ({
     boxShadow: theme.shadow4,

--- a/packages/react-image/src/stories/ImageBlock.stories.tsx
+++ b/packages/react-image/src/stories/ImageBlock.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image } from '../Image'; // codesandbox-dependency: @fluentui/react-image ^9.0.0-beta
+import { Image } from '../Image';
 
 export const Block = () => (
   <>

--- a/packages/react-image/src/stories/ImageBordered.stories.tsx
+++ b/packages/react-image/src/stories/ImageBordered.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image } from '../Image'; // codesandbox-dependency: @fluentui/react-image ^9.0.0-beta
+import { Image } from '../Image';
 
 export const Bordered = () => (
   <div>

--- a/packages/react-image/src/stories/ImageDefault.stories.tsx
+++ b/packages/react-image/src/stories/ImageDefault.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import type { ImageProps } from '../Image'; // codesandbox-dependency: @fluentui/react-image ^9.0.0-beta
+import type { ImageProps } from '../Image';
 import type { ArgTypes, Parameters } from '@storybook/react';
-import { Image } from '../Image'; // codesandbox-dependency: @fluentui/react-image ^9.0.0-beta
+import { Image } from '../Image';
 
 export const Default = (props: ImageProps) => {
   return <Image {...props} />;

--- a/packages/react-image/src/stories/ImageFallback.stories.tsx
+++ b/packages/react-image/src/stories/ImageFallback.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image } from '../Image'; // codesandbox-dependency: @fluentui/react-image ^9.0.0-beta
+import { Image } from '../Image';
 
 export const Fallback = () => (
   <div style={{ display: 'flex', gap: 8 }}>

--- a/packages/react-image/src/stories/ImageFit.stories.tsx
+++ b/packages/react-image/src/stories/ImageFit.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image } from '../Image'; // codesandbox-dependency: @fluentui/react-image ^9.0.0-beta
+import { Image } from '../Image';
 
 export const Fit = () => (
   <>

--- a/packages/react-image/src/stories/ImageShadow.stories.tsx
+++ b/packages/react-image/src/stories/ImageShadow.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image } from '../Image'; // codesandbox-dependency: @fluentui/react-image ^9.0.0-beta
+import { Image } from '../Image';
 
 export const Shadow = () => <Image shadow src="https://via.placeholder.com/300x300" />;
 Shadow.parameters = {

--- a/packages/react-image/src/stories/ImageShape.stories.tsx
+++ b/packages/react-image/src/stories/ImageShape.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image } from '../Image'; // codesandbox-dependency: @fluentui/react-image ^9.0.0-beta
+import { Image } from '../Image';
 
 export const Shape = () => (
   <div style={{ display: 'flex', gap: 8 }}>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: extracted from #20539, related to #20573
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR:
- updates styles to not use CSS shorthands
- removes `codesandbox-dependency` comment from stories