### PR TITLE
Fix test issues discovered while trying to test React 17 (take 2)

### DIFF
--- a/change/@fluentui-react-ab8e2990-b17d-4210-b514-30a0cb04b452.json
+++ b/change/@fluentui-react-ab8e2990-b17d-4210-b514-30a0cb04b452.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix test issues",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-0b77bb7d-5bbe-457b-95c9-6a5970609121.json
+++ b/change/@fluentui-react-experiments-0b77bb7d-5bbe-457b-95c9-6a5970609121.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix test issues",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-hooks-c07633ea-c71c-4e99-9a4a-cc10394bf71c.json
+++ b/change/@fluentui-react-hooks-c07633ea-c71c-4e99-9a4a-cc10394bf71c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix test issues",
+  "packageName": "@fluentui/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-test-utilities-493d57c1-c975-4c23-aea6-fd2dff463193.json
+++ b/change/@fluentui-test-utilities-493d57c1-c975-4c23-aea6-fd2dff463193.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Simplify safeMount attach API",
+  "packageName": "@fluentui/test-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-utilities-2d40b849-0e8a-4a69-a942-c4454fdde763.json
+++ b/change/@fluentui-utilities-2d40b849-0e8a-4a69-a942-c4454fdde763.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix test issues",
+  "packageName": "@fluentui/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsComposite.test.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsComposite.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { create, act } from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import { BaseFloatingSuggestions } from './FloatingSuggestions';
 import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-dom/test-utils';
