### PR TITLE
fix(makeStyles): improve return types for shorthand functions

### DIFF
--- a/change/@fluentui-make-styles-901b66ec-0438-4a53-9088-395f1a048d8d.json
+++ b/change/@fluentui-make-styles-901b66ec-0438-4a53-9088-395f1a048d8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: improve return types for shorthand functions",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/make-styles/src/shorthands/border.ts
+++ b/packages/make-styles/src/shorthands/border.ts
@@ -5,16 +5,29 @@ import { borderWidth } from './borderWidth';
 import { borderStyle } from './borderStyle';
 import { borderColor } from './borderColor';
 
-export function border(width: BorderWidthProperty<MakeStylesCSSValue>): MakeStylesStrictCSSObject;
-export function border(
-  width: BorderWidthProperty<MakeStylesCSSValue>,
-  style: BorderStyleProperty,
-): MakeStylesStrictCSSObject;
+type BorderStyles = Pick<
+  MakeStylesStrictCSSObject,
+  | 'borderTopColor'
+  | 'borderTopStyle'
+  | 'borderTopWidth'
+  | 'borderRightColor'
+  | 'borderRightStyle'
+  | 'borderRightWidth'
+  | 'borderBottomColor'
+  | 'borderBottomStyle'
+  | 'borderBottomWidth'
+  | 'borderLeftColor'
+  | 'borderLeftStyle'
+  | 'borderLeftWidth'
+>;
+
+export function border(width: BorderWidthProperty<MakeStylesCSSValue>): BorderStyles;
+export function border(width: BorderWidthProperty<MakeStylesCSSValue>, style: BorderStyleProperty): BorderStyles;
 export function border(
   width: BorderWidthProperty<MakeStylesCSSValue>,
   style: BorderStyleProperty,
   color: BorderColorProperty,
-): MakeStylesStrictCSSObject;
+): BorderStyles;
 
 /**
  * A function that implements expansion for "border" to all sides of an element, it's simplified - check usage examples.
@@ -28,7 +41,7 @@ export function border(
  */
 export function border(
   ...values: [BorderWidthProperty<MakeStylesCSSValue>, BorderStyleProperty?, BorderColorProperty?]
-): MakeStylesStrictCSSObject {
+): BorderStyles {
   return {
     ...borderWidth(values[0]),
     ...(values[1] && borderStyle(values[1])),

--- a/packages/make-styles/src/shorthands/border.ts
+++ b/packages/make-styles/src/shorthands/border.ts
@@ -5,7 +5,7 @@ import { borderWidth } from './borderWidth';
 import { borderStyle } from './borderStyle';
 import { borderColor } from './borderColor';
 
-type BorderStyles = Pick<
+type BorderStyle = Pick<
   MakeStylesStrictCSSObject,
   | 'borderTopColor'
   | 'borderTopStyle'
@@ -21,13 +21,13 @@ type BorderStyles = Pick<
   | 'borderLeftWidth'
 >;
 
-export function border(width: BorderWidthProperty<MakeStylesCSSValue>): BorderStyles;
-export function border(width: BorderWidthProperty<MakeStylesCSSValue>, style: BorderStyleProperty): BorderStyles;
+export function border(width: BorderWidthProperty<MakeStylesCSSValue>): BorderStyle;
+export function border(width: BorderWidthProperty<MakeStylesCSSValue>, style: BorderStyleProperty): BorderStyle;
 export function border(
   width: BorderWidthProperty<MakeStylesCSSValue>,
   style: BorderStyleProperty,
   color: BorderColorProperty,
-): BorderStyles;
+): BorderStyle;
 
 /**
  * A function that implements expansion for "border" to all sides of an element, it's simplified - check usage examples.
@@ -41,7 +41,7 @@ export function border(
  */
 export function border(
   ...values: [BorderWidthProperty<MakeStylesCSSValue>, BorderStyleProperty?, BorderColorProperty?]
-): BorderStyles {
+): BorderStyle {
   return {
     ...borderWidth(values[0]),
     ...(values[1] && borderStyle(values[1])),

--- a/packages/make-styles/src/shorthands/borderBottom.ts
+++ b/packages/make-styles/src/shorthands/borderBottom.ts
@@ -1,16 +1,21 @@
 import type { BorderColorProperty, BorderStyleProperty, BorderWidthProperty } from 'csstype';
 import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
 
-export function borderBottom(width: BorderWidthProperty<MakeStylesCSSValue>): MakeStylesStrictCSSObject;
+type BorderBottomStyle = Pick<
+  MakeStylesStrictCSSObject,
+  'borderBottomWidth' | 'borderBottomStyle' | 'borderBottomColor'
+>;
+
+export function borderBottom(width: BorderWidthProperty<MakeStylesCSSValue>): BorderBottomStyle;
 export function borderBottom(
   width: BorderWidthProperty<MakeStylesCSSValue>,
   style: BorderStyleProperty,
-): MakeStylesStrictCSSObject;
+): BorderBottomStyle;
 export function borderBottom(
   width: BorderWidthProperty<MakeStylesCSSValue>,
   style: BorderStyleProperty,
   color: BorderColorProperty,
-): MakeStylesStrictCSSObject;
+): BorderBottomStyle;
 
 /**
  * A function that implements expansion for "border-bottom", it's simplified - check usage examples.
@@ -24,10 +29,10 @@ export function borderBottom(
  */
 export function borderBottom(
   ...values: [BorderWidthProperty<MakeStylesCSSValue>, BorderStyleProperty?, BorderColorProperty?]
-): MakeStylesStrictCSSObject {
+): BorderBottomStyle {
   return {
     borderBottomWidth: values[0],
-    ...(values[1] && ({ borderBottomStyle: values[1] } as MakeStylesStrictCSSObject)),
+    ...(values[1] && ({ borderBottomStyle: values[1] } as BorderBottomStyle)),
     ...(values[2] && { borderBottomColor: values[2] }),
   };
 }

--- a/packages/make-styles/src/shorthands/borderColor.ts
+++ b/packages/make-styles/src/shorthands/borderColor.ts
@@ -3,19 +3,24 @@ import type { BorderColorProperty } from 'csstype';
 import type { MakeStylesStrictCSSObject } from '../types';
 import { generateStyles } from './generateStyles';
 
-export function borderColor(all: BorderColorProperty): MakeStylesStrictCSSObject;
-export function borderColor(vertical: BorderColorProperty, horizontal: BorderColorProperty): MakeStylesStrictCSSObject;
+type BorderColorStyles = Pick<
+  MakeStylesStrictCSSObject,
+  'borderTopColor' | 'borderRightColor' | 'borderBottomColor' | 'borderLeftColor'
+>;
+
+export function borderColor(all: BorderColorProperty): BorderColorStyles;
+export function borderColor(vertical: BorderColorProperty, horizontal: BorderColorProperty): BorderColorStyles;
 export function borderColor(
   top: BorderColorProperty,
   horizontal: BorderColorProperty,
   bottom: BorderColorProperty,
-): MakeStylesStrictCSSObject;
+): BorderColorStyles;
 export function borderColor(
   top: BorderColorProperty,
   right: BorderColorProperty,
   bottom: BorderColorProperty,
   left: BorderColorProperty,
-): MakeStylesStrictCSSObject;
+): BorderColorStyles;
 
 /**
  * A function that implements CSS spec conformant expansion for "borderColor"
@@ -28,6 +33,6 @@ export function borderColor(
  *
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/border-color
  */
