### PR TITLE
Update Avatar to use resizable icons

### DIFF
--- a/change/@fluentui-react-avatar-c49124f1-8234-4517-8772-40dd06e2157e.json
+++ b/change/@fluentui-react-avatar-c49124f1-8234-4517-8772-40dd06e2157e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update Avatar to use resizable icons",
+  "packageName": "@fluentui/react-avatar",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-avatar/src/AvatarIcon.stories.tsx
+++ b/packages/react-avatar/src/AvatarIcon.stories.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { Guest20Regular } from '@fluentui/react-icons';
+import { GuestRegular } from '@fluentui/react-icons';
 
 import { Avatar, AvatarProps } from './index';
 
 export const Icon = (props: Partial<AvatarProps>) => {
-  return <Avatar {...props} icon={<Guest20Regular />} />;
+  return <Avatar {...props} icon={<GuestRegular />} />;
 };
 
 Icon.parameters = {

--- a/packages/react-avatar/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/react-avatar/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -180,9 +180,9 @@ exports[`Avatar renders a default state 1`] = `
       aria-hidden={true}
       className=""
       fill="currentColor"
-      height={20}
+      height="1em"
       viewBox="0 0 20 20"
-      width={20}
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -222,9 +222,9 @@ exports[`Avatar renders an icon if the name is not alphabetic 1`] = `
       aria-hidden={true}
       className=""
       fill="currentColor"
-      height={20}
+      height="1em"
       viewBox="0 0 20 20"
-      width={20}
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -249,9 +249,9 @@ exports[`Avatar renders an image 1`] = `
       aria-hidden={true}
       className=""
       fill="currentColor"
-      height={20}
+      height="1em"
       viewBox="0 0 20 20"
-      width={20}
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/packages/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -2,14 +2,7 @@ import * as React from 'react';
 import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
 import { getInitials as getInitialsDefault } from '../../utils/index';
 import type { AvatarNamedColor, AvatarProps, AvatarState } from './Avatar.types';
-import {
-  Person16Regular,
-  Person20Regular,
-  Person24Regular,
-  Person28Regular,
-  Person32Regular,
-  Person48Regular,
-} from '@fluentui/react-icons';
+import { PersonRegular } from '@fluentui/react-icons';
 import { PresenceBadge } from '@fluentui/react-badge';
 import { useFluent } from '@fluentui/react-shared-contexts';
 
@@ -67,29 +60,13 @@ export const useAvatar = (props: AvatarProps, ref: React.Ref<HTMLElement>): Avat
       state.icon = resolveShorthand(props.icon, {
         required: true,
         defaultProps: {
-          children: getDefaultIcon(state.size),
+          children: <PersonRegular />,
         },
       });
     }
   }
 
   return state;
-};
-
-const getDefaultIcon = (size: NonNullable<AvatarProps['size']>) => {
-  if (size <= 24) {
-    return <Person16Regular />;
-  } else if (size <= 40) {
-    return <Person20Regular />;
-  } else if (size <= 48) {
-    return <Person24Regular />;
-  } else if (size <= 56) {
-    return <Person28Regular />;
-  } else if (size <= 72) {
-    return <Person32Regular />;
-  } else {
-    return <Person48Regular />;
-  }
 };
 
 const getBadgeSize = (size: NonNullable<AvatarProps['size']>) => {

--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -198,6 +198,13 @@ const useStyles = makeStyles({
     textAlign: 'center',
     ...shorthands.borderRadius('inherit'),
   },
+
+  icon16: { fontSize: '16px' },
+  icon20: { fontSize: '20px' },
+  icon24: { fontSize: '24px' },
+  icon28: { fontSize: '28px' },
+  icon32: { fontSize: '32px' },
+  icon48: { fontSize: '48px' },
 });
 
 const useSizeStyles = makeStyles({
@@ -442,7 +449,22 @@ export const useAvatarStyles = (state: AvatarState): AvatarState => {
   }
 
   if (state.icon) {
-    state.icon.className = mergeClasses(styles.iconLabel, state.icon.className);
+    let iconSizeClass;
+    if (size <= 24) {
+      iconSizeClass = styles.icon16;
+    } else if (size <= 40) {
+      iconSizeClass = styles.icon20;
+    } else if (size <= 48) {
+      iconSizeClass = styles.icon24;
+    } else if (size <= 56) {
+      iconSizeClass = styles.icon28;
+    } else if (size <= 72) {
+      iconSizeClass = styles.icon32;
+    } else {
+      iconSizeClass = styles.icon48;
+    }
+
+    state.icon.className = mergeClasses(styles.iconLabel, iconSizeClass, state.icon.className);
   }
 
   return state;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #20968
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Split off from #21074 to update react-avatar in a different way. This sets `fontSize` on the icon slot using styles, instead of specifying a fontSize on the icon itself. This makes it so the icon is appropriately sized even if the user specifies a custom icon without a size.