### PR TITLE
fix(DetailsList): remove aria-colindex and fix aria-label/description on column headers

### DIFF
--- a/apps/vr-tests/src/stories/DetailsHeader.stories.tsx
+++ b/apps/vr-tests/src/stories/DetailsHeader.stories.tsx
@@ -119,22 +119,26 @@ storiesOf('DetailsHeader', module)
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.ms-DetailsHeader' })
-        .hover('[aria-colindex=2]')
+        .hover('[role=columnheader]:nth-of-type(2)')
         .snapshot('hoverFrozenFirst', { cropTo: '.ms-DetailsHeader' })
-        .hover('[aria-colindex=3]')
+        .hover('[role=columnheader]:nth-of-type(3)')
         .snapshot('hoverDraggable', { cropTo: '.ms-DetailsHeader' })
-        .hover('[aria-colindex=7]')
+        .hover('[role=columnheader]:nth-of-type(7)')
         .snapshot('hoverFrozenLast', { cropTo: '.ms-DetailsHeader' })
-        .hover('[aria-colindex=3]')
+        .hover('[role=columnheader]:nth-of-type(3)')
         .executeScript(dndScript)
         // simulate a drag on column 'b' to render the border
         .cssAnimations(false)
-        .executeScript(`DndSimulator.simulate('[draggable="true"]', '[aria-colindex="5"]', false)`)
+        .executeScript(
+          `DndSimulator.simulate('[draggable="true"]', '[role=columnheader]:nth-of-type(5), false)`,
+        )
         .snapshot('borderWhileDragging')
         // do a dragover on 'd' to render the drop hint
-        .hover('[aria-colindex=5]')
+        .hover('[role=columnheader]:nth-of-type(5)')
         .cssAnimations(true)
-        .executeScript(`DndSimulator.simulate('[draggable="true"]', '[aria-colindex="5"]', true)`)
+        .executeScript(
+          `DndSimulator.simulate('[draggable="true"]', '[role=columnheader]:nth-of-type(5)', true)`,
+        )
         .snapshot('dropHint')
         .end()}
     >

--- a/apps/vr-tests/src/stories/DetailsHeader.stories.tsx
+++ b/apps/vr-tests/src/stories/DetailsHeader.stories.tsx
@@ -119,25 +119,25 @@ storiesOf('DetailsHeader', module)
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.ms-DetailsHeader' })
-        .hover('[role=columnheader]:nth-of-type(2)')
+        .hover('[role=columnheader][data-item-key=a]')
         .snapshot('hoverFrozenFirst', { cropTo: '.ms-DetailsHeader' })
-        .hover('[role=columnheader]:nth-of-type(3)')
+        .hover('[role=columnheader][data-item-key=b]')
         .snapshot('hoverDraggable', { cropTo: '.ms-DetailsHeader' })
-        .hover('[role=columnheader]:nth-of-type(7)')
+        .hover('[role=columnheader][data-item-key=f]')
         .snapshot('hoverFrozenLast', { cropTo: '.ms-DetailsHeader' })
-        .hover('[role=columnheader]:nth-of-type(3)')
+        .hover('[role=columnheader][data-item-key=b]')
         .executeScript(dndScript)
         // simulate a drag on column 'b' to render the border
         .cssAnimations(false)
         .executeScript(
-          `DndSimulator.simulate('[draggable="true"]', '[role=columnheader]:nth-of-type(5), false)`,
+          `DndSimulator.simulate('[draggable="true"]', '[role=columnheader][data-item-key=d], false)`,
         )
         .snapshot('borderWhileDragging')
         // do a dragover on 'd' to render the drop hint
-        .hover('[role=columnheader]:nth-of-type(5)')
+        .hover('[role=columnheader][data-item-key=d]')
         .cssAnimations(true)
         .executeScript(
-          `DndSimulator.simulate('[draggable="true"]', '[role=columnheader]:nth-of-type(5)', true)`,
+          `DndSimulator.simulate('[draggable="true"]', '[role=columnheader][data-item-key=d]', true)`,
         )
         .snapshot('dropHint')
         .end()}

--- a/apps/vr-tests/src/stories/DetailsHeader.stories.tsx
+++ b/apps/vr-tests/src/stories/DetailsHeader.stories.tsx
@@ -129,7 +129,7 @@ storiesOf('DetailsHeader', module)
         .executeScript(dndScript)
         // simulate a drag on column 'b' to render the border
         .cssAnimations(false)
-        .executeScript(`DndSimulator.simulate('[draggable="true"]', '[data-item-key="d"], false)`)
+        .executeScript(`DndSimulator.simulate('[draggable="true"]', '[data-item-key="d"]', false)`)
         .snapshot('borderWhileDragging')
         // do a dragover on 'd' to render the drop hint
         .hover('[data-item-key=d]')

--- a/apps/vr-tests/src/stories/DetailsHeader.stories.tsx
+++ b/apps/vr-tests/src/stories/DetailsHeader.stories.tsx
@@ -119,26 +119,22 @@ storiesOf('DetailsHeader', module)
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.ms-DetailsHeader' })
-        .hover('[role=columnheader][data-item-key=a]')
+        .hover('[data-item-key=a]')
         .snapshot('hoverFrozenFirst', { cropTo: '.ms-DetailsHeader' })
-        .hover('[role=columnheader][data-item-key=b]')
+        .hover('[data-item-key=b]')
         .snapshot('hoverDraggable', { cropTo: '.ms-DetailsHeader' })
-        .hover('[role=columnheader][data-item-key=f]')
+        .hover('[data-item-key=f]')
         .snapshot('hoverFrozenLast', { cropTo: '.ms-DetailsHeader' })
-        .hover('[role=columnheader][data-item-key=b]')
+        .hover('[data-item-key=b]')
         .executeScript(dndScript)
         // simulate a drag on column 'b' to render the border
         .cssAnimations(false)
-        .executeScript(
-          `DndSimulator.simulate('[draggable="true"]', '[role=columnheader][data-item-key=d], false)`,
-        )
+        .executeScript(`DndSimulator.simulate('[draggable="true"]', '[data-item-key="d"], false)`)
         .snapshot('borderWhileDragging')
         // do a dragover on 'd' to render the drop hint
-        .hover('[role=columnheader][data-item-key=d]')
+        .hover('[data-item-key=d]')
         .cssAnimations(true)
-        .executeScript(
-          `DndSimulator.simulate('[draggable="true"]', '[role=columnheader][data-item-key=d]', true)`,
-        )
+        .executeScript(`DndSimulator.simulate('[draggable="true"]', '[data-item-key="d"]', true)`)
         .snapshot('dropHint')
         .end()}
     >

--- a/change/@fluentui-react-4d5c0d4e-7f97-4ef4-91e0-987d52ee1b2c.json
+++ b/change/@fluentui-react-4d5c0d4e-7f97-4ef4-91e0-987d52ee1b2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove aria-colindex from DetailsList columns by default, fix aria-label and aria-description on column headers",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react-focus/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/react-examples/src/react-focus/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -113,7 +113,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       role="presentation"
     >
       <div
-        aria-colindex={1}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -170,7 +169,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         Item-0
       </div>
       <div
-        aria-colindex={2}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -283,7 +281,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </a>
       </div>
       <div
-        aria-colindex={3}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -476,7 +473,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-colindex={4}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -784,7 +780,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       role="presentation"
     >
       <div
-        aria-colindex={1}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -841,7 +836,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         Item-1
       </div>
       <div
-        aria-colindex={2}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -954,7 +948,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </a>
       </div>
       <div
-        aria-colindex={3}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -1147,7 +1140,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-colindex={4}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -1455,7 +1447,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       role="presentation"
     >
       <div
-        aria-colindex={1}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -1512,7 +1503,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         Item-2
       </div>
       <div
-        aria-colindex={2}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -1625,7 +1615,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </a>
       </div>
       <div
-        aria-colindex={3}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -1818,7 +1807,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-colindex={4}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -2126,7 +2114,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       role="presentation"
     >
       <div
-        aria-colindex={1}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -2183,7 +2170,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         Item-3
       </div>
       <div
-        aria-colindex={2}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -2296,7 +2282,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </a>
       </div>
       <div
-        aria-colindex={3}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -2489,7 +2474,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-colindex={4}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -2797,7 +2781,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       role="presentation"
     >
       <div
-        aria-colindex={1}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -2854,7 +2837,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         Item-4
       </div>
       <div
-        aria-colindex={2}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -2967,7 +2949,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </a>
       </div>
       <div
-        aria-colindex={3}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -3160,7 +3141,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-colindex={4}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -3468,7 +3448,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       role="presentation"
     >
       <div
-        aria-colindex={1}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -3525,7 +3504,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         Item-5
       </div>
       <div
-        aria-colindex={2}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -3638,7 +3616,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </a>
       </div>
       <div
-        aria-colindex={3}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -3831,7 +3808,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-colindex={4}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -4139,7 +4115,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       role="presentation"
     >
       <div
-        aria-colindex={1}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -4196,7 +4171,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         Item-6
       </div>
       <div
-        aria-colindex={2}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -4309,7 +4283,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </a>
       </div>
       <div
-        aria-colindex={3}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -4502,7 +4475,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-colindex={4}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -4810,7 +4782,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       role="presentation"
     >
       <div
-        aria-colindex={1}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -4867,7 +4838,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         Item-7
       </div>
       <div
-        aria-colindex={2}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -4980,7 +4950,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </a>
       </div>
       <div
-        aria-colindex={3}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -5173,7 +5142,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-colindex={4}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -5481,7 +5449,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       role="presentation"
     >
       <div
-        aria-colindex={1}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -5538,7 +5505,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         Item-8
       </div>
       <div
-        aria-colindex={2}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -5651,7 +5617,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </a>
       </div>
       <div
-        aria-colindex={3}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -5844,7 +5809,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-colindex={4}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -6152,7 +6116,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       role="presentation"
     >
       <div
-        aria-colindex={1}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -6209,7 +6172,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         Item-9
       </div>
       <div
-        aria-colindex={2}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -6322,7 +6284,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </a>
       </div>
       <div
-        aria-colindex={3}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell
@@ -6515,7 +6476,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-colindex={4}
         aria-readonly={true}
         className=
             ms-DetailsRow-cell

--- a/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
@@ -17,7 +17,7 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
     const items = createListItems(500);
     this.state = {
       sortedItems: items,
-      columns: _buildColumns(items),
+      columns: this._buildColumns(items),
     };
   }
 
@@ -30,7 +30,6 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
         setKey="set"
         columns={columns}
         onRenderItemColumn={_renderItemColumn}
-        onColumnHeaderClick={this._onColumnClick}
         onItemInvoked={this._onItemInvoked}
         onColumnHeaderContextMenu={this._onColumnHeaderContextMenu}
         ariaLabelForSelectionColumn="Toggle selection"
@@ -68,6 +67,20 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
     });
   };
 
+  private _buildColumns(items: IExampleItem[]): IColumn[] {
+    const columns = buildColumns(items, false, this._onColumnClick);
+
+    const thumbnailColumn = columns.filter(column => column.name === 'thumbnail')[0];
+
+    // Special case one column's definition.
+    thumbnailColumn.name = '';
+    thumbnailColumn.maxWidth = 50;
+    thumbnailColumn.ariaLabel = 'Thumbnail';
+    thumbnailColumn.onColumnClick = undefined;
+
+    return columns;
+  }
+
   private _onColumnHeaderContextMenu(column: IColumn | undefined, ev: React.MouseEvent<HTMLElement> | undefined): void {
     console.log(`column ${column!.key} contextmenu opened.`);
   }
@@ -75,19 +88,6 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
   private _onItemInvoked(item: any, index: number | undefined): void {
     alert(`Item ${item.name} at index ${index} has been invoked.`);
   }
-}
-
-function _buildColumns(items: IExampleItem[]): IColumn[] {
-  const columns = buildColumns(items);
-
-  const thumbnailColumn = columns.filter(column => column.name === 'thumbnail')[0];
-
-  // Special case one column's definition.
-  thumbnailColumn.name = '';
-  thumbnailColumn.maxWidth = 50;
-  thumbnailColumn.ariaLabel = 'Thumbnail';
-
-  return columns;
 }
 
 function _renderItemColumn(item: IExampleItem, index: number, column: IColumn) {

--- a/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -292,7 +292,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
             role="row"
           >
             <div
-              aria-colindex={1}
               aria-labelledby="header4-checkTooltip"
               className=
                   ms-DetailsHeader-cell
@@ -562,7 +561,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
               Toggle selection for all items
             </label>
             <div
-              aria-colindex={2}
               aria-labelledby="header4-name-name"
               aria-sort="none"
               className=
@@ -843,7 +841,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -1090,7 +1087,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -1264,7 +1260,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -1511,7 +1506,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -1685,7 +1679,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -1932,7 +1925,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -2106,7 +2098,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -2353,7 +2344,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -2527,7 +2517,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -2774,7 +2763,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -2948,7 +2936,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -3195,7 +3182,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3369,7 +3355,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -3616,7 +3601,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3790,7 +3774,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -4037,7 +4020,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4211,7 +4193,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -4458,7 +4439,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4632,7 +4612,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -4879,7 +4858,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -88,7 +88,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -358,7 +357,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
             Toggle selection for all items
           </label>
           <div
-            aria-colindex={2}
             aria-labelledby="header1-name-name"
             aria-sort="none"
             className=
@@ -639,7 +637,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -886,7 +883,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1195,7 +1191,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -1442,7 +1437,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1751,7 +1745,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -1998,7 +1991,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2307,7 +2299,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -2554,7 +2545,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2863,7 +2853,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -3110,7 +3099,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3419,7 +3407,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -3666,7 +3653,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3975,7 +3961,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -4222,7 +4207,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4531,7 +4515,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -4778,7 +4761,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5087,7 +5069,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -5334,7 +5315,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5643,7 +5623,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -5890,7 +5869,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -778,7 +778,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
             role="row"
           >
             <div
-              aria-colindex={1}
               aria-labelledby="header11-checkTooltip"
               className=
                   ms-DetailsHeader-cell
@@ -1048,7 +1047,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               Toggle selection for all items
             </label>
             <div
-              aria-colindex={2}
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -1127,8 +1125,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     }
               >
                 <span
