### PR TITLE
docs(react-storybook-addon): add demo stories to showcase the addon controls

### DIFF
--- a/packages/react-storybook-addon/src/demos.stories.tsx
+++ b/packages/react-storybook-addon/src/demos.stories.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { Button } from '@fluentui/react-button';
+import { Headline, Text } from '@fluentui/react-text';
+import { action } from '@storybook/addon-actions';
+
+export const Demos = () => {
+  return (
+    <div>
+      <Headline>This story is for testing purposes of this addon</Headline>
+      <section>
+        <Button onClick={action('button clicked')}>
+          <Text>Click me</Text>
+        </Button>
+      </section>
+    </div>
+  );
+};
+
+export default {
+  title: 'Demos',
+  components: Demos,
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

When running `storybook` within react-storybook-addon, user get blank storybook, which is confusing.

![2022-01-11 at 9 57](https://user-images.githubusercontent.com/1223799/148911706-25cea421-3131-4582-b541-08b3397249ac.png)


## New Behavior

`storybook` renders a demo stories that interacts with addon new controls (Theme in toolbar)


https://user-images.githubusercontent.com/1223799/148911892-de58aa73-c152-4f25-b994-c5ae3399953e.mov



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Relates to https://github.com/microsoft/fluentui/issues/21227 ( to demonstrate actual functionality )
