### PR TITLE
[web-components]: Remove unused declared variables in combobox

### DIFF
--- a/change/@fluentui-web-components-e23b11e5-b929-428a-a271-c8f6931c8133.json
+++ b/change/@fluentui-web-components-e23b11e5-b929-428a-a271-c8f6931c8133.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unused declared variables in combobox styles",
+  "packageName": "@fluentui/web-components",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/src/combobox/combobox.styles.ts
+++ b/packages/web-components/src/combobox/combobox.styles.ts
@@ -1,6 +1,5 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
-import { ComboboxOptions, disabledCursor, ElementDefinitionContext, focusVisible, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation';
-import { SystemColors } from "@microsoft/fast-web-utilities";
+import { ComboboxOptions, disabledCursor, ElementDefinitionContext, focusVisible } from '@microsoft/fast-foundation';
 import { selectFilledStyles, selectStyles } from '../select/select.styles';
 import { appearanceBehavior } from '../utilities/behaviors';
 import { strokeWidth, typeRampBaseFontSize, typeRampBaseLineHeight } from '../design-tokens';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

There are unused declared variables in `combobox.styles.ts` that are causing issues when trying to merge branches:

![image](https://user-images.githubusercontent.com/8649804/149584904-06f0ba69-51c7-4c61-8212-5076179a0af6.png)


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Removes unused variables.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
