### PR TITLE
Add workaround for Cypress issue on Windows (non-WSL)

### DIFF
--- a/change/@fluentui-react-menu-1422f6f8-159f-4fbb-8ab3-58e24e923beb.json
+++ b/change/@fluentui-react-menu-1422f6f8-159f-4fbb-8ab3-58e24e923beb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add workaround for cypress bug",
+  "packageName": "@fluentui/react-menu",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-aaf223d9-a59d-4043-8673-01dcea0a4caa.json
+++ b/change/@fluentui-react-popover-aaf223d9-a59d-4043-8673-01dcea0a4caa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add workaround for cypress bug",
+  "packageName": "@fluentui/react-popover",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-262e9d2a-fb1e-4972-8236-654d9a3c2b85.json
+++ b/change/@fluentui-react-tabster-262e9d2a-fb1e-4972-8236-654d9a3c2b85.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add workaround for cypress bug",
+  "packageName": "@fluentui/react-tabster",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/packages/react-menu/e2e/support.js
+++ b/packages/react-menu/e2e/support.js
@@ -1,0 +1,2 @@
+// workaround for https://github.com/cypress-io/cypress/issues/8599
+import '@fluentui/scripts/cypress/support';

--- a/packages/react-popover/e2e/support.js
+++ b/packages/react-popover/e2e/support.js
@@ -1,0 +1,2 @@
+// workaround for https://github.com/cypress-io/cypress/issues/8599
+import '@fluentui/scripts/cypress/support';

--- a/packages/react-tabster/e2e/support.js
+++ b/packages/react-tabster/e2e/support.js
@@ -1,0 +1,2 @@
+// workaround for https://github.com/cypress-io/cypress/issues/8599
+import '@fluentui/scripts/cypress/support';

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -8,11 +8,23 @@ const path = require('path');
  * https://github.com/cypress-io/cypress/issues/5674
  */
 
