### PR TITLE
react-button: remove fixed-size icons

### DIFF
--- a/change/@fluentui-react-button-5cc8ef32-ce96-4881-bd8e-e9dbc462c7c6.json
+++ b/change/@fluentui-react-button-5cc8ef32-ce96-4881-bd8e-e9dbc462c7c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove fontSize from default menuIcon, as it is already set via css",
+  "packageName": "@fluentui/react-button",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/components/Button/stories/ButtonDisabled.stories.tsx
+++ b/packages/react-button/src/components/Button/stories/ButtonDisabled.stories.tsx
@@ -13,10 +13,10 @@ export const Disabled = () => {
         <Button disabledFocusable>Disabled focusable</Button>
       </div>
       <div style={groupStyles}>
-        <Button appearance="primary" icon={<CalendarMonthRegular fontSize={24} />}>
+        <Button appearance="primary" icon={<CalendarMonthRegular />}>
           Primary
         </Button>
-        <Button appearance="primary" disabled icon={<CalendarMonthRegular fontSize={24} />}>
+        <Button appearance="primary" disabled icon={<CalendarMonthRegular />}>
           Primary disabled
         </Button>
         <Button appearance="primary" disabledFocusable>

--- a/packages/react-button/src/components/Button/stories/ButtonIcon.stories.tsx
+++ b/packages/react-button/src/components/Button/stories/ButtonIcon.stories.tsx
@@ -4,11 +4,11 @@ import { Button } from '../../../Button';
 
 export const Icon = () => (
   <>
-    <Button icon={<CalendarMonthRegular fontSize={24} />}>Text</Button>
-    <Button icon={<CalendarMonthRegular fontSize={24} />} iconPosition="after">
+    <Button icon={<CalendarMonthRegular />}>Text</Button>
+    <Button icon={<CalendarMonthRegular />} iconPosition="after">
       Text
     </Button>
-    <Button icon={<CalendarMonthRegular fontSize={24} />} />
+    <Button icon={<CalendarMonthRegular />} />
   </>
 );
 Icon.parameters = {

--- a/packages/react-button/src/components/Button/stories/ButtonSize.stories.tsx
+++ b/packages/react-button/src/components/Button/stories/ButtonSize.stories.tsx
@@ -11,24 +11,24 @@ export const Size = () => {
       <div style={groupStyles}>
         <h4 style={headerStyles}>small</h4>
         <Button size="small">Text</Button>
-        <Button size="small" icon={<CalendarMonthRegular fontSize={24} />}>
+        <Button size="small" icon={<CalendarMonthRegular />}>
           Text
         </Button>
-        <Button size="small" icon={<CalendarMonthRegular fontSize={24} />} />
+        <Button size="small" icon={<CalendarMonthRegular />} />
       </div>
       <div style={groupStyles}>
         <h4 style={headerStyles}>medium</h4>
         <Button>Text</Button>
-        <Button icon={<CalendarMonthRegular fontSize={24} />}>Text</Button>
-        <Button icon={<CalendarMonthRegular fontSize={24} />} />
+        <Button icon={<CalendarMonthRegular />}>Text</Button>
+        <Button icon={<CalendarMonthRegular />} />
       </div>
       <div style={groupStyles}>
         <h4 style={headerStyles}>large</h4>
         <Button size="large">Text</Button>
-        <Button size="large" icon={<CalendarMonthRegular fontSize={24} />}>
+        <Button size="large" icon={<CalendarMonthRegular />}>
           Text
         </Button>
-        <Button size="large" icon={<CalendarMonthRegular fontSize={24} />} />
+        <Button size="large" icon={<CalendarMonthRegular />} />
       </div>
     </>
   );

--- a/packages/react-button/src/components/CompoundButton/stories/CompoundButtonDisabled.stories.tsx
+++ b/packages/react-button/src/components/CompoundButton/stories/CompoundButtonDisabled.stories.tsx
@@ -20,7 +20,7 @@ export const Disabled = () => {
         <CompoundButton
           secondaryContent="This is the secondary content"
           appearance="primary"
-          icon={<CalendarMonthRegular fontSize={24} />}
+          icon={<CalendarMonthRegular />}
         >
           Primary
         </CompoundButton>
@@ -28,7 +28,7 @@ export const Disabled = () => {
           secondaryContent="This is the secondary content"
           appearance="primary"
           disabled
-          icon={<CalendarMonthRegular fontSize={24} />}
+          icon={<CalendarMonthRegular />}
         >
           Primary disabled
         </CompoundButton>

--- a/packages/react-button/src/components/CompoundButton/stories/CompoundButtonIcon.stories.tsx
+++ b/packages/react-button/src/components/CompoundButton/stories/CompoundButtonIcon.stories.tsx
@@ -4,17 +4,17 @@ import { CompoundButton } from '../../../CompoundButton';
 
 export const Icon = () => (
   <>
-    <CompoundButton secondaryContent="This is the secondary content" icon={<CalendarMonthRegular fontSize={24} />}>
+    <CompoundButton secondaryContent="This is the secondary content" icon={<CalendarMonthRegular />}>
       Text
     </CompoundButton>
     <CompoundButton
       secondaryContent="This is the secondary content"
-      icon={<CalendarMonthRegular fontSize={24} />}
+      icon={<CalendarMonthRegular />}
       iconPosition="after"
     >
       Text
     </CompoundButton>
-    <CompoundButton secondaryContent="This is the secondary content" icon={<CalendarMonthRegular fontSize={24} />} />
+    <CompoundButton secondaryContent="This is the secondary content" icon={<CalendarMonthRegular />} />
   </>
 );
 Icon.parameters = {

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonIcon.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonIcon.stories.tsx
@@ -8,7 +8,7 @@ export const Icon = () => (
   <>
     <Menu>
       <MenuTrigger>
-        <MenuButton icon={<CalendarMonthRegular fontSize={24} />}>This is a Menu Button</MenuButton>
+        <MenuButton icon={<CalendarMonthRegular />}>This is a Menu Button</MenuButton>
       </MenuTrigger>
       <MenuPopover>
         <MenuList>
@@ -20,7 +20,7 @@ export const Icon = () => (
 
     <Menu>
       <MenuTrigger>
-        <MenuButton icon={<CalendarMonthRegular fontSize={24} />} menuIcon={<FilterRegular fontSize={24} />}>
+        <MenuButton icon={<CalendarMonthRegular />} menuIcon={<FilterRegular />}>
           This is a Menu Button
         </MenuButton>
       </MenuTrigger>
@@ -34,7 +34,7 @@ export const Icon = () => (
 
     <Menu>
       <MenuTrigger>
-        <MenuButton icon={<CalendarMonthRegular fontSize={24} />} />
+        <MenuButton icon={<CalendarMonthRegular />} />
       </MenuTrigger>
       <MenuPopover>
         <MenuList>

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonSizeLarge.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonSizeLarge.stories.tsx
@@ -22,7 +22,7 @@ export const SizeLarge = () => {
 
       <Menu>
         <MenuTrigger>
-          <MenuButton icon={<CalendarMonthRegular fontSize={24} />} size="large">
+          <MenuButton icon={<CalendarMonthRegular />} size="large">
             This is a Menu Button
           </MenuButton>
         </MenuTrigger>

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonSizeMedium.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonSizeMedium.stories.tsx
@@ -22,7 +22,7 @@ export const SizeMedium = () => {
 
       <Menu>
         <MenuTrigger>
-          <MenuButton icon={<CalendarMonthRegular fontSize={24} />} size="medium">
+          <MenuButton icon={<CalendarMonthRegular />} size="medium">
             This is a Menu Button
           </MenuButton>
         </MenuTrigger>

--- a/packages/react-button/src/components/MenuButton/stories/MenuButtonSizeSmall.stories.tsx
+++ b/packages/react-button/src/components/MenuButton/stories/MenuButtonSizeSmall.stories.tsx
@@ -22,7 +22,7 @@ export const SizeSmall = () => {
 
       <Menu>
         <MenuTrigger>
-          <MenuButton icon={<CalendarMonthRegular fontSize={24} />} size="small">
+          <MenuButton icon={<CalendarMonthRegular />} size="small">
             This is a Menu Button
           </MenuButton>
         </MenuTrigger>

--- a/packages/react-button/src/components/MenuButton/useMenuButton.tsx
+++ b/packages/react-button/src/components/MenuButton/useMenuButton.tsx
@@ -28,8 +28,7 @@ export const useMenuButton = (
 
     menuIcon: resolveShorthand(menuIcon, {
       defaultProps: {
-        children:
-          buttonState.size === 'large' ? <ChevronDownRegular fontSize={24} /> : <ChevronDownRegular fontSize={20} />,
+        children: <ChevronDownRegular />,
       },
       required: true,
     }),

--- a/packages/react-button/src/components/SplitButton/stories/SplitButtonIcon.stories.tsx
+++ b/packages/react-button/src/components/SplitButton/stories/SplitButtonIcon.stories.tsx
@@ -12,7 +12,7 @@ export const Icon = () => (
           <SplitButton
             menuButton={triggerProps}
             primaryActionButton={'This is a split button'}
-            icon={<CalendarMonthRegular fontSize={24} />}
+            icon={<CalendarMonthRegular />}
           />
         )}
       </MenuTrigger>
@@ -30,8 +30,8 @@ export const Icon = () => (
           <SplitButton
             menuButton={triggerProps}
             primaryActionButton={'This is a split button'}
-            icon={<CalendarMonthRegular fontSize={24} />}
-            menuIcon={<FilterRegular fontSize={24} />}
+            icon={<CalendarMonthRegular />}
+            menuIcon={<FilterRegular />}
           />
         )}
       </MenuTrigger>
@@ -49,7 +49,7 @@ export const Icon = () => (
           <SplitButton
             menuButton={triggerProps}
             primaryActionButton={'This is a split button'}
-            icon={<CalendarMonthRegular fontSize={24} />}
+            icon={<CalendarMonthRegular />}
           />
         )}
       </MenuTrigger>

--- a/packages/react-button/src/components/SplitButton/stories/SplitButtonSizeLarge.stories.tsx
+++ b/packages/react-button/src/components/SplitButton/stories/SplitButtonSizeLarge.stories.tsx
@@ -28,7 +28,7 @@ export const SizeLarge = () => {
             <SplitButton
               menuButton={triggerProps}
               primaryActionButton={'This is a split button'}
-              icon={<CalendarMonthRegular fontSize={24} />}
+              icon={<CalendarMonthRegular />}
               size="large"
             />
           )}

--- a/packages/react-button/src/components/SplitButton/stories/SplitButtonSizeMedium.stories.tsx
+++ b/packages/react-button/src/components/SplitButton/stories/SplitButtonSizeMedium.stories.tsx
@@ -28,7 +28,7 @@ export const SizeMedium = () => {
             <SplitButton
               menuButton={triggerProps}
               primaryActionButton={'This is a split button'}
-              icon={<CalendarMonthRegular fontSize={24} />}
+              icon={<CalendarMonthRegular />}
               size="medium"
             />
           )}

--- a/packages/react-button/src/components/SplitButton/stories/SplitButtonSizeSmall.stories.tsx
+++ b/packages/react-button/src/components/SplitButton/stories/SplitButtonSizeSmall.stories.tsx
@@ -28,7 +28,7 @@ export const SizeSmall = () => {
             <SplitButton
               menuButton={triggerProps}
               primaryActionButton={'This is a split button'}
-              icon={<CalendarMonthRegular fontSize={24} />}
+              icon={<CalendarMonthRegular />}
               size="small"
             />
           )}

--- a/packages/react-button/src/components/ToggleButton/stories/ToggleButtonDisabled.stories.tsx
+++ b/packages/react-button/src/components/ToggleButton/stories/ToggleButtonDisabled.stories.tsx
@@ -13,10 +13,10 @@ export const Disabled = () => {
         <ToggleButton disabledFocusable>Disabled focusable</ToggleButton>
       </div>
       <div style={groupStyles}>
-        <ToggleButton appearance="primary" icon={<CalendarMonthRegular fontSize={24} />}>
+        <ToggleButton appearance="primary" icon={<CalendarMonthRegular />}>
           Primary
         </ToggleButton>
-        <ToggleButton appearance="primary" disabled icon={<CalendarMonthRegular fontSize={24} />}>
+        <ToggleButton appearance="primary" disabled icon={<CalendarMonthRegular />}>
           Primary disabled
         </ToggleButton>
         <ToggleButton appearance="primary" disabledFocusable>

--- a/packages/react-button/src/components/ToggleButton/stories/ToggleButtonIcon.stories.tsx
+++ b/packages/react-button/src/components/ToggleButton/stories/ToggleButtonIcon.stories.tsx
@@ -4,11 +4,11 @@ import { ToggleButton } from '../../../ToggleButton'; // codesandbox-dependency:
 
 export const Icon = () => (
   <>
-    <ToggleButton icon={<CalendarMonthRegular fontSize={24} />}>Text</ToggleButton>
-    <ToggleButton icon={<CalendarMonthRegular fontSize={24} />} iconPosition="after">
+    <ToggleButton icon={<CalendarMonthRegular />}>Text</ToggleButton>
+    <ToggleButton icon={<CalendarMonthRegular />} iconPosition="after">
       Text
     </ToggleButton>
-    <ToggleButton icon={<CalendarMonthRegular fontSize={24} />} />
+    <ToggleButton icon={<CalendarMonthRegular />} />
   </>
 );
 Icon.parameters = {


### PR DESCRIPTION
## Current Behavior

react-button has hard-coded icon sizes

## New Behavior

Remove the fixed-sized icons from react-button's stories. The Button's styles already apply a default size for the icons.

## Related Issue(s)

#21220