### PR TITLE
Input: Change fieldSize prop name back to size

### DIFF
--- a/change/@fluentui-react-conformance-22f06fc8-ab9b-441d-930e-1131d6665e17.json
+++ b/change/@fluentui-react-conformance-22f06fc8-ab9b-441d-930e-1131d6665e17.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add test preventing accidental application of native size prop",
+  "packageName": "@fluentui/react-conformance",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-conformance/src/defaultErrorMessages.tsx
+++ b/packages/react-conformance/src/defaultErrorMessages.tsx
@@ -245,6 +245,36 @@ export const defaultErrorMessages = {
     });
   },
 
+  'omits-size-prop': (testInfo: IsConformantOptions, error: Error, sizeValue: string, appliedToElement: Element) => {
+    const { displayName } = testInfo;
+    const { resolveInfo, testErrorName } = errorMessageColors;
+
+    // Message Description: Handles scenario where a component defines a custom 'size' prop but also
+    // applies 'size' as a native prop. (See the comment on the test definition for more background.)
+    //
+    // It appears that "displayName" has a custom 'size' prop but also applies 'size' as a native prop.
+    // After passing 'size="sizeValue"' to "displayName" it was applied to this element:
+    // <html here>
+    //
+    // Possible solutions:
+    // 1. Make sure that your component accepts a className prop.
+    // 2. Make sure that nothing is overwriting the className prop (it should be merged with defaults).
+    // 3. Make sure that your component is applying the className to the root.
+    return getErrorMessage({
+      displayName,
+      overview: `has a custom 'size' prop but also applies 'size' as a native prop.`,
+      details: [
+        `After passing 'size="${sizeValue}"' to ${testErrorName(displayName)} it was applied to this element:`,
+        appliedToElement.outerHTML,
+      ],
+      suggestions: [
+        `Ensure 'size' is omitted when calling native props helpers.`,
+        `If native 'size' functionality is needed, add an ${resolveInfo('htmlSize')} prop.`,
+      ],
+      error,
+    });
+  },
+
   'component-handles-classname': (
     testInfo: IsConformantOptions,
     error: Error,

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -189,6 +189,7 @@ export const defaultTests: TestObject = {
       const mergedProps = {
         ...requiredProps,
         size,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any; // we know the size prop is supported but there's not a good way to derive the actual type
 
       const el = customMount(<Component {...mergedProps} />);

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -157,6 +157,52 @@ export const defaultTests: TestObject = {
     });
   },
 
+  /**
+   * Component does not apply `size` as a native prop when a custom version is defined.
+   *
+   * Background: `input` and `select` support a `size` prop which is not very useful
+   * (https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size).
+   * Since we don't anticipate ever needing this functionality, and we often want to use the prop name
+   * `size` to refer to visual size (like small/medium/large), we want to ensure that components defining
+   * a custom `size` prop don't also apply it as a native prop by accident.
+   *
+   * (In the extremely unlikely event that someone has a compelling need for the native functionality
+   * in the future, it can be added under an `htmlSize` prop.)
+   */
+  'omits-size-prop': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
+    const sizeType = componentInfo.props.size?.type?.name;
+    if (!sizeType || componentInfo.props.htmlSize) {
+      return;
+    }
+    // if the size prop is defined, type.name will probably be 'string | undefined'
+    // or something like '"small" | "medium" | "large" | undefined'
+    const sizeIsString = /\bstring\b/.test(sizeType);
+    const sizeLiteralMatch = sizeType.match(/"(.*?)"/);
+    if (!sizeIsString || sizeLiteralMatch) {
+      return; // not a format we know how to test
+    }
+
+    it(`does not apply native size prop if custom one is defined (omits-size-prop)`, () => {
+      const { customMount = mount, Component, requiredProps, helperComponents = [], wrapperComponent } = testInfo;
+
+      const size = sizeLiteralMatch?.[1] || 'foo';
+      const mergedProps = {
+        ...requiredProps,
+        size,
+      } as any; // we know the size prop is supported but there's not a good way to derive the actual type
+
+      const el = customMount(<Component {...mergedProps} />);
+      const component = getComponent(el, helperComponents, wrapperComponent);
+      const elementWithSize = component.getDOMNode().querySelector('[size]');
+
+      try {
+        expect(elementWithSize).toBeFalsy();
+      } catch (e) {
+        throw new Error(defaultErrorMessages['omits-size-prop'](testInfo, e, size, elementWithSize!));
+      }
+    });
+  },
+
   /** Component file handles classname prop */
   'component-handles-classname': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
     const { Component, wrapperComponent, helperComponents = [], requiredProps, customMount = mount } = testInfo;

