### PR TITLE
chore: disable custom Storybook addon in react-components

### DIFF
--- a/change/@fluentui-react-components-74838f56-ea28-4f5a-87d3-0262737d8baa.json
+++ b/change/@fluentui-react-components-74838f56-ea28-4f5a-87d3-0262737d8baa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "temporary disable Storybook addon",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/.storybook/main.js
+++ b/packages/react-components/.storybook/main.js
@@ -11,7 +11,7 @@ module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript
   ],
   addons: [
     ...rootMain.addons,
-    // Should be re-enabled, see @GH
+    // Should be re-enabled, see https://github.com/microsoft/fluentui/issues/20896
     // '@fluentui/react-storybook-addon'
   ],
   webpackFinal: (config, options) => {

--- a/packages/react-components/.storybook/main.js
+++ b/packages/react-components/.storybook/main.js
@@ -9,7 +9,11 @@ module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript
     '../src/**/*.stories.@(ts|tsx)',
     ...utils.getVnextStories(),
   ],
-  addons: [...rootMain.addons, '@fluentui/react-storybook-addon'],
+  addons: [
+    ...rootMain.addons,
+    // Should be re-enabled, see @GH
+    // '@fluentui/react-storybook-addon'
+  ],
   webpackFinal: (config, options) => {
     const localConfig = { ...rootMain.webpackFinal(config, options) };
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: related to #20886
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR disables SB addon as it breaks buildless experience to start Storybook, we should reenable it later.
Issue to enable back: https://github.com/microsoft/fluentui/issues/20896