-                  aria-describedby="header11-thumbnail-tooltip"
-                  aria-label="thumbnail"
+                  aria-label="Operations for thumbnail"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1237,29 +1234,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                 </span>
               </span>
             </div>
-            <label
-              className=
-
-                  {
-                    border: 0px;
-                    height: 1px;
-                    margin-bottom: -1px;
-                    margin-left: -1px;
-                    margin-right: -1px;
-                    margin-top: -1px;
-                    overflow: hidden;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: absolute;
-                    white-space: nowrap;
-                    width: 1px;
-                  }
-              id="header11-thumbnail-tooltip"
-            >
-              Operations for thumbnail
-            </label>
             <span
               className=
 
@@ -1339,9 +1313,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   }
             />
             <div
-              aria-colindex={3}
-              aria-describedby="header11-key-tooltip"
-              aria-labelledby="header11-key-name"
+              aria-label="Operations for key"
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -1463,29 +1435,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                 </span>
               </span>
             </div>
-            <label
-              className=
-
-                  {
-                    border: 0px;
-                    height: 1px;
-                    margin-bottom: -1px;
-                    margin-left: -1px;
-                    margin-right: -1px;
-                    margin-top: -1px;
-                    overflow: hidden;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: absolute;
-                    white-space: nowrap;
-                    width: 1px;
-                  }
-              id="header11-key-tooltip"
-            >
-              Operations for key
-            </label>
             <span
               className=
 
@@ -1565,7 +1514,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   }
             />
             <div
-              aria-colindex={4}
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -1644,8 +1592,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     }
               >
                 <span
-                  aria-describedby="header11-name-tooltip"
-                  aria-labelledby="header11-name-name"
+                  aria-label="Operations for name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1699,29 +1646,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                 </span>
               </span>
             </div>
-            <label
-              className=
-
-                  {
-                    border: 0px;
-                    height: 1px;
-                    margin-bottom: -1px;
-                    margin-left: -1px;
-                    margin-right: -1px;
-                    margin-top: -1px;
-                    overflow: hidden;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: absolute;
-                    white-space: nowrap;
-                    width: 1px;
-                  }
-              id="header11-name-tooltip"
-            >
-              Operations for name
-            </label>
             <span
               className=
 
@@ -1801,7 +1725,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   }
             />
             <div
-              aria-colindex={5}
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -1880,8 +1803,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     }
               >
                 <span
-                  aria-describedby="header11-description-tooltip"
-                  aria-labelledby="header11-description-name"
+                  aria-label="Operations for description"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1935,29 +1857,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                 </span>
               </span>
             </div>
-            <label
-              className=
-
-                  {
-                    border: 0px;
-                    height: 1px;
-                    margin-bottom: -1px;
-                    margin-left: -1px;
-                    margin-right: -1px;
-                    margin-top: -1px;
-                    overflow: hidden;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: absolute;
-                    white-space: nowrap;
-                    width: 1px;
-                  }
-              id="header11-description-tooltip"
-            >
-              Operations for description
-            </label>
             <span
               className=
 
@@ -2037,7 +1936,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   }
             />
             <div
-              aria-colindex={6}
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -2116,8 +2014,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     }
               >
                 <span
-                  aria-describedby="header11-color-tooltip"
-                  aria-labelledby="header11-color-name"
+                  aria-label="Operations for color"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -2171,29 +2068,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                 </span>
               </span>
             </div>
-            <label
-              className=
-
-                  {
-                    border: 0px;
-                    height: 1px;
-                    margin-bottom: -1px;
-                    margin-left: -1px;
-                    margin-right: -1px;
-                    margin-top: -1px;
-                    overflow: hidden;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: absolute;
-                    white-space: nowrap;
-                    width: 1px;
-                  }
-              id="header11-color-tooltip"
-            >
-              Operations for color
-            </label>
             <span
               className=
 
@@ -2273,7 +2147,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   }
             />
             <div
-              aria-colindex={7}
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -2352,8 +2225,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     }
               >
                 <span
-                  aria-describedby="header11-shape-tooltip"
-                  aria-labelledby="header11-shape-name"
+                  aria-label="Operations for shape"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -2407,29 +2279,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                 </span>
               </span>
             </div>
-            <label
-              className=
-
-                  {
-                    border: 0px;
-                    height: 1px;
-                    margin-bottom: -1px;
-                    margin-left: -1px;
-                    margin-right: -1px;
-                    margin-top: -1px;
-                    overflow: hidden;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: absolute;
-                    white-space: nowrap;
-                    width: 1px;
-                  }
-              id="header11-shape-tooltip"
-            >
-              Operations for shape
-            </label>
             <span
               className=
 
@@ -2509,7 +2358,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   }
             />
             <div
-              aria-colindex={8}
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -2588,8 +2436,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     }
               >
                 <span
-                  aria-describedby="header11-location-tooltip"
-                  aria-labelledby="header11-location-name"
+                  aria-label="Operations for location"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -2643,29 +2490,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                 </span>
               </span>
             </div>
-            <label
-              className=
-
-                  {
-                    border: 0px;
-                    height: 1px;
-                    margin-bottom: -1px;
-                    margin-left: -1px;
-                    margin-right: -1px;
-                    margin-top: -1px;
-                    overflow: hidden;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: absolute;
-                    white-space: nowrap;
-                    width: 1px;
-                  }
-              id="header11-location-tooltip"
-            >
-              Operations for location
-            </label>
             <span
               className=
 
@@ -2745,7 +2569,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   }
             />
             <div
-              aria-colindex={9}
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -2824,8 +2647,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     }
               >
                 <span
-                  aria-describedby="header11-width-tooltip"
-                  aria-labelledby="header11-width-name"
+                  aria-label="Operations for width"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -2879,29 +2701,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                 </span>
               </span>
             </div>
-            <label
-              className=
-
-                  {
-                    border: 0px;
-                    height: 1px;
-                    margin-bottom: -1px;
-                    margin-left: -1px;
-                    margin-right: -1px;
-                    margin-top: -1px;
-                    overflow: hidden;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: absolute;
-                    white-space: nowrap;
-                    width: 1px;
-                  }
-              id="header11-width-tooltip"
-            >
-              Operations for width
-            </label>
             <span
               className=
 
@@ -2981,7 +2780,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   }
             />
             <div
-              aria-colindex={10}
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -3060,8 +2858,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     }
               >
                 <span
-                  aria-describedby="header11-height-tooltip"
-                  aria-labelledby="header11-height-name"
+                  aria-label="Operations for height"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -3115,29 +2912,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                 </span>
               </span>
             </div>
-            <label
-              className=
-
-                  {
-                    border: 0px;
-                    height: 1px;
-                    margin-bottom: -1px;
-                    margin-left: -1px;
-                    margin-right: -1px;
-                    margin-top: -1px;
-                    overflow: hidden;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: absolute;
-                    white-space: nowrap;
-                    width: 1px;
-                  }
-              id="header11-height-tooltip"
-            >
-              Operations for height
-            </label>
             <span
               className=
 
@@ -3365,7 +3139,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -3612,7 +3385,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3669,7 +3441,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             //via.placeholder.com/150x150
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3787,7 +3558,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3901,7 +3671,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3998,7 +3767,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Lorem ipsum dolor sit amet
                           </div>
                           <div
-                            aria-colindex={6}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4055,7 +3823,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             red
                           </div>
                           <div
-                            aria-colindex={7}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4112,7 +3879,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             circle
                           </div>
                           <div
-                            aria-colindex={8}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4169,7 +3935,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Seattle
                           </div>
                           <div
-                            aria-colindex={9}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4226,7 +3991,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             150
                           </div>
                           <div
-                            aria-colindex={10}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4400,7 +4164,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -4647,7 +4410,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4704,7 +4466,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             //via.placeholder.com/150x150
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4822,7 +4583,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4936,7 +4696,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5033,7 +4792,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Lorem ipsum dolor sit amet
                           </div>
                           <div
-                            aria-colindex={6}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5090,7 +4848,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             red
                           </div>
                           <div
-                            aria-colindex={7}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5147,7 +4904,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             circle
                           </div>
                           <div
-                            aria-colindex={8}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5204,7 +4960,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Seattle
                           </div>
                           <div
-                            aria-colindex={9}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5261,7 +5016,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             150
                           </div>
                           <div
-                            aria-colindex={10}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5435,7 +5189,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -5682,7 +5435,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5739,7 +5491,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             //via.placeholder.com/150x150
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5857,7 +5608,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5971,7 +5721,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -6068,7 +5817,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Lorem ipsum dolor sit amet
                           </div>
                           <div
-                            aria-colindex={6}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -6125,7 +5873,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             red
                           </div>
                           <div
-                            aria-colindex={7}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -6182,7 +5929,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             circle
                           </div>
                           <div
-                            aria-colindex={8}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -6239,7 +5985,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Seattle
                           </div>
                           <div
-                            aria-colindex={9}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -6296,7 +6041,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             150
                           </div>
                           <div
-                            aria-colindex={10}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -6470,7 +6214,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -6717,7 +6460,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -6774,7 +6516,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             //via.placeholder.com/150x150
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -6892,7 +6633,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -7006,7 +6746,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -7103,7 +6842,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Lorem ipsum dolor sit amet
                           </div>
                           <div
-                            aria-colindex={6}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -7160,7 +6898,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             red
                           </div>
                           <div
-                            aria-colindex={7}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -7217,7 +6954,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             circle
                           </div>
                           <div
-                            aria-colindex={8}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -7274,7 +7010,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Seattle
                           </div>
                           <div
-                            aria-colindex={9}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -7331,7 +7066,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             150
                           </div>
                           <div
-                            aria-colindex={10}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -7505,7 +7239,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -7752,7 +7485,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -7809,7 +7541,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             //via.placeholder.com/150x150
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -7927,7 +7658,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -8041,7 +7771,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -8138,7 +7867,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Lorem ipsum dolor sit amet
                           </div>
                           <div
-                            aria-colindex={6}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -8195,7 +7923,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             red
                           </div>
                           <div
-                            aria-colindex={7}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -8252,7 +7979,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             circle
                           </div>
                           <div
-                            aria-colindex={8}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -8309,7 +8035,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Seattle
                           </div>
                           <div
-                            aria-colindex={9}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -8366,7 +8091,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             150
                           </div>
                           <div
-                            aria-colindex={10}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -8540,7 +8264,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -8787,7 +8510,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -8844,7 +8566,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             //via.placeholder.com/150x150
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -8962,7 +8683,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -9076,7 +8796,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -9173,7 +8892,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Lorem ipsum dolor sit amet
                           </div>
                           <div
-                            aria-colindex={6}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -9230,7 +8948,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             red
                           </div>
                           <div
-                            aria-colindex={7}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -9287,7 +9004,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             circle
                           </div>
                           <div
-                            aria-colindex={8}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -9344,7 +9060,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Seattle
                           </div>
                           <div
-                            aria-colindex={9}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -9401,7 +9116,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             150
                           </div>
                           <div
-                            aria-colindex={10}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -9575,7 +9289,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -9822,7 +9535,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -9879,7 +9591,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             //via.placeholder.com/150x150
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -9997,7 +9708,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -10111,7 +9821,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -10208,7 +9917,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Lorem ipsum dolor sit amet
                           </div>
                           <div
-                            aria-colindex={6}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -10265,7 +9973,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             red
                           </div>
                           <div
-                            aria-colindex={7}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -10322,7 +10029,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             circle
                           </div>
                           <div
-                            aria-colindex={8}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -10379,7 +10085,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Seattle
                           </div>
                           <div
-                            aria-colindex={9}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -10436,7 +10141,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             150
                           </div>
                           <div
-                            aria-colindex={10}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -10610,7 +10314,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -10857,7 +10560,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -10914,7 +10616,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             //via.placeholder.com/150x150
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -11032,7 +10733,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -11146,7 +10846,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -11243,7 +10942,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Lorem ipsum dolor sit amet
                           </div>
                           <div
-                            aria-colindex={6}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -11300,7 +10998,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             red
                           </div>
                           <div
-                            aria-colindex={7}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -11357,7 +11054,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             circle
                           </div>
                           <div
-                            aria-colindex={8}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -11414,7 +11110,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Seattle
                           </div>
                           <div
-                            aria-colindex={9}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -11471,7 +11166,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             150
                           </div>
                           <div
-                            aria-colindex={10}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -11645,7 +11339,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -11892,7 +11585,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -11949,7 +11641,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             //via.placeholder.com/150x150
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -12067,7 +11758,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -12181,7 +11871,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -12278,7 +11967,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Lorem ipsum dolor sit amet
                           </div>
                           <div
-                            aria-colindex={6}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -12335,7 +12023,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             red
                           </div>
                           <div
-                            aria-colindex={7}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -12392,7 +12079,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             circle
                           </div>
                           <div
-                            aria-colindex={8}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -12449,7 +12135,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Seattle
                           </div>
                           <div
-                            aria-colindex={9}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -12506,7 +12191,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             150
                           </div>
                           <div
-                            aria-colindex={10}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -12680,7 +12364,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                       >
                         <div
-                          aria-colindex={1}
                           className=
                               ms-DetailsRow-cell
                               ms-DetailsRow-cellCheck
@@ -12927,7 +12610,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           role="presentation"
                         >
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -12984,7 +12666,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             //via.placeholder.com/150x150
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -13102,7 +12783,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -13216,7 +12896,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             </a>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -13313,7 +12992,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Lorem ipsum dolor sit amet
                           </div>
                           <div
-                            aria-colindex={6}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -13370,7 +13048,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             red
                           </div>
                           <div
-                            aria-colindex={7}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -13427,7 +13104,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             circle
                           </div>
                           <div
-                            aria-colindex={8}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -13484,7 +13160,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             Seattle
                           </div>
                           <div
-                            aria-colindex={9}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -13541,7 +13216,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             150
                           </div>
                           <div
-                            aria-colindex={10}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -88,7 +88,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -358,7 +357,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
             Toggle selection for all items
           </label>
           <div
