### PR TITLE
fix(slider|input|radio): use CSS shorthands in styles

### DIFF
--- a/change/@fluentui-react-slider-adb3b9a6-93c2-4a83-ac82-1978bd258e89.json
+++ b/change/@fluentui-react-slider-adb3b9a6-93c2-4a83-ac82-1978bd258e89.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use CSS shorthands in styles",
+  "packageName": "@fluentui/react-slider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-input/src/components/Input/Input.stories.tsx
+++ b/packages/react-input/src/components/Input/Input.stories.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@fluentui/react-icons" />
 import * as React from 'react';
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import { Input } from './Input';
 import { getNativeElementProps, useId } from '@fluentui/react-utilities';
 import { InputProps } from './Input.types';
@@ -18,10 +18,10 @@ const useStyles = makeStyles({
   container: {
     display: 'flex',
     flexDirection: 'column',
-    gap: '20px',
-    padding: '20px',
+    ...shorthands.gap('20px'),
+    ...shorthands.padding('20px'),
   },
-  storyFilledBackground: theme => ({ background: theme.colorNeutralBackground3 }),
+  storyFilledBackground: theme => ({ backgroundColor: theme.colorNeutralBackground3 }),
 });
 
 const icons = {

--- a/packages/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-input/src/components/Input/useInputStyles.ts
@@ -82,12 +82,16 @@ const useRootStyles = makeStyles({
 
       // Animation for focus OUT
       transform: 'scaleX(0)',
-      transition: `transform ${motionDurations.ultraFast} ${motionCurves.accelerateMid}`,
+      transitionProperty: 'transform',
+      transitionDuration: motionDurations.ultraFast,
+      transitionDelay: motionCurves.accelerateMid,
     },
     ':focus-within:after': {
       // Animation for focus IN
       transform: 'scaleX(1)',
-      transition: `transform ${motionDurations.normal} ${motionCurves.decelerateMid}`,
+      transitionProperty: 'transform',
+      transitionDuration: motionDurations.normal,
+      transitionDelay: motionCurves.decelerateMid,
     },
     ':focus-within:active:after': {
       // This is if the user clicks the field again while it's already focused
@@ -114,7 +118,7 @@ const useRootStyles = makeStyles({
     display: 'inline-flex',
   },
   outline: theme => ({
-    background: theme.colorNeutralBackground1,
+    backgroundColor: theme.colorNeutralBackground1,
     ...shorthands.border('1px', 'solid', theme.colorNeutralStroke1),
     borderBottomColor: theme.colorNeutralStrokeAccessible,
     ':hover': {
@@ -128,7 +132,7 @@ const useRootStyles = makeStyles({
     },
   }),
   underline: theme => ({
-    background: theme.colorTransparentBackground,
+    backgroundColor: theme.colorTransparentBackground,
     ...shorthands.borderRadius(0), // corners look strange if rounded
     ...shorthands.borderBottom('1px', 'solid', theme.colorNeutralStrokeAccessible),
     ':hover': {
@@ -150,10 +154,10 @@ const useRootStyles = makeStyles({
     },
   }),
   filledDarker: theme => ({
-    background: theme.colorNeutralBackground3,
+    backgroundColor: theme.colorNeutralBackground3,
   }),
   filledLighter: theme => ({
-    background: theme.colorNeutralBackground1,
+    backgroundColor: theme.colorNeutralBackground1,
   }),
   disabled: theme => ({
     cursor: 'not-allowed',
@@ -170,14 +174,14 @@ const useInputElementStyles = makeStyles({
     ...shorthands.padding('0', horizontalSpacing.xxs),
     color: theme.colorNeutralForeground1,
     // Use literal "transparent" (not from the theme) to always let the color from the root show through
-    background: 'transparent',
+    backgroundColor: 'transparent',
 
     '::placeholder': {
       color: theme.colorNeutralForeground4,
       opacity: 1, // browser style override
     },
     ':focus-visible': {
-      outline: 'none', // disable default browser outline
+      outlineStyle: 'none', // disable default browser outline
     },
   }),
   small: theme => ({
@@ -193,7 +197,7 @@ const useInputElementStyles = makeStyles({
   }),
   disabled: theme => ({
     color: theme.colorNeutralForegroundDisabled,
-    background: theme.colorTransparentBackground,
+    backgroundColor: theme.colorTransparentBackground,
     cursor: 'not-allowed',
     '::placeholder': {
       color: theme.colorNeutralForegroundDisabled,

--- a/packages/react-radio/src/components/RadioItem/useRadioItemStyles.ts
+++ b/packages/react-radio/src/components/RadioItem/useRadioItemStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-make-styles';
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import type { RadioItemState } from './RadioItem.types';
 
@@ -13,7 +13,7 @@ const useStyles = makeStyles({
     position: 'relative',
     alignSelf: 'flex-start',
     alignItems: 'center',
-    padding: '4px',
+    ...shorthands.padding('4px'),
     userSelect: 'none',
     cursor: 'pointer',
   }),
@@ -130,8 +130,8 @@ const useInputStyles = makeStyles({
   input: {
     opacity: 0,
     position: 'absolute',
-    margin: 0,
-    padding: 0,
+    ...shorthands.margin(0),
+    ...shorthands.padding(0),
     cursor: 'pointer',
   },
 
@@ -156,15 +156,15 @@ const useIndicatorStyles = makeStyles({
     width: '100%',
     height: '100%',
     fill: 'currentColor',
-    overflow: 'hidden',
+    ...shorthands.overflow('hidden'),
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     position: 'absolute',
     boxSizing: 'border-box',
-    borderStyle: 'solid',
-    borderRadius: theme.borderRadiusCircular,
-    borderWidth: theme.strokeWidthThin,
+    ...shorthands.borderStyle('solid'),
+    ...shorthands.borderRadius(theme.borderRadiusCircular),
+    ...shorthands.borderWidth(theme.strokeWidthThin),
   }),
 });
 

--- a/packages/react-slider/src/RangedSlider.stories.tsx
+++ b/packages/react-slider/src/RangedSlider.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@fluentui/react-make-styles';
 import { RangedSlider } from './index';
 import { Label } from '@fluentui/react-label';
 import type { RangedSliderProps } from './index';
@@ -9,7 +9,7 @@ const useStyles = makeStyles({
   root: {
     display: 'flex',
     flexDirection: 'column',
-    gap: '10px',
+    ...shorthands.gap('10px'),
     width: '400px',
   },
   slider: {
@@ -19,7 +19,7 @@ const useStyles = makeStyles({
   },
   verticalWrapper: {
     display: 'flex',
-    gap: '10px',
+    ...shorthands.gap('10px'),
   },
 });
 

--- a/packages/react-slider/src/Slider.stories.tsx
+++ b/packages/react-slider/src/Slider.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@fluentui/react-make-styles';
 import { Slider } from './index';
 import { Label } from '@fluentui/react-label';
 import type { SliderProps } from './index';
@@ -9,7 +9,7 @@ const useStyles = makeStyles({
   root: {
     display: 'flex',
     flexDirection: 'column',
-    gap: '10px',
+    ...shorthands.gap('10px'),
     width: '400px',
   },
   slider: {
@@ -19,7 +19,7 @@ const useStyles = makeStyles({
   },
   verticalWrapper: {
     display: 'flex',
-    gap: '10px',
+    ...shorthands.gap('10px'),
   },
 });
 

--- a/packages/react-slider/src/components/RangedSlider/useRangedSliderStyles.ts
+++ b/packages/react-slider/src/components/RangedSlider/useRangedSliderStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses, makeStyles } from '@fluentui/react-make-styles';
+import { shorthands, mergeClasses, makeStyles } from '@fluentui/react-make-styles';
 import {
   thumbClassName,
   trackClassName,
@@ -27,8 +27,8 @@ const useInputStyles = makeStyles({
   input: {
     opacity: 0,
     position: 'absolute',
-    padding: 0,
-    margin: 0,
+    ...shorthands.padding(0),
+    ...shorthands.margin(0),
     width: '0px',
     height: '0px',
     pointerEvents: 'none',
@@ -39,9 +39,9 @@ const useInputStyles = makeStyles({
       // TODO: Update this to [`& + .${lowerThumbClassName}`]
       '& + .fui-Slider-thumb-lower': {
         ':before': {
-          outline: 'none',
+          outlineStyle: 'none',
           boxSizing: 'border-box',
-          border: 'calc(var(--slider-thumb-size) * .05) solid black',
+          ...shorthands.border('calc(var(--slider-thumb-size) * .05)', 'solid', 'black'),
         },
       },
     }),
@@ -53,9 +53,9 @@ const useInputStyles = makeStyles({
       // TODO: Update this to [`& + .${upperThumbClassName}`]
       '& + .fui-Slider-thumb-upper': {
         ':before': {
-          outline: 'none',
+          outlineStyle: 'none',
           boxSizing: 'border-box',
-          border: 'calc(var(--slider-thumb-size) * .05) solid black',
+          ...shorthands.border('calc(var(--slider-thumb-size) * .05)', 'solid', 'black'),
         },
       },
     }),

--- a/packages/react-slider/src/components/Slider/useSliderStyles.ts
+++ b/packages/react-slider/src/components/Slider/useSliderStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import type { SliderState } from './Slider.types';
 
@@ -84,7 +84,7 @@ export const useRootStyles = makeStyles({
 export const useSliderWrapper = makeStyles({
   sliderWrapper: theme => ({
     position: 'absolute',
-    overflow: 'hidden',
+    ...shorthands.overflow('hidden'),
   }),
 
   horizontal: theme => ({
@@ -108,18 +108,18 @@ export const useSliderWrapper = makeStyles({
 export const useRailStyles = makeStyles({
   rail: theme => ({
     position: 'absolute',
-    borderRadius: theme.borderRadiusXLarge,
+    ...shorthands.borderRadius(theme.borderRadiusXLarge),
     boxSizing: 'border-box',
     pointerEvents: 'none',
   }),
 
   enabled: theme => ({
-    background: theme.colorNeutralStrokeAccessible,
+    backgroundColor: theme.colorNeutralStrokeAccessible,
   }),
 
   disabled: theme => ({
-    background: theme.colorNeutralBackgroundDisabled,
-    border: `1px solid ${theme.colorTransparentStrokeDisabled}`,
+    backgroundColor: theme.colorNeutralBackgroundDisabled,
+    ...shorthands.border('1px', 'solid', theme.colorTransparentStrokeDisabled),
   }),
 
   horizontal: theme => ({
@@ -166,7 +166,7 @@ export const useTrackWrapperStyles = makeStyles({
 export const useTrackStyles = makeStyles({
   track: theme => ({
     position: 'absolute',
-    borderRadius: theme.borderRadiusXLarge,
+    ...shorthands.borderRadius(theme.borderRadiusXLarge),
   }),
 
   horizontal: theme => ({
@@ -184,11 +184,11 @@ export const useTrackStyles = makeStyles({
   }),
 
   enabled: theme => ({
-    background: theme.colorCompoundBrandBackground,
+    backgroundColor: theme.colorCompoundBrandBackground,
   }),
 
   disabled: theme => ({
-    background: theme.colorNeutralForegroundDisabled,
+    backgroundColor: theme.colorNeutralForegroundDisabled,
   }),
 });
 
@@ -199,15 +199,15 @@ export const useMarksWrapperStyles = makeStyles({
   marksWrapper: theme => ({
     position: 'relative',
     display: 'grid',
-    outline: 'none',
-    zIndex: '1',
+    outlineStyle: 'none',
+    zIndex: 1,
     whiteSpace: 'nowrap',
     [`& .${markClassName}`]: {
-      background: theme.colorNeutralBackground1,
+      backgroundColor: theme.colorNeutralBackground1,
     },
 
     [`& .${markLabelClassName}`]: {
-      padding: '2px',
+      ...shorthands.padding('2px'),
       fontSize: '12px',
     },
 
@@ -280,8 +280,8 @@ export const useMarksWrapperStyles = makeStyles({
 export const useThumbWrapperStyles = makeStyles({
   thumbWrapper: theme => ({
     position: 'absolute',
-    outline: 'none',
-    zIndex: '2',
+    outlineStyle: 'none',
+    zIndex: 2,
   }),
 
   horizontal: theme => ({
@@ -309,8 +309,8 @@ export const useThumbStyles = makeStyles({
     left: '0px',
     bottom: '0px',
     right: '0px',
-    outline: 'none',
-    borderRadius: theme.borderRadiusCircular,
+    outlineStyle: 'none',
+    ...shorthands.borderRadius(theme.borderRadiusCircular),
     boxSizing: 'border-box',
     boxShadow: `0 0 0 calc(var(--slider-thumb-size) * .2) ${theme.colorNeutralBackground1} inset`,
     transform: 'translate(-50%, -50%)',
@@ -321,21 +321,21 @@ export const useThumbStyles = makeStyles({
       left: '0px',
       bottom: '0px',
       right: '0px',
-      borderRadius: theme.borderRadiusCircular,
+      ...shorthands.borderRadius(theme.borderRadiusCircular),
       boxSizing: 'border-box',
       content: "''",
-      border: `calc(var(--slider-thumb-size) * .05) solid ${theme.colorNeutralStroke1}`,
+      ...shorthands.border('calc(var(--slider-thumb-size) * .05)', 'solid', theme.colorNeutralStroke1),
     },
   }),
 
   enabled: theme => ({
-    background: theme.colorCompoundBrandBackground,
+    backgroundColor: theme.colorCompoundBrandBackground,
   }),
 
   disabled: theme => ({
-    background: theme.colorNeutralForegroundDisabled,
+    backgroundColor: theme.colorNeutralForegroundDisabled,
     ':before': {
-      border: `calc(var(--slider-thumb-size) * .05) solid ${theme.colorNeutralForegroundDisabled}`,
+      ...shorthands.border('calc(var(--slider-thumb-size) * .05)', 'solid', theme.colorNeutralForegroundDisabled),
     },
   }),
 
@@ -370,8 +370,8 @@ const useInputStyles = makeStyles({
   input: {
     opacity: 0,
     position: 'absolute',
-    padding: 0,
-    margin: 0,
+    ...shorthands.padding('0'),
+    ...shorthands.margin('0'),
     width: '100%',
     height: '100%',
     touchAction: 'none',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: extracted from #20539, related to #20573
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR updates styles to not use CSS shorthands in `@fluentui/react-slider`, `@fluentui/react-radio` and leftovers in `@fluentui/react-input`.

