### PR TITLE
chore: bump react-transition-group from 4.3.0 to 4.4.1

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- bump react-transition-group from 4.3.0 to 4.4.1 @yuanboxue-amber ([#21187](https://github.com/microsoft/fluentui/pull/21187))
 
 <!--------------------------------[ v0.60.0 ]------------------------------- -->
 ## [v0.60.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.60.0) (2021-12-14)

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -26,7 +26,7 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react-is": "^16.6.3",
-    "react-transition-group": "^4.3.0"
+    "react-transition-group": "^4.4.1"
   },
   "devDependencies": {
     "@fluentui/a11y-testing": "*",

--- a/scripts/dangerjs/detectNonApprovedDependencies/approvedPackages.ts
+++ b/scripts/dangerjs/detectNonApprovedDependencies/approvedPackages.ts
@@ -97,7 +97,7 @@ export default [
   'react-is@16.8.2',
   'react-is@16.9.0',
   'react-resize-detector@4.2.0',
-  'react-transition-group@4.3.0',
+  'react-transition-group@4.4.1',
   'react@16.8.3',
   'resize-observer-polyfill@1.5.1',
   'rtl-css-js@1.11.0',

--- a/yarn.lock
+++ b/yarn.lock
@@ -21143,10 +21143,10 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-transition-group@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.3.0.tgz#fea832e386cf8796c58b61874a3319704f5ce683"
-  integrity sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==
+react-transition-group@^4.3.0, react-transition-group@^4.4.1:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
   dependencies:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

We uses react-transition-group `Transition` component `nodeRef` prop, which is released after 4.4.0.
Therefore this PR bumps react-transition-group to 4.4.1

#### Focus areas to test

(optional)
