### PR TITLE
fix: add missing pointing indicator for menu vertical active

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemWrapperStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemWrapperStyles.ts
@@ -129,6 +129,20 @@ export const menuItemWrapperStyles: ComponentSlotStylesPrepared<MenuItemWrapperS
                 color: colors.foregroundActive,
               }),
           }),
+          ...(pointing &&
+            vertical && {
+              '::before': {
+                content: `''`,
+                position: 'absolute',
+                width: pxToRem(3),
+                height: `calc(100% + ${pxToRem(4)})`,
+                top: pxToRem(-2),
+                backgroundColor: v.pointingIndicatorBackgroundColor,
+
+                ...(isFromKeyboard && { display: 'none' }),
+                ...(pointing === 'end' ? { right: pxToRem(-2) } : { left: pxToRem(-2) }),
+              },
+            }),
         },
       }),
 


### PR DESCRIPTION
## Current Behavior

`pointing` menu when having active styles is missing the pointing indicator:

![Screenshot (34)](https://user-images.githubusercontent.com/86579954/149965798-28fa7768-305c-4864-b276-e2a78ad3d105.png)


## New Behavior

Adding the pointing indicator when required:

![Screenshot (35)](https://user-images.githubusercontent.com/86579954/149965862-950d6286-18f0-4bf5-9cfe-3247fac30ee5.png)

