### PR TITLE
SearchBox: fix event handling regressions in v8

### DIFF
--- a/change/@fluentui-react-fcd957e6-b238-45ac-903b-58074ead0e6a.json
+++ b/change/@fluentui-react-fcd957e6-b238-45ac-903b-58074ead0e6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "SearchBox: properly pass the new value to onChange, and only call onChange once",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.base.tsx
@@ -61,18 +61,25 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
   } = props;
 
   const [hasFocus, setHasFocus] = React.useState(false);
+
+  const prevChangeTimestamp = React.useRef<number | undefined>();
   const [uncastValue, setValue] = useControllableValue(
     props.value,
     defaultValue,
-    React.useCallback(
-      (ev: React.ChangeEvent<HTMLInputElement> | undefined) => {
-        onChange?.(ev, ev?.target.value);
-        onChanged?.(ev?.target.value);
-      },
-      [onChange, onChanged],
-    ),
+    (ev: React.ChangeEvent<HTMLInputElement> | undefined, newValue: string) => {
+      if (ev && ev.timeStamp === prevChangeTimestamp.current) {
+        // For historical reasons, SearchBox handles both onInput and onChange (we can't modify this
+        // outside a major version due to potential to break partners' tests and possibly apps).
+        // Only call props.onChange for one of the events.
+        return;
+      }
+      prevChangeTimestamp.current = ev?.timeStamp;
+      onChange?.(ev, newValue);
+      onChanged?.(newValue);
+    },
   );
   const value = String(uncastValue);
+
   const rootElementRef = React.useRef<HTMLDivElement>(null);
   const inputElementRef = React.useRef<HTMLInputElement>(null);
   const mergedRootRef = useMergedRefs(rootElementRef, forwardedRef);


### PR DESCRIPTION
## Current Behavior

There were two regressions with SearchBox's change event handling from v7 to v8:
- `onChange` is called twice (#17587)
- When the clear button is pressed, the new value of `''` is not passed to `onChange` (#19675)

The duplicate `onChange` issue is because for historical reasons, SearchBox handles both `onInput` and `onChange`. This is no longer necessary, but we can't modify it outside a major version due to risk of breaking partners (would be most likely to break only tests, but that's still very inconvenient for people). In v7 there was (essentially) debouncing code to work around this and only call `props.onChange` once, but this was removed in the function component conversion for v8.

The issue with not passing the new `''` value through to `onChange` on clear button press was because the change callback passed to `useControllableValue` was missing a `newValue` parameter. (Instead it was trying to read the value from the event, which doesn't work on clear.) I think this wasn't caught by typescript due to not having strict function types turned on.

## New Behavior

Restore debouncing for input/change events, so that `onChange` is only called for the first event to arrive. Instead of comparing against the previous change value, to more closely match the browser behavior I used an approach someone mentioned in the issue thread: checking the event timestamp (the `input` and `change` events should have identical timestamps).

Add a `newValue` parameter to the `useControllableValue` change callback so that it uses the proper value passed into `setValue` by `onClear`.

## Related Issue(s)

Fixes #17587, fixes #19675