-export function borderColor(...values: BorderColorProperty[]): MakeStylesStrictCSSObject {
+export function borderColor(...values: BorderColorProperty[]): BorderColorStyles {
   return generateStyles('border', 'Color', ...values);
 }

--- a/packages/make-styles/src/shorthands/borderColor.ts
+++ b/packages/make-styles/src/shorthands/borderColor.ts
@@ -3,24 +3,24 @@ import type { BorderColorProperty } from 'csstype';
 import type { MakeStylesStrictCSSObject } from '../types';
 import { generateStyles } from './generateStyles';
 
-type BorderColorStyles = Pick<
+type BorderColorStyle = Pick<
   MakeStylesStrictCSSObject,
   'borderTopColor' | 'borderRightColor' | 'borderBottomColor' | 'borderLeftColor'
 >;
 
-export function borderColor(all: BorderColorProperty): BorderColorStyles;
-export function borderColor(vertical: BorderColorProperty, horizontal: BorderColorProperty): BorderColorStyles;
+export function borderColor(all: BorderColorProperty): BorderColorStyle;
+export function borderColor(vertical: BorderColorProperty, horizontal: BorderColorProperty): BorderColorStyle;
 export function borderColor(
   top: BorderColorProperty,
   horizontal: BorderColorProperty,
   bottom: BorderColorProperty,
-): BorderColorStyles;
+): BorderColorStyle;
 export function borderColor(
   top: BorderColorProperty,
   right: BorderColorProperty,
   bottom: BorderColorProperty,
   left: BorderColorProperty,
-): BorderColorStyles;
+): BorderColorStyle;
 
 /**
  * A function that implements CSS spec conformant expansion for "borderColor"
@@ -33,6 +33,6 @@ export function borderColor(
  *
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/border-color
  */
