### PR TITLE
fix(makeStyles): correctly handle computed keys

### DIFF
--- a/change/@fluentui-babel-make-styles-e24db7df-1613-42dd-aa1a-a4ddb5b85b83.json
+++ b/change/@fluentui-babel-make-styles-e24db7df-1613-42dd-aa1a-a4ddb5b85b83.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: handle computed keys on objects",
+  "packageName": "@fluentui/babel-make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-make-styles/__fixtures__/function-imported-keys/code.ts
+++ b/packages/babel-make-styles/__fixtures__/function-imported-keys/code.ts
@@ -1,0 +1,9 @@
+import { makeStyles } from '@fluentui/react-make-styles';
+import { className, color, selector } from './consts';
+
+export const useStyles = makeStyles({
+  root: {
+    [selector]: () => ({ [color]: 'red' }),
+    [`& .${className}`]: () => ({ color: 'blue' }),
+  },
+});

--- a/packages/babel-make-styles/__fixtures__/function-imported-keys/code.ts
+++ b/packages/babel-make-styles/__fixtures__/function-imported-keys/code.ts
@@ -2,8 +2,10 @@ import { makeStyles } from '@fluentui/react-make-styles';
 import { className, color, selector } from './consts';
 
 export const useStyles = makeStyles({
-  root: {
-    [selector]: () => ({ [color]: 'red' }),
-    [`& .${className}`]: () => ({ color: 'blue' }),
-  },
+  rootA: theme => ({
+    [selector]: { [color]: theme.colorBrandBackground },
+  }),
+  rootB: theme => ({
+    [`& .${className}`]: { color: theme.colorBrandBackground },
+  }),
 });

--- a/packages/babel-make-styles/__fixtures__/function-imported-keys/consts.ts
+++ b/packages/babel-make-styles/__fixtures__/function-imported-keys/consts.ts
@@ -1,0 +1,3 @@
+export const color = 'color';
+export const className = 'component-foo';
+export const selector = '& .component-bar';

--- a/packages/babel-make-styles/__fixtures__/function-imported-keys/output.ts
+++ b/packages/babel-make-styles/__fixtures__/function-imported-keys/output.ts
@@ -1,0 +1,13 @@
+import { __styles } from '@fluentui/react-make-styles';
+import { className, color, selector } from './consts';
+export const useStyles = __styles(
+  {
+    root: {
+      B0egftl: 'f1wgwx3x',
+      qhv8v2: 'fglt6ox',
+    },
+  },
+  {
+    d: ['.f1wgwx3x .component-bar{color:red;}', '.fglt6ox .component-foo{color:blue;}'],
+  },
+);

--- a/packages/babel-make-styles/__fixtures__/function-imported-keys/output.ts
+++ b/packages/babel-make-styles/__fixtures__/function-imported-keys/output.ts
@@ -2,12 +2,17 @@ import { __styles } from '@fluentui/react-make-styles';
 import { className, color, selector } from './consts';
 export const useStyles = __styles(
   {
-    root: {
-      B0egftl: 'f1wgwx3x',
-      qhv8v2: 'fglt6ox',
+    rootA: {
+      B0egftl: 'felhwal',
+    },
+    rootB: {
+      qhv8v2: 'f17q1fco',
     },
   },
   {
-    d: ['.f1wgwx3x .component-bar{color:red;}', '.fglt6ox .component-foo{color:blue;}'],
+    d: [
+      '.felhwal .component-bar{color:var(--colorBrandBackground);}',
+      '.f17q1fco .component-foo{color:var(--colorBrandBackground);}',
+    ],
   },
 );

--- a/packages/babel-make-styles/__fixtures__/object-imported-keys/code.ts
+++ b/packages/babel-make-styles/__fixtures__/object-imported-keys/code.ts
@@ -1,0 +1,9 @@
+import { makeStyles } from '@fluentui/react-make-styles';
+import { className, selector } from './consts';
+
+export const useStyles = makeStyles({
+  root: {
+    [selector]: { color: 'red' },
+    [`& .${className}`]: { color: 'blue' },
+  },
+});

--- a/packages/babel-make-styles/__fixtures__/object-imported-keys/consts.ts
+++ b/packages/babel-make-styles/__fixtures__/object-imported-keys/consts.ts
@@ -1,0 +1,2 @@
+export const className = 'component-foo';
+export const selector = '& .component-bar';

--- a/packages/babel-make-styles/__fixtures__/object-imported-keys/output.ts
+++ b/packages/babel-make-styles/__fixtures__/object-imported-keys/output.ts
@@ -1,0 +1,13 @@
+import { __styles } from '@fluentui/react-make-styles';
+import { className, selector } from './consts';
+export const useStyles = __styles(
+  {
+    root: {
+      B0egftl: 'f1wgwx3x',
+      qhv8v2: 'fglt6ox',
+    },
+  },
+  {
+    d: ['.f1wgwx3x .component-bar{color:red;}', '.fglt6ox .component-foo{color:blue;}'],
+  },
+);

--- a/packages/babel-make-styles/src/plugin.ts
+++ b/packages/babel-make-styles/src/plugin.ts
@@ -327,7 +327,7 @@ function processDefinitions(
                 return;
               }
 
-              // This condition resolves "theme.alias.color.green.foreground1" to CSS variable
+              // This condition resolves "theme.aliasColorGreenForeground1" to CSS variable
               if (valuePath.isMemberExpression()) {
                 const identifierPath = getMemberExpressionIdentifier(valuePath);
                 const paramsName = paramsPath?.node.name;

--- a/packages/babel-make-styles/src/plugin.ts
+++ b/packages/babel-make-styles/src/plugin.ts
@@ -217,7 +217,19 @@ function processDefinitions(
           }
 
           if (propertyPath.isObjectProperty()) {
+            const keyPath = propertyPath.get('key');
             const valuePath = propertyPath.get('value');
+
+            /**
+             * Computed properties may require lazy evaluation.
+             *
+             * @example
+             *    makeStyles({ [var]: { color: 'red' } })
+             *    makeStyles({ [`${var}`]: { color: SOME_VARIABLE } })
+             */
+            if (propertyPath.node.computed) {
+              lazyPaths.push(keyPath);
+            }
 
             if (valuePath.isStringLiteral() || valuePath.isNullLiteral() || valuePath.isNumericLiteral()) {
               return;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #20970
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds to Babel plugin evaluation of computed keys on objects:

```tsx
const useStyles = makeStyles({
  root: {
    // 👇 regular key, no need to evaluate
    ":hover": { color: "red" },
    // 👇 computed key, may come from an import
    [selector]: { color: "red" }
  }
});
```

New fixture was also added ✅