### PR TITLE
Input: implement primary slot

### DIFF
--- a/apps/vr-tests/src/stories/InputConverged.stories.tsx
+++ b/apps/vr-tests/src/stories/InputConverged.stories.tsx
@@ -5,8 +5,6 @@ import { Input } from '@fluentui/react-input';
 import { Search20Regular, Dismiss20Regular } from '@fluentui/react-icons';
 import { TestWrapperDecoratorFixedWidth } from '../utilities/TestWrapperDecorator';
 
-// TODO move input.* props to root once primary slot helper is integrated
-
 storiesOf('Input Converged', module)
   .addDecorator(TestWrapperDecoratorFixedWidth)
   .addDecorator(story => (
@@ -23,22 +21,21 @@ storiesOf('Input Converged', module)
       {story()}
     </Screener>
   ))
-  .addStory('Appearance: outline (default)', () => <Input input={{ placeholder: 'Placeholder' }} />)
+  .addStory('Appearance: outline (default)', () => <Input placeholder="Placeholder" />)
   .addStory('Appearance: underline', () => (
-    <Input appearance="underline" input={{ placeholder: 'Placeholder' }} />
+    <Input appearance="underline" placeholder="Placeholder" />
   ))
   .addStory('Appearance: filledDarker', () => (
-    <Input appearance="filledDarker" input={{ placeholder: 'Placeholder' }} />
+    <Input appearance="filledDarker" placeholder="Placeholder" />
   ))
   .addStory('Appearance: filledLighter', () => (
     // filledLighter requires a background to show up (this is colorNeutralBackground3 in web light theme)
     <div style={{ background: '#f5f5f5', padding: '10px' }}>
-      <Input appearance="filledLighter" input={{ placeholder: 'Placeholder' }} />
+      <Input appearance="filledLighter" placeholder="Placeholder" />
     </div>
   ))
-  .addStory('Disabled', () => <Input input={{ disabled: true }} />)
-  // TODO move defaultValue prop to root
-  .addStory('With value', () => <Input input={{ defaultValue: 'Value!' }} />);
+  .addStory('Disabled', () => <Input disabled />)
+  .addStory('With value', () => <Input defaultValue="Value!" />);
 
 // Non-interactive stories
 storiesOf('Input Converged', module)
@@ -48,21 +45,20 @@ storiesOf('Input Converged', module)
       {story()}
     </Screener>
   ))
-  .addStory('Size: small', () => <Input size="small" input={{ placeholder: 'Placeholder' }} />)
-  .addStory('Size: large', () => <Input size="large" input={{ placeholder: 'Placeholder' }} />)
+  .addStory('Size: small', () => <Input size="small" placeholder="Placeholder" />)
+  .addStory('Size: large', () => <Input size="large" placeholder="Placeholder" />)
   .addStory('Inline', () => (
     <p>
-      Some text with <Input inline input={{ placeholder: 'hello', style: { width: '75px' } }} />{' '}
-      inline input
+      Some text with <Input inline placeholder="hello" style={{ width: '75px' }} /> inline input
     </p>
   ))
   .addStory(
     'contentBefore',
-    () => <Input contentBefore={<Search20Regular />} input={{ placeholder: 'Placeholder' }} />,
+    () => <Input contentBefore={<Search20Regular />} placeholder="Placeholder" />,
     { includeRtl: true },
   )
   .addStory(
     'contentAfter',
-    () => <Input contentAfter={<Dismiss20Regular />} input={{ placeholder: 'Placeholder' }} />,
+    () => <Input contentAfter={<Dismiss20Regular />} placeholder="Placeholder" />,
     { includeRtl: true },
   );

