### PR TITLE
Modernize getNativeElementProps and include default values

### DIFF
--- a/change/@fluentui-react-utilities-ab5a1f72-4870-4311-86cc-4f81f0eafe98.json
+++ b/change/@fluentui-react-utilities-ab5a1f72-4870-4311-86cc-4f81f0eafe98.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Modernize getNativeElementProps and stop exporting properties constants",
+  "packageName": "@fluentui/react-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -8,9 +8,6 @@ import { DispatchWithoutAction } from 'react';
 import * as React_2 from 'react';
 
 // @public
-export const anchorProperties: Record<string, number>;
-
-// @public
 export const applyTriggerPropsToChildren: <TTriggerProps>(children: React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | ((props: TTriggerProps) => React_2.ReactNode) | null | undefined, triggerProps: TTriggerProps) => React_2.ReactNode;
 
 // @public
@@ -19,28 +16,10 @@ export type AsIntrinsicElement<As extends keyof JSX.IntrinsicElements> = {
 };
 
 // @public
-export const audioProperties: Record<string, number>;
-
-// @public
-export const baseElementEvents: Record<string, number>;
-
-// @public
-export const baseElementProperties: Record<string, number>;
-
-// @public
-export const buttonProperties: Record<string, number>;
-
-// @public
 export function canUseDOM(): boolean;
 
 // @public
 export const clamp: (value: number, min: number, max: number) => number;
