### PR TITLE
GroupedList: removes aria-label attribute when rowgroup is empty.

### DIFF
--- a/change/@fluentui-react-0b4f7a14-5ede-4e1d-9ed9-e83d9eaf95ea.json
+++ b/change/@fluentui-react-0b4f7a14-5ede-4e1d-9ed9-e83d9eaf95ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "List: when role is removed, remove aria-label as well.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -3074,7 +3074,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           </div>
                         </div>
                         <div
-                          aria-label="Color: \\"green\\""
                           className="ms-List"
                           id="GroupedListSection11"
                         >

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -471,6 +471,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
         ...divProps,
         className: css('ms-List', className),
         role: pageElements.length > 0 ? role : undefined,
+        'aria-label': pageElements.length > 0 ? divProps['aria-label'] : undefined,
       },
     });
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [13148](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/13148)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- removes `aria-label` attribute using the same logic as when `role` is removed.
