### PR TITLE
Fix: performBrowserTest now utilizes unused port provided by express.

### DIFF
--- a/scripts/projects-test/performBrowserTest.ts
+++ b/scripts/projects-test/performBrowserTest.ts
@@ -2,8 +2,8 @@ import config from '../config';
 import { safeLaunchOptions } from '../puppeteer/puppeteer.config';
 import express from 'express';
 import http from 'http';
-import portfinder from 'portfinder';
 import puppeteer from 'puppeteer';
+import { AddressInfo } from 'net';
 
 function startServer(publicDirectory: string, listenPort: number) {
   return new Promise<http.Server>((resolve, reject) => {
@@ -23,9 +23,10 @@ function startServer(publicDirectory: string, listenPort: number) {
 }
 
 export async function performBrowserTest(publicDirectory: string) {
-  const listenPort = await portfinder.getPortPromise();
-  console.log(`Starting server on port ${listenPort} from directory ${publicDirectory}`);
-  const server = await startServer(publicDirectory, listenPort);
+  const server = await startServer(publicDirectory, 0);
+  const { port } = server.address() as AddressInfo;
+
+  console.log(`Starting server on port ${port} from directory ${publicDirectory}`);
   console.log('Started server. Launching Puppeteer...');
 
   const options = safeLaunchOptions();
@@ -58,7 +59,7 @@ export async function performBrowserTest(publicDirectory: string) {
     error = pageError;
   });
 
-  const url = `http://${config.server_host}:${listenPort}`;
+  const url = `http://${config.server_host}:${port}`;
   console.log(`Loading ${url} in puppeteer...`);
   await page.goto(url);
   console.log('Page loaded');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- `performBrowserTest` currently uses `portfinder` to find an unused port to use; however, it utilizes the same port when being ran by multiple packages at the same time which seems to cause a race condition, causing intermittent timeout errors. A similar issue regarding the same ports being used has been filed to `portfinder` and this seems to be a known limitation of the module (see issue [here](https://github.com/http-party/node-portfinder/issues/118))

- When tests for two different packages are ran simultaneously, same port (8000) is used:
  ![image](https://user-images.githubusercontent.com/8649804/149424939-21861d09-abeb-4e86-9a25-ae315ab6ef33.png)


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- `performBrowserTest` now uses `express` instead to provide an open port. Passing `0` to express' `app.listen` method lets the OS assign an arbitrary unused port which can be accessed via `server.address().port`.

- When tests for two different packages are ran simultaneously, different ports are used:
  ![image](https://user-images.githubusercontent.com/8649804/149424889-19c487fb-489b-4aa4-8849-4ffe085f419d.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21191
