### PR TITLE
fix: Animation to properly pass ref to root slot

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -85,6 +85,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Video` component to properly pass ref to root slots @chpalac ([#20878](https://github.com/microsoft/fluentui/pull/20878))
 - Fix `TooltipContent` component to properly pass ref to root slots @chpalac ([#20876](https://github.com/microsoft/fluentui/pull/20876))
 - Fix `Popup` to invoke event handlers on trigger wrapped in `Ref` @yuanboxue-amber ([#20911](https://github.com/microsoft/fluentui/pull/20911))
+- Fix `Animation` component to properly pass ref to root slots @chpalac ([#20972](https://github.com/microsoft/fluentui/pull/20972))
 
 ### Features
 - Adding `ViewPersonSparkleIcon`, `CartIcon`, and fixing `EmojiAddIcon` and `AccessibilityIcon` - @notandrew ([#20054](https://github.com/microsoft/fluentui/pull/20054))

--- a/packages/fluentui/react-northstar/src/components/Animation/Animation.tsx
+++ b/packages/fluentui/react-northstar/src/components/Animation/Animation.tsx
@@ -142,9 +142,7 @@ export interface AnimationProps extends ChildrenComponentProps<AnimationChildren
 /**
  * An Animation provides animation effects to rendered elements.
  */
-export const Animation: React.FC<AnimationProps> & {
-  handledProps: (keyof AnimationProps)[];
-} = props => {
+export const Animation = (React.forwardRef<HTMLDivElement, AnimationProps>((props, ref) => {
   const context = useFluentContext();
   const { setStart, setEnd } = useTelemetry(Animation.displayName, context.telemetry);
   setStart();
@@ -175,6 +173,7 @@ export const Animation: React.FC<AnimationProps> & {
 
   const element = (
     <Transition
+      nodeRef={ref}
       in={visible}
       appear={appear}
       mountOnEnter={mountOnEnter}
@@ -201,6 +200,8 @@ export const Animation: React.FC<AnimationProps> & {
   setEnd();
 
   return element;
+}) as unknown) as React.FC<AnimationProps> & {
+  handledProps: (keyof AnimationProps)[];
 };
 
 Animation.displayName = 'Animation';

--- a/packages/fluentui/react-northstar/test/__mocks__/react-transition-group.ts
+++ b/packages/fluentui/react-northstar/test/__mocks__/react-transition-group.ts
@@ -16,6 +16,7 @@ export const Transition = props => {
     onExiting,
     onExited,
     children,
+    nodeRef,
     ...rest
   } = props;
 


### PR DESCRIPTION
#### Description of changes

Fix `Animation` to properly pass ref to root slot

