### PR TITLE
Update required asterisk token for better contrast

### DIFF
--- a/change/@fluentui-react-label-4463527c-6817-4e1d-b35c-769552a8a677.json
+++ b/change/@fluentui-react-label-4463527c-6817-4e1d-b35c-769552a8a677.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update required asterisk token for better contrast",
+  "packageName": "@fluentui/react-label",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-label/src/components/Label/useLabelStyles.ts
+++ b/packages/react-label/src/components/Label/useLabelStyles.ts
@@ -17,7 +17,7 @@ const useStyles = makeStyles({
   }),
 
   required: theme => ({
-    color: theme.colorPaletteRedForeground3,
+    color: theme.colorPaletteRedForeground1,
     paddingLeft: '4px', // TODO: Once spacing tokens are added, change this to Horizontal XS
   }),
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20139
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR updates the design token used for the required asterisk in Label, so that it has a higher contrast in both light and dark themes

#### Focus areas to test

(optional)
