### PR TITLE
Cherry-pick from #20860: Azure-theme tooltip dark theme fix

### DIFF
--- a/change/@fluentui-azure-themes-e1e1c8ac-92f1-4423-aa03-d8234356ae79.json
+++ b/change/@fluentui-azure-themes-e1e1c8ac-92f1-4423-aa03-d8234356ae79.json
@@ -1,0 +1,10 @@
+{
+  "type": "patch",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "@fluentui/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/Constants.ts
+++ b/packages/azure-themes/src/azure/Constants.ts
@@ -18,6 +18,7 @@ export const fontFamily =
 export const fontWeightRegular = '400';
 export const fontWeightBold = '700';
 export const inputControlHeight = '24px';
+export const inputControlPadding = '12px';
 export const inputControlHeightInner = '20px';
 export const textAlignCenter = 'center';
 export const transparent = 'transparent';

--- a/packages/azure-themes/src/azure/styles/Tooltip.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Tooltip.styles.ts
@@ -1,9 +1,19 @@
 import { ITooltipStyles, ITooltipStyleProps } from '@fluentui/react/lib/Tooltip';
+import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import * as StyleConstants from '../Constants';
 
 export const TooltipStyles = (props: ITooltipStyleProps): Partial<ITooltipStyles> => {
+  const { theme } = props;
+  const { semanticColors } = theme;
+  const extendedSemanticColors = semanticColors as IExtendedSemanticColors;
   return {
     root: {
       maxWidth: '480px',
+      padding: 0,
+    },
+    content: {
+      backgroundColor: extendedSemanticColors.controlBackground,
+      padding: StyleConstants.inputControlPadding,
     },
   };
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fixed tooltip styling for dark theme. All other themes unchanged with this change. 

Before: 
![image](https://user-images.githubusercontent.com/30805892/144112536-00f2b25d-ceb6-4e0c-a76b-ea40b2e8e774.png)

After: 
![image](https://user-images.githubusercontent.com/30805892/144112545-890cd327-faaa-467f-ba82-67f686ec65fd.png)

Other themes with new change:
<img width="635" alt="image" src="https://user-images.githubusercontent.com/30805892/144112649-38b97bfc-cf3b-4855-a9f0-63ba346c3a70.png">
<img width="635" alt="image" src="https://user-images.githubusercontent.com/30805892/144113006-54fc41ec-756b-49cd-8951-618757ca8934.png">
<img width="635" alt="image" src="https://user-images.githubusercontent.com/30805892/144113064-d8f55241-9247-48a1-a12d-b0b6b99ffbac.png">


Cherry-pick from #20860
