### PR TITLE
fix(ChatMessage): use chat context as default value when user prop is explicitly undefined

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Fix `ChatMessage` to use chat context as default value when user prop is explicitly undefined @yuanboxue-amber ([#21189](https://github.com/microsoft/fluentui/pull/21189))
 
 <!--------------------------------[ v0.60.0 ]------------------------------- -->
 ## [v0.60.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.60.0) (2021-12-14)

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -229,9 +229,12 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
   });
 
   const props = {
-    density: chatProps.density,
-    accessibility: chatProps.accessibility || chatMessageBehavior,
     ...inputProps,
+    density: inputProps.density === undefined ? chatProps.density : inputProps.density,
+    accessibility:
+      inputProps.accessibility === undefined
+        ? chatProps.accessibility || chatMessageBehavior
+        : inputProps.accessibility,
   };
   const {
     accessibility,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
`ChatMessage` should use value from chat context as default prop. This change is introduced by PR #20998.
However, when user input is explicitly undefined, for example `<ChatMessage accessibility={undefined} />, the `undefined` value will be used, which is incorrect.
This PR fixed it.


#### Focus areas to test

(optional)
