### PR TITLE
Upgrade to node 14 (i.e. revert "Revert to node 12")

### DIFF
--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -2,7 +2,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '12.x'
+      versionSpec: '14.x'
       checkLatest: true
     displayName: 'Install Node.js'
 

--- a/change/@fluentui-eslint-plugin-85794a53-50f5-4b78-b297-dfc48bad0916.json
+++ b/change/@fluentui-eslint-plugin-85794a53-50f5-4b78-b297-dfc48bad0916.json
@@ -1,6 +1,6 @@
 {
-  "type": "none",
-  "comment": "Upgrade to node 14",
+  "type": "patch",
+  "comment": "Re-enable `@rnx-kit/no-export-all`",
   "packageName": "@fluentui/eslint-plugin",
   "email": "lingfangao@hotmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-eslint-plugin-85794a53-50f5-4b78-b297-dfc48bad0916.json
+++ b/change/@fluentui-eslint-plugin-85794a53-50f5-4b78-b297-dfc48bad0916.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Upgrade to node 14",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -292,6 +292,7 @@
         "dependencies": [
           "@babel/core",
           "@babel/preset-typescript",
+          "@rnx-kit/eslint-plugin",
           "@types/react-test-renderer",
           "@typescript-eslint/eslint-plugin",
           "@typescript-eslint/experimental-utils",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -12,6 +12,7 @@
     "lint": "tsc --noEmit && eslint --ext .js --cache ."
   },
   "dependencies": {
+    "@rnx-kit/eslint-plugin": "^0.2.5",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/experimental-utils": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -15,6 +15,7 @@ const config = {
   parser: '@typescript-eslint/parser',
   plugins: [
     '@fluentui',
+    '@rnx-kit',
     '@typescript-eslint',
     'deprecation',
     'import',
@@ -72,6 +73,7 @@ const config = {
     '**/*.scss.ts',
   ],
   rules: {
+    '@rnx-kit/no-export-all': ['error', { expand: 'external-only' }],
     '@fluentui/no-global-react': 'error',
     '@fluentui/max-len': [
       'error',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3137,6 +3137,17 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@rnx-kit/eslint-plugin@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/eslint-plugin/-/eslint-plugin-0.2.5.tgz#30b4398e6db4f7a81b301c5e825341c4386f6821"
+  integrity sha512-69Xlsz7fMMAQqLJ9ghglH5fXvU5xXZR09gCkjoK4gephhnQR/i+QDyt0wlqKt2HBo0RUGFbO+EA8aNPcOrJDJg==
+  dependencies:
+    "@typescript-eslint/eslint-plugin" "^5.0.0"
+    "@typescript-eslint/parser" "^5.0.0"
+    enhanced-resolve "^5.8.3"
+    eslint-plugin-jest "^25.0.0"
+    eslint-plugin-react "^7.26.0"
+
 "@rollup/pluginutils@^3.0.8":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
@@ -5246,7 +5257,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@4.22.0", "@typescript-eslint/eslint-plugin@^4.22.0":
+"@typescript-eslint/eslint-plugin@4.22.0", "@typescript-eslint/eslint-plugin@^4.22.0", "@typescript-eslint/eslint-plugin@^5.0.0":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz#3d5f29bb59e61a9dba1513d491b059e536e16dbc"
   integrity sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==
@@ -5260,7 +5271,7 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.22.0", "@typescript-eslint/experimental-utils@^2.19.2 || ^3.0.0", "@typescript-eslint/experimental-utils@^2.5.0", "@typescript-eslint/experimental-utils@^4.22.0":
+"@typescript-eslint/experimental-utils@4.22.0", "@typescript-eslint/experimental-utils@^2.19.2 || ^3.0.0", "@typescript-eslint/experimental-utils@^2.5.0", "@typescript-eslint/experimental-utils@^4.22.0", "@typescript-eslint/experimental-utils@^5.0.0":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz#68765167cca531178e7b650a53456e6e0bef3b1f"
   integrity sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==
@@ -5272,7 +5283,7 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@4.22.0", "@typescript-eslint/parser@^4.22.0":
+"@typescript-eslint/parser@4.22.0", "@typescript-eslint/parser@^4.22.0", "@typescript-eslint/parser@^5.0.0":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.22.0.tgz#e1637327fcf796c641fe55f73530e90b16ac8fe8"
   integrity sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==
@@ -10877,7 +10888,7 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0, enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.7.0, enhanced-resolve@^5.8.0, enhanced-resolve@^5.8.2:
+enhanced-resolve@^5.7.0, enhanced-resolve@^5.8.0, enhanced-resolve@^5.8.2, enhanced-resolve@^5.8.3:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
   integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
@@ -11270,6 +11281,13 @@ eslint-plugin-jest@23.13.2, eslint-plugin-jest@^23.13.2:
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 
+eslint-plugin-jest@^25.0.0:
+  version "25.2.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-25.2.4.tgz#bb9f6a0bd1fd524ffb0b8b7a159cd70a58a1a793"
+  integrity sha512-HRyinpgmEdkVr7pNPaYPHCoGqEzpgk79X8pg/xCeoAdurbyQjntJQ4pTzHl7BiVEBlam/F1Qsn+Dk0HtJO7Aaw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^5.0.0"
+
 eslint-plugin-jsdoc@^36.0.7:
   version "36.0.7"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.0.7.tgz#6e6f9897fc2ff3b3934b09c2748b998bc03d2bf6"
@@ -11327,7 +11345,7 @@ eslint-plugin-react@7.26.0:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.5"
 
-eslint-plugin-react@^7.24.0:
+eslint-plugin-react@^7.24.0, eslint-plugin-react@^7.26.0:
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz#f952c76517a3915b81c7788b220b2b4c96703124"
   integrity sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==


### PR DESCRIPTION
create-react-app recently released v5.0 which is incompatible with node 12. We also can't pin create-react-app to v4 because it will throw and tell us to use the latest version 🤦

cra errors without latest version
https://github.com/facebook/create-react-app/blob/69321b0d55859db3058266437b90c43eb4f0dbb7/packages/create-react-app/createReactApp.js#L211

cra errors with node < 14
https://github.com/facebook/create-react-app/blob/69321b0d55859db3058266437b90c43eb4f0dbb7/packages/create-react-app/createReactApp.js#L253

Fixes #20834

Reverts microsoft/fluentui#20781