+const argv = require('yargs')
+  .option('mode', {
+    describe: 'Choose a mode to run cypress',
+    choices: ['run', 'open'],
+  })
+  .option('port', {
+    describe: 'Port number storybook is running on',
+    default: 3000,
+    type: 'number',
+  })
+  .demandOption('mode').argv;
+
 const baseConfig = {
   baseUrl: process.env.DEPLOYURL
     ? // Base path hard coded for converged for now, can be modified to be configurable if required to other projects
       `${process.env.DEPLOYURL}/react-components/storybook`
-    : 'http://localhost:3000',
+    : `http://localhost:${argv.port}`,
   fixturesFolder: path.join(__dirname, 'cypress/fixtures'),
   integrationFolder: '.',
   pluginsFile: path.join(__dirname, 'cypress/plugins/index.js'),
@@ -27,7 +39,6 @@ const baseConfig = {
   testFiles: ['**/e2e/**/*.e2e.ts'],
   video: false,
 };
-console.dir(baseConfig);
 
 const run = () => {
   return cypress.run({
@@ -46,13 +57,6 @@ const open = () => {
     },
   });
 };
-
-const argv = require('yargs')
-  .option('mode', {
-    describe: 'Choose a mode to run cypress',
-    choices: ['run', 'open'],
-  })
-  .demandOption('mode').argv;
 
 if (argv.mode === 'open') {
   open();

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -13,18 +13,21 @@ const baseConfig = {
     ? // Base path hard coded for converged for now, can be modified to be configurable if required to other projects
       `${process.env.DEPLOYURL}/react-components/storybook`
     : 'http://localhost:3000',
-  fixturesFolder: path.relative(process.cwd(), path.resolve(__dirname, 'cypress/fixtures')),
+  fixturesFolder: path.join(__dirname, 'cypress/fixtures'),
   integrationFolder: '.',
-  pluginsFile: path.relative(process.cwd(), path.resolve(__dirname, 'cypress/plugins/index.js')),
+  pluginsFile: path.join(__dirname, 'cypress/plugins/index.js'),
   retries: {
     runMode: 2,
     openMode: 0,
   },
   screenshotOnRunFailure: false,
-  supportFile: path.relative(process.cwd(), path.resolve(__dirname, 'cypress/support/index.js')),
+  // due to https://github.com/cypress-io/cypress/issues/8599 this must point to a path within the package,
+  // not a relative path into scripts
+  supportFile: 'e2e/support.js',
   testFiles: ['**/e2e/**/*.e2e.ts'],
   video: false,
 };
+console.dir(baseConfig);
 
 const run = () => {
   return cypress.run({

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -710,6 +710,7 @@ describe('migrate-converged-pkg generator', () => {
       const projectConfig = readProjectConfiguration(tree, config.projectName);
       const paths = {
         e2eRoot: `${projectConfig.root}/e2e`,
+        e2eSupport: `${projectConfig.root}/e2e/support.js`,
         packageJson: `${projectConfig.root}/package.json`,
         tsconfig: {
           main: `${projectConfig.root}/tsconfig.json`,
@@ -771,6 +772,13 @@ describe('migrate-converged-pkg generator', () => {
         include: ['**/*.ts'],
       });
       expect(mainTsConfig.references).toEqual(expect.arrayContaining([{ path: './e2e/tsconfig.json' }]));
+
+      // support.js
+      const supportFile = tree.read(paths.e2eSupport)?.toString('utf-8');
+      expect(supportFile).toMatchInlineSnapshot(`
+        "// workaround for https://github.com/cypress-io/cypress/issues/8599
+        import '@fluentui/scripts/cypress/support';"
+      `);
 
       // package.json updates
       const packageJson: PackageJson = readJson(tree, paths.packageJson);

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -273,6 +273,10 @@ const templates = {
     },
   },
   e2e: {
+    support: stripIndents`
+    // workaround for https://github.com/cypress-io/cypress/issues/8599
+    import '@fluentui/scripts/cypress/support';
+    `,
     tsconfig: {
       extends: '../tsconfig.json',
       compilerOptions: {
@@ -709,6 +713,8 @@ function setupE2E(tree: Tree, options: NormalizedSchema) {
   tree.rename(joinPathFragments(options.paths.e2e.rootFolder, 'tsconfig.json'), options.paths.e2e.tsconfig);
 
   writeJson<TsConfig>(tree, options.paths.e2e.tsconfig, templates.e2e.tsconfig);
+
+  tree.write(options.paths.e2e.support, templates.e2e.support);
 
   updateJson(tree, options.paths.tsconfig.main, (json: TsConfig) => {
     json.references?.push({

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -107,6 +107,7 @@ export function getProjectConfig(tree: Tree, options: { packageName: string }) {
     },
     e2e: {
       rootFolder: joinPathFragments(projectConfig.root, 'e2e'),
+      support: joinPathFragments(projectConfig.root, 'e2e', 'support.js'),
       tsconfig: joinPathFragments(projectConfig.root, 'e2e', 'tsconfig.json'),
     },
   };


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

There's a [Cypress bug](https://github.com/cypress-io/cypress/issues/8599) where it improperly handles relative `supportFile` paths containing `..` segments on Windows non-WSL, causing an error like this (note the joining of two absolute paths):
```
Oops...we found an error preparing this test file:

  ..\..\scripts\cypress\support\index.js

The error was:

Error: EINVAL: invalid argument, mkdir 'C:\Users\elcraig\AppData\Roaming\Cypress\cy\production\projects\react-menu-63ba5bf5c951cc04cc81cc84c8c3f022\bundles\D:\git\fluentui\scripts\cypress\support'
```
 
I tried to debug the issue in Cypress but couldn't figure out which code was generating the bad path, so instead I implemented the workaround described in https://github.com/cypress-io/cypress/issues/8599#issuecomment-757977286: create `e2e/support.js` (which imports `@fluentui/scripts/cypress/support`) in each individual package, then set `supportFile` to `e2e/support.js`.

Note that if you want to try and debug this further, you'll need a repo clone on Windows *outside* WSL, and the actual Cypress files that you'll want to search/debug in are under `C:\Users\<you>\AppData\Local\Cypress\Cache\<version>\Cypress` rather than `node_modules`.

(Also added a `--port` option to the `e2e` script in case you're already running storybook on a different port number.)