### PR TITLE
Fix #20043 - Checkbox checkmark should have opacity 0 in indeterminate state

### DIFF
--- a/change/@fluentui-react-ad24fc8e-0cbf-4ec4-a54b-e64f35b51637.json
+++ b/change/@fluentui-react-ad24fc8e-0cbf-4ec4-a54b-e64f35b51637.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Made checkmark opacity 0 for indeterminate",
+  "packageName": "@fluentui/react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
@@ -351,7 +351,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
                 font-family: "FabricMDL2Icons";
                 font-style: normal;
                 font-weight: normal;
-                opacity: 1;
+                opacity: 0;
                 speak: none;
               }
               @media screen and (-ms-high-contrast: active), (forced-colors: active){& {

--- a/packages/react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/react/src/components/Checkbox/Checkbox.styles.ts
@@ -251,7 +251,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
     checkmark: [
       classNames.checkmark,
       {
-        opacity: checked ? '1' : '0',
+        opacity: checked && !indeterminate ? '1' : '0',
         color: checkmarkFontColor,
         [HighContrastSelector]: {
           color: disabled ? 'GrayText' : 'Window',


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #20043
- [X] Include a change request file using `$ yarn change`

#### Description of changes

When a checked checkbox (controlled) is set to indeterminate, the checkmark opacity is set to 1, but should be 0. This is not noticed in most cases because the mark and background are the same color.

- Updated to opacity 0 when indeterminate (style rule only change)

#### Focus areas to test

(optional)