--- a/packages/react-input/Spec.md
+++ b/packages/react-input/Spec.md
@@ -67,83 +67,67 @@ In the future we may implement behavior variants, such as a password field with 
 
 In this component, `input` is the primary slot. See notes under [Structure](#structure).
 
-```ts
-export type InputProps = InputCommons & Omit<ComponentProps<InputSlots, 'input'>, 'children'>;
-```
-
 ### Main props
 
 All native HTML `<input>` props are supported. Since the `input` slot is primary (more on that later), top-level native props except `className` and `style` will go to the input.
 
 The top-level `ref` prop also points to the `<input>`. This can be used for things like getting the current value or manipulating focus or selection (instead of explicitly exposing an imperative API).
 
-Most custom props are defined in `InputCommons` since they're shared with `InputState`.
+For the full current props, see the types file:
+https://github.com/microsoft/fluentui/blob/master/packages/react-input/src/components/Input/Input.types.ts
 
 ```ts
-export type InputCommons = {
-  /**
-   * If true, the field will have inline display, allowing it be used within text content.
-   * If false (the default), the field will have block display.
-   */
+// Simplified version of the props (including only summaries of custom props)
+type SimplifiedInputProps = {
+  /** Toggle inline display instead of block */
   inline?: boolean;
 
-  /**
-   * Controls the colors and borders of the field.
-   * @default 'outline'
-   */
+  /** Controls the colors and borders of the field (default `outline`) */
   appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
 
-  /**
-   * Size of the input (changes the font size and spacing).
-   * @default 'medium'
-   */
+  /** Size of the input (default `medium`) */
   size?: 'small' | 'medium' | 'large';
+
+  /** Default value (uncontrolled) */
+  defaultValue?: string;
+
+  /** Controlled value */
+  value?: string;
+
+  /** Called when the user changes the value */
+  onChange?: (ev: React.FormEvent<HTMLInputElement>, data: { value: string }) => void;
 };
 ```
 
-`size` [overlaps with a native prop](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size) which sets the width of the field in "number of characters." This isn't ideal, but we're going with it since the native prop isn't very useful in practice, and it was hard to find another reasonable/consistent name for the visual size prop. It's also consistent with the approach used by most other libraries which have a prop for setting the visual size. (If anyone needs the native functionality, we could add an `htmlSize` prop in the future.)
+Notes on native prop conflicts/overrides:
+
+- `size` [overlaps with a native prop](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size) which sets the width of the field in "number of characters." This isn't ideal, but we're going with it since the native prop isn't very useful in practice, and it was hard to find another reasonable/consistent name for the visual size prop. It's also consistent with the approach used by most other libraries which have a prop for setting the visual size. (If anyone needs the native functionality, we could add an `htmlSize` prop in the future.)
+- `value` and `defaultValue` are defined in `InputHTMLAttributes` (from `@types/react`) as `string | ReadonlyArray<string> | number` since the same props interface is used for all input element types. To reflect actual usage, we override the types to only accept strings.
 
 ### Slots
 
 Note that the field **does not** include a label, required indicator, description, or error message.
 
-```ts
-export type InputSlots = {
-  /**
-   * Wrapper element which visually appears to be the input and is used for borders, focus styling, etc.
-   * (A wrapper is needed to properly position `contentBefore` and `contentAfter` relative to `input`.)
-   */
-  root: IntrinsicShorthandProps<'span'>;
+An overview of the slots is as follows. For the current slot types and full docs, see the types file:
+https://github.com/microsoft/fluentui/blob/master/packages/react-input/src/components/Input/Input.types.ts
 
-  /**
-   * The actual `<input>` element. `type="text"` will be automatically applied unless overridden.
-   * This is the "primary" slot, so top-level native props (except `className` and `style`) and the
-   * top-level `ref` will go here.
-   */
-  input: IntrinsicShorthandProps<'input'>;
-
-  /** Element before the input text, within the input border */
-  contentBefore?: IntrinsicShorthandProps<'span'>;
-
-  /** Element after the input text, within the input border */
-  contentAfter?: IntrinsicShorthandProps<'span'>;
-};
-```
+- `root` (`span`): Wrapper which visually appears to be the input (needed to position `contentBefore` and `contentAfter` relative to the actual `input`)
+- `input` (`input`, primary slot): The actual text input element
+- `contentBefore` (`span`): Element before the input text, within the input border (most often used for icons)
+- `contentAfter` (`span`): Element after the input text, within the input border (most often used for icons)
 
 ## Structure
 
 In this component, `input` is the primary slot. Per the [native element props/primary slot RFC](https://github.com/microsoft/fluentui/blob/master/rfcs/convergence/native-element-props.md), this means that most top-level props will go to `input`, but the top-level `className` and `style` will go to the actual root element.
 
 ```tsx
-{
-  /* Out of top-level native props, only `className` and `style` go here */
-}
+// Out of top-level native props, only `className` and `style` go here
 <slots.root {...slotProps.root}>
   <slots.contentBefore {...slotProps.contentBefore} />
   {/* Primary slot. Top-level native props except `className` and `style` go here. */}
   <slots.input {...slotProps.input} />
   <slots.contentAfter {...slotProps.contentAfter} />
-</slots.root>;
+</slots.root>
 ```
 
 Notes on the HTML rendering:

--- a/packages/react-input/etc/react-input.api.md
+++ b/packages/react-input/etc/react-input.api.md
@@ -16,26 +16,31 @@ export const Input: ForwardRefComponent<InputProps>;
 // @public (undocumented)
 export const inputClassName = "fui-Input";
 
-// @public (undocumented)
-export type InputCommons = {
-    size?: 'small' | 'medium' | 'large';
-    inline?: boolean;
-    appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
+// @public
+export type InputOnChangeData = {
+    value: string;
 };
 
 // @public
-export type InputProps = InputCommons & Omit<ComponentProps<InputSlots, 'input'>, 'children'>;
+export type InputProps = Omit<ComponentProps<InputSlots, 'input'>, 'children' | 'defaultValue' | 'onChange' | 'size' | 'value'> & {
+    size?: 'small' | 'medium' | 'large';
+    inline?: boolean;
+    appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
+    defaultValue?: string;
+    value?: string;
+    onChange?: (ev: React_2.FormEvent<HTMLInputElement>, data: InputOnChangeData) => void;
+};
 
 // @public (undocumented)
 export type InputSlots = {
     root: IntrinsicShorthandProps<'span'>;
-    input: Omit<IntrinsicShorthandProps<'input'>, 'size'>;
+    input: IntrinsicShorthandProps<'input'>;
     contentBefore?: IntrinsicShorthandProps<'span'>;
     contentAfter?: IntrinsicShorthandProps<'span'>;
 };
 
 // @public
-export type InputState = InputCommons & ComponentState<InputSlots>;
+export type InputState = Required<Pick<InputProps, 'appearance' | 'inline' | 'size'>> & ComponentState<InputSlots>;
 
 // @public
 export const renderInput: (state: InputState) => JSX.Element;

--- a/packages/react-input/etc/react-input.api.md
+++ b/packages/react-input/etc/react-input.api.md
@@ -23,6 +23,7 @@ export type InputOnChangeData = {
 
 // @public
 export type InputProps = Omit<ComponentProps<InputSlots, 'input'>, 'children' | 'defaultValue' | 'onChange' | 'size' | 'value'> & {
+    children?: never;
     size?: 'small' | 'medium' | 'large';
     inline?: boolean;
     appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';

--- a/packages/react-input/etc/react-input.api.md
+++ b/packages/react-input/etc/react-input.api.md
@@ -24,10 +24,7 @@ export type InputCommons = {
 };
 
 // @public
-export type InputProps = InputCommons & Omit<ComponentProps<InputSlots>, 'children'>;
-
-// @public
-export const inputShorthandProps: (keyof InputSlots)[];
+export type InputProps = InputCommons & Omit<ComponentProps<InputSlots, 'input'>, 'children'>;
 
 // @public (undocumented)
 export type InputSlots = {
@@ -44,7 +41,7 @@ export type InputState = InputCommons & ComponentState<InputSlots>;
 export const renderInput: (state: InputState) => JSX.Element;
 
 // @public
-export const useInput: (props: InputProps, ref: React_2.Ref<HTMLElement>) => InputState;
+export const useInput: (props: InputProps, ref: React_2.Ref<HTMLInputElement>) => InputState;
 
 // @public
 export const useInputStyles: (state: InputState) => InputState;

--- a/packages/react-input/src/components/Input/Input.stories.tsx
+++ b/packages/react-input/src/components/Input/Input.stories.tsx
@@ -1,8 +1,7 @@
-/// <reference types="@fluentui/react-icons" />
 import * as React from 'react';
 import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import { Input } from './Input';
-import { getNativeElementProps, useId } from '@fluentui/react-utilities';
+import { useId } from '@fluentui/react-utilities';
 import { InputProps } from './Input.types';
 import { ArgTypes } from '@storybook/react';
 import {
@@ -29,20 +28,10 @@ const icons = {
   dismiss: { small: Dismiss16Regular, medium: Dismiss20Regular, large: Dismiss24Regular },
 };
 
-export const InputExamples = (
-  args: Partial<InputProps> & React.InputHTMLAttributes<HTMLInputElement> & { storyFilledBackground: boolean },
-) => {
+export const InputExamples = (args: InputProps & { storyFilledBackground: boolean }) => {
   const styles = useStyles();
   const inputId1 = useId();
-  // pass native input props to the internal input element and custom props to the root
-  const { storyFilledBackground, ...rest } = args;
-  const inputProps = getNativeElementProps('input', rest, ['size']);
-  const props: Partial<InputProps> = { input: inputProps };
-  for (const prop of Object.keys(rest) as (keyof InputProps)[]) {
-    if (!(inputProps as Partial<InputProps>)[prop]) {
-      props[prop] = rest[prop];
-    }
-  }
+  const { storyFilledBackground, ...props } = args;
   const SearchIcon = icons.search[props.size!];
   const DismissIcon = icons.dismiss[props.size!];
 
@@ -90,8 +79,6 @@ const argTypes: ArgTypes = {
   },
   // this one is for the example
   storyFilledBackground: { defaultValue: false, control: { type: 'boolean' } },
-  // NOTE: these are not actually top-level props right now until RFC is resolved,
-  // so they get passed through in the example via the input slot
   placeholder: { defaultValue: 'placeholder', control: { type: 'text' } },
   value: { control: { type: 'text' } },
   disabled: { defaultValue: false, control: { type: 'boolean' } },

--- a/packages/react-input/src/components/Input/Input.test.tsx
+++ b/packages/react-input/src/components/Input/Input.test.tsx
@@ -1,19 +1,88 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, RenderResult, fireEvent, screen } from '@testing-library/react';
 import { Input } from './Input';
 import { isConformant } from '../../common/isConformant';
 
+function getInput(): HTMLInputElement {
+  return screen.getByRole('textbox') as HTMLInputElement;
+}
+
 describe('Input', () => {
+  let renderedComponent: RenderResult | undefined;
+
+  afterEach(() => {
+    if (renderedComponent) {
+      renderedComponent.unmount();
+      renderedComponent = undefined;
+    }
+  });
+
   isConformant({
     Component: Input,
     displayName: 'Input',
     primarySlot: 'input',
   });
 
-  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
-
   it('renders a default state', () => {
     const result = render(<Input />);
     expect(result.container).toMatchSnapshot();
+  });
+
+  it('respects value', () => {
+    renderedComponent = render(<Input value="hello" />);
+    expect(getInput().value).toEqual('hello');
+  });
+
+  it('respects updates to value', () => {
+    renderedComponent = render(<Input value="hello" />);
+    expect(getInput().value).toEqual('hello');
+
+    renderedComponent.rerender(<Input value="world" />);
+    expect(getInput().value).toEqual('world');
+  });
+
+  it('respects defaultValue', () => {
+    renderedComponent = render(<Input defaultValue="hello" />);
+    expect(getInput().value).toEqual('hello');
+  });
+
+  it('ignores updates to defaultValue', () => {
+    renderedComponent = render(<Input defaultValue="hello" />);
+    expect(getInput().value).toEqual('hello');
+
+    renderedComponent.rerender(<Input defaultValue="world" />);
+    expect(getInput().value).toEqual('hello');
+  });
+
+  it('prefers value over defaultValue', () => {
+    renderedComponent = render(<Input value="hello" defaultValue="world" />);
+    expect(getInput().value).toEqual('hello');
+  });
+
+  it('with value, calls onChange but does not update on text entry', () => {
+    const onChange = jest.fn();
+    renderedComponent = render(<Input value="hello" onChange={onChange} />);
+    const input = getInput();
+    fireEvent.change(input, { target: { value: 'world' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][1]).toEqual({ value: 'world' });
+    expect(input.value).toBe('hello');
+  });
+
+  it('with defaultValue, calls onChange and updates value on text entry', () => {
+    const onChange = jest.fn();
+    renderedComponent = render(<Input defaultValue="hello" onChange={onChange} />);
+    const input = getInput();
+    fireEvent.change(input, { target: { value: 'world' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][1]).toEqual({ value: 'world' });
+    expect(input.value).toBe('world');
+  });
+
+  it('does not call onChange when value prop updates', () => {
+    const onChange = jest.fn();
+    renderedComponent = render(<Input value="hello" onChange={onChange} />);
+    renderedComponent.rerender(<Input value="world" onChange={onChange} />);
+    expect(onChange).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/react-input/src/components/Input/Input.test.tsx
+++ b/packages/react-input/src/components/Input/Input.test.tsx
@@ -7,6 +7,7 @@ describe('Input', () => {
   isConformant({
     Component: Input,
     displayName: 'Input',
+    primarySlot: 'input',
   });
 
   // TODO add more tests here, and create visual regression tests in /apps/vr-tests

--- a/packages/react-input/src/components/Input/Input.types.ts
+++ b/packages/react-input/src/components/Input/Input.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type { ComponentProps, ComponentState, IntrinsicShorthandProps } from '@fluentui/react-utilities';
 
 export type InputSlots = {
@@ -17,7 +18,7 @@ export type InputSlots = {
    * (except `className` and `style`, which go to the `root` slot). The top-level `ref` will
    * also go here.
    */
-  input: Omit<IntrinsicShorthandProps<'input'>, 'size'>;
+  input: IntrinsicShorthandProps<'input'>;
 
   /** Element before the input text, within the input border */
   contentBefore?: IntrinsicShorthandProps<'span'>;
@@ -26,7 +27,14 @@ export type InputSlots = {
   contentAfter?: IntrinsicShorthandProps<'span'>;
 };
 
-export type InputCommons = {
+/**
+ * Input Props
+ */
+export type InputProps = Omit<
+  ComponentProps<InputSlots, 'input'>,
+  // `children` is unsupported. The rest of these native props have customized definitions.
+  'children' | 'defaultValue' | 'onChange' | 'size' | 'value'
+> & {
   /**
    * Size of the input (changes the font size and spacing).
    * @default 'medium'
@@ -37,24 +45,48 @@ export type InputCommons = {
   size?: 'small' | 'medium' | 'large';
 
   /**
-   * If true, the field will have inline display, allowing it be used within text content.
-   * If false (the default), the field will have block display.
+   * If true, the input will have inline display, allowing it be used within text content.
+   * If false (the default), the input will have block display.
    */
   inline?: boolean;
 
   /**
-   * Controls the colors and borders of the field.
+   * Controls the colors and borders of the input.
    * @default 'outline'
    */
   appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
-};
 
-/**
- * Input Props
- */
-export type InputProps = InputCommons & Omit<ComponentProps<InputSlots, 'input'>, 'children'>;
+  /**
+   * Default value of the input. Provide this if the input should be an uncontrolled component
+   * which tracks its current state internally; otherwise, use `value`.
+   *
+   * (This prop is mutually exclusive with `value`.)
+   */
+  defaultValue?: string;
+
+  /**
+   * Current value of the input. Provide this if the input is a controlled component where you
+   * are maintaining its current state; otherwise, use `defaultValue`.
+   *
+   * (This prop is mutually exclusive with `defaultValue`.)
+   */
+  value?: string;
+
+  /**
+   * Called when the user changes the input's value.
+   */
+  onChange?: (ev: React.FormEvent<HTMLInputElement>, data: InputOnChangeData) => void;
+};
 
 /**
  * State used in rendering Input
  */
-export type InputState = InputCommons & ComponentState<InputSlots>;
+export type InputState = Required<Pick<InputProps, 'appearance' | 'inline' | 'size'>> & ComponentState<InputSlots>;
+
+/**
+ * Data passed to the `onChange` callback when a user changes the input's value.
+ */
+export type InputOnChangeData = {
+  /** Updated input value from the user */
+  value: string;
+};

--- a/packages/react-input/src/components/Input/Input.types.ts
+++ b/packages/react-input/src/components/Input/Input.types.ts
@@ -4,13 +4,18 @@ export type InputSlots = {
   /**
    * Wrapper element which visually appears to be the input and is used for borders, focus styling, etc.
    * (A wrapper is needed to properly position `contentBefore` and `contentAfter` relative to `input`.)
+   *
+   * The root slot receives the `className` and `style` specified directly on the `<Input>`.
+   * All other top-level native props will be applied to the primary slot, `input`.
    */
   root: IntrinsicShorthandProps<'span'>;
 
   /**
    * The actual `<input>` element. `type="text"` will be automatically applied unless overridden.
-   * This is the "primary" slot, so top-level native props (except `className` and `style`) and the
-   * top-level `ref` will go here.
+   *
+   * This is the "primary" slot, so native props specified directly on the `<Input>` will go here
+   * (except `className` and `style`, which go to the `root` slot). The top-level `ref` will
+   * also go here.
    */
   input: Omit<IntrinsicShorthandProps<'input'>, 'size'>;
 
@@ -47,7 +52,7 @@ export type InputCommons = {
 /**
  * Input Props
  */
-export type InputProps = InputCommons & Omit<ComponentProps<InputSlots>, 'children'>;
+export type InputProps = InputCommons & Omit<ComponentProps<InputSlots, 'input'>, 'children'>;
 
 /**
  * State used in rendering Input

--- a/packages/react-input/src/components/Input/Input.types.ts
+++ b/packages/react-input/src/components/Input/Input.types.ts
@@ -35,6 +35,9 @@ export type InputProps = Omit<
   // `children` is unsupported. The rest of these native props have customized definitions.
   'children' | 'defaultValue' | 'onChange' | 'size' | 'value'
 > & {
+  /** Input can't have children. */
+  children?: never;
+
   /**
    * Size of the input (changes the font size and spacing).
    * @default 'medium'

--- a/packages/react-input/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/packages/react-input/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Input renders a default state 1`] = `
   >
     <input
       class=""
+      type="text"
     />
   </span>
 </div>

--- a/packages/react-input/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/packages/react-input/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Input renders a default state 1`] = `
     <input
       class=""
       type="text"
+      value=""
     />
   </span>
 </div>

--- a/packages/react-input/src/components/Input/renderInput.tsx
+++ b/packages/react-input/src/components/Input/renderInput.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
-import { inputShorthandProps } from './useInput';
 import type { InputSlots, InputState } from './Input.types';
 
 /**
  * Render the final JSX of Input
  */
 export const renderInput = (state: InputState) => {
-  const { slots, slotProps } = getSlots<InputSlots>(state, inputShorthandProps);
+  const { slots, slotProps } = getSlots<InputSlots>(state, ['input', 'contentBefore', 'contentAfter', 'root']);
   return (
     <slots.root {...slotProps.root}>
       <slots.contentBefore {...slotProps.contentBefore} />

--- a/packages/react-input/src/components/Input/useInput.ts
+++ b/packages/react-input/src/components/Input/useInput.ts
@@ -1,11 +1,6 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
-import type { InputProps, InputSlots, InputState } from './Input.types';
-
-/**
- * Array of all shorthand properties listed as the keys of InputSlots
- */
-export const inputShorthandProps: (keyof InputSlots)[] = ['input', 'contentBefore', 'contentAfter', 'root'];
+import { getPartitionedNativeProps, resolveShorthand } from '@fluentui/react-utilities';
+import type { InputProps, InputState } from './Input.types';
 
 /**
  * Create the state required to render Input.
@@ -14,10 +9,15 @@ export const inputShorthandProps: (keyof InputSlots)[] = ['input', 'contentBefor
  * before being passed to renderInput.
  *
  * @param props - props from this instance of Input
- * @param ref - reference to root HTMLInputElement of Input
+ * @param ref - reference to `<input>` element of Input
  */
-export const useInput = (props: InputProps, ref: React.Ref<HTMLElement>): InputState => {
-  const { input, contentAfter, contentBefore, size, appearance, inline } = props;
+export const useInput = (props: InputProps, ref: React.Ref<HTMLInputElement>): InputState => {
+  const { size, appearance, inline } = props;
+
+  const nativeProps = getPartitionedNativeProps({
+    props,
+    primarySlotTagName: 'input',
+  });
 
   return {
     size,
@@ -29,12 +29,19 @@ export const useInput = (props: InputProps, ref: React.Ref<HTMLElement>): InputS
       contentBefore: 'span',
       contentAfter: 'span',
     },
-    input: resolveShorthand(input, { required: true }),
-    contentAfter: resolveShorthand(contentAfter),
-    contentBefore: resolveShorthand(contentBefore),
-    root: getNativeElementProps('span', {
-      ref,
-      ...props,
+    input: resolveShorthand(props.input, {
+      required: true,
+      defaultProps: {
+        type: 'text',
+        ref,
+        ...nativeProps.primary,
+      },
+    }),
+    contentAfter: resolveShorthand(props.contentAfter),
+    contentBefore: resolveShorthand(props.contentBefore),
+    root: resolveShorthand(props.root, {
+      required: true,
+      defaultProps: nativeProps.root,
     }),
   };
 };

--- a/packages/react-input/src/components/Input/useInput.ts
+++ b/packages/react-input/src/components/Input/useInput.ts
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { getPartitionedNativeProps, resolveShorthand, useEventCallback } from '@fluentui/react-utilities';
+import {
+  getPartitionedNativeProps,
+  resolveShorthand,
+  useControllableState,
+  useEventCallback,
+} from '@fluentui/react-utilities';
 import type { InputProps, InputState } from './Input.types';
 
 /**
@@ -14,10 +19,16 @@ import type { InputProps, InputState } from './Input.types';
 export const useInput = (props: InputProps, ref: React.Ref<HTMLInputElement>): InputState => {
   const { size = 'medium', appearance = 'outline', inline = false, onChange } = props;
 
+  const [value, setValue] = useControllableState({
+    state: props.value,
+    defaultState: props.defaultValue,
+    initialState: undefined,
+  });
+
   const nativeProps = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'input',
-    excludedPropNames: ['size', 'onChange'],
+    excludedPropNames: ['size', 'onChange', 'value', 'defaultValue'],
   });
 
   const state: InputState = {
@@ -46,9 +57,11 @@ export const useInput = (props: InputProps, ref: React.Ref<HTMLInputElement>): I
     }),
   };
 
+  state.input.value = value;
   state.input.onChange = useEventCallback(ev => {
     const newValue = ev.target.value;
     onChange?.(ev, { value: newValue });
+    setValue(newValue);
   });
 
   return state;

--- a/packages/react-input/src/components/Input/useInput.ts
+++ b/packages/react-input/src/components/Input/useInput.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getPartitionedNativeProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getPartitionedNativeProps, resolveShorthand, useEventCallback } from '@fluentui/react-utilities';
 import type { InputProps, InputState } from './Input.types';
 
 /**
@@ -12,14 +12,15 @@ import type { InputProps, InputState } from './Input.types';
  * @param ref - reference to `<input>` element of Input
  */
 export const useInput = (props: InputProps, ref: React.Ref<HTMLInputElement>): InputState => {
-  const { size, appearance, inline } = props;
+  const { size = 'medium', appearance = 'outline', inline = false, onChange } = props;
 
   const nativeProps = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'input',
+    excludedPropNames: ['size', 'onChange'],
   });
 
-  return {
+  const state: InputState = {
     size,
     appearance,
     inline,
@@ -44,4 +45,11 @@ export const useInput = (props: InputProps, ref: React.Ref<HTMLInputElement>): I
       defaultProps: nativeProps.root,
     }),
   };
+
+  state.input.onChange = useEventCallback(ev => {
+    const newValue = ev.target.value;
+    onChange?.(ev, { value: newValue });
+  });
+
+  return state;
 };

--- a/packages/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-input/src/components/Input/useInputStyles.ts
@@ -221,7 +221,7 @@ const useContentStyles = makeStyles({
  * Apply styling to the Input slots based on the state
  */
 export const useInputStyles = (state: InputState): InputState => {
-  const { size = 'medium', appearance = 'outline' } = state;
+  const { size, appearance } = state;
   const disabled = state.input.disabled;
   const filled = appearance.startsWith('filled');
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: part of #18131, #20936
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Set Input's primary slot to `input`
- Added an `onChange` callback with standard signature (since apparently I forgot to do that before)
- Fixed types of `value` and `defaultValue` to only accept strings (or undefined)
- Add tests for `value`, `defaultValue`, and `onChange`
- Updated the spec to reduce duplication with the types files and be clearer on certain points
- Removed `InputCommons`

#### Getting rid of `InputCommons`

One other change was getting rid of the `InputCommons` type. Everything is now in `InputProps`, and `InputState` uses `Required<Pick<InputProps, 'some' | 'prop' | 'names'>>`.

What got me thinking about this was noticing that components are inconsistent about how required/optional things are handled in commons and props--whether things are:
- optional in commons type (to reflect props) then do `type FooState = Required<FooCommons> & ...`.
- required in commons type (to reflect state) then do `type FooProps = Partial<FooCommons> & ...`

Thinking about it more, this could actually be quite confusing from the perspective of a user looking at our types:
- Not straightforward to understand what's optional or required when
- Additional level of indirection to understand what's included in props
- "Commons" is an implementation detail that the user shouldn't need to care about when looking at props typings

Having everything in props and using `Pick` to appropriately define state makes the user-facing type (props) very clear/explicit and limits the weirdness to the internal type (state). I'm planning to make an RFC about doing the same change in other components.