### PR TITLE
Allow override of Breadcrumb item content and per-item overrides

### DIFF
--- a/change/@fluentui-react-ed573539-35ce-4c02-8b39-24fb92cb0716.json
+++ b/change/@fluentui-react-ed573539-35ce-4c02-8b39-24fb92cb0716.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add an onRenderContent override to the Breadcrumb",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2339,6 +2339,8 @@ export interface IBreadcrumbItem extends React_2.AllHTMLAttributes<HTMLElement> 
     isCurrentItem?: boolean;
     key: string;
     onClick?: (ev?: React_2.MouseEvent<HTMLElement>, item?: IBreadcrumbItem) => void;
+    onRender?: IRenderFunction<IBreadcrumbItem>;
+    onRenderContent?: IRenderFunction<IBreadcrumbItem>;
     role?: string;
     text: string;
 }
@@ -2355,6 +2357,7 @@ export interface IBreadcrumbProps extends React_2.HTMLAttributes<HTMLElement> {
     onGrowData?: (data: IBreadcrumbData) => IBreadcrumbData | undefined;
     onReduceData?: (data: IBreadcrumbData) => IBreadcrumbData | undefined;
     onRenderItem?: IRenderFunction<IBreadcrumbItem>;
+    onRenderItemContent?: IRenderFunction<IBreadcrumbItem>;
     onRenderOverflowIcon?: IRenderFunction<IButtonProps>;
     overflowAriaLabel?: string;
     overflowButtonAs?: IComponentAs<IButtonProps>;

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -23,6 +23,7 @@ import type {
   IBreadcrumbStyleProps,
   IBreadcrumbStyles,
 } from './Breadcrumb.types';
+import { composeRenderFunction } from '../../Utilities';
 
 /** @deprecated Use IBreadcrumbData */
 export type IBreadCrumbData = IBreadcrumbData;
@@ -158,7 +159,7 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
     const {
       ariaLabel,
       dividerAs: DividerType = Icon as React.ElementType<IDividerAsProps>,
-      onRenderItem = this._onRenderItem,
+      onRenderItem,
       overflowAriaLabel,
       overflowIndex,
       onRenderOverflowIcon,
@@ -186,18 +187,30 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
     const lastItemIndex = renderedItems.length - 1;
     const hasOverflowItems = renderedOverflowItems && renderedOverflowItems.length !== 0;
 
-    const itemElements: JSX.Element[] = renderedItems.map((item, index) => (
-      <li className={this._classNames.listItem} key={item.key || String(index)}>
-        {onRenderItem(item, this._onRenderItem)}
-        {(index !== lastItemIndex || (hasOverflowItems && index === overflowIndex! - 1)) && (
-          <DividerType
-            className={this._classNames.chevron}
-            iconName={getRTL(this.props.theme) ? 'ChevronLeft' : 'ChevronRight'}
-            item={item}
-          />
-        )}
-      </li>
-    ));
+    const itemElements: JSX.Element[] = renderedItems.map((item, index) => {
+      let finalOnRenderItem = this._onRenderItem;
+
+      if (item.onRender) {
+        finalOnRenderItem = composeRenderFunction(item.onRender, finalOnRenderItem);
+      }
+
+      if (onRenderItem) {
+        finalOnRenderItem = composeRenderFunction(onRenderItem, finalOnRenderItem);
+      }
+
+      return (
+        <li className={this._classNames.listItem} key={item.key || String(index)}>
+          {finalOnRenderItem(item)}
+          {(index !== lastItemIndex || (hasOverflowItems && index === overflowIndex! - 1)) && (
+            <DividerType
+              className={this._classNames.chevron}
+              iconName={getRTL(this.props.theme) ? 'ChevronLeft' : 'ChevronRight'}
+              item={item}
+            />
+          )}
+        </li>
+      );
+    });
 
     if (hasOverflowItems) {
       const iconProps = !onRenderOverflowIcon ? { iconName: 'More' } : {};
@@ -248,8 +261,22 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
     );
   };
 
-  private _onRenderItem = (item: IBreadcrumbItem) => {
-    const { as, href, onClick, isCurrentItem, text, ...additionalProps } = item;
+  private _onRenderItem = (item?: IBreadcrumbItem) => {
+    if (!item) {
+      return null;
+    }
+
+    const { as, href, onClick, isCurrentItem, text, onRenderContent, ...additionalProps } = item;
+
+    let finalOnRenderContent = defaultOnRenderCrumbContent;
+
+    if (onRenderContent) {
+      finalOnRenderContent = composeRenderFunction(onRenderContent, finalOnRenderContent);
+    }
+
+    if (this.props.onRenderItemContent) {
+      finalOnRenderContent = composeRenderFunction(this.props.onRenderItemContent, finalOnRenderContent);
+    }
 
     if (onClick || href) {
       return (
@@ -263,7 +290,7 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
           onClick={this._onBreadcrumbClicked.bind(this, item)}
         >
           <TooltipHost content={text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
-            {text}
+            {finalOnRenderContent(item)}
           </TooltipHost>
         </Link>
       );
@@ -272,7 +299,7 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
       return (
         <Tag {...additionalProps} className={this._classNames.item}>
           <TooltipHost content={text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
-            {text}
+            {finalOnRenderContent(item)}
           </TooltipHost>
         </Tag>
       );
@@ -299,4 +326,8 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
       throw new Error('Breadcrumb: overflowIndex out of range');
     }
   }
+}
+
+function defaultOnRenderCrumbContent(item?: IBreadcrumbItem): JSX.Element | null {
+  return item ? <>{item.text}</> : null;
 }

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -66,8 +66,13 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
    */
   maxDisplayedItems?: number;
 
-  /** Custom render function for each breadcrumb item. */
+  /** Custom render function to render each crumb. Default renders as a link. */
   onRenderItem?: IRenderFunction<IBreadcrumbItem>;
+
+  /**
+   * Custom render function to render the content within a crumb. Default renders the text.
+   */
+  onRenderItemContent?: IRenderFunction<IBreadcrumbItem>;
 
   /**
    * Method that determines how to reduce the length of the breadcrumb.
@@ -141,6 +146,16 @@ export interface IBreadcrumbItem extends React.AllHTMLAttributes<HTMLElement> {
    * If true, `aria-current="page"` will be applied to this breadcrumb item.
    */
   isCurrentItem?: boolean;
+
+  /**
+   * A function to render the outer content of the crumb (the link).
+   */
+  onRender?: IRenderFunction<IBreadcrumbItem>;
+
+  /**
+   * A function to render the inner content of the crumb (the text inside the link).
+   */
+  onRenderContent?: IRenderFunction<IBreadcrumbItem>;
 
   /**
    * Optional prop to render the item as a heading of your choice.


### PR DESCRIPTION
## Current Behavior

The `Breadcrumb` component defines an `onRenderItem` prop which is used as a render override for every crumb. It takes responsibility for rendering the whole link given the item, and allows basic changing of props or wrapping the output.
There is no way to target a specific crumb, other than by matching `key`, or to render custom content inside a crumb without replacing the whole render logic.

## New Behavior

Added `onRender` and `onRenderContent` fields to `IBreadcrumbItem`, which are honored by the crumb render logic, so that individual crumbs can have custom render logic, either for the whole crumb or just the text content.

Also, added an `onRenderItemContent` field to `IBreadcrumbProps` for wholistic replacement, for consistency.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
