### PR TITLE
breaking: MenuTrigger must be the first child of the `Menu`

### DIFF
--- a/change/@fluentui-react-menu-faccd61d-d9b2-4508-bd9d-b8b5ac2a360b.json
+++ b/change/@fluentui-react-menu-faccd61d-d9b2-4508-bd9d-b8b5ac2a360b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "breaking: MenuTrigger must be the first child of the `Menu`",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/e2e/Menu.e2e.ts
+++ b/packages/react-menu/e2e/Menu.e2e.ts
@@ -4,6 +4,7 @@ const customTriggerStory = 'CustomTrigger';
 const selectionGroupStory = 'SelectionGroup';
 const nestedMenuStory = 'NestedSubmenus';
 const nestedMenuControlledStory = 'NestedSubmenusControlled';
+const anchorToCustomTargetStory = 'AnchorToCustomTarget';
 
 const menuStoriesTitle = 'Components/Menu';
 
@@ -75,6 +76,28 @@ describe('Menu', () => {
         .click('bottomRight')
         .get(menuSelector)
         .should('not.exist');
+    });
+  });
+
+  describe('Usage without trigger', () => {
+    it('should be able to share the same anchor target', () => {
+      cy.loadStory(menuStoriesTitle, anchorToCustomTargetStory)
+        .get(menuSelector)
+        .should('have.length', 0)
+        .get('body')
+        .contains('Open menu')
+        .click()
+        .get(menuSelector)
+        .should('be.visible')
+        .get('body')
+        .click('bottomRight')
+        .get(menuSelector)
+        .should('not.exist')
+        .get('body')
+        .contains('Custom target')
+        .click()
+        .get(menuSelector)
+        .should('be.visible');
     });
   });
 

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -32,7 +32,7 @@ export const useMenu = (props: MenuProps): MenuState => {
   const children = React.Children.toArray(props.children) as React.ReactElement[];
 
   if (process.env.NODE_ENV !== 'production') {
-    if (children.length == 0) {
+    if (children.length === 0) {
       // eslint-disable-next-line no-console
       console.warn('Menu must contain at least one child');
     }

--- a/packages/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-menu/src/components/Menu/useMenu.tsx
@@ -4,7 +4,6 @@ import { useControllableState, useId, useOnClickOutside, useEventCallback } from
 import { useFluent } from '@fluentui/react-shared-contexts';
 import { elementContains } from '@fluentui/react-portal';
 import { useFocusFinders } from '@fluentui/react-tabster';
-import { MenuTrigger } from '../MenuTrigger/index';
 import { useMenuContext } from '../../contexts/menuContext';
 import { MENU_ENTER_EVENT, useOnMenuMouseEnter } from '../../utils/index';
 import { useIsSubmenu } from '../../utils/useIsSubmenu';
@@ -32,20 +31,26 @@ export const useMenu = (props: MenuProps): MenuState => {
 
   const children = React.Children.toArray(props.children) as React.ReactElement[];
 
-  if (children.length !== 2 && process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line no-console
-    console.warn('Menu can only take one MenuTrigger and one MenuList as children');
-  }
-
-  const { menuTrigger, menuPopover } = children.reduce((acc, child) => {
-    if (child.type === MenuTrigger) {
-      acc.menuTrigger = child;
-    } else {
-      acc.menuPopover = child;
+  if (process.env.NODE_ENV !== 'production') {
+    if (children.length == 0) {
+      // eslint-disable-next-line no-console
+      console.warn('Menu must contain at least one child');
     }
 
-    return acc;
-  }, {} as Pick<MenuState, 'menuTrigger' | 'menuPopover'>);
+    if (children.length > 2) {
+      // eslint-disable-next-line no-console
+      console.warn('Menu must contain at most two children');
+    }
+  }
+
+  let menuTrigger: React.ReactElement | undefined = undefined;
+  let menuPopover: React.ReactElement | undefined = undefined;
+  if (children.length === 2) {
+    menuTrigger = children[0];
+    menuPopover = children[1];
+  } else if (children.length === 1) {
+    menuPopover = children[0];
+  }
   const { targetRef: triggerRef, containerRef: menuPopoverRef } = usePopper(popperState);
 
   const initialState = {

--- a/packages/react-menu/src/stories/MenuBestPractices.md
+++ b/packages/react-menu/src/stories/MenuBestPractices.md
@@ -5,12 +5,11 @@
 
 ### Do
 
+- Use `MenuTrigger` as the first child of `Menu`.
 - Use `MenuList` as the only child of `MenuPopover`.
 - Create nested menus as separate components.
 - Use the `hasIcons` prop for alignment if only some menu items have icons.
 - Use the `hasCheckmarks` prop for alignment if only some menu items are selectable.
-- Use sentence-style capitalization—only capitalize the first word. For more info, see
-  [Capitalization](https://docs.microsoft.com/en-us/style-guide/capitalization) in the Microsoft Writing Style Guide.
 
 ### Don't
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes partially #18317
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In order to support different types of menu trigger such as split
items and have more flexibility with the component, the `Menu` component
no longer does a runtime check to find a `MenuTrigger`component.

Now the usage of the `Menu` must have `MenuTrigger` as the first child.
This is already implicitly the case in all the documentation examples.
Added a documentation snippet to state this explicitly in the `Menu`
docs.

Added a test to make sure that the usage of `Menu` without a
`MenuTrigger` is still possible and does not regress.

#### Focus areas to test

(optional)
