### PR TITLE
chore: Bump tslib to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "ts-loader": "8.0.14",
     "tsconfig-paths": "3.9.0",
     "tsconfig-paths-webpack-plugin": "3.5.1",
-    "tslib": "2.2.0",
+    "tslib": "2.3.1",
     "typescript": "4.3.5",
     "webpack": "5.44.0",
     "webpack-bundle-analyzer": "4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24686,10 +24686,10 @@ tslib@1.11.2:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.2.tgz#9c79d83272c9a7aaf166f73915c9667ecdde3cc9"
   integrity sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==
 
-tslib@2.2.0, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
-  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+tslib@2.3.1, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslib@^1.10.0, tslib@^1.13.0, tslib@^1.14.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"


### PR DESCRIPTION
Bumps tslib which unblocks tabster upgrade in #21319

tabster uses tslib ^2.3.1 which will cause duplicate tslib versions to be used in v8
