### PR TITLE
Combobox: Provide a callback to listen to raw text input

### DIFF
--- a/change/@fluentui-react-a72f59c8-a71c-45c5-8372-f2ac3e1a1bd8.json
+++ b/change/@fluentui-react-a72f59c8-a71c-45c5-8372-f2ac3e1a1bd8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "ComboBox: Add callback to listen to raw text input",
+  "packageName": "@fluentui/react",
+  "email": "dennisgeorge.mec@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3733,6 +3733,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox,
     isButtonAriaHidden?: boolean;
     multiSelectDelimiter?: string;
     onChange?: (event: React_2.FormEvent<IComboBox>, option?: IComboBoxOption, index?: number, value?: string) => void;
+    onInputValueChange?: (text: string) => void;
     onItemClick?: (event: React_2.FormEvent<IComboBox>, option?: IComboBoxOption, index?: number) => void;
     onMenuDismiss?: () => void;
     onMenuDismissed?: () => void;

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -619,6 +619,29 @@ describe('ComboBox', () => {
     );
   });
 
+  it('onInputValueChange is called whenever the input changes', () => {
+    let changedValue: string | undefined = undefined;
+    const onInputValueChangeHandler = (value: string) => {
+      changedValue = value;
+    };
+
+    safeMount(
+      <ComboBox options={DEFAULT_OPTIONS} allowFreeform onInputValueChange={onInputValueChangeHandler} />,
+      wrapper => {
+        // Simulate typing one character into the ComboBox input
+        const input = wrapper.find('input');
+        input.simulate('input', { target: { value: 'a' } });
+        expect(changedValue).toEqual('a');
+
+        // Simulate clearing the ComboBox input
+        // (have to manually update the input element beforehand due to issues with Autofill in enzyme)
+        (input.getDOMNode() as HTMLInputElement).value = '';
+        input.simulate('input', { target: { value: '' } });
+        expect(changedValue).toEqual('');
+      },
+    );
+  });
+
   it('suggestedDisplayValue is set to undefined when the selected input is cleared', () => {
     safeMount(<ComboBox selectedKey="1" options={DEFAULT_OPTIONS} />, wrapper => {
       expect(wrapper.find('input').props().value).toEqual('1');

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -760,6 +760,10 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       return;
     }
 
+    if (this.props.onInputValueChange) {
+      this.props.onInputValueChange(updatedValue);
+    }
+
     this.props.allowFreeform
       ? this._processInputChangeWithFreeform(updatedValue)
       : this._processInputChangeWithoutFreeform(updatedValue);

--- a/packages/react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/react/src/components/ComboBox/ComboBox.types.ts
@@ -93,9 +93,16 @@ export interface IComboBoxProps
    * and the user types text matching the start of an option within a timeout, `option` and `index`
    * are provided and `value` is undefined. If `autoComplete` is off, typing does nothing.
    *
-   * If you simply want to be notified of raw text input, use the prop `autofill.onInputValueChange`.
+   * If you simply want to be notified of raw text input, use the prop `onInputValueChange`.
    */
   onPendingValueChanged?: (option?: IComboBoxOption, index?: number, value?: string) => void;
+
+  /**
+   * Called when the user types in to the input of the combo box
+   *
+   * Ideal if you want to be notified of raw text input
+   */
+  onInputValueChange?: (text: string) => void;
 
   /**
    * Called when the ComboBox menu is launched.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #21000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The [documentation](https://developer.microsoft.com/en-us/fluentui#/controls/web/combobox) mentions that you can override autofill.onInputValueChange if you want to be notified of raw text input to the ComboBox. But the issue is that this overrides the [ComboBox's implementation of onInputValueChange](https://github.com/microsoft/fluentui/blob/HEAD/packages/react/src/components/ComboBox/ComboBox.tsx#L588) to the underlying autofill, causing a lot of issues. (Text does not update; up, down, left, right, enter keys don't work as expected)

The change provides a way to extend rather than override the underlying autofill's onInputValueChange prop. An additional prop (callback) is added to the ComboBoxProps and called from [_onInputChange](https://github.com/microsoft/fluentui/blob/HEAD/packages/react/src/components/ComboBox/ComboBox.tsx#L757)  

#### Focus areas to test

Keyboard events to ComboBox input
