### PR TITLE
Remove fixed-size icons from vr-tests

### DIFF
--- a/apps/vr-tests/src/stories/AvatarConverged.stories.tsx
+++ b/apps/vr-tests/src/stories/AvatarConverged.stories.tsx
@@ -2,7 +2,7 @@ import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { Avatar, AvatarProps } from '@fluentui/react-avatar';
-import { People20Regular, PersonCall20Regular } from '@fluentui/react-icons';
+import { PeopleRegular, PersonCallRegular } from '@fluentui/react-icons';
 
 const imageRoot = 'http://fabricweb.azureedge.net/fabric-website/assets/images/avatar';
 
@@ -182,9 +182,9 @@ storiesOf('Avatar Converged', module)
         <Avatar name="First Last" />
         <Avatar name="Three Word Name" />
         <Avatar name="One" />
-        <Avatar name="(111)-555-1234" icon={<PersonCall20Regular />} />
-        <Avatar icon={<People20Regular />} shape="square" />
-        <Avatar name="Group" icon={<People20Regular />} shape="square" />
+        <Avatar name="(111)-555-1234" icon={<PersonCallRegular />} />
+        <Avatar icon={<PeopleRegular />} shape="square" />
+        <Avatar name="Group" icon={<PeopleRegular />} shape="square" />
         <Avatar image={{ src: examples.image[14] }} badge={{ status: 'away' }} />
         <Avatar
           name={examples.name[7]}

--- a/apps/vr-tests/src/stories/Badge.stories.tsx
+++ b/apps/vr-tests/src/stories/Badge.stories.tsx
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { Badge, BadgeCommons } from '@fluentui/react-badge';
-import { Circle12Regular } from '@fluentui/react-icons';
+import { CircleRegular } from '@fluentui/react-icons';
 import { mergeClasses, makeStyles, shorthands } from '@fluentui/react-make-styles';
 import { tokens } from '@fluentui/react-theme';
 
