### PR TITLE
fix(Accordion): removes children as slot from AccordionHeader

### DIFF
--- a/change/@fluentui-react-accordion-92351cf0-bf2f-428a-8481-a180fbbd6468.json
+++ b/change/@fluentui-react-accordion-92351cf0-bf2f-428a-8481-a180fbbd6468.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removes children as a slot from AccordionHeader",
+  "packageName": "@fluentui/react-accordion",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-accordion/etc/react-accordion.api.md
@@ -10,7 +10,6 @@ import type { ComponentState } from '@fluentui/react-utilities';
 import type { Context } from '@fluentui/react-context-selector';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { IntrinsicShorthandProps } from '@fluentui/react-utilities';
-import type { ObjectShorthandProps } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 
 // @public
@@ -81,7 +80,6 @@ export type AccordionHeaderSlots = {
     button: ARIAButtonShorthandProps;
     expandIcon: IntrinsicShorthandProps<'span'>;
     icon?: IntrinsicShorthandProps<'div'>;
-    children: ObjectShorthandProps<React_2.HTMLAttributes<HTMLElement>>;
 };
 
 // @public (undocumented)

--- a/packages/react-accordion/src/components/AccordionHeader/AccordionHeader.types.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/AccordionHeader.types.ts
@@ -1,10 +1,4 @@
-import * as React from 'react';
-import type {
-  ComponentProps,
-  ComponentState,
-  IntrinsicShorthandProps,
-  ObjectShorthandProps,
-} from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, IntrinsicShorthandProps } from '@fluentui/react-utilities';
 import type { ARIAButtonShorthandProps } from '@fluentui/react-aria';
 
 export type AccordionHeaderSize = 'small' | 'medium' | 'large' | 'extra-large';
@@ -35,7 +29,6 @@ export type AccordionHeaderSlots = {
    * Expand icon slot rendered before (or after) children content in heading
    */
   icon?: IntrinsicShorthandProps<'div'>;
-  children: ObjectShorthandProps<React.HTMLAttributes<HTMLElement>>;
 };
 
 export type AccordionHeaderCommons = {

--- a/packages/react-accordion/src/components/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
+++ b/packages/react-accordion/src/components/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
@@ -31,11 +31,7 @@ exports[`AccordionHeader renders a default state 1`] = `
         />
       </svg>
     </span>
-    <div
-      className=""
-    >
-      Default AccordionHeader
-    </div>
+    Default AccordionHeader
   </button>
 </div>
 `;

--- a/packages/react-accordion/src/components/AccordionHeader/renderAccordionHeader.tsx
+++ b/packages/react-accordion/src/components/AccordionHeader/renderAccordionHeader.tsx
@@ -15,7 +15,7 @@ export const renderAccordionHeader = (state: AccordionHeaderState, contextValues
         <slots.button {...slotProps.button}>
           {state.expandIconPosition === 'start' && <slots.expandIcon {...slotProps.expandIcon} />}
           <slots.icon {...slotProps.icon} />
-          <slots.children {...slotProps.children} />
+          {slotProps.root.children}
           {state.expandIconPosition === 'end' && <slots.expandIcon {...slotProps.expandIcon} />}
         </slots.button>
       </slots.root>

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.tsx
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.tsx
@@ -14,7 +14,7 @@ import { useFluent } from '@fluentui/react-shared-contexts';
  * @param ref - reference to root HTMLElement of AccordionHeader
  */
 export const useAccordionHeader = (props: AccordionHeaderProps, ref: React.Ref<HTMLElement>): AccordionHeaderState => {
-  const { icon, button, children, expandIcon, inline = false, size = 'medium', expandIconPosition = 'start' } = props;
+  const { icon, button, expandIcon, inline = false, size = 'medium', expandIconPosition = 'start' } = props;
   const { onHeaderClick: onAccordionHeaderClick, disabled, open } = useAccordionItemContext();
 
   /**
@@ -58,7 +58,6 @@ export const useAccordionHeader = (props: AccordionHeaderProps, ref: React.Ref<H
       button: 'button',
       expandIcon: 'span',
       icon: 'div',
-      children: 'div',
     },
     root: getNativeElementProps('div', {
       ref,
@@ -84,8 +83,5 @@ export const useAccordionHeader = (props: AccordionHeaderProps, ref: React.Ref<H
         },
       ),
     },
-    children: resolveShorthand(children as AccordionHeaderSlots['children'], {
-      required: true,
-    }),
   };
 };

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.tsx
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { getNativeElementProps, resolveShorthand, useEventCallback } from '@fluentui/react-utilities';
 import { useAccordionItemContext } from '../AccordionItem/index';
 import { useARIAButton } from '@fluentui/react-aria';
-import type { AccordionHeaderProps, AccordionHeaderState, AccordionHeaderSlots } from './AccordionHeader.types';
+import type { AccordionHeaderProps, AccordionHeaderState } from './AccordionHeader.types';
 import { useContextSelector } from '@fluentui/react-context-selector';
 import { AccordionContext } from '../Accordion/AccordionContext';
 import { ChevronRightRegular } from '@fluentui/react-icons';

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
@@ -43,9 +43,18 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     cursor: 'pointer',
+    fontSize: tokens.fontSizeBase300,
+    fontFamily: tokens.fontFamilyBase,
   },
   buttonSmall: {
     height: '32px',
+    fontSize: tokens.fontSizeBase200,
+  },
+  buttonLarge: {
+    fontSize: tokens.fontSizeBase400,
+  },
+  buttonExtraLarge: {
+    fontSize: tokens.fontSizeBase500,
   },
   buttonInline: {
     display: 'inline-flex',
@@ -72,22 +81,6 @@ const useStyles = makeStyles({
   iconExpandIconEnd: {
     marginLeft: '10px',
   },
-  children: {
-    fontSize: tokens.fontSizeBase300,
-    fontFamily: tokens.fontFamilyBase,
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    ...shorthands.overflow('hidden'),
-  },
-  childrenSmall: {
-    fontSize: tokens.fontSizeBase200,
-  },
-  childrenLarge: {
-    fontSize: tokens.fontSizeBase400,
-  },
-  childrenExtraLarge: {
-    fontSize: tokens.fontSizeBase500,
-  },
 });
 
 /** Applies style classnames to slots */
@@ -107,6 +100,8 @@ export const useAccordionHeaderStyles = (state: AccordionHeaderState) => {
     styles.focusIndicator,
     state.inline && styles.buttonInline,
     state.size === 'small' && styles.buttonSmall,
+    state.size === 'large' && styles.buttonLarge,
+    state.size === 'extra-large' && styles.buttonExtraLarge,
     state.button.className,
   );
 
@@ -118,16 +113,6 @@ export const useAccordionHeaderStyles = (state: AccordionHeaderState) => {
       state.expandIcon.className,
     );
   }
-  if (state.children) {
-    state.children.className = mergeClasses(
-      styles.children,
-      state.size === 'small' && styles.childrenSmall,
-      state.size === 'large' && styles.childrenLarge,
-      state.size === 'extra-large' && styles.childrenExtraLarge,
-      state.children.className,
-    );
-  }
-
   if (state.icon) {
     state.icon.className = mergeClasses(
       styles.icon,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

AccordionHeader currently has `children` property as a slot which is not encouraged by our API due to `children` being a common property shared between most components, therefore it's type should be well defined

## New Behavior

Removes declaration of `children` as a slot and ensures it follows proper behaviors and no styles have been broken in the process

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21119
