### PR TITLE
feat(react-theme) Add border1 color token for shared colors

### DIFF
--- a/change/@fluentui-react-theme-d84a9be2-458a-4000-8686-95f2ba2f0cfa.json
+++ b/change/@fluentui-react-theme-d84a9be2-458a-4000-8686-95f2ba2f0cfa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat(react-theme) Add border1 color token for shared colors",
+  "packageName": "@fluentui/react-theme",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-theme/etc/react-theme.api.md
+++ b/packages/react-theme/etc/react-theme.api.md
@@ -21,154 +21,154 @@ export type Brands = 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100 | 110 | 12
 export type BrandVariants = Record<Brands, string>;
 
 // @public (undocumented)
-export type ColorPaletteAnchor = 'colorPaletteAnchorBackground1' | 'colorPaletteAnchorBackground2' | 'colorPaletteAnchorBackground3' | 'colorPaletteAnchorForeground1' | 'colorPaletteAnchorForeground2' | 'colorPaletteAnchorForeground3' | 'colorPaletteAnchorBorderActive' | 'colorPaletteAnchorBorder2';
+export type ColorPaletteAnchor = 'colorPaletteAnchorBackground1' | 'colorPaletteAnchorBackground2' | 'colorPaletteAnchorBackground3' | 'colorPaletteAnchorForeground1' | 'colorPaletteAnchorForeground2' | 'colorPaletteAnchorForeground3' | 'colorPaletteAnchorBorderActive' | 'colorPaletteAnchorBorder1' | 'colorPaletteAnchorBorder2';
 
 // @public (undocumented)
-export type ColorPaletteBeige = 'colorPaletteBeigeBackground1' | 'colorPaletteBeigeBackground2' | 'colorPaletteBeigeBackground3' | 'colorPaletteBeigeForeground1' | 'colorPaletteBeigeForeground2' | 'colorPaletteBeigeForeground3' | 'colorPaletteBeigeBorderActive' | 'colorPaletteBeigeBorder2';
+export type ColorPaletteBeige = 'colorPaletteBeigeBackground1' | 'colorPaletteBeigeBackground2' | 'colorPaletteBeigeBackground3' | 'colorPaletteBeigeForeground1' | 'colorPaletteBeigeForeground2' | 'colorPaletteBeigeForeground3' | 'colorPaletteBeigeBorderActive' | 'colorPaletteBeigeBorder1' | 'colorPaletteBeigeBorder2';
 
 // @public (undocumented)
-export type ColorPaletteBerry = 'colorPaletteBerryBackground1' | 'colorPaletteBerryBackground2' | 'colorPaletteBerryBackground3' | 'colorPaletteBerryForeground1' | 'colorPaletteBerryForeground2' | 'colorPaletteBerryForeground3' | 'colorPaletteBerryBorderActive' | 'colorPaletteBerryBorder2';
+export type ColorPaletteBerry = 'colorPaletteBerryBackground1' | 'colorPaletteBerryBackground2' | 'colorPaletteBerryBackground3' | 'colorPaletteBerryForeground1' | 'colorPaletteBerryForeground2' | 'colorPaletteBerryForeground3' | 'colorPaletteBerryBorderActive' | 'colorPaletteBerryBorder1' | 'colorPaletteBerryBorder2';
 
 // @public (undocumented)
-export type ColorPaletteBlue = 'colorPaletteBlueBackground1' | 'colorPaletteBlueBackground2' | 'colorPaletteBlueBackground3' | 'colorPaletteBlueForeground1' | 'colorPaletteBlueForeground2' | 'colorPaletteBlueForeground3' | 'colorPaletteBlueBorderActive' | 'colorPaletteBlueBorder2';
+export type ColorPaletteBlue = 'colorPaletteBlueBackground1' | 'colorPaletteBlueBackground2' | 'colorPaletteBlueBackground3' | 'colorPaletteBlueForeground1' | 'colorPaletteBlueForeground2' | 'colorPaletteBlueForeground3' | 'colorPaletteBlueBorderActive' | 'colorPaletteBlueBorder1' | 'colorPaletteBlueBorder2';
 
 // @public (undocumented)
-export type ColorPaletteBrass = 'colorPaletteBrassBackground1' | 'colorPaletteBrassBackground2' | 'colorPaletteBrassBackground3' | 'colorPaletteBrassForeground1' | 'colorPaletteBrassForeground2' | 'colorPaletteBrassForeground3' | 'colorPaletteBrassBorderActive' | 'colorPaletteBrassBorder2';
+export type ColorPaletteBrass = 'colorPaletteBrassBackground1' | 'colorPaletteBrassBackground2' | 'colorPaletteBrassBackground3' | 'colorPaletteBrassForeground1' | 'colorPaletteBrassForeground2' | 'colorPaletteBrassForeground3' | 'colorPaletteBrassBorderActive' | 'colorPaletteBrassBorder1' | 'colorPaletteBrassBorder2';
 
 // @public (undocumented)
-export type ColorPaletteBronze = 'colorPaletteBronzeBackground1' | 'colorPaletteBronzeBackground2' | 'colorPaletteBronzeBackground3' | 'colorPaletteBronzeForeground1' | 'colorPaletteBronzeForeground2' | 'colorPaletteBronzeForeground3' | 'colorPaletteBronzeBorderActive' | 'colorPaletteBronzeBorder2';
+export type ColorPaletteBronze = 'colorPaletteBronzeBackground1' | 'colorPaletteBronzeBackground2' | 'colorPaletteBronzeBackground3' | 'colorPaletteBronzeForeground1' | 'colorPaletteBronzeForeground2' | 'colorPaletteBronzeForeground3' | 'colorPaletteBronzeBorderActive' | 'colorPaletteBronzeBorder1' | 'colorPaletteBronzeBorder2';
 
 // @public (undocumented)
-export type ColorPaletteBrown = 'colorPaletteBrownBackground1' | 'colorPaletteBrownBackground2' | 'colorPaletteBrownBackground3' | 'colorPaletteBrownForeground1' | 'colorPaletteBrownForeground2' | 'colorPaletteBrownForeground3' | 'colorPaletteBrownBorderActive' | 'colorPaletteBrownBorder2';
+export type ColorPaletteBrown = 'colorPaletteBrownBackground1' | 'colorPaletteBrownBackground2' | 'colorPaletteBrownBackground3' | 'colorPaletteBrownForeground1' | 'colorPaletteBrownForeground2' | 'colorPaletteBrownForeground3' | 'colorPaletteBrownBorderActive' | 'colorPaletteBrownBorder1' | 'colorPaletteBrownBorder2';
 
 // @public (undocumented)
-export type ColorPaletteBurgundy = 'colorPaletteBurgundyBackground1' | 'colorPaletteBurgundyBackground2' | 'colorPaletteBurgundyBackground3' | 'colorPaletteBurgundyForeground1' | 'colorPaletteBurgundyForeground2' | 'colorPaletteBurgundyForeground3' | 'colorPaletteBurgundyBorderActive' | 'colorPaletteBurgundyBorder2';
+export type ColorPaletteBurgundy = 'colorPaletteBurgundyBackground1' | 'colorPaletteBurgundyBackground2' | 'colorPaletteBurgundyBackground3' | 'colorPaletteBurgundyForeground1' | 'colorPaletteBurgundyForeground2' | 'colorPaletteBurgundyForeground3' | 'colorPaletteBurgundyBorderActive' | 'colorPaletteBurgundyBorder1' | 'colorPaletteBurgundyBorder2';
 
 // @public (undocumented)
-export type ColorPaletteCharcoal = 'colorPaletteCharcoalBackground1' | 'colorPaletteCharcoalBackground2' | 'colorPaletteCharcoalBackground3' | 'colorPaletteCharcoalForeground1' | 'colorPaletteCharcoalForeground2' | 'colorPaletteCharcoalForeground3' | 'colorPaletteCharcoalBorderActive' | 'colorPaletteCharcoalBorder2';
+export type ColorPaletteCharcoal = 'colorPaletteCharcoalBackground1' | 'colorPaletteCharcoalBackground2' | 'colorPaletteCharcoalBackground3' | 'colorPaletteCharcoalForeground1' | 'colorPaletteCharcoalForeground2' | 'colorPaletteCharcoalForeground3' | 'colorPaletteCharcoalBorderActive' | 'colorPaletteCharcoalBorder1' | 'colorPaletteCharcoalBorder2';
 
 // @public (undocumented)
