### PR TITLE
Add aria-multiselectable to multiselect Combobox

### DIFF
--- a/change/@fluentui-react-8c6f90dd-1df8-4efd-b3de-f26cbd10596e.json
+++ b/change/@fluentui-react-8c6f90dd-1df8-4efd-b3de-f26cbd10596e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add aria-multiselectable to multiselect Combobox",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1331,7 +1331,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
   // Render List of items
   private _onRenderList = (props: IComboBoxProps): JSX.Element => {
-    const { onRenderItem = this._onRenderItem, label, ariaLabel } = props;
+    const { onRenderItem = this._onRenderItem, label, ariaLabel, multiSelect } = props;
 
     let queue: { id?: string; items: JSX.Element[] } = { items: [] };
     let renderedList: JSX.Element[] = [];
@@ -1395,6 +1395,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         className={this._classNames.optionsContainer}
         aria-labelledby={label && id + '-label'}
         aria-label={ariaLabel && !label ? ariaLabel : undefined}
+        aria-multiselectable={multiSelect ? 'true' : undefined}
         role="listbox"
       >
         {renderedList}

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -1532,6 +1532,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
               class="ms-ComboBox-optionsContainerWrapper "
             >
               <div
+                aria-multiselectable="true"
                 class=
                     ms-ComboBox-optionsContainer
                     {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #21006
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds `aria-multiselectable` to the listbox element of multiselect Comboboxes. Single-line change + snapshot update.