### PR TITLE
RFC: Primary slot updates

### DIFF
--- a/change/@fluentui-react-utilities-dfc71375-b85e-4de5-bbb1-a092ae7df2f9.json
+++ b/change/@fluentui-react-utilities-dfc71375-b85e-4de5-bbb1-a092ae7df2f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update ComponentProps handling of a customized primary slot: the prop for root accepts any native props (but not shorthands), and the prop for the primary slot accepts only className and style",
+  "packageName": "@fluentui/react-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -42,10 +42,14 @@ export const colGroupProperties: Record<string, number>;
 // @public (undocumented)
 export const colProperties: Record<string, number>;
 
-// @public (undocumented)
-export type ComponentProps<Shorthands extends ObjectShorthandPropsRecord, Primary extends keyof Shorthands = 'root'> = Omit<{
-    [Key in keyof Shorthands]?: ShorthandProps<NonNullable<Shorthands[Key]>>;
-}, Primary & 'root'> & PropsWithoutRef<Shorthands[Primary]>;
+// @public
+export type ComponentProps<Shorthands extends ObjectShorthandPropsRecord, Primary extends keyof Shorthands = 'root'> = PropsWithoutRef<Shorthands[Primary]> & {
+    [Key in keyof Omit<Shorthands, Primary | 'root'>]?: ShorthandProps<NonNullable<Shorthands[Key]>>;
+} & (Primary extends 'root' ? {} : {
+    [Key in keyof Primary]?: Pick<React_2.HTMLAttributes<{}>, 'className' | 'style'>;
+} & {
+    root?: Shorthands['root'];
+});
 
 // @public (undocumented)
 export type ComponentState<Shorthands extends ObjectShorthandPropsRecord> = {

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -49,7 +49,7 @@ export type ComponentProps<Slots extends ObjectShorthandPropsRecord, Primary ext
     {
     [Key in Primary]?: Pick<React_2.HTMLAttributes<{}>, 'className' | 'style'>;
 } & {
-    root?: Slots['root'];
+    root?: Omit<Slots['root'], 'className' | 'style'>;
 });
 
 // @public (undocumented)
@@ -87,16 +87,13 @@ export function getNativeElementProps<TAttributes extends React_2.HTMLAttributes
 export function getNativeProps<T extends Record<string, any>>(props: Record<string, any>, allowedPropNames: string[] | Record<string, number>, excludedPropNames?: string[]): T;
 
 // @public