-export type ColorPaletteCornflower = 'colorPaletteCornflowerBackground1' | 'colorPaletteCornflowerBackground2' | 'colorPaletteCornflowerBackground3' | 'colorPaletteCornflowerForeground1' | 'colorPaletteCornflowerForeground2' | 'colorPaletteCornflowerForeground3' | 'colorPaletteCornflowerBorderActive' | 'colorPaletteCornflowerBorder2';
+export type ColorPaletteCornflower = 'colorPaletteCornflowerBackground1' | 'colorPaletteCornflowerBackground2' | 'colorPaletteCornflowerBackground3' | 'colorPaletteCornflowerForeground1' | 'colorPaletteCornflowerForeground2' | 'colorPaletteCornflowerForeground3' | 'colorPaletteCornflowerBorderActive' | 'colorPaletteCornflowerBorder1' | 'colorPaletteCornflowerBorder2';
 
 // @public (undocumented)
-export type ColorPaletteCranberry = 'colorPaletteCranberryBackground1' | 'colorPaletteCranberryBackground2' | 'colorPaletteCranberryBackground3' | 'colorPaletteCranberryForeground1' | 'colorPaletteCranberryForeground2' | 'colorPaletteCranberryForeground3' | 'colorPaletteCranberryBorderActive' | 'colorPaletteCranberryBorder2';
+export type ColorPaletteCranberry = 'colorPaletteCranberryBackground1' | 'colorPaletteCranberryBackground2' | 'colorPaletteCranberryBackground3' | 'colorPaletteCranberryForeground1' | 'colorPaletteCranberryForeground2' | 'colorPaletteCranberryForeground3' | 'colorPaletteCranberryBorderActive' | 'colorPaletteCranberryBorder1' | 'colorPaletteCranberryBorder2';
 
 // @public (undocumented)
-export type ColorPaletteCyan = 'colorPaletteCyanBackground1' | 'colorPaletteCyanBackground2' | 'colorPaletteCyanBackground3' | 'colorPaletteCyanForeground1' | 'colorPaletteCyanForeground2' | 'colorPaletteCyanForeground3' | 'colorPaletteCyanBorderActive' | 'colorPaletteCyanBorder2';
+export type ColorPaletteCyan = 'colorPaletteCyanBackground1' | 'colorPaletteCyanBackground2' | 'colorPaletteCyanBackground3' | 'colorPaletteCyanForeground1' | 'colorPaletteCyanForeground2' | 'colorPaletteCyanForeground3' | 'colorPaletteCyanBorderActive' | 'colorPaletteCyanBorder1' | 'colorPaletteCyanBorder2';
 
 // @public (undocumented)
-export type ColorPaletteDarkBlue = 'colorPaletteDarkBlueBackground1' | 'colorPaletteDarkBlueBackground2' | 'colorPaletteDarkBlueBackground3' | 'colorPaletteDarkBlueForeground1' | 'colorPaletteDarkBlueForeground2' | 'colorPaletteDarkBlueForeground3' | 'colorPaletteDarkBlueBorderActive' | 'colorPaletteDarkBlueBorder2';
+export type ColorPaletteDarkBlue = 'colorPaletteDarkBlueBackground1' | 'colorPaletteDarkBlueBackground2' | 'colorPaletteDarkBlueBackground3' | 'colorPaletteDarkBlueForeground1' | 'colorPaletteDarkBlueForeground2' | 'colorPaletteDarkBlueForeground3' | 'colorPaletteDarkBlueBorderActive' | 'colorPaletteDarkBlueBorder1' | 'colorPaletteDarkBlueBorder2';
 
 // @public (undocumented)
-export type ColorPaletteDarkBrown = 'colorPaletteDarkBrownBackground1' | 'colorPaletteDarkBrownBackground2' | 'colorPaletteDarkBrownBackground3' | 'colorPaletteDarkBrownForeground1' | 'colorPaletteDarkBrownForeground2' | 'colorPaletteDarkBrownForeground3' | 'colorPaletteDarkBrownBorderActive' | 'colorPaletteDarkBrownBorder2';
+export type ColorPaletteDarkBrown = 'colorPaletteDarkBrownBackground1' | 'colorPaletteDarkBrownBackground2' | 'colorPaletteDarkBrownBackground3' | 'colorPaletteDarkBrownForeground1' | 'colorPaletteDarkBrownForeground2' | 'colorPaletteDarkBrownForeground3' | 'colorPaletteDarkBrownBorderActive' | 'colorPaletteDarkBrownBorder1' | 'colorPaletteDarkBrownBorder2';
 
 // @public (undocumented)
-export type ColorPaletteDarkGreen = 'colorPaletteDarkGreenBackground1' | 'colorPaletteDarkGreenBackground2' | 'colorPaletteDarkGreenBackground3' | 'colorPaletteDarkGreenForeground1' | 'colorPaletteDarkGreenForeground2' | 'colorPaletteDarkGreenForeground3' | 'colorPaletteDarkGreenBorderActive' | 'colorPaletteDarkGreenBorder2';
+export type ColorPaletteDarkGreen = 'colorPaletteDarkGreenBackground1' | 'colorPaletteDarkGreenBackground2' | 'colorPaletteDarkGreenBackground3' | 'colorPaletteDarkGreenForeground1' | 'colorPaletteDarkGreenForeground2' | 'colorPaletteDarkGreenForeground3' | 'colorPaletteDarkGreenBorderActive' | 'colorPaletteDarkGreenBorder1' | 'colorPaletteDarkGreenBorder2';
 
 // @public (undocumented)
-export type ColorPaletteDarkOrange = 'colorPaletteDarkOrangeBackground1' | 'colorPaletteDarkOrangeBackground2' | 'colorPaletteDarkOrangeBackground3' | 'colorPaletteDarkOrangeForeground1' | 'colorPaletteDarkOrangeForeground2' | 'colorPaletteDarkOrangeForeground3' | 'colorPaletteDarkOrangeBorderActive' | 'colorPaletteDarkOrangeBorder2';
+export type ColorPaletteDarkOrange = 'colorPaletteDarkOrangeBackground1' | 'colorPaletteDarkOrangeBackground2' | 'colorPaletteDarkOrangeBackground3' | 'colorPaletteDarkOrangeForeground1' | 'colorPaletteDarkOrangeForeground2' | 'colorPaletteDarkOrangeForeground3' | 'colorPaletteDarkOrangeBorderActive' | 'colorPaletteDarkOrangeBorder1' | 'colorPaletteDarkOrangeBorder2';
 
 // @public (undocumented)
-export type ColorPaletteDarkPurple = 'colorPaletteDarkPurpleBackground1' | 'colorPaletteDarkPurpleBackground2' | 'colorPaletteDarkPurpleBackground3' | 'colorPaletteDarkPurpleForeground1' | 'colorPaletteDarkPurpleForeground2' | 'colorPaletteDarkPurpleForeground3' | 'colorPaletteDarkPurpleBorderActive' | 'colorPaletteDarkPurpleBorder2';
+export type ColorPaletteDarkPurple = 'colorPaletteDarkPurpleBackground1' | 'colorPaletteDarkPurpleBackground2' | 'colorPaletteDarkPurpleBackground3' | 'colorPaletteDarkPurpleForeground1' | 'colorPaletteDarkPurpleForeground2' | 'colorPaletteDarkPurpleForeground3' | 'colorPaletteDarkPurpleBorderActive' | 'colorPaletteDarkPurpleBorder1' | 'colorPaletteDarkPurpleBorder2';
 
 // @public (undocumented)
-export type ColorPaletteDarkRed = 'colorPaletteDarkRedBackground1' | 'colorPaletteDarkRedBackground2' | 'colorPaletteDarkRedBackground3' | 'colorPaletteDarkRedForeground1' | 'colorPaletteDarkRedForeground2' | 'colorPaletteDarkRedForeground3' | 'colorPaletteDarkRedBorderActive' | 'colorPaletteDarkRedBorder2';
+export type ColorPaletteDarkRed = 'colorPaletteDarkRedBackground1' | 'colorPaletteDarkRedBackground2' | 'colorPaletteDarkRedBackground3' | 'colorPaletteDarkRedForeground1' | 'colorPaletteDarkRedForeground2' | 'colorPaletteDarkRedForeground3' | 'colorPaletteDarkRedBorderActive' | 'colorPaletteDarkRedBorder1' | 'colorPaletteDarkRedBorder2';
 
 // @public (undocumented)