--- a/packages/react-input/Spec.md
+++ b/packages/react-input/Spec.md
@@ -101,7 +101,7 @@ export type InputCommons = FieldSizeProps & {
 };
 ```
 
-`size` [overlaps with a native prop](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size) which sets the width of the field in "number of characters." This isn't ideal, but we're going with it since the native prop isn't very useful in practice, and it was hard to find another reasonable/consistent name for the visual size prop. (If anyone needs the native functionality, we could add an `htmlSize` prop in the future.)
+`size` [overlaps with a native prop](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size) which sets the width of the field in "number of characters." This isn't ideal, but we're going with it since the native prop isn't very useful in practice, and it was hard to find another reasonable/consistent name for the visual size prop. It's also consistent with the approach used by most other libraries which have a prop for setting the visual size. (If anyone needs the native functionality, we could add an `htmlSize` prop in the future.)
 
 ### Slots
 

--- a/packages/react-input/Spec.md
+++ b/packages/react-input/Spec.md
@@ -92,42 +92,16 @@ export type InputCommons = FieldSizeProps & {
    * @default 'outline'
    */
   appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
-};
-```
 
-### Field sizing
-
-This should be common between most types of fields.
-
-```ts
-export type FieldSize = 'small' | 'medium' | 'large';
-
-export type FieldSizeProps = {
   /**
    * Size of the input (changes the font size and spacing).
    * @default 'medium'
    */
-  // NOTE: can't use `size` as the name due to overlap with a native input prop
-  // (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attributes)
-  fieldSize?: FieldSize;
+  size?: 'small' | 'medium' | 'large';
 };
 ```
 
-```ts
-export const fieldHeights = {
-  small: '24px',
-  medium: '32px',
-  large: '40px',
-};
-
-export const useFieldSizeStyles = makeStyles({
-  small: theme => ({
-    // font sizes, height
-  }),
-  medium: theme => ({}),
-  large: theme => ({}),
-});
-```
+`size` [overlaps with a native prop](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size) which sets the width of the field in "number of characters." This isn't ideal, but we're going with it since the native prop isn't very useful in practice, and it was hard to find another reasonable/consistent name for the visual size prop. (If anyone needs the native functionality, we could add an `htmlSize` prop in the future.)
 
 ### Slots
 

--- a/packages/react-input/etc/react-input.api.md
+++ b/packages/react-input/etc/react-input.api.md
@@ -18,7 +18,7 @@ export const inputClassName = "fui-Input";
 
 // @public (undocumented)
 export type InputCommons = {
-    fieldSize?: 'small' | 'medium' | 'large';
+    size?: 'small' | 'medium' | 'large';
     inline?: boolean;
     appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
 };
@@ -32,7 +32,7 @@ export const inputShorthandProps: (keyof InputSlots)[];
 // @public (undocumented)
 export type InputSlots = {
     root: IntrinsicShorthandProps<'span'>;
-    input: IntrinsicShorthandProps<'input'>;
+    input: Omit<IntrinsicShorthandProps<'input'>, 'size'>;
     contentBefore?: IntrinsicShorthandProps<'span'>;
     contentAfter?: IntrinsicShorthandProps<'span'>;
 };

