### PR TITLE
Update just-scripts and remove some workarounds for customizing build tasks

### DIFF
--- a/apps/ssr-tests/just.config.ts
+++ b/apps/ssr-tests/just.config.ts
@@ -1,5 +1,4 @@
-import { preset, task, logger } from '@fluentui/scripts';
-import { spawn } from 'just-scripts-utils';
+import { preset, task, logger, spawn } from '@fluentui/scripts';
 
 preset();
 

--- a/apps/ssr-tests/package.json
+++ b/apps/ssr-tests/package.json
@@ -18,7 +18,6 @@
     "@types/mocha": "^7.0.2",
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/public-docsite-resources": "^8.1.41",
-    "just-scripts-utils": "^1.1.1",
     "mocha": "^7.1.2",
     "react": "16.8.6",
     "react-dom": "16.8.6"

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "jest-watch-typeahead": "0.6.5",
     "jju": "1.4.0",
     "json-schema": "0.4.0",
-    "just-scripts": "1.3.1",
+    "just-scripts": "1.6.1",
     "lage": "1.1.3",
     "lerna": "^3.21.0",
     "lint-staged": "10.2.10",
@@ -235,7 +235,8 @@
     "webpack-merge": "5.7.3",
     "workspace-tools": "0.16.2",
     "yargs": "13.3.2",