-export type ColorPaletteDarkTeal = 'colorPaletteDarkTealBackground1' | 'colorPaletteDarkTealBackground2' | 'colorPaletteDarkTealBackground3' | 'colorPaletteDarkTealForeground1' | 'colorPaletteDarkTealForeground2' | 'colorPaletteDarkTealForeground3' | 'colorPaletteDarkTealBorderActive' | 'colorPaletteDarkTealBorder2';
+export type ColorPaletteDarkTeal = 'colorPaletteDarkTealBackground1' | 'colorPaletteDarkTealBackground2' | 'colorPaletteDarkTealBackground3' | 'colorPaletteDarkTealForeground1' | 'colorPaletteDarkTealForeground2' | 'colorPaletteDarkTealForeground3' | 'colorPaletteDarkTealBorderActive' | 'colorPaletteDarkTealBorder1' | 'colorPaletteDarkTealBorder2';
 
 // @public (undocumented)
-export type ColorPaletteForest = 'colorPaletteForestBackground1' | 'colorPaletteForestBackground2' | 'colorPaletteForestBackground3' | 'colorPaletteForestForeground1' | 'colorPaletteForestForeground2' | 'colorPaletteForestForeground3' | 'colorPaletteForestBorderActive' | 'colorPaletteForestBorder2';
+export type ColorPaletteForest = 'colorPaletteForestBackground1' | 'colorPaletteForestBackground2' | 'colorPaletteForestBackground3' | 'colorPaletteForestForeground1' | 'colorPaletteForestForeground2' | 'colorPaletteForestForeground3' | 'colorPaletteForestBorderActive' | 'colorPaletteForestBorder1' | 'colorPaletteForestBorder2';
 
 // @public (undocumented)
-export type ColorPaletteGold = 'colorPaletteGoldBackground1' | 'colorPaletteGoldBackground2' | 'colorPaletteGoldBackground3' | 'colorPaletteGoldForeground1' | 'colorPaletteGoldForeground2' | 'colorPaletteGoldForeground3' | 'colorPaletteGoldBorderActive' | 'colorPaletteGoldBorder2';
+export type ColorPaletteGold = 'colorPaletteGoldBackground1' | 'colorPaletteGoldBackground2' | 'colorPaletteGoldBackground3' | 'colorPaletteGoldForeground1' | 'colorPaletteGoldForeground2' | 'colorPaletteGoldForeground3' | 'colorPaletteGoldBorderActive' | 'colorPaletteGoldBorder1' | 'colorPaletteGoldBorder2';
 
 // @public (undocumented)
-export type ColorPaletteGrape = 'colorPaletteGrapeBackground1' | 'colorPaletteGrapeBackground2' | 'colorPaletteGrapeBackground3' | 'colorPaletteGrapeForeground1' | 'colorPaletteGrapeForeground2' | 'colorPaletteGrapeForeground3' | 'colorPaletteGrapeBorderActive' | 'colorPaletteGrapeBorder2';
+export type ColorPaletteGrape = 'colorPaletteGrapeBackground1' | 'colorPaletteGrapeBackground2' | 'colorPaletteGrapeBackground3' | 'colorPaletteGrapeForeground1' | 'colorPaletteGrapeForeground2' | 'colorPaletteGrapeForeground3' | 'colorPaletteGrapeBorderActive' | 'colorPaletteGrapeBorder1' | 'colorPaletteGrapeBorder2';
 
 // @public (undocumented)
-export type ColorPaletteGreen = 'colorPaletteGreenBackground1' | 'colorPaletteGreenBackground2' | 'colorPaletteGreenBackground3' | 'colorPaletteGreenForeground1' | 'colorPaletteGreenForeground2' | 'colorPaletteGreenForeground3' | 'colorPaletteGreenBorderActive' | 'colorPaletteGreenBorder2';
+export type ColorPaletteGreen = 'colorPaletteGreenBackground1' | 'colorPaletteGreenBackground2' | 'colorPaletteGreenBackground3' | 'colorPaletteGreenForeground1' | 'colorPaletteGreenForeground2' | 'colorPaletteGreenForeground3' | 'colorPaletteGreenBorderActive' | 'colorPaletteGreenBorder1' | 'colorPaletteGreenBorder2';
 
 // @public (undocumented)
-export type ColorPaletteHotPink = 'colorPaletteHotPinkBackground1' | 'colorPaletteHotPinkBackground2' | 'colorPaletteHotPinkBackground3' | 'colorPaletteHotPinkForeground1' | 'colorPaletteHotPinkForeground2' | 'colorPaletteHotPinkForeground3' | 'colorPaletteHotPinkBorderActive' | 'colorPaletteHotPinkBorder2';
+export type ColorPaletteHotPink = 'colorPaletteHotPinkBackground1' | 'colorPaletteHotPinkBackground2' | 'colorPaletteHotPinkBackground3' | 'colorPaletteHotPinkForeground1' | 'colorPaletteHotPinkForeground2' | 'colorPaletteHotPinkForeground3' | 'colorPaletteHotPinkBorderActive' | 'colorPaletteHotPinkBorder1' | 'colorPaletteHotPinkBorder2';
 
 // @public (undocumented)
-export type ColorPaletteLavender = 'colorPaletteLavenderBackground1' | 'colorPaletteLavenderBackground2' | 'colorPaletteLavenderBackground3' | 'colorPaletteLavenderForeground1' | 'colorPaletteLavenderForeground2' | 'colorPaletteLavenderForeground3' | 'colorPaletteLavenderBorderActive' | 'colorPaletteLavenderBorder2';
+export type ColorPaletteLavender = 'colorPaletteLavenderBackground1' | 'colorPaletteLavenderBackground2' | 'colorPaletteLavenderBackground3' | 'colorPaletteLavenderForeground1' | 'colorPaletteLavenderForeground2' | 'colorPaletteLavenderForeground3' | 'colorPaletteLavenderBorderActive' | 'colorPaletteLavenderBorder1' | 'colorPaletteLavenderBorder2';
 
 // @public (undocumented)
-export type ColorPaletteLightBlue = 'colorPaletteLightBlueBackground1' | 'colorPaletteLightBlueBackground2' | 'colorPaletteLightBlueBackground3' | 'colorPaletteLightBlueForeground1' | 'colorPaletteLightBlueForeground2' | 'colorPaletteLightBlueForeground3' | 'colorPaletteLightBlueBorderActive' | 'colorPaletteLightBlueBorder2';
+export type ColorPaletteLightBlue = 'colorPaletteLightBlueBackground1' | 'colorPaletteLightBlueBackground2' | 'colorPaletteLightBlueBackground3' | 'colorPaletteLightBlueForeground1' | 'colorPaletteLightBlueForeground2' | 'colorPaletteLightBlueForeground3' | 'colorPaletteLightBlueBorderActive' | 'colorPaletteLightBlueBorder1' | 'colorPaletteLightBlueBorder2';
 
 // @public (undocumented)
-export type ColorPaletteLightGreen = 'colorPaletteLightGreenBackground1' | 'colorPaletteLightGreenBackground2' | 'colorPaletteLightGreenBackground3' | 'colorPaletteLightGreenForeground1' | 'colorPaletteLightGreenForeground2' | 'colorPaletteLightGreenForeground3' | 'colorPaletteLightGreenBorderActive' | 'colorPaletteLightGreenBorder2';
+export type ColorPaletteLightGreen = 'colorPaletteLightGreenBackground1' | 'colorPaletteLightGreenBackground2' | 'colorPaletteLightGreenBackground3' | 'colorPaletteLightGreenForeground1' | 'colorPaletteLightGreenForeground2' | 'colorPaletteLightGreenForeground3' | 'colorPaletteLightGreenBorderActive' | 'colorPaletteLightGreenBorder1' | 'colorPaletteLightGreenBorder2';
 
 // @public (undocumented)
