### PR TITLE
fix(bundle-size): incorrect promise test

### DIFF
--- a/change/@fluentui-bundle-size-f8a1b468-b3bf-466c-a6fc-ee3258d5da53.json
+++ b/change/@fluentui-bundle-size-f8a1b468-b3bf-466c-a6fc-ee3258d5da53.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix: incorrect promise test",
+  "packageName": "@fluentui/bundle-size",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/bundle-size/src/utils/buildFixture.test.js
+++ b/packages/bundle-size/src/utils/buildFixture.test.js
@@ -46,6 +46,6 @@ describe('buildFixture', () => {
 
   it('should throw on compilation errors', async () => {
     const fixturePath = await setup(`import something from 'unknown-pkg'`);
-    expect(buildFixture(fixturePath, true)).rejects.toThrow();
+    await expect(buildFixture(fixturePath, true)).rejects.toBeDefined();
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`buildFixture` was trying to test that the function would throw asynchronously. However, the `expect` call was never awaited, and the usage of `.rejects`  was incorrect.

Therefore the test always passed and the jest was left with an unresolved promise error

#### Focus areas to test

(optional)
