### PR TITLE
Azure-theme tooltip dark theme fix (7.0)

### DIFF
--- a/change/@uifabric-azure-themes-cc16cfa0-d0c6-4594-8bc9-2636f3fc6b47.json
+++ b/change/@uifabric-azure-themes-cc16cfa0-d0c6-4594-8bc9-2636f3fc6b47.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Tooltip dark theme fix",
+  "packageName": "@uifabric/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/Constants.ts
+++ b/packages/azure-themes/src/azure/Constants.ts
@@ -19,6 +19,7 @@ export const fontFamily =
 export const fontWeightRegular = '400';
 export const fontWeightBold = '700';
 export const inputControlHeight = '24px';
+export const inputControlPadding = '12px';
 export const inputControlHeightInner = '20px';
 export const textAlignCenter = 'center';
 export const transparent = 'transparent';

--- a/packages/azure-themes/src/azure/styles/Tooltip.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Tooltip.styles.ts
@@ -1,5 +1,6 @@
 import { ITooltipStyles, ITooltipStyleProps } from 'office-ui-fabric-react';
 import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import * as StyleConstants from '../Constants';
 
 export const TooltipStyles = (props: ITooltipStyleProps): Partial<ITooltipStyles> => {
   const { theme } = props;
@@ -9,11 +10,11 @@ export const TooltipStyles = (props: ITooltipStyleProps): Partial<ITooltipStyles
   return {
     root: {
       maxWidth: '480px',
-      padding: '0',
+      padding: 0,
     },
     content: {
       backgroundColor: extendedSemanticColors.controlBackground,
-      padding: 8,
+      padding: StyleConstants.inputControlPadding,
     },
   };
 };

--- a/packages/azure-themes/src/azure/styles/Tooltip.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Tooltip.styles.ts
@@ -1,9 +1,19 @@
 import { ITooltipStyles, ITooltipStyleProps } from 'office-ui-fabric-react';
+import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const TooltipStyles = (props: ITooltipStyleProps): Partial<ITooltipStyles> => {
+  const { theme } = props;
+  const { semanticColors } = theme;
+  const extendedSemanticColors = semanticColors as IExtendedSemanticColors;
+
   return {
     root: {
       maxWidth: '480px',
+      padding: '0',
+    },
+    content: {
+      backgroundColor: extendedSemanticColors.controlBackground,
+      padding: 8,
     },
   };
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fixed tooltip styling for dark theme. All other themes unchanged with this change. 

Before: 
![image](https://user-images.githubusercontent.com/30805892/144112536-00f2b25d-ceb6-4e0c-a76b-ea40b2e8e774.png)

After: 
![image](https://user-images.githubusercontent.com/30805892/144112545-890cd327-faaa-467f-ba82-67f686ec65fd.png)

Other themes with new change:
<img width="635" alt="image" src="https://user-images.githubusercontent.com/30805892/144112649-38b97bfc-cf3b-4855-a9f0-63ba346c3a70.png">
<img width="635" alt="image" src="https://user-images.githubusercontent.com/30805892/144113006-54fc41ec-756b-49cd-8951-618757ca8934.png">
<img width="635" alt="image" src="https://user-images.githubusercontent.com/30805892/144113064-d8f55241-9247-48a1-a12d-b0b6b99ffbac.png">


Cherry-pick: #20861