-export type ColorPaletteLightTeal = 'colorPaletteLightTealBackground1' | 'colorPaletteLightTealBackground2' | 'colorPaletteLightTealBackground3' | 'colorPaletteLightTealForeground1' | 'colorPaletteLightTealForeground2' | 'colorPaletteLightTealForeground3' | 'colorPaletteLightTealBorderActive' | 'colorPaletteLightTealBorder2';
+export type ColorPaletteLightTeal = 'colorPaletteLightTealBackground1' | 'colorPaletteLightTealBackground2' | 'colorPaletteLightTealBackground3' | 'colorPaletteLightTealForeground1' | 'colorPaletteLightTealForeground2' | 'colorPaletteLightTealForeground3' | 'colorPaletteLightTealBorderActive' | 'colorPaletteLightTealBorder1' | 'colorPaletteLightTealBorder2';
 
 // @public (undocumented)
-export type ColorPaletteLilac = 'colorPaletteLilacBackground1' | 'colorPaletteLilacBackground2' | 'colorPaletteLilacBackground3' | 'colorPaletteLilacForeground1' | 'colorPaletteLilacForeground2' | 'colorPaletteLilacForeground3' | 'colorPaletteLilacBorderActive' | 'colorPaletteLilacBorder2';
+export type ColorPaletteLilac = 'colorPaletteLilacBackground1' | 'colorPaletteLilacBackground2' | 'colorPaletteLilacBackground3' | 'colorPaletteLilacForeground1' | 'colorPaletteLilacForeground2' | 'colorPaletteLilacForeground3' | 'colorPaletteLilacBorderActive' | 'colorPaletteLilacBorder1' | 'colorPaletteLilacBorder2';
 
 // @public (undocumented)
-export type ColorPaletteLime = 'colorPaletteLimeBackground1' | 'colorPaletteLimeBackground2' | 'colorPaletteLimeBackground3' | 'colorPaletteLimeForeground1' | 'colorPaletteLimeForeground2' | 'colorPaletteLimeForeground3' | 'colorPaletteLimeBorderActive' | 'colorPaletteLimeBorder2';
+export type ColorPaletteLime = 'colorPaletteLimeBackground1' | 'colorPaletteLimeBackground2' | 'colorPaletteLimeBackground3' | 'colorPaletteLimeForeground1' | 'colorPaletteLimeForeground2' | 'colorPaletteLimeForeground3' | 'colorPaletteLimeBorderActive' | 'colorPaletteLimeBorder1' | 'colorPaletteLimeBorder2';
 
 // @public (undocumented)
-export type ColorPaletteMagenta = 'colorPaletteMagentaBackground1' | 'colorPaletteMagentaBackground2' | 'colorPaletteMagentaBackground3' | 'colorPaletteMagentaForeground1' | 'colorPaletteMagentaForeground2' | 'colorPaletteMagentaForeground3' | 'colorPaletteMagentaBorderActive' | 'colorPaletteMagentaBorder2';
+export type ColorPaletteMagenta = 'colorPaletteMagentaBackground1' | 'colorPaletteMagentaBackground2' | 'colorPaletteMagentaBackground3' | 'colorPaletteMagentaForeground1' | 'colorPaletteMagentaForeground2' | 'colorPaletteMagentaForeground3' | 'colorPaletteMagentaBorderActive' | 'colorPaletteMagentaBorder1' | 'colorPaletteMagentaBorder2';
 
 // @public (undocumented)
-export type ColorPaletteMarigold = 'colorPaletteMarigoldBackground1' | 'colorPaletteMarigoldBackground2' | 'colorPaletteMarigoldBackground3' | 'colorPaletteMarigoldForeground1' | 'colorPaletteMarigoldForeground2' | 'colorPaletteMarigoldForeground3' | 'colorPaletteMarigoldBorderActive' | 'colorPaletteMarigoldBorder2';
+export type ColorPaletteMarigold = 'colorPaletteMarigoldBackground1' | 'colorPaletteMarigoldBackground2' | 'colorPaletteMarigoldBackground3' | 'colorPaletteMarigoldForeground1' | 'colorPaletteMarigoldForeground2' | 'colorPaletteMarigoldForeground3' | 'colorPaletteMarigoldBorderActive' | 'colorPaletteMarigoldBorder1' | 'colorPaletteMarigoldBorder2';
 
 // @public (undocumented)
-export type ColorPaletteMink = 'colorPaletteMinkBackground1' | 'colorPaletteMinkBackground2' | 'colorPaletteMinkBackground3' | 'colorPaletteMinkForeground1' | 'colorPaletteMinkForeground2' | 'colorPaletteMinkForeground3' | 'colorPaletteMinkBorderActive' | 'colorPaletteMinkBorder2';
+export type ColorPaletteMink = 'colorPaletteMinkBackground1' | 'colorPaletteMinkBackground2' | 'colorPaletteMinkBackground3' | 'colorPaletteMinkForeground1' | 'colorPaletteMinkForeground2' | 'colorPaletteMinkForeground3' | 'colorPaletteMinkBorderActive' | 'colorPaletteMinkBorder1' | 'colorPaletteMinkBorder2';
 
 // @public (undocumented)
-export type ColorPaletteNavy = 'colorPaletteNavyBackground1' | 'colorPaletteNavyBackground2' | 'colorPaletteNavyBackground3' | 'colorPaletteNavyForeground1' | 'colorPaletteNavyForeground2' | 'colorPaletteNavyForeground3' | 'colorPaletteNavyBorderActive' | 'colorPaletteNavyBorder2';
+export type ColorPaletteNavy = 'colorPaletteNavyBackground1' | 'colorPaletteNavyBackground2' | 'colorPaletteNavyBackground3' | 'colorPaletteNavyForeground1' | 'colorPaletteNavyForeground2' | 'colorPaletteNavyForeground3' | 'colorPaletteNavyBorderActive' | 'colorPaletteNavyBorder1' | 'colorPaletteNavyBorder2';
 
 // @public (undocumented)
-export type ColorPaletteOrange = 'colorPaletteOrangeBackground1' | 'colorPaletteOrangeBackground2' | 'colorPaletteOrangeBackground3' | 'colorPaletteOrangeForeground1' | 'colorPaletteOrangeForeground2' | 'colorPaletteOrangeForeground3' | 'colorPaletteOrangeBorderActive' | 'colorPaletteOrangeBorder2';
+export type ColorPaletteOrange = 'colorPaletteOrangeBackground1' | 'colorPaletteOrangeBackground2' | 'colorPaletteOrangeBackground3' | 'colorPaletteOrangeForeground1' | 'colorPaletteOrangeForeground2' | 'colorPaletteOrangeForeground3' | 'colorPaletteOrangeBorderActive' | 'colorPaletteOrangeBorder1' | 'colorPaletteOrangeBorder2';
 
 // @public (undocumented)
-export type ColorPaletteOrchid = 'colorPaletteOrchidBackground1' | 'colorPaletteOrchidBackground2' | 'colorPaletteOrchidBackground3' | 'colorPaletteOrchidForeground1' | 'colorPaletteOrchidForeground2' | 'colorPaletteOrchidForeground3' | 'colorPaletteOrchidBorderActive' | 'colorPaletteOrchidBorder2';
+export type ColorPaletteOrchid = 'colorPaletteOrchidBackground1' | 'colorPaletteOrchidBackground2' | 'colorPaletteOrchidBackground3' | 'colorPaletteOrchidForeground1' | 'colorPaletteOrchidForeground2' | 'colorPaletteOrchidForeground3' | 'colorPaletteOrchidBorderActive' | 'colorPaletteOrchidBorder1' | 'colorPaletteOrchidBorder2';
 
 // @public (undocumented)
-export type ColorPalettePeach = 'colorPalettePeachBackground1' | 'colorPalettePeachBackground2' | 'colorPalettePeachBackground3' | 'colorPalettePeachForeground1' | 'colorPalettePeachForeground2' | 'colorPalettePeachForeground3' | 'colorPalettePeachBorderActive' | 'colorPalettePeachBorder2';
+export type ColorPalettePeach = 'colorPalettePeachBackground1' | 'colorPalettePeachBackground2' | 'colorPalettePeachBackground3' | 'colorPalettePeachForeground1' | 'colorPalettePeachForeground2' | 'colorPalettePeachForeground3' | 'colorPalettePeachBorderActive' | 'colorPalettePeachBorder1' | 'colorPalettePeachBorder2';
 
 // @public (undocumented)