@@ -62,10 +62,10 @@ const BadgeAppearanceTemplate: React.FC<{ appearance: BadgeCommons['appearance']
       </Badge>
     );
     const circularWithIcon = (
-      <Badge color={color} appearance={appearance} icon={<Circle12Regular />} />
+      <Badge color={color} appearance={appearance} icon={<CircleRegular />} />
     );
     const roundedWithIcon = (
-      <Badge color={color} appearance={appearance} shape="rounded" icon={<Circle12Regular />} />
+      <Badge color={color} appearance={appearance} shape="rounded" icon={<CircleRegular />} />
     );
     const roundedWithText = (
       <Badge color={color} appearance={appearance} shape="rounded">
@@ -77,7 +77,7 @@ const BadgeAppearanceTemplate: React.FC<{ appearance: BadgeCommons['appearance']
         color={color}
         appearance={appearance}
         shape="rounded"
-        icon={<Circle12Regular />}
+        icon={<CircleRegular />}
         iconPosition="before"
       >
         {appearance.toUpperCase()}
@@ -88,7 +88,7 @@ const BadgeAppearanceTemplate: React.FC<{ appearance: BadgeCommons['appearance']
         color={color}
         appearance={appearance}
         shape="rounded"
-        icon={<Circle12Regular />}
+        icon={<CircleRegular />}
         iconPosition="after"
       >
         {appearance.toUpperCase()}

--- a/apps/vr-tests/src/stories/MenuConverged.stories.tsx
+++ b/apps/vr-tests/src/stories/MenuConverged.stories.tsx
@@ -14,7 +14,7 @@ import {
   MenuDivider,
   MenuSplitGroup,
 } from '@fluentui/react-menu';
-import { Cut20Regular, Edit20Regular, ClipboardPaste20Regular } from '@fluentui/react-icons';
+import { CutRegular, EditRegular, ClipboardPasteRegular } from '@fluentui/react-icons';
 
 storiesOf('Menu Converged - basic', module)
   .addDecorator(story => (
@@ -34,9 +34,9 @@ storiesOf('Menu Converged - basic', module)
 
         <MenuPopover>
           <MenuList>
-            <MenuItem icon={<Cut20Regular />}>Cut</MenuItem>
-            <MenuItem icon={<Edit20Regular />}>Edit</MenuItem>
-            <MenuItem icon={<ClipboardPaste20Regular />}>Paste</MenuItem>
+            <MenuItem icon={<CutRegular />}>Cut</MenuItem>
+            <MenuItem icon={<EditRegular />}>Edit</MenuItem>
+            <MenuItem icon={<ClipboardPasteRegular />}>Paste</MenuItem>
           </MenuList>
         </MenuPopover>
       </Menu>
@@ -62,11 +62,11 @@ storiesOf('Menu Converged - secondary content', module)
 
         <MenuPopover>
           <MenuList>
-            <MenuItem icon={<Cut20Regular />} secondaryContent="Ctrl+X">
+            <MenuItem icon={<CutRegular />} secondaryContent="Ctrl+X">
               Cut
             </MenuItem>
-            <MenuItem icon={<Edit20Regular />}>Edit</MenuItem>
-            <MenuItem icon={<ClipboardPaste20Regular />} secondaryContent="Ctrl+P">
+            <MenuItem icon={<EditRegular />}>Edit</MenuItem>
+            <MenuItem icon={<ClipboardPasteRegular />} secondaryContent="Ctrl+P">
               Paste
             </MenuItem>
           </MenuList>
@@ -90,16 +90,16 @@ storiesOf('Menu Converged - groups', module)
           <MenuList>
             <MenuGroup>
               <MenuGroupHeader>Section header</MenuGroupHeader>
-              <MenuItem icon={<Cut20Regular />}>Cut</MenuItem>
-              <MenuItem icon={<ClipboardPaste20Regular />}>Paste</MenuItem>
-              <MenuItem icon={<Edit20Regular />}>Edit</MenuItem>
+              <MenuItem icon={<CutRegular />}>Cut</MenuItem>
+              <MenuItem icon={<ClipboardPasteRegular />}>Paste</MenuItem>
+              <MenuItem icon={<EditRegular />}>Edit</MenuItem>
             </MenuGroup>
             <MenuDivider />
             <MenuGroup>
               <MenuGroupHeader>Section header</MenuGroupHeader>
-              <MenuItem icon={<Cut20Regular />}>Cut</MenuItem>
-              <MenuItem icon={<ClipboardPaste20Regular />}>Paste</MenuItem>
-              <MenuItem icon={<Edit20Regular />}>Edit</MenuItem>
+              <MenuItem icon={<CutRegular />}>Cut</MenuItem>
+              <MenuItem icon={<ClipboardPasteRegular />}>Paste</MenuItem>
+              <MenuItem icon={<EditRegular />}>Edit</MenuItem>
             </MenuGroup>
           </MenuList>
         </MenuPopover>
@@ -126,13 +126,13 @@ storiesOf('Menu Converged - selection', module)
 
         <MenuPopover>
           <MenuList>
-            <MenuItemCheckbox icon={<Cut20Regular />} name="edit" value="cut">
+            <MenuItemCheckbox icon={<CutRegular />} name="edit" value="cut">
               Cut
             </MenuItemCheckbox>
-            <MenuItemCheckbox icon={<ClipboardPaste20Regular />} name="edit" value="paste">
+            <MenuItemCheckbox icon={<ClipboardPasteRegular />} name="edit" value="paste">
               Paste
             </MenuItemCheckbox>
-            <MenuItemCheckbox icon={<Edit20Regular />} name="edit" value="edit">
+            <MenuItemCheckbox icon={<EditRegular />} name="edit" value="edit">
               Edit
             </MenuItemCheckbox>
           </MenuList>
@@ -162,26 +162,26 @@ storiesOf('Menu Converged - selection groups', module)
           <MenuList>
             <MenuGroup>
               <MenuGroupHeader>Checkbox group</MenuGroupHeader>
-              <MenuItemCheckbox icon={<Cut20Regular />} name="edit" value="cut">
+              <MenuItemCheckbox icon={<CutRegular />} name="edit" value="cut">
                 Cut
               </MenuItemCheckbox>
-              <MenuItemCheckbox icon={<ClipboardPaste20Regular />} name="edit" value="paste">
+              <MenuItemCheckbox icon={<ClipboardPasteRegular />} name="edit" value="paste">
                 Paste
               </MenuItemCheckbox>
-              <MenuItemCheckbox icon={<Edit20Regular />} name="edit" value="edit">
+              <MenuItemCheckbox icon={<EditRegular />} name="edit" value="edit">
                 Edit
               </MenuItemCheckbox>
             </MenuGroup>
             <MenuDivider />
             <MenuGroup>
               <MenuGroupHeader>Radio group</MenuGroupHeader>
-              <MenuItemRadio icon={<Cut20Regular />} name="font" value="segoe">
+              <MenuItemRadio icon={<CutRegular />} name="font" value="segoe">
                 Segoe
               </MenuItemRadio>
-              <MenuItemRadio icon={<ClipboardPaste20Regular />} name="font" value="calibri">
+              <MenuItemRadio icon={<ClipboardPasteRegular />} name="font" value="calibri">
                 Caliri
               </MenuItemRadio>
-              <MenuItemRadio icon={<Edit20Regular />} name="font" value="arial">
+              <MenuItemRadio icon={<EditRegular />} name="font" value="arial">
                 Arial
               </MenuItemRadio>
             </MenuGroup>


### PR DESCRIPTION
## Current Behavior

Some Screener tests are using fixed-size icons.

## New Behavior

Replace the fixed sized icons with resizable versions. The components have already been updated to apply the correct size to their icon slots.

## Related Issue(s)

This is part of the work for #21220
