### PR TITLE
docs/examples: rename deprecated 'name' property to 'text' to avoid disappearing link upon filtering 🪄

### DIFF
--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.CustomMenuList.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.CustomMenuList.Example.tsx
@@ -85,7 +85,7 @@ const menuItems: IContextualMenuItem[] = [
   { key: 'linkWithTarget', text: 'Link new window', href: 'http://bing.com', target: '_blank' },
   {
     key: 'linkWithOnClick',
-    name: 'Link click',
+    text: 'Link click',
     href: 'http://bing.com',
     onClick: (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
       alert('Link clicked');


### PR DESCRIPTION
[Link](https://developer.microsoft.com/en-us/fluentui#/controls/web/contextualmenu#:~:text=ContextualMenu%20with%20custom%20rendered%20menu%20list%20that%20renders%20a%20search%20box%20to%20filter%20menu%20items) for quick reference.
Upon filtering, the "Link click" item in the menu is removed permanently.