-export type ColorPalettePink = 'colorPalettePinkBackground1' | 'colorPalettePinkBackground2' | 'colorPalettePinkBackground3' | 'colorPalettePinkForeground1' | 'colorPalettePinkForeground2' | 'colorPalettePinkForeground3' | 'colorPalettePinkBorderActive' | 'colorPalettePinkBorder2';
+export type ColorPalettePink = 'colorPalettePinkBackground1' | 'colorPalettePinkBackground2' | 'colorPalettePinkBackground3' | 'colorPalettePinkForeground1' | 'colorPalettePinkForeground2' | 'colorPalettePinkForeground3' | 'colorPalettePinkBorderActive' | 'colorPalettePinkBorder1' | 'colorPalettePinkBorder2';
 
 // @public (undocumented)
-export type ColorPalettePlatinum = 'colorPalettePlatinumBackground1' | 'colorPalettePlatinumBackground2' | 'colorPalettePlatinumBackground3' | 'colorPalettePlatinumForeground1' | 'colorPalettePlatinumForeground2' | 'colorPalettePlatinumForeground3' | 'colorPalettePlatinumBorderActive' | 'colorPalettePlatinumBorder2';
+export type ColorPalettePlatinum = 'colorPalettePlatinumBackground1' | 'colorPalettePlatinumBackground2' | 'colorPalettePlatinumBackground3' | 'colorPalettePlatinumForeground1' | 'colorPalettePlatinumForeground2' | 'colorPalettePlatinumForeground3' | 'colorPalettePlatinumBorderActive' | 'colorPalettePlatinumBorder1' | 'colorPalettePlatinumBorder2';
 
 // @public (undocumented)
-export type ColorPalettePlum = 'colorPalettePlumBackground1' | 'colorPalettePlumBackground2' | 'colorPalettePlumBackground3' | 'colorPalettePlumForeground1' | 'colorPalettePlumForeground2' | 'colorPalettePlumForeground3' | 'colorPalettePlumBorderActive' | 'colorPalettePlumBorder2';
+export type ColorPalettePlum = 'colorPalettePlumBackground1' | 'colorPalettePlumBackground2' | 'colorPalettePlumBackground3' | 'colorPalettePlumForeground1' | 'colorPalettePlumForeground2' | 'colorPalettePlumForeground3' | 'colorPalettePlumBorderActive' | 'colorPalettePlumBorder1' | 'colorPalettePlumBorder2';
 
 // @public (undocumented)
-export type ColorPalettePumpkin = 'colorPalettePumpkinBackground1' | 'colorPalettePumpkinBackground2' | 'colorPalettePumpkinBackground3' | 'colorPalettePumpkinForeground1' | 'colorPalettePumpkinForeground2' | 'colorPalettePumpkinForeground3' | 'colorPalettePumpkinBorderActive' | 'colorPalettePumpkinBorder2';
+export type ColorPalettePumpkin = 'colorPalettePumpkinBackground1' | 'colorPalettePumpkinBackground2' | 'colorPalettePumpkinBackground3' | 'colorPalettePumpkinForeground1' | 'colorPalettePumpkinForeground2' | 'colorPalettePumpkinForeground3' | 'colorPalettePumpkinBorderActive' | 'colorPalettePumpkinBorder1' | 'colorPalettePumpkinBorder2';
 
 // @public (undocumented)
-export type ColorPalettePurple = 'colorPalettePurpleBackground1' | 'colorPalettePurpleBackground2' | 'colorPalettePurpleBackground3' | 'colorPalettePurpleForeground1' | 'colorPalettePurpleForeground2' | 'colorPalettePurpleForeground3' | 'colorPalettePurpleBorderActive' | 'colorPalettePurpleBorder2';
+export type ColorPalettePurple = 'colorPalettePurpleBackground1' | 'colorPalettePurpleBackground2' | 'colorPalettePurpleBackground3' | 'colorPalettePurpleForeground1' | 'colorPalettePurpleForeground2' | 'colorPalettePurpleForeground3' | 'colorPalettePurpleBorderActive' | 'colorPalettePurpleBorder1' | 'colorPalettePurpleBorder2';
 
 // @public (undocumented)
-export type ColorPaletteRed = 'colorPaletteRedBackground1' | 'colorPaletteRedBackground2' | 'colorPaletteRedBackground3' | 'colorPaletteRedForeground1' | 'colorPaletteRedForeground2' | 'colorPaletteRedForeground3' | 'colorPaletteRedBorderActive' | 'colorPaletteRedBorder2';
+export type ColorPaletteRed = 'colorPaletteRedBackground1' | 'colorPaletteRedBackground2' | 'colorPaletteRedBackground3' | 'colorPaletteRedForeground1' | 'colorPaletteRedForeground2' | 'colorPaletteRedForeground3' | 'colorPaletteRedBorderActive' | 'colorPaletteRedBorder1' | 'colorPaletteRedBorder2';
 
 // @public (undocumented)
-export type ColorPaletteRoyalBlue = 'colorPaletteRoyalBlueBackground1' | 'colorPaletteRoyalBlueBackground2' | 'colorPaletteRoyalBlueBackground3' | 'colorPaletteRoyalBlueForeground1' | 'colorPaletteRoyalBlueForeground2' | 'colorPaletteRoyalBlueForeground3' | 'colorPaletteRoyalBlueBorderActive' | 'colorPaletteRoyalBlueBorder2';
+export type ColorPaletteRoyalBlue = 'colorPaletteRoyalBlueBackground1' | 'colorPaletteRoyalBlueBackground2' | 'colorPaletteRoyalBlueBackground3' | 'colorPaletteRoyalBlueForeground1' | 'colorPaletteRoyalBlueForeground2' | 'colorPaletteRoyalBlueForeground3' | 'colorPaletteRoyalBlueBorderActive' | 'colorPaletteRoyalBlueBorder1' | 'colorPaletteRoyalBlueBorder2';
 
 // @public (undocumented)
-export type ColorPaletteSeafoam = 'colorPaletteSeafoamBackground1' | 'colorPaletteSeafoamBackground2' | 'colorPaletteSeafoamBackground3' | 'colorPaletteSeafoamForeground1' | 'colorPaletteSeafoamForeground2' | 'colorPaletteSeafoamForeground3' | 'colorPaletteSeafoamBorderActive' | 'colorPaletteSeafoamBorder2';
+export type ColorPaletteSeafoam = 'colorPaletteSeafoamBackground1' | 'colorPaletteSeafoamBackground2' | 'colorPaletteSeafoamBackground3' | 'colorPaletteSeafoamForeground1' | 'colorPaletteSeafoamForeground2' | 'colorPaletteSeafoamForeground3' | 'colorPaletteSeafoamBorderActive' | 'colorPaletteSeafoamBorder1' | 'colorPaletteSeafoamBorder2';
 
 // @public (undocumented)
-export type ColorPaletteSilver = 'colorPaletteSilverBackground1' | 'colorPaletteSilverBackground2' | 'colorPaletteSilverBackground3' | 'colorPaletteSilverForeground1' | 'colorPaletteSilverForeground2' | 'colorPaletteSilverForeground3' | 'colorPaletteSilverBorderActive' | 'colorPaletteSilverBorder2';
+export type ColorPaletteSilver = 'colorPaletteSilverBackground1' | 'colorPaletteSilverBackground2' | 'colorPaletteSilverBackground3' | 'colorPaletteSilverForeground1' | 'colorPaletteSilverForeground2' | 'colorPaletteSilverForeground3' | 'colorPaletteSilverBorderActive' | 'colorPaletteSilverBorder1' | 'colorPaletteSilverBorder2';
 
 // @public (undocumented)
-export type ColorPaletteSteel = 'colorPaletteSteelBackground1' | 'colorPaletteSteelBackground2' | 'colorPaletteSteelBackground3' | 'colorPaletteSteelForeground1' | 'colorPaletteSteelForeground2' | 'colorPaletteSteelForeground3' | 'colorPaletteSteelBorderActive' | 'colorPaletteSteelBorder2';
+export type ColorPaletteSteel = 'colorPaletteSteelBackground1' | 'colorPaletteSteelBackground2' | 'colorPaletteSteelBackground3' | 'colorPaletteSteelForeground1' | 'colorPaletteSteelForeground2' | 'colorPaletteSteelForeground3' | 'colorPaletteSteelBorderActive' | 'colorPaletteSteelBorder1' | 'colorPaletteSteelBorder2';
 
 // @public (undocumented)
