### PR TITLE
Combobox(v7): adds check so it cannot be opened if disabled

### DIFF
--- a/change/office-ui-fabric-react-5820edc7-b4f7-4378-bd2e-5b207c0da688.json
+++ b/change/office-ui-fabric-react-5820edc7-b4f7-4378-bd2e-5b207c0da688.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added check for disabled prop",
+  "packageName": "office-ui-fabric-react",
+  "email": "tkrasniqi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -468,6 +468,16 @@ describe('ComboBox', () => {
     expect(comboBoxRoot.find('.is-opened').length).toEqual(0);
   });
 
+  it('Cannot expand the menu when focused with a button while combobox is disabled', () => {
+    const comboBoxRef = React.createRef<any>();
+    wrapper = mount(
+      <ComboBox defaultSelectedKey="1" options={DEFAULT_OPTIONS2} componentRef={comboBoxRef} disabled={true} />,
+    );
+
+    comboBoxRef.current?.focus(true);
+    expect((comboBoxRef.current as ComboBox).state.isOpen).toEqual(false);
+  });
+
   it('Call onMenuOpened when clicking on the button', () => {
     const onMenuOpenMock = jest.fn();
 

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -437,6 +437,10 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
    * {@inheritdoc}
    */
   public focus = (shouldOpenOnFocus?: boolean, useFocusAsync?: boolean): void => {
+    if (this.props.disabled === true) {
+      return;
+    }
+
     if (this._autofill.current) {
       if (useFocusAsync) {
         focusAsync(this._autofill.current);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17955
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Adds a check so that the combobox cannot be opened if it is disabled (either focused)
- Adds a unit test for this case