-export function borderColor(...values: BorderColorProperty[]): BorderColorStyles {
+export function borderColor(...values: BorderColorProperty[]): BorderColorStyle {
   return generateStyles('border', 'Color', ...values);
 }

--- a/packages/make-styles/src/shorthands/borderLeft.ts
+++ b/packages/make-styles/src/shorthands/borderLeft.ts
@@ -1,16 +1,18 @@
 import type { BorderColorProperty, BorderStyleProperty, BorderWidthProperty } from 'csstype';
 import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
 
-export function borderLeft(width: BorderWidthProperty<MakeStylesCSSValue>): MakeStylesStrictCSSObject;
+type BorderLeftStyles = Pick<MakeStylesStrictCSSObject, 'borderLeftColor' | 'borderLeftStyle' | 'borderLeftWidth'>;
+
+export function borderLeft(width: BorderWidthProperty<MakeStylesCSSValue>): BorderLeftStyles;
 export function borderLeft(
   width: BorderWidthProperty<MakeStylesCSSValue>,
   style: BorderStyleProperty,
-): MakeStylesStrictCSSObject;
+): BorderLeftStyles;
 export function borderLeft(
   width: BorderWidthProperty<MakeStylesCSSValue>,
   style: BorderStyleProperty,
   color: BorderColorProperty,
-): MakeStylesStrictCSSObject;
+): BorderLeftStyles;
 
 /**
  * A function that implements expansion for "border-left", it's simplified - check usage examples.
@@ -24,7 +26,7 @@ export function borderLeft(
  */
 export function borderLeft(
   ...values: [BorderWidthProperty<MakeStylesCSSValue>, BorderStyleProperty?, BorderColorProperty?]
-): MakeStylesStrictCSSObject {
+): BorderLeftStyles {
   return {
     borderLeftWidth: values[0],
     ...(values[1] && ({ borderLeftStyle: values[1] } as MakeStylesStrictCSSObject)),

--- a/packages/make-styles/src/shorthands/borderLeft.ts
+++ b/packages/make-styles/src/shorthands/borderLeft.ts
@@ -1,18 +1,15 @@
 import type { BorderColorProperty, BorderStyleProperty, BorderWidthProperty } from 'csstype';
 import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
 
-type BorderLeftStyles = Pick<MakeStylesStrictCSSObject, 'borderLeftColor' | 'borderLeftStyle' | 'borderLeftWidth'>;
+type BorderLeftStyle = Pick<MakeStylesStrictCSSObject, 'borderLeftColor' | 'borderLeftStyle' | 'borderLeftWidth'>;
 
-export function borderLeft(width: BorderWidthProperty<MakeStylesCSSValue>): BorderLeftStyles;
-export function borderLeft(
-  width: BorderWidthProperty<MakeStylesCSSValue>,
-  style: BorderStyleProperty,
-): BorderLeftStyles;
+export function borderLeft(width: BorderWidthProperty<MakeStylesCSSValue>): BorderLeftStyle;
+export function borderLeft(width: BorderWidthProperty<MakeStylesCSSValue>, style: BorderStyleProperty): BorderLeftStyle;
 export function borderLeft(
   width: BorderWidthProperty<MakeStylesCSSValue>,
   style: BorderStyleProperty,
   color: BorderColorProperty,
-): BorderLeftStyles;
+): BorderLeftStyle;
 
 /**
  * A function that implements expansion for "border-left", it's simplified - check usage examples.
@@ -26,7 +23,7 @@ export function borderLeft(
  */
 export function borderLeft(
   ...values: [BorderWidthProperty<MakeStylesCSSValue>, BorderStyleProperty?, BorderColorProperty?]
-): BorderLeftStyles {
+): BorderLeftStyle {
   return {
     borderLeftWidth: values[0],
     ...(values[1] && ({ borderLeftStyle: values[1] } as MakeStylesStrictCSSObject)),

--- a/packages/make-styles/src/shorthands/borderRadius.ts
+++ b/packages/make-styles/src/shorthands/borderRadius.ts
@@ -1,6 +1,6 @@
 import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
 
-type BorderRadiusStyles = Pick<
+type BorderRadiusStyle = Pick<
   MakeStylesStrictCSSObject,
   'borderBottomRightRadius' | 'borderBottomLeftRadius' | 'borderTopRightRadius' | 'borderTopLeftRadius'
 >;
@@ -22,7 +22,7 @@ export function borderRadius(
   value2: MakeStylesCSSValue = value1,
   value3: MakeStylesCSSValue = value1,
   value4: MakeStylesCSSValue = value2,
-): BorderRadiusStyles {
+): BorderRadiusStyle {
   return {
     borderBottomRightRadius: value3,
     borderBottomLeftRadius: value4,

--- a/packages/make-styles/src/shorthands/borderRadius.ts
+++ b/packages/make-styles/src/shorthands/borderRadius.ts
@@ -1,5 +1,10 @@
 import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
 
+type BorderRadiusStyles = Pick<
+  MakeStylesStrictCSSObject,
+  'borderBottomRightRadius' | 'borderBottomLeftRadius' | 'borderTopRightRadius' | 'borderTopLeftRadius'
+>;
+
 /**
  * A function that implements CSS spec conformant expansion for "borderRadius". "/" is not supported, please use CSS
  * longhands directly.
@@ -17,7 +22,7 @@ export function borderRadius(
   value2: MakeStylesCSSValue = value1,
   value3: MakeStylesCSSValue = value1,
   value4: MakeStylesCSSValue = value2,
-): MakeStylesStrictCSSObject {
+): BorderRadiusStyles {
   return {
     borderBottomRightRadius: value3,
     borderBottomLeftRadius: value4,

--- a/packages/make-styles/src/shorthands/borderRight.ts
+++ b/packages/make-styles/src/shorthands/borderRight.ts
@@ -1,16 +1,18 @@
 import type { BorderColorProperty, BorderStyleProperty, BorderWidthProperty } from 'csstype';
 import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
 
-export function borderRight(width: BorderWidthProperty<MakeStylesCSSValue>): MakeStylesStrictCSSObject;
+type BorderRightStyle = Pick<MakeStylesStrictCSSObject, 'borderRightWidth' | 'borderRightStyle' | 'borderRightColor'>;
+
+export function borderRight(width: BorderWidthProperty<MakeStylesCSSValue>): BorderRightStyle;
 export function borderRight(
   width: BorderWidthProperty<MakeStylesCSSValue>,
   style: BorderStyleProperty,
-): MakeStylesStrictCSSObject;
+): BorderRightStyle;
 export function borderRight(
   width: BorderWidthProperty<MakeStylesCSSValue>,
   style: BorderStyleProperty,
   color: BorderColorProperty,
-): MakeStylesStrictCSSObject;
+): BorderRightStyle;
 
 /**
  * A function that implements expansion for "border-right", it's simplified - check usage examples.
@@ -24,10 +26,10 @@ export function borderRight(
  */
 export function borderRight(
   ...values: [BorderWidthProperty<MakeStylesCSSValue>, BorderStyleProperty?, BorderColorProperty?]
-): MakeStylesStrictCSSObject {
+): BorderRightStyle {
   return {
     borderRightWidth: values[0],
-    ...(values[1] && ({ borderRightStyle: values[1] } as MakeStylesStrictCSSObject)),
+    ...(values[1] && ({ borderRightStyle: values[1] } as BorderRightStyle)),
     ...(values[2] && { borderRightColor: values[2] }),
   };
 }

--- a/packages/make-styles/src/shorthands/borderStyle.ts
+++ b/packages/make-styles/src/shorthands/borderStyle.ts
@@ -3,19 +3,24 @@ import type { BorderStyleProperty } from 'csstype';
 import type { MakeStylesStrictCSSObject } from '../types';
 import { generateStyles } from './generateStyles';
 
-export function borderStyle(all: BorderStyleProperty): MakeStylesStrictCSSObject;
-export function borderStyle(vertical: BorderStyleProperty, horizontal: BorderStyleProperty): MakeStylesStrictCSSObject;
+type BorderStyleStyle = Pick<
+  MakeStylesStrictCSSObject,
+  'borderTopStyle' | 'borderRightStyle' | 'borderBottomStyle' | 'borderLeftStyle'
+>;
+
+export function borderStyle(all: BorderStyleProperty): BorderStyleStyle;
+export function borderStyle(vertical: BorderStyleProperty, horizontal: BorderStyleProperty): BorderStyleStyle;
 export function borderStyle(
   top: BorderStyleProperty,
   horizontal: BorderStyleProperty,
   bottom: BorderStyleProperty,
-): MakeStylesStrictCSSObject;
+): BorderStyleStyle;
 export function borderStyle(
   top: BorderStyleProperty,
   right: BorderStyleProperty,
   bottom: BorderStyleProperty,
   left: BorderStyleProperty,
-): MakeStylesStrictCSSObject;
+): BorderStyleStyle;
 
 /**
  * A function that implements CSS spec conformant expansion for "borderStyle"
@@ -28,6 +33,6 @@ export function borderStyle(
  *
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/border-style
  */
-export function borderStyle(...values: BorderStyleProperty[]): MakeStylesStrictCSSObject {
+export function borderStyle(...values: BorderStyleProperty[]): BorderStyleStyle {
   return generateStyles('border', 'Style', ...values);
 }

--- a/packages/make-styles/src/shorthands/borderTop.ts
+++ b/packages/make-styles/src/shorthands/borderTop.ts
@@ -1,16 +1,15 @@
 import type { BorderColorProperty, BorderStyleProperty, BorderWidthProperty } from 'csstype';
 import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
 
-export function borderTop(width: BorderWidthProperty<MakeStylesCSSValue>): MakeStylesStrictCSSObject;
-export function borderTop(
-  width: BorderWidthProperty<MakeStylesCSSValue>,
-  style: BorderStyleProperty,
-): MakeStylesStrictCSSObject;
+type Created = Pick<MakeStylesStrictCSSObject, 'borderTopWidth' | 'borderTopStyle' | 'borderTopColor'>;
+
+export function borderTop(width: BorderWidthProperty<MakeStylesCSSValue>): Created;
+export function borderTop(width: BorderWidthProperty<MakeStylesCSSValue>, style: BorderStyleProperty): Created;
 export function borderTop(
   width: BorderWidthProperty<MakeStylesCSSValue>,
   style: BorderStyleProperty,
   color: BorderColorProperty,
-): MakeStylesStrictCSSObject;
+): Created;
 
 /**
  * A function that implements expansion for "border-top", it's simplified - check usage examples.
@@ -24,10 +23,10 @@ export function borderTop(
  */
 export function borderTop(
   ...values: [BorderWidthProperty<MakeStylesCSSValue>, BorderStyleProperty?, BorderColorProperty?]
-): MakeStylesStrictCSSObject {
+): Created {
   return {
     borderTopWidth: values[0],
-    ...(values[1] && ({ borderTopStyle: values[1] } as MakeStylesStrictCSSObject)),
+    ...(values[1] && ({ borderTopStyle: values[1] } as Created)),
     ...(values[2] && { borderTopColor: values[2] }),
   };
 }

--- a/packages/make-styles/src/shorthands/borderTop.ts
+++ b/packages/make-styles/src/shorthands/borderTop.ts
@@ -1,15 +1,15 @@
 import type { BorderColorProperty, BorderStyleProperty, BorderWidthProperty } from 'csstype';
 import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
 
-type Created = Pick<MakeStylesStrictCSSObject, 'borderTopWidth' | 'borderTopStyle' | 'borderTopColor'>;
+type BorderTopStyle = Pick<MakeStylesStrictCSSObject, 'borderTopWidth' | 'borderTopStyle' | 'borderTopColor'>;
 
-export function borderTop(width: BorderWidthProperty<MakeStylesCSSValue>): Created;
-export function borderTop(width: BorderWidthProperty<MakeStylesCSSValue>, style: BorderStyleProperty): Created;
+export function borderTop(width: BorderWidthProperty<MakeStylesCSSValue>): BorderTopStyle;
+export function borderTop(width: BorderWidthProperty<MakeStylesCSSValue>, style: BorderStyleProperty): BorderTopStyle;
 export function borderTop(
   width: BorderWidthProperty<MakeStylesCSSValue>,
   style: BorderStyleProperty,
   color: BorderColorProperty,
-): Created;
+): BorderTopStyle;
 
 /**
  * A function that implements expansion for "border-top", it's simplified - check usage examples.
@@ -23,10 +23,10 @@ export function borderTop(
  */
 export function borderTop(
   ...values: [BorderWidthProperty<MakeStylesCSSValue>, BorderStyleProperty?, BorderColorProperty?]
-): Created {
+): BorderTopStyle {
   return {
     borderTopWidth: values[0],
-    ...(values[1] && ({ borderTopStyle: values[1] } as Created)),
+    ...(values[1] && ({ borderTopStyle: values[1] } as BorderTopStyle)),
     ...(values[2] && { borderTopColor: values[2] }),
   };
 }

--- a/packages/make-styles/src/shorthands/borderWidth.ts
+++ b/packages/make-styles/src/shorthands/borderWidth.ts
@@ -3,22 +3,27 @@ import type { BorderWidthProperty } from 'csstype';
 import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
 import { generateStyles } from './generateStyles';
 
-export function borderWidth(all: BorderWidthProperty<MakeStylesCSSValue>): MakeStylesStrictCSSObject;
+type BorderWidthStyle = Pick<
+  MakeStylesStrictCSSObject,
+  'borderTopStyle' | 'borderRightStyle' | 'borderBottomStyle' | 'borderLeftStyle'
+>;
+
+export function borderWidth(all: BorderWidthProperty<MakeStylesCSSValue>): BorderWidthStyle;
 export function borderWidth(
   vertical: BorderWidthProperty<MakeStylesCSSValue>,
   horizontal: BorderWidthProperty<MakeStylesCSSValue>,
-): MakeStylesStrictCSSObject;
+): BorderWidthStyle;
 export function borderWidth(
   top: BorderWidthProperty<MakeStylesCSSValue>,
   horizontal: BorderWidthProperty<MakeStylesCSSValue>,
   bottom: BorderWidthProperty<MakeStylesCSSValue>,
-): MakeStylesStrictCSSObject;
+): BorderWidthStyle;
 export function borderWidth(
   top: BorderWidthProperty<MakeStylesCSSValue>,
   right: BorderWidthProperty<MakeStylesCSSValue>,
   bottom: BorderWidthProperty<MakeStylesCSSValue>,
   left: BorderWidthProperty<MakeStylesCSSValue>,
-): MakeStylesStrictCSSObject;
+): BorderWidthStyle;
 
 /**
  * A function that implements CSS spec conformant expansion for "borderWidth"
@@ -31,6 +36,6 @@ export function borderWidth(
  *
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/border-width
  */
