### PR TITLE
docs(tools): add nx style-guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ dist
 dist-storybook
 screenshots
 .cache
+!tools/**/lib
 
 *.tar.gz
 

--- a/tools/STYLE-GUIDE.md
+++ b/tools/STYLE-GUIDE.md
@@ -1,0 +1,91 @@
+# NX tooling dev/style guide
+
+## Generators
+
+- generators live in `tools/generators` folder
+
+### Scaffolding
+
+```sh
+<generator-name>/
+|- files/
+    |- some-file.ts.__tmpl__
+    |- config.json.__tmpl__
+|- lib/
+    |- utils.ts
+    |- utils.spec.ts
+    |- add-foo.ts
+    |- add-foo.spec.ts
+|- index.ts
+|- index.spec.ts
+|- schema.ts
+|- schema.json
+|- README.md
+```
+
+**`files/` (optional)**
+
+- static or dynamic templates used to generated files should live here.
+- every file ends with `__tmpl__` suffix.
+  - eg `my-file.ts__tmpl__`
+  - `__tmpl__` will be removed during generation
+
+**`lib/` (optional)**
+
+- if your generator becomes too big/complicated this is the place where you should split your logic into smaller modules.
+- every module should have unit test if it makes sense
+
+**`index.ts`**
+
+- entry point to the generator
+
+**`index.spec.ts`**
+
+- integration tests for the generator as a whole
+
+**`schema.ts`**
+
+- TypeScript interface that matches schema.json
+- you can use following command to automate the conversion from json:
+  - `npx json-schema-to-typescript -i tools/generators/<generator-name>/schema.json -o tools/generators/<generator-name>/schema.ts`
+
+**`schema.json`**
+
+- provides a description of the generator, available options, validation information, and default values. This is processed by nx cli when invoking generator to provide argument validations/processing/prompts.
+
+**`README.md`**
+
+- generator documentation - about + API
+  - NOTE: in future this will be automatically generated
+
+### Bootstrap new generator
+
+- via CLI:
+
+```sh
+yarn nx workspace-generator workspace-generator
+```
+
+- via Nx Console:
+
+![Generate new workspace generator via NX Console](https://user-images.githubusercontent.com/1223799/148544909-034ebe44-eef1-4686-960d-cb3547da55b7.png)
+
+## Migrations
+
+- migrations live in `tools/generators` folder
+  - ideally this should live under `tools/migrations` but because constraint of how workspace generators invocation works in nx, we are restricted to to place them alongside standard generators
+- everything from `Generators` guide applies
+  - migration generator is just a standard generator with different purpose
+- generator name starts with `migrate-*` (for example - `migrate-my-package`)
+
+## Executors
+
+- executors live in `tools/executors` folder
+
+### Scaffolding
+
+TBA
+
+### Bootstrap new executor
+
+TBA

--- a/tools/STYLE-GUIDE.md
+++ b/tools/STYLE-GUIDE.md
@@ -3,6 +3,7 @@
 ## Generators
 
 - generators live in `tools/generators` folder
+- [learn more about generators](https://nx.dev/generators/workspace-generators)
 
 ### Scaffolding
 
@@ -81,6 +82,7 @@ yarn nx workspace-generator workspace-generator
 ## Executors
 
 - executors live in `tools/executors` folder
+- [learn more about executors](https://nx.dev/executors/using-builders)
 
 ### Scaffolding
 

--- a/tools/STYLE-GUIDE.md
+++ b/tools/STYLE-GUIDE.md
@@ -2,16 +2,15 @@
 
 ## Generators
 
-- generators live in `tools/generators` folder
-- [learn more about generators](https://nx.dev/generators/workspace-generators)
+Generators should live in the `tools/generators` folder. [Learn more about Nx generators](https://nx.dev/generators/workspace-generators).
 
 ### Scaffolding
 
 ```sh
 <generator-name>/
 |- files/
-    |- some-file.ts.__tmpl__
-    |- config.json.__tmpl__
+    |- some-file.ts__tmpl__
+    |- config.json__tmpl__
 |- lib/
     |- utils.ts
     |- utils.spec.ts
@@ -26,63 +25,68 @@
 
 **`files/` (optional)**
 
-- static or dynamic templates used to generated files should live here.
-- every file ends with `__tmpl__` suffix.
-  - eg `my-file.ts__tmpl__`
-  - `__tmpl__` will be removed during generation
+Place for static or dynamic templates used to generate files.
+
+⚠️ Make sure every file ends with `__tmpl__` suffix. This suffix should be part of the extension, not a separate extension.
+  - ✅ `my-file.ts__tmpl__`
+  - ❌ `my-file.ts.__tmpl__` (notice the extra `.`)
+
+The `__tmpl__` suffix will be removed as part of the generation.
 
 **`lib/` (optional)**
 
-- if your generator becomes too big/complicated this is the place where you should split your logic into smaller modules.
-- every module should have unit test if it makes sense
+Consider splitting your logic into smaller modules if your generator becomes too big/complicated. This is the place where you should split your logic into smaller modules.
+
+If it makes sense, try to provide a unit test for every module.
 
 **`index.ts`**
 
-- entry point to the generator
+Entry point to the generator.
 
 **`index.spec.ts`**
 
-- integration tests for the generator as a whole
+Integration tests for the generator as a whole.
 
 **`schema.ts`**
 
-- TypeScript interface that matches schema.json
-- you can use the following command to automate the conversion from json:
-  - `npx json-schema-to-typescript -i tools/generators/<generator-name>/schema.json -o tools/generators/<generator-name>/schema.ts`
+TypeScript interface that matches `schema.json`. You can generate this from the json file by running:
+- `npx json-schema-to-typescript -i tools/generators/<generator-name>/schema.json -o tools/generators/<generator-name>/schema.ts`
 
 **`schema.json`**
 
-- provides a description of the generator, available options, validation information, and default values. This is processed by nx cli when invoking generator to provide argument validations/processing/prompts.
+Provides a description of the generator, available options, validation information, and default values. This is processed by nx cli when invoking generator to provide argument validations/processing/prompts.
 
 **`README.md`**
 
-- generator documentation - about + API
-  - NOTE: in future this will be automatically generated
+Generator documentation - about + API
+
+ℹ️ _NOTE: In future, this will be automatically generated._
 
 ### Bootstrap new generator
 
-- via CLI:
+#### CLI:
 
 ```sh
 yarn nx workspace-generator workspace-generator
 ```
 
-- via Nx Console:
+#### Nx Console:
 
 ![Generate new workspace generator via NX Console](https://user-images.githubusercontent.com/1223799/148544909-034ebe44-eef1-4686-960d-cb3547da55b7.png)
 
 ## Migrations
 
-- migrations live in `tools/generators` folder
-  - ideally this should live under `tools/migrations` but because constraint of how workspace generators invocation works in nx, we are restricted to to place them alongside standard generators
-- everything from `Generators` guide applies
-  - migration generator is just a standard generator with different purpose
-- generator name starts with `migrate-*` (for example - `migrate-my-package`)
+Migrations live in the `tools/generators` folder. They should ideally live in `tools/migrations` but due to how workspace generator invocations works in nx, we are restricted to place them alongside standard generators.
+
+Migrations follow same rules as [Generators](#Generators) as they behave the same but serve a different purpose.
+
+⚠️ Migrations generator's name should start with `migrate-*`.
+  - ✅ `migrate-my-package`
+  - ❌ `migration-mu-package`
 
 ## Executors
 
-- executors live in `tools/executors` folder
-- [learn more about executors](https://nx.dev/executors/using-builders)
+Executors should live in the `tools/executors` folder. [Learn more about Nx executors](https://nx.dev/executors/using-builders).
 
 ### Scaffolding
 

--- a/tools/STYLE-GUIDE.md
+++ b/tools/STYLE-GUIDE.md
@@ -28,8 +28,9 @@ Generators should live in the `tools/generators` folder. [Learn more about Nx ge
 Place for static or dynamic templates used to generate files.
 
 ⚠️ Make sure every file ends with `__tmpl__` suffix. This suffix should be part of the extension, not a separate extension.
-  - ✅ `my-file.ts__tmpl__`
-  - ❌ `my-file.ts.__tmpl__` (notice the extra `.`)
+
+- ✅ `my-file.ts__tmpl__`
+- ❌ `my-file.ts.__tmpl__` (notice the extra `.`)
 
 The `__tmpl__` suffix will be removed as part of the generation.
 
@@ -50,6 +51,7 @@ Integration tests for the generator as a whole.
 **`schema.ts`**
 
 TypeScript interface that matches `schema.json`. You can generate this from the json file by running:
+
 - `npx json-schema-to-typescript -i tools/generators/<generator-name>/schema.json -o tools/generators/<generator-name>/schema.ts`
 
 **`schema.json`**
@@ -81,8 +83,9 @@ Migrations live in the `tools/generators` folder. They should ideally live in `t
 Migrations follow same rules as [Generators](#Generators) as they behave the same but serve a different purpose.
 
 ⚠️ Migrations generator's name should start with `migrate-*`.
-  - ✅ `migrate-my-package`
-  - ❌ `migration-mu-package`
+
+- ✅ `migrate-my-package`
+- ❌ `migration-mu-package`
 
 ## Executors
 

--- a/tools/STYLE-GUIDE.md
+++ b/tools/STYLE-GUIDE.md
@@ -46,7 +46,7 @@
 **`schema.ts`**
 
 - TypeScript interface that matches schema.json
-- you can use following command to automate the conversion from json:
+- you can use the following command to automate the conversion from json:
   - `npx json-schema-to-typescript -i tools/generators/<generator-name>/schema.json -o tools/generators/<generator-name>/schema.ts`
 
 **`schema.json`**

--- a/tools/generators/workspace-generator/files/README.md__tmpl__
+++ b/tools/generators/workspace-generator/files/README.md__tmpl__
@@ -1,0 +1,38 @@
+# <%= name %>
+
+Workspace Generator ...TODO...
+
+<!-- toc -->
+
+- [Usage](#usage)
+  - [Examples](#examples)
+- [Options](#options)
+  - [`name`](#name)
+
+<!-- tocstop -->
+
+## Usage
+
+```sh
+yarn nx workspace-generator <%= name %> ...
+```
+
+Show what will be generated without writing to disk:
+
+```sh
+yarn nx workspace-generator <%= name %> --dry-run
+```
+
+### Examples
+
+```sh
+yarn nx workspace-generator <%= name %>
+```
+
+## Options
+
+#### `name`
+
+Type: `string`
+
+TODO...

--- a/tools/generators/workspace-generator/files/index.ts__tmpl__
+++ b/tools/generators/workspace-generator/files/index.ts__tmpl__
@@ -1,12 +1,53 @@
-import { Tree, formatFiles, installPackagesTask } from '@nrwl/devkit';
+import * as path from 'path';
+import { Tree, formatFiles, installPackagesTask, names, generateFiles } from '@nrwl/devkit';
 import { libraryGenerator } from '@nrwl/workspace/generators';
+
+import { getProjectConfig } from '../../utils';
 
 import { <%= className %>GeneratorSchema } from './schema'
 
-export default async function(host: Tree, schema: <%= className %>GeneratorSchema) {
-  await libraryGenerator(host, {name: schema.name});
-  await formatFiles(host);
+interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}
+
+export default async function(tree: Tree, schema: <%= className %>GeneratorSchema) {
+  await libraryGenerator(tree, {name: schema.name});
+
+  const normalizedOptions = normalizeOptions(tree, schema);
+
+  addFiles(tree, normalizedOptions);
+
+  await formatFiles(tree);
+
   return () => {
-    installPackagesTask(host)
+    installPackagesTask(tree)
   }
+}
+
+function normalizeOptions(
+  tree: Tree,
+  options: <%= className %>GeneratorSchema
+) {
+  const project = getProjectConfig(tree, { packageName: options.name });
+
+  return {
+    ...options,
+    ...project,
+    ...names(options.name),
+  };
+}
+
+/**
+ * NOTE: remove this if your generator doesn't process any static/dynamic templates
+ */
+function addFiles(tree: Tree, options: NormalizedSchema) {
+  const templateOptions = {
+    ...options,
+    tmpl: '',
+  };
+
+  generateFiles(
+    tree,
+    path.join(__dirname, 'files'),
+    path.join(options.projectConfig.root, options.name),
+    templateOptions
+  );
 }

--- a/tools/generators/workspace-generator/files/lib/utils.spec.ts__tmpl__
+++ b/tools/generators/workspace-generator/files/lib/utils.spec.ts__tmpl__
@@ -1,0 +1,8 @@
+import {dummyHelper} from './utils';
+
+describe(`utils`, () => {
+  it(`should behave...`, () => {
+    expect(dummyHelper()).toBe(undefined);
+  });
+});
+

--- a/tools/generators/workspace-generator/files/lib/utils.ts__tmpl__
+++ b/tools/generators/workspace-generator/files/lib/utils.ts__tmpl__
@@ -1,4 +1,4 @@
-// use this module to define any kind of generic utilities that are used in more than 1 palce within the generator implementation
+// use this module to define any kind of generic utilities that are used in more than 1 place within the generator implementation
 
 export function dummyHelper(){
   return;

--- a/tools/generators/workspace-generator/files/lib/utils.ts__tmpl__
+++ b/tools/generators/workspace-generator/files/lib/utils.ts__tmpl__
@@ -1,0 +1,5 @@
+// use this module to define any kind of generic utilities that are used in more than 1 palce within the generator implementation
+
+export function dummyHelper(){
+  return;
+}

--- a/tools/generators/workspace-generator/index.ts
+++ b/tools/generators/workspace-generator/index.ts
@@ -41,10 +41,9 @@ function addFiles(host: Tree, options: NormalizedSchema) {
     tmpl: '',
   };
 
-  generateFiles(
-    host,
-    path.join(__dirname, 'files'),
-    path.join(options.paths.generators, options.name),
-    templateOptions,
-  );
+  const projectRoot = path.join(options.paths.generators, options.name);
+
+  generateFiles(host, path.join(__dirname, 'files'), projectRoot, templateOptions);
+
+  host.write(path.join(projectRoot, 'files', 'constants.ts__tmpl__'), 'exportconst variable = "<%= name %>";');
 }

--- a/tools/generators/workspace-generator/index.ts
+++ b/tools/generators/workspace-generator/index.ts
@@ -45,5 +45,5 @@ function addFiles(host: Tree, options: NormalizedSchema) {
 
   generateFiles(host, path.join(__dirname, 'files'), projectRoot, templateOptions);
 
-  host.write(path.join(projectRoot, 'files', 'constants.ts__tmpl__'), 'exportconst variable = "<%= name %>";');
+  host.write(path.join(projectRoot, 'files', 'constants.ts__tmpl__'), 'export const variable = "<%= name %>";');
 }

--- a/tools/generators/workspace-generator/index.ts
+++ b/tools/generators/workspace-generator/index.ts
@@ -5,17 +5,17 @@ import { WorkspaceGeneratorGeneratorSchema } from './schema';
 
 interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}
 
-export default async function (host: Tree, schema: WorkspaceGeneratorGeneratorSchema) {
-  const options = normalizeOptions(host, schema);
+export default async function (tree: Tree, schema: WorkspaceGeneratorGeneratorSchema) {
+  const options = normalizeOptions(tree, schema);
 
-  addFiles(host, options);
+  addFiles(tree, options);
 
   if (!options.skipFormat) {
-    await formatFiles(host);
+    await formatFiles(tree);
   }
 }
 
-function normalizeOptions(host: Tree, options: WorkspaceGeneratorGeneratorSchema) {
+function normalizeOptions(tree: Tree, options: WorkspaceGeneratorGeneratorSchema) {
   if (options.name.length === 0) {
     throw new Error('name is required');
   }
@@ -33,7 +33,7 @@ function normalizeOptions(host: Tree, options: WorkspaceGeneratorGeneratorSchema
   };
 }
 
-function addFiles(host: Tree, options: NormalizedSchema) {
+function addFiles(tree: Tree, options: NormalizedSchema) {
   const templateOptions = {
     ...options,
     ...names(options.name),
@@ -43,7 +43,7 @@ function addFiles(host: Tree, options: NormalizedSchema) {
 
   const projectRoot = path.join(options.paths.generators, options.name);
 
-  generateFiles(host, path.join(__dirname, 'files'), projectRoot, templateOptions);
+  generateFiles(tree, path.join(__dirname, 'files'), projectRoot, templateOptions);
 
-  host.write(path.join(projectRoot, 'files', 'constants.ts__tmpl__'), 'export const variable = "<%= name %>";');
+  tree.write(path.join(projectRoot, 'files', 'constants.ts__tmpl__'), 'export const variable = "<%= name %>";');
 }

--- a/tools/jest.config.js
+++ b/tools/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
       tsconfig: '<rootDir>/tsconfig.json',
     },
   },
+  testPathIgnorePatterns: ['/node_modules/'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -115,6 +115,10 @@ export function getProjectConfig(tree: Tree, options: { packageName: string }) {
   return {
     projectConfig,
     workspaceConfig,
+    /**
+     * package name without npmScope (@scopeName)
+     */
+    normalizedPkgName: options.packageName.replace(`@${workspaceConfig.npmScope}/`, ''),
     paths,
   };
 }


### PR DESCRIPTION
#### Description of changes

Based on initiative to split our existing `migrate-converged-pkg` migration generator started in https://github.com/microsoft/fluentui/pull/20962, this PR:

- adds simple style guide how to structure our nx generators based on common OSS community patterns
- updates `workspace-generator`  generator to mirror that styleguide


