### PR TITLE
react-menu: remove fixed-size icons

### DIFF
--- a/change/@fluentui-react-menu-9f983fe2-dde4-4d1d-a059-cb0132875ecf.json
+++ b/change/@fluentui-react-menu-9f983fe2-dde4-4d1d-a059-cb0132875ecf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Apply fontSize styling to icon slot",
+  "packageName": "@fluentui/react-menu",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-menu/src/components/MenuItem/useMenuItem.tsx
@@ -63,7 +63,7 @@ export const useMenuItem = (props: MenuItemProps, ref: React.Ref<HTMLElement>): 
     submenuIndicator: resolveShorthand(props.submenuIndicator, {
       required: hasSubmenu,
       defaultProps: {
-        children: dir === 'ltr' ? <ChevronRightIcon fontSize={20} /> : <ChevronLeftIcon fontSize={20} />,
+        children: dir === 'ltr' ? <ChevronRightIcon /> : <ChevronLeftIcon />,
       },
     }),
     content: resolveShorthand(props.content, {

--- a/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
+++ b/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
@@ -50,10 +50,12 @@ const useStyles = makeStyles({
   icon: {
     width: '20px',
     height: '20px',
+    fontSize: '20px',
   },
   submenuIndicator: {
     width: '20px',
     height: '20px',
+    fontSize: '20px',
   },
   disabled: {
     color: tokens.colorNeutralForegroundDisabled,

--- a/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
+++ b/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
@@ -51,11 +51,13 @@ const useStyles = makeStyles({
     width: '20px',
     height: '20px',
     fontSize: '20px',
+    lineHeight: 0,
   },
   submenuIndicator: {
     width: '20px',
     height: '20px',
     fontSize: '20px',
+    lineHeight: 0,
   },
   disabled: {
     color: tokens.colorNeutralForegroundDisabled,

--- a/packages/react-menu/src/stories/MenuAligningWithIcons.stories.tsx
+++ b/packages/react-menu/src/stories/MenuAligningWithIcons.stories.tsx
@@ -13,7 +13,7 @@ export const AligningWithIcons = () => (
     <MenuPopover>
       <MenuList>
         <MenuItem>Cut</MenuItem>
-        <MenuItem icon={<PasteIcon fontSize={20} />}>Paste</MenuItem>
+        <MenuItem icon={<PasteIcon />}>Paste</MenuItem>
         <MenuItem>Edit</MenuItem>
       </MenuList>
     </MenuPopover>

--- a/packages/react-menu/src/stories/MenuAligningWithSelectableItems.stories.tsx
+++ b/packages/react-menu/src/stories/MenuAligningWithSelectableItems.stories.tsx
@@ -12,7 +12,7 @@ export const AligningWithSelectableItems = () => (
     </MenuTrigger>
     <MenuPopover>
       <MenuList>
-        <MenuItemCheckbox icon={<CutIcon fontSize={20} />} name="edit" value="cut">
+        <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut">
           Checkbox item
         </MenuItemCheckbox>
         <MenuItem>Menu item</MenuItem>

--- a/packages/react-menu/src/stories/MenuCheckboxItems.stories.tsx
+++ b/packages/react-menu/src/stories/MenuCheckboxItems.stories.tsx
@@ -17,13 +17,13 @@ export const CheckboxItems = () => {
       </MenuTrigger>
       <MenuPopover>
         <MenuList>
-          <MenuItemCheckbox icon={<CutIcon fontSize={20} />} name="edit" value="cut">
+          <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut">
             Cut
           </MenuItemCheckbox>
-          <MenuItemCheckbox icon={<PasteIcon fontSize={20} />} name="edit" value="paste">
+          <MenuItemCheckbox icon={<PasteIcon />} name="edit" value="paste">
             Paste
           </MenuItemCheckbox>
-          <MenuItemCheckbox icon={<EditIcon fontSize={20} />} name="edit" value="edit">
+          <MenuItemCheckbox icon={<EditIcon />} name="edit" value="edit">
             Edit
           </MenuItemCheckbox>
         </MenuList>

--- a/packages/react-menu/src/stories/MenuControlledCheckboxItems.stories.tsx
+++ b/packages/react-menu/src/stories/MenuControlledCheckboxItems.stories.tsx
@@ -24,13 +24,13 @@ export const ControlledCheckboxItems = () => {
       </MenuTrigger>
       <MenuPopover>
         <MenuList checkedValues={checkedValues} onCheckedValueChange={onChange}>
-          <MenuItemCheckbox icon={<CutIcon fontSize={20} />} name="edit" value="cut">
+          <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut">
             Cut
           </MenuItemCheckbox>
-          <MenuItemCheckbox icon={<PasteIcon fontSize={20} />} name="edit" value="paste">
+          <MenuItemCheckbox icon={<PasteIcon />} name="edit" value="paste">
             Paste
           </MenuItemCheckbox>
-          <MenuItemCheckbox icon={<EditIcon fontSize={20} />} name="edit" value="edit">
+          <MenuItemCheckbox icon={<EditIcon />} name="edit" value="edit">
             Edit
           </MenuItemCheckbox>
         </MenuList>

--- a/packages/react-menu/src/stories/MenuControlledRadioItems.stories.tsx
+++ b/packages/react-menu/src/stories/MenuControlledRadioItems.stories.tsx
@@ -22,13 +22,13 @@ export const ControlledRadioItems = () => {
       </MenuTrigger>
       <MenuPopover>
         <MenuList checkedValues={checkedValues} onCheckedValueChange={onChange}>
-          <MenuItemRadio icon={<CutIcon fontSize={20} />} name="font" value="segoe">
+          <MenuItemRadio icon={<CutIcon />} name="font" value="segoe">
             Segoe
           </MenuItemRadio>
-          <MenuItemRadio icon={<PasteIcon fontSize={20} />} name="font" value="calibri">
+          <MenuItemRadio icon={<PasteIcon />} name="font" value="calibri">
             Calibri
           </MenuItemRadio>
-          <MenuItemRadio icon={<EditIcon fontSize={20} />} name="font" value="arial">
+          <MenuItemRadio icon={<EditIcon />} name="font" value="arial">
             Arial
           </MenuItemRadio>
         </MenuList>

--- a/packages/react-menu/src/stories/MenuGrouppingItems.stories.tsx
+++ b/packages/react-menu/src/stories/MenuGrouppingItems.stories.tsx
@@ -18,16 +18,16 @@ export const GrouppingItems = () => (
       <MenuList>
         <MenuGroup>
           <MenuGroupHeader>Section header</MenuGroupHeader>
-          <MenuItem icon={<CutIcon fontSize={20} />}>Cut</MenuItem>
-          <MenuItem icon={<PasteIcon fontSize={20} />}>Paste</MenuItem>
-          <MenuItem icon={<EditIcon fontSize={20} />}>Edit</MenuItem>
+          <MenuItem icon={<CutIcon />}>Cut</MenuItem>
+          <MenuItem icon={<PasteIcon />}>Paste</MenuItem>
+          <MenuItem icon={<EditIcon />}>Edit</MenuItem>
         </MenuGroup>
         <MenuDivider />
         <MenuGroup>
           <MenuGroupHeader>Section header</MenuGroupHeader>
-          <MenuItem icon={<CutIcon fontSize={20} />}>Cut</MenuItem>
-          <MenuItem icon={<PasteIcon fontSize={20} />}>Paste</MenuItem>
-          <MenuItem icon={<EditIcon fontSize={20} />}>Edit</MenuItem>
+          <MenuItem icon={<CutIcon />}>Cut</MenuItem>
+          <MenuItem icon={<PasteIcon />}>Paste</MenuItem>
+          <MenuItem icon={<EditIcon />}>Edit</MenuItem>
         </MenuGroup>
       </MenuList>
     </MenuPopover>

--- a/packages/react-menu/src/stories/MenuMemoizedMenuItems.stories.tsx
+++ b/packages/react-menu/src/stories/MenuMemoizedMenuItems.stories.tsx
@@ -8,7 +8,7 @@ const MemoCheckbox = React.memo((props: MenuItemCheckboxProps) => {
   // use icons in the memo because JSX will always create a new object
   // possible to memoize icons but it can be overkill
   return (
-    <MenuItemCheckbox icon={<EditIcon fontSize={20} />} name={props.name} value={props.value}>
+    <MenuItemCheckbox icon={<EditIcon />} name={props.name} value={props.value}>
       {props.children}
     </MenuItemCheckbox>
   );

--- a/packages/react-menu/src/stories/MenuMenuItemsWithIcons.stories.tsx
+++ b/packages/react-menu/src/stories/MenuMenuItemsWithIcons.stories.tsx
@@ -17,9 +17,9 @@ export const MenuItemsWithIcons = () => (
 
     <MenuPopover>
       <MenuList>
-        <MenuItem icon={<CutIcon fontSize={20} />}>Cut</MenuItem>
-        <MenuItem icon={<PasteIcon fontSize={20} />}>Paste</MenuItem>
-        <MenuItem icon={<EditIcon fontSize={20} />}>Edit</MenuItem>
+        <MenuItem icon={<CutIcon />}>Cut</MenuItem>
+        <MenuItem icon={<PasteIcon />}>Paste</MenuItem>
+        <MenuItem icon={<EditIcon />}>Edit</MenuItem>
       </MenuList>
     </MenuPopover>
   </Menu>

--- a/packages/react-menu/src/stories/MenuRadioItems.stories.tsx
+++ b/packages/react-menu/src/stories/MenuRadioItems.stories.tsx
@@ -17,13 +17,13 @@ export const RadioItems = () => {
       </MenuTrigger>
       <MenuPopover>
         <MenuList>
-          <MenuItemRadio icon={<CutIcon fontSize={20} />} name="font" value="segoe">
+          <MenuItemRadio icon={<CutIcon />} name="font" value="segoe">
             Segoe
           </MenuItemRadio>
-          <MenuItemRadio icon={<PasteIcon fontSize={20} />} name="font" value="calibri">
+          <MenuItemRadio icon={<PasteIcon />} name="font" value="calibri">
             Calibri
           </MenuItemRadio>
-          <MenuItemRadio icon={<EditIcon fontSize={20} />} name="font" value="arial">
+          <MenuItemRadio icon={<EditIcon />} name="font" value="arial">
             Arial
           </MenuItemRadio>
         </MenuList>

--- a/packages/react-menu/src/stories/MenuSelectionGroup.stories.tsx
+++ b/packages/react-menu/src/stories/MenuSelectionGroup.stories.tsx
@@ -28,34 +28,29 @@ export const SelectionGroup = () => (
       <MenuList>
         <MenuGroup>
           <MenuGroupHeader>Checkbox group</MenuGroupHeader>
-          <MenuItemCheckbox secondaryContent="Ctrl+N" icon={<CutIcon fontSize={20} />} name="edit" value="cut">
+          <MenuItemCheckbox secondaryContent="Ctrl+N" icon={<CutIcon />} name="edit" value="cut">
             Show Menu Bar
           </MenuItemCheckbox>
-          <MenuItemCheckbox
-            secondaryContent="Ctrl+Shift+N"
-            icon={<PasteIcon fontSize={20} />}
-            name="edit"
-            value="paste"
-          >
+          <MenuItemCheckbox secondaryContent="Ctrl+Shift+N" icon={<PasteIcon />} name="edit" value="paste">
             Show Side Bar
           </MenuItemCheckbox>
-          <MenuItemCheckbox secondaryContent="Ctrl+Shift+O" icon={<EditIcon fontSize={20} />} name="edit" value="edit">
+          <MenuItemCheckbox secondaryContent="Ctrl+Shift+O" icon={<EditIcon />} name="edit" value="edit">
             Show Status Bar
           </MenuItemCheckbox>
-          <MenuItemCheckbox disabled icon={<EditIcon fontSize={20} />} name="disabled" value="disabled">
+          <MenuItemCheckbox disabled icon={<EditIcon />} name="disabled" value="disabled">
             Show Debug Panel
           </MenuItemCheckbox>
         </MenuGroup>
         <MenuDivider />
         <MenuGroup>
           <MenuGroupHeader>Radio group</MenuGroupHeader>
-          <MenuItemRadio secondaryContent="Ctrl+N" icon={<CutIcon fontSize={20} />} name="font" value="segoe">
+          <MenuItemRadio secondaryContent="Ctrl+N" icon={<CutIcon />} name="font" value="segoe">
             Segoe
           </MenuItemRadio>
-          <MenuItemRadio secondaryContent="Ctrl+Shift+N" icon={<PasteIcon fontSize={20} />} name="font" value="calibri">
+          <MenuItemRadio secondaryContent="Ctrl+Shift+N" icon={<PasteIcon />} name="font" value="calibri">
             Caliri
           </MenuItemRadio>
-          <MenuItemRadio secondaryContent="Ctrl+Shift+N" icon={<EditIcon fontSize={20} />} name="font" value="arial">
+          <MenuItemRadio secondaryContent="Ctrl+Shift+N" icon={<EditIcon />} name="font" value="arial">
             Arial
           </MenuItemRadio>
         </MenuGroup>

--- a/packages/react-menu/src/stories/MenuVisualDividerOnly.stories.tsx
+++ b/packages/react-menu/src/stories/MenuVisualDividerOnly.stories.tsx
@@ -17,13 +17,13 @@ export const VisualDividerOnly = () => (
 
     <MenuPopover>
       <MenuList>
-        <MenuItem icon={<CutIcon fontSize={20} />}>Cut</MenuItem>
-        <MenuItem icon={<PasteIcon fontSize={20} />}>Paste</MenuItem>
-        <MenuItem icon={<EditIcon fontSize={20} />}>Edit</MenuItem>
+        <MenuItem icon={<CutIcon />}>Cut</MenuItem>
+        <MenuItem icon={<PasteIcon />}>Paste</MenuItem>
+        <MenuItem icon={<EditIcon />}>Edit</MenuItem>
         <MenuDivider />
-        <MenuItem icon={<CutIcon fontSize={20} />}>Cut</MenuItem>
-        <MenuItem icon={<PasteIcon fontSize={20} />}>Paste</MenuItem>
-        <MenuItem icon={<EditIcon fontSize={20} />}>Edit</MenuItem>
+        <MenuItem icon={<CutIcon />}>Cut</MenuItem>
+        <MenuItem icon={<PasteIcon />}>Paste</MenuItem>
+        <MenuItem icon={<EditIcon />}>Edit</MenuItem>
       </MenuList>
     </MenuPopover>
   </Menu>


### PR DESCRIPTION
## Current Behavior

Icons provided to the MenuItem component won't be sized properly without explicitly specifying their size.

## New Behavior

Add fontSize styling to MenuItem's `icon` and `submenuIndicator` slots. This provides a default size for icons provided by the user.

## Related Issue(s)

#21220