-export function borderWidth(...values: BorderWidthProperty<MakeStylesCSSValue>[]): MakeStylesStrictCSSObject {
+export function borderWidth(...values: BorderWidthProperty<MakeStylesCSSValue>[]): BorderWidthStyle {
   return generateStyles('border', 'Width', ...values);
 }

--- a/packages/make-styles/src/shorthands/gap.ts
+++ b/packages/make-styles/src/shorthands/gap.ts
@@ -1,5 +1,7 @@
 import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
 
+type GapStyle = Pick<MakeStylesStrictCSSObject, 'columnGap' | 'rowGap'>;
+
 /**
  * A function that implements CSS spec conformant expansion for "gap"
  *
@@ -9,7 +11,7 @@ import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
  *
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/gap
  */
-export function gap(columnGap: MakeStylesCSSValue, rowGap: MakeStylesCSSValue = columnGap): MakeStylesStrictCSSObject {
+export function gap(columnGap: MakeStylesCSSValue, rowGap: MakeStylesCSSValue = columnGap): GapStyle {
   return {
     columnGap,
     rowGap,

--- a/packages/make-styles/src/shorthands/margin.ts
+++ b/packages/make-styles/src/shorthands/margin.ts
@@ -1,19 +1,21 @@
 import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
 import { generateStyles } from './generateStyles';
 
-export function margin(all: MakeStylesCSSValue): MakeStylesStrictCSSObject;
-export function margin(vertical: MakeStylesCSSValue, horizontal: MakeStylesCSSValue): MakeStylesStrictCSSObject;
+type MarginStyle = Pick<MakeStylesStrictCSSObject, 'marginTop' | 'marginRight' | 'marginBottom' | 'marginLeft'>;
+
+export function margin(all: MakeStylesCSSValue): MarginStyle;
+export function margin(vertical: MakeStylesCSSValue, horizontal: MakeStylesCSSValue): MarginStyle;
 export function margin(
   top: MakeStylesCSSValue,
   horizontal: MakeStylesCSSValue,
   bottom: MakeStylesCSSValue,
-): MakeStylesStrictCSSObject;
+): MarginStyle;
 export function margin(
   top: MakeStylesCSSValue,
   right: MakeStylesCSSValue,
   bottom: MakeStylesCSSValue,
   left: MakeStylesCSSValue,
-): MakeStylesStrictCSSObject;
+): MarginStyle;
 
 /**
  * A function that implements CSS spec conformant expansion for "margin"
@@ -26,6 +28,6 @@ export function margin(
  *
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/margin
  */
-export function margin(...values: MakeStylesCSSValue[]): MakeStylesStrictCSSObject {
+export function margin(...values: MakeStylesCSSValue[]): MarginStyle {
   return generateStyles('margin', '', ...values);
 }

--- a/packages/make-styles/src/shorthands/overflow.ts
+++ b/packages/make-styles/src/shorthands/overflow.ts
@@ -1,7 +1,7 @@
 import type { OverflowProperty } from 'csstype';
 import type { MakeStylesStrictCSSObject } from '../types';
 
-type OverflowStyles = Pick<MakeStylesStrictCSSObject, 'overflowX' | 'overflowY'>;
+type OverflowStyle = Pick<MakeStylesStrictCSSObject, 'overflowX' | 'overflowY'>;
 
 /**
  * A function that implements CSS spec conformant expansion for "overflow"
@@ -12,9 +12,9 @@ type OverflowStyles = Pick<MakeStylesStrictCSSObject, 'overflowX' | 'overflowY'>
  *
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/overflow
  */
-export function overflow(overflowX: OverflowProperty, overflowY: OverflowProperty = overflowX): OverflowStyles {
+export function overflow(overflowX: OverflowProperty, overflowY: OverflowProperty = overflowX): OverflowStyle {
   return {
     overflowX,
     overflowY,
-  } as OverflowStyles;
+  } as OverflowStyle;
 }

--- a/packages/make-styles/src/shorthands/overflow.ts
+++ b/packages/make-styles/src/shorthands/overflow.ts
@@ -1,6 +1,8 @@
 import type { OverflowProperty } from 'csstype';
 import type { MakeStylesStrictCSSObject } from '../types';
 
+type OverflowStyles = Pick<MakeStylesStrictCSSObject, 'overflowX' | 'overflowY'>;
+
 /**
  * A function that implements CSS spec conformant expansion for "overflow"
  *
@@ -10,12 +12,9 @@ import type { MakeStylesStrictCSSObject } from '../types';
  *
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/overflow
  */
-export function overflow(
-  overflowX: OverflowProperty,
-  overflowY: OverflowProperty = overflowX,
-): MakeStylesStrictCSSObject {
+export function overflow(overflowX: OverflowProperty, overflowY: OverflowProperty = overflowX): OverflowStyles {
   return {
     overflowX,
     overflowY,
-  } as MakeStylesStrictCSSObject;
+  } as OverflowStyles;
 }

--- a/packages/make-styles/src/shorthands/padding.ts
+++ b/packages/make-styles/src/shorthands/padding.ts
@@ -1,19 +1,21 @@
 import type { MakeStylesStrictCSSObject, MakeStylesCSSValue } from '../types';
 import { generateStyles } from './generateStyles';
 
-export function padding(all: MakeStylesCSSValue): MakeStylesStrictCSSObject;
-export function padding(vertical: MakeStylesCSSValue, horizontal: MakeStylesCSSValue): MakeStylesStrictCSSObject;
+type PaddingStyle = Pick<MakeStylesStrictCSSObject, 'paddingTop' | 'paddingRight' | 'paddingBottom' | 'paddingLeft'>;
+
+export function padding(all: MakeStylesCSSValue): PaddingStyle;
+export function padding(vertical: MakeStylesCSSValue, horizontal: MakeStylesCSSValue): PaddingStyle;
 export function padding(
   top: MakeStylesCSSValue,
   horizontal: MakeStylesCSSValue,
   bottom: MakeStylesCSSValue,
-): MakeStylesStrictCSSObject;
+): PaddingStyle;
 export function padding(
   top: MakeStylesCSSValue,
   right: MakeStylesCSSValue,
   bottom: MakeStylesCSSValue,
   left: MakeStylesCSSValue,
-): MakeStylesStrictCSSObject;
+): PaddingStyle;
 
 /**
  * A function that implements CSS spec conformant expansion for "padding"
@@ -26,6 +28,6 @@ export function padding(
  *
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/padding
  */
-export function padding(...values: MakeStylesCSSValue[]): MakeStylesStrictCSSObject {
+export function padding(...values: MakeStylesCSSValue[]): PaddingStyle {
   return generateStyles('padding', '', ...values);
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ yarn change`

#### Description of changes

A minor improvement to shorthand functions to have proper return types instead of full object.