### PR TITLE
Combobox(v8): adds check so it cannot be opened if disabled #17955

### DIFF
--- a/change/@fluentui-react-1675c06d-4fee-408f-8f9b-19a8b360d88e.json
+++ b/change/@fluentui-react-1675c06d-4fee-408f-8f9b-19a8b360d88e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added check for disabled prop",
+  "packageName": "@fluentui/react",
+  "email": "tkrasniqi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -535,6 +535,17 @@ describe('ComboBox', () => {
     });
   });
 
+  it('Cannot expand the menu when focused with a button while combobox is disabled', () => {
+    const comboBoxRef = React.createRef<any>();
+    safeMount(
+      <ComboBox defaultSelectedKey="1" options={DEFAULT_OPTIONS2} componentRef={comboBoxRef} disabled />,
+      wrapper => {
+        comboBoxRef.current?.focus(true);
+        expect(comboBoxRef.current.state.isOpen).toEqual(false);
+      },
+    );
+  });
+
   it('Calls onMenuOpen when clicking on the button', () => {
     const onMenuOpenMock = jest.fn();
     safeMount(<ComboBox defaultSelectedKey="1" options={DEFAULT_OPTIONS2} onMenuOpen={onMenuOpenMock} />, wrapper => {

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -477,7 +477,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
    * {@inheritdoc}
    */
   public focus = (shouldOpenOnFocus?: boolean, useFocusAsync?: boolean): void => {
-    if (this.props.disabled === true) {
+    if (this.props.disabled) {
       return;
     }
 

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -477,6 +477,10 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
    * {@inheritdoc}
    */
   public focus = (shouldOpenOnFocus?: boolean, useFocusAsync?: boolean): void => {
+    if (this.props.disabled === true) {
+      return;
+    }
+
     if (this._autofill.current) {
       if (useFocusAsync) {
         focusAsync(this._autofill.current);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #17955
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Adds a check so that the combobox cannot be opened if it is disabled (either focused)
- Adds a unit test for this case
Cherry pick of this PR #20839
