### PR TITLE
feat: add storybook runner wrapper for vNext packages consumption

### DIFF
--- a/scripts/storybook/runner.js
+++ b/scripts/storybook/runner.js
@@ -1,0 +1,58 @@
+// @ts-check
+
+/**
+ * This is a start-storybook wrapper that automatically pre-builds dependencies that are needed to run storybook,
+ * then invokes `start-storybook` so CLI experience is the same as running raw `start-storybook` binary
+ *
+ *
+ * Note:
+ * - This is used only for vNext packages
+ * - We cannot leverage build-less experience unfortunately at the moment. To have it we will need a bigger overhaul of "how we build" things.
+ *
+ * @example
+ *
+ * ```sh
+ * node ./scripts/storybook/runner
+ * ```
+ */
+
+const { execSync } = require('child_process');
+const chalk = require('chalk');
+
+main();
+
+function main() {
+  const args = process.argv.slice(2);
+  const COMMAND_PREFIX = `${chalk.cyan('>')} ${chalk.inverse(chalk.bold(chalk.cyan(' STORYBOOK RUNNER ')))}`;
+  const dependencies = [
+    { name: '@fluentui/babel-make-styles', description: 'custom babel plugin that compiles make-styles definitions' },
+    {
+      name: '@fluentui/react-storybook-addon',
+      description: 'fluentui storybook addon that adds functionality to storybook',
+    },
+  ];
+
+  const sbCommand = `start-storybook ${args.join(' ')}`;
+  const dependencyBuildCommand = `lage build --to ${dependencies.map(dep => dep.name).join(' ')}`;
+
+  console.log(COMMAND_PREFIX, shouldInvokeHelp() ? '\n' : `pre-building dependencies needed to run storybook:\n`);
+
+  if (!shouldInvokeHelp()) {
+    listDependencies();
+    execSync(dependencyBuildCommand, { stdio: [0, 1, 2] });
+  }
+
+  execSync(sbCommand, { stdio: [0, 1, 2] });
+
+  function shouldInvokeHelp() {
+    return args.includes('--help');
+  }
+
+  function listDependencies() {
+    dependencies.map(dep => {
+      console.log(`${chalk.bold(dep.name)} (${dep.description})`);
+    });
+
+    process.stdout.write('\n');
+  }
+}

--- a/scripts/storybook/runner.js
+++ b/scripts/storybook/runner.js
@@ -45,12 +45,8 @@ function main() {
     ...dependencies.filter(dep => {
       return projectPackageJson.devDependencies[dep.name];
     }),
-    ...implicitDependencies.filter(dep => {
-      return projectPackageJson.name !== dep.name;
-    }),
+    ...implicitDependencies,
   ];
-
-  console.log({ devDep: projectPackageJson.devDependencies, pName: projectPackageJson.name, dependenciesToBuild });
 
   const shouldInvokeHelp = args.includes('--help');
   const shouldExecPreBuild = !shouldInvokeHelp && dependenciesToBuild.length > 0;

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -820,7 +820,7 @@ describe('migrate-converged-pkg generator', () => {
         just: 'just-scripts',
         lint: 'just-scripts lint',
         start: 'yarn storybook',
-        storybook: 'start-storybook',
+        storybook: 'node ../../scripts/storybook/runner',
         test: 'jest --passWithNoTests',
         'type-check': 'tsc -b tsconfig.json',
       });

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -524,7 +524,7 @@ function updateNpmScripts(tree: Tree, options: NormalizedSchema) {
   const scripts = {
     docs: 'api-extractor run --config=config/api-extractor.local.json --local',
     'build:local': `tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output ./dist/packages/${options.normalizedPkgName}/src && yarn docs`,
-    storybook: 'start-storybook',
+    storybook: 'node ../../scripts/storybook/runner',
     start: 'yarn storybook',
     test: 'jest --passWithNoTests',
     'type-check': 'tsc -b tsconfig.json',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- babel-make-styles doesn't work in storybooks for vNext
- react-storybook-addon is not enabled for vNext
- storybook is invoked directly via `start-storybook` binary

## New Behavior

this PR:
-  implements simple storybook runner that replace all `start-storybooks` ( until we overhaul how we build ), that will pre-build `babel-make-styles` and `react-storybook-addon` when running `storybook` command **only when it makes sense**.
- update migration-converged-pkg generator

> **NOTE:** 
> - This will add  cold/no-cache performance penalty as user will need to wait to build those. Any consecutive build will be fetched from cache thus the perf will be the same as with having "build-less" experience

**Demo:**

https://user-images.githubusercontent.com/1223799/149202754-4f84be64-8769-464c-b7f7-2f6b442152f2.mov


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follow up of https://github.com/microsoft/fluentui/pull/21247, to enable this behavior in all vNext packages, to get consistent DX
- actual usage implementations  https://github.com/microsoft/fluentui/pull/21267

