### PR TITLE
docs(react-card): Add Alpha notice to docs

### DIFF
--- a/change/@fluentui-react-card-44f41c2d-fa7d-4d71-af4c-4d1266a58268.json
+++ b/change/@fluentui-react-card-44f41c2d-fa7d-4d71-af4c-4d1266a58268.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add Alpha notice",
+  "packageName": "@fluentui/react-card",
+  "email": "39736248+andrefcdias@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-card/README.md
+++ b/packages/react-card/README.md
@@ -1,6 +1,8 @@
-# @fluentui/react-card
+# @fluentui/react-card [ALPHA]
 
 **React Card components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+
+**⚠️ Please note that functionality is still being added to this package. Due to lockstep versioning, the version of this package is aligned with the others in _react-components_.**
 
 These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
 

--- a/packages/react-card/src/Card.stories.tsx
+++ b/packages/react-card/src/Card.stories.tsx
@@ -1,11 +1,19 @@
 import { Card, CardFooter, CardHeader, CardPreview } from './index';
+import descriptionMd from './CardDescription.md';
 
 export { Default } from './stories/CardDefault.stories';
 export { ActionCard } from './stories/CardAction.stories';
 export { GridCard } from './stories/CardGrid.stories';
 
 export default {
-  title: 'Components/Card',
+  title: 'Components/Card [ALPHA]',
   component: Card,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd].join('\n'),
+      },
+    },
+  },
   subcomponents: { CardHeader, CardPreview, CardFooter },
 };

--- a/packages/react-card/src/CardDescription.md
+++ b/packages/react-card/src/CardDescription.md
@@ -1,0 +1,3 @@
+**This component is available for limited production use, please contact us if you intend to use it in your product.**
+
+**The APIs will change before final release as functionality is still being added.**


### PR DESCRIPTION
## Current Behavior

Card component did not have any notices regarding it still being an Alpha, as functionality is still missing. This created possible confusion given that due to lockstep versioning it's marked as a Beta component and soon to be RC.
Suggestions for the text/phrasing are more than welcome. 🙏

## New Behavior

README and Storybook docs were updated to reflect the current status.