### PR TITLE
Tooltip: Move arrowHeight and tooltipBorderRadius into a common constants.ts file

### DIFF
--- a/change/@fluentui-react-tooltip-12cd10b5-3dc5-4754-8481-c51c14a5ed2f.json
+++ b/change/@fluentui-react-tooltip-12cd10b5-3dc5-4754-8481-c51c14a5ed2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Move arrowHeight and tooltipBorderRadius into a shared constants.ts file",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tooltip/src/components/Tooltip/private/constants.ts
+++ b/packages/react-tooltip/src/components/Tooltip/private/constants.ts
@@ -1,0 +1,13 @@
+/**
+ * The height of the tooltip's arrow in pixels.
+ */
+export const arrowHeight = 6;
+
+/**
+ * The default value of the tooltip's border radius (borderRadiusMedium).
+ *
+ * Unfortunately, Popper requires it to be specified as a variable instead of using CSS.
+ * While we could use getComputedStyle, that adds a performance penalty for something that
+ * will likely never change.
+ */
+export const tooltipBorderRadius = 4;

--- a/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -12,10 +12,7 @@ import {
   useTimeout,
 } from '@fluentui/react-utilities';
 import type { TooltipProps, TooltipState, TooltipTriggerProps } from './Tooltip.types';
-
-// Style values that are required for popper to properly position the tooltip
-const tooltipBorderRadius = 4; // Update the root's borderRadius in useTooltipStyles.ts if this changes
-const arrowHeight = 6; // Update arrowHeight in useTooltipStyles.ts if this changes
+import { arrowHeight, tooltipBorderRadius } from './private/constants';
 
 /**
  * Create the state required to render Tooltip.

--- a/packages/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
@@ -1,5 +1,6 @@
 import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
 import { createArrowStyles } from '@fluentui/react-positioning';
+import { arrowHeight } from './private/constants';
 import type { TooltipState } from './Tooltip.types';
 
 export const tooltipClassName = 'fui-Tooltip';
@@ -17,7 +18,7 @@ const useStyles = makeStyles({
     fontSize: theme.fontSizeBase200,
     lineHeight: theme.lineHeightBase200,
 
-    ...shorthands.borderRadius(theme.borderRadiusMedium), // Must match tooltipBorderRadius in useTooltip.tsx
+    ...shorthands.borderRadius(theme.borderRadiusMedium),
     ...shorthands.border('1px', 'solid', theme.colorTransparentStroke),
     ...shorthands.padding('4px', '11px', '6px', '11px'), // '5px 12px 7px 12px' minus the border width '1px'
     backgroundColor: theme.colorNeutralBackground1,
@@ -38,7 +39,7 @@ const useStyles = makeStyles({
     color: theme.colorNeutralForegroundInverted,
   }),
 
-  arrow: createArrowStyles({ arrowHeight: 6 }), // Must match arrowHeight in useTooltip.tsx
+  arrow: createArrowStyles({ arrowHeight }),
 });
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Issue

PR feedback from @khmakoto - https://github.com/microsoft/fluentui/pull/21086#discussion_r779798499
> Not blocking for this PR: Is this a case for maybe exporting out of one file and importing into another while not exporting from the package itself so we don't have duplicate information?

#### Fix

Move the `arrowHeight` and `tooltipBorderRadius` constants into ./private/constants.ts. They aren't exported from the package, but are exported for use within the component code.