### PR TITLE
Stop exporting Commons types from react-components

### DIFF
--- a/change/@fluentui-react-components-a3109946-9e50-442e-8917-9b82951226c7.json
+++ b/change/@fluentui-react-components-a3109946-9e50-442e-8917-9b82951226c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove exports of Commons types",
+  "packageName": "@fluentui/react-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/etc/react-components.api.md
+++ b/packages/react-components/etc/react-components.api.md
@@ -7,13 +7,11 @@
 import { __styles } from '@fluentui/react-make-styles';
 import { Accordion } from '@fluentui/react-accordion';
 import { accordionClassName } from '@fluentui/react-accordion';
-import { AccordionCommons } from '@fluentui/react-accordion';
 import { AccordionContext } from '@fluentui/react-accordion';
 import { AccordionContextValue } from '@fluentui/react-accordion';
 import { AccordionContextValues } from '@fluentui/react-accordion';
 import { AccordionHeader } from '@fluentui/react-accordion';
 import { accordionHeaderClassName } from '@fluentui/react-accordion';
-import { AccordionHeaderCommons } from '@fluentui/react-accordion';
 import { AccordionHeaderContextValue } from '@fluentui/react-accordion';
 import { AccordionHeaderContextValues } from '@fluentui/react-accordion';
 import { AccordionHeaderExpandIcon } from '@fluentui/react-accordion';
@@ -27,7 +25,6 @@ import { AccordionHeaderState } from '@fluentui/react-accordion';
 import { AccordionIndex } from '@fluentui/react-accordion';
 import { AccordionItem } from '@fluentui/react-accordion';
 import { accordionItemClassName } from '@fluentui/react-accordion';
-import { AccordionItemCommons } from '@fluentui/react-accordion';
 import { AccordionItemContext } from '@fluentui/react-accordion';
 import { AccordionItemContextValue } from '@fluentui/react-accordion';
 import { AccordionItemContextValues } from '@fluentui/react-accordion';
@@ -52,14 +49,12 @@ import { AccordionToggleEventHandler } from '@fluentui/react-accordion';
 import { arrowHeights } from '@fluentui/react-popover';
 import { Avatar } from '@fluentui/react-avatar';
 import { avatarClassName } from '@fluentui/react-avatar';
-import { AvatarCommons } from '@fluentui/react-avatar';
 import { AvatarNamedColor } from '@fluentui/react-avatar';
 import { AvatarProps } from '@fluentui/react-avatar';
 import { AvatarSlots } from '@fluentui/react-avatar';
 import { AvatarState } from '@fluentui/react-avatar';
 import { Badge } from '@fluentui/react-badge';
 import { badgeClassName } from '@fluentui/react-badge';
-import { BadgeCommons } from '@fluentui/react-badge';
 import { BadgeProps } from '@fluentui/react-badge';
 import { BadgeSlots } from '@fluentui/react-badge';
 import { BadgeState } from '@fluentui/react-badge';
@@ -69,7 +64,6 @@ import { BorderRadiusTokens } from '@fluentui/react-theme';
 import { BrandVariants } from '@fluentui/react-theme';
 import { Button } from '@fluentui/react-button';
 import { buttonClassName } from '@fluentui/react-button';
-import { ButtonCommons } from '@fluentui/react-button';
 import { ButtonProps } from '@fluentui/react-button';
 import { ButtonSlots } from '@fluentui/react-button';
 import { ButtonState } from '@fluentui/react-button';
@@ -84,7 +78,6 @@ import { CompoundButtonSlots } from '@fluentui/react-button';
 import { CompoundButtonState } from '@fluentui/react-button';
 import { CounterBadge } from '@fluentui/react-badge';
 import { counterBadgeClassName } from '@fluentui/react-badge';
-import { CounterBadgeCommons } from '@fluentui/react-badge';
 import { CounterBadgeProps } from '@fluentui/react-badge';
 import { CounterBadgeState } from '@fluentui/react-badge';
 import { createDarkTheme } from '@fluentui/react-theme';
@@ -96,14 +89,12 @@ import { Display } from '@fluentui/react-text';
 import { displayClassName } from '@fluentui/react-text';
 import { Divider } from '@fluentui/react-divider';
 import { dividerClassName } from '@fluentui/react-divider';
-import { DividerCommons } from '@fluentui/react-divider';
 import { DividerProps } from '@fluentui/react-divider';
 import { DividerSlots } from '@fluentui/react-divider';
 import { DividerState } from '@fluentui/react-divider';
 import { elementContains } from '@fluentui/react-portal';
 import { FluentProvider } from '@fluentui/react-provider';
 import { fluentProviderClassName } from '@fluentui/react-provider';
