### PR TITLE
fix: Housekeeping workflow - Add missing permissions

### DIFF
--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -2,6 +2,10 @@ name: Pull request houskeeping 🧹
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Pull request checklist

- [ ] ~Addresses an existing issue: Fixes #0000~
- [ ] ~Include a change request file using `$ yarn change`~

#### Description of changes

Due to testing this in a non restrictive permission environment, I forgot to add the needed permissions to allow for editing the PR (so the action can add the label).
This PR adds said needed perms to the GITHUB_TOKEN.
