### PR TITLE
fix(react-menu): update styles to not use CSS shorthands

### DIFF
--- a/change/@fluentui-react-menu-51a84edb-faf4-40ce-b165-89b7f4bfc088.json
+++ b/change/@fluentui-react-menu-51a84edb-faf4-40ce-b165-89b7f4bfc088.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update styles to not use CSS shorthands",
+  "packageName": "@fluentui/react-menu",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/src/components/MenuDivider/useMenuDividerStyles.ts
+++ b/packages/react-menu/src/components/MenuDivider/useMenuDividerStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
+import { shorthands, mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import type { MenuDividerState } from './MenuDivider.types';
 
 export const menuDividerClassName = 'fui-MenuDivider';
@@ -6,7 +6,7 @@ export const menuDividerClassName = 'fui-MenuDivider';
 const useStyles = makeStyles({
   root: theme => ({
     height: '1px',
-    margin: '4px -5px 4px -5px',
+    ...shorthands.margin('4px', '-5px', '4px', '-5px'),
     width: 'auto',
     backgroundColor: theme.colorNeutralStroke2,
   }),

--- a/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
+++ b/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
+import { mergeClasses, makeStyles, shorthands } from '@fluentui/react-make-styles';
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import type { MenuItemState } from './MenuItem.types';
 
@@ -7,7 +7,7 @@ export const menuItemClassName = 'fui-MenuItem';
 const useStyles = makeStyles({
   focusIndicator: theme => createFocusOutlineStyle(theme),
   root: theme => ({
-    borderRadius: theme.borderRadiusMedium,
+    ...shorthands.borderRadius(theme.borderRadiusMedium),
     position: 'relative',
     color: theme.colorNeutralForeground1,
     backgroundColor: theme.colorNeutralBackground1,
@@ -18,7 +18,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     fontSize: theme.fontSizeBase300,
     cursor: 'pointer',
-    gap: '4px',
+    ...shorthands.gap('4px'),
 
     ':hover': {
       backgroundColor: theme.colorNeutralBackground1Hover,

--- a/packages/react-menu/src/components/MenuList/useMenuListStyles.ts
+++ b/packages/react-menu/src/components/MenuList/useMenuListStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
+import { mergeClasses, makeStyles, shorthands } from '@fluentui/react-make-styles';
 import type { MenuListState } from './MenuList.types';
 
 export const menuListClassName = 'fui-MenuList';
@@ -7,7 +7,7 @@ const useStyles = makeStyles({
   root: {
     display: 'flex',
     flexDirection: 'column',
-    gap: '2px',
+    ...shorthands.gap('2px'),
   },
 });
 

--- a/packages/react-menu/src/components/MenuPopover/useMenuPopoverStyles.ts
+++ b/packages/react-menu/src/components/MenuPopover/useMenuPopoverStyles.ts
@@ -1,18 +1,18 @@
-import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
+import { shorthands, mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import type { MenuPopoverState } from './MenuPopover.types';
 
 export const menuPopoverClassName = 'fui-MenuPopover';
 
 const useStyles = makeStyles({
   root: theme => ({
-    borderRadius: theme.borderRadiusMedium,
+    ...shorthands.borderRadius(theme.borderRadiusMedium),
     backgroundColor: theme.colorNeutralBackground1,
     minWidth: '128px',
     maxWidth: '300px',
     width: 'max-content',
     boxShadow: `${theme.shadow16}`,
-    padding: '4px',
-    border: `1px solid ${theme.colorTransparentStroke}`,
+    ...shorthands.padding('4px'),
+    ...shorthands.border('1px', 'solid', theme.colorTransparentStroke),
   }),
 });
 

--- a/packages/react-menu/src/stories/MenuCustomTrigger.stories.tsx
+++ b/packages/react-menu/src/stories/MenuCustomTrigger.stories.tsx
@@ -1,16 +1,7 @@
 import * as React from 'react';
-
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuTriggerChildProps } from '../index';
-
 import { Button } from '@fluentui/react-button';
 
-// FIXME need to redeclare types since type import is under a @ts-ignore
-type MenuOpenEvents =
-  | MouseEvent
-  | TouchEvent
-  | React.MouseEvent<HTMLElement>
-  | React.KeyboardEvent<HTMLElement>
-  | React.FocusEvent<HTMLElement>;
+import { Menu, MenuProps, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuTriggerChildProps } from '../index';
 
 const CustomMenuTrigger = React.forwardRef<HTMLButtonElement, Partial<MenuTriggerChildProps>>((props, ref) => {
   return (
@@ -22,7 +13,7 @@ const CustomMenuTrigger = React.forwardRef<HTMLButtonElement, Partial<MenuTrigge
 
 export const CustomTrigger = () => {
   const [open, setOpen] = React.useState(false);
-  const onOpenChange = (e: MenuOpenEvents, data: { open: boolean }) => {
+  const onOpenChange: MenuProps['onOpenChange'] = (e, data) => {
     setOpen(data.open);
   };
 

--- a/packages/react-menu/src/stories/MenuInteraction.stories.tsx
+++ b/packages/react-menu/src/stories/MenuInteraction.stories.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
+import { Button } from '@fluentui/react-button';
+import { makeStyles, shorthands } from '@fluentui/react-make-styles';
 
 import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuProps } from '../index';
-
-import { Button } from '@fluentui/react-button';
-
-import { makeStyles } from '@fluentui/react-make-styles';
 
 const useStyles = makeStyles({
   container: {
     display: 'flex',
-    gap: '10px',
+    ...shorthands.gap('10px'),
   },
 
   indicator: {

--- a/packages/react-menu/src/stories/MenuRenderFunctionTrigger.stories.tsx
+++ b/packages/react-menu/src/stories/MenuRenderFunctionTrigger.stories.tsx
@@ -1,21 +1,13 @@
 import * as React from 'react';
 import { ChevronDown16Regular } from '@fluentui/react-icons';
 
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuTriggerChildProps } from '../index';
-
-// FIXME need to redeclare types since type import is under a @ts-ignore
-type MenuOpenEvents =
-  | MouseEvent
-  | TouchEvent
-  | React.MouseEvent<HTMLElement>
-  | React.KeyboardEvent<HTMLElement>
-  | React.FocusEvent<HTMLElement>;
+import { Menu, MenuProps, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuTriggerChildProps } from '../index';
 
 const buttonStyle = { height: 22, verticalAlign: 'middle' };
 
 export const RenderFunctionTrigger = () => {
   const [open, setOpen] = React.useState(false);
-  const onOpenChange = (e: MenuOpenEvents, data: { open: boolean }) => {
+  const onOpenChange: MenuProps['onOpenChange'] = (e, data) => {
     setOpen(data.open);
   };
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: extracted from #20539, related to #20573
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR:
- updates styles to not use CSS shorthands
- cleanups TODOs in stories