### PR TITLE
chore: re-enable react-storybook-addon and babel-make-styles for react-components

### DIFF
--- a/change/@fluentui-react-components-9d99eb03-ece2-4410-be0a-ef3e876c43b3.json
+++ b/change/@fluentui-react-components-9d99eb03-ece2-4410-be0a-ef3e876c43b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(react-components): make sb start work with babel-make-styles and react-sb-addon",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/.storybook/main.js
+++ b/packages/react-components/.storybook/main.js
@@ -9,11 +9,7 @@ module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript
     '../src/**/*.stories.@(ts|tsx)',
     ...utils.getVnextStories(),
   ],
-  addons: [
-    ...rootMain.addons,
-    // Should be re-enabled, see https://github.com/microsoft/fluentui/issues/20896
-    // '@fluentui/react-storybook-addon'
-  ],
+  addons: [...rootMain.addons, '@fluentui/react-storybook-addon'],
   webpackFinal: (config, options) => {
     const localConfig = { ...rootMain.webpackFinal(config, options) };
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -22,9 +22,12 @@
     "start": "yarn storybook",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output ./dist/packages/react-components/src && yarn docs",
-    "storybook": "start-storybook --port 3000 -s ./public",
+    "prestorybook": "yarn prepare-storybook-local-build",
+    "storybook": "start-storybook --port 3000 -s ./public --no-manager-cache",
+    "prestorybook:docs": "yarn prepare-storybook-local-build",
     "storybook:docs": "start-storybook --port 3000 -s ./public --docs --no-manager-cache",
     "build-storybook": "build-storybook -s ./public -o ./dist/storybook --docs",
+    "prepare-storybook-local-build": "lage build --to @fluentui/babel-make-styles @fluentui/react-storybook-addon",
     "test": "jest",
     "type-check": "tsc -b tsconfig.json"
   },

--- a/packages/react-storybook-addon/README.md
+++ b/packages/react-storybook-addon/README.md
@@ -65,6 +65,6 @@ module.exports = {
 
 1. Run inner loop from monorepo root `yarn workspace @fluentui/react-storybook-addon storybook`
 
-   - > 💡 this will run `build` script that compiles addon implementation so it can be consumed by local storybook
+   - > 💡 this will run `prestorybook` script that compiles addon implementation with all of its direct dependencies that live within monorepo, so it can be consumed by local storybook
 
 2. Every time you do any change to implementation, after you ran your local storybook you'll need to manually run `yarn workspace @fluentui/react-storybook-addon build` to reflect those changes

--- a/packages/react-storybook-addon/package.json
+++ b/packages/react-storybook-addon/package.json
@@ -22,6 +22,7 @@
     "test": "jest --passWithNoTests",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output ./dist/packages/react-storybook-addon/src && yarn docs",
+    "prestorybook": "lage build --to @fluentui/react-storybook-addon",
     "storybook": "start-storybook",
     "type-check": "tsc -b tsconfig.json"
   },

--- a/packages/react-storybook-addon/preset.js
+++ b/packages/react-storybook-addon/preset.js
@@ -1,17 +1,9 @@
 function config(entry = []) {
-  // This entrypoint is deliberately set to ts for monorepo DX
-  // However this is bad for publishing
-  // https://github.com/microsoft/fluentui/issues/20474
-  // https://github.com/microsoft/fluentui/issues/18357
-  return [...entry, require.resolve('./src/preset/preview.ts')];
+  return [...entry, require.resolve('./lib/preset/preview')];
 }
 
 function managerEntries(entry = []) {
-  // This entrypoint is deliberately set to ts for monorepo DX
-  // However this is bad for publishing
-  // https://github.com/microsoft/fluentui/issues/20474
-  // https://github.com/microsoft/fluentui/issues/18357
-  return [...entry, require.resolve('./src/preset/manager.ts')];
+  return [...entry, require.resolve('./lib/preset/manager')];
 }
 
 module.exports = { managerEntries, config };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- Theme switching doesn't work (react-storybook-addon) in `react-components` suite
- `babel-make-styles` doesn't work in `react-components` suite

## New Behavior

- theme switching works
- babel-make-styles is enabled

**NOTE:**
- initial cold run will be a bit slower as all dependencies of `babel-make-styles` and `react-storybook-addon` will need to be build. every consecutive run will be pulled from cache so the time implications will be negligible

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #21227 
- Fixes #20886
- fixes partially #20896 - if our addon needs to consume other packages within monorepo, it looks like we won't be able to provide build-less experience 
