### PR TITLE
fix: video component to properly pass ref to root slot

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -67,6 +67,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Label` component to properly pass ref to root slots @chpalac ([#20813](https://github.com/microsoft/fluentui/pull/20813))
 - Fix `MenuItemIcon` to allow icon `size` to be in effect @yuanboxue-amber ([#20803](https://github.com/microsoft/fluentui/pull/20803))
 - Fix `MenuButton` component to properly pass ref to root slots @chpalac ([#20837](https://github.com/microsoft/fluentui/pull/20837))
+- Fix `Video` component to properly pass ref to root slots @chpalac ([#20878](https://github.com/microsoft/fluentui/pull/20878))
 
 ### Features
 - Adding `ViewPersonSparkleIcon`, `CartIcon`, and fixing `EmojiAddIcon` and `AccessibilityIcon` - @notandrew ([#20054](https://github.com/microsoft/fluentui/pull/20054))

--- a/packages/fluentui/react-northstar/src/components/Video/Video.tsx
+++ b/packages/fluentui/react-northstar/src/components/Video/Video.tsx
@@ -6,13 +6,13 @@ import { Accessibility, VideoBehaviorProps, videoBehavior } from '@fluentui/acce
 import { createShorthandFactory, UIComponentProps, commonPropTypes } from '../../utils';
 import { FluentComponentStaticProps } from '../../types';
 import {
-  ComponentWithAs,
   getElementType,
   useStyles,
   useFluentContext,
   useUnhandledProps,
   useTelemetry,
   useAccessibility,
+  ForwardRefWithAs,
 } from '@fluentui/react-bindings';
 
 export interface VideoProps extends UIComponentProps {
@@ -47,7 +47,7 @@ export type VideoStylesProps = Required<Pick<VideoProps, 'variables'>>;
 /**
  * A Video provides ability to embed video content.
  */
-export const Video: ComponentWithAs<'video', VideoProps> & FluentComponentStaticProps<VideoProps> = props => {
+export const Video = (React.forwardRef<HTMLVideoElement, VideoProps>((props, ref) => {
   const context = useFluentContext();
   const { setStart, setEnd } = useTelemetry(Video.displayName, context.telemetry);
   setStart();
@@ -94,6 +94,7 @@ export const Video: ComponentWithAs<'video', VideoProps> & FluentComponentStatic
           className: classes.root,
           autoPlay,
           controls,
+          ref,
           loop,
           poster,
           src,
@@ -104,7 +105,7 @@ export const Video: ComponentWithAs<'video', VideoProps> & FluentComponentStatic
   );
   setEnd();
   return element;
-};
+}) as unknown) as ForwardRefWithAs<'video', HTMLVideoElement, VideoProps> & FluentComponentStaticProps<VideoProps>;
 
 Video.create = createShorthandFactory({ Component: Video, mappedProp: 'src' });
 
@@ -124,7 +125,7 @@ Video.propTypes = {
 };
 
 Video.defaultProps = {
-  as: 'video',
+  as: 'video' as const,
   accessibility: videoBehavior,
   controls: true,
   autoPlay: false,


### PR DESCRIPTION
#### Description of changes

Fix `Video` component to properly pass ref to root slot

#### Focus areas to test

(optional)
