### PR TITLE
Remove Tooltip's inverted prop in favor of the appearance prop

### DIFF
--- a/change/@fluentui-react-tooltip-b682fed9-f100-424e-ad72-301cc3084a23.json
+++ b/change/@fluentui-react-tooltip-b682fed9-f100-424e-ad72-301cc3084a23.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove Tooltip's inverted prop in favor of the appearance prop",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tooltip/etc/react-tooltip.api.md
+++ b/packages/react-tooltip/etc/react-tooltip.api.md
@@ -27,9 +27,8 @@ export const tooltipClassName = "fui-Tooltip";
 
 // @public
 export type TooltipCommons = {
-    appearance?: 'inverted';
+    appearance?: 'normal' | 'inverted';
     content: React_2.ReactNode;
-    inverted?: boolean;
     withArrow?: boolean;
     positioning?: PositioningShorthand;
     visible?: boolean;

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
@@ -25,22 +25,18 @@ export type TooltipSlots = {
  */
 export type TooltipCommons = {
   /**
-   * A tooltip can appear with the default appearance or inverted.
-   * When not specified, the default appearance is used.
+   * The tooltip's visual appearance.
+   * * `normal` - Uses the theme's background and text colors.
+   * * `inverted` - Higher contrast variant that uses the theme's inverted colors.
+   *
+   * @defaultvalue normal
    */
-  appearance?: 'inverted';
+  appearance?: 'normal' | 'inverted';
 
   /**
    * The content displayed inside the tooltip.
    */
   content: React.ReactNode;
-
-  /**
-   * Color variant with inverted colors
-   *
-   * @defaultvalue false
-   */
-  inverted?: boolean;
 
   /**
    * Render an arrow pointing to the target element

--- a/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -31,7 +31,7 @@ export const useTooltip = (props: TooltipProps, ref: React.Ref<HTMLDivElement>):
 
   const {
     content,
-    inverted,
+    appearance,
     withArrow,
     positioning,
     onVisibleChange,
@@ -56,7 +56,6 @@ export const useTooltip = (props: TooltipProps, ref: React.Ref<HTMLDivElement>):
 
   const state: TooltipState = {
     content,
-    inverted,
     withArrow,
     positioning,
     showDelay,
@@ -64,7 +63,7 @@ export const useTooltip = (props: TooltipProps, ref: React.Ref<HTMLDivElement>):
     triggerAriaAttribute,
     visible,
     shouldRenderTooltip: visible,
-    appearance: props.appearance,
+    appearance,
 
     // Slots
     components: {


### PR DESCRIPTION
## Current Behavior

* Tooltip's `inverted` prop had been removed but was added back by a merge conflict.
* Tooltip's `appearance` prop is an enum but doesn't have any value for `"normal"` besides `undefined`.

## New Behavior

* Remove Tooltip's inverted prop in favor of the appearance prop
* Add a `normal` value for the appearance prop, and update its documentation
