### PR TITLE
Publish react-input and add to react-components under unstable

### DIFF
--- a/apps/pr-deploy-site/just.config.ts
+++ b/apps/pr-deploy-site/just.config.ts
@@ -26,7 +26,6 @@ const dependencies = [
   '@fluentui/react-charting',
   '@fluentui/react-components',
   '@fluentui/react-experiments',
-  '@fluentui/react-input',
   '@fluentui/web-components',
   'perf-test',
   'theming-designer',

--- a/apps/pr-deploy-site/pr-deploy-site.js
+++ b/apps/pr-deploy-site/pr-deploy-site.js
@@ -55,12 +55,6 @@ var siteInfo = [
     title: 'Charting',
   },
   {
-    package: '@fluentui/react-input',
-    link: './react-input/storybook/index.html',
-    icon: 'TextField',
-    title: 'Input',
-  },
-  {
     package: 'theming-designer',
     link: './theming-designer/index.html',
     icon: 'CheckMark',

--- a/change/@fluentui-react-components-ea4050e0-fb62-4709-a678-0baf10d7bcfa.json
+++ b/change/@fluentui-react-components-ea4050e0-fb62-4709-a678-0baf10d7bcfa.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Add Input to react-components",
+  "comment": "Add Input components (exported as /unstable)",
   "packageName": "@fluentui/react-components",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-components-ea4050e0-fb62-4709-a678-0baf10d7bcfa.json
+++ b/change/@fluentui-react-components-ea4050e0-fb62-4709-a678-0baf10d7bcfa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add Input to react-components",
+  "packageName": "@fluentui/react-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-c5b897ac-9f07-4c14-8dcf-16702a2e9e1a.json
+++ b/change/@fluentui-react-input-c5b897ac-9f07-4c14-8dcf-16702a2e9e1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Publish react-input",
+  "packageName": "@fluentui/react-input",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-c5b897ac-9f07-4c14-8dcf-16702a2e9e1a.json
+++ b/change/@fluentui-react-input-c5b897ac-9f07-4c14-8dcf-16702a2e9e1a.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Publish react-input",
+  "comment": "Initial release",
   "packageName": "@fluentui/react-input",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -46,6 +46,7 @@
     "@fluentui/react-card": "9.0.0-beta.5",
     "@fluentui/react-divider": "9.0.0-beta.4",
     "@fluentui/react-image": "9.0.0-beta.4",
+    "@fluentui/react-input": "9.0.0-beta.0",
     "@fluentui/react-label": "9.0.0-beta.4",
     "@fluentui/react-link": "9.0.0-beta.5",
     "@fluentui/react-make-styles": "9.0.0-beta.4",

--- a/packages/react-components/src/unstable/index.ts
+++ b/packages/react-components/src/unstable/index.ts
@@ -40,3 +40,5 @@ export type {
   CardSlots,
   CardState,
 } from '@fluentui/react-card';
+export { Input, inputClassName, renderInput, useInput, useInputStyles } from '@fluentui/react-input';
+export type { InputOnChangeData, InputProps, InputSlots, InputState } from '@fluentui/react-input';

--- a/packages/react-input/package.json
+++ b/packages/react-input/package.json
@@ -2,7 +2,6 @@
   "name": "@fluentui/react-input",
   "version": "9.0.0-beta.0",
   "description": "Fluent UI React Input component",
-  "private": true,
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/react-input/src/components/Input/Input.tsx
+++ b/packages/react-input/src/components/Input/Input.tsx
@@ -7,6 +7,8 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 
 /**
  * The Input component allows people to enter and edit text.
+ *
+ * ⚠️ **This component is still in alpha (unstable) status. APIs may change before the final release.**
  */
 export const Input: ForwardRefComponent<InputProps> = React.forwardRef((props, ref) => {
   const state = useInput(props, ref);

--- a/packages/react-input/src/stories/Input.stories.tsx
+++ b/packages/react-input/src/stories/Input.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta = {
           ...(context.viewMode === 'docs' && {
             // docs mode has buttons on the bottom right which cover the input
             // if it's allowed to be full width
-            maxWidth: '600px',
+            maxWidth: '500px',
             // and the corners of the rounded box clip the example
             padding: '24px',
           }),


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: part of #18131, #20936
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Publish the `@fluentui/react-input` package and add it to `@fluentui/react-components/unstable`.

Since Input is now available in the react-components storybook, I removed its separate pr-deploy-site entry.
