### PR TITLE
[FIX] String Misspelling in Theme Slots

### DIFF
--- a/apps/public-docsite/src/pages/Styles/ThemeSlotsPage/docs/web/ThemeSlotsOverview.md
+++ b/apps/public-docsite/src/pages/Styles/ThemeSlotsPage/docs/web/ThemeSlotsOverview.md
@@ -1,4 +1,4 @@
-Fluent UI includes 9 theme colors, 14 neutral colors, and 24 accent colors. In Fluent UI React, these are all within the `theme.palette` object. In Fabric Core, each has helper classes for text, background, border, and hover states. When selecting colors, refer to the [color accessibility guidance (PDF)](https://static2.sharepointonline.com/files/fabric/fabric-website/files/coloraccessibility_29sep2016.pdf) to ensure that your text can be read by everyone. If you need to customize your theme, see the [Theme Designer](https://aka.ms/themedesigner).
+Fluent UI includes 9 theme colors, 14 neutral colors, and 24 accent colors. In Fluent UI React, these are all within the `theme.palette` object. In Fabric Core, each has helper classes for text, background, border, and hover states. When selecting colors, refer to the [color accessibility guidance (PDF)](https://static2.sharepointonline.com/files/fabric/fabric-website/files/coloraccessibility_29sep2016.pdf) to ensure your text can be read by everyone. If you need to customize your theme, see the [Theme Designer](https://aka.ms/themedesigner).
 
 ### What is theming?
 

--- a/apps/public-docsite/src/pages/Styles/ThemeSlotsPage/docs/web/ThemeSlotsOverview.md
+++ b/apps/public-docsite/src/pages/Styles/ThemeSlotsPage/docs/web/ThemeSlotsOverview.md
@@ -1,4 +1,4 @@
-Fluent UI includes 9 theme colors, 14 neutral colors, and 24 accent colors. In Fluent UI React, these are all within the `theme.palette` object. In Fabric Core, each has helper classes for text, background, border, and hover states. When selecting colors, refer to the [color accessibility guidance (PDF)](https://static2.sharepointonline.com/files/fabric/fabric-website/files/coloraccessibility_29sep2016.pdf) to ensure that your text can be ready by everyone. If you need to customize your theme, see the [Theme Designer](https://aka.ms/themedesigner).
+Fluent UI includes 9 theme colors, 14 neutral colors, and 24 accent colors. In Fluent UI React, these are all within the `theme.palette` object. In Fabric Core, each has helper classes for text, background, border, and hover states. When selecting colors, refer to the [color accessibility guidance (PDF)](https://static2.sharepointonline.com/files/fabric/fabric-website/files/coloraccessibility_29sep2016.pdf) to ensure that your text can be read by everyone. If you need to customize your theme, see the [Theme Designer](https://aka.ms/themedesigner).
 
 ### What is theming?
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

String misspelling in: https://developer.microsoft.com/en-us/fluentui#/styles/web/colors/theme-slots

`When selecting colors, refer to the color accessibility guidance (PDF) to ensure that your text can be ready by everyone. `

## New Behavior

Fixed String to read:

`When selecting colors, refer to the [color accessibility guidance (PDF) to ensure your text can be read by everyone. `

## Related Issue(s)

Fixes #19031 