-            aria-colindex={2}
             aria-labelledby="header1-column1-name"
             aria-sort="none"
             className=
@@ -547,7 +545,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
             role="button"
           />
           <div
-            aria-colindex={3}
             aria-labelledby="header1-column2-name"
             aria-sort="none"
             className=
@@ -884,7 +881,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -1131,7 +1127,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1188,7 +1183,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           Item 0
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1362,7 +1356,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -1609,7 +1602,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1666,7 +1658,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           Item 1
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1840,7 +1831,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -2087,7 +2077,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2144,7 +2133,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           Item 2
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2318,7 +2306,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -2565,7 +2552,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2622,7 +2608,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           Item 3
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2796,7 +2781,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -3043,7 +3027,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3100,7 +3083,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           Item 4
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3274,7 +3256,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -3521,7 +3502,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3578,7 +3558,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           Item 5
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3752,7 +3731,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -3999,7 +3977,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4056,7 +4033,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           Item 6
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4230,7 +4206,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -4477,7 +4452,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4534,7 +4508,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           Item 7
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4708,7 +4681,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -4955,7 +4927,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5012,7 +4983,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           Item 8
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5186,7 +5156,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -5433,7 +5402,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5490,7 +5458,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           Item 9
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -301,7 +301,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
               role="row"
             >
               <div
-                aria-colindex={1}
                 aria-labelledby="header6-checkTooltip"
                 className=
                     ms-DetailsHeader-cell
@@ -571,7 +570,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 Toggle selection for all items
               </label>
               <div
-                aria-colindex={2}
                 aria-labelledby="header6-column1-name"
                 aria-sort="none"
                 className=
@@ -760,7 +758,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 role="button"
               />
               <div
-                aria-colindex={3}
                 aria-labelledby="header6-column2-name"
                 aria-sort="none"
                 className=
