### PR TITLE
Add aria-level to TeachingBubble heading

### DIFF
--- a/change/office-ui-fabric-react-5217a157-b9b8-4ab3-b9c4-5f7713d1f168.json
+++ b/change/office-ui-fabric-react-5217a157-b9b8-4ab3-b9c4-5f7713d1f168.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add aria-level to TeachingBubble heading",
+  "packageName": "office-ui-fabric-react",
+  "email": "huiyan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -89,7 +89,7 @@ export class TeachingBubbleContentBase extends React.Component<ITeachingBubblePr
 
       headerContent = (
         <div className={classNames.header}>
-          <HeaderWrapperAs role="heading" className={classNames.headline} id={ariaLabelledBy}>
+          <HeaderWrapperAs role="heading" aria-level={3} className={classNames.headline} id={ariaLabelledBy}>
             {headline}
           </HeaderWrapperAs>
         </div>

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
             }
       >
         <p
+          aria-level={3}
           className=
               ms-TeachingBubble-headline
               {

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -217,6 +217,7 @@ exports[`TeachingBubble renders TeachingBubbleContent correctly 1`] = `
             }
       >
         <p
+          aria-level={3}
           className=
               ms-TeachingBubble-headline
               {
@@ -331,6 +332,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
             }
       >
         <p
+          aria-level={3}
           className=
               ms-TeachingBubble-headline
               {
@@ -1020,6 +1022,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with condensed headline co
             }
       >
         <p
+          aria-level={3}
           className=
               ms-TeachingBubble-headline
               {
@@ -1316,6 +1319,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
             }
       >
         <p
+          aria-level={3}
           className=
               ms-TeachingBubble-headline
               {
@@ -1434,6 +1438,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with small headline correc
             }
       >
         <p
+          aria-level={3}
           className=
               ms-TeachingBubble-headline
               {

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -915,6 +915,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                                 }
                                           >
                                             <p
+                                              aria-level={3}
                                               className=
                                                   ms-TeachingBubble-headline
                                                   {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes aria-level missing in TeachingBubble heading.
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Add aria-level to heading. Cherry-pick of #19374.

#### Focus areas to test

(optional)