-export type ColorPaletteTeal = 'colorPaletteTealBackground1' | 'colorPaletteTealBackground2' | 'colorPaletteTealBackground3' | 'colorPaletteTealForeground1' | 'colorPaletteTealForeground2' | 'colorPaletteTealForeground3' | 'colorPaletteTealBorderActive' | 'colorPaletteTealBorder2';
+export type ColorPaletteTeal = 'colorPaletteTealBackground1' | 'colorPaletteTealBackground2' | 'colorPaletteTealBackground3' | 'colorPaletteTealForeground1' | 'colorPaletteTealForeground2' | 'colorPaletteTealForeground3' | 'colorPaletteTealBorderActive' | 'colorPaletteTealBorder1' | 'colorPaletteTealBorder2';
 
 // @public (undocumented)
 export type ColorPaletteTokens = Record<ColorPaletteDarkRed | ColorPaletteBurgundy | ColorPaletteCranberry | ColorPaletteRed | ColorPaletteDarkOrange | ColorPaletteBronze | ColorPalettePumpkin | ColorPaletteOrange | ColorPalettePeach | ColorPaletteMarigold | ColorPaletteYellow | ColorPaletteGold | ColorPaletteBrass | ColorPaletteBrown | ColorPaletteDarkBrown | ColorPaletteLime | ColorPaletteForest | ColorPaletteSeafoam | ColorPaletteLightGreen | ColorPaletteGreen | ColorPaletteDarkGreen | ColorPaletteLightTeal | ColorPaletteTeal | ColorPaletteDarkTeal | ColorPaletteCyan | ColorPaletteSteel | ColorPaletteLightBlue | ColorPaletteBlue | ColorPaletteRoyalBlue | ColorPaletteDarkBlue | ColorPaletteCornflower | ColorPaletteNavy | ColorPaletteLavender | ColorPalettePurple | ColorPaletteDarkPurple | ColorPaletteOrchid | ColorPaletteGrape | ColorPaletteBerry | ColorPaletteLilac | ColorPalettePink | ColorPaletteHotPink | ColorPaletteMagenta | ColorPalettePlum | ColorPaletteBeige | ColorPaletteMink | ColorPaletteSilver | ColorPalettePlatinum | ColorPaletteAnchor | ColorPaletteCharcoal, string>;
 
 // @public (undocumented)