-import { FluentProviderCommons } from '@fluentui/react-provider';
 import { FluentProviderContextValues } from '@fluentui/react-provider';
 import { FluentProviderProps } from '@fluentui/react-provider';
 import { fluentProviderShorthandProps } from '@fluentui/react-provider';
@@ -116,14 +107,12 @@ import { Headline } from '@fluentui/react-text';
 import { headlineClassName } from '@fluentui/react-text';
 import { Image as Image_2 } from '@fluentui/react-image';
 import { imageClassName } from '@fluentui/react-image';
-import { ImageCommons } from '@fluentui/react-image';
 import { ImageProps } from '@fluentui/react-image';
 import { imageShorthandProps } from '@fluentui/react-image';
 import { ImageSlots } from '@fluentui/react-image';
 import { ImageState } from '@fluentui/react-image';
 import { Label } from '@fluentui/react-label';
 import { labelClassName } from '@fluentui/react-label';
-import { LabelCommons } from '@fluentui/react-label';
 import { LabelProps } from '@fluentui/react-label';
 import { labelShorthandProps } from '@fluentui/react-label';
 import { LabelSlots } from '@fluentui/react-label';
@@ -133,7 +122,6 @@ import { largeTitleClassName } from '@fluentui/react-text';
 import { LineHeightTokens } from '@fluentui/react-theme';
 import { Link } from '@fluentui/react-link';
 import { linkClassName } from '@fluentui/react-link';
-import { LinkCommons } from '@fluentui/react-link';
 import { LinkProps } from '@fluentui/react-link';
 import { LinkSlots } from '@fluentui/react-link';
 import { LinkState } from '@fluentui/react-link';
@@ -186,7 +174,6 @@ import { menuItemSlots } from '@fluentui/react-menu';
 import { MenuItemState } from '@fluentui/react-menu';
 import { MenuList } from '@fluentui/react-menu';
 import { menuListClassName } from '@fluentui/react-menu';
-import { MenuListCommons } from '@fluentui/react-menu';
 import { MenuListContext } from '@fluentui/react-menu';
 import { MenuListContextValue } from '@fluentui/react-menu';
 import { MenuListContextValues } from '@fluentui/react-menu';
@@ -217,7 +204,6 @@ import { OnVisibleChangeData } from '@fluentui/react-tooltip';
 import { OpenPopoverEvents } from '@fluentui/react-popover';
 import { PartialTheme } from '@fluentui/react-theme';
 import { Popover } from '@fluentui/react-popover';
-import { PopoverCommons } from '@fluentui/react-popover';
 import { PopoverContext } from '@fluentui/react-popover';
 import { PopoverContextValue } from '@fluentui/react-popover';
 import { PopoverProps } from '@fluentui/react-popover';
@@ -233,12 +219,10 @@ import { PopoverTrigger } from '@fluentui/react-popover';
 import { PopoverTriggerProps } from '@fluentui/react-popover';
 import { PopoverTriggerState } from '@fluentui/react-popover';
 import { Portal } from '@fluentui/react-portal';
-import { PortalCommons } from '@fluentui/react-portal';
 import { PortalProps } from '@fluentui/react-portal';
 import { PortalState } from '@fluentui/react-portal';
 import { PresenceBadge } from '@fluentui/react-badge';
 import { presenceBadgeClassName } from '@fluentui/react-badge';
-import { PresenceBadgeCommons } from '@fluentui/react-badge';
 import { PresenceBadgeProps } from '@fluentui/react-badge';
 import { PresenceBadgeState } from '@fluentui/react-badge';
 import { PresenceBadgeStatus } from '@fluentui/react-badge';
@@ -297,7 +281,6 @@ import { teamsHighContrastTheme } from '@fluentui/react-theme';
 import { teamsLightTheme } from '@fluentui/react-theme';
 import { Text as Text_2 } from '@fluentui/react-text';
 import { textClassName } from '@fluentui/react-text';
-import { TextCommons } from '@fluentui/react-text';
 import { TextProps } from '@fluentui/react-text';
 import { TextSlots } from '@fluentui/react-text';
 import { TextState } from '@fluentui/react-text';
@@ -310,12 +293,10 @@ import { Title3 } from '@fluentui/react-text';
 import { title3ClassName } from '@fluentui/react-text';
 import { ToggleButton } from '@fluentui/react-button';
 import { toggleButtonClassName } from '@fluentui/react-button';
-import { ToggleButtonCommons } from '@fluentui/react-button';
 import { ToggleButtonProps } from '@fluentui/react-button';
 import { ToggleButtonState } from '@fluentui/react-button';
 import { Tooltip } from '@fluentui/react-tooltip';
 import { tooltipClassName } from '@fluentui/react-tooltip';
-import { TooltipCommons } from '@fluentui/react-tooltip';
 import { TooltipProps } from '@fluentui/react-tooltip';
 import { TooltipSlots } from '@fluentui/react-tooltip';
 import { TooltipState } from '@fluentui/react-tooltip';
