### PR TITLE
react-input: Removed config with just-scripts

### DIFF
--- a/change/@fluentui-react-input-4f50d0b5-cd5f-411f-8f45-66cf55fae951.json
+++ b/change/@fluentui-react-input-4f50d0b5-cd5f-411f-8f45-66cf55fae951.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rmoved config with just-scripts",
+  "packageName": "@fluentui/react-input",
+  "email": "tkrasniqi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-input/package.json
+++ b/packages/react-input/package.json
@@ -22,7 +22,6 @@
     "test": "jest --passWithNoTests",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output ./dist/packages/react-input/src && yarn docs",
-    "build-storybook": "just-scripts storybook:build",
     "storybook": "node ../../scripts/storybook/runner",
     "type-check": "tsc -b tsconfig.json"
   },


### PR DESCRIPTION
## Current Behavior
The package.json of react-input has a configuration with just-script that are no longer needed for v9 components. 
This issue caused the CI to fail in this PR: https://github.com/microsoft/fluentui/pull/21123 

## New Behavior
Removed the `"build-storybook": "just-scripts storybook:build"` from `react-input` package.

