### PR TITLE
temp fix: resolve mini-css-extractor-plugin to an older version for cra-template & projects-test

### DIFF
--- a/change/@fluentui-cra-template-69213d33-73e4-4b2f-b41a-09cc17439a07.json
+++ b/change/@fluentui-cra-template-69213d33-73e4-4b2f-b41a-09cc17439a07.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "temp fix: resolve mini-css-extractor-plugin to older version to fix error.",
+  "packageName": "@fluentui/cra-template",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/cra-template/scripts/test.ts
+++ b/packages/cra-template/scripts/test.ts
@@ -77,6 +77,14 @@ async function runE2ETest() {
 
   logger('STEP 2. Create test React app from template');
   await prepareCreateReactApp(tempPaths, `file:${templatePath}`);
+  /**
+   * This is a temporary quick-fix solution. Remove once issue with mini-css-extract-plugin
+   * is resolved @see https://github.com/facebook/create-react-app/issues/11930
+   */
+  const parsedJSON = JSON.parse(fs.readFileSync(`${tempPaths.testApp}/package.json`, 'utf-8'));
+  parsedJSON.resolutions['mini-css-extract-plugin'] = '2.4.5';
+  fs.writeFileSync(`${tempPaths.testApp}/package.json`, JSON.stringify(parsedJSON));
+
   await shEcho('yarn add cross-env', tempPaths.testApp);
   logger(`✔️ Test React app is successfully created: ${tempPaths.testApp}`);
 

--- a/packages/fluentui/projects-test/src/createReactApp.ts
+++ b/packages/fluentui/projects-test/src/createReactApp.ts
@@ -42,7 +42,6 @@ export async function createReactApp() {
    * is resolved @see https://github.com/facebook/create-react-app/issues/11930
    */
   const parsedJSON = JSON.parse(fs.readFileSync(`${tempPaths.testApp}/package.json`, 'utf-8'));
-  console.log('parsed JSOJN ', parsedJSON);
   parsedJSON.resolutions['mini-css-extract-plugin'] = '2.4.5';
   fs.writeFileSync(`${tempPaths.testApp}/package.json`, JSON.stringify(parsedJSON));
 

--- a/packages/fluentui/projects-test/src/createReactApp.ts
+++ b/packages/fluentui/projects-test/src/createReactApp.ts
@@ -37,6 +37,15 @@ export async function createReactApp() {
   const packedPackages = await packProjectPackages(logger, config.paths.packages(), ['@fluentui/react-northstar']);
   await addResolutionPathsForProjectPackages(testAppPath());
 
+  /**
+   * This is a temporary quick-fix solution. Remove once issue with mini-css-extract-plugin
+   * is resolved @see https://github.com/facebook/create-react-app/issues/11930
+   */
+  const parsedJSON = JSON.parse(fs.readFileSync(`${tempPaths.testApp}/package.json`, 'utf-8'));
+  console.log('parsed JSOJN ', parsedJSON);
+  parsedJSON.resolutions['mini-css-extract-plugin'] = '2.4.5';
+  fs.writeFileSync(`${tempPaths.testApp}/package.json`, JSON.stringify(parsedJSON));
+
   await shEcho(`yarn add ${packedPackages['@fluentui/react-northstar']}`, testAppPath());
   logger(`✔️ Fluent UI packages were added to dependencies`);
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
The latest version of `mini-css-extractor-plugin` released today is causing the `cra-template` and `projects-test` packages builds to fail (see screenshot). An issue has already been filed for this (see [here](https://github.com/facebook/create-react-app/issues/11930)).

![image](https://user-images.githubusercontent.com/8649804/149597769-0c9b8de6-a376-470f-932c-358bc3efeb89.png)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Uses workaround and adds `mini-css-extractor-plugin` version `2.4.5` to the resolutions section of the testApp's `package.json`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
