### PR TITLE
Remove outdated or unused boilerplate comments and types

### DIFF
--- a/change/@fluentui-react-badge-02ab58cb-4550-4fe4-a652-70fea147324e.json
+++ b/change/@fluentui-react-badge-02ab58cb-4550-4fe4-a652-70fea147324e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove outdated boilerplate comments",
+  "packageName": "@fluentui/react-badge",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-card-44d69321-d166-4988-b3e9-9672c6f95f49.json
+++ b/change/@fluentui-react-card-44d69321-d166-4988-b3e9-9672c6f95f49.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove empty CardCommons type and outdated boilerplate comments",
+  "packageName": "@fluentui/react-card",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-5af6dd84-ecda-4733-8732-7819f8368484.json
+++ b/change/@fluentui-react-label-5af6dd84-ecda-4733-8732-7819f8368484.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Relocate comment about props to the correct type, and update spec to accurately reflect props",
+  "packageName": "@fluentui/react-label",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-db9f0c54-986d-407e-a0f0-c84cf44b74a5.json
+++ b/change/@fluentui-react-tooltip-db9f0c54-986d-407e-a0f0-c84cf44b74a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove outdated boilerplate comment in useTooltip",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-badge/src/components/CounterBadge/CounterBadge.types.ts
+++ b/packages/react-badge/src/components/CounterBadge/CounterBadge.types.ts
@@ -44,12 +44,6 @@ export type CounterBadgeCommons = {
   color: Extract<BadgeProps['color'], 'brand' | 'danger' | 'important' | 'informative'>;
 };
 
-/**
- * {@docCategory CounterBadge}
- */
 export type CounterBadgeProps = Omit<BadgeProps, 'appearance' | 'shape' | 'color'> & Partial<CounterBadgeCommons>;
 
-/**
- * {@docCategory CounterBadge}
- */
 export type CounterBadgeState = Omit<BadgeState, 'appearance' | 'shape' | 'color'> & CounterBadgeCommons;

--- a/packages/react-card/etc/react-card.api.md
+++ b/packages/react-card/etc/react-card.api.md
@@ -16,9 +16,6 @@ export const Card: ForwardRefComponent<CardProps>;
 // @public (undocumented)
 export const cardClassName = "fui-Card";
 
-// @public (undocumented)
-export type CardCommons = {};
-
 // @public
 export const CardFooter: ForwardRefComponent<CardFooterProps>;
 
