### PR TITLE
fix: restore missing exports in v8

### DIFF
--- a/change/@fluentui-react-e62b6d7b-78cd-4608-875d-64734092f5fb.json
+++ b/change/@fluentui-react-e62b6d7b-78cd-4608-875d-64734092f5fb.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "restore exports for CommunicationColors, NeutralColors & SharedColors",
   "packageName": "@fluentui/react",
   "email": "olfedias@microsoft.com",

--- a/change/@fluentui-react-e62b6d7b-78cd-4608-875d-64734092f5fb.json
+++ b/change/@fluentui-react-e62b6d7b-78cd-4608-875d-64734092f5fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "restore exports for CommunicationColors, NeutralColors & SharedColors",
+  "packageName": "@fluentui/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -34,6 +34,7 @@ import { classNamesFunction } from '@fluentui/utilities';
 import { colGroupProperties } from '@fluentui/utilities';
 import { ColorClassNames } from '@fluentui/style-utilities';
 import { colProperties } from '@fluentui/utilities';
+import { CommunicationColors } from '@fluentui/theme';
 import { compareDatePart } from '@fluentui/date-time-utilities/lib/dateMath/dateMath';
 import { compareDates } from '@fluentui/date-time-utilities/lib/dateMath/dateMath';
 import { ComponentsStyles } from '@fluentui/theme';
@@ -281,6 +282,7 @@ import { mergeStyleSets } from '@fluentui/style-utilities';
 import { mergeThemes } from '@fluentui/theme';
 import { modalize } from '@fluentui/utilities';
 import { MonthOfYear } from '@fluentui/date-time-utilities/lib/dateValues/dateValues';
+import { NeutralColors } from '@fluentui/theme';
 import { normalize } from '@fluentui/style-utilities';
 import { noWrap } from '@fluentui/style-utilities';
 import { nullRender } from '@fluentui/utilities';
@@ -342,6 +344,7 @@ import { SettingsFunction } from '@fluentui/utilities';
 import { setVirtualParent } from '@fluentui/utilities';
 import { setWarningCallback } from '@fluentui/utilities';
 import { shallowCompare } from '@fluentui/utilities';
+import { SharedColors } from '@fluentui/theme';
 import { shouldWrapFocus } from '@fluentui/utilities';
 import { styled } from '@fluentui/utilities';
 import { StyleFunction } from '@fluentui/utilities';
@@ -1018,6 +1021,8 @@ export class CommandBarButton extends React_2.Component<IButtonProps, {}> {
 
 // @public (undocumented)
 export const CommandButton: typeof ActionButton;
+
+export { CommunicationColors }
 
 // @public (undocumented)
 export const CompactPeoplePicker: React_2.FunctionComponent<IPeoplePickerProps>;
@@ -9664,6 +9669,8 @@ export class NavBase extends React_2.Component<INavProps, INavState> implements 
     get selectedKey(): string | undefined;
 }
 
+export { NeutralColors }
+
 export { normalize }
 
 // @public (undocumented)
@@ -10381,6 +10388,8 @@ export enum Shade {
 }
 
 export { shallowCompare }
+
+export { SharedColors }
 
 // @public (undocumented)
 export const Shimmer: React_2.FunctionComponent<IShimmerProps>;

--- a/packages/react/src/Theme.ts
+++ b/packages/react/src/Theme.ts
@@ -1,6 +1,7 @@
 export {
   AnimationStyles,
   AnimationVariables,
+  CommunicationColors,
   DefaultEffects,
   DefaultFontStyles,
   DefaultPalette,
@@ -10,6 +11,8 @@ export {
   createFontStyles,
   createTheme,
   mergeThemes,
+  NeutralColors,
+  SharedColors,
   registerDefaultFontFaces,
 } from '@fluentui/theme';
 export type {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20822
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In #20665 we went away from `export *` everywhere, but unfortunately lost few re-exports and it's an unexpected breaking change 💥

```sh
# Before
PS office-ui-fabric-react> node 1.js
undefined

# After
PS office-ui-fabric-react> node 1.js
{
  black: '#000000',
  gray220: '#11100f',
}
```