### PR TITLE
Tooltip: add support for composition with other *Trigger components

### DIFF
--- a/change/@fluentui-react-tooltip-d72389de-38fd-4083-bb0a-1863efa97396.json
+++ b/change/@fluentui-react-tooltip-d72389de-38fd-4083-bb0a-1863efa97396.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add composition support (could be used as a child of other triggers)",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tooltip/etc/react-tooltip.api.md
+++ b/packages/react-tooltip/etc/react-tooltip.api.md
@@ -62,7 +62,7 @@ export type TooltipTriggerProps = {
 } & Pick<React_2.HTMLAttributes<HTMLElement>, 'onPointerEnter' | 'onPointerLeave' | 'onFocus' | 'onBlur' | 'aria-describedby' | 'aria-labelledby' | 'aria-label'>;
 
 // @public
-export const useTooltip_unstable: (props: TooltipProps) => TooltipState;
+export const useTooltip_unstable: (props: TooltipProps, ref: React_2.Ref<HTMLElement>) => TooltipState;
 
 // @public
 export const useTooltipStyles_unstable: (state: TooltipState) => TooltipState;

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.tsx
@@ -7,11 +7,11 @@ import type { TooltipProps } from './Tooltip.types';
 /**
  * A tooltip provides light weight contextual information on top of its target element.
  */
-export const Tooltip: React.FC<TooltipProps> = props => {
-  const state = useTooltip_unstable(props);
+export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>((props, ref) => {
+  const state = useTooltip_unstable(props, ref);
 
   useTooltipStyles_unstable(state);
   return renderTooltip_unstable(state);
-};
+}) as React.FC<TooltipProps>;
 
 Tooltip.displayName = 'Tooltip';


### PR DESCRIPTION
## PR changes

`Tooltip` in this PR uses `useTriggerElement()` hook introduced in #21225. This adds support for composition with `*Trigger` components:

```tsx
<>
  <Menu>
    <MenuTrigger>
      <Tooltip content="opens a menu">
        <Button>Menu only</Button>
      </Tooltip>
    </MenuTrigger>
  </Menu>
  <Menu>
    <Tooltip content="opens a menu">
      <MenuTrigger>
        <Button>Menu only</Button>
      </MenuTrigger>
    </Tooltip>
  </Menu>
</>
```

With changes in this PR the order of `MenuTrigger` & `Tooltip` in markup does matter anymore.