@@ -87,7 +84,7 @@ export type CardPreviewSlots = {
 export type CardPreviewState = ComponentState<CardPreviewSlots>;
 
 // @public
-export type CardProps = ComponentProps<CardSlots> & Partial<CardCommons>;
+export type CardProps = ComponentProps<CardSlots>;
 
 // @public (undocumented)
 export type CardSlots = {
@@ -95,7 +92,7 @@ export type CardSlots = {
 };
 
 // @public
-export type CardState = ComponentState<CardSlots> & CardCommons;
+export type CardState = ComponentState<CardSlots>;
 
 // @public
 export const renderCard: (state: CardState) => JSX.Element;

--- a/packages/react-card/src/components/Card/Card.types.ts
+++ b/packages/react-card/src/components/Card/Card.types.ts
@@ -4,20 +4,12 @@ export type CardSlots = {
   root: IntrinsicShorthandProps<'div'>;
 };
 
-export type CardCommons = {
-  /*
-   * TODO Add props and slots here
-   * Any slot property should be listed in the cardShorthandProps array below
-   * Any property that has a default value should be listed in CardDefaultedProps as e.g. 'size' | 'icon'
-   */
-};
-
 /**
  * Card Props
  */
-export type CardProps = ComponentProps<CardSlots> & Partial<CardCommons>;
+export type CardProps = ComponentProps<CardSlots>;
 
 /**
  * State used in rendering Card
  */
-export type CardState = ComponentState<CardSlots> & CardCommons;
+export type CardState = ComponentState<CardSlots>;

--- a/packages/react-components/src/unstable/index.ts
+++ b/packages/react-components/src/unstable/index.ts
@@ -26,7 +26,6 @@ export {
   useCardStyles,
 } from '@fluentui/react-card';
 export type {
-  CardCommons,
   CardFooterProps,
   CardFooterSlots,
   CardFooterState,

--- a/packages/react-label/Spec.md
+++ b/packages/react-label/Spec.md
@@ -75,55 +75,48 @@ The Label component should be simple as shown below. It will just need the text 
 ## API
 
 ```ts
-/**
- * Label Props
- */
-export type LabelProps = ComponentProps &
-  React.LabelHTMLAttributes<HTMLElement> & {
-    /**
-     * Renders the label as disabled
-     * @defaultvalue false
-     */
-    disabled?: boolean;
+export type LabelCommons = {
+  /**
+   * Renders the label as disabled
+   * @defaultvalue false
+   */
+  disabled: boolean;
 
-    /**
-     * Whether the associated form field is required or not. If true it will be an asterisk, otherwise it will be what is provided.
-     * @defaultvalue false
-     */
-    required?: boolean | ShorthandProps<ComponentProps>;
+  /**
+   * A label supports different sizes.
+   * @defaultvalue 'medium'
+   */
+  size: 'small' | 'medium' | 'large';
 
-    /**
-     * A label supports different font sizes, see tokens for reference.
-     * @defaultvalue 'medium'
-     */
-    size?: 'small' | 'medium' | 'large';
+  /**
+   * A label supports semibold/strong fontweight.
+   * @defaultvalue false
+   */
+  strong: boolean;
+};
 
-    /**
-     * A label supports semibold/strong fontweight. When size is set to large, label strong will be set by default.
-     * @defaultvalue false
-     */
-    strong?: boolean;
-  };
-
-/**
- * Names of the shorthand properties in LabelProps
- */
-export type LabelShorthandProps = 'required';
-
-/**
- * Names of LabelProps that have a default value in useLabel
- */
-export type LabelDefaultedProps = never;
+export type LabelSlots = {
+  root: IntrinsicShorthandProps<'label'>;
+  required?: IntrinsicShorthandProps<'span'>;
+};
 
 /**
  * State used in rendering Label
  */
-export type LabelState = ComponentState<LabelProps, LabelShorthandProps, LabelDefaultedProps> & {
-  /**
-   * Ref to the root element
-   */
-  ref: React.Ref<HTMLElement>;
-};
+export type LabelState = ComponentState<LabelSlots> & LabelCommons;
+
+/**
+ * Label Props
+ */
+export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> &
+  Partial<LabelCommons> & {
+    /**
+     * Displays and indicator that the label is for a required field. The required prop can be set to true to display
+     * an asterisk (*). Or it can be set to a string or jsx content to display a different indicator.
+     * @defaultvalue false
+     */
+    required?: boolean | ObjectShorthandProps<React.HTMLAttributes<HTMLElement>> | React.ReactNode;
+  };
 ```
 
 ## Structure

--- a/packages/react-label/etc/react-label.api.md
+++ b/packages/react-label/etc/react-label.api.md
@@ -17,14 +17,14 @@ export const Label: ForwardRefComponent<LabelProps>;
 // @public (undocumented)
 export const labelClassName = "fui-Label";
 
-// @public
+// @public (undocumented)
 export type LabelCommons = {
     disabled: boolean;
     size: 'small' | 'medium' | 'large';
     strong: boolean;
 };
 
-// @public (undocumented)
+// @public
 export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> & Partial<LabelCommons> & {
     required?: boolean | ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>> | React_2.ReactNode;
 };

--- a/packages/react-label/src/components/Label/Label.types.ts
+++ b/packages/react-label/src/components/Label/Label.types.ts
@@ -6,9 +6,6 @@ import type {
 } from '@fluentui/react-utilities';
 import * as React from 'react';
 
-/**
- * Label Props
- */
 export type LabelCommons = {
   /**
    * Renders the label as disabled
@@ -39,6 +36,9 @@ export type LabelSlots = {
  */
 export type LabelState = ComponentState<LabelSlots> & LabelCommons;
 
+/**
+ * Label Props
+ */
 export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> &
   Partial<LabelCommons> & {
     /**

--- a/packages/react-radio/etc/react-radio.api.md
+++ b/packages/react-radio/etc/react-radio.api.md
@@ -19,12 +19,6 @@ export const Radio: ForwardRefComponent<RadioProps>;
 // @public (undocumented)
 export const radioClassName = "fui-Radio";
 
-// @public (undocumented)
-export type RadioCommons = {};
-
-// @public
-export type RadioDefaultedProps = never;
-
 // @public
 export const RadioItem: ForwardRefComponent<RadioItemProps>;
 
@@ -58,10 +52,7 @@ export type RadioItemSlots = {
 export type RadioItemState = ComponentState<RadioItemSlots> & RadioItemCommons;
 
 // @public
-export type RadioProps = ComponentProps<RadioSlots> & Partial<RadioCommons> & {};
-
-// @public
-export type RadioShorthandProps = never;
+export type RadioProps = ComponentProps<RadioSlots>;
 
 // @public
 export const radioShorthandProps: Array<keyof RadioSlots>;
@@ -72,7 +63,7 @@ export type RadioSlots = {
 };
 
 // @public
-export type RadioState = ComponentState<RadioSlots> & RadioCommons;
+export type RadioState = ComponentState<RadioSlots>;
 
 // @public
 export const renderRadio: (state: RadioState) => JSX.Element;

--- a/packages/react-radio/src/components/Radio/Radio.types.ts
+++ b/packages/react-radio/src/components/Radio/Radio.types.ts
@@ -4,30 +4,12 @@ export type RadioSlots = {
   root: IntrinsicShorthandProps<'span'>;
 };
 
-export type RadioCommons = {};
 /**
  * Radio Props
  */
-export type RadioProps = ComponentProps<RadioSlots> &
-  Partial<RadioCommons> & {
-    /*
-     * TODO Add props and slots here
-     * Any slot property should be listed in the radioShorthandProps array below
-     * Any property that has a default value should be listed in RadioDefaultedProps as e.g. 'size' | 'icon'
-     */
-  };
-
-/**
- * Names of the shorthand properties in RadioProps
- */
-export type RadioShorthandProps = never; // TODO add shorthand property names
-
-/**
- * Names of RadioProps that have a default value in useRadio
- */
-export type RadioDefaultedProps = never; // TODO add names of properties with default values
+export type RadioProps = ComponentProps<RadioSlots>;
 
 /**
  * State used in rendering Radio
  */
-export type RadioState = ComponentState<RadioSlots> & RadioCommons;
+export type RadioState = ComponentState<RadioSlots>;

--- a/packages/react-radio/src/components/Radio/useRadio.ts
+++ b/packages/react-radio/src/components/Radio/useRadio.ts
@@ -15,7 +15,6 @@ export const radioShorthandProps: Array<keyof RadioSlots> = ['root'];
  *
  * @param props - props from this instance of Radio
  * @param ref - reference to root HTMLElement of Radio
- * @param defaultProps - (optional) default prop values provided by the implementing type
  */
 export const useRadio = (props: RadioProps, ref: React.Ref<HTMLElement>): RadioState => {
   const state: RadioState = {

--- a/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -25,7 +25,6 @@ const arrowHeight = 6; // Update the arrow's width/height in useTooltipStyles.ts
  *
  * @param props - props from this instance of Tooltip
  * @param ref - reference to root HTMLElement of Tooltip
- * @param defaultProps - (optional) default prop values provided by the implementing type
  */
 export const useTooltip = (props: TooltipProps, ref: React.Ref<HTMLDivElement>): TooltipState => {
   const context = React.useContext(TooltipContext);


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

A few components still had outdated boilerplate from previous versions of the component template, such as `___DefaultedProps` types (or comments mentioning the type), `___ShorthandProps` types, or `@docCategory` tags. Remove those comments and types, as well as references to them in the specs where possible.

In types files where I was already making changes, if there was an empty `___Commons` type (which was where one of the outdated boilerplate comments was), I deleted that as well since it doesn't serve any purpose and can be added back later if needed without a breaking change. I can revert this part if desired.