### PR TITLE
Slider: Update high contrast styles for better a11y

### DIFF
--- a/packages/react-slider/src/components/Slider/useSliderStyles.ts
+++ b/packages/react-slider/src/components/Slider/useSliderStyles.ts
@@ -64,12 +64,26 @@ export const useRootStyles = makeStyles({
       [thumbColorVar]: tokens.colorBrandBackgroundPressed,
       [progressColorVar]: tokens.colorBrandBackgroundPressed,
     },
+    '@media (forced-colors: active)': {
+      [railColorVar]: 'CanvasText',
+      [thumbColorVar]: 'Highlight',
+      [progressColorVar]: 'Highlight',
+      ':hover': {
+        [thumbColorVar]: 'Highlight',
+        [progressColorVar]: 'Highlight',
+      },
+    },
   },
 
   disabled: {
     [thumbColorVar]: tokens.colorNeutralForegroundDisabled,
     [railColorVar]: tokens.colorNeutralBackgroundDisabled,
     [progressColorVar]: tokens.colorNeutralForegroundDisabled,
+    '@media (forced-colors: active)': {
+      [railColorVar]: 'GrayText',
+      [thumbColorVar]: 'GrayText',
+      [progressColorVar]: 'GrayText',
+    },
   },
 
   focusIndicatorHorizontal: createFocusOutlineStyle({
@@ -95,6 +109,8 @@ export const useRailStyles = makeStyles({
     gridColumnStart: 'slider',
     gridColumnEnd: 'slider',
     position: 'relative',
+    forcedColorAdjust: 'none',
+    // Background gradient represents the progress of the slider
     backgroundImage: `linear-gradient(
       var(${railDirectionVar}),
       var(${railColorVar}) 0%,
@@ -109,6 +125,7 @@ export const useRailStyles = makeStyles({
     ':before': {
       content: "''",
       position: 'absolute',
+      // Repeating gradient represents the steps if provided
       backgroundImage: `repeating-linear-gradient(
         var(${railDirectionVar}),
         #0000 0%,
@@ -150,6 +167,7 @@ export const useThumbStyles = makeStyles({
     height: `var(${thumbSizeVar})`,
     pointerEvents: 'none',
     outlineStyle: 'none',
+    forcedColorAdjust: 'none',
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
     boxShadow: `0 0 0 calc(var(${thumbSizeVar}) * .2) ${tokens.colorNeutralBackground1} inset`,
     backgroundColor: `var(${thumbColorVar})`,


### PR DESCRIPTION
Slider leverages background colors to show progress. High contrast by default removes those backgrounds. 

Fixes #21342 
Fixes #21341


Before (Default and disabled)
![Image Before](https://user-images.githubusercontent.com/1434956/150419972-a6953150-84fc-431c-98c2-58baedb38623.png)


After:

Default

![After image, default](https://user-images.githubusercontent.com/1434956/150419717-e4be108b-8d58-478c-8320-b7cb6195546a.png)

Disabled

![After image, disabled](https://user-images.githubusercontent.com/1434956/150419769-24f9ec84-28b1-4060-8486-4034000bcbf3.png)


