### PR TITLE
test(date-time-utils): make test pass for every contributor

### DIFF
--- a/change/@fluentui-date-time-utilities-7c5c9bb3-ffd3-45cc-9aef-cb226b301d7b.json
+++ b/change/@fluentui-date-time-utilities-7c5c9bb3-ffd3-45cc-9aef-cb226b301d7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test(date-time-utils): make test pass for every contributor",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/date-time-utilities/src/timeFormatting/timeFormatting.test.ts
+++ b/packages/date-time-utilities/src/timeFormatting/timeFormatting.test.ts
@@ -2,6 +2,34 @@ import { formatTimeString } from '.';
 
 describe('timeFormatting', () => {
   const date = new Date(2021, 6, 14, 13, 26, 39);
+
+  const originalToLocaleTimeString = date.toLocaleTimeString.bind(date);
+
+  /**
+   *
+   * This is needed to make this test pass in any time-zone as the implementation defines no locales,
+   * thus it will be determined on users physical location - making the test non-deterministic
+   *
+   */
+  const toLocaleTimeStringMock: (locales?: string | string[], options?: Intl.DateTimeFormatOptions) => string = (
+    locales,
+    options,
+  ) => {
+    if (!locales || (Array.isArray(locales) && locales.length === 0)) {
+      return originalToLocaleTimeString('en-US', options);
+    }
+
+    // this branch will never run as the implementation uses `[]` for locales.
+    // keeping it here to follow best testing/mocking practices
+    return originalToLocaleTimeString(locales, options);
+  };
+
+  jest.spyOn(date, 'toLocaleTimeString').mockImplementation(toLocaleTimeStringMock);
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
   it('returns locale time string', () => {
     const result = formatTimeString(date);
     expect(result).toBe('1:26 PM');


### PR DESCRIPTION
#### Pull request checklist

- ~[ ] Addresses an existing issue:~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- this package was failing on local machine if contributor wasn't based in USA or didnt have set locale to `en-US`

**Before:**

![2021-12-01 at 16 34](https://user-images.githubusercontent.com/1223799/144264221-82c03088-9130-42a3-bc92-83a252e049ad.png)


**After:**

![2021-12-01 at 16 36](https://user-images.githubusercontent.com/1223799/144264391-fdfc8974-b82f-4cd1-bfd5-dcd663894b52.png)

