### PR TITLE
(web-components) Update tab panel to base type size

### DIFF
--- a/change/@fluentui-web-components-0e8033b0-8a6d-486e-bb1f-c6d0054108b5.json
+++ b/change/@fluentui-web-components-0e8033b0-8a6d-486e-bb1f-c6d0054108b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update tab panel to base type size",
+  "packageName": "@fluentui/web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/tabs/tab-panel/tab-panel.styles.ts
+++ b/packages/web-components/src/tabs/tab-panel/tab-panel.styles.ts
@@ -1,6 +1,6 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import { display, ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
-import { bodyFont, density, designUnit, typeRampMinus1FontSize, typeRampMinus1LineHeight } from '../../design-tokens';
+import { bodyFont, density, designUnit, typeRampBaseFontSize, typeRampBaseLineHeight } from '../../design-tokens';
 
 export const tabPanelStyles: (
   context: ElementDefinitionContext,
@@ -9,9 +9,9 @@ export const tabPanelStyles: (
   ${display('block')} :host {
     box-sizing: border-box;
     font-family: ${bodyFont};
-    font-size: ${typeRampMinus1FontSize};
+    font-size: ${typeRampBaseFontSize};
     font-weight: 400;
-    line-height: ${typeRampMinus1LineHeight};
+    line-height: ${typeRampBaseLineHeight};
     padding: 0 calc((6 + (${designUnit} * 2 * ${density})) * 1px);
   }
 `;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

I noticed the tab panel was using a smaller size, though it should be treated as normal content. I believe this was an error in the original styling.

#### Focus areas to test

(optional)
