### PR TITLE
Added aria-orientation to divider

### DIFF
--- a/change/@fluentui-react-divider-8007dcbe-33ef-4d80-9b15-0cfca85bdc66.json
+++ b/change/@fluentui-react-divider-8007dcbe-33ef-4d80-9b15-0cfca85bdc66.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Added aria-orientation to divider",
+  "packageName": "@fluentui/react-divider",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-divider/src/components/Divider/Divider.test.tsx
+++ b/packages/react-divider/src/components/Divider/Divider.test.tsx
@@ -32,43 +32,43 @@ describe('Divider', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a subtle state with content', () => {
+  it('renders a subtle appearance', () => {
     const component = renderer.create(<Divider appearance="subtle">Subtle</Divider>);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a brand state with content', () => {
+  it('renders a brand appearance', () => {
     const component = renderer.create(<Divider appearance="brand">Brand</Divider>);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a strong state with content', () => {
+  it('renders a strong appearance', () => {
     const component = renderer.create(<Divider appearance="strong">Strong</Divider>);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a content aligned start', () => {
+  it('renders content start aligned', () => {
     const component = renderer.create(<Divider alignContent="start">Start</Divider>);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a content aligned center', () => {
+  it('renders content center aligned', () => {
     const component = renderer.create(<Divider alignContent="center">Center</Divider>);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a content aligned end', () => {
+  it('renders content end aligned', () => {
     const component = renderer.create(<Divider alignContent="end">End</Divider>);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a divider with different color', () => {
+  it('renders a divider with a different color', () => {
     const component = renderer.create(<Divider color="#FF00FF" />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
@@ -81,18 +81,22 @@ describe('Divider', () => {
   });
 
   it('renders a vertical divider with content', () => {
-    const component = renderer.create(<Divider>Vertical</Divider>);
+    const component = renderer.create(<Divider vertical>Vertical</Divider>);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a vertical a fixed height', () => {
-    const component = renderer.create(<Divider style={{ height: 100 }}>fixed 100px height</Divider>);
+  it('renders a vertical divider with a fixed height', () => {
+    const component = renderer.create(
+      <Divider style={{ height: 100 }} vertical>
+        fixed 100px height
+      </Divider>,
+    );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a horizontal a fixed width', () => {
+  it('renders a horizontal divider with a fixed width', () => {
     const component = renderer.create(<Divider style={{ width: 100 }}>fixed 100px width</Divider>);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/react-divider/src/components/Divider/__snapshots__/Divider.test.tsx.snap
+++ b/packages/react-divider/src/components/Divider/__snapshots__/Divider.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Divider renders a brand state with content 1`] = `
+exports[`Divider renders a brand appearance 1`] = `
 <div
   aria-labelledby="divider-1"
   aria-orientation="horizontal"
@@ -15,52 +15,15 @@ exports[`Divider renders a brand state with content 1`] = `
 </div>
 `;
 
-exports[`Divider renders a content aligned center 1`] = `
-<div
-  aria-labelledby="divider-1"
-  aria-orientation="horizontal"
-  className="fui-Divider"
-  role="separator"
->
-  <div
-    id="divider-1"
-  >
-    Center
-  </div>
-</div>
-`;
-
-exports[`Divider renders a content aligned end 1`] = `
-<div
-  aria-labelledby="divider-1"
-  aria-orientation="horizontal"
-  className="fui-Divider"
-  role="separator"
->
-  <div
-    id="divider-1"
-  >
-    End
-  </div>
-</div>
-`;
-
-exports[`Divider renders a content aligned start 1`] = `
-<div
-  aria-labelledby="divider-1"
-  aria-orientation="horizontal"
-  className="fui-Divider"
-  role="separator"
->
-  <div
-    id="divider-1"
-  >
-    Start
-  </div>
-</div>
-`;
-
 exports[`Divider renders a default divider 1`] = `
+<div
+  aria-orientation="horizontal"
+  className="fui-Divider"
+  role="separator"
+/>
+`;
+
+exports[`Divider renders a divider with a different color 1`] = `
 <div
   aria-orientation="horizontal"
   className="fui-Divider"
@@ -83,14 +46,6 @@ exports[`Divider renders a divider with content 1`] = `
 </div>
 `;
 
-exports[`Divider renders a divider with different color 1`] = `
-<div
-  aria-orientation="horizontal"
-  className="fui-Divider"
-  role="separator"
-/>
-`;
-
 exports[`Divider renders a divider with inset 1`] = `
 <div
   aria-labelledby="divider-1"
@@ -106,7 +61,7 @@ exports[`Divider renders a divider with inset 1`] = `
 </div>
 `;
 
-exports[`Divider renders a horizontal a fixed width 1`] = `
+exports[`Divider renders a horizontal divider with a fixed width 1`] = `
 <div
   aria-labelledby="divider-1"
   aria-orientation="horizontal"
@@ -126,7 +81,7 @@ exports[`Divider renders a horizontal a fixed width 1`] = `
 </div>
 `;
 
-exports[`Divider renders a strong state with content 1`] = `
+exports[`Divider renders a strong appearance 1`] = `
 <div
   aria-labelledby="divider-1"
   aria-orientation="horizontal"
@@ -141,7 +96,7 @@ exports[`Divider renders a strong state with content 1`] = `
 </div>
 `;
 
-exports[`Divider renders a subtle state with content 1`] = `
+exports[`Divider renders a subtle appearance 1`] = `
 <div
   aria-labelledby="divider-1"
   aria-orientation="horizontal"
@@ -156,10 +111,18 @@ exports[`Divider renders a subtle state with content 1`] = `
 </div>
 `;
 
-exports[`Divider renders a vertical a fixed height 1`] = `
+exports[`Divider renders a vertical divider 1`] = `
+<div
+  aria-orientation="vertical"
+  className="fui-Divider"
+  role="separator"
+/>
+`;
+
+exports[`Divider renders a vertical divider with a fixed height 1`] = `
 <div
   aria-labelledby="divider-1"
-  aria-orientation="horizontal"
+  aria-orientation="vertical"
   className="fui-Divider"
   role="separator"
   style={
@@ -176,15 +139,22 @@ exports[`Divider renders a vertical a fixed height 1`] = `
 </div>
 `;
 
-exports[`Divider renders a vertical divider 1`] = `
+exports[`Divider renders a vertical divider with content 1`] = `
 <div
+  aria-labelledby="divider-1"
   aria-orientation="vertical"
   className="fui-Divider"
   role="separator"
-/>
+>
+  <div
+    id="divider-1"
+  >
+    Vertical
+  </div>
+</div>
 `;
 
-exports[`Divider renders a vertical divider with content 1`] = `
+exports[`Divider renders content center aligned 1`] = `
 <div
   aria-labelledby="divider-1"
   aria-orientation="horizontal"
@@ -194,7 +164,37 @@ exports[`Divider renders a vertical divider with content 1`] = `
   <div
     id="divider-1"
   >
-    Vertical
+    Center
+  </div>
+</div>
+`;
+
+exports[`Divider renders content end aligned 1`] = `
+<div
+  aria-labelledby="divider-1"
+  aria-orientation="horizontal"
+  className="fui-Divider"
+  role="separator"
+>
+  <div
+    id="divider-1"
+  >
+    End
+  </div>
+</div>
+`;
+
+exports[`Divider renders content start aligned 1`] = `
+<div
+  aria-labelledby="divider-1"
+  aria-orientation="horizontal"
+  className="fui-Divider"
+  role="separator"
+>
+  <div
+    id="divider-1"
+  >
+    Start
   </div>
 </div>
 `;

--- a/packages/react-divider/src/components/Divider/__snapshots__/Divider.test.tsx.snap
+++ b/packages/react-divider/src/components/Divider/__snapshots__/Divider.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Divider renders a brand state with content 1`] = `
 <div
   aria-labelledby="divider-1"
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
 >
@@ -17,6 +18,7 @@ exports[`Divider renders a brand state with content 1`] = `
 exports[`Divider renders a content aligned center 1`] = `
 <div
   aria-labelledby="divider-1"
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
 >
@@ -31,6 +33,7 @@ exports[`Divider renders a content aligned center 1`] = `
 exports[`Divider renders a content aligned end 1`] = `
 <div
   aria-labelledby="divider-1"
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
 >
@@ -45,6 +48,7 @@ exports[`Divider renders a content aligned end 1`] = `
 exports[`Divider renders a content aligned start 1`] = `
 <div
   aria-labelledby="divider-1"
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
 >
@@ -58,6 +62,7 @@ exports[`Divider renders a content aligned start 1`] = `
 
 exports[`Divider renders a default divider 1`] = `
 <div
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
 />
@@ -66,6 +71,7 @@ exports[`Divider renders a default divider 1`] = `
 exports[`Divider renders a divider with content 1`] = `
 <div
   aria-labelledby="divider-1"
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
 >
@@ -79,6 +85,7 @@ exports[`Divider renders a divider with content 1`] = `
 
 exports[`Divider renders a divider with different color 1`] = `
 <div
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
 />
@@ -87,6 +94,7 @@ exports[`Divider renders a divider with different color 1`] = `
 exports[`Divider renders a divider with inset 1`] = `
 <div
   aria-labelledby="divider-1"
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
 >
@@ -101,6 +109,7 @@ exports[`Divider renders a divider with inset 1`] = `
 exports[`Divider renders a horizontal a fixed width 1`] = `
 <div
   aria-labelledby="divider-1"
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
   style={
@@ -120,6 +129,7 @@ exports[`Divider renders a horizontal a fixed width 1`] = `
 exports[`Divider renders a strong state with content 1`] = `
 <div
   aria-labelledby="divider-1"
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
 >
@@ -134,6 +144,7 @@ exports[`Divider renders a strong state with content 1`] = `
 exports[`Divider renders a subtle state with content 1`] = `
 <div
   aria-labelledby="divider-1"
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
 >
@@ -148,6 +159,7 @@ exports[`Divider renders a subtle state with content 1`] = `
 exports[`Divider renders a vertical a fixed height 1`] = `
 <div
   aria-labelledby="divider-1"
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
   style={
@@ -166,6 +178,7 @@ exports[`Divider renders a vertical a fixed height 1`] = `
 
 exports[`Divider renders a vertical divider 1`] = `
 <div
+  aria-orientation="vertical"
   className="fui-Divider"
   role="separator"
 />
@@ -174,6 +187,7 @@ exports[`Divider renders a vertical divider 1`] = `
 exports[`Divider renders a vertical divider with content 1`] = `
 <div
   aria-labelledby="divider-1"
+  aria-orientation="horizontal"
   className="fui-Divider"
   role="separator"
 >

--- a/packages/react-divider/src/components/Divider/useDivider.ts
+++ b/packages/react-divider/src/components/Divider/useDivider.ts
@@ -28,6 +28,7 @@ export const useDivider = (props: DividerProps, ref: React.Ref<HTMLElement>): Di
       ...props,
       ref,
       role: 'separator',
+      'aria-orientation': vertical ? 'vertical' : 'horizontal',
       'aria-labelledby': props.children ? dividerId : undefined,
     }),
     wrapper: resolveShorthand(wrapper, {


### PR DESCRIPTION
Please verify that:
* [X] Code is up-to-date with the `master` branch
* [X] Your changes are covered by tests (if possible)
* [X] You've run `yarn change` locally


## Current Behavior

aria-orientation attribute is missing, making screen readers read a vertical divider as horizontal.

## New Behavior

aria-orientation attribute is set for horizontal and vertical dividers, screen reader reads correctly.

## Related Issue(s)

Fixes #21291
