### PR TITLE
fix(Menu): Focus on first menu item on click

### DIFF
--- a/change/@fluentui-react-menu-108a6441-1cfd-416b-bf2e-86d29fca5c90.json
+++ b/change/@fluentui-react-menu-108a6441-1cfd-416b-bf2e-86d29fca5c90.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Focus on first menu item on click",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/e2e/Menu.e2e.ts
+++ b/packages/react-menu/e2e/Menu.e2e.ts
@@ -21,24 +21,13 @@ describe('Menu', () => {
   });
 
   describe('MenuTrigger', () => {
-    it('should open menu when clicked', () => {
-      cy.loadStory(menuStoriesTitle, defaultStory)
-        .get(menuTriggerSelector)
-        .click()
-        .get(menuSelector)
-        .should('be.visible');
-    });
-
-    it('should focus first menu item on down arrow when focus is on the trigger', () => {
+    it('should open menu and focus first item when clicked', () => {
       cy.loadStory(menuStoriesTitle, defaultStory)
         .get(menuTriggerSelector)
         .click()
         .get(menuSelector)
         .should('be.visible')
-        .get(menuTriggerSelector)
-        .type('{downarrow}')
         .get(menuItemSelector)
-        .first()
         .should('be.focused');
     });
 
@@ -260,7 +249,7 @@ describe('Menu', () => {
   // [nestedMenuStory, nestedMenuControlledStory].forEach(story => {
   [nestedMenuStory, nestedMenuControlledStory].forEach(story => {
     describe(`Nested Menus (${story.includes('Controlled') ? 'Controlled' : 'Uncontrolled'})`, () => {
-      it('should open on trigger hover', () => {
+      it('should open on trigger hover and focus first item', () => {
         cy.loadStory(menuStoriesTitle, story)
           .get(menuTriggerSelector)
           .click()
@@ -269,11 +258,16 @@ describe('Menu', () => {
             cy.get(menuTriggerSelector).trigger('mousemove');
           })
           .get(menuSelector)
-          .should('have.length', 2);
+          .should('have.length', 2)
+          .get(menuSelector)
+          .eq(1)
+          .within(() => {
+            cy.get(menuItemSelector).first().should('be.focused');
+          });
       });
 
       ['{rightarrow}', '{enter}', ' '].forEach(key => {
-        it(`should open on trigger ${key === ' ' ? 'space' : key}`, () => {
+        it(`should open on trigger ${key === ' ' ? 'space' : key} and focus first item`, () => {
           cy.loadStory(menuStoriesTitle, story)
             .get(menuTriggerSelector)
             .click()

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -219,18 +219,19 @@ const useMenuOpenState = (
   }, [open, focusFirst]);
 
   React.useEffect(() => {
+    if (open) {
+      focusFirst();
+    }
+
+    // rest of this effect is for keyboard focus handling
     if (!shouldHandleKeyboardRef.current) {
       return;
     }
 
-    if (open) {
-      focusFirst();
+    if (shouldHandleTabRef.current && !state.isSubmenu) {
+      pressedShiftRef.current ? focusBeforeMenuTrigger() : focusAfterMenuTrigger();
     } else {
-      if (shouldHandleTabRef.current && !state.isSubmenu) {
-        pressedShiftRef.current ? focusBeforeMenuTrigger() : focusAfterMenuTrigger();
-      } else {
-        state.triggerRef.current?.focus();
-      }
+      state.triggerRef.current?.focus();
     }
 
     shouldHandleKeyboardRef.current = false;

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -223,15 +223,12 @@ const useMenuOpenState = (
       focusFirst();
     }
 
-    // rest of this effect is for keyboard focus handling
-    if (!shouldHandleKeyboardRef.current) {
-      return;
-    }
-
-    if (shouldHandleTabRef.current && !state.isSubmenu) {
-      pressedShiftRef.current ? focusBeforeMenuTrigger() : focusAfterMenuTrigger();
-    } else {
-      state.triggerRef.current?.focus();
+    if (shouldHandleKeyboardRef.current && !open) {
+      if (shouldHandleTabRef.current && !state.isSubmenu) {
+        pressedShiftRef.current ? focusBeforeMenuTrigger() : focusAfterMenuTrigger();
+      } else {
+        state.triggerRef.current?.focus();
+      }
     }
 
     shouldHandleKeyboardRef.current = false;

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -213,6 +213,12 @@ const useMenuOpenState = (
   }, [findPrevFocusable, state.triggerRef]);
 
   React.useEffect(() => {
+    if (open) {
+      focusFirst();
+    }
+  }, [open, focusFirst]);
+
+  React.useEffect(() => {
     if (!shouldHandleKeyboardRef.current) {
       return;
     }

--- a/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useTriggerElement.ts
@@ -81,10 +81,6 @@ export const useTriggerElement = (state: MenuTriggerState): MenuTriggerState => 
       focusFirst();
     }
 
-    if (open && key === ArrowDown && !isSubmenu) {
-      focusFirst();
-    }
-
     child?.props?.onKeyDown?.(e);
   });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20047
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Reverts a part of #18618 where the first menu item was not focused on click, but was done for `Enter`

#### Focus areas to test

(optional)
