### PR TITLE
Pickers Suggestions: add searchForMoreText button to the suggestions listbox.

### DIFF
--- a/change/@fluentui-react-59dcc92e-109f-4a42-b52d-6a080b3c0cbc.json
+++ b/change/@fluentui-react-59dcc92e-109f-4a42-b52d-6a080b3c0cbc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Suggestions: add searchForMoreText button to the suggestions listbox.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -93,6 +93,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
       theme,
       styles,
       suggestionsListId,
+      suggestionsContainerAriaLabel,
     } = this.props;
 
     // TODO
@@ -175,7 +176,12 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
       this.state.selectedActionType === SuggestionActionType.searchMore ? 'sug-selectedAction' : undefined;
 
     return (
-      <div className={this._classNames.root} role="listbox" id={suggestionsListId}>
+      <div
+        className={this._classNames.root}
+        aria-label={suggestionsContainerAriaLabel || headerText}
+        id={suggestionsListId}
+        role="listbox"
+      >
         <Announced message={this._getAlertText()} aria-live="polite" />
 
         {headerText ? <div className={this._classNames.title}>{headerText}</div> : null}
@@ -359,15 +365,11 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
 
   private _renderSuggestions(): JSX.Element | null {
     const {
-      isMostRecentlyUsedVisible,
-      mostRecentlyUsedHeaderText,
       onRenderSuggestion,
       removeSuggestionAriaLabel,
       suggestionsItemClassName,
       resultsMaximumNumber,
       showRemoveButtons,
-      suggestionsContainerAriaLabel,
-      suggestionsHeaderText,
       removeButtonIconProps,
     } = this.props;
 
@@ -395,18 +397,8 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
       return null;
     }
 
-    // MostRecently Used text should supercede the header text if it's there and available.
-    let headerText: string | undefined = suggestionsHeaderText;
-    if (isMostRecentlyUsedVisible && mostRecentlyUsedHeaderText) {
-      headerText = mostRecentlyUsedHeaderText;
-    }
-
     return (
-      <div
-        className={this._classNames.suggestionsContainer}
-        ref={this._scrollContainer}
-        aria-label={suggestionsContainerAriaLabel || headerText}
-      >
+      <div className={this._classNames.suggestionsContainer} ref={this._scrollContainer} role="presentation">
         {suggestions.map((suggestion, index) => (
           <div
             ref={suggestion.selected ? this._selectedElement : undefined}

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -168,8 +168,6 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
     }
 
     const hasNoSuggestions = (!suggestions || !suggestions.length) && !isLoading;
-    const divProps: React.HtmlHTMLAttributes<HTMLDivElement> =
-      hasNoSuggestions || isLoading ? { role: 'listbox', id: suggestionsListId } : {};
 
     const forceResolveId =
       this.state.selectedActionType === SuggestionActionType.forceResolve ? 'sug-selectedAction' : undefined;
@@ -177,7 +175,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
       this.state.selectedActionType === SuggestionActionType.searchMore ? 'sug-selectedAction' : undefined;
 
     return (
-      <div className={this._classNames.root} {...divProps}>
+      <div className={this._classNames.root} role="listbox" id={suggestionsListId}>
         <Announced message={this._getAlertText()} aria-live="polite" />
 
         {headerText ? <div className={this._classNames.title}>{headerText}</div> : null}
@@ -202,6 +200,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
             id={searchForMoreId}
             onClick={this._getMoreResults}
             data-automationid={'sug-searchForMore'}
+            role={'option'}
           >
             {searchForMoreText}
           </CommandButton>
@@ -369,7 +368,6 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
       showRemoveButtons,
       suggestionsContainerAriaLabel,
       suggestionsHeaderText,
-      suggestionsListId,
       removeButtonIconProps,
     } = this.props;
 
@@ -406,9 +404,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
     return (
       <div
         className={this._classNames.suggestionsContainer}
-        id={suggestionsListId}
         ref={this._scrollContainer}
-        role="listbox"
         aria-label={suggestionsContainerAriaLabel || headerText}
       >
         {suggestions.map((suggestion, index) => (

--- a/packages/react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Suggestions renders a list properly 1`] = `
 <div
   className="ms-Suggestions"
+  role="listbox"
 >
   <div
     aria-live="polite"
@@ -11,7 +12,6 @@ exports[`Suggestions renders a list properly 1`] = `
   />
   <div
     className="ms-Suggestions-container"
-    role="listbox"
   >
     <div
       role="presentation"
@@ -2069,6 +2069,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
       {
         min-width: 260px;
       }
+  role="listbox"
 >
   <div
     aria-live="polite"
@@ -2084,7 +2085,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
           overflow-y: auto;
           transform: translate3d(0,0,0);
         }
-    role="listbox"
   >
     <div
       role="presentation"
@@ -4138,6 +4138,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
 exports[`Suggestions scrolls to selected index properly 1`] = `
 <div
   className="ms-Suggestions"
+  role="listbox"
 >
   <div
     aria-live="polite"
@@ -4146,7 +4147,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
   />
   <div
     className="ms-Suggestions-container"
-    role="listbox"
   >
     <div
       role="presentation"

--- a/packages/react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Suggestions renders a list properly 1`] = `
   />
   <div
     className="ms-Suggestions-container"
+    role="presentation"
   >
     <div
       role="presentation"
@@ -2085,6 +2086,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
           overflow-y: auto;
           transform: translate3d(0,0,0);
         }
+    role="presentation"
   >
     <div
       role="presentation"
@@ -4147,6 +4149,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
   />
   <div
     className="ms-Suggestions-container"
+    role="presentation"
   >
     <div
       role="presentation"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [13011](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/13011)
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Moves `role=listbox`, `aria-label` and `suggestionsList` `id` permanently to the root (unlike before when it was only in the root when there are no suggestions available).
- Adds `role=option` to `searchForMoreText` button so it becomes a part of the listbox and is accessible to screen readers.