@@ -95,7 +95,7 @@ describe('FloatingSuggestions', () => {
     // since callout mount a new react root with ReactDOM.
     //
     // see https://github.com/facebook/react/pull/12895
-    act(() => {
+    ReactTestUtils.act(() => {
       (ReactDOM.render(
         <BaseFloatingSuggestions
           suggestions={_suggestions}
@@ -130,7 +130,7 @@ describe('FloatingSuggestions', () => {
   });
 
   it('renders FloatingSuggestions and updates when suggestions are removed', () => {
-    act(() => {
+    ReactTestUtils.act(() => {
       (ReactDOM.render(
         <BaseFloatingSuggestions
           suggestions={_suggestions}
@@ -165,7 +165,7 @@ describe('FloatingSuggestions', () => {
 
   it('shows no suggestions when no suggestions are provided', () => {
     _suggestions = [];
-    act(() => {
+    ReactTestUtils.act(() => {
       (ReactDOM.render(
         <BaseFloatingSuggestions
           suggestions={_suggestions}

--- a/packages/react-hooks/src/useUnmount.test.tsx
+++ b/packages/react-hooks/src/useUnmount.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import { useUnmount } from './useUnmount';
 
@@ -17,7 +18,9 @@ describe('useUnmount', () => {
     expect(onUnmount).toBeCalledTimes(0);
     const wrapper = mount(<TestComponent />);
     expect(onUnmount).toBeCalledTimes(0);
-    wrapper.unmount();
+    ReactTestUtils.act(() => {
+      wrapper.unmount();
+    });
     expect(onUnmount).toBeCalledTimes(1);
   });
 });

--- a/packages/react/__mocks__/@fluentui/utilities.ts
+++ b/packages/react/__mocks__/@fluentui/utilities.ts
@@ -36,7 +36,9 @@ class MockAsync extends Async {
   }
 
   public dispose() {
-    clearTimeout(this._timeoutId);
+    if (this._timeoutId) {
+      clearTimeout(this._timeoutId);
+    }
     this._timeoutId = undefined;
 
     super.dispose();

--- a/packages/react/src/common/testUtilities.ts
+++ b/packages/react/src/common/testUtilities.ts
@@ -28,6 +28,7 @@ export function delay(millisecond: number): Promise<void> {
 /**
  * Mounts the element attached to a child of document.body. This is primarily for tests involving
  * event handlers (which don't work right unless the element is attached).
+ * @deprecated Use `safeMount` from `@fluentui/test-utilities` instead
  */
 export function mountAttached<C extends Component, P = C['props'], S = C['state']>(
   element: React.ReactElement<P>,

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroup.test.tsx
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroup.test.tsx
@@ -5,7 +5,7 @@ import * as renderer from 'react-test-renderer';
 
 import { ChoiceGroup } from './ChoiceGroup';
 import { merge, resetIds } from '../../Utilities';
-import { mountAttached } from '../../common/testUtilities';
+import { safeMount } from '@fluentui/test-utilities';
 import { isConformant } from '../../common/isConformant';
 import type { IChoiceGroupOption, IChoiceGroup, IChoiceGroupProps } from './ChoiceGroup.types';
 
@@ -253,30 +253,34 @@ describe('ChoiceGroup', () => {
   it('can focus the checked option', () => {
     // This test has to mount the element to the document since ChoiceGroup.focus() uses document.getElementById()
     const choiceGroupRef = React.createRef<IChoiceGroup>();
-    choiceGroup = mountAttached(
+    safeMount(
       <ChoiceGroup options={TEST_OPTIONS} defaultSelectedKey="1" componentRef={choiceGroupRef} />,
+      choiceGroup2 => {
+        const option = choiceGroup2.getDOMNode().querySelector(CHOICE_QUERY_SELECTOR) as HTMLInputElement;
+        const focusSpy = jest.spyOn(option, 'focus');
+
+        choiceGroupRef.current!.focus();
+        expect(focusSpy).toHaveBeenCalled();
+      },
+      true /* attach */,
     );
-
-    const option = choiceGroup.getDOMNode().querySelector(CHOICE_QUERY_SELECTOR) as HTMLInputElement;
-    const focusSpy = jest.spyOn(option, 'focus');
-
-    choiceGroupRef.current!.focus();
-    expect(focusSpy).toHaveBeenCalled();
   });
 
   it('can focus the first enabled option', () => {
     const choiceGroupRef = React.createRef<IChoiceGroup>();
-    choiceGroup = mountAttached(
+    safeMount(
       <ChoiceGroup
         options={[{ key: '0', text: 'disabled', disabled: true }, ...TEST_OPTIONS]}
         componentRef={choiceGroupRef}
       />,
+      choiceGroup2 => {
+        const option = choiceGroup2.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR)![1] as HTMLInputElement;
+        const focusSpy = jest.spyOn(option, 'focus');
+
+        choiceGroupRef.current!.focus();
+        expect(focusSpy).toHaveBeenCalled();
+      },
+      true /* attach */,
     );
-
-    const option = choiceGroup.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR)![1] as HTMLInputElement;
-    const focusSpy = jest.spyOn(option, 'focus');
-
-    choiceGroupRef.current!.focus();
-    expect(focusSpy).toHaveBeenCalled();
   });
 });

--- a/packages/react/src/components/Pivot/Pivot.test.tsx
+++ b/packages/react/src/components/Pivot/Pivot.test.tsx
@@ -1,26 +1,31 @@
 import * as React from 'react';
-import { create } from '@fluentui/utilities/lib/test';
 import { mount } from 'enzyme';
 import { resetIds } from '@fluentui/utilities';
-import { Pivot, PivotItem } from './index';
+import { safeMount, safeCreate } from '@fluentui/test-utilities';
+import { Pivot, PivotItem, IPivot } from './index';
 import { isConformant } from '../../common/isConformant';
-import { mountAttached } from '../../common/testUtilities';
-import type { IPivot } from './index';
 
 describe('Pivot', () => {
   beforeEach(() => {
     // Resetting ids to create predictability in generated ids.
     resetIds();
   });
+
+  afterEach(() => {
+    delete (HTMLElement.prototype as any).isVisible;
+  });
+
   it('renders link Pivot correctly', () => {
-    const component = create(
+    safeCreate(
       <Pivot>
         <PivotItem headerText="Test Link 1" />
         <PivotItem headerText="" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
 
   isConformant({
@@ -31,29 +36,31 @@ describe('Pivot', () => {
   it('can be focused', () => {
     const pivotRef = React.createRef<IPivot>();
 
-    mountAttached(
+    // Instruct FocusZone to treat all elements as visible.
+    (HTMLElement.prototype as any).isVisible = true;
+
+    safeMount(
       <Pivot componentRef={pivotRef}>
         <PivotItem headerText="Link 1" />
         <PivotItem headerText="Link 2" />
       </Pivot>,
+      () => {
+        try {
+          expect(pivotRef.current).toBeTruthy();
+
+          pivotRef.current!.focus();
+          expect(document.activeElement).toBeTruthy();
+          expect(document.activeElement!.textContent?.trim()).toEqual('Link 1');
+        } finally {
+          delete (HTMLElement.prototype as any).isVisible;
+        }
+      },
+      true /* attach, for focus tests */,
     );
-
-    // Instruct FocusZone to treat all elements as visible.
-    (HTMLElement.prototype as any).isVisible = true;
-
-    try {
-      expect(pivotRef.current).toBeTruthy();
-
-      pivotRef.current!.focus();
-      expect(document.activeElement).toBeTruthy();
-      expect(document.activeElement!.textContent?.trim()).toEqual('Link 1');
-    } finally {
-      delete (HTMLElement.prototype as any).isVisible;
-    }
   });
 
   it('supports JSX expressions', () => {
-    const component = create(
+    safeCreate(
       <Pivot defaultSelectedKey="1">
         <PivotItem headerText="Test Link 1">
           <div>This is item 1</div>
@@ -63,81 +70,105 @@ describe('Pivot', () => {
           <div>This is Item 3</div>
         </PivotItem>
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders large link Pivot correctly', () => {
-    const component = create(
+    safeCreate(
       <Pivot linkSize="large">
         <PivotItem headerText="Test Link 1" />
         <PivotItem headerText="" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders tabbed Pivot correctly', () => {
-    const component = create(
+    safeCreate(
       <Pivot linkFormat="tabs">
         <PivotItem headerText="Test Link 1" />
         <PivotItem headerText="" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders large tabbed Pivot correctly', () => {
-    const component = create(
+    safeCreate(
       <Pivot linkFormat="tabs" linkSize="large">
         <PivotItem headerText="Test Link 1" />
         <PivotItem headerText="" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders Pivot correctly with custom className', () => {
-    const component = create(
+    safeCreate(
       <Pivot className="specialClassName">
         <PivotItem headerText="Test Link 1" className="specialClassName" />
         <PivotItem headerText="Test Link 2" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders Pivot correctly with icon, text and count', () => {
-    const component = create(
+    safeCreate(
       <Pivot>
         <PivotItem itemCount={12} />
         <PivotItem headerText="Test Link" itemCount={12} />
         <PivotItem headerText="Text with icon" itemIcon="Recent" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders Pivot correctly when itemCount is a string', () => {
-    const component = create(
+    safeCreate(
       <Pivot>
         <PivotItem headerText="test" />
         <PivotItem headerText="Test Link" itemCount="20+" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('renders Pivot with overflow', () => {
-    const component = create(
+    safeCreate(
       <Pivot overflowBehavior="menu">
         <PivotItem headerText="Test 1" />
         <PivotItem headerText="Test 2" />
       </Pivot>,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
   });
+
   it('passes aria-label and aria-labelledby to tablist', () => {
     const wrapper = mount(
       <Pivot aria-label="test label" aria-labelledby="testID" data-foo="not passed to tablist">

--- a/packages/react/src/components/TextField/TextField.test.tsx
+++ b/packages/react/src/components/TextField/TextField.test.tsx
@@ -6,7 +6,8 @@ import { renderToStaticMarkup } from 'react-dom/server';
 
 import * as path from 'path';
 import { resetIds, setWarningCallback, resetControlledWarnings } from '../../Utilities';
-import { mountAttached, mockEvent, flushPromises } from '../../common/testUtilities';
+import { mockEvent, flushPromises } from '../../common/testUtilities';
+import { safeMount } from '@fluentui/test-utilities';
 
 import { TextField } from './TextField';
 import { TextFieldBase } from './TextField.base';
@@ -826,23 +827,33 @@ describe('TextField', () => {
   });
 
   it('sets focus to the input via ITextField focus', () => {
-    wrapper = mountAttached(<TextField componentRef={textFieldRef} />);
-    const inputEl = wrapper.find('input').getDOMNode();
+    safeMount(
+      <TextField componentRef={textFieldRef} />,
+      wrapper2 => {
+        const inputEl = wrapper2.find('input').getDOMNode();
 
-    textField!.focus();
+        textField!.focus();
 
-    expect(document.activeElement).toBe(inputEl);
+        expect(document.activeElement).toBe(inputEl);
+      },
+      true /* attach */,
+    );
   });
 
   it('blurs the input via ITextField blur', () => {
-    wrapper = mountAttached(<TextField componentRef={textFieldRef} />);
-    const inputEl = wrapper.find('input').getDOMNode();
+    safeMount(
+      <TextField componentRef={textFieldRef} />,
+      wrapper2 => {
+        const inputEl = wrapper2.find('input').getDOMNode();
 
-    textField!.focus();
-    expect(document.activeElement).toBe(inputEl);
+        textField!.focus();
+        expect(document.activeElement).toBe(inputEl);
 
-    textField!.blur();
-    expect(document.activeElement).toBe(document.body);
+        textField!.blur();
+        expect(document.activeElement).toBe(document.body);
+      },
+      true /* attach */,
+    );
   });
 
   it('can switch from single to multi line and back', () => {
@@ -866,45 +877,55 @@ describe('TextField', () => {
   });
 
   it('maintains focus when switching single to multi line and back', () => {
-    wrapper = mountAttached(<TextField componentRef={textFieldRef} />);
-    // focus input
-    textField!.focus();
-    let input = wrapper.find('input').getDOMNode();
-    expect(document.activeElement).toBe(input);
+    safeMount(
+      <TextField componentRef={textFieldRef} />,
+      wrapper2 => {
+        // focus input
+        textField!.focus();
+        let input = wrapper2.find('input').getDOMNode();
+        expect(document.activeElement).toBe(input);
 
-    // switch to multiline
-    wrapper.setProps({ multiline: true });
-    // verify still focused
-    const textarea = wrapper.find('textarea').getDOMNode();
-    expect(document.activeElement).toBe(textarea);
+        // switch to multiline
+        wrapper2.setProps({ multiline: true });
+        // verify still focused
+        const textarea = wrapper2.find('textarea').getDOMNode();
+        expect(document.activeElement).toBe(textarea);
 
-    // back to single line
-    wrapper.setProps({ multiline: false });
-    // verify still focused
-    input = wrapper.find('input').getDOMNode();
-    expect(document.activeElement).toBe(input);
+        // back to single line
+        wrapper2.setProps({ multiline: false });
+        // verify still focused
+        input = wrapper2.find('input').getDOMNode();
+        expect(document.activeElement).toBe(input);
+      },
+      true /* attach */,
+    );
   });
 
   it('maintains selection when switching single to multi line and back', () => {
     const start = 1;
     const end = 3;
-    wrapper = mountAttached(<TextField componentRef={textFieldRef} defaultValue="some text" />);
-    // select
-    textField!.focus();
-    textField!.setSelectionRange(start, end);
-    expect(textField!.selectionStart).toBe(start);
-    expect(textField!.selectionEnd).toBe(end);
+    safeMount(
+      <TextField componentRef={textFieldRef} defaultValue="some text" />,
+      wrapper2 => {
+        // select
+        textField!.focus();
+        textField!.setSelectionRange(start, end);
+        expect(textField!.selectionStart).toBe(start);
+        expect(textField!.selectionEnd).toBe(end);
 
-    // switch to multiline
-    wrapper.setProps({ multiline: true });
-    // verify still selected
-    expect(textField!.selectionStart).toBe(start);
-    expect(textField!.selectionEnd).toBe(end);
+        // switch to multiline
+        wrapper2.setProps({ multiline: true });
+        // verify still selected
+        expect(textField!.selectionStart).toBe(start);
+        expect(textField!.selectionEnd).toBe(end);
 
-    // back to single line
-    wrapper.setProps({ multiline: false });
-    // verify still selected
-    expect(textField!.selectionStart).toBe(start);
-    expect(textField!.selectionEnd).toBe(end);
+        // back to single line
+        wrapper2.setProps({ multiline: false });
+        // verify still selected
+        expect(textField!.selectionStart).toBe(start);
+        expect(textField!.selectionEnd).toBe(end);
+      },
+      true /* attach */,
+    );
   });
 });

--- a/packages/react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/react/src/components/pickers/BasePicker.test.tsx
@@ -134,7 +134,7 @@ describe('BasePicker', () => {
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
-    ReactTestUtils.Simulate.focus(input); // input.focus() doesn't work in react 17/jest 25
+    input.focus();
     input.value = 'b';
     ReactTestUtils.Simulate.input(input);
     runAllTimers();
@@ -159,7 +159,7 @@ describe('BasePicker', () => {
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
-    ReactTestUtils.Simulate.focus(input); // input.focus() doesn't work in react 17/jest 25
+    input.focus();
     input.value = 'bl';
     ReactTestUtils.Simulate.input(input);
     runAllTimers();
@@ -487,12 +487,16 @@ describe('BasePicker', () => {
     jest.useFakeTimers();
     document.body.appendChild(root);
 
-    const resolveMock = jest.fn(onResolveSuggestions);
+    let count = 0;
+    const resolveCounter = (val: string) => {
+      count++;
+      return onResolveSuggestions(val);
+    };
     const picker = React.createRef<IBasePicker<ISimple>>();
 
     ReactDOM.render(
       <BasePickerWithType
-        onResolveSuggestions={resolveMock}
+        onResolveSuggestions={resolveCounter}
         onRenderItem={onRenderItem}
         onRenderSuggestionsItem={basicSuggestionRenderer}
         componentRef={picker}
@@ -502,10 +506,10 @@ describe('BasePicker', () => {
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
-    ReactTestUtils.Simulate.focus(input); // input.focus() doesn't work in react 17/jest 25
+    input.focus();
     runAllTimers();
 
-    expect(resolveMock).toHaveBeenCalledTimes(1);
+    expect(count).toEqual(1);
 
     expect(getSuggestions(document)).toBeTruthy();
   });

--- a/packages/react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/react/src/components/pickers/BasePicker.test.tsx
@@ -134,7 +134,7 @@ describe('BasePicker', () => {
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
-    input.focus();
+    ReactTestUtils.Simulate.focus(input); // input.focus() doesn't work in react 17/jest 25
     input.value = 'b';
     ReactTestUtils.Simulate.input(input);
     runAllTimers();
@@ -159,7 +159,7 @@ describe('BasePicker', () => {
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
-    input.focus();
+    ReactTestUtils.Simulate.focus(input); // input.focus() doesn't work in react 17/jest 25
     input.value = 'bl';
     ReactTestUtils.Simulate.input(input);
     runAllTimers();
@@ -487,16 +487,12 @@ describe('BasePicker', () => {
     jest.useFakeTimers();
     document.body.appendChild(root);
 
-    let count = 0;
-    const resolveCounter = (val: string) => {
-      count++;
-      return onResolveSuggestions(val);
-    };
+    const resolveMock = jest.fn(onResolveSuggestions);
     const picker = React.createRef<IBasePicker<ISimple>>();
 
     ReactDOM.render(
       <BasePickerWithType
-        onResolveSuggestions={resolveCounter}
+        onResolveSuggestions={resolveMock}
         onRenderItem={onRenderItem}
         onRenderSuggestionsItem={basicSuggestionRenderer}
         componentRef={picker}
@@ -506,10 +502,10 @@ describe('BasePicker', () => {
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
-    input.focus();
+    ReactTestUtils.Simulate.focus(input); // input.focus() doesn't work in react 17/jest 25
     runAllTimers();
 
-    expect(count).toEqual(1);
+    expect(resolveMock).toHaveBeenCalledTimes(1);
 
     expect(getSuggestions(document)).toBeTruthy();
   });

--- a/packages/react/src/utilities/ThemeProvider/ThemeProvider.test.tsx
+++ b/packages/react/src/utilities/ThemeProvider/ThemeProvider.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import { ThemeProvider } from './ThemeProvider';
 import * as renderer from 'react-test-renderer';
 import { useTheme } from './useTheme';
@@ -65,7 +66,9 @@ describe('ThemeProvider', () => {
     expect(themeProvider1.getAttribute('dir')).toBe('ltr');
     expect(themeProvider2.getAttribute('dir')).toBe(null);
 
-    wrapper.unmount();
+    ReactTestUtils.act(() => {
+      wrapper.unmount();
+    });
   });
 
   it('renders a div with styling', () => {
@@ -132,7 +135,9 @@ describe('ThemeProvider', () => {
 
     expect(document.body).toMatchSnapshot();
 
-    wrapper.unmount();
+    ReactTestUtils.act(() => {
+      wrapper.unmount();
+    });
 
     expect(document.body.className).toBe('');
 

--- a/packages/test-utilities/src/safeMount.ts
+++ b/packages/test-utilities/src/safeMount.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { mount, MountRendererProps, ReactWrapper } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
+import { createTestContainer } from './createTestContainer';
 
 /**
  * Calls `mount` from enzyme, calls the callback, and unmounts. This prevents mounted components
@@ -7,8 +8,8 @@ import { mount, MountRendererProps, ReactWrapper } from 'enzyme';
  *
  * @param content - JSX content to test.
  * @param callback - Function callback which receives the component to use.
- * @param mountOptions - Options for enzyme mount function. If `attachTo` is provided, the element
- * will be removed during the cleanup.
+ * @param attach - Whether to use a container element which is attached to the document
+ * (sometimes needed for event handlers)
  */
 export function safeMount<
   TComponent extends React.Component,
@@ -17,9 +18,10 @@ export function safeMount<
 >(
   content: React.ReactElement<TProps>,
   callback?: (wrapper: ReactWrapper<TProps, TState, TComponent>) => void,
-  mountOptions?: MountRendererProps,
+  attach?: boolean,
 ): void {
-  const wrapper = mount<TComponent, TProps, TState>(content, mountOptions);
+  const testContainer = attach ? createTestContainer() : undefined;
+  const wrapper = mount<TComponent, TProps, TState>(content, { ...(testContainer && { attachTo: testContainer }) });
 
   try {
     callback?.(wrapper);
@@ -27,8 +29,6 @@ export function safeMount<
     if (wrapper.exists()) {
       wrapper.unmount();
     }
-    if (mountOptions?.attachTo) {
-      mountOptions.attachTo.remove();
-    }
+    testContainer?.remove();
   }
 }

--- a/packages/utilities/src/customizations/useCustomizationSettings.test.tsx
+++ b/packages/utilities/src/customizations/useCustomizationSettings.test.tsx
@@ -10,10 +10,10 @@ describe('useCustomizatioSettings', () => {
   let wrapper: ReactWrapper | undefined;
 
   afterEach(() => {
-    if (wrapper) {
-      wrapper.unmount();
-    }
-
+    ReactTestUtils.act(() => {
+      wrapper?.unmount();
+      wrapper = undefined;
+    });
     Customizations.reset();
   });
 

--- a/packages/utilities/src/styled.test.tsx
+++ b/packages/utilities/src/styled.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable deprecation/deprecation */
 import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import { styled } from './styled';
 import * as renderer from 'react-test-renderer';
 import { Customizer } from './customizations/Customizer';
@@ -74,10 +75,10 @@ describe('styled', () => {
   });
 
   afterEach(() => {
-    if (component) {
-      component.unmount();
+    ReactTestUtils.act(() => {
+      component?.unmount();
       component = undefined;
-    }
+    });
 
     lastStylesInBaseComponent = undefined;
   });

--- a/packages/utilities/src/useFocusRects.test.tsx
+++ b/packages/utilities/src/useFocusRects.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import { FocusRects } from './useFocusRects';
 import { IsFocusHiddenClassName, IsFocusVisibleClassName } from './setFocusVisibility';
 import { KeyCodes } from './KeyCodes';
@@ -136,9 +137,13 @@ describe('useFocusRects', () => {
 
     expect(mockWindow.addEventListenerCallCount).toBe(3);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects1.unmount();
+    ReactTestUtils.act(() => {
+      focusRects1.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects2.unmount();
+    ReactTestUtils.act(() => {
+      focusRects2.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(3);
   });
 
@@ -169,12 +174,16 @@ describe('useFocusRects', () => {
 
     expect(mockWindow.addEventListenerCallCount).toBe(3);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects1.unmount();
+    ReactTestUtils.act(() => {
+      focusRects1.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(3);
 
     expect(mockWindow2.addEventListenerCallCount).toBe(3);
     expect(mockWindow2.removeEventListenerCallCount).toBe(0);
-    focusRects2.unmount();
+    ReactTestUtils.act(() => {
+      focusRects2.unmount();
+    });
     expect(mockWindow2.removeEventListenerCallCount).toBe(3);
   });
 
@@ -191,9 +200,13 @@ describe('useFocusRects', () => {
 
     expect(mockWindow.addEventListenerCallCount).toBe(3);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects1.unmount();
+    ReactTestUtils.act(() => {
+      focusRects1.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects2.unmount();
+    ReactTestUtils.act(() => {
+      focusRects2.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(3);
   });
 
@@ -214,7 +227,9 @@ describe('useFocusRects', () => {
 
     expect(mockWindow.addEventListenerCallCount).toBe(3);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects1.unmount();
+    ReactTestUtils.act(() => {
+      focusRects1.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(3);
   });
 
@@ -237,9 +252,13 @@ describe('useFocusRects', () => {
 
     expect(mockWindow.addEventListenerCallCount).toBe(3);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects1.unmount();
+    ReactTestUtils.act(() => {
+      focusRects1.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRects2.unmount();
+    ReactTestUtils.act(() => {
+      focusRects2.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(3);
   });
 
@@ -257,7 +276,9 @@ describe('useFocusRects', () => {
 
     expect(mockWindow.addEventListenerCallCount).toBe(0);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
-    focusRect.unmount();
+    ReactTestUtils.act(() => {
+      focusRect.unmount();
+    });
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
     expect(mockWindow.removeEventListenerCallCount).toBe(0);
   });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Related to #15732, #20145
- [x] Include a change request file using `$ yarn change`

#### Description of changes

New edition of #17050. Copying the original description...

--------

While trying to run tests with React 17 (see #16886), I found a few instances where either:
- Tests were doing things incorrectly in ways that (for whatever reason) worked in master, but doesn't work after upgrading React/Jest
- Tests were doing things in a less than ideal way which outright stops working after upgrading React/Jest

This PR fixes those issues where it makes sense to go ahead and do so. Some common ones:
- React 17-related test utilities have a nice warning when you use the wrong `act` helper, which several tests were.
  - When rendering with `react-dom`, should use `act` from `react-dom/test-utils`
  - When rendering with Enzyme, should use `act` from `enzyme`
- React 17 and/or Jest 25 (and its jsdom version) make focus-related tests trickier. There are a few issues I've yet to resolve, but in a lot of cases the resolution is simple: attach the root element to the document when testing.
- In a few cases, React 17 is pickier about wrapping things such as `unmount()` with `act`. Go ahead and add this since it's harmless.