-export type ColorPaletteYellow = 'colorPaletteYellowBackground1' | 'colorPaletteYellowBackground2' | 'colorPaletteYellowBackground3' | 'colorPaletteYellowForeground1' | 'colorPaletteYellowForeground2' | 'colorPaletteYellowForeground3' | 'colorPaletteYellowBorderActive' | 'colorPaletteYellowBorder2';
+export type ColorPaletteYellow = 'colorPaletteYellowBackground1' | 'colorPaletteYellowBackground2' | 'colorPaletteYellowBackground3' | 'colorPaletteYellowForeground1' | 'colorPaletteYellowForeground2' | 'colorPaletteYellowForeground3' | 'colorPaletteYellowBorderActive' | 'colorPaletteYellowBorder1' | 'colorPaletteYellowBorder2';
 
 // @public
 export type ColorTokens = {

--- a/packages/react-theme/src/alias/dark.ts
+++ b/packages/react-theme/src/alias/dark.ts
@@ -151,6 +151,7 @@ export const colorPaletteTokens: ColorPaletteTokens = (Object.keys(sharedColors)
     [`colorPalette${color}Foreground2`]: sharedColors[sharedColor].tint40,
     [`colorPalette${color}Foreground3`]: sharedColors[sharedColor].tint20,
     [`colorPalette${color}BorderActive`]: sharedColors[sharedColor].tint30,
+    [`colorPalette${color}Border1`]: sharedColors[sharedColor].primary,
     [`colorPalette${color}Border2`]: sharedColors[sharedColor].tint20,
   };
 

--- a/packages/react-theme/src/alias/highContrast.ts
+++ b/packages/react-theme/src/alias/highContrast.ts
@@ -164,6 +164,7 @@ export const colorPaletteTokens: ColorPaletteTokens = (Object.keys(sharedColors)
     [`colorPalette${color}Foreground2`]: white,
     [`colorPalette${color}Foreground3`]: white,
     [`colorPalette${color}BorderActive`]: hcHighlight,
+    [`colorPalette${color}Border1`]: white,
     [`colorPalette${color}Border2`]: white,
   };
 

--- a/packages/react-theme/src/alias/light.ts
+++ b/packages/react-theme/src/alias/light.ts
@@ -151,6 +151,7 @@ export const colorPaletteTokens: ColorPaletteTokens = (Object.keys(sharedColors)
     [`colorPalette${color}Foreground2`]: sharedColors[sharedColor].shade30,
     [`colorPalette${color}Foreground3`]: sharedColors[sharedColor].primary,
     [`colorPalette${color}BorderActive`]: sharedColors[sharedColor].primary,
+    [`colorPalette${color}Border1`]: sharedColors[sharedColor].tint40,
     [`colorPalette${color}Border2`]: sharedColors[sharedColor].primary,
   };
 

--- a/packages/react-theme/src/alias/teamsDark.ts
+++ b/packages/react-theme/src/alias/teamsDark.ts
@@ -151,6 +151,7 @@ export const colorPaletteTokens: ColorPaletteTokens = (Object.keys(sharedColors)
     [`colorPalette${color}Foreground2`]: sharedColors[sharedColor].tint40,
     [`colorPalette${color}Foreground3`]: sharedColors[sharedColor].tint20,
     [`colorPalette${color}BorderActive`]: sharedColors[sharedColor].tint30,
+    [`colorPalette${color}Border1`]: sharedColors[sharedColor].primary,
     [`colorPalette${color}Border2`]: sharedColors[sharedColor].tint20,
   };
 

--- a/packages/react-theme/src/types.ts
+++ b/packages/react-theme/src/types.ts
@@ -147,6 +147,7 @@ export type ColorPaletteDarkRed =
   | 'colorPaletteDarkRedForeground2'
   | 'colorPaletteDarkRedForeground3'
   | 'colorPaletteDarkRedBorderActive'
+  | 'colorPaletteDarkRedBorder1'
   | 'colorPaletteDarkRedBorder2';
 
 export type ColorPaletteBurgundy =
@@ -157,6 +158,7 @@ export type ColorPaletteBurgundy =
   | 'colorPaletteBurgundyForeground2'
   | 'colorPaletteBurgundyForeground3'
   | 'colorPaletteBurgundyBorderActive'
+  | 'colorPaletteBurgundyBorder1'
   | 'colorPaletteBurgundyBorder2';
 
 export type ColorPaletteCranberry =
@@ -167,6 +169,7 @@ export type ColorPaletteCranberry =
   | 'colorPaletteCranberryForeground2'
   | 'colorPaletteCranberryForeground3'
   | 'colorPaletteCranberryBorderActive'
+  | 'colorPaletteCranberryBorder1'
   | 'colorPaletteCranberryBorder2';
 
 export type ColorPaletteRed =
@@ -177,6 +180,7 @@ export type ColorPaletteRed =
   | 'colorPaletteRedForeground2'
   | 'colorPaletteRedForeground3'
   | 'colorPaletteRedBorderActive'
+  | 'colorPaletteRedBorder1'
   | 'colorPaletteRedBorder2';
 
 export type ColorPaletteDarkOrange =
@@ -187,6 +191,7 @@ export type ColorPaletteDarkOrange =
   | 'colorPaletteDarkOrangeForeground2'
   | 'colorPaletteDarkOrangeForeground3'
   | 'colorPaletteDarkOrangeBorderActive'
+  | 'colorPaletteDarkOrangeBorder1'
   | 'colorPaletteDarkOrangeBorder2';
 
 export type ColorPaletteBronze =
@@ -197,6 +202,7 @@ export type ColorPaletteBronze =
   | 'colorPaletteBronzeForeground2'
   | 'colorPaletteBronzeForeground3'
   | 'colorPaletteBronzeBorderActive'
+  | 'colorPaletteBronzeBorder1'
   | 'colorPaletteBronzeBorder2';
 
 export type ColorPalettePumpkin =
@@ -207,6 +213,7 @@ export type ColorPalettePumpkin =
   | 'colorPalettePumpkinForeground2'
   | 'colorPalettePumpkinForeground3'
   | 'colorPalettePumpkinBorderActive'
+  | 'colorPalettePumpkinBorder1'
   | 'colorPalettePumpkinBorder2';
 
 export type ColorPaletteOrange =
@@ -217,6 +224,7 @@ export type ColorPaletteOrange =
   | 'colorPaletteOrangeForeground2'
   | 'colorPaletteOrangeForeground3'
   | 'colorPaletteOrangeBorderActive'
+  | 'colorPaletteOrangeBorder1'
   | 'colorPaletteOrangeBorder2';
 
 export type ColorPalettePeach =
@@ -227,6 +235,7 @@ export type ColorPalettePeach =
   | 'colorPalettePeachForeground2'
   | 'colorPalettePeachForeground3'
   | 'colorPalettePeachBorderActive'
+  | 'colorPalettePeachBorder1'
   | 'colorPalettePeachBorder2';
 
 export type ColorPaletteMarigold =
@@ -237,6 +246,7 @@ export type ColorPaletteMarigold =
   | 'colorPaletteMarigoldForeground2'
   | 'colorPaletteMarigoldForeground3'
   | 'colorPaletteMarigoldBorderActive'
+  | 'colorPaletteMarigoldBorder1'
   | 'colorPaletteMarigoldBorder2';
 
 export type ColorPaletteYellow =
@@ -247,6 +257,7 @@ export type ColorPaletteYellow =
   | 'colorPaletteYellowForeground2'
   | 'colorPaletteYellowForeground3'
   | 'colorPaletteYellowBorderActive'
+  | 'colorPaletteYellowBorder1'
   | 'colorPaletteYellowBorder2';
 
 export type ColorPaletteGold =
@@ -257,6 +268,7 @@ export type ColorPaletteGold =
   | 'colorPaletteGoldForeground2'
   | 'colorPaletteGoldForeground3'
   | 'colorPaletteGoldBorderActive'
+  | 'colorPaletteGoldBorder1'
   | 'colorPaletteGoldBorder2';
 
 export type ColorPaletteBrass =
@@ -267,6 +279,7 @@ export type ColorPaletteBrass =
   | 'colorPaletteBrassForeground2'
   | 'colorPaletteBrassForeground3'
   | 'colorPaletteBrassBorderActive'
+  | 'colorPaletteBrassBorder1'
   | 'colorPaletteBrassBorder2';
 
 export type ColorPaletteBrown =
@@ -277,6 +290,7 @@ export type ColorPaletteBrown =
   | 'colorPaletteBrownForeground2'
   | 'colorPaletteBrownForeground3'
   | 'colorPaletteBrownBorderActive'
+  | 'colorPaletteBrownBorder1'
   | 'colorPaletteBrownBorder2';
 
 export type ColorPaletteDarkBrown =
@@ -287,6 +301,7 @@ export type ColorPaletteDarkBrown =
   | 'colorPaletteDarkBrownForeground2'
   | 'colorPaletteDarkBrownForeground3'
   | 'colorPaletteDarkBrownBorderActive'
+  | 'colorPaletteDarkBrownBorder1'
   | 'colorPaletteDarkBrownBorder2';
 
 export type ColorPaletteLime =
@@ -297,6 +312,7 @@ export type ColorPaletteLime =
   | 'colorPaletteLimeForeground2'
   | 'colorPaletteLimeForeground3'
   | 'colorPaletteLimeBorderActive'
+  | 'colorPaletteLimeBorder1'
   | 'colorPaletteLimeBorder2';
 
 export type ColorPaletteForest =
@@ -307,6 +323,7 @@ export type ColorPaletteForest =
   | 'colorPaletteForestForeground2'
   | 'colorPaletteForestForeground3'
   | 'colorPaletteForestBorderActive'
+  | 'colorPaletteForestBorder1'
   | 'colorPaletteForestBorder2';
 
 export type ColorPaletteSeafoam =
@@ -317,6 +334,7 @@ export type ColorPaletteSeafoam =
   | 'colorPaletteSeafoamForeground2'
   | 'colorPaletteSeafoamForeground3'
   | 'colorPaletteSeafoamBorderActive'
+  | 'colorPaletteSeafoamBorder1'
   | 'colorPaletteSeafoamBorder2';
 
 export type ColorPaletteLightGreen =
@@ -327,6 +345,7 @@ export type ColorPaletteLightGreen =
   | 'colorPaletteLightGreenForeground2'
   | 'colorPaletteLightGreenForeground3'
   | 'colorPaletteLightGreenBorderActive'
+  | 'colorPaletteLightGreenBorder1'
   | 'colorPaletteLightGreenBorder2';
 
 export type ColorPaletteGreen =
@@ -337,6 +356,7 @@ export type ColorPaletteGreen =
   | 'colorPaletteGreenForeground2'
   | 'colorPaletteGreenForeground3'
   | 'colorPaletteGreenBorderActive'
+  | 'colorPaletteGreenBorder1'
   | 'colorPaletteGreenBorder2';
 
 export type ColorPaletteDarkGreen =
@@ -347,6 +367,7 @@ export type ColorPaletteDarkGreen =
   | 'colorPaletteDarkGreenForeground2'
   | 'colorPaletteDarkGreenForeground3'
   | 'colorPaletteDarkGreenBorderActive'
+  | 'colorPaletteDarkGreenBorder1'
   | 'colorPaletteDarkGreenBorder2';
 
 export type ColorPaletteLightTeal =
@@ -357,6 +378,7 @@ export type ColorPaletteLightTeal =
   | 'colorPaletteLightTealForeground2'
   | 'colorPaletteLightTealForeground3'
   | 'colorPaletteLightTealBorderActive'
+  | 'colorPaletteLightTealBorder1'
   | 'colorPaletteLightTealBorder2';
 
 export type ColorPaletteTeal =
@@ -367,6 +389,7 @@ export type ColorPaletteTeal =
   | 'colorPaletteTealForeground2'
   | 'colorPaletteTealForeground3'
   | 'colorPaletteTealBorderActive'
+  | 'colorPaletteTealBorder1'
   | 'colorPaletteTealBorder2';
 
 export type ColorPaletteDarkTeal =
@@ -377,6 +400,7 @@ export type ColorPaletteDarkTeal =
   | 'colorPaletteDarkTealForeground2'
   | 'colorPaletteDarkTealForeground3'
   | 'colorPaletteDarkTealBorderActive'
+  | 'colorPaletteDarkTealBorder1'
   | 'colorPaletteDarkTealBorder2';
 
 export type ColorPaletteCyan =
@@ -387,6 +411,7 @@ export type ColorPaletteCyan =
   | 'colorPaletteCyanForeground2'
   | 'colorPaletteCyanForeground3'
   | 'colorPaletteCyanBorderActive'
+  | 'colorPaletteCyanBorder1'
   | 'colorPaletteCyanBorder2';
 
 export type ColorPaletteSteel =
@@ -397,6 +422,7 @@ export type ColorPaletteSteel =
   | 'colorPaletteSteelForeground2'
   | 'colorPaletteSteelForeground3'
   | 'colorPaletteSteelBorderActive'
+  | 'colorPaletteSteelBorder1'
   | 'colorPaletteSteelBorder2';
 
 export type ColorPaletteLightBlue =
@@ -407,6 +433,7 @@ export type ColorPaletteLightBlue =
   | 'colorPaletteLightBlueForeground2'
   | 'colorPaletteLightBlueForeground3'
   | 'colorPaletteLightBlueBorderActive'
+  | 'colorPaletteLightBlueBorder1'
   | 'colorPaletteLightBlueBorder2';
 
 export type ColorPaletteBlue =
@@ -417,6 +444,7 @@ export type ColorPaletteBlue =
   | 'colorPaletteBlueForeground2'
   | 'colorPaletteBlueForeground3'
   | 'colorPaletteBlueBorderActive'
+  | 'colorPaletteBlueBorder1'
   | 'colorPaletteBlueBorder2';
 
 export type ColorPaletteRoyalBlue =
@@ -427,6 +455,7 @@ export type ColorPaletteRoyalBlue =
   | 'colorPaletteRoyalBlueForeground2'
   | 'colorPaletteRoyalBlueForeground3'
   | 'colorPaletteRoyalBlueBorderActive'
+  | 'colorPaletteRoyalBlueBorder1'
   | 'colorPaletteRoyalBlueBorder2';
 
 export type ColorPaletteDarkBlue =
@@ -437,6 +466,7 @@ export type ColorPaletteDarkBlue =
   | 'colorPaletteDarkBlueForeground2'
   | 'colorPaletteDarkBlueForeground3'
   | 'colorPaletteDarkBlueBorderActive'
+  | 'colorPaletteDarkBlueBorder1'
   | 'colorPaletteDarkBlueBorder2';
 
 export type ColorPaletteCornflower =
@@ -447,6 +477,7 @@ export type ColorPaletteCornflower =
   | 'colorPaletteCornflowerForeground2'
   | 'colorPaletteCornflowerForeground3'
   | 'colorPaletteCornflowerBorderActive'
+  | 'colorPaletteCornflowerBorder1'
   | 'colorPaletteCornflowerBorder2';
 
 export type ColorPaletteNavy =
@@ -457,6 +488,7 @@ export type ColorPaletteNavy =
   | 'colorPaletteNavyForeground2'
   | 'colorPaletteNavyForeground3'
   | 'colorPaletteNavyBorderActive'
+  | 'colorPaletteNavyBorder1'
   | 'colorPaletteNavyBorder2';
 
 export type ColorPaletteLavender =
@@ -467,6 +499,7 @@ export type ColorPaletteLavender =
   | 'colorPaletteLavenderForeground2'
   | 'colorPaletteLavenderForeground3'
   | 'colorPaletteLavenderBorderActive'
+  | 'colorPaletteLavenderBorder1'
   | 'colorPaletteLavenderBorder2';
 
 export type ColorPalettePurple =
@@ -477,6 +510,7 @@ export type ColorPalettePurple =
   | 'colorPalettePurpleForeground2'
   | 'colorPalettePurpleForeground3'
   | 'colorPalettePurpleBorderActive'
+  | 'colorPalettePurpleBorder1'
   | 'colorPalettePurpleBorder2';
 
 export type ColorPaletteDarkPurple =
@@ -487,6 +521,7 @@ export type ColorPaletteDarkPurple =
   | 'colorPaletteDarkPurpleForeground2'
   | 'colorPaletteDarkPurpleForeground3'
   | 'colorPaletteDarkPurpleBorderActive'
+  | 'colorPaletteDarkPurpleBorder1'
   | 'colorPaletteDarkPurpleBorder2';
 
 export type ColorPaletteOrchid =
@@ -497,6 +532,7 @@ export type ColorPaletteOrchid =
   | 'colorPaletteOrchidForeground2'
   | 'colorPaletteOrchidForeground3'
   | 'colorPaletteOrchidBorderActive'
+  | 'colorPaletteOrchidBorder1'
   | 'colorPaletteOrchidBorder2';
 
 export type ColorPaletteGrape =
@@ -507,6 +543,7 @@ export type ColorPaletteGrape =
   | 'colorPaletteGrapeForeground2'
   | 'colorPaletteGrapeForeground3'
   | 'colorPaletteGrapeBorderActive'
+  | 'colorPaletteGrapeBorder1'
   | 'colorPaletteGrapeBorder2';
 
 export type ColorPaletteBerry =
@@ -517,6 +554,7 @@ export type ColorPaletteBerry =
   | 'colorPaletteBerryForeground2'
   | 'colorPaletteBerryForeground3'
   | 'colorPaletteBerryBorderActive'
+  | 'colorPaletteBerryBorder1'
   | 'colorPaletteBerryBorder2';
 
 export type ColorPaletteLilac =
@@ -527,6 +565,7 @@ export type ColorPaletteLilac =
   | 'colorPaletteLilacForeground2'
   | 'colorPaletteLilacForeground3'
   | 'colorPaletteLilacBorderActive'
+  | 'colorPaletteLilacBorder1'
   | 'colorPaletteLilacBorder2';
 
 export type ColorPalettePink =
@@ -537,6 +576,7 @@ export type ColorPalettePink =
   | 'colorPalettePinkForeground2'
   | 'colorPalettePinkForeground3'
   | 'colorPalettePinkBorderActive'
+  | 'colorPalettePinkBorder1'
   | 'colorPalettePinkBorder2';
 
 export type ColorPaletteHotPink =
@@ -547,6 +587,7 @@ export type ColorPaletteHotPink =
   | 'colorPaletteHotPinkForeground2'
   | 'colorPaletteHotPinkForeground3'
   | 'colorPaletteHotPinkBorderActive'
+  | 'colorPaletteHotPinkBorder1'
   | 'colorPaletteHotPinkBorder2';
 
 export type ColorPaletteMagenta =
@@ -557,6 +598,7 @@ export type ColorPaletteMagenta =
   | 'colorPaletteMagentaForeground2'
   | 'colorPaletteMagentaForeground3'
   | 'colorPaletteMagentaBorderActive'
+  | 'colorPaletteMagentaBorder1'
   | 'colorPaletteMagentaBorder2';
 
 export type ColorPalettePlum =
@@ -567,6 +609,7 @@ export type ColorPalettePlum =
   | 'colorPalettePlumForeground2'
   | 'colorPalettePlumForeground3'
   | 'colorPalettePlumBorderActive'
+  | 'colorPalettePlumBorder1'
   | 'colorPalettePlumBorder2';
 
 export type ColorPaletteBeige =
@@ -577,6 +620,7 @@ export type ColorPaletteBeige =
   | 'colorPaletteBeigeForeground2'
   | 'colorPaletteBeigeForeground3'
   | 'colorPaletteBeigeBorderActive'
+  | 'colorPaletteBeigeBorder1'
   | 'colorPaletteBeigeBorder2';
 
 export type ColorPaletteMink =
@@ -587,6 +631,7 @@ export type ColorPaletteMink =
   | 'colorPaletteMinkForeground2'
   | 'colorPaletteMinkForeground3'
   | 'colorPaletteMinkBorderActive'
+  | 'colorPaletteMinkBorder1'
   | 'colorPaletteMinkBorder2';
 
 export type ColorPaletteSilver =
@@ -597,6 +642,7 @@ export type ColorPaletteSilver =
   | 'colorPaletteSilverForeground2'
   | 'colorPaletteSilverForeground3'
   | 'colorPaletteSilverBorderActive'
+  | 'colorPaletteSilverBorder1'
   | 'colorPaletteSilverBorder2';
 
 export type ColorPalettePlatinum =
@@ -607,6 +653,7 @@ export type ColorPalettePlatinum =
   | 'colorPalettePlatinumForeground2'
   | 'colorPalettePlatinumForeground3'
   | 'colorPalettePlatinumBorderActive'
+  | 'colorPalettePlatinumBorder1'
   | 'colorPalettePlatinumBorder2';
 
 export type ColorPaletteAnchor =
@@ -617,6 +664,7 @@ export type ColorPaletteAnchor =
   | 'colorPaletteAnchorForeground2'
   | 'colorPaletteAnchorForeground3'
   | 'colorPaletteAnchorBorderActive'
+  | 'colorPaletteAnchorBorder1'
   | 'colorPaletteAnchorBorder2';
 
 export type ColorPaletteCharcoal =
@@ -627,6 +675,7 @@ export type ColorPaletteCharcoal =
   | 'colorPaletteCharcoalForeground2'
   | 'colorPaletteCharcoalForeground3'
   | 'colorPaletteCharcoalBorderActive'
+  | 'colorPaletteCharcoalBorder1'
   | 'colorPaletteCharcoalBorder2';
 
 export type ColorPaletteTokens = Record<


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20952
- [x] Include a change request file using `$ yarn change`

#### Design requirement
![image](https://user-images.githubusercontent.com/9615899/145097917-13497712-da8a-4dbf-8919-f918d3c3d348.png)

#### Description of changes

Add border1 color token for all shared colors, e.g. `colorPaletteDarkRedBorder1` for dark red:
![image](https://user-images.githubusercontent.com/9615899/145097747-ae7eb1dc-cb4e-4b9e-aab8-802e86c8565c.png)

