### PR TITLE
Charting: CherryPick #21249: Custom style for AreaLine, Point and Point Line in Area Chart #21249

### DIFF
--- a/change/@uifabric-charting-cc0d3b1e-9b93-41ea-877a-bf8b2d4ec71d.json
+++ b/change/@uifabric-charting-cc0d3b1e-9b93-41ea-877a-bf8b2d4ec71d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "style control prop added in area chart",
+  "packageName": "@uifabric/charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -128,6 +128,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
           onMouseMove={[Function]}
           onMouseOut={[Function]}
           onMouseOver={[Function]}
+          opacity={1}
         />
         <g
           clipPath="url(#clip)"
@@ -460,6 +461,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
           onMouseMove={[Function]}
           onMouseOut={[Function]}
           onMouseOver={[Function]}
+          opacity={1}
         />
         <g
           clipPath="url(#clip)"
@@ -772,6 +774,7 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
           onMouseMove={[Function]}
           onMouseOut={[Function]}
           onMouseOver={[Function]}
+          opacity={1}
         />
         <g
           clipPath="url(#clip)"
@@ -952,6 +955,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
           onMouseMove={[Function]}
           onMouseOut={[Function]}
           onMouseOver={[Function]}
+          opacity={1}
         />
         <g
           clipPath="url(#clip)"
@@ -1284,6 +1288,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
           onMouseMove={[Function]}
           onMouseOut={[Function]}
           onMouseOver={[Function]}
+          opacity={1}
         />
         <g
           clipPath="url(#clip)"
@@ -1616,6 +1621,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
           onMouseMove={[Function]}
           onMouseOut={[Function]}
           onMouseOver={[Function]}
+          opacity={1}
         />
         <g
           clipPath="url(#clip)"
@@ -1948,6 +1954,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
           onMouseMove={[Function]}
           onMouseOut={[Function]}
           onMouseOver={[Function]}
+          opacity={1}
         />
         <g
           clipPath="url(#clip)"

--- a/packages/charting/src/types/IDataPoint.ts
+++ b/packages/charting/src/types/IDataPoint.ts
@@ -1,3 +1,4 @@
+import { SVGProps } from 'react';
 import { LegendShape } from '../components/Legends/Legends.types';
 
 export interface IBasestate {
@@ -247,7 +248,7 @@ export interface ILineChartGap {
   endIndex: number;
 }
 
-export interface ILineChartLineOptions {
+export interface ILineChartLineOptions extends SVGProps<SVGPathElement> {
   /**
    * Width of the line/stroke.
    * Overrides the strokeWidth set on ICartesianChartProps level.
@@ -313,6 +314,11 @@ export interface ILineChartPoints {
   color: string;
 
   /**
+   * opacity for chart fill color
+   */
+  opacity?: number;
+
+  /**
    * options for the line drawn
    */
   lineOptions?: ILineChartLineOptions;
@@ -358,6 +364,16 @@ export interface IChartProps {
    * data for the points in the line chart
    */
   lineChartData?: ILineChartPoints[];
+
+  /**
+   * data for the points in the line chart
+   */
+  pointOptions?: SVGProps<SVGCircleElement>;
+
+  /**
+   * data for the dotted line on hovering the point
+   */
+  pointLineOptions?: SVGProps<SVGLineElement>;
 }
 
 export interface IAccessibilityProps {

--- a/packages/react-examples/src/charting/AreaChart/AreaChart.Styled.Example.tsx
+++ b/packages/react-examples/src/charting/AreaChart/AreaChart.Styled.Example.tsx
@@ -81,17 +81,29 @@ export class AreaChartStyledExample extends React.Component<{}, IAreaChartBasicS
         legend: 'legend1',
         data: chart1Points,
         color: DefaultPalette.accent,
+        opacity: 0.7,
+        lineOptions: {
+          strokeWidth: 2,
+          strokeDasharray: '5 5',
+        },
       },
       {
         legend: 'legend2',
         data: chart2Points,
         color: DefaultPalette.blueLight,
+        opacity: 0.8,
+        lineOptions: {
+          strokeWidth: 5,
+          stroke: DefaultPalette.blueDark,
+        },
       },
     ];
 
     const chartData = {
-      chartTtitle: 'Area chart styled example',
+      chartTitle: 'Area chart styled example',
       lineChartData: chartPoints,
+      pointOptions: { radius: 8, strokeWidth: 3, opacity: 1, stroke: DefaultPalette.blueDark },
+      pointLineOptions: { strokeWidth: 2, strokeDasharray: '10 10', stroke: DefaultPalette.blueDark },
     };
 
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

### Original description
Cherry pick of [#21249](https://github.com/microsoft/fluentui/pull/21249)

## Current Behavior

Currently, the area chart didn't have the facility to change the style for Area Line, Active Point, and Point Line (Dotted Line).


## New Behavior

With these changes, users can add custom styles for Area Line, Active Point, and Point Line (Dotted Line).
All the styles which can be used for SVG elements, the user can pass all and modify that element. 
Below are the props and SVG elements we are using for

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>



  | Prop Added | SVG Element
-- | -- | --
Area Line | lineOptions | Path
Active Points | pointOptions | Circle
Point Line | pointLineOptions | Line



</div>

<!--EndFragment-->
</body>

</html>


Along with this, an opacity prop is added for Area Fill. 

AreaChart.Styled.Example.tsx is updated with all these changes

### **Before Changes:** 

![image](https://user-images.githubusercontent.com/29042635/149129402-07fd04e3-9dda-4477-b00e-efc69fa49863.png)


### **After Changes:** 

![image](https://user-images.githubusercontent.com/29042635/149129055-b1a944e8-791d-4487-87ca-605df5e53ebc.png)

Data passed for this example

![image](https://user-images.githubusercontent.com/29042635/149130162-7007e70e-4633-45a6-a9ca-8098ea0895a1.png)


## Related Issue(s)

This is the new requirement from **Vivek Sangameswaran** 

Fixes #
