### PR TITLE
react-components: Stop generating a folder with a file inside and instead flatten to a single file for 'Migrating from @fluentui/react v8' storybook story

### DIFF
--- a/change/@fluentui-react-components-059500c6-1617-4bd9-9f42-ea4726c5ece3.json
+++ b/change/@fluentui-react-components-059500c6-1617-4bd9-9f42-ea4726c5ece3.json
@@ -1,7 +1,7 @@
 {
-  "type": "prerelease",
+  "type": "none",
   "comment": "react-components: Stop generating a folder with a file inside and instead flatten to a single file for 'Migrating from @fluentui/react v8' storybook story.",
   "packageName": "@fluentui/react-components",
   "email": "Humberto.Morimoto@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@fluentui-react-components-059500c6-1617-4bd9-9f42-ea4726c5ece3.json
+++ b/change/@fluentui-react-components-059500c6-1617-4bd9-9f42-ea4726c5ece3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "react-components: Stop generating a folder with a file inside and instead flatten to a single file for 'Migrating from @fluentui/react v8' storybook story.",
+  "packageName": "@fluentui/react-components",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/.storybook/preview.js
+++ b/packages/react-components/.storybook/preview.js
@@ -17,7 +17,7 @@ const options = {
       [
         'Introduction',
         'Developer',
-        ['Quick Start', 'Migrating from @fluentui/react v8', 'Styling Components', 'Positioning Components'],
+        ['Quick Start', 'Migrating from @fluentui᜵react v8', 'Styling Components', 'Positioning Components'],
       ],
       'Theme',
       'Components',

--- a/packages/react-components/src/Concepts/MigratingFromV8.stories.mdx
+++ b/packages/react-components/src/Concepts/MigratingFromV8.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs';
 
-<Meta title="Concepts/Developer/Migrating from @fluentui/react v8" />
+<Meta title="Concepts/Developer/Migrating from @fluentui᜵react v8" />
 
 ## Moving to `@fluentui/react-components` version 9-BETA from `@fluentui/react` version 8
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The `/` character in `@fluentui/react` under the title of the "Migrating from @fluentui/react v8" story was causing a "Migrating from @fluentui" folder with a "react v8" file inside to be generated. Replacing this character with a similar unicode character (`᜵`) that is not the forward slash fixes the issue and flattens the structure into a single file.