--- a/packages/react-input/src/components/Input/Input.stories.tsx
+++ b/packages/react-input/src/components/Input/Input.stories.tsx
@@ -36,15 +36,15 @@ export const InputExamples = (
   const inputId1 = useId();
   // pass native input props to the internal input element and custom props to the root
   const { storyFilledBackground, ...rest } = args;
-  const inputProps = getNativeElementProps('input', rest);
+  const inputProps = getNativeElementProps('input', rest, ['size']);
   const props: Partial<InputProps> = { input: inputProps };
   for (const prop of Object.keys(rest) as (keyof InputProps)[]) {
     if (!(inputProps as Partial<InputProps>)[prop]) {
       props[prop] = rest[prop];
     }
   }
-  const SearchIcon = icons.search[props.fieldSize!];
-  const DismissIcon = icons.dismiss[props.fieldSize!];
+  const SearchIcon = icons.search[props.size!];
+  const DismissIcon = icons.dismiss[props.size!];
 
   return (
     <div className={mergeClasses(styles.container, storyFilledBackground && styles.storyFilledBackground)}>
@@ -83,7 +83,7 @@ export const InputExamples = (
 };
 
 const argTypes: ArgTypes = {
-  fieldSize: { defaultValue: 'medium', control: { type: 'radio', options: ['small', 'medium', 'large'] } },
+  size: { defaultValue: 'medium', control: { type: 'radio', options: ['small', 'medium', 'large'] } },
   appearance: {
     defaultValue: 'outline',
     control: { type: 'radio', options: ['filledDarker', 'filledLighter', 'underline', 'outline'] },

--- a/packages/react-input/src/components/Input/Input.types.ts
+++ b/packages/react-input/src/components/Input/Input.types.ts
@@ -12,7 +12,7 @@ export type InputSlots = {
    * This is the "primary" slot, so top-level native props (except `className` and `style`) and the
    * top-level `ref` will go here.
    */
-  input: IntrinsicShorthandProps<'input'>;
+  input: Omit<IntrinsicShorthandProps<'input'>, 'size'>;
 
   /** Element before the input text, within the input border */
   contentBefore?: IntrinsicShorthandProps<'span'>;
@@ -26,9 +26,10 @@ export type InputCommons = {
    * Size of the input (changes the font size and spacing).
    * @default 'medium'
    */
-  // NOTE: can't use `size` as the name due to overlap with a native input prop :(
-  // (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attributes)
-  fieldSize?: 'small' | 'medium' | 'large';
+  // This name overlaps with the native `size` prop, but that prop isn't very useful in practice
+  // (we could add `htmlSize` for the native functionality if someone needs it)
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size
+  size?: 'small' | 'medium' | 'large';
 
   /**
    * If true, the field will have inline display, allowing it be used within text content.

--- a/packages/react-input/src/components/Input/useInput.ts
+++ b/packages/react-input/src/components/Input/useInput.ts
@@ -17,10 +17,10 @@ export const inputShorthandProps: (keyof InputSlots)[] = ['input', 'contentBefor
  * @param ref - reference to root HTMLInputElement of Input
  */
 export const useInput = (props: InputProps, ref: React.Ref<HTMLElement>): InputState => {
-  const { input, contentAfter, contentBefore, fieldSize, appearance, inline } = props;
+  const { input, contentAfter, contentBefore, size, appearance, inline } = props;
 
   return {
-    fieldSize,
+    size,
     appearance,
     inline,
     components: {

--- a/packages/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-input/src/components/Input/useInputStyles.ts
@@ -147,7 +147,7 @@ const useContentStyles = makeStyles({
  * Apply styling to the Input slots based on the state
  */
 export const useInputStyles = (state: InputState): InputState => {
-  const { fieldSize = 'medium', appearance = 'outline' } = state;
+  const { size = 'medium', appearance = 'outline' } = state;
   const disabled = state.input.disabled;
   const filled = appearance.startsWith('filled');
 
@@ -158,7 +158,7 @@ export const useInputStyles = (state: InputState): InputState => {
   state.root.className = mergeClasses(
     inputClassName,
     rootStyles.base,
-    rootStyles[fieldSize],
+    rootStyles[size],
     rootStyles[appearance],
     state.inline && rootStyles.inline,
     filled && rootStyles.filled,
@@ -168,7 +168,7 @@ export const useInputStyles = (state: InputState): InputState => {
 
   state.input.className = mergeClasses(
     inputStyles.base,
-    inputStyles[fieldSize],
+    inputStyles[size],
     disabled && inputStyles.disabled,
     state.input.className,
   );


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: part of #18131, #20159
- [x] Include a change request file using `$ yarn change`

#### Description of changes

After a discussion in the input sync, we decided to change the name of `Input`'s `fieldSize` prop back to `size` for consistency across all components. 

`size` [overlaps with a native prop](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size) which sets the width of the field in "number of characters." This isn't ideal, but we're going with it since the native prop isn't very useful in practice, and it was hard to find another reasonable/consistent name for the visual size prop. (If anyone needs the native functionality, we could add an `htmlSize` prop in the future.)

Also includes a test to prevent application of `size` as a native prop.