### PR TITLE
Use a custom cache directory for each test that runs yarn

### DIFF
--- a/apps/ts-minbar-test-react/src/index.ts
+++ b/apps/ts-minbar-test-react/src/index.ts
@@ -1,24 +1,24 @@
 import config from '@fluentui/scripts/config';
-import sh from '@fluentui/scripts/gulp/sh';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import {
   addResolutionPathsForProjectPackages,
   packProjectPackages,
 } from '@fluentui/scripts/projects-test/packPackages';
-import { createTempDir, log } from '@fluentui/scripts/projects-test/utils';
+import { prepareTempDirs, log, shEcho, TempPaths } from '@fluentui/scripts/projects-test/utils';
 
 const tsVersion = '3.9';
+const testName = 'ts-minbar-react';
 
 async function performTest() {
-  let tmpDirectory: string;
-  const logger = log('test:ts-minbar-react');
+  let tempPaths: TempPaths;
+  const logger = log(`test:${testName}`);
 
   try {
     const scaffoldPath = config.paths.withRootAt(path.resolve(__dirname, '../assets/'));
-    tmpDirectory = createTempDir('ts-minbar-react-typings-');
 
-    logger(`✔️ Temporary directory was created: ${tmpDirectory}`);
+    tempPaths = prepareTempDirs(`${testName}-`);
+    logger(`✔️ Temporary directories created under ${tempPaths.root}`);
 
     // Install dependencies, using the minimum TS version supported for consumers
     const dependencies = [
@@ -29,26 +29,26 @@ async function performTest() {
       'react-dom',
       `typescript@${tsVersion}`,
     ].join(' ');
-    await sh(`yarn add ${dependencies}`, tmpDirectory);
+    await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);
     logger(`✔️ Dependencies were installed`);
 
     const lernaRoot = config.paths.allPackages();
     const packedPackages = await packProjectPackages(logger, lernaRoot, ['@fluentui/react']);
-    await addResolutionPathsForProjectPackages(tmpDirectory);
+    await addResolutionPathsForProjectPackages(tempPaths.testApp);
 
-    await sh(`yarn add ${packedPackages['@fluentui/react']}`, tmpDirectory);
+    await shEcho(`yarn add ${packedPackages['@fluentui/react']}`, tempPaths.testApp);
     logger(`✔️ Fluent UI packages were added to dependencies`);
 
-    fs.mkdirSync(path.resolve(tmpDirectory, 'src'));
-    fs.copyFileSync(scaffoldPath('index.tsx'), path.resolve(tmpDirectory, 'src/index.tsx'));
-    fs.copyFileSync(scaffoldPath('tsconfig.json'), path.resolve(tmpDirectory, 'tsconfig.json'));
+    fs.mkdirSync(path.join(tempPaths.testApp, 'src'));
+    fs.copyFileSync(scaffoldPath('index.tsx'), path.join(tempPaths.testApp, 'src/index.tsx'));
+    fs.copyFileSync(scaffoldPath('tsconfig.json'), path.join(tempPaths.testApp, 'tsconfig.json'));
     logger(`✔️ Source and configs were copied`);
 
-    await sh(`npx npm-which yarn`);
+    await shEcho(`npx npm-which yarn`);
 
-    await sh(`yarn --version`);
-    await sh(`yarn tsc --version`);
-    await sh(`yarn tsc --version`, tmpDirectory);
+    await shEcho(`yarn --version`);
+    await shEcho(`yarn tsc --version`);
+    await shEcho(`yarn tsc --version`, tempPaths.testApp);
   } catch (e) {
     console.error('Something went wrong setting up the test:');
     console.error(e?.stack || e);
@@ -56,7 +56,7 @@ async function performTest() {
   }
 
   try {
-    await sh(`yarn tsc --noEmit`, tmpDirectory);
+    await shEcho(`yarn tsc --noEmit`, tempPaths.testApp);
     logger(`✔️ Example project was successfully built with typescript@${tsVersion}`);
   } catch (e) {
     console.error(e);

--- a/change/@fluentui-cra-template-48461590-a8b5-440d-8741-30860247bd1b.json
+++ b/change/@fluentui-cra-template-48461590-a8b5-440d-8741-30860247bd1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use a custom yarn cache in the test",
+  "packageName": "@fluentui/cra-template",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/cra-template/scripts/test.ts
+++ b/packages/cra-template/scripts/test.ts
@@ -6,10 +6,11 @@ import {
   addResolutionPathsForProjectPackages,
   packProjectPackages,
   performBrowserTest,
-  createTempDir,
+  prepareTempDirs,
   log,
   shEcho,
   prepareCreateReactApp,
+  TempPaths,
 } from '@fluentui/scripts/projects-test/index';
 import { findGitRoot } from '@fluentui/scripts/monorepo/index';
 
@@ -40,10 +41,10 @@ function verifyVersion() {
  * If we tested the template as-is, it would install the latest packages from npm, which is pointless.
  * Instead, pack up the locally-built packages and make a copy of the template which references them.
  */
-async function prepareTemplate(logger: Function, tmpDirectory: string) {
+async function prepareTemplate(logger: Function, tempPaths: TempPaths) {
   await packProjectPackages(logger, findGitRoot(), ['@fluentui/react']);
 
-  const templatePath = path.join(tmpDirectory, 'cra-template');
+  const templatePath = path.join(tempPaths.root, 'cra-template');
 
   const packageJson = fs.readJSONSync(path.resolve(__dirname, '../package.json'));
   // Copy only the template files that would be installed from npm
@@ -65,26 +66,28 @@ async function prepareTemplate(logger: Function, tmpDirectory: string) {
  * - Build and test the test app
  */
 async function runE2ETest() {
-  const logger = log('@fluentui/cra-template');
+  const testName = '@fluentui/cra-template';
+  const logger = log(testName);
 
-  const tmpDirectory = createTempDir('test-cra-template-');
-  logger(`✔️ Temporary directory was created: ${tmpDirectory}`);
+  const tempPaths = prepareTempDirs(`${path.basename(testName)}-`);
+  logger(`✔️ Temporary directories created under ${tempPaths.root}`);
 
   logger('STEP 1. Update template to reference local packages');
-  const templatePath = await prepareTemplate(logger, tmpDirectory);
+  const templatePath = await prepareTemplate(logger, tempPaths);
 
   logger('STEP 2. Create test React app from template');
-  const testAppPath = await prepareCreateReactApp(tmpDirectory, `file:${templatePath}`, 'test-app');
-  logger(`✔️ Test React app is successfully created: ${testAppPath}`);
+  await prepareCreateReactApp(tempPaths, `file:${templatePath}`);
+  await shEcho('yarn add cross-env', tempPaths.testApp);
+  logger(`✔️ Test React app is successfully created: ${tempPaths.testApp}`);
 
   logger('STEP 3. Build test app');
-  await shEcho(`npx cross-env CI=1 yarn build`, testAppPath);
+  await shEcho(`yarn cross-env CI=1 yarn build`, tempPaths.testApp);
 
   logger('STEP 4. Run test app tests');
-  await shEcho(`npx cross-env CI=1 yarn test`, testAppPath);
+  await shEcho(`yarn cross-env CI=1 yarn test`, tempPaths.testApp);
 
   logger('STEP 5. Load the test app in the browser');
-  await performBrowserTest(path.join(testAppPath, 'build'));
+  await performBrowserTest(path.join(tempPaths.testApp, 'build'));
   logger('✔️ Browser test passed');
 }
 

--- a/packages/fluentui/projects-test/src/rollup.ts
+++ b/packages/fluentui/projects-test/src/rollup.ts
@@ -1,5 +1,4 @@
 import config from '@fluentui/scripts/config';
-import sh from '@fluentui/scripts/gulp/sh';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -7,17 +6,19 @@ import {
   addResolutionPathsForProjectPackages,
   packProjectPackages,
   performBrowserTest,
-  createTempDir,
+  prepareTempDirs,
   log,
+  shEcho,
 } from '@fluentui/scripts/projects-test';
 
 export async function rollup() {
   const logger = log('test:projects:rollup');
 
   const scaffoldPath = config.paths.withRootAt(path.resolve(__dirname, '../assets/rollup'));
-  const tmpDirectory = createTempDir('project-rollup-');
+  const tempPaths = prepareTempDirs('project-rollup-');
+  logger(`✔️ Temporary directories created under ${tempPaths.root}`);
 
-  logger(`✔️ Temporary directory was created: ${tmpDirectory}`);
+  logger('STEP 1. Add dependencies to test project');
 
   const rollupVersion = '2.7.3';
   const dependencies = [
@@ -30,23 +31,28 @@ export async function rollup() {
     'react-dom',
   ].join(' ');
 
-  await sh(`yarn add ${dependencies}`, tmpDirectory);
+  await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);
   logger(`✔️ Dependencies were installed`);
 
-  const packedPackages = await packProjectPackages(logger, config.paths.packages(), ['@fluentui/react-northstar']);
-  await addResolutionPathsForProjectPackages(tmpDirectory);
+  logger('STEP 2. Add Fluent UI dependency to test project');
 
-  await sh(`yarn add ${packedPackages['@fluentui/react-northstar']}`, tmpDirectory);
+  const packedPackages = await packProjectPackages(logger, config.paths.packages(), ['@fluentui/react-northstar']);
+  await addResolutionPathsForProjectPackages(tempPaths.testApp);
+
+  await shEcho(`yarn add ${packedPackages['@fluentui/react-northstar']}`, tempPaths.testApp);
   logger(`✔️ Fluent UI packages were added to dependencies`);
 
-  fs.copyFileSync(scaffoldPath('app.js'), path.resolve(tmpDirectory, 'app.js'));
-  fs.copyFileSync(scaffoldPath('rollup.config.js'), path.resolve(tmpDirectory, 'rollup.config.js'));
-  fs.copyFileSync(scaffoldPath('index.html'), path.resolve(tmpDirectory, 'index.html'));
+  logger('STEP 3. Copy scaffold files to test project');
+  fs.copyFileSync(scaffoldPath('app.js'), path.resolve(tempPaths.testApp, 'app.js'));
+  fs.copyFileSync(scaffoldPath('rollup.config.js'), path.resolve(tempPaths.testApp, 'rollup.config.js'));
+  fs.copyFileSync(scaffoldPath('index.html'), path.resolve(tempPaths.testApp, 'index.html'));
   logger(`✔️ Source and bundler's config were created`);
 
-  await sh(`yarn rollup -c`, tmpDirectory);
-  logger(`✔️ Example project was successfully built: ${tmpDirectory}`);
+  logger('STEP 4. Build test project');
+  await shEcho(`yarn rollup -c`, tempPaths.testApp);
+  logger(`✔️ Example project was successfully built: ${tempPaths.testApp}`);
 
-  await performBrowserTest(tmpDirectory);
+  logger('STEP 5. Load the test app in the browser');
+  await performBrowserTest(tempPaths.testApp);
   logger(`✔️ Browser test was passed`);
 }

--- a/packages/fluentui/projects-test/src/typings.ts
+++ b/packages/fluentui/projects-test/src/typings.ts
@@ -1,45 +1,44 @@
 import config from '@fluentui/scripts/config';
-import sh from '@fluentui/scripts/gulp/sh';
 import fs from 'fs-extra';
 import path from 'path';
 
 import {
   addResolutionPathsForProjectPackages,
   packProjectPackages,
-  createTempDir,
+  prepareTempDirs,
   log,
+  shEcho,
 } from '@fluentui/scripts/projects-test';
 
 export async function typings() {
   const logger = log('test:projects:typings');
 
   const scaffoldPath = config.paths.withRootAt(path.resolve(__dirname, '../assets/typings'));
-  const tmpDirectory = createTempDir('project-typings-');
-
-  logger(`✔️ Temporary directory was created: ${tmpDirectory}`);
+  const tempPaths = prepareTempDirs('project-typings-');
+  logger(`✔️ Temporary directories created under ${tempPaths.root}`);
 
   // Install dependencies, ensuring we specify the same TS version as our projects use
   const rootPkgJson: { devDependencies: Record<string, string> } = fs.readJSONSync(config.paths.base('package.json'));
   const { typescript: tsVersion } = rootPkgJson.devDependencies;
 
   const dependencies = ['@types/react', '@types/react-dom', 'react', 'react-dom', `typescript@${tsVersion}`].join(' ');
-  await sh(`yarn add ${dependencies}`, tmpDirectory);
+  await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);
   logger(`✔️ Dependencies were installed`);
 
   const packedPackages = await packProjectPackages(logger, config.paths.packages(), ['@fluentui/react-northstar']);
-  await addResolutionPathsForProjectPackages(tmpDirectory);
+  await addResolutionPathsForProjectPackages(tempPaths.testApp);
 
-  await sh(`yarn add ${packedPackages['@fluentui/react-northstar']}`, tmpDirectory);
+  await shEcho(`yarn add ${packedPackages['@fluentui/react-northstar']}`, tempPaths.testApp);
   logger(`✔️ Fluent UI packages were added to dependencies`);
 
-  fs.mkdirSync(path.resolve(tmpDirectory, 'src'));
-  fs.copyFileSync(scaffoldPath('index.tsx'), path.resolve(tmpDirectory, 'src/index.tsx'));
-  fs.copyFileSync(scaffoldPath('tsconfig.json'), path.resolve(tmpDirectory, 'tsconfig.json'));
+  fs.mkdirSync(path.resolve(tempPaths.testApp, 'src'));
+  fs.copyFileSync(scaffoldPath('index.tsx'), path.resolve(tempPaths.testApp, 'src/index.tsx'));
+  fs.copyFileSync(scaffoldPath('tsconfig.json'), path.resolve(tempPaths.testApp, 'tsconfig.json'));
   logger(`✔️ Source and configs were copied`);
 
-  await sh(`which yarn`);
-  await sh(`yarn --version`);
-  await sh(`yarn tsc --version`);
-  await sh(`yarn tsc --noEmit`, tmpDirectory);
-  logger(`✔️ Example project was successfully built: ${tmpDirectory}`);
+  await shEcho(`which yarn`);
+  await shEcho(`yarn --version`);
+  await shEcho(`yarn tsc --version`, tempPaths.testApp);
+  await shEcho(`yarn tsc --noEmit`, tempPaths.testApp);
+  logger(`✔️ Example project was successfully built: ${tempPaths.testApp}`);
 }

--- a/scripts/gulp/sh.ts
+++ b/scripts/gulp/sh.ts
@@ -7,7 +7,7 @@ const sh = (command: string, cwd?: string, pipeOutputToResult: boolean = false):
     const options: childProcess.SpawnOptions = {
       cwd: cwd || process.cwd(),
       env: process.env,
-      stdio: pipeOutputToResult ? 'pipe' : [0, 1, 2],
+      stdio: pipeOutputToResult ? 'pipe' : 'inherit',
       shell: true,
     };
 

--- a/scripts/projects-test/createReactApp.ts
+++ b/scripts/projects-test/createReactApp.ts
@@ -1,36 +1,25 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { shEcho } from './utils';
+import { shEcho, TempPaths } from './utils';
 
 /**
  * Install create-react-app in a temporary utility project to avoid polluting global state
  * (or the test project), then use it to create an app from the specified template.
- * @param tmpDirectory Temporary directory for this test
+ * @param tempPaths Temporary directories for this test
  * @param templateSpec Template name or `file:...` path
- * @param appName Name of the app to create
- * @returns Path to the app
  */
-export async function prepareCreateReactApp(
-  tmpDirectory: string,
-  templateSpec: string,
-  appName: string,
-): Promise<string> {
-  const tempUtilProjectPath = path.join(tmpDirectory, 'util');
-  const appProjectPath = path.join(tmpDirectory, appName);
-
+export async function prepareCreateReactApp(tempPaths: TempPaths, templateSpec: string): Promise<void> {
+  const tempUtilProjectPath = path.join(tempPaths.root, 'util');
   fs.mkdirSync(tempUtilProjectPath);
 
   try {
     // restoring bits of create-react-app inside util project
-    await shEcho('yarn add create-react-app', tempUtilProjectPath);
+    await shEcho(`yarn add create-react-app`, tempUtilProjectPath);
 
     // create test project with util's create-react-app
-    fs.mkdirSync(appProjectPath);
-    await shEcho(`yarn create-react-app ${appProjectPath} --template ${templateSpec}`, tempUtilProjectPath);
+    await shEcho(`yarn create-react-app ${tempPaths.testApp} --template ${templateSpec}`, tempUtilProjectPath);
   } finally {
     // remove temp util directory
     fs.removeSync(tempUtilProjectPath);
   }
-
-  return appProjectPath;
 }

--- a/scripts/projects-test/utils.ts
+++ b/scripts/projects-test/utils.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import tmp from 'tmp';
 // note: there's nothing gulp-specific about this utility, it just runs commands
 import sh from '../gulp/sh';
@@ -5,6 +7,36 @@ import sh from '../gulp/sh';
 // Clean up created files/folders on exit, even after exceptions
 // (will not catch SIGINT on windows)
 tmp.setGracefulCleanup();
+
+export interface TempPaths {
+  /** Parent temp directory */
+  root: string;
+  /** Directory for the test app (under `root`) */
+  testApp: string;
+  /** Directory for the yarn cache (under `root`) */
+  yarnCache: string;
+}
+
+/**
+ * Prepare a temp directory which contains folders used for the test, and a `.yarnrc` file.
+ * The `.yarnrc` contains a custom `cache-folder` under the parent temp directory to avoid race
+ * conditions with multiple tests modifying the global cache.
+ * @param prefix Prefix to use in the directory name
+ */
+export function prepareTempDirs(prefix: string): TempPaths {
+  const root = createTempDir(prefix);
+
+  const testApp = path.join(root, 'test-app');
+  fs.mkdirSync(testApp);
+
+  const yarnCache = path.join(root, 'yarn-cache');
+  fs.mkdirSync(yarnCache);
+
+  // Putting this in the parent folder ensures that running yarn in any child folder uses it
+  fs.writeFileSync(path.join(root, '.yarnrc'), `cache-folder "${yarnCache}"`);
+
+  return { root, testApp, yarnCache };
+}
 
 export function createTempDir(prefix: string): string {
   // "Unsafe" means delete even if it still has files inside (our desired behavior)
@@ -21,6 +53,6 @@ export function log(context: string) {
 }
 
 export async function shEcho(cmd: string, cwd?: string) {
-  console.log(`+ cd ${cwd ?? '.'} && ${cmd}`);
+  console.log(`+ cd ${cwd ?? '.'} &&\n    ${cmd}`);
   await sh(cmd, cwd);
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

We were seeing intermittent errors running `yarn` in the test for `@fluentui/cra-template`, the TS minbar tests, and possibly also projects-test. Things like this:
`verb @fluentui/cra-template test |  error An unexpected error occurred: "ENOENT: no such file or directory, open '/home/cloudtest/.cache/yarn/v6/npm-@babel-runtime-7.16.3-b86f0db02a04187a3c17caa77de69840165d42d5-integrity/node_modules/@babel/runtime/.yarn-metadata.json'".`
`verb ts-minbar-test-react-components test |  error https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "EEXIST: file already exists, mkdir '/home/cloudtest/.cache/yarn/v6/npm-@babel-runtime-7.16.3-b86f0db02a04187a3c17caa77de69840165d42d5-integrity/node_modules/@babel/runtime/helpers'" `

Based on the specific errors and the timing, I'm guessing this was due to multiple processes trying to run `yarn` at the same time with the same cache directory.

Fix is to make each test use its own temp directory for the yarn cache. This could make builds a little slower since the tests can no longer take advantage of things already downloaded to the global cache, but having reliable builds is more important.

NOTE: Since `create-react-app` doesn't pass `--cache-folder` through when running `yarn` internally, I moved each test's temp folders under a common parent (for just that test) and created a `.yarnrc` in the parent with the cache override. This makes everything including `create-react-app` run inside that folder use the correct cache.