### PR TITLE
feat(react-conformance): add tsconfigDir config + change tsconfig default dir to componentPath

### DIFF
--- a/change/@fluentui-react-conformance-7ec1375c-c01f-4dcd-b4a8-ef2c353b237d.json
+++ b/change/@fluentui-react-conformance-7ec1375c-c01f-4dcd-b4a8-ef2c353b237d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add option 'tsconfigDir'; change default tsconfig dir to component path",
+  "packageName": "@fluentui/react-conformance",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-conformance/src/isConformant.ts
+++ b/packages/react-conformance/src/isConformant.ts
@@ -8,14 +8,14 @@ import { getComponentDoc } from './utils/getComponentDoc';
 
 export function isConformant<TProps = {}>(...testInfo: Partial<IsConformantOptions<TProps>>[]) {
   const mergedOptions = merge<IsConformantOptions>(...testInfo);
-  const { componentPath, displayName, disabledTests = [], extraTests } = mergedOptions;
+  const { componentPath, displayName, disabledTests = [], extraTests, tsconfigDir } = mergedOptions;
 
   describe('isConformant', () => {
     if (!fs.existsSync(componentPath)) {
       throw new Error(`Path ${componentPath} does not exist`);
     }
 
-    const tsProgram = createTsProgram(componentPath);
+    const tsProgram = createTsProgram(componentPath, tsconfigDir);
 
     const components = getComponentDoc(componentPath, tsProgram);
     const mainComponents = components.filter(comp => comp.displayName === displayName);

--- a/packages/react-conformance/src/types.ts
+++ b/packages/react-conformance/src/types.ts
@@ -94,6 +94,11 @@ export interface IsConformantOptions<TProps = {}> {
    * This is 'root' by default, and only needs to be specified if it's a slot other than 'root'.
    */
   primarySlot?: keyof TProps | 'root';
+
+  /**
+   * Directory to tsconfig.json
+   */
+  tsconfigDir?: string;
 }
 
 export type ConformanceTest<TProps = {}> = (

--- a/packages/react-conformance/src/types.ts
+++ b/packages/react-conformance/src/types.ts
@@ -96,7 +96,8 @@ export interface IsConformantOptions<TProps = {}> {
   primarySlot?: keyof TProps | 'root';
 
   /**
-   * Directory to tsconfig.json
+   * Test will load the first tsconfig.json file working upwards from `tsconfigDir`.
+   * The default value of `tsconfigDir` is the directory of the component being tested
    */
   tsconfigDir?: string;
 }

--- a/packages/react-conformance/src/types.ts
+++ b/packages/react-conformance/src/types.ts
@@ -97,7 +97,7 @@ export interface IsConformantOptions<TProps = {}> {
 
   /**
    * Test will load the first tsconfig.json file working upwards from `tsconfigDir`.
-   * The default value of `tsconfigDir` is the directory of the component being tested
+   * @defaultvalue the directory of the component being tested
    */
   tsconfigDir?: string;
 }

--- a/packages/react-conformance/src/utils/createTsProgram.ts
+++ b/packages/react-conformance/src/utils/createTsProgram.ts
@@ -7,13 +7,13 @@ let program: ts.Program;
 /**
  * Creates a cached TS Program.
  */
-export function createTsProgram(componentPath: string): ts.Program {
+export function createTsProgram(componentPath: string, tsconfigDir?: string): ts.Program {
   if (!program) {
     // Calling parse() from react-docgen-typescript would create a new ts.Program for every component,
     // which can take multiple seconds in a large project. For better performance, we create a single
     // ts.Program per package and pass it to parseWithProgramProvider().
 
-    const tsconfigPath = ts.findConfigFile(process.cwd(), fs.existsSync);
+    const tsconfigPath = ts.findConfigFile(tsconfigDir ?? componentPath, fs.existsSync);
 
     if (!tsconfigPath) {
       throw new Error('Cannot find tsconfig.json');


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

react-conformance is requesting tsconfig.json.
Before this PR, it always tries to look for tsconfig.json in `process.cwd()` and its ancestor directories. But this is not always the case: when running test from the root of a monorepo, `process.cwd()` is the project root, which does not always have tsconfig.json. 

This PR makes the path to tsconfig.json configurable through `tsconfigDir`. typescript `findConfigFile` will use tsconfigDir as starting point and work upwards to find the closest tsconfig.json.
This PR also changed the default starting point, from `process.cwd()` to component path.

#### Focus areas to test

(optional)
