### PR TITLE
perf(makeStyles): rework mergeClasses() to compute cache key faster

### DIFF
--- a/change/@fluentui-make-styles-6ed780fb-da77-4bcf-84b2-6337e72da9f5.json
+++ b/change/@fluentui-make-styles-6ed780fb-da77-4bcf-84b2-6337e72da9f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "perf: rework mergeClasses() to compute cache key faster",
+  "packageName": "@fluentui/make-styles",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/make-styles/src/mergeClasses.ts
+++ b/packages/make-styles/src/mergeClasses.ts
@@ -36,6 +36,7 @@ export function mergeClasses(...classNames: (string | false | undefined)[]): str
 export function mergeClasses(): string {
   // arguments are parsed manually to avoid double loops as TS & Babel transforms rest via an additional loop
   // @see https://babeljs.io/docs/en/babel-plugin-transform-parameters
+  /* eslint-disable prefer-rest-params */
 
   let dir: 'ltr' | 'rtl' | null = null;
   let resultClassName = '';
@@ -45,7 +46,6 @@ export function mergeClasses(): string {
   const sequencesIds: (SequenceHash | undefined)[] = new Array(arguments.length);
 
   for (let i = 0; i < arguments.length; i++) {
-    // eslint-disable-next-line prefer-rest-params
     const className = arguments[i];
 
     if (typeof className === 'string') {

--- a/packages/make-styles/src/mergeClasses.ts
+++ b/packages/make-styles/src/mergeClasses.ts
@@ -7,7 +7,7 @@ import {
 } from './constants';
 import { hashSequence } from './runtime/utils/hashSequence';
 import { reduceToClassName } from './runtime/reduceToClassNameForSlots';
-import { CSSClassesMap } from './types';
+import { CSSClassesMap, SequenceHash } from './types';
 
 // Contains a mapping of previously resolved sequences of atomic classnames
 const mergeClassesCachedResults: Record<string, string> = {};
@@ -39,10 +39,10 @@ export function mergeClasses(): string {
 
   let dir: 'ltr' | 'rtl' | null = null;
   let resultClassName = '';
+
   // Is used as a cache key to avoid object merging
   let sequenceMatch = '';
-
-  const sequenceMappings: CSSClassesMap[] = [];
+  const sequencesIds: (SequenceHash | undefined)[] = new Array(arguments.length);
 
   for (let i = 0; i < arguments.length; i++) {
     // eslint-disable-next-line prefer-rest-params
@@ -56,39 +56,15 @@ export function mergeClasses(): string {
       if (sequenceIndex === -1) {
         resultClassName += className + ' ';
       } else {
-        const sequenceId = className.slice(sequenceIndex, sequenceIndex + SEQUENCE_SIZE);
-        const sequenceMapping = DEFINITION_LOOKUP_TABLE[sequenceId];
+        const sequenceId = className.substr(sequenceIndex, SEQUENCE_SIZE);
 
         // Handles a case with mixed classnames, i.e. "ui-button ATOMIC_CLASSES"
         if (sequenceIndex > 0) {
           resultClassName += className.slice(0, sequenceIndex);
         }
 
-        if (sequenceMapping) {
-          sequenceMatch += sequenceId;
-          sequenceMappings.push(sequenceMapping[LOOKUP_DEFINITIONS_INDEX]);
-
-          if (process.env.NODE_ENV !== 'production') {
-            if (dir !== null && dir !== sequenceMapping[LOOKUP_DIR_INDEX]) {
-              // eslint-disable-next-line no-console
-              console.error(
-                `mergeClasses(): a passed string contains an identifier (${sequenceId}) that has different direction ` +
-                  `(dir="${sequenceMapping[1] ? 'rtl' : 'ltr'}") setting than other classes. This is not supported. ` +
-                  `Source string: ${className}`,
-              );
-            }
-          }
-
-          dir = sequenceMapping[LOOKUP_DIR_INDEX];
-        } else {
-          if (process.env.NODE_ENV !== 'production') {
-            // eslint-disable-next-line no-console
-            console.error(
-              `mergeClasses(): a passed string contains an identifier (${sequenceId}) that does not match any entry ` +
-                `in cache. Source string: ${className}`,
-            );
-          }
-        }
+        sequenceMatch += sequenceId;
+        sequencesIds[i] = sequenceId;
       }
 
       if (process.env.NODE_ENV !== 'production') {
@@ -116,6 +92,38 @@ export function mergeClasses(): string {
 
   if (mergeClassesResult !== undefined) {
     return resultClassName + mergeClassesResult;
+  }
+
+  const sequenceMappings: CSSClassesMap[] = [];
+
+  for (let i = 0; i < arguments.length; i++) {
+    const sequenceId = sequencesIds[i];
+    const sequenceMapping = sequenceId ? DEFINITION_LOOKUP_TABLE[sequenceId] : undefined;
+
+    if (sequenceMapping) {
+      sequenceMappings.push(sequenceMapping[LOOKUP_DEFINITIONS_INDEX]);
+
+      if (process.env.NODE_ENV !== 'production') {
+        if (dir !== null && dir !== sequenceMapping[LOOKUP_DIR_INDEX]) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `mergeClasses(): a passed string contains an identifier (${sequenceId}) that has different direction ` +
+              `(dir="${sequenceMapping[1] ? 'rtl' : 'ltr'}") setting than other classes. This is not supported. ` +
+              `Source string: ${arguments[i]}`,
+          );
+        }
+      }
+
+      dir = sequenceMapping[LOOKUP_DIR_INDEX];
+    } else {
+      if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.error(
+          `mergeClasses(): a passed string contains an identifier (${sequenceId}) that does not match any entry ` +
+            `in cache. Source string: ${arguments[i]}`,
+        );
+      }
+    }
   }
 
   // eslint-disable-next-line prefer-spread


### PR DESCRIPTION
## New Behavior

`mergeClasses()` parses each passed argument to understand if passed classes are Atomic or not:

https://github.com/microsoft/fluentui/blob/5e128714ba386902c0650ce61dfdeedee71ec0c8/packages/make-styles/src/mergeClasses.ts#L47-L60

If classes are Atomic it will build cache key (1️⃣ `sequenceMatch`) and will extract mapping from properties to classes (2️⃣ `sequenceMappings`).

- (1) `sequenceMatch` works poorly with strings
- (2) `sequenceMappings` includes accessing objects & arrays and

Surprisingly it's not free to access objects & arrays in JavaScript (_at least in v8_) and strings are much cheaper (_it's actually the reason why we use them for key computation_). Taking this into account this PR splits works into two separate loops instead of a single - this makes cache key computation much cheaper.

## Results

This test runs multiple `mergeClasses()` calls:

```ts
mergeClasses(
  "ui-button",
  "ui-flex",
  "red",
  styles.root,
  styles.focus,
  styles.rootCopy
);
mergeClasses(styles.root, styles.rootCopy);
mergeClasses(styles.root, styles.focus);
```

#### Re-render scenario

Shows re-render performance, we are using cache for Atomic classes.

| Case                        |    ops/sec (higher is better) |
| :-------------------------- | ----------------------------: |
| before (_current `master`_) | (🔻 40.75%) 1271674 _ops/sec_ |
| after (_this branch_)       |             1922512 _ops/sec_ |

#### Render scenario

Shows initial render performance (when classes are merged first), cache for Atomic classes is **disabled**.

| Case                        | ops/sec (higher is better) |
| :-------------------------- | -------------------------: |
| before (_current `master`_) |            59246 _ops/sec_ |
| after (_this branch_)       |            59165 _ops/sec_ |

(these tests are available in [fela-benchmark repo](https://github.com/layershifter/fela-benchmark), branch `perf/griffel`)