-export function getPartitionedNativeProps<NativeProps extends React_2.HTMLAttributes<unknown>>({ primarySlotTagName, props, excludedPropNames, }: {
+export function getPartitionedNativeProps<Props extends Pick<React_2.HTMLAttributes<HTMLElement>, 'className' | 'style'>>(params: {
     primarySlotTagName: keyof JSX.IntrinsicElements;
-    props: Pick<NativeProps, 'style' | 'className'>;
+    props: Props;
     excludedPropNames?: string[];
 }): {
-    root: {
-        style: NativeProps["style"] | undefined;
-        className: NativeProps["className"] | undefined;
-    };
-    primary: NativeProps;
+    root: Pick<Props, 'className' | 'style'>;
+    primary: Omit<Props, 'className' | 'style'>;
 };
 
 // @public

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -43,12 +43,13 @@ export const colGroupProperties: Record<string, number>;
 export const colProperties: Record<string, number>;
 
 // @public
-export type ComponentProps<Shorthands extends ObjectShorthandPropsRecord, Primary extends keyof Shorthands = 'root'> = PropsWithoutRef<Shorthands[Primary]> & {
-    [Key in keyof Omit<Shorthands, Primary | 'root'>]?: ShorthandProps<NonNullable<Shorthands[Key]>>;
-} & (Primary extends 'root' ? {} : {
-    [Key in keyof Primary]?: Pick<React_2.HTMLAttributes<{}>, 'className' | 'style'>;
+export type ComponentProps<Slots extends ObjectShorthandPropsRecord, Primary extends keyof Slots = 'root'> = PropsWithoutRef<Slots[Primary]> & {
+    [Key in keyof Omit<Slots, Primary | 'root'>]?: ShorthandProps<NonNullable<Slots[Key]>>;
+} & (Primary extends 'root' ? {} : // If the primary slot is customized...
+    {
+    [Key in Primary]?: Pick<React_2.HTMLAttributes<{}>, 'className' | 'style'>;
 } & {
-    root?: Shorthands['root'];
+    root?: Slots['root'];
 });
 
 // @public (undocumented)
@@ -86,16 +87,16 @@ export function getNativeElementProps<TAttributes extends React_2.HTMLAttributes
 export function getNativeProps<T extends Record<string, any>>(props: Record<string, any>, allowedPropNames: string[] | Record<string, number>, excludedPropNames?: string[]): T;
 
 // @public
-export const getPartitionedNativeProps: ({ primarySlotTagName, props, excludedPropNames, }: {
+export function getPartitionedNativeProps<NativeProps extends React_2.HTMLAttributes<unknown>>({ primarySlotTagName, props, excludedPropNames, }: {
     primarySlotTagName: keyof JSX.IntrinsicElements;
-    props: Pick<React_2.HTMLAttributes<HTMLElement>, 'style' | 'className'>;
-    excludedPropNames?: string[] | undefined;
-}) => {
+    props: Pick<NativeProps, 'style' | 'className'>;
+    excludedPropNames?: string[];
+}): {
     root: {
-        style: React_2.CSSProperties | undefined;
-        className: string | undefined;
+        style: NativeProps["style"] | undefined;
+        className: NativeProps["className"] | undefined;
     };
-    primary: React_2.HTMLAttributes<any>;
+    primary: NativeProps;
 };
 
 // @public

--- a/packages/react-utilities/src/compose/resolveShorthand.ts
+++ b/packages/react-utilities/src/compose/resolveShorthand.ts
@@ -13,7 +13,10 @@ export type ResolveShorthandOptions<Props extends Record<string, any>, Required 
  * @param value - the base ShorthandProps
  * @param options - options to resolve ShorthandProps
  */
-export function resolveShorthand<Props extends DefaultObjectShorthandProps, Required extends boolean = false>(
+export function resolveShorthand<
+  Props extends Omit<DefaultObjectShorthandProps, 'style' | 'className'>,
+  Required extends boolean = false
+>(
   value: ShorthandProps<Props>,
   options?: ResolveShorthandOptions<Props, Required>,
 ): Required extends false ? Props | undefined : Props {

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -103,23 +103,23 @@ export type PropsWithoutRef<P> = 'ref' extends keyof P ? (P extends unknown ? Om
  *   - There's an optional named prop for the primary slot which ONLY takes `className` and `style`.
  *   - There's an optional prop for `root` which accepts appropriate native props, but NOT shorthands.
  */
-export type ComponentProps<Shorthands extends ObjectShorthandPropsRecord, Primary extends keyof Shorthands = 'root'> =
+export type ComponentProps<Slots extends ObjectShorthandPropsRecord, Primary extends keyof Slots = 'root'> =
   // Allow all props from the primary slot to be specified at the root
-  PropsWithoutRef<Shorthands[Primary]> &
+  PropsWithoutRef<Slots[Primary]> &
     // Include shorthand slot props for each of the component's slots, except the primary slot and `root`
     {
-      [Key in keyof Omit<Shorthands, Primary | 'root'>]?: ShorthandProps<NonNullable<Shorthands[Key]>>;
+      [Key in keyof Omit<Slots, Primary | 'root'>]?: ShorthandProps<NonNullable<Slots[Key]>>;
     } &
-    // If the primary slot is customized...
-    // (per https://github.com/microsoft/fluentui/blob/master/rfcs/convergence/native-element-props.md)
     (Primary extends 'root'
       ? {}
-      : {
+      : // If the primary slot is customized...
+        // (per https://github.com/microsoft/fluentui/blob/master/rfcs/convergence/native-element-props.md)
+        {
           // Add a named prop for the primary slot which ONLY accepts className and style
-          [Key in keyof Primary]?: Pick<React.HTMLAttributes<{}>, 'className' | 'style'>;
+          [Key in Primary]?: Pick<React.HTMLAttributes<{}>, 'className' | 'style'>;
         } & {
           // Add a `root` prop which accepts any native props, but NOT shorthand syntax
-          root?: Shorthands['root'];
+          root?: Slots['root'];
         });
 
 export type ComponentState<Shorthands extends ObjectShorthandPropsRecord> = {

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -118,8 +118,8 @@ export type ComponentProps<Slots extends ObjectShorthandPropsRecord, Primary ext
           // Add a named prop for the primary slot which ONLY accepts className and style
           [Key in Primary]?: Pick<React.HTMLAttributes<{}>, 'className' | 'style'>;
         } & {
-          // Add a `root` prop which accepts any native props, but NOT shorthand syntax
-          root?: Slots['root'];
+          // Add a `root` prop which accepts any native props (EXCEPT className and style), but NOT shorthand syntax
+          root?: Omit<Slots['root'], 'className' | 'style'>;
         });
 
 export type ComponentState<Shorthands extends ObjectShorthandPropsRecord> = {

--- a/packages/react-utilities/src/utils/getNativeElementProps.ts
+++ b/packages/react-utilities/src/utils/getNativeElementProps.ts
@@ -74,26 +74,25 @@ export function getNativeElementProps<TAttributes extends React.HTMLAttributes<a
  *
  * @returns An object containing the native props for the `root` and primary slots.
  */
-export function getPartitionedNativeProps<NativeProps extends React.HTMLAttributes<unknown>>({
-  primarySlotTagName,
-  props,
-  excludedPropNames,
-}: {
+export function getPartitionedNativeProps<
+  Props extends Pick<React.HTMLAttributes<HTMLElement>, 'className' | 'style'>
+>(params: {
   /** The primary slot's element type (e.g. 'div') */
   primarySlotTagName: keyof JSX.IntrinsicElements;
 
   /** The component's props object */
-  props: Pick<NativeProps, 'style' | 'className'>;
+  props: Props;
 
   /** List of native props to exclude from the returned value */
   excludedPropNames?: string[];
-}) {
+}): {
+  root: Pick<Props, 'className' | 'style'>;
+  primary: Omit<Props, 'className' | 'style'>;
+} {
+  const { primarySlotTagName, props, excludedPropNames } = params;
+
   return {
     root: { style: props.style, className: props.className },
-    primary: getNativeElementProps<NativeProps>(primarySlotTagName, props, [
-      ...(excludedPropNames || []),
-      'style',
-      'className',
-    ]),
+    primary: getNativeElementProps(primarySlotTagName, props, [...(excludedPropNames || []), 'style', 'className']),
   };
 }

--- a/packages/react-utilities/src/utils/getNativeElementProps.ts
+++ b/packages/react-utilities/src/utils/getNativeElementProps.ts
@@ -74,7 +74,7 @@ export function getNativeElementProps<TAttributes extends React.HTMLAttributes<a
  *
  * @returns An object containing the native props for the `root` and primary slots.
  */
-export const getPartitionedNativeProps = ({
+export function getPartitionedNativeProps<NativeProps extends React.HTMLAttributes<unknown>>({
   primarySlotTagName,
   props,
   excludedPropNames,
@@ -83,13 +83,17 @@ export const getPartitionedNativeProps = ({
   primarySlotTagName: keyof JSX.IntrinsicElements;
 
   /** The component's props object */
-  props: Pick<React.HTMLAttributes<HTMLElement>, 'style' | 'className'>;
+  props: Pick<NativeProps, 'style' | 'className'>;
 
   /** List of native props to exclude from the returned value */
   excludedPropNames?: string[];
-}) => {
+}) {
   return {
     root: { style: props.style, className: props.className },
-    primary: getNativeElementProps(primarySlotTagName, props, [...(excludedPropNames || []), 'style', 'className']),
+    primary: getNativeElementProps<NativeProps>(primarySlotTagName, props, [
+      ...(excludedPropNames || []),
+      'style',
+      'className',
+    ]),
   };
-};
+}

--- a/rfcs/convergence/native-element-props.md
+++ b/rfcs/convergence/native-element-props.md
@@ -148,8 +148,8 @@ Something along the lines of this:
 const nativeProps = getPartitionedNativeProps(props, 'input');
 const state = {
   // ...
-  root: nativeProps.root,
-  input: nativeProps.primary, // primary slot
+  root: resolveShorthand(props.root, { required: true, defaultProps: nativeProps.root }),
+  input: resolveShorthand(props.input, { required: true, defaultProps: nativeProps.primary }), // primary slot
 };
 ```
 
@@ -163,9 +163,13 @@ const state = {
 
 ## Usage examples
 
-### Example with `root` as the primary slot (default case)
+### `root` as the primary slot (default case)
 
-`Button` falls into the default case, where `root` is its primary slot. All native props specified on the component go to the `root` slot:
+`Button` falls into the default case, where `root` is its primary slot.
+
+#### Top-level native props
+
+All native props specified on the component go to the `root` slot:
 
 **Given JSX:**
 
@@ -179,15 +183,19 @@ const state = {
 <button id="myId" class="myClass" />
 ```
 
+#### Error: using `root` prop
+
 There is no `root` prop:
 
 ```jsx
 <Button root={{ id: 'myId' }} /> // ❌ Fails to compile: root is not a prop
 ```
 
-### Example with `input` as the primary slot
+### `input` as custom primary slot
 
 `Checkbox` specifies its `input` slot as the primary slot. (Its `root` slot is a wrapper `<div>` around the `<input>` element.)
+
+#### Top-level native props + primary slot props
 
 **Given JSX:**
 
@@ -203,12 +211,16 @@ There is no `root` prop:
 </div>
 ```
 
+#### Error: specifying extra props on primary slot
+
 To reduce confusion about which props take precedence, it's not allowed to specify props other than `className` and `style` on the primary slot:
 
 ```jsx
 // ❌ Fails to compile
 <Checkbox input={{ id: 'inputId' }} />
 ```
+
+#### Precedence of `className` and `style` at top level vs. on `root` slot
 
 However, explicitly specifying `className` and `style` on the `root` slot is allowed, and these will win over props specified on the element itself:
 
@@ -217,6 +229,7 @@ However, explicitly specifying `className` and `style` on the `root` slot is all
 ```jsx
 <Checkbox
   className="myClass" // ⚠ overridden by "rootClass" below
+  id="myId"
   style={{ color: 'red' }}
   root={{ id: 'rootId', className: 'rootClass' }}
 />
@@ -226,7 +239,7 @@ However, explicitly specifying `className` and `style` on the `root` slot is all
 
 ```html
 <div id="rootId" class="rootClass" style="color: red">
-  <input class="inputClass" />
+  <input id="myId" />
 </div>
 ```
 

--- a/rfcs/convergence/native-element-props.md
+++ b/rfcs/convergence/native-element-props.md
@@ -91,7 +91,7 @@ The _**primary**_ slot is the slot that receives the native props that are speci
 - All native props are forwarded to the primary slot, _except_ `className` and `style`.
 - The `className` and `style` props are _always_ forwarded to the `root` slot.
 - Both `root` and the primary slot are exposed as props:
-  - For the `root` slot, all native props can be set on the slot.
+  - For the `root` slot, all native props _except_ `className` and `style` can be set on the slot. It also doesn't accept shorthands (because overriding the root in this way doesn't make sense).
   - For the primary slot, only `className` and `style` can be set on the slot.
 - The primary slot is intrinsic to the component, and is part of how it works. Users cannot designate a different slot as primary.
 
@@ -158,7 +158,7 @@ const state = {
 - Need to be able to specify which is the primary slot in conformance tests
 - Check that `className` and `style` always go to the root slot
 - Check that specifying `className` and `style` on the primary slot works
-- Check that `className` and `style` specified on the `root` slot take precedence over top-level props (with custom primary slot): `<Input className="foo" root={{ className: 'bar' }} />` => root element has `className="bar"`
+- Check that specifying `className` and `style` directly on the `root` slot is not allowed
 - Check that `<input>` elements are always the primary slot
 
 ## Usage examples
@@ -220,27 +220,13 @@ To reduce confusion about which props take precedence, it's not allowed to speci
 <Checkbox input={{ id: 'inputId' }} />
 ```
 
-#### Precedence of `className` and `style` at top level vs. on `root` slot
+#### Error: specifying `className` or `style` on `root` slot
 
-However, explicitly specifying `className` and `style` on the `root` slot is allowed, and these will win over props specified on the element itself:
-
-**Given JSX:**
+It's also not allowed to specify `className` and `style` on the `root` slot.
 
 ```jsx
-<Checkbox
-  className="myClass" // ⚠ overridden by "rootClass" below
-  id="myId"
-  style={{ color: 'red' }}
-  root={{ id: 'rootId', className: 'rootClass' }}
-/>
-```
-
-**Resulting DOM (simplified):**
-
-```html
-<div id="rootId" class="rootClass" style="color: red">
-  <input id="myId" />
-</div>
+// ❌ Fails to compile
+<Checkbox root={{ className: 'rootClass' }} />
 ```
 
 ## Discarded Solutions


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR updates the primary slot RFC and implementation to address some issues myself, @behowell, and @micahgodbolt noticed while using the primary slot in our components.

- The prop for the primary slot accepts ONLY `className` and `style`. Why?
  - Eliminates the question of precedence
  - Reduces some typing issues 
- The `root` prop accepts any native props EXCEPT `className` and `style` (and no shorthands--pretty sure the fact that it was previously accepting shorthands was an oversight)