### PR TITLE
chore: remove temp fix for mini-css-extractor-plugin error

### DIFF
--- a/change/@fluentui-cra-template-cbd4d3f6-f50e-4c14-9ff8-387e2f41bb71.json
+++ b/change/@fluentui-cra-template-cbd4d3f6-f50e-4c14-9ff8-387e2f41bb71.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove temporary mini-css-extractor-plugin fix",
+  "packageName": "@fluentui/cra-template",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/cra-template/scripts/test.ts
+++ b/packages/cra-template/scripts/test.ts
@@ -77,14 +77,6 @@ async function runE2ETest() {
 
   logger('STEP 2. Create test React app from template');
   await prepareCreateReactApp(tempPaths, `file:${templatePath}`);
-  /**
-   * This is a temporary quick-fix solution. Remove once issue with mini-css-extract-plugin
-   * is resolved @see https://github.com/facebook/create-react-app/issues/11930
-   */
-  const parsedJSON = JSON.parse(fs.readFileSync(`${tempPaths.testApp}/package.json`, 'utf-8'));
-  parsedJSON.resolutions['mini-css-extract-plugin'] = '2.4.5';
-  fs.writeFileSync(`${tempPaths.testApp}/package.json`, JSON.stringify(parsedJSON));
-
   await shEcho('yarn add cross-env', tempPaths.testApp);
   logger(`✔️ Test React app is successfully created: ${tempPaths.testApp}`);
 

--- a/packages/fluentui/projects-test/src/createReactApp.ts
+++ b/packages/fluentui/projects-test/src/createReactApp.ts
@@ -37,14 +37,6 @@ export async function createReactApp() {
   const packedPackages = await packProjectPackages(logger, config.paths.packages(), ['@fluentui/react-northstar']);
   await addResolutionPathsForProjectPackages(testAppPath());
 
-  /**
-   * This is a temporary quick-fix solution. Remove once issue with mini-css-extract-plugin
-   * is resolved @see https://github.com/facebook/create-react-app/issues/11930
-   */
-  const parsedJSON = JSON.parse(fs.readFileSync(`${tempPaths.testApp}/package.json`, 'utf-8'));
-  parsedJSON.resolutions['mini-css-extract-plugin'] = '2.4.5';
-  fs.writeFileSync(`${tempPaths.testApp}/package.json`, JSON.stringify(parsedJSON));
-
   await shEcho(`yarn add ${packedPackages['@fluentui/react-northstar']}`, testAppPath());
   logger(`✔️ Fluent UI packages were added to dependencies`);
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- An older version of the `mini-css-extractor-plugin` was added to the the resolutions section of the test app's `package.json` for both `cra-template` and `projects-test` packages. The root issue has since been fixed in the latest version (see [comment](https://github.com/facebook/create-react-app/issues/11930#issuecomment-1014519316)) of `mini-css-extrator-plugin` so this temp fix is no longer needed. 

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Removes temporary fix added in #21295

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