@@ -411,8 +392,6 @@ export { Accordion }
 
 export { accordionClassName }
 
-export { AccordionCommons }
-
 export { AccordionContext }
 
 export { AccordionContextValue }
@@ -422,8 +401,6 @@ export { AccordionContextValues }
 export { AccordionHeader }
 
 export { accordionHeaderClassName }
-
-export { AccordionHeaderCommons }
 
 export { AccordionHeaderContextValue }
 
@@ -450,8 +427,6 @@ export { AccordionIndex }
 export { AccordionItem }
 
 export { accordionItemClassName }
-
-export { AccordionItemCommons }
 
 export { AccordionItemContext }
 
@@ -501,8 +476,6 @@ export { Avatar }
 
 export { avatarClassName }
 
-export { AvatarCommons }
-
 export { AvatarNamedColor }
 
 export { AvatarProps }
@@ -514,8 +487,6 @@ export { AvatarState }
 export { Badge }
 
 export { badgeClassName }
-
-export { BadgeCommons }
 
 export { BadgeProps }
 
@@ -534,8 +505,6 @@ export { BrandVariants }
 export { Button }
 
 export { buttonClassName }
-
-export { ButtonCommons }
 
 export { ButtonProps }
 
@@ -565,8 +534,6 @@ export { CounterBadge }
 
 export { counterBadgeClassName }
 
-export { CounterBadgeCommons }
-
 export { CounterBadgeProps }
 
 export { CounterBadgeState }
@@ -589,8 +556,6 @@ export { Divider }
 
 export { dividerClassName }
 
-export { DividerCommons }
-
 export { DividerProps }
 
 export { DividerSlots }
@@ -602,8 +567,6 @@ export { elementContains }
 export { FluentProvider }
 
 export { fluentProviderClassName }
-
-export { FluentProviderCommons }
 
 export { FluentProviderContextValues }
 
@@ -629,8 +592,6 @@ export { Image_2 as Image }
 
 export { imageClassName }
 
-export { ImageCommons }
-
 export { ImageProps }
 
 export { imageShorthandProps }
@@ -642,8 +603,6 @@ export { ImageState }
 export { Label }
 
 export { labelClassName }
-
-export { LabelCommons }
 
 export { LabelProps }
 
@@ -662,8 +621,6 @@ export { LineHeightTokens }
 export { Link }
 
 export { linkClassName }
-
-export { LinkCommons }
 
 export { LinkProps }
 
@@ -769,8 +726,6 @@ export { MenuList }
 
 export { menuListClassName }
 
-export { MenuListCommons }
-
 export { MenuListContext }
 
 export { MenuListContextValue }
@@ -831,8 +786,6 @@ export { PartialTheme }
 
 export { Popover }
 
-export { PopoverCommons }
-
 export { PopoverContext }
 
 export { PopoverContextValue }
@@ -863,8 +816,6 @@ export { PopoverTriggerState }
 
 export { Portal }
 
-export { PortalCommons }
-
 export { PortalProps }
 
 export { PortalState }
@@ -872,8 +823,6 @@ export { PortalState }
 export { PresenceBadge }
 
 export { presenceBadgeClassName }
-
-export { PresenceBadgeCommons }
 
 export { PresenceBadgeProps }
 
@@ -991,8 +940,6 @@ export { Text_2 as Text }
 
 export { textClassName }
 
-export { TextCommons }
-
 export { TextProps }
 
 export { TextSlots }
@@ -1017,8 +964,6 @@ export { ToggleButton }
 
 export { toggleButtonClassName }
 
-export { ToggleButtonCommons }
-
 export { ToggleButtonProps }
 
 export { ToggleButtonState }
@@ -1026,8 +971,6 @@ export { ToggleButtonState }
 export { Tooltip }
 
 export { tooltipClassName }
