### PR TITLE
Pin to create-react-app 4 to avoid errors on Node 12

### DIFF
--- a/scripts/projects-test/createReactApp.ts
+++ b/scripts/projects-test/createReactApp.ts
@@ -22,7 +22,7 @@ export async function prepareCreateReactApp(
 
   try {
     // restoring bits of create-react-app inside util project
-    await shEcho('yarn add create-react-app', tempUtilProjectPath);
+    await shEcho('yarn add create-react-app@4', tempUtilProjectPath);
 
     // create test project with util's create-react-app
     fs.mkdirSync(appProjectPath);


### PR DESCRIPTION
`create-react-app` version 5 just released and requires Node 14. We're still on Node 12, so all our tests that use `create-react-app` must be pinned to version 4.

I added a note to the Node 14 upgrade issue (#20834) to revert this change.