### PR TITLE
react-components: Cleaning up change file to indicate change as type none since the change was affecting just stories and not published code

### DIFF
--- a/change/@fluentui-react-components-1b3e39f8-2025-47cb-bf2e-c541853c97b8.json
+++ b/change/@fluentui-react-components-1b3e39f8-2025-47cb-bf2e-c541853c97b8.json
@@ -1,7 +1,7 @@
 {
-  "type": "prerelease",
-  "comment": "react-components: Replacing use of functions in makeStyles with direct use of tokens.",
+  "type": "none",
+  "comment": "Replacing use of functions in makeStyles with direct use of tokens.",
   "packageName": "@fluentui/react-components",
   "email": "Humberto.Morimoto@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Comment in https://github.com/microsoft/fluentui/pull/21042#discussion_r779510404
- ~[ ] Include a change request file using `$ yarn change`~

#### Description of changes

This PR cleans up a change file for #21042 in the `@fluentui/react-components` package to indicate change as `type: none` since the change was affecting just stories and not published code.
