### PR TITLE
fix(codemods): Remove v9 make-styles dependency

### DIFF
--- a/change/@fluentui-codemods-c84885d7-44fa-4817-9bdb-34a26522cf13.json
+++ b/change/@fluentui-codemods-c84885d7-44fa-4817-9bdb-34a26522cf13.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Remove v9 make-styles dependency",
   "packageName": "@fluentui/codemods",
   "email": "lingfangao@hotmail.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@fluentui-codemods-c84885d7-44fa-4817-9bdb-34a26522cf13.json
+++ b/change/@fluentui-codemods-c84885d7-44fa-4817-9bdb-34a26522cf13.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove v9 make-styles dependency",
+  "packageName": "@fluentui/codemods",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/make-styles": "9.0.0-beta.3",
     "@fluentui/scripts": "^1.0.0",
     "@types/react": "16.9.42"
   },

--- a/packages/codemods/src/codeMods/tests/mock/v9/mMakeStylesDeep.ts
+++ b/packages/codemods/src/codeMods/tests/mock/v9/mMakeStylesDeep.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { makeStyles } from '@fluentui/react-make-styles';
+const makeStyles = () => null;
 
 export const useStylesA = makeStyles({
   neutral: theme => ({

--- a/packages/codemods/src/codeMods/tests/v9ThemeFlattening/v9ThemeFlattening.test.ts
+++ b/packages/codemods/src/codeMods/tests/v9ThemeFlattening/v9ThemeFlattening.test.ts
@@ -14,7 +14,7 @@ describe('v9: Theme flattening', () => {
     v9ThemeFlattening.run(file);
 
     expect(file.getText()).toMatchInlineSnapshot(`
-      "import { makeStyles } from '@fluentui/react-make-styles';
+      "const makeStyles = () => null;
 
       export const useStylesA = makeStyles({
         neutral: theme => ({


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20835
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Refactors the current test to not require an import from v9. The import itself is actually not important to the test.

#### Focus areas to test

(optional)
