### PR TITLE
Bugfix/choice group focus trap zone

### DIFF
--- a/change/@fluentui-react-9464ff30-d1fc-4a10-81ea-a3fb6e19e622.json
+++ b/change/@fluentui-react-9464ff30-d1fc-4a10-81ea-a3fb6e19e622.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update ChoiceGroup focus handling",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -15,6 +15,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
 >
   <div
     aria-labelledby="ChoiceGroupLabel1"
+    onFocus={[Function]}
     role="radiogroup"
   >
     <label

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
@@ -15,6 +15,7 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
 >
   <div
     aria-labelledby="ChoiceGroupLabel1"
+    onFocus={[Function]}
     role="radiogroup"
   >
     <label

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -15,6 +15,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
 >
   <div
     aria-labelledby="ChoiceGroupLabel1"
+    onFocus={[Function]}
     role="radiogroup"
   >
     <label

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -15,6 +15,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
 >
   <div
     aria-labelledby="ChoiceGroupLabel1"
+    onFocus={[Function]}
     role="radiogroup"
   >
     <label

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -15,6 +15,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
 >
   <div
     aria-labelledby="ChoiceGroupLabel1"
+    onFocus={[Function]}
     role="radiogroup"
   >
     <label

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -86,6 +86,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
   >
     <div
       aria-labelledby="labelElement0"
+      onFocus={[Function]}
       role="radiogroup"
     >
       <div

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -1394,6 +1394,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
     >
       <div
         aria-labelledby="ChoiceGroupLabel23"
+        onFocus={[Function]}
         role="radiogroup"
       >
         <label

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -41,6 +41,11 @@ const focusSelectedOption = (options: IChoiceGroupOption[], keyChecked: string |
   }
 };
 
+// Test if focus came from a sibling DOM element
+const focusFromSibling = (evt: React.FocusEvent<HTMLElement>): boolean => {
+  return !!(evt.relatedTarget && !elementContains(evt.currentTarget, evt.relatedTarget as HTMLElement));
+};
+
 const useComponentRef = (
   options: IChoiceGroupOption[],
   keyChecked: string | number | undefined,
@@ -134,9 +139,8 @@ export const ChoiceGroupBase: React.FunctionComponent<IChoiceGroupProps> = React
 
   const onRadioFocus = React.useCallback(
     (evt: React.FocusEvent<HTMLElement>) => {
-      // Override focus behavior when the focus comes from oustide the DOM subtree of the radio group.
       // Handles scenarios like this bug: https://github.com/microsoft/fluentui/issues/20173
-      if (evt.relatedTarget && !elementContains(evt.currentTarget, evt.relatedTarget as HTMLElement)) {
+      if (focusFromSibling(evt)) {
         focusSelectedOption(options, keyChecked, id);
       }
     },

--- a/packages/react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
       }
 >
   <div
+    onFocus={[Function]}
     role="radiogroup"
   >
     <div
@@ -448,6 +449,7 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
 >
   <div
     aria-labelledby="ChoiceGroupLabel1"
+    onFocus={[Function]}
     role="radiogroup"
   >
     <label


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20173
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This commit overrides focus handling for ChoiceGroup when focus comes
from outside the DOM tree of the ChoiceGroup (e.g., from a sibling of
ChoiceGroup). This addresses a bug raised in #20173 where a ChoiceGroup
wrapped in a FocusTrapZone would not correctly focus the selected option
in ChoiceGroup.

The issue arises when ChoiceGroup is the first child of FocusTrapZone and
the focus is wrapped from the end of the focus trap back to the begining.
In this case FocusTrapZone walks its DOM children looking for the first
tabbable child, calling `focus()` on it. In the case of ChoiceGroup this
is always the first option in the group.

The fix is to listen for focus events on ChoiceGroups `radiogroup` child
and override focus behavior when the focus event comes from outside of the
ChoiceGroup, like when FocusTrapZone wraps the focus. This provides the
correct behavior for ChoiceGroup without adding new focus logic to FocusTrapZone.

See: https://github.com/microsoft/fluentui/issues/20173

#### Focus areas to test

Codesandbox with fix: https://codesandbox.io/s/focustrapzone-choicegroup-focus-conflict-fixed-y97qy

Original code sandbox with bug:: https://codesandbox.io/s/focustrapzone-choicegroup-focus-conflict-9d96j?file=/src/index.tsx

To test, tab through the sample application. The correct behavior is that when `FocusTrapZone` wraps the focus from the end of the trap back to the beginning (to focus back on `ChoiceGroup`) that the selected option in `ChoiceGroup` will be focused.