@@ -1097,7 +1094,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -1344,7 +1340,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -1401,7 +1396,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               Item 0
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -1575,7 +1569,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -1822,7 +1815,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -1879,7 +1871,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               Item 1
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -2053,7 +2044,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -2300,7 +2290,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -2357,7 +2346,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               Item 2
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -2531,7 +2519,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -2778,7 +2765,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -2835,7 +2821,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               Item 3
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -3009,7 +2994,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -3256,7 +3240,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -3313,7 +3296,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               Item 4
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -3487,7 +3469,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -3734,7 +3715,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -3791,7 +3771,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               Item 5
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -3965,7 +3944,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -4212,7 +4190,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -4269,7 +4246,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               Item 6
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -4443,7 +4419,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -4690,7 +4665,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -4747,7 +4721,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               Item 7
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -4921,7 +4894,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -5168,7 +5140,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -5225,7 +5196,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               Item 8
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -5399,7 +5369,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -5646,7 +5615,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -5703,7 +5671,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               Item 9
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.ColumnResize.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.ColumnResize.Example.tsx.shot
@@ -976,7 +976,6 @@ Array [
               role="row"
             >
               <div
-                aria-colindex={1}
                 aria-labelledby="header17-0-name"
                 aria-sort="none"
                 className=
@@ -1165,7 +1164,6 @@ Array [
                 role="button"
               />
               <div
-                aria-colindex={2}
                 aria-labelledby="header17-1-name"
                 aria-sort="none"
                 className=
@@ -1354,7 +1352,6 @@ Array [
                 role="button"
               />
               <div
-                aria-colindex={3}
                 aria-labelledby="header17-2-name"
                 aria-sort="none"
                 className=
@@ -1543,7 +1540,6 @@ Array [
                 role="button"
               />
               <div
-                aria-colindex={4}
                 aria-labelledby="header17-3-name"
                 aria-sort="none"
                 className=
@@ -1886,7 +1882,6 @@ Array [
                             role="presentation"
                           >
                             <div
-                              aria-colindex={1}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -1943,7 +1938,6 @@ Array [
                               A-0
                             </div>
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -2000,7 +1994,6 @@ Array [
                               A-1
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -2057,7 +2050,6 @@ Array [
                               A-2
                             </div>
                             <div
-                              aria-colindex={4}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -2287,7 +2279,6 @@ Array [
               role="row"
             >
               <div
-                aria-colindex={1}
                 aria-labelledby="header21-0-name"
                 aria-sort="none"
                 className=
@@ -2476,7 +2467,6 @@ Array [
                 role="button"
               />
               <div
-                aria-colindex={2}
                 aria-labelledby="header21-1-name"
                 aria-sort="none"
                 className=
@@ -2665,7 +2655,6 @@ Array [
                 role="button"
               />
               <div
-                aria-colindex={3}
                 aria-labelledby="header21-2-name"
                 aria-sort="none"
                 className=
@@ -2854,7 +2843,6 @@ Array [
                 role="button"
               />
               <div
-                aria-colindex={4}
                 aria-labelledby="header21-3-name"
                 aria-sort="none"
                 className=
@@ -3197,7 +3185,6 @@ Array [
                             role="presentation"
                           >
                             <div
-                              aria-colindex={1}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -3254,7 +3241,6 @@ Array [
                               A-0
                             </div>
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -3311,7 +3297,6 @@ Array [
                               A-1
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -3368,7 +3353,6 @@ Array [
                               A-2
                             </div>
                             <div
-                              aria-colindex={4}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -285,7 +285,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
               role="row"
             >
               <div
-                aria-colindex={1}
                 aria-labelledby="header6-checkTooltip"
                 className=
                     ms-DetailsHeader-cell
@@ -555,7 +554,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 Toggle selection for all items
               </label>
               <div
-                aria-colindex={2}
                 aria-labelledby="header6-column1-name"
                 aria-sort="none"
                 className=
@@ -744,7 +742,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 role="button"
               />
               <div
-                aria-colindex={3}
                 aria-labelledby="header6-column2-name"
                 aria-sort="none"
                 className=
@@ -1082,7 +1079,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -1329,7 +1325,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -1386,7 +1381,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               Item 0
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -1561,7 +1555,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -1808,7 +1801,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -1865,7 +1857,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               Item 1
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -2040,7 +2031,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -2287,7 +2277,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -2344,7 +2333,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               Item 2
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -2519,7 +2507,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -2766,7 +2753,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -2823,7 +2809,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               Item 3
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -2998,7 +2983,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -3245,7 +3229,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -3302,7 +3285,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               Item 4
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -3477,7 +3459,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -3724,7 +3705,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -3781,7 +3761,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               Item 5
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -3956,7 +3935,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -4203,7 +4181,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -4260,7 +4237,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               Item 6
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -4435,7 +4411,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -4682,7 +4657,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -4739,7 +4713,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               Item 7
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -4914,7 +4887,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -5161,7 +5133,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -5218,7 +5189,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               Item 8
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -5393,7 +5363,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           }
                         >
                           <div
-                            aria-colindex={1}
                             className=
                                 ms-DetailsRow-cell
                                 ms-DetailsRow-cellCheck
@@ -5640,7 +5609,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             role="presentation"
                           >
                             <div
-                              aria-colindex={2}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell
@@ -5697,7 +5665,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               Item 9
                             </div>
                             <div
-                              aria-colindex={3}
                               aria-readonly={true}
                               className=
                                   ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -87,7 +87,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -357,7 +356,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             Toggle selection for all items
           </label>
           <div
-            aria-colindex={2}
+            aria-label="Thumbnail"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -415,6 +414,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                 }
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
+            data-is-focusable="true"
             data-item-key="thumbnail"
             draggable={false}
             role="columnheader"
@@ -437,8 +437,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                   }
             >
               <span
-                aria-describedby="header1-thumbnail-tooltip"
-                aria-labelledby="header1-thumbnail-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -469,11 +467,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       top: 1px;
                       z-index: 1;
                     }
-                data-is-focusable="true"
                 id="header1-thumbnail"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
               >
                 <span
                   className=
@@ -492,31 +488,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
               </span>
             </span>
           </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  white-space: nowrap;
-                  width: 1px;
-                }
-            id="header1-thumbnail-tooltip"
-          >
-            Thumbnail
-          </label>
           <div
-            aria-colindex={3}
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -650,7 +622,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             </span>
           </div>
           <div
-            aria-colindex={4}
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -784,7 +755,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             </span>
           </div>
           <div
-            aria-colindex={5}
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -918,7 +888,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             </span>
           </div>
           <div
-            aria-colindex={6}
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -1052,7 +1021,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             </span>
           </div>
           <div
-            aria-colindex={7}
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -1186,7 +1154,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             </span>
           </div>
           <div
-            aria-colindex={8}
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -1320,7 +1287,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             </span>
           </div>
           <div
-            aria-colindex={9}
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -1454,7 +1420,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             </span>
           </div>
           <div
-            aria-colindex={10}
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -1736,7 +1701,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -1983,7 +1947,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2077,7 +2040,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </div>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2136,7 +2098,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2249,7 +2210,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </a>
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2308,7 +2268,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2376,7 +2335,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2435,7 +2393,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2494,7 +2451,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2553,7 +2509,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2729,7 +2684,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -2976,7 +2930,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3070,7 +3023,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </div>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3129,7 +3081,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3242,7 +3193,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </a>
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3301,7 +3251,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3369,7 +3318,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3428,7 +3376,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3487,7 +3434,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3546,7 +3492,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3722,7 +3667,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -3969,7 +3913,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4063,7 +4006,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </div>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4122,7 +4064,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4235,7 +4176,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </a>
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4294,7 +4234,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4362,7 +4301,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4421,7 +4359,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4480,7 +4417,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4539,7 +4475,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4715,7 +4650,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -4962,7 +4896,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5056,7 +4989,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </div>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5115,7 +5047,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5228,7 +5159,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </a>
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5287,7 +5217,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5355,7 +5284,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5414,7 +5342,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5473,7 +5400,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5532,7 +5458,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5708,7 +5633,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -5955,7 +5879,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6049,7 +5972,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </div>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6108,7 +6030,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6221,7 +6142,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </a>
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6280,7 +6200,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6348,7 +6267,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6407,7 +6325,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6466,7 +6383,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6525,7 +6441,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6701,7 +6616,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -6948,7 +6862,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7042,7 +6955,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </div>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7101,7 +7013,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7214,7 +7125,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </a>
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7273,7 +7183,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7341,7 +7250,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7400,7 +7308,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7459,7 +7366,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7518,7 +7424,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7694,7 +7599,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -7941,7 +7845,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8035,7 +7938,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </div>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8094,7 +7996,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8207,7 +8108,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </a>
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8266,7 +8166,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8334,7 +8233,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8393,7 +8291,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8452,7 +8349,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8511,7 +8407,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8687,7 +8582,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -8934,7 +8828,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9028,7 +8921,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </div>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9087,7 +8979,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9200,7 +9091,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </a>
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9259,7 +9149,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9327,7 +9216,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9386,7 +9274,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9445,7 +9332,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9504,7 +9390,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9680,7 +9565,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -9927,7 +9811,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10021,7 +9904,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </div>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10080,7 +9962,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10193,7 +10074,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </a>
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10252,7 +10132,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10320,7 +10199,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10379,7 +10257,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10438,7 +10315,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10497,7 +10373,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10673,7 +10548,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -10920,7 +10794,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -11014,7 +10887,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </div>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -11073,7 +10945,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -11186,7 +11057,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </a>
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -11245,7 +11115,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -11313,7 +11182,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -11372,7 +11240,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -11431,7 +11298,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -11490,7 +11356,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           </span>
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -87,7 +87,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -357,7 +356,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             Toggle selection for all items
           </label>
           <div
-            aria-colindex={2}
             aria-labelledby="header1-column1-name"
             aria-sort="none"
             className=
@@ -546,7 +544,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             role="button"
           />
           <div
-            aria-colindex={3}
             aria-labelledby="header1-column2-name"
             aria-sort="none"
             className=
@@ -883,7 +880,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -1130,7 +1126,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1187,7 +1182,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           Item 0
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1361,7 +1355,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -1608,7 +1601,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1665,7 +1657,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           Item 1
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1839,7 +1830,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -2086,7 +2076,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2143,7 +2132,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           Item 2
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2317,7 +2305,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -2564,7 +2551,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2621,7 +2607,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           Item 3
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2795,7 +2780,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -3042,7 +3026,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3099,7 +3082,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           Item 4
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3269,7 +3251,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
         }
       >
         <div
-          aria-colindex={1}
           className=
               ms-DetailsRow-cell
               ms-DetailsRow-cellCheck
@@ -3381,7 +3362,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
           role="presentation"
         >
           <div
-            aria-colindex={2}
             aria-readonly={true}
             className=
                 ms-DetailsRow-cell
@@ -3442,7 +3422,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             </div>
           </div>
           <div
-            aria-colindex={3}
             aria-readonly={true}
             className=
                 ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -293,7 +293,6 @@ Array [
             role="row"
           >
             <div
-              aria-colindex={1}
               aria-labelledby="header2-checkTooltip"
               className=
                   ms-DetailsHeader-cell
@@ -649,7 +648,6 @@ Array [
               </i>
             </div>
             <div
-              aria-colindex={2}
               aria-labelledby="header2-thumbnail-name"
               aria-sort="none"
               className=
@@ -838,7 +836,6 @@ Array [
               role="button"
             />
             <div
-              aria-colindex={3}
               aria-labelledby="header2-key-name"
               aria-sort="none"
               className=
@@ -1027,7 +1024,6 @@ Array [
               role="button"
             />
             <div
-              aria-colindex={4}
               aria-labelledby="header2-name-name"
               aria-sort="none"
               className=
@@ -1216,7 +1212,6 @@ Array [
               role="button"
             />
             <div
-              aria-colindex={5}
               aria-labelledby="header2-description-name"
               aria-sort="none"
               className=
@@ -1405,7 +1400,6 @@ Array [
               role="button"
             />
             <div
-              aria-colindex={6}
               aria-labelledby="header2-color-name"
               aria-sort="none"
               className=
@@ -1594,7 +1588,6 @@ Array [
               role="button"
             />
             <div
-              aria-colindex={7}
               aria-labelledby="header2-shape-name"
               aria-sort="none"
               className=
@@ -1783,7 +1776,6 @@ Array [
               role="button"
             />
             <div
-              aria-colindex={8}
               aria-labelledby="header2-location-name"
               aria-sort="none"
               className=
@@ -1972,7 +1964,6 @@ Array [
               role="button"
             />
             <div
-              aria-colindex={9}
               aria-labelledby="header2-width-name"
               aria-sort="none"
               className=
@@ -2161,7 +2152,6 @@ Array [
               role="button"
             />
             <div
-              aria-colindex={10}
               aria-labelledby="header2-height-name"
               aria-sort="none"
               className=
@@ -2741,7 +2731,6 @@ Array [
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -2998,7 +2987,6 @@ Array [
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -3055,7 +3043,6 @@ Array [
                                       //via.placeholder.com/150x150
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -3112,7 +3099,6 @@ Array [
                                       item-0 Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={5}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -3169,7 +3155,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={6}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -3226,7 +3211,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={7}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -3283,7 +3267,6 @@ Array [
                                       red
                                     </div>
                                     <div
-                                      aria-colindex={8}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -3340,7 +3323,6 @@ Array [
                                       circle
                                     </div>
                                     <div
-                                      aria-colindex={9}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -3397,7 +3379,6 @@ Array [
                                       Seattle
                                     </div>
                                     <div
-                                      aria-colindex={10}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -3454,7 +3435,6 @@ Array [
                                       150
                                     </div>
                                     <div
-                                      aria-colindex={11}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -3629,7 +3609,6 @@ Array [
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -3886,7 +3865,6 @@ Array [
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -3943,7 +3921,6 @@ Array [
                                       //via.placeholder.com/150x150
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4000,7 +3977,6 @@ Array [
                                       item-1 Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={5}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4057,7 +4033,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={6}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4114,7 +4089,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={7}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4171,7 +4145,6 @@ Array [
                                       red
                                     </div>
                                     <div
-                                      aria-colindex={8}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4228,7 +4201,6 @@ Array [
                                       circle
                                     </div>
                                     <div
-                                      aria-colindex={9}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4285,7 +4257,6 @@ Array [
                                       Seattle
                                     </div>
                                     <div
-                                      aria-colindex={10}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4342,7 +4313,6 @@ Array [
                                       150
                                     </div>
                                     <div
-                                      aria-colindex={11}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4517,7 +4487,6 @@ Array [
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -4774,7 +4743,6 @@ Array [
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4831,7 +4799,6 @@ Array [
                                       //via.placeholder.com/150x150
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4888,7 +4855,6 @@ Array [
                                       item-2 Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={5}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4945,7 +4911,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={6}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -5002,7 +4967,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={7}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -5059,7 +5023,6 @@ Array [
                                       red
                                     </div>
                                     <div
-                                      aria-colindex={8}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -5116,7 +5079,6 @@ Array [
                                       circle
                                     </div>
                                     <div
-                                      aria-colindex={9}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -5173,7 +5135,6 @@ Array [
                                       Seattle
                                     </div>
                                     <div
-                                      aria-colindex={10}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -5230,7 +5191,6 @@ Array [
                                       150
                                     </div>
                                     <div
-                                      aria-colindex={11}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -5405,7 +5365,6 @@ Array [
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -5662,7 +5621,6 @@ Array [
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -5719,7 +5677,6 @@ Array [
                                       //via.placeholder.com/150x150
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -5776,7 +5733,6 @@ Array [
                                       item-3 Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={5}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -5833,7 +5789,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={6}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -5890,7 +5845,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={7}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -5947,7 +5901,6 @@ Array [
                                       red
                                     </div>
                                     <div
-                                      aria-colindex={8}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -6004,7 +5957,6 @@ Array [
                                       circle
                                     </div>
                                     <div
-                                      aria-colindex={9}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -6061,7 +6013,6 @@ Array [
                                       Seattle
                                     </div>
                                     <div
-                                      aria-colindex={10}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -6118,7 +6069,6 @@ Array [
                                       150
                                     </div>
                                     <div
-                                      aria-colindex={11}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -6293,7 +6243,6 @@ Array [
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -6550,7 +6499,6 @@ Array [
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -6607,7 +6555,6 @@ Array [
                                       //via.placeholder.com/150x150
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -6664,7 +6611,6 @@ Array [
                                       item-4 Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={5}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -6721,7 +6667,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={6}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -6778,7 +6723,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={7}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -6835,7 +6779,6 @@ Array [
                                       red
                                     </div>
                                     <div
-                                      aria-colindex={8}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -6892,7 +6835,6 @@ Array [
                                       circle
                                     </div>
                                     <div
-                                      aria-colindex={9}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -6949,7 +6891,6 @@ Array [
                                       Seattle
                                     </div>
                                     <div
-                                      aria-colindex={10}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -7006,7 +6947,6 @@ Array [
                                       150
                                     </div>
                                     <div
-                                      aria-colindex={11}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -7181,7 +7121,6 @@ Array [
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -7438,7 +7377,6 @@ Array [
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -7495,7 +7433,6 @@ Array [
                                       //via.placeholder.com/150x150
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -7552,7 +7489,6 @@ Array [
                                       item-5 Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={5}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -7609,7 +7545,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={6}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -7666,7 +7601,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={7}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -7723,7 +7657,6 @@ Array [
                                       red
                                     </div>
                                     <div
-                                      aria-colindex={8}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -7780,7 +7713,6 @@ Array [
                                       circle
                                     </div>
                                     <div
-                                      aria-colindex={9}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -7837,7 +7769,6 @@ Array [
                                       Seattle
                                     </div>
                                     <div
-                                      aria-colindex={10}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -7894,7 +7825,6 @@ Array [
                                       150
                                     </div>
                                     <div
-                                      aria-colindex={11}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -8069,7 +7999,6 @@ Array [
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -8326,7 +8255,6 @@ Array [
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -8383,7 +8311,6 @@ Array [
                                       //via.placeholder.com/150x150
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -8440,7 +8367,6 @@ Array [
                                       item-6 Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={5}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -8497,7 +8423,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={6}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -8554,7 +8479,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={7}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -8611,7 +8535,6 @@ Array [
                                       red
                                     </div>
                                     <div
-                                      aria-colindex={8}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -8668,7 +8591,6 @@ Array [
                                       circle
                                     </div>
                                     <div
-                                      aria-colindex={9}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -8725,7 +8647,6 @@ Array [
                                       Seattle
                                     </div>
                                     <div
-                                      aria-colindex={10}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -8782,7 +8703,6 @@ Array [
                                       150
                                     </div>
                                     <div
-                                      aria-colindex={11}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -8957,7 +8877,6 @@ Array [
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -9214,7 +9133,6 @@ Array [
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -9271,7 +9189,6 @@ Array [
                                       //via.placeholder.com/150x150
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -9328,7 +9245,6 @@ Array [
                                       item-7 Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={5}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -9385,7 +9301,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={6}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -9442,7 +9357,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={7}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -9499,7 +9413,6 @@ Array [
                                       red
                                     </div>
                                     <div
-                                      aria-colindex={8}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -9556,7 +9469,6 @@ Array [
                                       circle
                                     </div>
                                     <div
-                                      aria-colindex={9}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -9613,7 +9525,6 @@ Array [
                                       Seattle
                                     </div>
                                     <div
-                                      aria-colindex={10}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -9670,7 +9581,6 @@ Array [
                                       150
                                     </div>
                                     <div
-                                      aria-colindex={11}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -9845,7 +9755,6 @@ Array [
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -10102,7 +10011,6 @@ Array [
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -10159,7 +10067,6 @@ Array [
                                       //via.placeholder.com/150x150
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -10216,7 +10123,6 @@ Array [
                                       item-8 Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={5}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -10273,7 +10179,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={6}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -10330,7 +10235,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={7}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -10387,7 +10291,6 @@ Array [
                                       red
                                     </div>
                                     <div
-                                      aria-colindex={8}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -10444,7 +10347,6 @@ Array [
                                       circle
                                     </div>
                                     <div
-                                      aria-colindex={9}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -10501,7 +10403,6 @@ Array [
                                       Seattle
                                     </div>
                                     <div
-                                      aria-colindex={10}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -10558,7 +10459,6 @@ Array [
                                       150
                                     </div>
                                     <div
-                                      aria-colindex={11}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -10733,7 +10633,6 @@ Array [
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -10990,7 +10889,6 @@ Array [
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -11047,7 +10945,6 @@ Array [
                                       //via.placeholder.com/150x150
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -11104,7 +11001,6 @@ Array [
                                       item-9 Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={5}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -11161,7 +11057,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={6}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -11218,7 +11113,6 @@ Array [
                                       Lorem ipsum dolor sit amet
                                     </div>
                                     <div
-                                      aria-colindex={7}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -11275,7 +11169,6 @@ Array [
                                       red
                                     </div>
                                     <div
-                                      aria-colindex={8}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -11332,7 +11225,6 @@ Array [
                                       circle
                                     </div>
                                     <div
-                                      aria-colindex={9}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -11389,7 +11281,6 @@ Array [
                                       Seattle
                                     </div>
                                     <div
-                                      aria-colindex={10}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -11446,7 +11337,6 @@ Array [
                                       150
                                     </div>
                                     <div
-                                      aria-colindex={11}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -87,7 +87,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -332,7 +331,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             </span>
           </div>
           <div
-            aria-colindex={2}
             aria-labelledby="header1-thumbnail-name"
             aria-sort="none"
             className=
@@ -521,7 +519,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             role="button"
           />
           <div
-            aria-colindex={3}
             aria-labelledby="header1-key-name"
             aria-sort="none"
             className=
@@ -710,7 +707,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             role="button"
           />
           <div
-            aria-colindex={4}
             aria-labelledby="header1-name-name"
             aria-sort="none"
             className=
@@ -899,7 +895,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             role="button"
           />
           <div
-            aria-colindex={5}
             aria-labelledby="header1-description-name"
             aria-sort="none"
             className=
@@ -1088,7 +1083,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             role="button"
           />
           <div
-            aria-colindex={6}
             aria-labelledby="header1-color-name"
             aria-sort="none"
             className=
@@ -1277,7 +1271,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             role="button"
           />
           <div
-            aria-colindex={7}
             aria-labelledby="header1-shape-name"
             aria-sort="none"
             className=
@@ -1466,7 +1459,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             role="button"
           />
           <div
-            aria-colindex={8}
             aria-labelledby="header1-location-name"
             aria-sort="none"
             className=
@@ -1655,7 +1647,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             role="button"
           />
           <div
-            aria-colindex={9}
             aria-labelledby="header1-width-name"
             aria-sort="none"
             className=
@@ -1844,7 +1835,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             role="button"
           />
           <div
-            aria-colindex={10}
             aria-labelledby="header1-height-name"
             aria-sort="none"
             className=
@@ -2182,7 +2172,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -2429,7 +2418,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2486,7 +2474,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           //via.placeholder.com/150x150
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2543,7 +2530,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           item-0 Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2600,7 +2586,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2657,7 +2642,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2714,7 +2698,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           red
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2771,7 +2754,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           circle
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2828,7 +2810,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Seattle
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2885,7 +2866,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           150
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3059,7 +3039,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -3306,7 +3285,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3363,7 +3341,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           //via.placeholder.com/150x150
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3420,7 +3397,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           item-1 Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3477,7 +3453,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3534,7 +3509,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3591,7 +3565,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           red
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3648,7 +3621,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           circle
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3705,7 +3677,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Seattle
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3762,7 +3733,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           150
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3937,7 +3907,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -4184,7 +4153,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4241,7 +4209,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           //via.placeholder.com/150x150
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4298,7 +4265,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           item-2 Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4355,7 +4321,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4412,7 +4377,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4469,7 +4433,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           red
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4526,7 +4489,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           circle
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4583,7 +4545,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Seattle
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4640,7 +4601,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           150
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4814,7 +4774,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -5061,7 +5020,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5118,7 +5076,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           //via.placeholder.com/150x150
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5175,7 +5132,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           item-3 Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5232,7 +5188,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5289,7 +5244,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5346,7 +5300,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           red
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5403,7 +5356,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           circle
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5460,7 +5412,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Seattle
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5517,7 +5468,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           150
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5692,7 +5642,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -5939,7 +5888,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5996,7 +5944,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           //via.placeholder.com/150x150
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6053,7 +6000,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           item-4 Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6110,7 +6056,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6167,7 +6112,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6224,7 +6168,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           red
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6281,7 +6224,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           circle
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6338,7 +6280,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Seattle
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6395,7 +6336,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           150
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6569,7 +6509,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -6816,7 +6755,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6873,7 +6811,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           //via.placeholder.com/150x150
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6930,7 +6867,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           item-5 Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6987,7 +6923,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7044,7 +6979,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7101,7 +7035,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           red
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7158,7 +7091,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           circle
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7215,7 +7147,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Seattle
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7272,7 +7203,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           150
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7447,7 +7377,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -7694,7 +7623,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7751,7 +7679,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           //via.placeholder.com/150x150
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7808,7 +7735,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           item-6 Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7865,7 +7791,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7922,7 +7847,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -7979,7 +7903,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           red
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8036,7 +7959,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           circle
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8093,7 +8015,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Seattle
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8150,7 +8071,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           150
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8324,7 +8244,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -8571,7 +8490,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8628,7 +8546,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           //via.placeholder.com/150x150
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8685,7 +8602,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           item-7 Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8742,7 +8658,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8799,7 +8714,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8856,7 +8770,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           red
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8913,7 +8826,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           circle
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -8970,7 +8882,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Seattle
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9027,7 +8938,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           150
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9202,7 +9112,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -9449,7 +9358,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9506,7 +9414,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           //via.placeholder.com/150x150
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9563,7 +9470,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           item-8 Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9620,7 +9526,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9677,7 +9582,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9734,7 +9638,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           red
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9791,7 +9694,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           circle
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9848,7 +9750,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Seattle
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -9905,7 +9806,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           150
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10079,7 +9979,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -10326,7 +10225,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10383,7 +10281,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           //via.placeholder.com/150x150
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10440,7 +10337,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           item-9 Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10497,7 +10393,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={5}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10554,7 +10449,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Lorem ipsum dolor sit amet
                         </div>
                         <div
-                          aria-colindex={6}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10611,7 +10505,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           red
                         </div>
                         <div
-                          aria-colindex={7}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10668,7 +10561,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           circle
                         </div>
                         <div
-                          aria-colindex={8}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10725,7 +10617,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           Seattle
                         </div>
                         <div
-                          aria-colindex={9}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -10782,7 +10673,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           150
                         </div>
                         <div
-                          aria-colindex={10}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -633,7 +633,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
             role="row"
           >
             <div
-              aria-colindex={1}
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -712,8 +711,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     }
               >
                 <span
-                  aria-describedby="header8-column1-tooltip"
-                  aria-label="File Type"
+                  aria-label="Column operations for File type, Press to sort on File type"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -827,31 +825,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                 </span>
               </span>
             </div>
-            <label
-              className=
-
-                  {
-                    border: 0px;
-                    height: 1px;
-                    margin-bottom: -1px;
-                    margin-left: -1px;
-                    margin-right: -1px;
-                    margin-top: -1px;
-                    overflow: hidden;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: absolute;
-                    white-space: nowrap;
-                    width: 1px;
-                  }
-              id="header8-column1-tooltip"
-            >
-              Column operations for File type, Press to sort on File type
-            </label>
             <div
-              aria-colindex={2}
               aria-sort="ascending"
               className=
                   ms-DetailsHeader-cell
@@ -1036,6 +1010,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     white-space: nowrap;
                     width: 1px;
                   }
+              hidden={true}
               id="header8-column2-tooltip"
             >
               Sorted A to Z
@@ -1097,7 +1072,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               role="button"
             />
             <div
-              aria-colindex={3}
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -1287,7 +1261,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               role="button"
             />
             <div
-              aria-colindex={4}
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -1477,7 +1450,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               role="button"
             />
             <div
-              aria-colindex={5}
               aria-sort="none"
               className=
                   ms-DetailsHeader-cell
@@ -1821,7 +1793,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           role="presentation"
                         >
                           <div
-                            aria-colindex={1}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -1913,7 +1884,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </div>
                           </div>
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 is-row-header
@@ -1979,7 +1949,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             Lorem ipsum.accdb
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -2041,7 +2010,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -2103,7 +2071,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -2285,7 +2252,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           role="presentation"
                         >
                           <div
-                            aria-colindex={1}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -2377,7 +2343,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </div>
                           </div>
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 is-row-header
@@ -2443,7 +2408,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             Amet consectetur.accdb
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -2505,7 +2469,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -2567,7 +2530,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -2749,7 +2711,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           role="presentation"
                         >
                           <div
-                            aria-colindex={1}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -2841,7 +2802,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </div>
                           </div>
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 is-row-header
@@ -2907,7 +2867,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             Sed do.accdb
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -2969,7 +2928,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3031,7 +2989,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3213,7 +3170,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           role="presentation"
                         >
                           <div
-                            aria-colindex={1}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3305,7 +3261,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </div>
                           </div>
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 is-row-header
@@ -3371,7 +3326,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             Incididunt ut.accdb
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3433,7 +3387,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3495,7 +3448,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3677,7 +3629,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           role="presentation"
                         >
                           <div
-                            aria-colindex={1}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3769,7 +3720,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </div>
                           </div>
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 is-row-header
@@ -3835,7 +3785,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             Dolore magna.accdb
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3897,7 +3846,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -3959,7 +3907,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4141,7 +4088,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           role="presentation"
                         >
                           <div
-                            aria-colindex={1}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4233,7 +4179,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </div>
                           </div>
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 is-row-header
@@ -4299,7 +4244,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             Enim ad.accdb
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4361,7 +4305,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4423,7 +4366,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4605,7 +4547,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           role="presentation"
                         >
                           <div
-                            aria-colindex={1}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4697,7 +4638,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </div>
                           </div>
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 is-row-header
@@ -4763,7 +4703,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             Quis nostrud.accdb
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4825,7 +4764,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -4887,7 +4825,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5069,7 +5006,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           role="presentation"
                         >
                           <div
-                            aria-colindex={1}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5161,7 +5097,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </div>
                           </div>
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 is-row-header
@@ -5227,7 +5162,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             Laboris nisi.accdb
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5289,7 +5223,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5351,7 +5284,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5533,7 +5465,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           role="presentation"
                         >
                           <div
-                            aria-colindex={1}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5625,7 +5556,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </div>
                           </div>
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 is-row-header
@@ -5691,7 +5621,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             Ex ea.accdb
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5753,7 +5682,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5815,7 +5743,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -5997,7 +5924,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           role="presentation"
                         >
                           <div
-                            aria-colindex={1}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -6089,7 +6015,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </div>
                           </div>
                           <div
-                            aria-colindex={2}
                             aria-readonly={true}
                             className=
                                 is-row-header
@@ -6155,7 +6080,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             Duis aute.accdb
                           </div>
                           <div
-                            aria-colindex={3}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -6217,7 +6141,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={4}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell
@@ -6279,7 +6202,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                             </span>
                           </div>
                           <div
-                            aria-colindex={5}
                             aria-readonly={true}
                             className=
                                 ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -488,7 +488,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
             role="row"
           >
             <div
-              aria-colindex={1}
               aria-labelledby="header6-checkTooltip"
               className=
                   ms-DetailsHeader-cell
@@ -844,7 +843,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               </i>
             </div>
             <div
-              aria-colindex={2}
               aria-labelledby="header6-name-name"
               aria-sort="none"
               className=
@@ -1033,7 +1031,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               role="button"
             />
             <div
-              aria-colindex={3}
               aria-labelledby="header6-color-name"
               aria-sort="none"
               className=
@@ -1757,7 +1754,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -2014,7 +2010,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -2075,7 +2070,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       </div>
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -2254,7 +2248,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -2511,7 +2504,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -2572,7 +2564,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       </div>
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -3618,7 +3609,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -3875,7 +3865,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -3936,7 +3925,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       </div>
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4115,7 +4103,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -4372,7 +4359,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4433,7 +4419,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       </div>
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4612,7 +4597,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                   }
                                 >
                                   <div
-                                    aria-colindex={1}
                                     className=
                                         ms-DetailsRow-cell
                                         ms-DetailsRow-cellCheck
@@ -4869,7 +4853,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                     role="presentation"
                                   >
                                     <div
-                                      aria-colindex={3}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell
@@ -4930,7 +4913,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                       </div>
                                     </div>
                                     <div
-                                      aria-colindex={4}
                                       aria-readonly={true}
                                       className=
                                           ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -87,7 +87,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -443,7 +442,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
             </i>
           </div>
           <div
-            aria-colindex={2}
             aria-labelledby="header1-name-name"
             aria-sort="none"
             className=
@@ -632,7 +630,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
             role="button"
           />
           <div
-            aria-colindex={3}
             aria-labelledby="header1-value-name"
             aria-sort="none"
             className=
@@ -1412,7 +1409,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 }
                               >
                                 <div
-                                  aria-colindex={1}
                                   className=
                                       ms-DetailsRow-cell
                                       ms-DetailsRow-cellCheck
@@ -1669,7 +1665,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -1726,7 +1721,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     Item 0
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -1901,7 +1895,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 }
                               >
                                 <div
-                                  aria-colindex={1}
                                   className=
                                       ms-DetailsRow-cell
                                       ms-DetailsRow-cellCheck
@@ -2158,7 +2151,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -2215,7 +2207,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     Item 1
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -2390,7 +2381,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 }
                               >
                                 <div
-                                  aria-colindex={1}
                                   className=
                                       ms-DetailsRow-cell
                                       ms-DetailsRow-cellCheck
@@ -2647,7 +2637,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -2704,7 +2693,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     Item 2
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -2879,7 +2867,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 }
                               >
                                 <div
-                                  aria-colindex={1}
                                   className=
                                       ms-DetailsRow-cell
                                       ms-DetailsRow-cellCheck
@@ -3136,7 +3123,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -3193,7 +3179,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     Item 3
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -3368,7 +3353,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 }
                               >
                                 <div
-                                  aria-colindex={1}
                                   className=
                                       ms-DetailsRow-cell
                                       ms-DetailsRow-cellCheck
@@ -3625,7 +3609,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -3682,7 +3665,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     Item 4
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -3857,7 +3839,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 }
                               >
                                 <div
-                                  aria-colindex={1}
                                   className=
                                       ms-DetailsRow-cell
                                       ms-DetailsRow-cellCheck
@@ -4114,7 +4095,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -4171,7 +4151,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     Item 5
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -4346,7 +4325,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 }
                               >
                                 <div
-                                  aria-colindex={1}
                                   className=
                                       ms-DetailsRow-cell
                                       ms-DetailsRow-cellCheck
@@ -4603,7 +4581,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -4660,7 +4637,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     Item 6
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -4835,7 +4811,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 }
                               >
                                 <div
-                                  aria-colindex={1}
                                   className=
                                       ms-DetailsRow-cell
                                       ms-DetailsRow-cellCheck
@@ -5092,7 +5067,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -5149,7 +5123,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     Item 7
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -5324,7 +5297,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 }
                               >
                                 <div
-                                  aria-colindex={1}
                                   className=
                                       ms-DetailsRow-cell
                                       ms-DetailsRow-cellCheck
@@ -5581,7 +5553,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -5638,7 +5609,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     Item 8
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -5813,7 +5783,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                 }
                               >
                                 <div
-                                  aria-colindex={1}
                                   className=
                                       ms-DetailsRow-cell
                                       ms-DetailsRow-cellCheck
@@ -6070,7 +6039,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -6127,7 +6095,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                     Item 9
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -87,7 +87,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -357,7 +356,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
             Toggle selection for all items
           </label>
           <div
-            aria-colindex={2}
             aria-labelledby="header1-filepath-name"
             aria-sort="none"
             className=
@@ -490,7 +488,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
             </span>
           </div>
           <div
-            aria-colindex={3}
             aria-labelledby="header1-size-name"
             aria-sort="none"
             className=
@@ -771,7 +768,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -1018,7 +1014,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1149,7 +1144,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           </button>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1323,7 +1317,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -1570,7 +1563,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1701,7 +1693,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           </button>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1875,7 +1866,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -2122,7 +2112,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2253,7 +2242,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           </button>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2427,7 +2415,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -2674,7 +2661,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2805,7 +2791,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           </button>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2979,7 +2964,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -3226,7 +3210,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3357,7 +3340,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           </button>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3531,7 +3513,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -3778,7 +3759,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3909,7 +3889,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           </button>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4083,7 +4062,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -4330,7 +4308,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4461,7 +4438,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           </button>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4635,7 +4611,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -4882,7 +4857,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5013,7 +4987,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           </button>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5187,7 +5160,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -5434,7 +5406,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5565,7 +5536,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           </button>
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.ProportionalColumns.Example.tsx.shot
@@ -88,7 +88,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -358,7 +357,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
             Toggle selection for all items
           </label>
           <div
-            aria-colindex={2}
             aria-labelledby="header1-column1-name"
             aria-sort="none"
             className=
@@ -643,7 +641,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
             role="button"
           />
           <div
-            aria-colindex={3}
             aria-labelledby="header1-column2-name"
             aria-sort="none"
             className=
@@ -832,7 +829,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
             role="button"
           />
           <div
-            aria-colindex={4}
             aria-labelledby="header1-column3-name"
             aria-sort="none"
             className=
@@ -1169,7 +1165,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -1416,7 +1411,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1473,7 +1467,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           Item 0
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1530,7 +1523,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           0
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1704,7 +1696,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -1951,7 +1942,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2008,7 +1998,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           Item 1
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2065,7 +2054,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           1
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2239,7 +2227,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -2486,7 +2473,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2543,7 +2529,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           Item 2
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2600,7 +2585,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           2
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2774,7 +2758,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -3021,7 +3004,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3078,7 +3060,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           Item 3
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3135,7 +3116,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           3
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3309,7 +3289,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -3556,7 +3535,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3613,7 +3591,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           Item 4
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3670,7 +3647,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           4
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -3844,7 +3820,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -4091,7 +4066,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4148,7 +4122,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           Item 5
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4205,7 +4178,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           5
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4379,7 +4351,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -4626,7 +4597,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4683,7 +4653,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           Item 6
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4740,7 +4709,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           6
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -4914,7 +4882,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -5161,7 +5128,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5218,7 +5184,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           Item 7
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5275,7 +5240,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           7
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5449,7 +5413,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -5696,7 +5659,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5753,7 +5715,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           Item 8
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5810,7 +5771,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           8
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -5984,7 +5944,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                       }
                     >
                       <div
-                        aria-colindex={1}
                         className=
                             ms-DetailsRow-cell
                             ms-DetailsRow-cellCheck
@@ -6231,7 +6190,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                         role="presentation"
                       >
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6288,7 +6246,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           Item 9
                         </div>
                         <div
-                          aria-colindex={3}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -6345,7 +6302,6 @@ exports[`Component Examples renders DetailsList.ProportionalColumns.Example.tsx 
                           9
                         </div>
                         <div
-                          aria-colindex={4}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -558,7 +558,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                             }
                           >
                             <div
-                              aria-colindex={1}
                               className=
                                   ms-DetailsRow-cell
                                   ms-DetailsRow-cellCheck
@@ -812,7 +811,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               role="presentation"
                             >
                               <div
-                                aria-colindex={3}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -869,7 +867,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 //via.placeholder.com/150x150
                               </div>
                               <div
-                                aria-colindex={4}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -926,7 +923,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 item-0 Lorem ipsum dolor sit amet
                               </div>
                               <div
-                                aria-colindex={5}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -1101,7 +1097,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                             }
                           >
                             <div
-                              aria-colindex={1}
                               className=
                                   ms-DetailsRow-cell
                                   ms-DetailsRow-cellCheck
@@ -1355,7 +1350,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               role="presentation"
                             >
                               <div
-                                aria-colindex={3}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -1412,7 +1406,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 //via.placeholder.com/150x150
                               </div>
                               <div
-                                aria-colindex={4}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -1469,7 +1462,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 item-1 Lorem ipsum dolor sit amet
                               </div>
                               <div
-                                aria-colindex={5}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -1644,7 +1636,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                             }
                           >
                             <div
-                              aria-colindex={1}
                               className=
                                   ms-DetailsRow-cell
                                   ms-DetailsRow-cellCheck
@@ -1898,7 +1889,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               role="presentation"
                             >
                               <div
-                                aria-colindex={3}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -1955,7 +1945,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 //via.placeholder.com/150x150
                               </div>
                               <div
-                                aria-colindex={4}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -2012,7 +2001,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 item-2 Lorem ipsum dolor sit amet
                               </div>
                               <div
-                                aria-colindex={5}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -2591,7 +2579,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                             }
                           >
                             <div
-                              aria-colindex={1}
                               className=
                                   ms-DetailsRow-cell
                                   ms-DetailsRow-cellCheck
@@ -2845,7 +2832,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               role="presentation"
                             >
                               <div
-                                aria-colindex={3}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -2902,7 +2888,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 //via.placeholder.com/150x150
                               </div>
                               <div
-                                aria-colindex={4}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -2959,7 +2944,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 item-3 Lorem ipsum dolor sit amet
                               </div>
                               <div
-                                aria-colindex={5}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -3134,7 +3118,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                             }
                           >
                             <div
-                              aria-colindex={1}
                               className=
                                   ms-DetailsRow-cell
                                   ms-DetailsRow-cellCheck
@@ -3388,7 +3371,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               role="presentation"
                             >
                               <div
-                                aria-colindex={3}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -3445,7 +3427,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 //via.placeholder.com/150x150
                               </div>
                               <div
-                                aria-colindex={4}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -3502,7 +3483,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 item-4 Lorem ipsum dolor sit amet
                               </div>
                               <div
-                                aria-colindex={5}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -3677,7 +3657,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                             }
                           >
                             <div
-                              aria-colindex={1}
                               className=
                                   ms-DetailsRow-cell
                                   ms-DetailsRow-cellCheck
@@ -3931,7 +3910,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               role="presentation"
                             >
                               <div
-                                aria-colindex={3}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -3988,7 +3966,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 //via.placeholder.com/150x150
                               </div>
                               <div
-                                aria-colindex={4}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -4045,7 +4022,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 item-5 Lorem ipsum dolor sit amet
                               </div>
                               <div
-                                aria-colindex={5}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -4624,7 +4600,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                             }
                           >
                             <div
-                              aria-colindex={1}
                               className=
                                   ms-DetailsRow-cell
                                   ms-DetailsRow-cellCheck
@@ -4878,7 +4853,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               role="presentation"
                             >
                               <div
-                                aria-colindex={3}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -4935,7 +4909,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 //via.placeholder.com/150x150
                               </div>
                               <div
-                                aria-colindex={4}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -4992,7 +4965,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 item-6 Lorem ipsum dolor sit amet
                               </div>
                               <div
-                                aria-colindex={5}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -5167,7 +5139,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                             }
                           >
                             <div
-                              aria-colindex={1}
                               className=
                                   ms-DetailsRow-cell
                                   ms-DetailsRow-cellCheck
@@ -5421,7 +5392,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               role="presentation"
                             >
                               <div
-                                aria-colindex={3}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -5478,7 +5448,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 //via.placeholder.com/150x150
                               </div>
                               <div
-                                aria-colindex={4}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -5535,7 +5504,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 item-7 Lorem ipsum dolor sit amet
                               </div>
                               <div
-                                aria-colindex={5}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -5710,7 +5678,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                             }
                           >
                             <div
-                              aria-colindex={1}
                               className=
                                   ms-DetailsRow-cell
                                   ms-DetailsRow-cellCheck
@@ -5964,7 +5931,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                               role="presentation"
                             >
                               <div
-                                aria-colindex={3}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -6021,7 +5987,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 //via.placeholder.com/150x150
                               </div>
                               <div
-                                aria-colindex={4}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell
@@ -6078,7 +6043,6 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                 item-8 Lorem ipsum dolor sit amet
                               </div>
                               <div
-                                aria-colindex={5}
                                 aria-readonly={true}
                                 className=
                                     ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -266,7 +266,6 @@ Array [
               role="row"
             >
               <div
-                aria-colindex={1}
                 aria-label="FileType"
                 aria-sort="none"
                 className=
@@ -454,7 +453,6 @@ Array [
                 </span>
               </div>
               <div
-                aria-colindex={2}
                 aria-labelledby="header2-key-name"
                 aria-sort="none"
                 className=
@@ -587,7 +585,6 @@ Array [
                 </span>
               </div>
               <div
-                aria-colindex={3}
                 aria-labelledby="header2-name-name"
                 aria-sort="none"
                 className=
@@ -720,7 +717,6 @@ Array [
                 </span>
               </div>
               <div
-                aria-colindex={4}
                 aria-labelledby="header2-description-name"
                 aria-sort="none"
                 className=
@@ -853,7 +849,6 @@ Array [
                 </span>
               </div>
               <div
-                aria-colindex={5}
                 aria-labelledby="header2-color-name"
                 aria-sort="none"
                 className=
@@ -986,7 +981,6 @@ Array [
                 </span>
               </div>
               <div
-                aria-colindex={6}
                 aria-labelledby="header2-shape-name"
                 aria-sort="none"
                 className=
@@ -1119,7 +1113,6 @@ Array [
                 </span>
               </div>
               <div
-                aria-colindex={7}
                 aria-labelledby="header2-location-name"
                 aria-sort="none"
                 className=
@@ -1252,7 +1245,6 @@ Array [
                 </span>
               </div>
               <div
-                aria-colindex={8}
                 aria-labelledby="header2-width-name"
                 aria-sort="none"
                 className=
@@ -1385,7 +1377,6 @@ Array [
                 </span>
               </div>
               <div
-                aria-colindex={9}
                 aria-labelledby="header2-height-name"
                 aria-sort="none"
                 className=

--- a/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -88,7 +88,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-column1-name"
             aria-sort="none"
             className=
@@ -277,7 +276,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
             role="button"
           />
           <div
-            aria-colindex={2}
             aria-labelledby="header1-column2-name"
             aria-sort="none"
             className=
@@ -620,7 +618,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -677,7 +674,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           tiny
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -876,7 +872,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -933,7 +928,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           xSmall
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1132,7 +1126,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1189,7 +1182,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           small
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1388,7 +1380,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1445,7 +1436,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           smallPlus
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1644,7 +1634,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1701,7 +1690,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           medium
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1900,7 +1888,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1957,7 +1944,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           mediumPlus
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2156,7 +2142,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2213,7 +2198,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           large
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2412,7 +2396,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2469,7 +2452,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           xLarge
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2668,7 +2650,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2725,7 +2706,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           xxLarge
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2924,7 +2904,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -2981,7 +2960,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                           mega
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell

--- a/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Text.Weights.Example.tsx.shot
@@ -88,7 +88,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-column1-name"
             aria-sort="none"
             className=
@@ -277,7 +276,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
             role="button"
           />
           <div
-            aria-colindex={2}
             aria-labelledby="header1-column2-name"
             aria-sort="none"
             className=
@@ -620,7 +618,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -677,7 +674,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                           400
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -878,7 +874,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -935,7 +930,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                           600
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1136,7 +1130,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                         role="presentation"
                       >
                         <div
-                          aria-colindex={1}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell
@@ -1193,7 +1186,6 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
                           700
                         </div>
                         <div
-                          aria-colindex={2}
                           aria-readonly={true}
                           className=
                               ms-DetailsRow-cell

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -57,7 +57,6 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
   public render(): JSX.Element {
     const {
       column,
-      columnIndex,
       parentId,
       isDraggable,
       styles,
@@ -96,10 +95,10 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
       column.columnActionsMode !== ColumnActionsMode.disabled &&
       (column.onColumnClick !== undefined || this.props.onColumnClick !== undefined);
     const accNameDescription = {
-      'aria-label': column.isIconOnly ? column.name : undefined,
-      'aria-labelledby': column.isIconOnly ? undefined : `${parentId}-${column.key}-name`,
+      'aria-label': column.ariaLabel || (column.isIconOnly ? column.name : undefined),
+      'aria-labelledby': column.ariaLabel || column.isIconOnly ? undefined : `${parentId}-${column.key}-name`,
       'aria-describedby':
-        !this.props.onRenderColumnHeaderTooltip && this._hasAccessibleLabel()
+        !this.props.onRenderColumnHeaderTooltip && this._hasAccessibleDescription()
           ? `${parentId}-${column.key}-tooltip`
           : undefined,
     };
@@ -112,7 +111,6 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
           role={'columnheader'}
           {...(!hasInnerButton && accNameDescription)}
           aria-sort={column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none'}
-          aria-colindex={columnIndex}
           // when the column is not disabled and has no inner button, this node should be in the focus order
           data-is-focusable={
             !hasInnerButton && column.columnActionsMode !== ColumnActionsMode.disabled ? 'true' : undefined
@@ -190,7 +188,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
             this._onRenderColumnHeaderTooltip,
           )}
         </div>
-        {!this.props.onRenderColumnHeaderTooltip ? this._renderAccessibleLabel() : null}
+        {!this.props.onRenderColumnHeaderTooltip ? this._renderAccessibleDescription() : null}
       </>
     );
   }
@@ -287,11 +285,10 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     return options;
   }
 
-  private _hasAccessibleLabel(): boolean {
+  private _hasAccessibleDescription(): boolean {
     const { column } = this.props;
 
     return !!(
-      column.ariaLabel ||
       column.filterAriaLabel ||
       column.sortAscendingAriaLabel ||
       column.sortDescendingAriaLabel ||
@@ -299,17 +296,17 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     );
   }
 
-  private _renderAccessibleLabel(): JSX.Element | null {
+  private _renderAccessibleDescription(): JSX.Element | null {
     const { column, parentId } = this.props;
     const classNames = this._classNames;
 
-    return this._hasAccessibleLabel() && !this.props.onRenderColumnHeaderTooltip ? (
+    return this._hasAccessibleDescription() && !this.props.onRenderColumnHeaderTooltip ? (
       <label
         key={`${column.key}_label`}
         id={`${parentId}-${column.key}-tooltip`}
         className={classNames.accessibleLabel}
+        hidden
       >
-        {column.ariaLabel}
         {(column.isFiltered && column.filterAriaLabel) || null}
         {(column.isSorted &&
           (column.isSortedDescending ? column.sortDescendingAriaLabel : column.sortAscendingAriaLabel)) ||

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -95,7 +95,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
       column.columnActionsMode !== ColumnActionsMode.disabled &&
       (column.onColumnClick !== undefined || this.props.onColumnClick !== undefined);
     const accNameDescription = {
-      'aria-label': column.ariaLabel || (column.isIconOnly ? column.name : undefined),
+      'aria-label': column.ariaLabel ? column.ariaLabel : column.isIconOnly ? column.name : undefined,
       'aria-labelledby': column.ariaLabel || column.isIconOnly ? undefined : `${parentId}-${column.key}-name`,
       'aria-describedby':
         !this.props.onRenderColumnHeaderTooltip && this._hasAccessibleDescription()

--- a/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -121,8 +121,27 @@ describe('DetailsColumn', () => {
     expect(mockOnColumnClick.mock.calls.length).toBe(0);
   });
 
-  it('by default, has aria-describedby set for columns which provide an ariaLabel value', () => {
+  it('has aria-label set for filtered columns which provide an ariaLabel', () => {
     const column: IColumn = { ...baseColumn, ariaLabel: 'Foo' };
+    let component: any;
+    const columns = [column];
+
+    component = mount(
+      <DetailsList
+        items={[]}
+        setKey={'key1'}
+        initialFocusedIndex={0}
+        skipViewportMeasures={true}
+        columns={columns}
+        componentRef={ref => (component = ref)}
+        onShouldVirtualize={() => false}
+      />,
+    );
+    expect(component.find('[aria-label]')).toHaveLength(1);
+  });
+
+  it('by default, has aria-describedby set for filtered columns which provide a filter label', () => {
+    const column: IColumn = { ...baseColumn, isFiltered: true, filterAriaLabel: 'Foo' };
     let component: any;
     const columns = [column];
 
@@ -142,7 +161,7 @@ describe('DetailsColumn', () => {
   });
 
   it("by default, has a node present in the DOM referenced by the column's aria-describedby attribute", () => {
-    const column: IColumn = { ...baseColumn, ariaLabel: 'Foo' };
+    const column: IColumn = { ...baseColumn, isFiltered: true, filterAriaLabel: 'Foo' };
     let component: any;
     const columns = [column];
 
@@ -165,7 +184,7 @@ describe('DetailsColumn', () => {
   });
 
   it('does not render invalid aria-describedby if custom DetailsHeader has onRenderColumnHeaderTooltip', () => {
-    const column: IColumn = { ...baseColumn, ariaLabel: 'Foo' };
+    const column: IColumn = { ...baseColumn, isFiltered: true, filterAriaLabel: 'Foo' };
     let component: any;
     const columns = [column];
 

--- a/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -121,7 +121,7 @@ describe('DetailsColumn', () => {
     expect(mockOnColumnClick.mock.calls.length).toBe(0);
   });
 
-  it('has aria-label set for filtered columns which provide an ariaLabel', () => {
+  it('has aria-label set for columns which provide an ariaLabel', () => {
     const column: IColumn = { ...baseColumn, ariaLabel: 'Foo' };
     let component: any;
     const columns = [column];

--- a/packages/react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -202,6 +202,9 @@ export class DetailsHeaderBase
 
     const classNames = this._classNames;
     const IconComponent = useFastIcons ? FontIcon : Icon;
+    const showGroupExpander =
+      groupNestingDepth! > 0 && this.props.collapseAllVisibility === CollapseAllVisibility.visible;
+    const columnIndexOffset = 1 + (showCheckbox ? 1 : 0) + (showGroupExpander ? 1 : 0);
 
     const isRTL = getRTL(theme);
     return (
@@ -222,7 +225,6 @@ export class DetailsHeaderBase
                 className={classNames.cellIsCheck}
                 aria-labelledby={`${this._id}-checkTooltip`}
                 onClick={!isCheckboxHidden ? this._onSelectAllClicked : undefined}
-                aria-colindex={1}
                 role={'columnheader'}
               >
                 {onRenderColumnHeaderTooltip(
@@ -277,7 +279,7 @@ export class DetailsHeaderBase
               ) : null,
             ]
           : null}
-        {groupNestingDepth! > 0 && this.props.collapseAllVisibility === CollapseAllVisibility.visible ? (
+        {showGroupExpander ? (
           <div
             className={classNames.cellIsGroupExpander}
             onClick={this._onToggleCollapseAll}
@@ -305,7 +307,7 @@ export class DetailsHeaderBase
               column={column}
               styles={column.styles}
               key={column.key}
-              columnIndex={(showCheckbox ? 2 : 1) + columnIndex}
+              columnIndex={columnIndexOffset + columnIndex}
               parentId={this._id}
               isDraggable={_isDraggable}
               updateDragInfo={this._updateDragInfo}

--- a/packages/react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -339,7 +339,8 @@ describe('DetailsHeader', () => {
     );
 
     const selectAllCheckBoxAriaLabelledBy = component
-      .find('[aria-colindex=1]')
+      .find('[role="columnheader"]')
+      .at(0)
       .getDOMNode()
       .getAttribute('aria-labelledby');
 
@@ -361,7 +362,8 @@ describe('DetailsHeader', () => {
     );
 
     const selectAllColumnAriaLabelledBy = component
-      .find('[aria-colindex=1]')
+      .find('[role="columnheader"]')
+      .at(0)
       .getDOMNode()
       .getAttribute('aria-labelledby');
 
@@ -387,17 +389,17 @@ describe('DetailsHeader', () => {
     );
 
     const detailsColNotDraggable = component.find('[draggable=false]').getElements();
-    const detailsColNotDraggableA = component.find('[aria-colindex=2]').getElement();
-    const detailsColNotDraggableF = component.find('[aria-colindex=7]').getElement();
+    const detailsColNotDraggableA = component.find('[role="columnheader"]').at(1).getElement();
+    const detailsColNotDraggableF = component.find('[role="columnheader"]').at(6).getElement();
 
     expect(detailsColNotDraggable[0]).toEqual(detailsColNotDraggableA);
     expect(detailsColNotDraggable[1]).toEqual(detailsColNotDraggableF);
 
     const detailsColDraggable = component.find('[draggable=true]').getElements();
-    const detailsColDraggableB = component.find('[aria-colindex=3]').getElement();
-    const detailsColDraggableC = component.find('[aria-colindex=4]').getElement();
-    const detailsColDraggableD = component.find('[aria-colindex=5]').getElement();
-    const detailsColDraggableE = component.find('[aria-colindex=6]').getElement();
+    const detailsColDraggableB = component.find('[role="columnheader"]').at(2).getElement();
+    const detailsColDraggableC = component.find('[role="columnheader"]').at(3).getElement();
+    const detailsColDraggableD = component.find('[role="columnheader"]').at(4).getElement();
+    const detailsColDraggableE = component.find('[role="columnheader"]').at(5).getElement();
 
     expect(detailsColDraggable[0]).toEqual(detailsColDraggableB);
     expect(detailsColDraggable[1]).toEqual(detailsColDraggableC);
@@ -419,7 +421,7 @@ describe('DetailsHeader', () => {
       />,
     );
 
-    const detailsColSourceA = component.find('[aria-colindex=2]').getDOMNode();
+    const detailsColSourceA = component.find('[role="columnheader"]').at(1).getDOMNode();
     const header: any = headerRef.current!;
 
     // try dragging first frozen column a
@@ -430,7 +432,7 @@ describe('DetailsHeader', () => {
     expect(header._dragDropHelper._dragData).toBe(undefined);
     expect(detailsColSourceA.classList.item(4)).toBe(null);
 
-    const detailsColSourceF = component.find('[aria-colindex=7]').getDOMNode();
+    const detailsColSourceF = component.find('[role="columnheader"]').at(6).getDOMNode();
 
     // try dragging last frozen column e
     _RaiseEvent(detailsColSourceF, _MOUSEDOWN, 950);
@@ -455,7 +457,7 @@ describe('DetailsHeader', () => {
       />,
     );
 
-    const detailsColSourceB = component.find('[aria-colindex=3]').getDOMNode();
+    const detailsColSourceB = component.find('[role="columnheader"]').at(2).getDOMNode();
     const header: any = headerRef.current!;
 
     // raise mouse down and dragstart on column b
@@ -493,11 +495,11 @@ describe('DetailsHeader', () => {
     );
 
     // moving column c and dragover from a to f
-    const detailsColSourceC = component.find('[aria-colindex=4]').getDOMNode();
-    const detailsColTargetB = component.find('[aria-colindex=3]').getDOMNode();
-    const detailsColTargetD = component.find('[aria-colindex=5]').getDOMNode();
-    const detailsColTargetE = component.find('[aria-colindex=6]').getDOMNode();
-    const detailsColTargetF = component.find('[aria-colindex=7]').getDOMNode();
+    const detailsColSourceC = component.find('[role="columnheader"]').at(3).getDOMNode();
+    const detailsColTargetB = component.find('[role="columnheader"]').at(2).getDOMNode();
+    const detailsColTargetD = component.find('[role="columnheader"]').at(4).getDOMNode();
+    const detailsColTargetE = component.find('[role="columnheader"]').at(5).getDOMNode();
+    const detailsColTargetF = component.find('[role="columnheader"]').at(6).getDOMNode();
     const header: any = headerRef.current!;
 
     // do a mousedown and dragstart on source column c
@@ -611,8 +613,8 @@ describe('DetailsHeader', () => {
     );
 
     // moving column e to between a and b (abcdef -> aebcdf)
-    const detailsColSourceE = component.find('[aria-colindex=6]').getDOMNode();
-    let detailsColTarget = component.find('[aria-colindex=3]').getDOMNode();
+    const detailsColSourceE = component.find('[role="columnheader"]').at(5).getDOMNode();
+    let detailsColTarget = component.find('[role="columnheader"]').at(2).getDOMNode();
     const header: any = headerRef.current!;
 
     // do a mousedown and dragstart on source column e
@@ -639,8 +641,8 @@ describe('DetailsHeader', () => {
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: none;');
 
     // try moving column c after frozen column f (abcdef -> abdecf)
-    let detailsColSourceC = component.find('[aria-colindex=4]').getDOMNode();
-    detailsColTarget = component.find('[aria-colindex=7]').getDOMNode();
+    let detailsColSourceC = component.find('[role="columnheader"]').at(3).getDOMNode();
+    detailsColTarget = component.find('[role="columnheader"]').at(6).getDOMNode();
 
     // do a mousedown and dragstart on source column c
     _RaiseEvent(detailsColSourceC, _MOUSEDOWN, 490);
@@ -666,8 +668,8 @@ describe('DetailsHeader', () => {
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: none;');
 
     // source and target column are the same
-    detailsColSourceC = component.find('[aria-colindex=4]').getDOMNode();
-    detailsColTarget = component.find('[aria-colindex=4]').getDOMNode();
+    detailsColSourceC = component.find('[role="columnheader"]').at(3).getDOMNode();
+    detailsColTarget = component.find('[role="columnheader"]').at(3).getDOMNode();
     _RaiseEvent(detailsColSourceC, _MOUSEDOWN, 490);
     _RaiseEvent(detailsColSourceC, _DRAGSTART, 490);
 

--- a/packages/react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.test.tsx
@@ -156,12 +156,9 @@ describe('DetailsList', () => {
         expect(component).toBeTruthy();
         component!.focusIndex(2);
         setTimeout(() => {
-          const elements = (document.activeElement as HTMLElement).querySelectorAll('div[aria-colindex]');
-          elements.forEach((element: Element) => {
-            const itemKey = element.getAttribute('aria-colindex')!;
-            expect(itemKey).toBeDefined();
-
-            if (itemKey === '1') {
+          const elements = (document.activeElement as HTMLElement).querySelectorAll('div[role=columnheader]');
+          elements.forEach((element: Element, index: number) => {
+            if (index === 0) {
               return;
             }
 
@@ -172,14 +169,14 @@ describe('DetailsList', () => {
             expect(width).toBeDefined();
             expect(width[0]).toBeDefined();
 
-            if (itemKey === '2') {
+            if (index === 1) {
               expect(width[0]).toBe('121');
-            } else if (itemKey === '3') {
+            } else if (index === 2) {
               expect(width[0]).toBe('348');
-            } else if (itemKey === '4') {
+            } else if (index === 3) {
               expect(width[0]).toBe('123');
             } else {
-              fail('Unexpected itemKey.');
+              fail('Unexpected index.');
             }
           });
         }, 0);
@@ -210,12 +207,9 @@ describe('DetailsList', () => {
         expect(component).toBeTruthy();
         component!.focusIndex(2);
         setTimeout(() => {
-          const elements = (document.activeElement as HTMLElement).querySelectorAll('div[aria-colindex]');
-          elements.forEach((element: Element) => {
-            const itemKey = element.getAttribute('aria-colindex')!;
-            expect(itemKey).toBeDefined();
-
-            if (itemKey === '1') {
+          const elements = (document.activeElement as HTMLElement).querySelectorAll('div[role=columnheader]');
+          elements.forEach((element: Element, index: number) => {
+            if (index === 0) {
               return;
             }
 
@@ -226,12 +220,12 @@ describe('DetailsList', () => {
             expect(width).toBeDefined();
             expect(width[0]).toBeDefined();
 
-            if (itemKey === '2') {
+            if (index === 1) {
               expect(width[0]).toBe('336');
-            } else if (itemKey === '3') {
+            } else if (index === 2) {
               expect(width[0]).toBe('255');
             } else {
-              fail('Unexpected itemKey.');
+              fail('Unexpected index.');
             }
           });
         }, 0);
@@ -263,12 +257,9 @@ describe('DetailsList', () => {
         expect(component).toBeTruthy();
         component!.focusIndex(2);
         setTimeout(() => {
-          const elements = (document.activeElement as HTMLElement).querySelectorAll('div[aria-colindex]');
-          elements.forEach((element: Element) => {
-            const itemKey = element.getAttribute('aria-colindex')!;
-            expect(itemKey).toBeDefined();
-
-            if (itemKey === '1') {
+          const elements = (document.activeElement as HTMLElement).querySelectorAll('div[role=columnheader]');
+          elements.forEach((element: Element, index: number) => {
+            if (index === 0) {
               return;
             }
 
@@ -279,12 +270,12 @@ describe('DetailsList', () => {
             expect(width).toBeDefined();
             expect(width[0]).toBeDefined();
 
-            if (itemKey === '2') {
+            if (index === 1) {
               expect(width[0]).toBe('336');
-            } else if (itemKey === '3') {
+            } else if (index === 2) {
               expect(width[0]).toBe('255');
             } else {
-              fail('Unexpected itemKey.');
+              fail('Unexpected index.');
             }
           });
         }, 0);

--- a/packages/react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRow.base.tsx
@@ -319,7 +319,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
           </span>
         ) : null}
         {showCheckbox && (
-          <div role="gridcell" aria-colindex={1} data-selection-toggle={true} className={this._classNames.checkCell}>
+          <div role="gridcell" data-selection-toggle={true} className={this._classNames.checkCell}>
             {onRenderCheck({
               id: id ? `${id}-checkbox` : undefined,
               selected: isSelected,

--- a/packages/react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRowFields.tsx
@@ -26,7 +26,6 @@ const getCellText = (item: any, column: IColumn): string => {
 export const DetailsRowFields: React.FunctionComponent<IDetailsRowFieldsProps> = props => {
   const {
     columns,
-    columnStartIndex,
     rowClassNames,
     cellStyleProps = DEFAULT_CELL_STYLE_PROPS,
     item,
@@ -46,7 +45,7 @@ export const DetailsRowFields: React.FunctionComponent<IDetailsRowFieldsProps> =
 
   return (
     <div className={rowClassNames.fields} data-automationid="DetailsRowFields" role="presentation">
-      {columns.map((column, columnIndex) => {
+      {columns.map(column => {
         const width: string | number =
           typeof column.calculatedWidth === 'undefined'
             ? 'auto'
@@ -84,7 +83,6 @@ export const DetailsRowFields: React.FunctionComponent<IDetailsRowFieldsProps> =
             id={column.isRowHeader ? rowHeaderId : undefined}
             role={column.isRowHeader ? 'rowheader' : 'gridcell'}
             aria-readonly
-            aria-colindex={columnIndex + columnStartIndex + 1}
             className={css(
               column.className,
               column.isMultiline && rowClassNames.isMultiline,

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -44,7 +44,6 @@ exports[`DetailsHeader can render 1`] = `
   role="row"
 >
   <div
-    aria-colindex={1}
     aria-labelledby="header0-checkTooltip"
     className=
         ms-DetailsHeader-cell
@@ -289,7 +288,6 @@ exports[`DetailsHeader can render 1`] = `
     </span>
   </div>
   <div
-    aria-colindex={2}
     aria-labelledby="header0-a-name"
     aria-sort="none"
     className=
@@ -478,7 +476,6 @@ exports[`DetailsHeader can render 1`] = `
     role="button"
   />
   <div
-    aria-colindex={3}
     aria-labelledby="header0-b-name"
     aria-sort="ascending"
     className=
@@ -699,7 +696,6 @@ exports[`DetailsHeader can render 1`] = `
     role="button"
   />
   <div
-    aria-colindex={4}
     aria-labelledby="header0-c-name"
     aria-sort="none"
     className=
@@ -967,7 +963,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
   role="row"
 >
   <div
-    aria-colindex={1}
     aria-labelledby="header2-checkTooltip"
     className=
         ms-DetailsHeader-cell
@@ -1075,7 +1070,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     </span>
   </div>
   <div
-    aria-colindex={2}
     aria-labelledby="header2-a-name"
     aria-sort="none"
     className=
@@ -1264,7 +1258,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     role="button"
   />
   <div
-    aria-colindex={3}
     aria-labelledby="header2-b-name"
     aria-sort="ascending"
     className=
@@ -1485,7 +1478,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     role="button"
   />
   <div
-    aria-colindex={4}
     aria-labelledby="header2-c-name"
     aria-sort="none"
     className=
@@ -1753,7 +1745,6 @@ exports[`DetailsHeader renders accessible labels 1`] = `
   role="row"
 >
   <div
-    aria-colindex={1}
     aria-labelledby="header6-checkTooltip"
     className=
         ms-DetailsHeader-cell
@@ -2023,7 +2014,6 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     Toggle selection for all items
   </label>
   <div
-    aria-colindex={2}
     aria-labelledby="header6-a-name"
     aria-sort="none"
     className=
@@ -2212,9 +2202,8 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     role="button"
   />
   <div
-    aria-colindex={3}
     aria-describedby="header6-b-tooltip"
-    aria-labelledby="header6-b-name"
+    aria-label="Click to sort."
     aria-sort="ascending"
     className=
         ms-DetailsHeader-cell
@@ -2396,9 +2385,9 @@ exports[`DetailsHeader renders accessible labels 1`] = `
           white-space: nowrap;
           width: 1px;
         }
+    hidden={true}
     id="header6-b-tooltip"
   >
-    Click to sort.
     Sorted up.
   </label>
   <div
@@ -2458,9 +2447,8 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     role="button"
   />
   <div
-    aria-colindex={4}
     aria-describedby="header6-c-tooltip"
-    aria-labelledby="header6-c-name"
+    aria-label="Click to sort, filter, or group."
     aria-sort="none"
     className=
         ms-DetailsHeader-cell
@@ -2704,9 +2692,9 @@ exports[`DetailsHeader renders accessible labels 1`] = `
           white-space: nowrap;
           width: 1px;
         }
+    hidden={true}
     id="header6-c-tooltip"
   >
-    Click to sort, filter, or group.
     Filtered.
     Grouped.
   </label>

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -1935,7 +1935,6 @@ exports[`DetailsList renders List correctly 1`] = `
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -2180,7 +2179,6 @@ exports[`DetailsList renders List correctly 1`] = `
             </span>
           </div>
           <div
-            aria-colindex={2}
             aria-labelledby="header1-key-name"
             aria-sort="none"
             className=
@@ -2369,7 +2367,6 @@ exports[`DetailsList renders List correctly 1`] = `
             role="button"
           />
           <div
-            aria-colindex={3}
             aria-labelledby="header1-name-name"
             aria-sort="none"
             className=
@@ -2558,7 +2555,6 @@ exports[`DetailsList renders List correctly 1`] = `
             role="button"
           />
           <div
-            aria-colindex={4}
             aria-labelledby="header1-value-name"
             aria-sort="none"
             className=
@@ -2923,7 +2919,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -3168,9 +3163,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             </span>
           </div>
           <div
-            aria-colindex={2}
-            aria-describedby="header1-column_key_0-tooltip"
-            aria-labelledby="header1-column_key_0-name"
+            aria-label="column_0"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -3301,33 +3294,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
               </span>
             </span>
           </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  white-space: nowrap;
-                  width: 1px;
-                }
-            id="header1-column_key_0-tooltip"
-          >
-            column_0
-          </label>
           <div
-            aria-colindex={3}
-            aria-describedby="header1-column_key_1-tooltip"
-            aria-labelledby="header1-column_key_1-name"
+            aria-label="column_1"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -3458,33 +3426,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
               </span>
             </span>
           </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  white-space: nowrap;
-                  width: 1px;
-                }
-            id="header1-column_key_1-tooltip"
-          >
-            column_1
-          </label>
           <div
-            aria-colindex={4}
-            aria-describedby="header1-column_key_2-tooltip"
-            aria-labelledby="header1-column_key_2-name"
+            aria-label="column_2"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -3615,33 +3558,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
               </span>
             </span>
           </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  white-space: nowrap;
-                  width: 1px;
-                }
-            id="header1-column_key_2-tooltip"
-          >
-            column_2
-          </label>
           <div
-            aria-colindex={5}
-            aria-describedby="header1-column_key_3-tooltip"
-            aria-labelledby="header1-column_key_3-name"
+            aria-label="column_3"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -3772,33 +3690,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
               </span>
             </span>
           </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  white-space: nowrap;
-                  width: 1px;
-                }
-            id="header1-column_key_3-tooltip"
-          >
-            column_3
-          </label>
           <div
-            aria-colindex={6}
-            aria-describedby="header1-column_key_4-tooltip"
-            aria-labelledby="header1-column_key_4-name"
+            aria-label="column_4"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -3929,29 +3822,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
               </span>
             </span>
           </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  white-space: nowrap;
-                  width: 1px;
-                }
-            id="header1-column_key_4-tooltip"
-          >
-            column_4
-          </label>
         </div>
       </div>
       <div
@@ -4130,7 +4000,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -4375,7 +4244,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
             </span>
           </div>
           <div
-            aria-colindex={2}
             aria-labelledby="header1-key-name"
             aria-sort="none"
             className=
@@ -4564,7 +4432,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
             role="button"
           />
           <div
-            aria-colindex={3}
             aria-labelledby="header1-name-name"
             aria-sort="none"
             className=
@@ -4753,7 +4620,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
             role="button"
           />
           <div
-            aria-colindex={4}
             aria-labelledby="header1-value-name"
             aria-sort="none"
             className=
@@ -5119,7 +4985,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -5364,7 +5229,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             </span>
           </div>
           <div
-            aria-colindex={2}
             aria-labelledby="header1-key-name"
             aria-sort="none"
             className=
@@ -5553,7 +5417,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             role="button"
           />
           <div
-            aria-colindex={3}
             aria-labelledby="header1-name-name"
             aria-sort="none"
             className=
@@ -5742,7 +5605,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             role="button"
           />
           <div
-            aria-colindex={4}
             aria-labelledby="header1-value-name"
             aria-sort="none"
             className=
@@ -6107,7 +5969,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -6352,9 +6213,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             </span>
           </div>
           <div
-            aria-colindex={2}
-            aria-describedby="header1-column_key_0-tooltip"
-            aria-labelledby="header1-column_key_0-name"
+            aria-label="column_0"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -6485,36 +6344,11 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
               </span>
             </span>
           </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  white-space: nowrap;
-                  width: 1px;
-                }
-            id="header1-column_key_0-tooltip"
-          >
-            column_0
-          </label>
           <span>
             |
           </span>
           <div
-            aria-colindex={3}
-            aria-describedby="header1-column_key_1-tooltip"
-            aria-labelledby="header1-column_key_1-name"
+            aria-label="column_1"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -6645,36 +6479,11 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
               </span>
             </span>
           </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  white-space: nowrap;
-                  width: 1px;
-                }
-            id="header1-column_key_1-tooltip"
-          >
-            column_1
-          </label>
           <span>
             |
           </span>
           <div
-            aria-colindex={4}
-            aria-describedby="header1-column_key_2-tooltip"
-            aria-labelledby="header1-column_key_2-name"
+            aria-label="column_2"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -6805,36 +6614,11 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
               </span>
             </span>
           </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  white-space: nowrap;
-                  width: 1px;
-                }
-            id="header1-column_key_2-tooltip"
-          >
-            column_2
-          </label>
           <span>
             |
           </span>
           <div
-            aria-colindex={5}
-            aria-describedby="header1-column_key_3-tooltip"
-            aria-labelledby="header1-column_key_3-name"
+            aria-label="column_3"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -6965,36 +6749,11 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
               </span>
             </span>
           </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  white-space: nowrap;
-                  width: 1px;
-                }
-            id="header1-column_key_3-tooltip"
-          >
-            column_3
-          </label>
           <span>
             |
           </span>
           <div
-            aria-colindex={6}
-            aria-describedby="header1-column_key_4-tooltip"
-            aria-labelledby="header1-column_key_4-name"
+            aria-label="column_4"
             aria-sort="none"
             className=
                 ms-DetailsHeader-cell
@@ -7125,29 +6884,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
               </span>
             </span>
           </div>
-          <label
-            className=
-
-                {
-                  border: 0px;
-                  height: 1px;
-                  margin-bottom: -1px;
-                  margin-left: -1px;
-                  margin-right: -1px;
-                  margin-top: -1px;
-                  overflow: hidden;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  position: absolute;
-                  white-space: nowrap;
-                  width: 1px;
-                }
-            id="header1-column_key_4-tooltip"
-          >
-            column_4
-          </label>
           <span>
             |
           </span>
@@ -7413,7 +7149,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
             </i>
           </div>
           <div
-            aria-colindex={1}
             aria-labelledby="header1-key-name"
             aria-sort="none"
             className=
@@ -7602,7 +7337,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
             role="button"
           />
           <div
-            aria-colindex={2}
             aria-labelledby="header1-name-name"
             aria-sort="none"
             className=
@@ -7791,7 +7525,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
             role="button"
           />
           <div
-            aria-colindex={3}
             aria-labelledby="header1-value-name"
             aria-sort="none"
             className=
@@ -8406,7 +8139,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={2}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -8463,7 +8195,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     0
                                   </div>
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -8520,7 +8251,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     Item 0
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -8715,7 +8445,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={2}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -8772,7 +8501,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     1
                                   </div>
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -8829,7 +8557,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     Item 1
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -9277,7 +9004,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={2}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -9334,7 +9060,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     2
                                   </div>
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -9391,7 +9116,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     Item 2
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -9586,7 +9310,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={2}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -9643,7 +9366,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     3
                                   </div>
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -9700,7 +9422,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     Item 3
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -9895,7 +9616,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   role="presentation"
                                 >
                                   <div
-                                    aria-colindex={2}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -9952,7 +9672,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     4
                                   </div>
                                   <div
-                                    aria-colindex={3}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell
@@ -10009,7 +9728,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     Item 4
                                   </div>
                                   <div
-                                    aria-colindex={4}
                                     aria-readonly={true}
                                     className=
                                         ms-DetailsRow-cell

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -87,7 +87,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -332,7 +331,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             </span>
           </div>
           <div
-            aria-colindex={2}
             aria-labelledby="header1-key-name"
             aria-sort="none"
             className=
@@ -465,7 +463,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             </span>
           </div>
           <div
-            aria-colindex={3}
             aria-labelledby="header1-name-name"
             aria-sort="none"
             className=
@@ -598,7 +595,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             </span>
           </div>
           <div
-            aria-colindex={4}
             aria-labelledby="header1-value-name"
             aria-sort="none"
             className=
@@ -927,7 +923,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header13-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -1172,7 +1167,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             </span>
           </div>
           <div
-            aria-colindex={2}
             aria-labelledby="header13-key-name"
             aria-sort="none"
             className=
@@ -1305,7 +1299,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             </span>
           </div>
           <div
-            aria-colindex={3}
             aria-labelledby="header13-name-name"
             aria-sort="none"
             className=
@@ -1438,7 +1431,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             </span>
           </div>
           <div
-            aria-colindex={4}
             aria-labelledby="header13-value-name"
             aria-sort="none"
             className=
@@ -1771,7 +1763,6 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
   }
 >
   <div
-    aria-colindex={1}
     className=
         ms-DetailsRow-cell
         ms-DetailsRow-cellCheck
@@ -2015,7 +2006,6 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
     role="presentation"
   >
     <div
-      aria-colindex={2}
       aria-readonly={true}
       className=
           ms-DetailsRow-cell
@@ -2072,7 +2062,6 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
       
     </div>
     <div
-      aria-colindex={3}
       aria-readonly={true}
       className=
           ms-DetailsRow-cell
@@ -2129,7 +2118,6 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
       
     </div>
     <div
-      aria-colindex={4}
       aria-readonly={true}
       className=
           ms-DetailsRow-cell
@@ -2291,7 +2279,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header5-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -2536,7 +2523,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             </span>
           </div>
           <div
-            aria-colindex={2}
             aria-labelledby="header5-key-name"
             aria-sort="none"
             className=
@@ -2669,7 +2655,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             </span>
           </div>
           <div
-            aria-colindex={3}
             aria-labelledby="header5-name-name"
             aria-sort="none"
             className=
@@ -2802,7 +2787,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             </span>
           </div>
           <div
-            aria-colindex={4}
             aria-labelledby="header5-value-name"
             aria-sort="none"
             className=
@@ -3131,7 +3115,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header9-checkTooltip"
             className=
                 ms-DetailsHeader-cell
@@ -3376,7 +3359,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             </span>
           </div>
           <div
-            aria-colindex={2}
             aria-labelledby="header9-key-name"
             aria-sort="none"
             className=
@@ -3509,7 +3491,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             </span>
           </div>
           <div
-            aria-colindex={3}
             aria-labelledby="header9-name-name"
             aria-sort="none"
             className=
@@ -3642,7 +3623,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             </span>
           </div>
           <div
-            aria-colindex={4}
             aria-labelledby="header9-value-name"
             aria-sort="none"
             className=

--- a/packages/react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -88,7 +88,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
           role="row"
         >
           <div
-            aria-colindex={1}
             aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell


### PR DESCRIPTION
Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally

## Current Behavior

- Text assigned through `column.ariaLabel` was being added to the description rather than the label.
- Column headers had incorrect and unnecessary `aria-colindex` values, which made columns sometimes disappear for screen reader users

## New Behavior

- `column.ariaLabel` now is used for the `aria-label`, and `column.name` is still a fallback for icon columns
- `aria-colindex` is removed entirely, since it's not necessary and should not have been added.
- tests updated to not use `aria-colindex`

### Some context:
Looking through history, it looks like `aria-colindex` was added because of a poor testing recommendation some time ago: https://github.com/microsoft/fluentui/pull/1667/. The only reason it would ever be needed is for virtualized columns, which we do not support. It also creates an unnecessarily fragile accessibility issue where an author adding an extra column not included in the `aria-colindex` indexing will cause entire columns to get dropped for screen reader users.

Fixes [13245](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/13245)