### PR TITLE
Overhaul v8 icon doc text and add search for SVG icons

### DIFF
--- a/apps/public-docsite/package.json
+++ b/apps/public-docsite/package.json
@@ -38,6 +38,8 @@
     "@fluentui/react-examples": "^8.34.4",
     "@fluentui/react-experiments": "^8.4.16",
     "@fluentui/react-file-type-icons": "^8.5.8",
+    "@fluentui/react-icons-mdl2": "^1.2.11",
+    "@fluentui/react-icons-mdl2-branded": "^1.1.20",
     "@fluentui/set-version": "^8.1.5",
     "@fluentui/theme": "^2.4.6",
     "@fluentui/theme-samples": "^8.2.63",

--- a/apps/public-docsite/src/components/IconGrid/IconGrid.module.scss
+++ b/apps/public-docsite/src/components/IconGrid/IconGrid.module.scss
@@ -17,7 +17,7 @@
     width: 80px;
     overflow: hidden;
 
-    span {
+    .iconName {
       color: $ms-color-neutralPrimary;
       font-size: $ms-font-size-xs;
       opacity: 0;
@@ -27,7 +27,7 @@
     &:hover {
       overflow: visible;
 
-      span {
+      .iconName {
         opacity: 1;
       }
     }

--- a/apps/public-docsite/src/components/IconGrid/IconGrid.module.scss
+++ b/apps/public-docsite/src/components/IconGrid/IconGrid.module.scss
@@ -1,5 +1,13 @@
 @import '../../styles/common';
 
+.root {
+  min-height: 200px;
+}
+
+.loading {
+  margin: 20px 0;
+}
+
 .grid {
   display: flex;
   flex-wrap: wrap;

--- a/apps/public-docsite/src/components/IconGrid/IconGrid.tsx
+++ b/apps/public-docsite/src/components/IconGrid/IconGrid.tsx
@@ -1,40 +1,98 @@
 import * as React from 'react';
-import { Icon, SearchBox } from '@fluentui/react';
+import { FontIcon, ISearchBoxProps, SearchBox, Spinner } from '@fluentui/react';
 import * as stylesImport from './IconGrid.module.scss';
 const styles: any = stylesImport;
 
-export interface IIconGridProps {
+export interface IFontIconGridProps {
   /**
-   * An array of icons.
+   * An array of font-based icon names.
    */
   icons: { name: string }[];
 
   /**
-   * If we should render using `Icon` from Fabric
+   * Type of icons:
+   * - `core-font` is Fabric Core font icons, rendered in an `<i>` tag with classes
+   * - `react-font` is Fluent UI React font icons, rendered using `<FontIcon>`
+   * - `react-svg` is SVG icon components, rendered directly
    */
-  useFabricIcons?: boolean;
+  iconType: 'core-font' | 'react-font';
 }
 
-export interface IIconGridState {
+export interface ISvgIconGridProps {
+  /**
+   * A promise loading a package of SVG icon components.
+   */
+  icons: Promise<{ [exportName: string]: any }>;
+
+  iconType: 'react-svg';
+}
+
+export type IIconGridProps = IFontIconGridProps | ISvgIconGridProps;
+
+interface IFontIconDefinition {
+  name: string;
+  ref: React.RefObject<HTMLElement>;
+  iconType: 'core-font' | 'react-font';
+}
+
+interface ISvgIconDefinition {
+  name: string;
+  component: React.ComponentType;
+  iconType: 'react-svg';
+}
+
+type IIconDefinition = IFontIconDefinition | ISvgIconDefinition;
+
+interface IIconGridState {
   /**
    * The text we are filtering the icons by.
    */
   searchQuery: string;
+
+  /**
+   * The actual icons to show. This is generated immediately for a static list of font-based icons,
+   * or generated on load for a list of SVG icon components.
+   */
+  resolvedIcons?: IIconDefinition[];
 }
 
 export class IconGrid extends React.Component<IIconGridProps, IIconGridState> {
-  private _iconRefs: { [iconName: string]: React.RefObject<HTMLElement> };
-
   constructor(props: IIconGridProps) {
     super(props);
 
-    this.state = {
+    const state: IIconGridState = {
       searchQuery: '',
     };
 
-    this._iconRefs = {};
-    for (const icon of props.icons) {
-      this._iconRefs[icon.name] = React.createRef();
+    if (props.iconType !== 'react-svg') {
+      state.resolvedIcons = props.icons
+        // filter out any json meta properties or whatever
+        .filter(icon => !!icon?.name)
+        .map(icon => ({
+          name: icon.name,
+          ref: React.createRef(),
+          // this is duplicated in each icon as a type discriminant
+          iconType: props.iconType,
+        }));
+    }
+
+    this.state = state;
+  }
+
+  public componentDidMount() {
+    if (this.props.iconType === 'react-svg') {
+      this.props.icons.then(iconExports => {
+        this.setState({
+          resolvedIcons: Object.keys(iconExports)
+            // Remove any exports that aren't react components
+            .filter(exportName => !!iconExports[exportName]?.displayName)
+            .map(exportName => ({
+              component: iconExports[exportName],
+              name: exportName.replace(/Icon$/, ''),
+              iconType: 'react-svg',
+            })),
+        });
+      });
     }
   }
 
@@ -51,39 +109,56 @@ export class IconGrid extends React.Component<IIconGridProps, IIconGridState> {
           onChange={this._onSearchQueryChanged}
           className={styles.searchBox}
         />
-        <ul className={styles.grid}>{icons.map(this._renderIcon)}</ul>
+        {icons.length ? (
+          <ul className={styles.grid}>{icons.map(this._renderIcon)}</ul>
+        ) : (
+          <Spinner label="Loading icons..." />
+        )}
       </div>
     );
   }
 
-  private _getItems = (): { name: string }[] => {
-    const { icons } = this.props;
-    const { searchQuery } = this.state;
+  private _getItems = (): IIconDefinition[] => {
+    const { searchQuery, resolvedIcons } = this.state;
 
-    return icons.filter(icon => icon && icon.name && icon.name.toLowerCase().indexOf(searchQuery.toLowerCase()) !== -1);
+    if (!resolvedIcons) {
+      return [];
+    }
+    if (!searchQuery) {
+      return resolvedIcons;
+    }
+
+    return resolvedIcons.filter(icon => icon.name.toLowerCase().indexOf(searchQuery.toLowerCase()) !== -1);
   };
 
-  private _renderIcon = (icon: { name: string }, index?: number): JSX.Element => {
-    const { useFabricIcons } = this.props;
-    let iconClassName = `ms-Icon ms-Icon--${icon.name}`;
-    const iconRef = this._iconRefs[icon.name];
-    if (iconRef.current && iconRef.current.offsetWidth > 80) {
-      iconClassName += ' hoverIcon';
+  private _renderIcon = (icon: IIconDefinition, index?: number): JSX.Element => {
+    let renderedIcon: JSX.Element;
+    switch (icon.iconType) {
+      case 'core-font':
+        let iconClassName = `ms-Icon ms-Icon--${icon.name}`;
+        if (icon.ref.current && icon.ref.current.offsetWidth > 80) {
+          iconClassName += ' hoverIcon';
+        }
+        renderedIcon = <i ref={icon.ref} className={iconClassName} title={icon.name} aria-hidden="true" />;
+        break;
+      case 'react-font':
+        renderedIcon = <FontIcon iconName={icon.name} />;
+        break;
+      case 'react-svg':
+        const IconComponent = (icon as ISvgIconDefinition).component;
+        renderedIcon = <IconComponent />;
+        break;
     }
 
     return (
       <li key={icon.name + index} aria-label={icon.name + ' icon'}>
-        {useFabricIcons ? (
-          <Icon iconName={icon.name} />
-        ) : (
-          <i ref={iconRef} className={iconClassName} title={icon.name} aria-hidden="true" />
-        )}
-        <span>{icon.name}</span>
+        {renderedIcon}
+        <span className={styles.iconName}>{icon.name}</span>
       </li>
     );
   };
 
-  private _onSearchQueryChanged = (ev, newValue: string): void => {
+  private _onSearchQueryChanged: ISearchBoxProps['onChange'] = (ev, newValue) => {
     this.setState({
       searchQuery: newValue,
     });

--- a/apps/public-docsite/src/components/IconGrid/IconGrid.tsx
+++ b/apps/public-docsite/src/components/IconGrid/IconGrid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FontIcon, ISearchBoxProps, SearchBox, Spinner } from '@fluentui/react';
+import { FontIcon, ISearchBoxProps, SearchBox, Spinner, SpinnerSize } from '@fluentui/react';
 import * as stylesImport from './IconGrid.module.scss';
 const styles: any = stylesImport;
 
@@ -97,22 +97,23 @@ export class IconGrid extends React.Component<IIconGridProps, IIconGridState> {
   }
 
   public render(): JSX.Element {
-    let { searchQuery } = this.state;
-
+    const areIconsLoaded = !!this.state.resolvedIcons;
     const icons = this._getItems();
 
     return (
-      <div>
-        <SearchBox
-          placeholder="Search icons"
-          value={searchQuery}
-          onChange={this._onSearchQueryChanged}
-          className={styles.searchBox}
-        />
-        {icons.length ? (
-          <ul className={styles.grid}>{icons.map(this._renderIcon)}</ul>
+      <div className={styles.root}>
+        {areIconsLoaded ? (
+          <>
+            <SearchBox
+              placeholder="Search icons"
+              value={this.state.searchQuery}
+              onChange={this._onSearchQueryChanged}
+              className={styles.searchBox}
+            />
+            {icons.length ? <ul className={styles.grid}>{icons.map(this._renderIcon)}</ul> : <div>No results</div>}
+          </>
         ) : (
-          <Spinner label="Loading icons..." />
+          <Spinner label="Loading icons..." className={styles.loading} size={SpinnerSize.large} />
         )}
       </div>
     );

--- a/apps/public-docsite/src/pages/Styles/FabricIconsPage/FabricIconsPage.tsx
+++ b/apps/public-docsite/src/pages/Styles/FabricIconsPage/FabricIconsPage.tsx
@@ -26,31 +26,53 @@ export const FabricIconsPage: React.FunctionComponent<IStylesPageProps> = props 
 };
 
 function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
+  const [selectedItem, setSelectedItem] = React.useState('react-font');
   switch (platform) {
     case 'web':
       return [
         {
-          sectionName: 'Usage',
+          sectionName: 'Usage: Font icons',
           editUrl: `${baseUrl}/web/FabricIconsUsage.md`,
           content: require('!raw-loader?esModule=false!@fluentui/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsUsage.md') as string,
           jumpLinks: [
-            // prettier-ignore
-            { text: enDash + ' Fluent UI React (font)', url: 'fluent-ui-react-font-based-icons' },
-            { text: enDash + ' Fluent UI React (SVG)', url: 'fluent-ui-react-svg-based-icons' },
+            { text: enDash + ' Fluent UI React', url: 'fluent-ui-react' },
             { text: enDash + ' Fabric Core', url: 'fabric-core' },
             { text: enDash + ' Fluent UI Icons tool', url: 'fluent-ui-icons-tool' },
           ],
         },
 
         {
+          sectionName: 'Usage: SVG icons',
+          editUrl: `${baseUrl}/web/FabricIconsSvgUsage.md`,
+          content: require('!raw-loader?esModule=false!@fluentui/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsSvgUsage.md') as string,
+        },
+
+        {
           sectionName: 'Available icons',
           content: (
-            <Pivot>
-              <PivotItem headerText="Fluent UI React (font-based)" className={styles.iconGrid}>
-                <IconGrid icons={fabricReactIcons} useFabricIcons={true} />
+            <Pivot
+              onLinkClick={item => {
+                setSelectedItem(item.props.itemKey);
+              }}
+            >
+              <PivotItem headerText="Fluent UI React (font)" itemKey="react-font" className={styles.iconGrid}>
+                <IconGrid icons={fabricReactIcons} iconType="react-font" />
               </PivotItem>
-              <PivotItem headerText="Fabric Core" className={styles.iconGrid}>
-                <IconGrid icons={fabricCoreIcons} />
+              <PivotItem headerText="Fabric Core" itemKey="core-font" className={styles.iconGrid}>
+                <IconGrid icons={fabricCoreIcons} iconType="core-font" />
+              </PivotItem>
+              <PivotItem headerText="SVG icons" itemKey="svg" className={styles.iconGrid}>
+                {
+                  // The icon components are a large download and slow to render, so wait until the tab is clicked
+                  selectedItem === 'svg' && (
+                    <IconGrid icons={import('@fluentui/react-icons-mdl2')} iconType="react-svg" />
+                  )
+                }
+              </PivotItem>
+              <PivotItem headerText="SVG icons (branded)" itemKey="svg-branded" className={styles.iconGrid}>
+                {selectedItem === 'svg-branded' && (
+                  <IconGrid icons={import('@fluentui/react-icons-mdl2-branded')} iconType="react-svg" />
+                )}
               </PivotItem>
             </Pivot>
           ),

--- a/apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsOverview.md
+++ b/apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsOverview.md
@@ -1,7 +1,7 @@
-Fluent UI uses a custom font for its iconography. This font contains glyphs that you can scale, color, and style in any way. There are also mirrored icons available for right-to-left localization. You can also download and install the icon font to use it with various design apps like Sketch, Figma, or Adobe XD.
+Fluent UI primarily uses a custom font for its iconography, released under the [Microsoft Fabric Assets License](https://aka.ms/fluentui-assets-license). As of Fluent UI React version 8, an SVG-based version of the same icon set is available under the MIT license.
 
 **This page is about the general-use monoline icons. See the [brand icons page](#/styles/web/office-brand-icons) for multi-color product icons and the [file type icons page](#/styles/web/file-type-icons) for document icons.**
 
 ### When should I use Fluent UI icons?
 
-It is recommended to use Fluent UI icons for command bars, navigation or status indicators. If you need icons to represent Office apps, see the [Office brand icons page](#/styles/web/office-brand-icons) . If you are representing files or digital content, see the [file type icons page](#/styles/web/file-type-icons).
+It is recommended to use Fluent UI icons for command bars, navigation or status indicators. If you need icons to represent Office apps, see the [Office brand icons page](#/styles/web/office-brand-icons). If you are representing files or digital content, see the [file type icons page](#/styles/web/file-type-icons).

--- a/apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsSvgUsage.md
+++ b/apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsSvgUsage.md
@@ -1,0 +1,29 @@
+An SVG-based version of Fluent UI's icon set is available from `@fluentui/react-icons-mdl2` and is released under the MIT license. This is the same MDL2 icon set used in the font icons, excluding any branded icons.
+
+Branded SVG icons are available from `@fluentui/react-icons-mdl2-branded` and are still subject to the [Microsoft Fabric Assets License](https://aka.ms/fluentui-assets-license).
+
+Both packages contain SVG icons wrapped in React components. This allows you to import and bundle only the icons you need, resulting in smaller download sizes compared to the font-based approach with `initializeIcons`, which downloads all icons by default.
+
+The SVG icon components are primarily intended to be used directly, rather than registering them globally (via `registerIcons` or `initializeIcons`) and referencing them by name in Fluent UI React's `Icon` component or via `iconProps.name`. For example:
+
+```tsx
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { ChevronDownIcon } from '@fluentui/react-icons-mdl2';
+
+ReactDOM.render(<ChevronDownIcon />, document.body.firstChild);
+```
+
+If you do need to make SVG icons available to reference by name (for example, in Fluent UI React components which take `iconProps`), this can be done using `registerIcons` as follows:
+
+```tsx
+import { registerIcons } from '@fluentui/react/lib/Styling';
+// Note: This approach works with any SVG icon set, not just @fluentui/react-icons-mdl2
+import { ChevronDownIcon } from '@fluentui/react-icons-mdl2';
+
+registerIcons({
+  icons: {
+    ChevronDown: <ChevronDownIcon />,
+  },
+});
+```

--- a/apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsUsage.md
+++ b/apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsUsage.md
@@ -1,10 +1,10 @@
-You can use Fluent UI's icons in a few ways, depending on if you're using Fluent UI React or Fabric Core.
+Fluent UI has traditionally used a custom font for its iconography. This font is part of the MDL2 design system and contains glyphs that you can scale, color, and style in any way. You can also download and install the [icon font](#/resources) to use it with various design apps like Sketch, Figma, or Adobe XD.
 
-### Fluent UI React: Font-based icons
+### Fluent UI React
 
 The Fluent UI font-based icon set is released under the [Microsoft Fabric Assets License](https://aka.ms/fluentui-assets-license).
 
-If you're using Fluent UI React, note that icons are not included in your bundle by default. To make the icons available, you'll need to initialize them by calling `initializeIcons` from the `@fluentui/font-icons-mdl2` package. This is usually done at the root of your app:
+To make the font-based icons available when using Fluent UI React, you'll need to initialize them by calling `initializeIcons` from the `@fluentui/font-icons-mdl2` package. This is usually done at the root of your app:
 
 ```ts
 import { initializeIcons } from '@fluentui/font-icons-mdl2';
@@ -43,27 +43,11 @@ const MyIconButton = () => <IconButton iconProps={{ iconName: 'Add' }} title="Ad
 ReactDOM.render(<MyIconButton />, document.body.firstChild);
 ```
 
-#### Fluent UI React: SVG-based icons
-
-The Fluent UI SVG-based icon set is open source and released under the MIT license.
-
-This icon set allows you to import and bundle only the icons you need, resulting in smaller download sizes compared to the font-based approach with `initializeIcons`, which downloads all icons by default.
-
-In `@fluentui/react` version 8, we are enabling more widespread use by open sourcing the core icon set. Be aware that any branded icons have been removed from `@fluentui/react-icons-mdl2`.
-
-Each SVG icon is wrapped with a React element and can be imported and used as follows:
-
-```ts
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import { ChevronIcon } from '@fluentui/react-icons-mdl2';
-
-ReactDOM.render(<ChevronIcon />, document.body.firstChild);
-```
-
 ### Fabric Core
 
 The Fabric Core icon set is released under the [Microsoft Fabric Assets License](https://aka.ms/fluentui-assets-license).
+
+This approach is primarily intended for non-React-based pages or apps.
 
 First, ensure that you've loaded the Fabric Core stylesheet following the [getting started instructions](#/get-started/web#fabric-core).
 
@@ -75,6 +59,6 @@ In your app, combine the base `ms-Icon` class with a modifier class for the spec
 
 Note the `aria-hidden` attribute, which prevents screen readers from reading the icon. In cases where meaning is conveyed only through the icon, such as an icon-only navigation bar, use the [`aria-label` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) on the button for accessibility.
 
-### Fluent UI Icons tool
+### Fluent UI icons tool
 
-The [Fluent UI Icons tool](https://aka.ms/fluentui-icons) lets you search and browse all of Fluent UI's icons. You can also use it to create and maintain subsets of the icon font to use in your web apps, which are drop-in replacements for the default Fabric Core and Fluent UI React icon sets. In addition, the Fluent UI Icons tool is updated with new icons several times a month, whereas the default Fluent UI set is updated only occasionally. You can see detailed docs for the tool at https://aka.ms/fluentui-icons?help. (Note: This tool is only for use with font-based icons currently.)
+The [Fluent UI icons tool](https://aka.ms/fluentui-icons) lets you search and browse all of Fluent UI's font-based icons. You can also use it to create and maintain subsets of the icon font to use in your web apps, which are drop-in replacements for the default Fabric Core and Fluent UI React icon sets. In addition, the Fluent UI Icons tool is updated with new icons more frequently than the Fluent UI set. You can see detailed docs for the tool at https://aka.ms/fluentui-icons?help=1.

--- a/apps/public-docsite/tsconfig.json
+++ b/apps/public-docsite/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom", "ES2015.Promise"],
+    "lib": ["es2015", "dom"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["webpack-env", "custom-global"]
   },

--- a/apps/public-docsite/tsconfig.json
+++ b/apps/public-docsite/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "outDir": "lib",
     "target": "es5",
-    "module": "commonjs",
+    // ensure webpack can split async imports into separate chunks
+    "module": "esnext",
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,
@@ -14,7 +15,7 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es5", "dom", "ES2015.Promise"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["webpack-env", "custom-global"]
   },

--- a/apps/public-docsite/webpack.serve.config.js
+++ b/apps/public-docsite/webpack.serve.config.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const IgnoreNotFoundExportWebpackPlugin = require('ignore-not-found-export-webpack-plugin');
 const resources = require('../../scripts/webpack/webpack-resources');
 const getResolveAlias = require('../../scripts/webpack/getResolveAlias');
 const { addMonacoWebpackConfig } = require('@fluentui/react-monaco-editor/scripts/addMonacoWebpackConfig');
@@ -51,6 +52,11 @@ module.exports = [
       optimization: {
         removeAvailableModules: false,
       },
+
+      plugins: [
+        // This plugin was added to ignore warnings wherever types are imported.
+        new IgnoreNotFoundExportWebpackPlugin({ include: [/\.tsx?$/] }),
+      ],
 
       resolve: {
         alias: getResolveAlias(),

--- a/change/@fluentui-react-icons-mdl2-8882c28b-5494-4624-b8e4-7c154b6a68cb.json
+++ b/change/@fluentui-react-icons-mdl2-8882c28b-5494-4624-b8e4-7c154b6a68cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Clarify readme",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icons-mdl2-branded-9032da2d-4806-4448-99f8-1fd1b315a19f.json
+++ b/change/@fluentui-react-icons-mdl2-branded-9032da2d-4806-4448-99f8-1fd1b315a19f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Clarify readme",
+  "packageName": "@fluentui/react-icons-mdl2-branded",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "gulp": "^4.0.2",
     "gzip-size": "6.0.0",
     "html-webpack-plugin": "5.1.0",
+    "ignore-not-found-export-webpack-plugin": "1.0.2",
     "imports-loader": "1.2.0",
     "jest": "26.6.3",
     "jest-axe": "5.0.1",

--- a/packages/fluentui/perf-test/package.json
+++ b/packages/fluentui/perf-test/package.json
@@ -19,7 +19,6 @@
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "flamegrill": "0.2.0",
-    "ignore-not-found-export-webpack-plugin": "^1.0.1",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },

--- a/packages/react-icons-mdl2-branded/README.md
+++ b/packages/react-icons-mdl2-branded/README.md
@@ -4,8 +4,10 @@
 
 This package contains branded icons from the MDL2 SVG icon set. Usage of these icons is subject to the [Microsoft Fabric Assets License](https://aka.ms/fluentui-assets-license).
 
-To import React Icons Mdl2 Branded components:
+For more information, including a list of available icons, see the [Fluent UI website](https://developer.microsoft.com/en-us/fluentui#/styles/web/icons).
+
+To import the icon components:
 
 ```js
-import { ComponentName } from '@fluentui/react-icons-mdl2-branded';
+import { IconName } from '@fluentui/react-icons-mdl2-branded';
 ```

--- a/packages/react-icons-mdl2/README.md
+++ b/packages/react-icons-mdl2/README.md
@@ -2,10 +2,12 @@
 
 **Icon components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
 
-This package provides utilities for creating svg icons, as well as set of customizable Icons.
+This package contains SVG versions of the MDL2 icon set(excluding any branded icons), wrapped in React components. It also includes utilities for creating SVG icon components. These icons are available under the MIT license.
 
-To import ReactIcons components:
+For more information, including a list of available icons, see the [Fluent UI website](https://developer.microsoft.com/en-us/fluentui#/styles/web/icons).
+
+To import the icon components:
 
 ```js
-import { ComponentName } from '@fluentui/react-icons-mdl2';
+import { IconName } from '@fluentui/react-icons-mdl2';
 ```

--- a/packages/react-icons-mdl2/package.json
+++ b/packages/react-icons-mdl2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluentui/react-icons-mdl2",
   "version": "1.2.11",
-  "description": "React components for building web experiences.",
+  "description": "SVG icon components for @fluentui/react",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -55,7 +55,6 @@
     "gulp-remember": "^1.0.1",
     "gulp-sourcemaps": "^2.6.5",
     "gulp-util": "^3.0.8",
-    "ignore-not-found-export-webpack-plugin": "^1.0.1",
     "inquirer": "^7.3.3",
     "json-stable-stringify-without-jsonify": "^1.0.1",
     "lerna-alias": "^3.0.3-0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14301,10 +14301,10 @@ ignore-loader@^0.1.2:
   resolved "https://registry.yarnpkg.com/ignore-loader/-/ignore-loader-0.1.2.tgz#d81f240376d0ba4f0d778972c3ad25874117a463"
   integrity sha1-2B8kA3bQuk8Nd4lyw60lh0EXpGM=
 
-ignore-not-found-export-webpack-plugin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ignore-not-found-export-webpack-plugin/-/ignore-not-found-export-webpack-plugin-1.0.1.tgz#9227691ea6a7478843563fede883e45c89297dc9"
-  integrity sha512-rVGtZt7wHdigYMlu3B/YHj9GHvutG7dG1D98UEgAY7sr3vj9Q8cQbqUTS9hDseFRkn8yzl9qvuuIRc4wncHsWg==
+ignore-not-found-export-webpack-plugin@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ignore-not-found-export-webpack-plugin/-/ignore-not-found-export-webpack-plugin-1.0.2.tgz#53c14198a45f05be306af4cb273890a3edf145c8"
+  integrity sha512-CeMqul+L7fEEc59NpQhzr5sh/LRjbMW4cYmMUJWdCm3dYyWF8Big6qea0YSBHQvajKfrnKTcARmwzd9rTp+50w==
 
 ignore-walk@^3.0.1, ignore-walk@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
This PR is a modified version of some work @tomi-msft and I started in #20862: 
- Clarify some text on the icons doc page for v8
- Add SVG icons (the MDL2 sets in this case) to the icon grid/search at the bottom of the page

Background: today, the text of the v8 doc site page about icons is kind of confusing and outdated in places, and it would have gotten a lot more complex if we added the new `@fluentui/react-icons` SVG icon set to the same page (as we started to do in #20862). Even though we ultimately we decided to put the react-icons docs in the v9 storybook instead (NOT included in this PR), some of the text clarification I'd started working on for the other PR should still be helpful.

I also reused some of the code we started working on in #20862 to display SVG icon sets in the icon grid/search at the bottom of the page, and modified it to use the existing `IconGrid` component to show the icons from `@fluentui/react-icons-mdl2` and `@fluentui/react-icons-mdl2-branded`.