### PR TITLE
Adding the  translate="no" tags for the icons

### DIFF
--- a/change/@fluentui-react-5f7dd00b-9a41-4311-9b0a-e4ed0c4dc0b3.json
+++ b/change/@fluentui-react-5f7dd00b-9a41-4311-9b0a-e4ed0c4dc0b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding the translate='no' tag for the icons",
+  "packageName": "@fluentui/react",
+  "email": "mavarsh@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Icon/FontIcon.tsx
+++ b/packages/react/src/components/Icon/FontIcon.tsx
@@ -78,6 +78,7 @@ export const FontIcon: React.FunctionComponent<IFontIconProps> = props => {
       // Apply the font family this way to ensure it doesn't get overridden by Fabric Core ms-Icon styles
       // https://github.com/microsoft/fluentui/issues/10449
       style={{ fontFamily, ...style }}
+      translate="no"
     >
       {finalChildren}
     </i>

--- a/packages/react/src/components/Icon/Icon.base.tsx
+++ b/packages/react/src/components/Icon/Icon.base.tsx
@@ -93,6 +93,7 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
             }
           : {})}
         className={classNames.root}
+        translate="no"
       >
         {isImage ? <ImageType {...imageProps} /> : children || finalIconContentChildren}
       </RootType>

--- a/packages/react/src/components/Icon/ImageIcon.tsx
+++ b/packages/react/src/components/Icon/ImageIcon.tsx
@@ -41,7 +41,12 @@ export const ImageIcon: React.FunctionComponent<IImageIconProps> = props => {
       };
 
   return (
-    <div {...containerProps} {...nativeProps} className={css(MS_ICON, classNames.root, classNames.image, className)}>
+    <div
+      {...containerProps}
+      {...nativeProps}
+      className={css(MS_ICON, classNames.root, classNames.image, className)}
+      translate="no"
+    >
       <Image {...imageNameProps} {...imageProps} alt={hasName ? altText : ''} />
     </div>
   );


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #20948
- [X] Include a change request file using `$ yarn change`

#### Description of changes

**Type of change:**
- [X] Bug
- [ ] User Story

**Issue / User story:**
Icons gets translated/ messed up when translating a page using google translate to some other languages

![image](https://user-images.githubusercontent.com/47146595/146643749-f212cf09-9efe-432d-8c75-00f23061a95f.png)


**Issue analysis / Design:**
Any client browser assumes the icon tag as a normal text and try to translate that which eventually translates that as unknown.  

**Proposed fix/change:**
Added the  translate="no" tag for all the icons element tag

![image](https://user-images.githubusercontent.com/47146595/146643666-646ac93f-e654-4867-a972-d9b8ddeabe9e.png)