-
-export { TooltipCommons }
 
 export { TooltipProps }
 

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -24,7 +24,6 @@ export {
   useTheme,
 } from '@fluentui/react-provider';
 export type {
-  FluentProviderCommons,
   FluentProviderContextValues,
   FluentProviderProps,
   FluentProviderSlots,
@@ -95,10 +94,8 @@ export {
   useAccordionStyles,
 } from '@fluentui/react-accordion';
 export type {
-  AccordionCommons,
   AccordionContextValue,
   AccordionContextValues,
-  AccordionHeaderCommons,
   AccordionHeaderContextValue,
   AccordionHeaderContextValues,
   AccordionHeaderExpandIconPosition,
@@ -108,7 +105,6 @@ export type {
   AccordionHeaderSlots,
   AccordionHeaderState,
   AccordionIndex,
-  AccordionItemCommons,
   AccordionItemContextValue,
   AccordionItemContextValues,
   AccordionItemProps,
@@ -126,7 +122,7 @@ export type {
   AccordionToggleEventHandler,
 } from '@fluentui/react-accordion';
 export { Avatar, avatarClassName, renderAvatar, useAvatar, useAvatarStyles } from '@fluentui/react-avatar';
-export type { AvatarCommons, AvatarNamedColor, AvatarProps, AvatarSlots, AvatarState } from '@fluentui/react-avatar';
+export type { AvatarNamedColor, AvatarProps, AvatarSlots, AvatarState } from '@fluentui/react-avatar';
 export {
   Badge,
   CounterBadge,
@@ -142,14 +138,11 @@ export {
   usePresenceBadge,
 } from '@fluentui/react-badge';
 export type {
-  BadgeCommons,
   BadgeProps,
   BadgeSlots,
   BadgeState,
-  CounterBadgeCommons,
   CounterBadgeProps,
   CounterBadgeState,
-  PresenceBadgeCommons,
   PresenceBadgeProps,
   PresenceBadgeState,
   PresenceBadgeStatus,
@@ -182,7 +175,6 @@ export {
   useToggleButtonStyles,
 } from '@fluentui/react-button';
 export type {
-  ButtonCommons,
   ButtonProps,
   ButtonSlots,
   ButtonState,
@@ -195,12 +187,11 @@ export type {
   SplitButtonProps,
   SplitButtonSlots,
   SplitButtonState,
-  ToggleButtonCommons,
   ToggleButtonProps,
   ToggleButtonState,
 } from '@fluentui/react-button';
 export { Divider, dividerClassName, renderDivider, useDivider, useDividerStyles } from '@fluentui/react-divider';
-export type { DividerCommons, DividerProps, DividerSlots, DividerState } from '@fluentui/react-divider';
+export type { DividerProps, DividerSlots, DividerState } from '@fluentui/react-divider';
 export {
   Image,
   imageClassName,
@@ -209,7 +200,7 @@ export {
   useImage,
   useImageStyles,
 } from '@fluentui/react-image';
-export type { ImageCommons, ImageProps, ImageSlots, ImageState } from '@fluentui/react-image';
+export type { ImageProps, ImageSlots, ImageState } from '@fluentui/react-image';
 export {
   Label,
   labelClassName,
@@ -218,9 +209,9 @@ export {
   useLabel,
   useLabelStyles,
 } from '@fluentui/react-label';
-export type { LabelCommons, LabelProps, LabelSlots, LabelState } from '@fluentui/react-label';
+export type { LabelProps, LabelSlots, LabelState } from '@fluentui/react-label';
 export { Link, linkClassName, renderLink, useLink, useLinkState, useLinkStyles } from '@fluentui/react-link';
-export type { LinkCommons, LinkProps, LinkSlots, LinkState } from '@fluentui/react-link';
+export type { LinkProps, LinkSlots, LinkState } from '@fluentui/react-link';
 export {
   Menu,
   MenuContext,
@@ -309,7 +300,6 @@ export type {
   MenuItemSelectableState,
   MenuItemSlots,
   MenuItemState,
-  MenuListCommons,
   MenuListContextValue,
   MenuListContextValues,
   MenuListProps,
@@ -349,7 +339,6 @@ export {
 export type {
   OnOpenChangeData,
   OpenPopoverEvents,
-  PopoverCommons,
   PopoverContextValue,
   PopoverProps,
   PopoverSize,
@@ -361,7 +350,7 @@ export type {
   PopoverTriggerState,
 } from '@fluentui/react-popover';
 export { Portal, elementContains, renderPortal, setVirtualParent, usePortal } from '@fluentui/react-portal';
-export type { PortalCommons, PortalProps, PortalState } from '@fluentui/react-portal';
+export type { PortalProps, PortalState } from '@fluentui/react-portal';
 export {
   Body,
   Caption,
@@ -387,11 +376,10 @@ export {
   useText,
   useTextStyles,
 } from '@fluentui/react-text';
-export type { TextCommons, TextProps, TextSlots, TextState } from '@fluentui/react-text';
+export type { TextProps, TextSlots, TextState } from '@fluentui/react-text';
 export { Tooltip, renderTooltip, tooltipClassName, useTooltip, useTooltipStyles } from '@fluentui/react-tooltip';
 export type {
   OnVisibleChangeData,
-  TooltipCommons,
   TooltipProps,
   TooltipSlots,
   TooltipState,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #21194
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Per agreement in discussion of #20964, as an intermediate step we want to stop exporting all Commons types from `@fluentui/react-components`. This reduces likelihood of breaking consumers with whatever final solution we choose, while keeping the Commons types in individual component packages' API report files.

The follow-up PR #21196 will introduce an eslint rule to prevent new re-exports of commons types from being added.