-
-// @public (undocumented)
-export const colGroupProperties: Record<string, number>;
-
-// @public (undocumented)
-export const colProperties: Record<string, number>;
 
 // @public (undocumented)
 export type ComponentProps<Shorthands extends ObjectShorthandPropsRecord, Primary extends keyof Shorthands = 'root'> = Omit<{
@@ -64,12 +43,6 @@ export type DefaultObjectShorthandProps = ObjectShorthandProps<Pick<React_2.HTML
 // @internal
 export const defaultSSRContextValue: SSRContextValue;
 
-// @public
-export const divProperties: Record<string, number>;
-
-// @public
-export const formProperties: Record<string, number>;
-
 // Warning: (ae-forgotten-export) The symbol "ObscureEventName" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -79,19 +52,16 @@ export type ForwardRefComponent<Props> = ObscureEventName extends keyof Props ? 
 export function getNativeElementProps<TAttributes extends React_2.HTMLAttributes<any>>(tagName: string, props: {}, excludedPropNames?: string[]): TAttributes;
 
 // @public
-export function getNativeProps<T extends Record<string, any>>(props: Record<string, any>, allowedPropNames: string[] | Record<string, number>, excludedPropNames?: string[]): T;
-
-// @public
-export const getPartitionedNativeProps: ({ primarySlotTagName, props, excludedPropNames, }: {
+export function getPartitionedNativeProps<NativeProps extends React_2.HTMLAttributes<unknown>>({ primarySlotTagName, props, excludedPropNames, }: {
     primarySlotTagName: keyof JSX.IntrinsicElements;
-    props: Pick<React_2.HTMLAttributes<HTMLElement>, 'style' | 'className'>;
-    excludedPropNames?: string[] | undefined;
-}) => {
+    props: Pick<NativeProps, 'style' | 'className'>;
+    excludedPropNames?: string[];
+}): {
     root: {
-        style: React_2.CSSProperties | undefined;
-        className: string | undefined;
+        style: NativeProps["style"] | undefined;
+        className: NativeProps["className"] | undefined;
     };
-    primary: React_2.HTMLAttributes<any>;
+    primary: NativeProps;
 };
 
 // @public
@@ -102,21 +72,6 @@ export function getSlots<R extends ObjectShorthandPropsRecord>(state: ComponentS
     slots: Slots<R>;
     slotProps: SlotProps<R>;
 };
-
-// @public
-export const htmlElementProperties: Record<string, number>;
-
-// @public
-export const iframeProperties: Record<string, number>;
-
-// @public @deprecated (undocumented)
-export const imageProperties: Record<string, number>;
-
-// @public
-export const imgProperties: Record<string, number>;
-
-// @public
-export const inputProperties: Record<string, number>;
 
 // @public
 export type IntrinsicShorthandProps<DefaultAs extends keyof JSX.IntrinsicElements, AlternateAs extends keyof JSX.IntrinsicElements = never> = IsSingleton<DefaultAs> extends false ? 'Error: first parameter to IntrinsicShorthandProps must be a single element type, not a union of types' : ({
@@ -133,12 +88,6 @@ export type IsSingleton<T extends string> = {
 }[T];
 
 // @public
-export const labelProperties: Record<string, number>;
-
-// @public
-export const liProperties: Record<string, number>;
-
-// @public
 export const nullRender: () => null;
 
 // @public
@@ -152,16 +101,10 @@ export type ObjectShorthandProps<Props extends {
 export type ObjectShorthandPropsRecord = Record<string, DefaultObjectShorthandProps | undefined>;
 
 // @public
-export const olProperties: Record<string, number>;
-
-// @public
 export function omit<TObj extends Record<string, any>, Exclusions extends (keyof TObj)[]>(obj: TObj, exclusions: Exclusions): Omit<TObj, Exclusions[number]>;
 
 // @public
 export const onlyChild: <P>(child: boolean | React_2.ReactText | React_2.ReactFragment | React_2.ReactPortal | React_2.ReactElement<P, string | React_2.JSXElementConstructor<any>> | null | undefined) => React_2.ReactElement<P, string | React_2.JSXElementConstructor<any>>;
-
-// @public (undocumented)
-export const optionProperties: Record<string, number>;
 
 // @public
 export type PropsWithoutRef<P> = 'ref' extends keyof P ? (P extends unknown ? Omit<P, 'ref'> : P) : P;
@@ -180,9 +123,6 @@ export type ResolveShorthandOptions<Props extends Record<string, any>, Required 
     required?: Required;
     defaultProps?: Props;
 };
-
-// @public
-export const selectProperties: Record<string, number>;
 
 // @public (undocumented)
 export type ShorthandProps<Props extends DefaultObjectShorthandProps> = React_2.ReactChild | React_2.ReactNodeArray | React_2.ReactPortal | number | null | undefined | Props;
@@ -212,21 +152,6 @@ export type SSRContextValue = {
 
 // @public
 export const SSRProvider: React_2.FC;
-
-// @public
-export const tableProperties: Record<string, number>;
-
-// @public
-export const tdProperties: Record<string, number>;
-
-// @public
-export const textAreaProperties: Record<string, number>;
-
-// @public
-export const thProperties: Record<string, number>;
-
-// @public
-export const trProperties: Record<string, number>;
 
 // @public
 export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) extends (x: infer I) => U ? I : never;
@@ -306,9 +231,6 @@ export function useTimeout(): readonly [(fn: () => void, delay: number) => void,
 
 // @public
 export const useUnmount: (callback: () => void) => void;
-
-// @public
-export const videoProperties: Record<string, number>;
 
 // Warnings were encountered during analysis:
 //

--- a/packages/react-utilities/src/utils/getNativeElementProps.ts
+++ b/packages/react-utilities/src/utils/getNativeElementProps.ts
@@ -24,7 +24,7 @@ import {
   getNativeProps,
 } from './properties';
 
-const nativeElementMap: Record<string, Record<string, number>> = {
+const nativeElementMap: Record<keyof JSX.IntrinsicElements, Set<string>> = {
   label: labelProperties,
   audio: audioProperties,
   video: videoProperties,
@@ -40,7 +40,7 @@ const nativeElementMap: Record<string, Record<string, number>> = {
   tr: trProperties,
   th: thProperties,
   td: tdProperties,
-  colGroup: colGroupProperties,
+  colgroup: colGroupProperties,
   col: colProperties,
   form: formProperties,
   iframe: iframeProperties,
@@ -56,14 +56,13 @@ const nativeElementMap: Record<string, Record<string, number>> = {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getNativeElementProps<TAttributes extends React.HTMLAttributes<any>>(
-  tagName: string,
+  tagName: keyof JSX.IntrinsicElements,
   props: {},
   excludedPropNames?: string[],
 ): TAttributes {
   const allowedPropNames = (tagName && nativeElementMap[tagName]) || htmlElementProperties;
-  allowedPropNames.as = 1;
 
-  return getNativeProps(props, allowedPropNames, excludedPropNames);
+  return getNativeProps(props, allowedPropNames, excludedPropNames, ['as']);
 }
 
 /**
@@ -74,7 +73,7 @@ export function getNativeElementProps<TAttributes extends React.HTMLAttributes<a
  *
  * @returns An object containing the native props for the `root` and primary slots.
  */
-export const getPartitionedNativeProps = ({
+export function getPartitionedNativeProps<NativeProps extends React.HTMLAttributes<unknown>>({
   primarySlotTagName,
   props,
   excludedPropNames,
@@ -83,13 +82,17 @@ export const getPartitionedNativeProps = ({
   primarySlotTagName: keyof JSX.IntrinsicElements;
 
   /** The component's props object */
-  props: Pick<React.HTMLAttributes<HTMLElement>, 'style' | 'className'>;
+  props: Pick<NativeProps, 'style' | 'className'>;
 
   /** List of native props to exclude from the returned value */
   excludedPropNames?: string[];
-}) => {
+}) {
   return {
     root: { style: props.style, className: props.className },
-    primary: getNativeElementProps(primarySlotTagName, props, [...(excludedPropNames || []), 'style', 'className']),
+    primary: getNativeElementProps<NativeProps>(primarySlotTagName, props, [
+      ...(excludedPropNames || []),
+      'style',
+      'className',
+    ]),
   };
-};
+}

--- a/packages/react-utilities/src/utils/index.ts
+++ b/packages/react-utilities/src/utils/index.ts
@@ -4,5 +4,4 @@ export * from './getNativeElementProps';
 export * from './getRTLSafeKey';
 export * from './omit';
 export * from './onlyChild';
-export * from './properties';
 export * from './shouldPreventDefaultOnKeyDown';

--- a/packages/react-utilities/src/utils/properties.test.ts
+++ b/packages/react-utilities/src/utils/properties.test.ts
@@ -58,7 +58,7 @@ describe('getNativeProps', () => {
   });
 
   it('can exclude properties', () => {
-    const result = getNativeProps<{ a: number; b: number }>({ a: 1, b: 2 }, ['a', 'b'], ['b']);
+    const result = getNativeProps<{ a: number; b: number }>({ a: 1, b: 2 }, new Set(['a', 'b']), ['b']);
 
     expect(result.a).toBeDefined();
     expect(result.b).toBeUndefined();

--- a/packages/react-utilities/src/utils/properties.ts
+++ b/packages/react-utilities/src/utils/properties.ts
@@ -1,23 +1,9 @@
-const toObjectMap = (...items: (string[] | Record<string, number>)[]) => {
-  const result: Record<string, number> = {};
-
-  for (const item of items) {
-    const keys = Array.isArray(item) ? item : Object.keys(item);
-
-    for (const key of keys) {
-      result[key] = 1;
-    }
-  }
-
-  return result;
-};
+import * as React from 'react';
 
 /**
- * An array of events that are allowed on every html element type.
- *
- * @public
+ * A set of events that are allowed on every html element type.
  */
-export const baseElementEvents = toObjectMap([
+export const baseElementEvents = new Set<keyof React.DOMAttributes<{}>>([
   'onAuxClick',
   'onCopy',
   'onCut',
@@ -100,12 +86,12 @@ export const baseElementEvents = toObjectMap([
   'onLostPointerCapture',
 ]);
 
+type CommonAttributes = 'ref' | 'name';
+
 /**
- * An array of element attributes which are allowed on every html element type.
- *
- * @public
+ * A set of element attributes which are allowed on every html element type.
  */
-export const baseElementProperties = toObjectMap([
+export const baseElementProperties = new Set<keyof React.HTMLAttributes<{}> | CommonAttributes>([
   'accessKey', // global
   'children', // global
   'className', // global
@@ -113,7 +99,6 @@ export const baseElementProperties = toObjectMap([
   'dir', // global
   'draggable', // global
   'hidden', // global
-  'htmlFor', // global
   'id', // global
   'lang', // global
   'ref', // global
@@ -127,68 +112,64 @@ export const baseElementProperties = toObjectMap([
 ]);
 
 /**
- * An array of HTML element properties and events.
- *
- * @public
+ * A set of HTML element properties and events.
  */
-export const htmlElementProperties = toObjectMap(baseElementProperties, baseElementEvents);
-
-/**
- * An array of LABEL tag properties and events.
- *
- * @public
- */
-export const labelProperties = toObjectMap(htmlElementProperties, [
-  'form', // button, fieldset, input, label, meter, object, output, select, textarea
+export const htmlElementProperties = new Set<keyof React.HTMLAttributes<{}> | CommonAttributes>([
+  ...baseElementProperties,
+  ...baseElementEvents,
 ]);
 
 /**
- * An array of AUDIO tag properties and events.
-
- * @public
+ * A set of LABEL tag properties and events.
  */
-export const audioProperties = toObjectMap(htmlElementProperties, [
-  'height', // canvas, embed, iframe, img, input, object, video
+export const labelProperties = new Set<keyof React.LabelHTMLAttributes<{}> | CommonAttributes>([
+  ...htmlElementProperties,
+  'form', // button, fieldset, input, label, meter, object, output, select, textarea
+  'htmlFor', // label, output
+]);
+
+/**
+ * A set of AUDIO tag properties and events.
+ */
+export const audioProperties = new Set<keyof React.AudioHTMLAttributes<{}> | CommonAttributes>([
+  ...htmlElementProperties,
   'loop', // audio, video
   'muted', // audio, video
   'preload', // audio, video
   'src', // audio, embed, iframe, img, input, script, source, track, video
+]);
+
+/**
+ * A set of VIDEO tag properties and events.
+ */
+export const videoProperties = new Set<keyof React.VideoHTMLAttributes<{}> | CommonAttributes>([
+  ...audioProperties,
+  'height', // canvas, embed, iframe, img, input, object, video
+  'poster', // video
   'width', // canvas, embed, iframe, img, input, object, video
 ]);
 
 /**
- * An array of VIDEO tag properties and events.
- *
- * @public
+ * A set of OL tag properties and events.
  */
-export const videoProperties = toObjectMap(audioProperties, [
-  'poster', // video
-]);
-
-/**
- * An array of OL tag properties and events.
- *
- * @public
- */
-export const olProperties = toObjectMap(htmlElementProperties, [
+export const olProperties = new Set<keyof React.OlHTMLAttributes<{}> | CommonAttributes>([
+  ...htmlElementProperties,
   'start', // ol
 ]);
 
 /**
- * An array of LI tag properties and events.
- *
- * @public
+ * A set of LI tag properties and events.
  */
-export const liProperties = toObjectMap(htmlElementProperties, [
+export const liProperties = new Set<keyof React.LiHTMLAttributes<{}> | CommonAttributes>([
+  ...htmlElementProperties,
   'value', // button, input, li, option, meter, progress, param
 ]);
 
 /**
- * An array of A tag properties and events.
- *
- * @public
+ * A set of A tag properties and events.
  */
-export const anchorProperties = toObjectMap(htmlElementProperties, [
+export const anchorProperties = new Set<keyof React.AnchorHTMLAttributes<{}> | CommonAttributes>([
+  ...htmlElementProperties,
   'download', // a, area
   'href', // a, area, base, link
   'hrefLang', // a, area, link
@@ -199,11 +180,10 @@ export const anchorProperties = toObjectMap(htmlElementProperties, [
 ]);
 
 /**
- * An array of BUTTON tag properties and events.
- *
- * @public
+ * A set of BUTTON tag properties and events.
  */
-export const buttonProperties = toObjectMap(htmlElementProperties, [
+export const buttonProperties = new Set<keyof React.ButtonHTMLAttributes<{}> | CommonAttributes>([
+  ...htmlElementProperties,
   'autoFocus', // button, input, select, textarea
   'disabled', // button, fieldset, input, optgroup, option, select, textarea
   'form', // button, fieldset, input, label, meter, object, output, select, textarea
@@ -217,17 +197,17 @@ export const buttonProperties = toObjectMap(htmlElementProperties, [
 ]);
 
 /**
- * An array of INPUT tag properties and events.
- *
- * @public
+ * A set of INPUT tag properties and events.
  */
-export const inputProperties = toObjectMap(buttonProperties, [
+export const inputProperties = new Set<keyof React.InputHTMLAttributes<{}> | CommonAttributes>([
+  ...buttonProperties,
   'accept', // input
   'alt', // area, img, input
   'autoCapitalize', // input, textarea
   'autoComplete', // form, input
   'checked', // input
-  'dirname', // input, textarea
+  'defaultChecked',
+  'defaultValue',
   'form', // button, fieldset, input, label, meter, object, output, select, textarea
   'height', // canvas, embed, iframe, img, input, object, video
   'inputMode', // input
@@ -249,92 +229,99 @@ export const inputProperties = toObjectMap(buttonProperties, [
 ]);
 
 /**
- * An array of TEXTAREA tag properties and events.
- *
- * @public
+ * A set of TEXTAREA tag properties and events.
  */
-export const textAreaProperties = toObjectMap(buttonProperties, [
+export const textAreaProperties = new Set<keyof React.TextareaHTMLAttributes<{}> | CommonAttributes>([
+  ...htmlElementProperties,
   'autoCapitalize', // input, textarea
+  'autoComplete',
+  'autoFocus',
   'cols', // textarea
-  'dirname', // input, textarea
+  'dirName', // textarea
+  'disabled',
   'form', // button, fieldset, input, label, meter, object, output, select, textarea
   'maxLength', // input, textarea
+  'minLength',
   'placeholder', // input, textarea
   'readOnly', // input, textarea
   'required', // input, select, textarea
   'rows', // textarea
+  'value',
   'wrap', // textarea
 ]);
 
 /**
- * An array of SELECT tag properties and events.
- *
- * @public
+ * A set of SELECT tag properties and events.
  */
-export const selectProperties = toObjectMap(buttonProperties, [
+export const selectProperties = new Set<keyof React.SelectHTMLAttributes<{}> | CommonAttributes>([
+  ...htmlElementProperties,
+  'autoComplete',
+  'autoFocus',
+  'defaultValue',
+  'disabled',
   'form', // button, fieldset, input, label, meter, object, output, select, textarea
   'multiple', // input, select
+  'name',
   'required', // input, select, textarea
+  'size',
+  'value',
 ]);
 
-export const optionProperties = toObjectMap(htmlElementProperties, [
+export const optionProperties = new Set<keyof React.OptionHTMLAttributes<{}> | CommonAttributes>([
+  ...htmlElementProperties,
   'selected', // option
   'value', // button, input, li, option, meter, progress, param
 ]);
 
 /**
- * An array of TABLE tag properties and events.
- *
- * @public
+ * A set of TABLE tag properties and events.
  */
-export const tableProperties = toObjectMap(htmlElementProperties, [
+export const tableProperties = new Set<keyof React.TableHTMLAttributes<{}> | CommonAttributes>([
+  ...htmlElementProperties,
   'cellPadding', // table
   'cellSpacing', // table
 ]);
 
 /**
- * An array of TR tag properties and events.
- *
- * @public
+ * A set of TR tag properties and events.
  */
 export const trProperties = htmlElementProperties;
 
 /**
- * An array of TH tag properties and events.
- *
- * @public
+ * A set of TH tag properties and events.
  */
-export const thProperties = toObjectMap(htmlElementProperties, [
+export const thProperties = new Set([
+  ...htmlElementProperties,
   'rowSpan', // td, th
   'scope', // th
 ]);
 
 /**
- * An array of TD tag properties and events.
- *
- * @public
+ * A set of TD tag properties and events.
  */
-export const tdProperties = toObjectMap(htmlElementProperties, [
+export const tdProperties = new Set([
+  ...htmlElementProperties,
   'colSpan', // td
   'headers', // td
   'rowSpan', // td, th
   'scope', // th
 ]);
 
-export const colGroupProperties = toObjectMap(htmlElementProperties, [
+export const colGroupProperties = new Set([
+  ...htmlElementProperties,
   'span', // col, colgroup
 ]);
 
-export const colProperties = toObjectMap(htmlElementProperties, [
+export const colProperties = new Set([
+  ...htmlElementProperties,
   'span', // col, colgroup
 ]);
 
 /**
- * An array of FORM tag properties and events.
- *
- * @public
+ * A set of FORM tag properties and events.
  */
-export const formProperties = toObjectMap(htmlElementProperties, [
+export const formProperties = new Set([
+  ...htmlElementProperties,
   'acceptCharset', // form
   'action', // form
   'encType', // form
@@ -345,11 +332,10 @@ export const formProperties = toObjectMap(htmlElementProperties, [
 ]);
 
 /**
- * An array of IFRAME tag properties and events.
- *
- * @public
+ * A set of IFRAME tag properties and events.
  */
-export const iframeProperties = toObjectMap(htmlElementProperties, [
+export const iframeProperties = new Set([
+  ...htmlElementProperties,
   'allow', // iframe
   'allowFullScreen', // iframe
   'allowPaymentRequest', // iframe
@@ -365,11 +351,10 @@ export const iframeProperties = toObjectMap(htmlElementProperties, [
 ]);
 
 /**
- * An array of IMAGE tag properties and events.
- *
- * @public
+ * A set of IMAGE tag properties and events.
  */
-export const imgProperties = toObjectMap(htmlElementProperties, [
+export const imgProperties = new Set([
+  ...htmlElementProperties,
   'alt', // area, img, input
   'crossOrigin', // img
   'height', // canvas, embed, iframe, img, input, object, video
@@ -380,37 +365,30 @@ export const imgProperties = toObjectMap(htmlElementProperties, [
 ]);
 
 /**
- * @deprecated Use imgProperties for img elements.
- */
-export const imageProperties = imgProperties;
-
-/**
- * An array of DIV tag properties and events.
- *
- * @public
+ * A set of DIV tag properties and events.
  */
 export const divProperties = htmlElementProperties;
 
 /**
- * Gets native supported props for an html element provided the allowance set. Use one of the property
- * sets defined (divProperties, buttonPropertes, etc) to filter out supported properties from a given
- * props set. Note that all data- and aria- prefixed attributes will be allowed.
- * NOTE: getNativeProps should always be applied first when adding props to a react component. The
- * non-native props should be applied second. This will prevent getNativeProps from overriding your custom props.
- * For example, if props passed to getNativeProps has an onClick function and getNativeProps is added to
- * the component after an onClick function is added, then the getNativeProps onClick will override it.
+ * Gets native supported props for an HTML element provided the allowance set. Use one of the property
+ * sets defined (`divProperties`, `buttonPropertes`, etc) to filter out supported properties from a given
+ * props set. Note that all `data-` and `aria-` prefixed attributes will be allowed.
  *
- * @public
+ * NOTE: `getNativeProps` should always be applied first when adding props to a React component. The
+ * non-native props should be applied second. This will prevent `getNativeProps` from overriding your custom props.
+ * For example, if props passed to `getNativeProps` has an `onClick` function and `getNativeProps` is added to
+ * the component after an `onClick` function is added, then the `getNativeProps` `onClick` will override it.
  * @param props - The unfiltered input props
- * @param allowedPropsNames - The array or record of allowed prop names.
+ * @param allowedPropsNames - The set of allowed prop names.
  * @returns The filtered props
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getNativeProps<T extends Record<string, any>>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   props: Record<string, any>,
-  allowedPropNames: string[] | Record<string, number>,
+  allowedPropNames: Set<string>,
   excludedPropNames?: string[],
+  extraPropNames?: string[],
 ): T {
   // It'd be great to properly type this while allowing 'aria-` and 'data-' attributes like TypeScript does for
   // JSX attributes, but that ability is hardcoded into the TS compiler with no analog in TypeScript typings.
@@ -418,21 +396,16 @@ export function getNativeProps<T extends Record<string, any>>(
   // return native props.
   // We should be able to do this once this PR is merged: https://github.com/microsoft/TypeScript/pull/26797
 
-  const isArray = Array.isArray(allowedPropNames);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: Record<string, any> = {};
   const keys = Object.keys(props);
 
   for (const key of keys) {
     const isNativeProp =
-      (!isArray && (allowedPropNames as Record<string, number>)[key]) ||
-      (isArray && (allowedPropNames as string[]).indexOf(key) >= 0) ||
-      key.indexOf('data-') === 0 ||
-      key.indexOf('aria-') === 0;
+      allowedPropNames.has(key) || extraPropNames?.includes(key) || key.startsWith('data-') || key.startsWith('aria-');
 
-    if (isNativeProp && (!excludedPropNames || excludedPropNames?.indexOf(key) === -1)) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      result[key] = props![key] as any;
+    if (isNativeProp && !excludedPropNames?.includes(key)) {
+      result[key] = props[key];
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

> Note that **this change is only for the converged/v9 version of `getNativeElementProps`** (v8 is unaffected).

The motivation for this change was discovering that `defaultValue` is not returned by `getNativeElementProps`. Upon looking into the implementation, I noticed some opportunities for modernization (now that we don't have to support IE 11) and some other minor issues with which props were considered valid for which elements.

Summary of changes:

- ~~Update properties constants to use `Set` rather than object maps~~ UPDATE: for some reason this is LESS efficient and this section is performance-critical, so this part is reverted
- Add more detailed types to the properties constants, and fix issues this revealed (some property sets included things which weren't actually supported for that element)
- Include `defaultValue` and `defaultChecked` in native props for appropriate elements
- Since all the converged components only use `getNativeElementProps`, stop exporting `getNativeProps` and the properties constants. We can always add them back later if there's a compelling need (the main advantage I can think of for the old approach is tree-shaking).
