### PR TITLE
fix(react-northstar): use native ARIA props

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -57,6 +57,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Chat` components to properly pass ref to root slots @chpalac ([#20691](https://github.com/microsoft/fluentui/pull/20691))
 - Fix `Flex` component to properly pass ref to root slots @chpalac ([#20752](https://github.com/microsoft/fluentui/pull/20752))
 - Fix `Animation` to expose `Transition` state for the consumer @chpalac ([#20776](https://github.com/microsoft/fluentui/pull/20776))
+- Fix `MenuItemIcon` to allow icon `size` to be in effect @yuanboxue-amber ([#20803](https://github.com/microsoft/fluentui/pull/20803))
 
 ### Features
 - Adding `ViewPersonSparkleIcon`, `CartIcon`, and fixing `EmojiAddIcon` and `AccessibilityIcon` - @notandrew ([#20054](https://github.com/microsoft/fluentui/pull/20054))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### BREAKING CHANGES
 - fix(Accordion) Render divs instead of dd and dt elements for Accordion and AccordionTitle @jurokapsiar ([#20773](https://github.com/microsoft/fluentui/pull/20773))
+- Carousels uses native ARIA props @layershifter ([#20773](https://github.com/microsoft/fluentui/pull/20773))
 
 ### Fixes
 - Fix aria-labelledby passed to `DropdownSearchInput` @chpalac ([#20312](https://github.com/microsoft/fluentui/pull/20312))

--- a/packages/fluentui/accessibility/src/behaviors/Carousel/carouselBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Carousel/carouselBehavior.ts
@@ -27,8 +27,8 @@ export const carouselBehavior: Accessibility<CarouselBehaviorProps> = props => (
     root: {
       ...(!props.navigation && {
         role: 'region',
-        'aria-roledescription': props.ariaRoleDescription,
-        'aria-label': props.ariaLabel,
+        'aria-roledescription': props['aria-roledescription'],
+        'aria-label': props['aria-label'],
       }),
     },
     itemsContainerWrapper: {
@@ -36,7 +36,7 @@ export const carouselBehavior: Accessibility<CarouselBehaviorProps> = props => (
     },
     itemsContainer: {
       ...(props.navigation
-        ? { role: 'region', 'aria-roledescription': props.ariaRoleDescription, 'aria-label': props.ariaLabel }
+        ? { role: 'region', 'aria-roledescription': props['aria-roledescription'], 'aria-label': props['aria-label'] }
         : { tabIndex: -1, role: 'none' }),
     },
 
@@ -80,6 +80,6 @@ export type CarouselBehaviorProps = {
   /** Element type. */
   navigation: Object | Object[];
   ariaLiveOn: boolean;
-  ariaRoleDescription?: string;
-  ariaLabel?: string;
+  'aria-roledescription'?: string;
+  'aria-label'?: string;
 };

--- a/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
@@ -23,7 +23,7 @@ describe('carouselBehavior.ts', () => {
       const expectedResult = carouselBehavior({
         ariaLiveOn: false,
         navigation: false,
-        ariaLabel: label,
+        'aria-label': label,
       });
       expect(expectedResult.attributes.root['aria-label']).toEqual(label);
     });
@@ -33,7 +33,7 @@ describe('carouselBehavior.ts', () => {
         ariaLiveOn: false,
         navigation: true,
         'aria-roledescription': roleDescription,
-        ariaLabel: label,
+        'aria-label': label,
       });
       expect(expectedResult.attributes.root['aria-roledescription']).toBeUndefined();
       expect(expectedResult.attributes.root['aria-label']).toBeUndefined();

--- a/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
@@ -14,7 +14,7 @@ describe('carouselBehavior.ts', () => {
       const expectedResult = carouselBehavior({
         ariaLiveOn: false,
         navigation: false,
-        ariaRoleDescription: roleDescription,
+        'aria-roledescription': roleDescription,
       });
       expect(expectedResult.attributes.root['aria-roledescription']).toEqual(roleDescription);
     });
@@ -32,7 +32,7 @@ describe('carouselBehavior.ts', () => {
       const expectedResult = carouselBehavior({
         ariaLiveOn: false,
         navigation: true,
-        ariaRoleDescription: roleDescription,
+        'aria-roledescription': roleDescription,
         ariaLabel: label,
       });
       expect(expectedResult.attributes.root['aria-roledescription']).toBeUndefined();
@@ -51,7 +51,7 @@ describe('carouselBehavior.ts', () => {
       const expectedResult = carouselBehavior({
         ariaLiveOn: false,
         navigation: true,
-        ariaRoleDescription: roleDescription,
+        'aria-roledescription': roleDescription,
       });
       expect(expectedResult.attributes.itemsContainer['aria-roledescription']).toEqual(roleDescription);
     });
@@ -60,7 +60,7 @@ describe('carouselBehavior.ts', () => {
       const expectedResult = carouselBehavior({
         ariaLiveOn: false,
         navigation: true,
-        ariaLabel: label,
+        'aria-label': label,
       });
       expect(expectedResult.attributes.itemsContainer['aria-label']).toEqual(label);
     });
@@ -69,8 +69,8 @@ describe('carouselBehavior.ts', () => {
       const expectedResult = carouselBehavior({
         ariaLiveOn: false,
         navigation: false,
-        ariaRoleDescription: roleDescription,
-        ariaLabel: label,
+        'aria-roledescription': roleDescription,
+        'aria-label': label,
       });
       expect(expectedResult.attributes.itemsContainer['aria-roledescription']).toBeUndefined();
       expect(expectedResult.attributes.itemsContainer['aria-label']).toBeUndefined();

--- a/packages/fluentui/docs/src/examples/components/Carousel/BestPractices/CarouselBestPractices.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/BestPractices/CarouselBestPractices.tsx
@@ -10,8 +10,8 @@ const doList = [
     {link('reported issue', 'https://bugs.chromium.org/p/chromium/issues/detail?id=1040924')} for details).
   </Text>,
   'Provide localized string for items positioning using `getItemPositionText` prop.',
-  'Provide localized string of the "carousel" using `ariaRoleDescription` prop.',
-  'Provide label to the carousel using `ariaLabel` prop.',
+  'Provide localized string of the "carousel" using `aria-roledescription` prop.',
+  'Provide label to the carousel using `aria-label` prop.',
   <Box>
     If carousel contains `navigation`:
     <ul>

--- a/packages/fluentui/docs/src/examples/components/Carousel/Types/CarouselExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Types/CarouselExample.shorthand.tsx
@@ -60,8 +60,8 @@ const carouselItems = [
 
 const CarouselExample = () => (
   <Carousel
-    ariaRoleDescription="carousel"
-    ariaLabel="Portrait collection"
+    aria-roledescription="carousel"
+    aria-label="Portrait collection"
     navigation={{
       'aria-label': 'people portraits',
       items: carouselItems.map((item, index) => ({

--- a/packages/fluentui/docs/src/examples/components/Carousel/Types/CarouselPaginationExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Types/CarouselPaginationExample.shorthand.tsx
@@ -46,8 +46,8 @@ const carouselItems = [
 
 const CarouselExample = () => (
   <Carousel
-    ariaRoleDescription="carousel"
-    ariaLabel="Portrait collection"
+    aria-roledescription="carousel"
+    aria-label="Portrait collection"
     items={carouselItems}
     paddleNext={{ 'aria-label': 'go to next slide' }}
     paddlePrevious={{ 'aria-label': 'go to previous slide' }}

--- a/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselCircularExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselCircularExample.shorthand.tsx
@@ -57,8 +57,8 @@ const carouselItems = [
 const CarouselExample = () => (
   <Carousel
     circular
-    ariaRoleDescription="carousel"
-    ariaLabel="Portrait collection"
+    aria-roledescription="carousel"
+    aria-label="Portrait collection"
     navigation={{
       'aria-label': 'people portraits',
       items: carouselItems.map((item, index) => ({

--- a/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselExampleWithFocusableElements.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselExampleWithFocusableElements.tsx
@@ -118,7 +118,7 @@ const carouselItems = [
 
 const CarouselExample = () => (
   <Carousel
-    ariaRoleDescription="carousel"
+    aria-roledescription="carousel"
     navigation={{
       'aria-label': 'people cards',
       items: carouselItems.map((item, index) => ({

--- a/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselThumbnailsExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselThumbnailsExample.shorthand.tsx
@@ -126,8 +126,8 @@ const carouselItems = [
 
 const CarouselExample = () => (
   <Carousel
-    ariaRoleDescription="carousel"
-    ariaLabel="Portrait collection"
+    aria-roledescription="carousel"
+    aria-label="Portrait collection"
     thumbnails
     navigation={{
       'aria-label': 'people portraits',

--- a/packages/fluentui/e2e/tests/carouselClickableContent-example.tsx
+++ b/packages/fluentui/e2e/tests/carouselClickableContent-example.tsx
@@ -41,7 +41,7 @@ const CarouselClickableContentExample = () => {
           })),
         }}
         className={selectors.CarouselClass}
-        ariaRoleDescription="carousel"
+        aria-roledescription="carousel"
         items={carouselItems}
       />
     </>

--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -58,12 +58,12 @@ export interface CarouselProps extends UIComponentProps, ChildrenComponentProps 
   /**
    * Sets the aria-roledescription attribute.
    */
-  ariaRoleDescription?: string;
+  'aria-roledescription'?: string;
 
   /**
    * Sets the aria-label attribute for carousel.
    */
-  ariaLabel?: string;
+  'aria-label'?: string;
 
   /** Specifies if the process of switching slides is circular. */
   circular?: boolean;
@@ -150,8 +150,8 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
     navigation,
     thumbnails,
     children,
-    ariaRoleDescription,
-    ariaLabel,
+    'aria-roledescription': ariaRoleDescription,
+    'aria-label': ariaLabel,
     className,
     design,
     styles,
@@ -205,8 +205,8 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
     mapPropsToBehavior: () => ({
       navigation,
       ariaLiveOn,
-      ariaRoleDescription,
-      ariaLabel,
+      'aria-roledescription': ariaRoleDescription,
+      'aria-label': ariaLabel,
     }),
   });
 
@@ -501,8 +501,8 @@ Carousel.propTypes = {
     content: false,
   }),
   activeIndex: PropTypes.number,
-  ariaRoleDescription: PropTypes.string,
-  ariaLabel: PropTypes.string,
+  'aria-roledescription': PropTypes.string,
+  'aria-label': PropTypes.string,
   circular: PropTypes.bool,
   defaultActiveIndex: PropTypes.number,
   getItemPositionText: PropTypes.func,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemIconStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemIconStyles.ts
@@ -14,10 +14,6 @@ export const menuItemIconStyles: ComponentSlotStylesPrepared<MenuItemIconStylesP
     '& > :first-child': {
       height: '100%',
       width: '100%',
-      '& svg': {
-        height: '100%',
-        width: '100%',
-      },
     },
 
     ...(p.hasContent && {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12703
- [x] ~~Include a change request file using `$ yarn change`~~

## BREAKING CHANGES

We initially should use native ARIA props, but somehow we overlooked this 🙉

### Before

```tsx
<Carousel ariaRoleDescription="carousel" ariaLabel="Portrait collection" />
```

### After

```tsx
<Carousel aria-roledescription="carousel" aria-label="Portrait collection" />
```
