### PR TITLE
breaking: stop exporting useTheme() hook

### DIFF
--- a/change/@fluentui-react-components-c4676f9d-868b-4612-8296-8a30d56a2a12.json
+++ b/change/@fluentui-react-components-c4676f9d-868b-4612-8296-8a30d56a2a12.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "breaking: stop exporting useTheme hook",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/etc/react-components.api.md
+++ b/packages/react-components/etc/react-components.api.md
@@ -295,6 +295,7 @@ import { ToggleButton } from '@fluentui/react-button';
 import { toggleButtonClassName } from '@fluentui/react-button';
 import { ToggleButtonProps } from '@fluentui/react-button';
 import { ToggleButtonState } from '@fluentui/react-button';
+import { tokens } from '@fluentui/react-theme';
 import { Tooltip } from '@fluentui/react-tooltip';
 import { tooltipClassName } from '@fluentui/react-tooltip';
 import { TooltipProps } from '@fluentui/react-tooltip';
@@ -377,7 +378,6 @@ import { useSplitButton } from '@fluentui/react-button';
 import { useSplitButtonStyles } from '@fluentui/react-button';
 import { useText } from '@fluentui/react-text';
 import { useTextStyles } from '@fluentui/react-text';
-import { useTheme } from '@fluentui/react-provider';
 import { useToggleButton } from '@fluentui/react-button';
 import { useToggleButtonStyles } from '@fluentui/react-button';
 import { useTooltip } from '@fluentui/react-tooltip';
@@ -968,6 +968,8 @@ export { ToggleButtonProps }
 
 export { ToggleButtonState }
 
+export { tokens }
+
 export { Tooltip }
 
 export { tooltipClassName }
@@ -1131,8 +1133,6 @@ export { useSplitButtonStyles }
 export { useText }
 
 export { useTextStyles }
-
-export { useTheme }
 
 export { useToggleButton }
 

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -21,7 +21,6 @@ export {
   useFluentProvider,
   useFluentProviderContextValues,
   useFluentProviderStyles,
-  useTheme,
 } from '@fluentui/react-provider';
 export type {
   FluentProviderContextValues,
@@ -38,6 +37,7 @@ export {
   teamsDarkTheme,
   teamsHighContrastTheme,
   teamsLightTheme,
+  tokens,
   webDarkTheme,
   webHighContrastTheme,
   webLightTheme,


### PR DESCRIPTION
# BREAKING CHANGES 🚨

This PR removes an export of `useTheme()` hook from `@fluentui/react-components`. The hook is still used internally, but should not be used in applications anymore.

### Before

```tsx
import { useTheme } from `@fluentui/react-components`;

function App() {
  const theme = useTheme();

  //                          👇 an exact value, for example "#242424"
  return <div style={{ color: theme.colorNeutralForeground1 }} />;
}
```

### After

```tsx
import { tokens } from `@fluentui/react-components`;

function App() {
  //                          👇 a CSS variable, for example "var(--colorNeutralForeground1)"
  return <div style={{ color: tokens.colorNeutralForeground1 }} />;
}
```

#### ⚠️ Change in behavior

- `useTheme()` returned an exact value, for example `#242424`
- `tokens` is a set of CSS variables, for example `var(--colorNeutralForeground1)`

### Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20482.
