### PR TITLE
fix: prevent disabled flipper from emitting event

### DIFF
--- a/change/@fluentui-web-components-2ae56d3f-5f09-4765-89cd-f5dbcf84acea.json
+++ b/change/@fluentui-web-components-2ae56d3f-5f09-4765-89cd-f5dbcf84acea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: prevent disabled flipper from emitting event",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/src/flipper/flipper.styles.ts
@@ -45,6 +45,7 @@ export const flipperStyles: (context: ElementDefinitionContext, definition: Flip
     :host(.disabled) {
       opacity: ${disabledOpacity};
       cursor: ${disabledCursor};
+      pointer-events: none;
     }
 
     .next,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Adds `pointer-events: none` to the `disabled` class

#### Focus areas to test

(optional)
