### PR TITLE
fix(Popup): remove unsupported styling props

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - fix(Accordion) Render divs instead of dd and dt elements for Accordion and AccordionTitle @jurokapsiar ([#20773](https://github.com/microsoft/fluentui/pull/20773))
 
 ### Fixes
+- Remove unsupported styling props in `Popup` @layershifter ([#20312](https://github.com/microsoft/fluentui/pull/20312))
 - Fix aria-labelledby passed to `DropdownSearchInput` @chpalac ([#20312](https://github.com/microsoft/fluentui/pull/20312))
 - Fix `preventFocusRestoration` in `FocusZone` @chpalac ([#20328](https://github.com/microsoft/fluentui/pull/20328))
 - `Popup` should not dismiss when its iframe content is focused @ling1726 ([#19955](https://github.com/microsoft/fluentui/pull/19955))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - fix(Accordion) Render divs instead of dd and dt elements for Accordion and AccordionTitle @jurokapsiar ([#20773](https://github.com/microsoft/fluentui/pull/20773))
 
 ### Fixes
-- Remove unsupported styling props in `Popup` @layershifter ([#20312](https://github.com/microsoft/fluentui/pull/20312))
+- Remove unsupported styling props in `Popup` @layershifter ([#20853](https://github.com/microsoft/fluentui/pull/20853))
 - Fix aria-labelledby passed to `DropdownSearchInput` @chpalac ([#20312](https://github.com/microsoft/fluentui/pull/20312))
 - Fix `preventFocusRestoration` in `FocusZone` @chpalac ([#20328](https://github.com/microsoft/fluentui/pull/20328))
 - `Popup` should not dismiss when its iframe content is focused @ling1726 ([#19955](https://github.com/microsoft/fluentui/pull/19955))

--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentProp/ComponentPropName.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentProp/ComponentPropName.tsx
@@ -19,19 +19,11 @@ export default class ComponentPropName extends React.PureComponent<any, any> {
     return (
       <div>
         <code>{name}</code>
-        {required && (
-          <Popup
-            content="Required"
-            align="center"
-            styles={{ fontSize: 'x-small' }}
-            trigger={<span style={{ color: 'red' }}>*</span>}
-          />
-        )}
+        {required && <Popup content="Required" align="center" trigger={<span style={{ color: 'red' }}>*</span>} />}
         {slot && (
           <Popup
             content="Slot - see Shorthand Props page for details."
             align="center"
-            styles={{ fontSize: 'x-small' }}
             trigger={<span style={slotStyle}>&nbsp;S&nbsp;</span>}
           />
         )}

--- a/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
@@ -189,7 +189,6 @@ export const MenuButton: ComponentWithAs<'div', MenuButtonProps> &
   const popupProps: PopupProps = {
     accessibility,
     align,
-    className,
     defaultOpen,
     mountNode,
     mouseLeaveDelay,
@@ -204,13 +203,11 @@ export const MenuButton: ComponentWithAs<'div', MenuButtonProps> &
     position,
     positionFixed,
     tabbableTrigger,
-    styles: props.styles,
     target,
     trigger,
     unstable_disableTether,
     unstable_pinned,
     autoSize,
-    variables,
   };
 
   const { classes, styles: resolvedStyles } = useStyles<MenuButtonStylesProps>(MenuButton.displayName, {

--- a/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
@@ -29,7 +29,6 @@ import { elementContains, setVirtualParent } from '@fluentui/dom-utilities';
 import {
   ChildrenComponentProps,
   ContentComponentProps,
-  StyledComponentProps,
   commonPropTypes,
   isFromKeyboard,
   doesNodeContainClick,
@@ -69,8 +68,7 @@ function getRealEventProps(element: React.ReactElement) {
 }
 
 export interface PopupProps
-  extends StyledComponentProps<PopupProps>,
-    ChildrenComponentProps,
+  extends ChildrenComponentProps,
     ContentComponentProps<ShorthandValue<PopupContentProps>>,
     PositioningProps {
   /**
@@ -78,9 +76,6 @@ export interface PopupProps
    * @available dialogBehavior
    */
   accessibility?: Accessibility<PopupBehaviorProps>;
-
-  /** Additional CSS class name(s) to apply.  */
-  className?: string;
 
   /** Initial value for 'open'. */
   defaultOpen?: boolean;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #19931
- [X] ~~Include a change request file using `$ yarn change`~~

#### Description of changes

`className`, `styles` & `variables` were exposed on `Popup` component, but never really worked. This PR removes them from types.