### PR TITLE
fix an issue with ChoiceGroup and focus rectangles

### DIFF
--- a/change/@fluentui-react-3b2991ef-caf7-43f9-aacf-62b7cf3451b1.json
+++ b/change/@fluentui-react-3b2991ef-caf7-43f9-aacf-62b7cf3451b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix an issue with ChoiceGroup and focus rectangles",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Custom.Example.tsx
+++ b/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Custom.Example.tsx
@@ -1,38 +1,28 @@
 import * as React from 'react';
 import { ChoiceGroup, IChoiceGroupOption } from '@fluentui/react/lib/ChoiceGroup';
-import { Dropdown, IDropdownStyles, IDropdownOption } from '@fluentui/react/lib/Dropdown';
 import { mergeStyles } from '@fluentui/react/lib/Styling';
+import { CatIcon } from '@fluentui/react-icons-mdl2';
 
 export const ChoiceGroupCustomExample: React.FunctionComponent = () => {
   return <ChoiceGroup defaultSelectedKey="B" options={options} label="Pick one" />;
 };
 
-const optionRootClass = mergeStyles({ display: 'flex', alignItems: 'baseline' });
-const dropdownStyles: Partial<IDropdownStyles> = {
-  root: { marginBottom: 0, marginLeft: 5 },
+const optionRootClass = mergeStyles({ display: 'flex', alignItems: 'center' });
+const iconStyles = {
+  marginBottom: 0,
+  marginLeft: 5,
 };
-const dropdownOptions: IDropdownOption[] = [
-  { key: 'A', text: '5 seconds' },
-  { key: 'B', text: '10 seconds' },
-  { key: 'C', text: '20 seconds' },
-];
 
 const options: IChoiceGroupOption[] = [
   {
     key: 'A',
-    text: 'Mark displayed items as read after',
-    ariaLabel: 'Mark displayed items as read after - Press tab for further action',
+    text: 'A label with an icon',
+    ariaLabel: 'A label with a cat icon',
     onRenderField: (props, render) => {
       return (
         <div className={optionRootClass}>
           {render!(props)}
-          <Dropdown
-            defaultSelectedKey="A"
-            styles={dropdownStyles}
-            options={dropdownOptions}
-            disabled={props ? !props.checked : false}
-            ariaLabel="Select a time span"
-          />
+          <CatIcon style={iconStyles} />
         </div>
       );
     },

--- a/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Custom.Example.tsx
+++ b/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Custom.Example.tsx
@@ -7,11 +7,7 @@ export const ChoiceGroupCustomExample: React.FunctionComponent = () => {
   return <ChoiceGroup defaultSelectedKey="B" options={options} label="Pick one" />;
 };
 
-const optionRootClass = mergeStyles({ display: 'flex', alignItems: 'center' });
-const iconStyles = {
-  marginBottom: 0,
-  marginLeft: 5,
-};
+const optionRootClass = mergeStyles({ display: 'flex', alignItems: 'center', gap: '5px' });
 
 const options: IChoiceGroupOption[] = [
   {
@@ -22,7 +18,7 @@ const options: IChoiceGroupOption[] = [
       return (
         <div className={optionRootClass}>
           {render!(props)}
-          <CatIcon style={iconStyles} />
+          <CatIcon />
         </div>
       );
     },

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -76,7 +76,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
           className="ms-ChoiceField-wrapper"
         >
           <input
-            aria-label="Mark displayed items as read after - Press tab for further action"
+            aria-label="A label with a cat icon"
             checked={false}
             className=
                 ms-ChoiceField-input
@@ -103,7 +103,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
             className=
 
                 {
-                  align-items: baseline;
+                  align-items: center;
                   display: flex;
                 }
           >
@@ -187,180 +187,29 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                 className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-A"
               >
-                Mark displayed items as read after
+                A label with an icon
               </span>
             </label>
-            <div
-              className=
-                  ms-Dropdown-container
-                  {
-                    margin-bottom: 0px;
-                    margin-left: 5px;
-                  }
+            <span
+              aria-hidden={true}
+              className=""
+              style={
+                Object {
+                  "marginBottom": 0,
+                  "marginLeft": 5,
+                }
+              }
             >
-              <div
-                aria-disabled={true}
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                aria-label="Select a time span"
-                className=
-                    ms-Dropdown
-                    is-disabled
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border-color: #605e5c;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      color: #323130;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      outline: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      user-select: none;
-                    }
-                    &:hover .ms-Dropdown-title {
-                      border-color: #323130;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Dropdown-title {
-                      border-color: Highlight;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Dropdown-title {
-                      color: Highlight;
-                    }
-                    &:focus:after {
-                      border-radius: 2px;
-                      border: none;
-                      box-sizing: border-box;
-                      content: '';
-                      height: 100%;
-                      left: 0px;
-                      pointer-events: none;
-                      position: absolute;
-                      top: 0px;
-                      width: 100%;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus:after {
-                      color: Highlight;
-                    }
-                    &:active .ms-Dropdown-title {
-                      border-color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Dropdown-title {
-                      border-color: Highlight;
-                    }
-                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:focus .ms-Dropdown-caretDown {
-                      color: Highlight;
-                    }
-                    &:hover .ms-Dropdown-title--hasError {
-                      border-color: #a4262c;
-                    }
-                    &:active .ms-Dropdown-title--hasError {
-                      border-color: #a4262c;
-                    }
-                data-is-focusable={false}
-                data-ktp-target={true}
-                id="Dropdown2"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                role="combobox"
-                tabIndex={-1}
+              <svg
+                focusable="false"
+                viewBox="0 0 2048 2048"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <span
-                  aria-invalid={false}
-                  className=
-                      ms-Dropdown-title
-                      {
-                        background-color: #f3f2f1;
-                        border-color: #605e5c;
-                        border-radius: 2px;
-                        border-style: solid;
-                        border-width: 1px;
-                        border: none;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        color: #a19f9d;
-                        cursor: default;
-                        display: block;
-                        height: 32px;
-                        line-height: 30px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 28px;
-                        padding-top: 0;
-                        position: relative;
-                        text-overflow: ellipsis;
-                        white-space: nowrap;
-                      }
-                      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                        -ms-high-contrast-adjust: none;
-                        background-color: Window;
-                        border: 1px solid GrayText;
-                        color: GrayText;
-                        forced-color-adjust: none;
-                      }
-                  id="Dropdown2-option"
-                >
-                  5 seconds
-                </span>
-                <span
-                  className=
-                      ms-Dropdown-caretDownWrapper
-                      {
-                        height: 32px;
-                        line-height: 30px;
-                        padding-top: 1px;
-                        position: absolute;
-                        right: 8px;
-                        top: 0px;
-                      }
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Dropdown-caretDown
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #a19f9d;
-                          display: inline-block;
-                          font-family: "FabricMDL2Icons";
-                          font-size: 12px;
-                          font-style: normal;
-                          font-weight: normal;
-                          pointer-events: none;
-                          speak: none;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                          -ms-high-contrast-adjust: none;
-                          color: GrayText;
-                          forced-color-adjust: none;
-                        }
-                    data-icon-name="ChevronDown"
-                  >
-                    
-                  </i>
-                </span>
-              </div>
-            </div>
+                <path
+                  d="M2048 576q0 40-15 75t-41 61-61 41-75 15h-64v640q0 66 11 131t34 129q46 8 84 31t67 56 44 76 16 89v40q0 22-4 42t-18 33-42 13H512q-106 0-199-40t-162-110-110-163-41-199q0-79 30-149t82-122 122-83 150-30q26 0 49-10t41-27 28-41 10-50q0-27-10-50t-27-40-41-28-50-10V768q53 0 99 20t82 55 55 81 20 100q0 53-20 99t-55 82-81 55-100 20q-53 0-99 20t-82 55-55 81-20 100q0 80 30 149t82 122 122 83 150 30q26 0 49-10t41-27 28-41 10-50q0-198 69-369t205-315q117-124 177-274t61-322V384q0-79 30-149t82-122 122-83 150-30h128v113q0 17 9 33t26 24q61 30 121 60t122 61q49 25 77 71t29 101v113zm-128 1344q0-26-10-49t-27-41-41-28-50-10q-21 0-35-10t-24-29q-18-34-31-78t-21-90-13-93-4-84V768q0-27 10-50t27-40 41-28 50-10h40q22 0 42-4t33-18 13-42V463q0-17-9-33t-26-24q-61-30-121-60t-122-61q-45-23-72-64t-32-93q-53 0-100 20t-82 54-55 81-21 101v128q0 197-69 369t-205 315q-117 124-177 274t-61 322q0 34-9 66t-27 62h804q0-26-10-49t-27-41-41-28-50-10h-256v-128h256q8 0 15 1t16 2l-93-371 124-32 119 475q36 36 55 83t20 98h256zM1600 384q26 0 45 19t19 45q0 26-19 45t-45 19q-26 0-45-19t-19-45q0-26 19-45t45-19z"
+                />
+              </svg>
+            </span>
           </div>
         </div>
       </div>

--- a/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -105,6 +105,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                 {
                   align-items: center;
                   display: flex;
+                  gap: 5px;
                 }
           >
             <label
@@ -193,12 +194,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
             <span
               aria-hidden={true}
               className=""
-              style={
-                Object {
-                  "marginBottom": 0,
-                  "marginLeft": 5,
-                }
-              }
+              style={Object {}}
             >
               <svg
                 focusable="false"

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -7,6 +7,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
 >
   <div
     aria-hidden={true}
+    data-is-focus-trap-zone-bumper={true}
     data-is-visible={true}
     style={
       Object {
@@ -1558,6 +1559,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
   </div>
   <div
     aria-hidden={true}
+    data-is-focus-trap-zone-bumper={true}
     data-is-visible={true}
     style={
       Object {

--- a/packages/react-examples/src/react/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -866,6 +866,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                               >
                                 <div
                                   aria-hidden={true}
+                                  data-is-focus-trap-zone-bumper={true}
                                   data-is-visible={true}
                                   style={
                                     Object {
@@ -918,6 +919,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                       >
                                         <div
                                           aria-hidden={true}
+                                          data-is-focus-trap-zone-bumper={true}
                                           data-is-visible={true}
                                           style={
                                             Object {
@@ -1134,6 +1136,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                         </div>
                                         <div
                                           aria-hidden={true}
+                                          data-is-focus-trap-zone-bumper={true}
                                           data-is-visible={true}
                                           style={
                                             Object {
@@ -1149,6 +1152,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                 </div>
                                 <div
                                   aria-hidden={true}
+                                  data-is-focus-trap-zone-bumper={true}
                                   data-is-visible={true}
                                   style={
                                     Object {

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -7,6 +7,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
 >
   <div
     aria-hidden={true}
+    data-is-focus-trap-zone-bumper={true}
     data-is-visible={true}
     style={
       Object {
@@ -442,6 +443,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
   </div>
   <div
     aria-hidden={true}
+    data-is-focus-trap-zone-bumper={true}
     data-is-visible={true}
     style={
       Object {

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -190,6 +190,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
   >
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -625,6 +626,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
     </div>
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -190,6 +190,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
   >
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -626,6 +627,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
     </div>
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -7,6 +7,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
 >
   <div
     aria-hidden={true}
+    data-is-focus-trap-zone-bumper={true}
     data-is-visible={true}
     style={
       Object {
@@ -1102,6 +1103,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
   </div>
   <div
     aria-hidden={true}
+    data-is-focus-trap-zone-bumper={true}
     data-is-visible={true}
     style={
       Object {

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -8,6 +8,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
   >
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -336,6 +337,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
       >
         <div
           aria-hidden={true}
+          data-is-focus-trap-zone-bumper={true}
           data-is-visible={true}
           style={
             Object {
@@ -665,6 +667,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           >
             <div
               aria-hidden={true}
+              data-is-focus-trap-zone-bumper={true}
               data-is-visible={true}
               style={
                 Object {
@@ -991,6 +994,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             </div>
             <div
               aria-hidden={true}
+              data-is-focus-trap-zone-bumper={true}
               data-is-visible={true}
               style={
                 Object {
@@ -1007,6 +1011,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           >
             <div
               aria-hidden={true}
+              data-is-focus-trap-zone-bumper={true}
               data-is-visible={true}
               style={
                 Object {
@@ -1333,6 +1338,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             </div>
             <div
               aria-hidden={true}
+              data-is-focus-trap-zone-bumper={true}
               data-is-visible={true}
               style={
                 Object {
@@ -1346,6 +1352,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         </div>
         <div
           aria-hidden={true}
+          data-is-focus-trap-zone-bumper={true}
           data-is-visible={true}
           style={
             Object {
@@ -1362,6 +1369,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
       >
         <div
           aria-hidden={true}
+          data-is-focus-trap-zone-bumper={true}
           data-is-visible={true}
           style={
             Object {
@@ -1687,6 +1695,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         </div>
         <div
           aria-hidden={true}
+          data-is-focus-trap-zone-bumper={true}
           data-is-visible={true}
           style={
             Object {
@@ -1700,6 +1709,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
     </div>
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -43,7 +43,11 @@ const focusSelectedOption = (options: IChoiceGroupOption[], keyChecked: string |
 
 // Test if focus came from a sibling DOM element
 const focusFromSibling = (evt: React.FocusEvent<HTMLElement>): boolean => {
-  return !!(evt.relatedTarget && !elementContains(evt.currentTarget, evt.relatedTarget as HTMLElement));
+  return !!(
+    evt.relatedTarget &&
+    !elementContains(evt.currentTarget, evt.relatedTarget as HTMLElement) &&
+    !elementContains(evt.relatedTarget as HTMLElement, evt.currentTarget)
+  );
 };
 
 const useComponentRef = (

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -41,7 +41,7 @@ const focusSelectedOption = (options: IChoiceGroupOption[], keyChecked: string |
 };
 
 const focusFromFocusTrapZone = (evt: React.FocusEvent<HTMLElement>): boolean => {
-  return !!(evt.relatedTarget && (evt.relatedTarget as HTMLElement)?.dataset.isFocusTrapZoneBumper === 'true');
+  return (evt.relatedTarget instanceof HTMLElement) && evt.relatedTarget.dataset.isFocusTrapZoneBumper === 'true';
 };
 
 const useComponentRef = (

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -41,7 +41,7 @@ const focusSelectedOption = (options: IChoiceGroupOption[], keyChecked: string |
 };
 
 const focusFromFocusTrapZone = (evt: React.FocusEvent<HTMLElement>): boolean => {
-  return (evt.relatedTarget instanceof HTMLElement) && evt.relatedTarget.dataset.isFocusTrapZoneBumper === 'true';
+  return evt.relatedTarget instanceof HTMLElement && evt.relatedTarget.dataset.isFocusTrapZoneBumper === 'true';
 };
 
 const useComponentRef = (

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Label } from '../../Label';
 import {
   classNamesFunction,
-  elementContains,
   find,
   getNativeProps,
   divProperties,
@@ -41,13 +40,8 @@ const focusSelectedOption = (options: IChoiceGroupOption[], keyChecked: string |
   }
 };
 
-// Test if focus came from a sibling DOM element
-const focusFromSibling = (evt: React.FocusEvent<HTMLElement>): boolean => {
-  return !!(
-    evt.relatedTarget &&
-    !elementContains(evt.currentTarget, evt.relatedTarget as HTMLElement) &&
-    !elementContains(evt.relatedTarget as HTMLElement, evt.currentTarget)
-  );
+const focusFromFocusTrapZone = (evt: React.FocusEvent<HTMLElement>): boolean => {
+  return !!(evt.relatedTarget && (evt.relatedTarget as HTMLElement)?.dataset.isFocusTrapZoneBumper === 'true');
 };
 
 const useComponentRef = (
@@ -144,7 +138,7 @@ export const ChoiceGroupBase: React.FunctionComponent<IChoiceGroupProps> = React
   const onRadioFocus = React.useCallback(
     (evt: React.FocusEvent<HTMLElement>) => {
       // Handles scenarios like this bug: https://github.com/microsoft/fluentui/issues/20173
-      if (focusFromSibling(evt)) {
+      if (focusFromFocusTrapZone(evt)) {
         focusSelectedOption(options, keyChecked, id);
       }
     },

--- a/packages/react/src/components/Coachmark/__snapshots__/Coachmark.test.tsx.snap
+++ b/packages/react/src/components/Coachmark/__snapshots__/Coachmark.test.tsx.snap
@@ -226,6 +226,7 @@ exports[`Coachmark renders Coachmark (color properties) 1`] = `
                   >
                     <div
                       aria-hidden={true}
+                      data-is-focus-trap-zone-bumper={true}
                       data-is-visible={true}
                       style={
                         Object {
@@ -255,6 +256,7 @@ exports[`Coachmark renders Coachmark (color properties) 1`] = `
                     </div>
                     <div
                       aria-hidden={true}
+                      data-is-focus-trap-zone-bumper={true}
                       data-is-visible={true}
                       style={
                         Object {
@@ -502,6 +504,7 @@ exports[`Coachmark renders Coachmark (correctly) 1`] = `
                   >
                     <div
                       aria-hidden={true}
+                      data-is-focus-trap-zone-bumper={true}
                       data-is-visible={true}
                       style={
                         Object {
@@ -533,6 +536,7 @@ exports[`Coachmark renders Coachmark (correctly) 1`] = `
                     </div>
                     <div
                       aria-hidden={true}
+                      data-is-focus-trap-zone-bumper={true}
                       data-is-visible={true}
                       style={
                         Object {
@@ -723,6 +727,7 @@ exports[`Coachmark renders Coachmark (isCollapsed) 1`] = `
                   >
                     <div
                       aria-hidden={true}
+                      data-is-focus-trap-zone-bumper={true}
                       data-is-visible={true}
                       style={
                         Object {
@@ -755,6 +760,7 @@ exports[`Coachmark renders Coachmark (isCollapsed) 1`] = `
                     </div>
                     <div
                       aria-hidden={true}
+                      data-is-focus-trap-zone-bumper={true}
                       data-is-visible={true}
                       style={
                         Object {

--- a/packages/react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
+++ b/packages/react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`Dialog deprecated props renders Dialog with className 1`] = `
         >
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -295,6 +296,7 @@ exports[`Dialog deprecated props renders Dialog with className 1`] = `
           </div>
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -450,6 +452,7 @@ exports[`Dialog deprecated props renders Dialog with containerClassName 1`] = `
         >
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -606,6 +609,7 @@ exports[`Dialog deprecated props renders Dialog with containerClassName 1`] = `
           </div>
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -761,6 +765,7 @@ exports[`Dialog deprecated props renders Dialog with isBlocking set to true 1`] 
         >
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -1047,6 +1052,7 @@ exports[`Dialog deprecated props renders Dialog with isBlocking set to true 1`] 
           </div>
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -1202,6 +1208,7 @@ exports[`Dialog deprecated props renders Dialog with isDarkOverlay set to true 1
         >
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -1358,6 +1365,7 @@ exports[`Dialog deprecated props renders Dialog with isDarkOverlay set to true 1
           </div>
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {

--- a/packages/react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -94,6 +94,7 @@ export const FocusTrapZone: React.FunctionComponent<IFocusTrapZoneProps> & {
     },
     tabIndex: disabled ? -1 : 0, // make bumpers tabbable only when enabled
     'data-is-visible': true,
+    'data-is-focus-trap-zone-bumper': true,
   } as React.HTMLAttributes<HTMLDivElement>;
 
   const focus = React.useCallback(() => {

--- a/packages/react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -125,6 +125,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
           >
             <div
               aria-hidden={true}
+              data-is-focus-trap-zone-bumper={true}
               data-is-visible={true}
               style={
                 Object {
@@ -152,6 +153,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
             </div>
             <div
               aria-hidden={true}
+              data-is-focus-trap-zone-bumper={true}
               data-is-visible={true}
               style={
                 Object {
@@ -294,6 +296,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
           >
             <div
               aria-hidden={true}
+              data-is-focus-trap-zone-bumper={true}
               data-is-visible={true}
               style={
                 Object {
@@ -319,6 +322,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
             </div>
             <div
               aria-hidden={true}
+              data-is-focus-trap-zone-bumper={true}
               data-is-visible={true}
               style={
                 Object {

--- a/packages/react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -126,6 +126,7 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
         >
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -152,6 +153,7 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
           </div>
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -307,6 +309,7 @@ exports[`Modal renders Modal correctly 1`] = `
         >
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -333,6 +336,7 @@ exports[`Modal renders Modal correctly 1`] = `
           </div>
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -465,6 +469,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
         >
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -491,6 +496,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
           </div>
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {

--- a/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -154,6 +154,7 @@ exports[`Panel allows the consumer to pass through popup props 1`] = `
         >
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -386,6 +387,7 @@ exports[`Panel allows the consumer to pass through popup props 1`] = `
           </div>
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -555,6 +557,7 @@ exports[`Panel renders Panel correctly 1`] = `
         >
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {
@@ -787,6 +790,7 @@ exports[`Panel renders Panel correctly 1`] = `
           </div>
           <div
             aria-hidden={true}
+            data-is-focus-trap-zone-bumper={true}
             data-is-visible={true}
             style={
               Object {

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
   >
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -592,6 +593,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
     </div>
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -101,6 +101,7 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
           >
             <div
               aria-hidden={true}
+              data-is-focus-trap-zone-bumper={true}
               data-is-visible={true}
               style={
                 Object {
@@ -147,6 +148,7 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
             </div>
             <div
               aria-hidden={true}
+              data-is-focus-trap-zone-bumper={true}
               data-is-visible={true}
               style={
                 Object {
@@ -191,6 +193,7 @@ exports[`TeachingBubble renders TeachingBubbleContent correctly 1`] = `
   >
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -265,6 +268,7 @@ exports[`TeachingBubble renders TeachingBubbleContent correctly 1`] = `
     </div>
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -305,6 +309,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
   >
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -870,6 +875,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
     </div>
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -910,6 +916,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with calloutProps that dea
   >
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -956,6 +963,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with calloutProps that dea
     </div>
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -996,6 +1004,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with condensed headline co
   >
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -1074,6 +1083,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with condensed headline co
     </div>
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -1114,6 +1124,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with custom footer text 1`
   >
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -1223,6 +1234,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with custom footer text 1`
     </div>
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -1263,6 +1275,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with generated aria-descri
   >
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -1337,6 +1350,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with generated aria-descri
     </div>
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -1414,6 +1428,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
   >
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -1488,6 +1503,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
     </div>
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -1528,6 +1544,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with small headline correc
   >
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {
@@ -1608,6 +1625,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with small headline correc
     </div>
     <div
       aria-hidden={true}
+      data-is-focus-trap-zone-bumper={true}
       data-is-visible={true}
       style={
         Object {


### PR DESCRIPTION
* [X] Code is up-to-date with the `master` branch
* [X] You've run `yarn change` locally


PR flow tips:
* [X] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.

## Current Behavior

When `ChoiceGroup` is the child of an element that has focus clicking on an option will incorrectly draw a focus rectangle around the previously selected option. This is observable on the docs page for `ChoiceGroup` but not in an exported Codepen as described in #21193.

## New Behavior

#20859 added code to check if an element is a sibling of `ChoiceGroup` but it only tested that the element under consideration was not a descendant of `ChoiceGroup`. This change updates this code to also check that the element being tested is not an ancestor of `ChoiceGroup`.

### BEFORE
![Animated GIF showing the behavior before the change](https://user-images.githubusercontent.com/93940821/148620547-7404ae8a-2254-48f1-836a-3585a1b3f80c.gif)

### AFTER
![Animated GIF showing the behavior after the change](https://user-images.githubusercontent.com/93940821/148620576-622e7f9a-e38a-4a8e-98c2-b65183c153b6.gif)


## How to Test

1. Pull this branch locally
2. Run `yarn start`
3. Select "@fluentui/public-docsite"
4. Open the docsite in your browser (this should happen automatically)
    1. Under the "React" section click "Controls"
    2. On the next page click through Basic Controls > ChoiceGroup
    3. Scroll down an interact with any of the Usage examples

## Related Issue(s)

https://github.com/microsoft/fluentui/issues/21193

Fixes #21193