-    "yargs-parser": "13.1.2"
+    "yargs-parser": "13.1.2",
+    "yargs-unparser": "2.0.0"
   },
   "license": "MIT",
   "workspaces": {

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "@types/webpack-dev-middleware": "4.1.0",
     "@types/webpack-env": "1.16.0",
     "@types/yargs": "13.0.11",
+    "@types/yargs-unparser": "2.0.1",
     "@typescript-eslint/eslint-plugin": "4.22.0",
     "@typescript-eslint/experimental-utils": "4.22.0",
     "@typescript-eslint/parser": "4.22.0",

--- a/packages/fluentui/digest/package.json
+++ b/packages/fluentui/digest/package.json
@@ -18,7 +18,7 @@
     "test": "just-scripts test"
   },
   "dependencies": {
-    "just-scripts": "1.3.1",
+    "just-scripts": "1.6.1",
     "querystring": "^0.2.0"
   },
   "publishConfig": {

--- a/packages/fluentui/perf-test/package.json
+++ b/packages/fluentui/perf-test/package.json
@@ -20,7 +20,6 @@
     "@types/react-dom": "16.9.10",
     "flamegrill": "0.2.0",
     "ignore-not-found-export-webpack-plugin": "^1.0.1",
-    "just-scripts": "1.3.1",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -1,5 +1,4 @@
-import { task, series, parallel, condition, option, argv, addResolvePath } from 'just-scripts';
-import { Arguments } from 'yargs-parser';
+import { task, series, parallel, condition, option, addResolvePath } from 'just-scripts';
 
 import path from 'path';
 import fs from 'fs';
@@ -22,22 +21,7 @@ import { postprocessAmdTask } from './tasks/postprocess-amd';
 import { postprocessCommonjsTask } from './tasks/postprocess-commonjs';
 import { startStorybookTask, buildStorybookTask } from './tasks/storybook';
 import { isConvergedPackage } from './monorepo/index';
-
-interface BasicPresetArgs extends Arguments {
-  babel: boolean;
-  production: boolean;
-  webpackConfig: string;
-  commonjs: boolean;
-  cached: boolean;
-  registry: string;
-  push: boolean;
-  package: string;
-  min: boolean;
-}
-
-function getJustArgv() {
-  return argv() as Partial<BasicPresetArgs>;
-}
+import { getJustArgv } from './tasks/argv';
 
 /** Do only the bare minimum setup of options and resolve paths */
 function basicPreset() {
@@ -63,6 +47,8 @@ function basicPreset() {
 export function preset() {
   basicPreset();
 
+  const args = getJustArgv();
+
   task('no-op', () => {}).cached();
   task('clean', clean);
   task('copy', copy);
@@ -78,7 +64,7 @@ export function preset() {
   task('eslint', eslint);
   task('ts:commonjs-only', ts.commonjsOnly);
   task('webpack', webpack);
-  task('webpack-dev-server', webpackDevServer(getJustArgv()));
+  task('webpack-dev-server', webpackDevServer(args));
   task('api-extractor', apiExtractor());
   task('lint-imports', lintImports);
   task('prettier', prettier);
@@ -89,15 +75,13 @@ export function preset() {
   task('babel:postprocess', babel);
 
   task('ts:compile', () => {
-    const args = getJustArgv();
-
     return args.commonjs
       ? series('ts:commonjs-only')
       : parallel(
           // Converged packages must always build commonjs because of babel-make-styles transforms
           condition('ts:commonjs', () => !args.min || isConvergedPackage()),
           'ts:esm',
-          condition('ts:amd', () => !!args.production),
+          condition('ts:amd', () => !!args.production && !isConvergedPackage()),
         );
   });
 
@@ -130,7 +114,7 @@ export function preset() {
       'copy',
       'sass',
       'ts',
-      condition('api-extractor', () => !getJustArgv().min),
+      condition('api-extractor', () => !args.min),
     ),
   ).cached();
 

--- a/scripts/tasks/api-extractor.ts
+++ b/scripts/tasks/api-extractor.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import * as glob from 'glob';
 import * as path from 'path';
 import jju from 'jju';
-import { apiExtractorVerifyTask, task, series, resolveCwd, logger, TscTaskOptions, condition } from 'just-scripts';
+import { apiExtractorVerifyTask, task, series, resolveCwd, logger, TaskFunction, TscTaskOptions } from 'just-scripts';
 
 const apiExtractorConfigs = glob
   .sync(path.join(process.cwd(), 'config/api-extractor*.json'))
@@ -14,40 +14,35 @@ const localBuild = !process.env.TF_BUILD;
 
 export function apiExtractor() {
   return apiExtractorConfigs.length
-    ? series(
+    ? (series(
         ...apiExtractorConfigs.map(([configPath, configName]) => {
-          // note we have `"strictNullChecks": false,` turned off - so from TS point of view this always returns API 🚨
-          const overrideApi = overrideExtractorConfigForPackagesWithTsPathAliases({
-            apiExtractorConfigPath: configPath,
-            tsConfigPath: resolveCwd('./tsconfig.json'),
-          });
-
-          const shouldExecOverrideTasks = () => overrideApi !== null;
-
-          task('api-extractor:override-config', () => {
-            if (overrideApi) {
-              overrideApi.overrideConfig();
-            }
-          });
-          task('api-extractor:cleanup-override-config', () => {
-            if (overrideApi) {
-              overrideApi.resetConfig();
-            }
-          });
-
           const taskName = `api-extractor:${configName}`;
+
           task(
             taskName,
-            series(
-              condition('api-extractor:override-config', shouldExecOverrideTasks),
-              apiExtractorVerifyTask({ configJsonFilePath: configPath, localBuild }),
-              condition('api-extractor:cleanup-override-config', shouldExecOverrideTasks),
-            ),
+            apiExtractorVerifyTask({
+              configJsonFilePath: configPath,
+              localBuild,
+              onConfigLoaded: config => {
+                const tsConfig: TsConfig = jju.parse(fs.readFileSync(resolveCwd('./tsconfig.json'), 'utf-8'));
+                const isUsingTsSolutionConfigs = fs.existsSync(resolveCwd('./tsconfig.lib.json'));
+
+                if (isUsingTsSolutionConfigs) {
+                  logger.info(`api-extractor: package is using TS path aliases. Overriding TS compiler settings.`);
+                  // baseUrl is the only override needed, but if any overrides are specified, API Extractor
+                  // no longer reads the default tsconfig.json. So we have to include the whole tsconfig here.
+                  tsConfig.compilerOptions.baseUrl = '.';
+                  config.compiler = {
+                    overrideTsconfig: tsConfig,
+                  };
+                }
+              },
+            }),
           );
 
           return taskName;
         }),
-      )
+      ) as TaskFunction)
     : 'no-op';
 }
 
@@ -56,44 +51,9 @@ interface TsConfig {
 
   /**
    * typescript doesn't provide a correct type for the compiler options file
-   * -> (typescript.CompilerOptions has enum values instead of raw options in some cases)
+   * (`typescript.CompilerOptions` has enum values instead of raw options in some cases)
    */
-  compilerOptions: TscTaskOptions;
+  compilerOptions: Omit<TscTaskOptions, 'nodeArgs'>;
   include?: string[];
   exclude?: string[];
-}
-
-function overrideExtractorConfigForPackagesWithTsPathAliases(options: {
-  tsConfigPath: string;
-  apiExtractorConfigPath: string;
-}) {
-  const tsConfig: TsConfig = jju.parse(fs.readFileSync(options.tsConfigPath, 'utf-8'));
-  const shouldOverrideConfig = Boolean(tsConfig.extends);
-
-  if (!shouldOverrideConfig) {
-    return null;
-  }
-
-  logger.info(`📣 API-EXTRACTOR: package is using TS path aliases. Overriding ts compiler settings for api-extractor.`);
-
-  const originalContent = fs.readFileSync(options.apiExtractorConfigPath, 'utf-8');
-  const apiExtractorConfigOriginal = jju.parse(originalContent, { mode: 'json' });
-
-  tsConfig.compilerOptions.baseUrl = '.';
-  apiExtractorConfigOriginal.compiler = {
-    overrideTsconfig: tsConfig,
-  };
-
-  const api = {
-    overrideConfig: () => {
-      const newContent = jju.update(originalContent, apiExtractorConfigOriginal, { mode: 'json', indent: 2 });
-
-      fs.writeFileSync(options.apiExtractorConfigPath, newContent, 'utf-8');
-    },
-    resetConfig: () => {
-      fs.writeFileSync(options.apiExtractorConfigPath, originalContent, 'utf-8');
-    },
-  };
-
-  return api;
 }

--- a/scripts/tasks/argv.ts
+++ b/scripts/tasks/argv.ts
@@ -1,0 +1,19 @@
+import { argv } from 'just-scripts';
+import { Arguments } from 'yargs-parser';
+
+/** Custom command line arguments for the preset in scripts/just.config.ts */
+export interface JustArgs extends Arguments {
+  babel: boolean;
+  production: boolean;
+  webpackConfig: string;
+  commonjs: boolean;
+  cached: boolean;
+  registry: string;
+  push: boolean;
+  package: string;
+  min: boolean;
+}
+
+export function getJustArgv() {
+  return argv() as Partial<JustArgs>;
+}

--- a/scripts/tasks/jest.ts
+++ b/scripts/tasks/jest.ts
@@ -1,6 +1,6 @@
 import { jestTask, JestTaskOptions } from 'just-scripts';
 import * as path from 'path';
-import * as unparse from 'yargs-unparser';
+import unparse from 'yargs-unparser';
 import { getJustArgv, JustArgs } from './argv';
 
 const commonJestTask = (options: JestTaskOptions = {}) => {
@@ -29,7 +29,7 @@ const commonJestTask = (options: JestTaskOptions = {}) => {
     _: [
       // jestTask doesn't have explicit support for all jest args (https://jestjs.io/docs/en/cli),
       // so unparse any extra args and pass them through here
-      ...unparse(otherArgs),
+      ...unparse({ ...otherArgs, _: [] }),
       // and pass any positional args (to narrow down tests to be run)
       ..._.filter(arg => arg !== 'jest' && arg !== 'jest-watch'),
     ],

--- a/scripts/tasks/jest.ts
+++ b/scripts/tasks/jest.ts
@@ -1,37 +1,43 @@
-import { jestTask, argv, JestTaskOptions } from 'just-scripts';
+import { jestTask, JestTaskOptions } from 'just-scripts';
 import * as path from 'path';
-
-/**
- * Partial support of native jest CLI arguments https://jestjs.io/docs/en/cli
- * > Why partial support only? just jestTask limits support to only those specified as return value of this function
- */
-const commonArgs = (): JestTaskOptions => {
-  const args: JestTaskOptions = argv();
-  return {
-    ...((process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME || args.runInBand) && { runInBand: true }),
-    ...((args.u || args.updateSnapshot) && { updateSnapshot: true }),
-    clearCache: args.clearCache,
-    config: args.config,
-    watch: args.watch,
-    coverage: args.coverage,
-    passWithNoTests: args.passWithNoTests === undefined ? true : args.passWithNoTests,
-    testNamePattern: args.testNamePattern,
-    testPathPattern: args.testPathPattern,
-
-    // Just specific config
-    nodeArgs: args.nodeArgs,
-    // pass forward positional args (to narrow down tests to be run)
-    _: (args._ || []).filter(arg => arg !== 'jest' && arg !== 'jest-watch'),
-  };
-};
+import * as unparse from 'yargs-unparser';
+import { getJustArgv, JustArgs } from './argv';
 
 const commonJestTask = (options: JestTaskOptions = {}) => {
+  const {
+    runInBand = !!(process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME),
+    passWithNoTests = true,
+    nodeArgs,
+    _ = [],
+    // args for our just preset which should not be passed through to jest
+    cached,
+    commonjs,
+    min,
+    package: packageName,
+    production,
+    push,
+    registry,
+    // these args without explicit handling will be passed directly through to jest
+    ...otherArgs
+  } = getJustArgv() as JustArgs & JestTaskOptions;
+
   return jestTask({
-    ...commonArgs(),
+    runInBand,
+    passWithNoTests,
+    nodeArgs, // Just-specific config
+
+    _: [
+      // jestTask doesn't have explicit support for all jest args (https://jestjs.io/docs/en/cli),
+      // so unparse any extra args and pass them through here
+      ...unparse(otherArgs),
+      // and pass any positional args (to narrow down tests to be run)
+      ..._.filter(arg => arg !== 'jest' && arg !== 'jest-watch'),
+    ],
+
     env: {
       ...process.env,
       NODE_ENV: 'test',
-      PACKAGE_NAME: argv().package,
+      PACKAGE_NAME: packageName,
     },
     ...options,
   });

--- a/scripts/tasks/ts.ts
+++ b/scripts/tasks/ts.ts
@@ -1,21 +1,7 @@
 import fs from 'fs';
 import * as path from 'path';
-import { tscTask, argv, TscTaskOptions, resolveCwd, logger } from 'just-scripts';
-import { Arguments } from 'yargs';
-import jju from 'jju';
-
-interface JustArgs extends Arguments {
-  production?: boolean;
-}
-
-interface TsConfig {
-  extends?: string;
-  // typescript doesn't provide a correct type for the compiler options file
-  // (typescript.CompilerOptions has enum values instead of raw options in some cases)
-  compilerOptions: object;
-  include?: string[];
-  exclude?: string[];
-}
+import { tscTask, TscTaskOptions, resolveCwd, logger } from 'just-scripts';
+import { getJustArgv } from './argv';
 
 const libPath = path.resolve(process.cwd(), 'lib');
 const srcPath = path.resolve(process.cwd(), 'src');
@@ -23,56 +9,40 @@ const srcPath = path.resolve(process.cwd(), 'src');
 const useTsBuildInfo =
   /[\\/]packages[\\/]fluentui[\\/]/.test(process.cwd()) && path.basename(process.cwd()) !== 'perf-test';
 
-/**
- *
- * Explicitly set `baseUrl,rootDir` to current package root for packages (converged packages) that use TS path aliases.
- * > - This is a temporary workaround for current way of building packages via lage and just scripts.
- * > - Without setting baseUrl we would get all aliased packages build within outDir
- * > - Without setting rootDir we would get output dir mapping following path from monorepo root
- */
 function prepareTsTaskConfig(options: TscTaskOptions) {
-  const tsConfigMainFilePath = resolveCwd('./tsconfig.json');
-  const tsConfigLibFilePath = resolveCwd('./tsconfig.lib.json');
-  const isUsingTsSolutionConfigs = fs.existsSync(tsConfigLibFilePath);
+  // docs say pretty is on by default, but it's actually disabled when tsc is run in a
+  // non-TTY context (which is what just-scripts tscTask does)
+  options.pretty = true;
 
-  const tsConfigFilePath = isUsingTsSolutionConfigs ? tsConfigLibFilePath : tsConfigMainFilePath;
-  const tsConfig: TsConfig = jju.parse(fs.readFileSync(tsConfigFilePath, 'utf-8'));
-
-  if (tsConfig.extends) {
-    logger.info(`📣 TSC: package is using TS path aliases. Overriding tsconfig settings.`);
-
-    const normalizedOptions = { ...options };
-    normalizedOptions.baseUrl = '.';
-    normalizedOptions.rootDir = './src';
-    normalizedOptions.project = path.basename(tsConfigFilePath);
-
-    return normalizedOptions;
+  if (getJustArgv().production) {
+    // sourceMap must be true for inlineSources and sourceRoot to work
+    options.inlineSources = true;
+    options.sourceRoot = path.relative(libPath, srcPath);
+    options.sourceMap = true;
   }
 
-  options.target = 'es5';
+  const tsConfigLib = 'tsconfig.lib.json';
+  const isUsingTsSolutionConfigs = fs.existsSync(resolveCwd(tsConfigLib));
+
+  if (isUsingTsSolutionConfigs) {
+    // For converged packages (which use TS path aliases), explicitly set `baseUrl` and `rootDir` to current package root.
+    // > - This is a temporary workaround for current way of building packages via lage and just scripts.
+    // > - Without setting baseUrl we would get all aliased packages build within outDir
+    // > - Without setting rootDir we would get output dir mapping following path from monorepo root
+    logger.info(`📣 TSC: package is using TS path aliases. Overriding tsconfig settings.`);
+    options.baseUrl = '.';
+    options.rootDir = './src';
+    options.project = tsConfigLib;
+  } else {
+    options.target = 'es5';
+  }
 
   return options;
 }
 
-function getExtraTscParams(args: JustArgs) {
-  return {
-    // sourceMap must be true for inlineSources and sourceRoot to work
-    ...(args.production && { inlineSources: true, sourceRoot: path.relative(libPath, srcPath), sourceMap: true }),
-    // docs say pretty is on by default, but it's actually disabled when tsc is run in a
-    // non-TTY context (which is what just-scripts tscTask does)
-    pretty: true,
-  };
-}
-
-function getJustArgv(): JustArgs {
-  return argv();
-}
-
 export const ts = {
   commonjs: () => {
-    const extraOptions = getExtraTscParams(getJustArgv());
     const options = prepareTsTaskConfig({
-      ...extraOptions,
       outDir: 'lib-commonjs',
       module: 'commonjs',
       ...(useTsBuildInfo && { tsBuildInfoFile: '.commonjs.tsbuildinfo' }),
@@ -81,9 +51,7 @@ export const ts = {
     return tscTask(options);
   },
   esm: () => {
-    const extraOptions = getExtraTscParams(getJustArgv());
     const options = prepareTsTaskConfig({
-      ...extraOptions,
       outDir: 'lib',
       module: 'esnext',
     });
@@ -92,9 +60,7 @@ export const ts = {
     return tscTask(options);
   },
   amd: () => {
-    const extraOptions = getExtraTscParams(getJustArgv());
     const options = prepareTsTaskConfig({
-      ...extraOptions,
       target: 'es5',
       outDir: 'lib-amd',
       module: 'amd',
@@ -104,9 +70,11 @@ export const ts = {
     return tscTask(options);
   },
   commonjsOnly: () => {
-    const extraOptions = getExtraTscParams(getJustArgv());
     // Use default tsbuildinfo for this variant (since it's the only variant)
-    const options = prepareTsTaskConfig({ ...extraOptions, outDir: 'lib', module: 'commonjs' });
+    const options = prepareTsTaskConfig({
+      outDir: 'lib',
+      module: 'commonjs',
+    });
 
     return tscTask(options);
   },

--- a/scripts/tasks/webpack.ts
+++ b/scripts/tasks/webpack.ts
@@ -2,12 +2,10 @@ import { webpackCliTask, argv, logger } from 'just-scripts';
 import * as path from 'path';
 import * as fs from 'fs';
 import execSync from '../exec-sync';
-import { Arguments } from 'yargs-parser';
-
-type JustArguments<T extends Record<string, unknown>> = Arguments & T;
+import { getJustArgv } from './argv';
 
 export function webpack() {
-  const args: JustArguments<Partial<{ production: boolean }>> = argv();
+  const args = getJustArgv();
   return webpackCliTask({
     webpackCliArgs: args.production ? ['--mode=production'] : [],
     nodeArgs: ['--max-old-space-size=4096'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8281,7 +8281,7 @@ chokidar@^2.0.0, chokidar@^2.1.2, chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^3.0.0, chokidar@^3.2.1, chokidar@^3.3.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.1:
+chokidar@^3.0.0, chokidar@^3.2.1, chokidar@^3.3.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.1, chokidar@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
   integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
@@ -9932,6 +9932,11 @@ decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decamelize@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
+  integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
 decimal.js@^10.2.1:
   version "10.3.1"
@@ -13555,7 +13560,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
-handlebars@*, handlebars@^4.0.1, handlebars@^4.1.0, handlebars@^4.4.3, handlebars@^4.7.6:
+handlebars@*, handlebars@^4.0.1, handlebars@^4.1.0, handlebars@^4.4.3, handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -15038,7 +15043,7 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-obj@^2.0.0:
+is-plain-obj@^2.0.0, is-plain-obj@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
@@ -16268,36 +16273,37 @@ just-debounce@^1.0.0:
   resolved "https://registry.yarnpkg.com/just-debounce/-/just-debounce-1.0.0.tgz#87fccfaeffc0b68cd19d55f6722943f929ea35ea"
   integrity sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=
 
-"just-scripts-utils@>=1.1.1 <2.0.0", just-scripts-utils@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/just-scripts-utils/-/just-scripts-utils-1.1.1.tgz#0dd86ad07301fdb5634844524021b78cc077f364"
-  integrity sha512-pyb/1vHfgpZwHPqG2KJm92DbByjwqhZYOTFI1zRVtwEjDy0laxnqPl4+5Gp1NK+9u12W1OxK04iMjoQScXimsw==
+"just-scripts-utils@>=1.1.4 <2.0.0":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/just-scripts-utils/-/just-scripts-utils-1.1.4.tgz#202a8af49f02d5e96f8fa5936a9d2ea6055fd9ee"
+  integrity sha512-Yo//Ir6xHRKVAHzHug70mqe6LaKOTdCaGTRsmBmuRonCttDyKilIA11gBpqwjAhNpHMRE9qdwXuKNn8oYtu7+w==
   dependencies:
     fs-extra "^8.0.0"
     glob "^7.1.3"
-    handlebars "^4.7.6"
+    handlebars "^4.7.7"
     jju "^1.4.0"
     just-task-logger ">=1.1.1 <2.0.0"
-    marked "^1.2.7"
+    marked "^2.0.0"
     marked-terminal "^4.1.0"
     semver "^7.0.0"
-    tar "^6.1.0"
+    tar "^6.1.6"
     yargs "^16.2.0"
 
-just-scripts@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/just-scripts/-/just-scripts-1.3.1.tgz#f42b32a2618aaee822747484500b6ff945a10f32"
-  integrity sha512-E6OCYYZUGAbSXcBYtPz93FjeYxW2yZ00IA6IBOao8Z1BT/TzJ74dNvUY/s4Kw0TG842d6NkbgXCjGqNAgqVP6A==
+just-scripts@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/just-scripts/-/just-scripts-1.6.1.tgz#ede10118e396e658a157ff154f99116edc9d8302"
+  integrity sha512-qlCCNUqI4Kh58OmD/bD2tFoqlMtY/F9JGY1n2VL3Uxb1o8XO8Rn5n+e1UsRNMtbD2NrHhRip6qn/RqElltQNGg==
   dependencies:
     "@types/node" "^10.12.18"
     chalk "^4.0.0"
     diff-match-patch "1.0.5"
     fs-extra "^8.0.0"
     glob "^7.1.3"
-    just-scripts-utils ">=1.1.1 <2.0.0"
-    just-task ">=1.1.1 <2.0.0"
+    just-scripts-utils ">=1.1.4 <2.0.0"
+    just-task ">=1.4.2 <2.0.0"
     prompts "^2.4.0"
     run-parallel-limit "^1.0.6"
+    semver "^7.0.0"
     supports-color "^8.1.0"
     webpack-merge "^5.7.3"
 
@@ -16309,14 +16315,15 @@ just-scripts@1.3.1:
     chalk "^4.0.0"
     yargs "^16.2.0"
 
-"just-task@>=1.1.1 <2.0.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/just-task/-/just-task-1.1.1.tgz#74cc58fd67d40d25a7838cb3d6d8aa8468d155e5"
-  integrity sha512-XwBrJtOLqjBHWvqCzzrTBiEfN1HZBXv+TTqAENMcivKoMNuNFIVdfBGtXpU2u9xnVm01XNwOCXg6BePBxty6nA==
+"just-task@>=1.4.2 <2.0.0":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/just-task/-/just-task-1.4.2.tgz#71b1ce9e539605dcb9b416e938398543d3573b66"
+  integrity sha512-ZSdS/N8zgjA00cjftNxTbOjjY+xDpHg/jHuJNP6p71avrCrvBiMBZSUBnMeZrBYWwDZ14hxjV5D7UwXg05c4HQ==
   dependencies:
     "@rushstack/package-deps-hash" "^2.4.109"
     bach "^1.2.0"
     chalk "^4.0.0"
+    chokidar "^3.5.2"
     fs-extra "^8.0.0"
     just-task-logger ">=1.1.1 <2.0.0"
     resolve "^1.19.0"
@@ -17545,10 +17552,10 @@ marked-terminal@^4.1.0:
     node-emoji "^1.10.0"
     supports-hyperlinks "^2.1.0"
 
-marked@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.7.tgz#6e14b595581d2319cdcf033a24caaf41455a01fb"
-  integrity sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA==
+marked@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
+  integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
 
 matchdep@^2.0.0:
   version "2.0.0"
@@ -23992,10 +23999,10 @@ tar@^4, tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
     safe-buffer "^5.2.1"
     yallist "^3.1.1"
 
-tar@^6.0.1, tar@^6.0.2, tar@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
-  integrity sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==
+tar@^6.0.1, tar@^6.0.2, tar@^6.1.6:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
@@ -26429,6 +26436,16 @@ yargs-unparser@1.6.0:
     flat "^4.1.0"
     lodash "^4.17.15"
     yargs "^13.3.0"
+
+yargs-unparser@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
+  integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
+  dependencies:
+    camelcase "^6.0.0"
+    decamelize "^4.0.0"
+    flat "^5.0.2"
+    is-plain-obj "^2.1.0"
 
 yargs@13.3.2, yargs@^13.3.0, yargs@^13.3.2:
   version "13.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5276,6 +5276,11 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
 
+"@types/yargs-unparser@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/yargs-unparser/-/yargs-unparser-2.0.1.tgz#9c804fddbe3693f7efade3fe24eccb35818a5217"
+  integrity sha512-fAnDylacESFJBN4a1J2VnYCl2bTIMkwZ6f3CLCA04x/qCDalGR9aAec89KtS3K4zu05JxjQGn0aRWSPYQJ6zRQ==
+
 "@types/yargs@13.0.11":
   version "13.0.11"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.11.tgz#def2f0c93e4bdf2c61d7e34899b17e34be28d3b1"


### PR DESCRIPTION
Update `just-scripts` to allow removing some of the more complex workarounds for build task customization.

- Use a [new API Extractor task option I added](https://github.com/microsoft/just/pull/563) to override API Extractor options for converged packages without overwriting any files on the disk. (API Extractor itself provides a way to do this, we just didn't have a way to access it via the task before.)
- Allow passing through arbitrary options to `jest`
- Factor out arg parsing into a separate helper with appropriate types, and use that in appropriate places
- Simplify how TS task args are calculated