### PR TITLE
Avatar: Rename `label` slot to `initials`, remove `getInitials` prop, and improve accessibility

### DIFF
--- a/change/@fluentui-react-avatar-63302eb2-4c8b-47b4-ba87-d1755cea3fbd.json
+++ b/change/@fluentui-react-avatar-63302eb2-4c8b-47b4-ba87-d1755cea3fbd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Rename `label` slot to `initials`, remove `getInitials` prop, and improve accessibility",
+  "packageName": "@fluentui/react-avatar",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-avatar/etc/react-avatar.api.md
@@ -21,8 +21,7 @@ export const avatarClassName = "fui-Avatar";
 
 // @public (undocumented)
 export type AvatarCommons = Omit<React_2.HTMLAttributes<HTMLElement>, 'children'> & {
-    name: string;
-    getInitials: (name: string, isRtl: boolean) => string;
+    name?: string;
     size: 20 | 24 | 28 | 32 | 36 | 40 | 48 | 56 | 64 | 72 | 96 | 120 | 128;
     shape: 'circular' | 'square';
     active: 'active' | 'inactive' | 'unset';
@@ -47,7 +46,7 @@ export type AvatarSlots = {
         children?: never;
     };
     image?: IntrinsicShorthandProps<'img'>;
-    label?: IntrinsicShorthandProps<'span'>;
+    initials?: IntrinsicShorthandProps<'span'>;
     icon?: IntrinsicShorthandProps<'span'>;
     badge?: ObjectShorthandProps<PresenceBadgeProps>;
 };

--- a/packages/react-avatar/src/AvatarGetInitials.stories.tsx
+++ b/packages/react-avatar/src/AvatarGetInitials.stories.tsx
@@ -1,19 +1,16 @@
 import * as React from 'react';
-import { Avatar, AvatarProps } from './index';
+import { Avatar } from './index';
 
-const formatter = (name: string, isRTL: boolean) => {
-  return `${name[0]} ${name[name.length - 1]}`;
+export const GetInitials = () => {
+  const name = 'Jane Doe';
+  return <Avatar name={name} initials={`${name[0]} ${name[name.length - 1]}`} />;
 };
 
-export const GetInitials = (props: Partial<AvatarProps>) => {
-  return <Avatar {...props} name="Jane Doe" getInitials={formatter} />;
-};
-
-GetInitials.storyName = 'Initials: from a callback';
+GetInitials.storyName = 'Custom initials';
 GetInitials.parameters = {
   docs: {
     description: {
-      story: 'An avatar can display initials from a callaback.',
+      story: 'An avatar can display custom initials by setting the initials prop.',
     },
   },
 };

--- a/packages/react-avatar/src/AvatarSize.stories.tsx
+++ b/packages/react-avatar/src/AvatarSize.stories.tsx
@@ -3,19 +3,19 @@ import { Avatar, AvatarProps } from './index';
 
 export const Size = (props: Partial<AvatarProps>) => (
   <>
-    <Avatar {...props} label={20} size={20} />
-    <Avatar {...props} label={24} size={24} />
-    <Avatar {...props} label={28} size={28} />
-    <Avatar {...props} label={32} size={32} />
-    <Avatar {...props} label={36} size={36} />
-    <Avatar {...props} label={40} size={40} />
-    <Avatar {...props} label={48} size={48} />
-    <Avatar {...props} label={56} size={56} />
-    <Avatar {...props} label={64} size={64} />
-    <Avatar {...props} label={72} size={72} />
-    <Avatar {...props} label={96} size={96} />
-    <Avatar {...props} label={120} size={120} />
-    <Avatar {...props} label={128} size={128} />
+    <Avatar name="20" initials="20" size={20} />
+    <Avatar name="24" initials="24" size={24} />
+    <Avatar name="28" initials="28" size={28} />
+    <Avatar name="32" initials="32" size={32} />
+    <Avatar name="36" initials="36" size={36} />
+    <Avatar name="40" initials="40" size={40} />
+    <Avatar name="48" initials="48" size={48} />
+    <Avatar name="56" initials="56" size={56} />
+    <Avatar name="64" initials="64" size={64} />
+    <Avatar name="72" initials="72" size={72} />
+    <Avatar name="96" initials="96" size={96} />
+    <Avatar name="120" initials="120" size={120} />
+    <Avatar name="128" initials="128" size={128} />
   </>
 );
 

--- a/packages/react-avatar/src/components/Avatar/Avatar.test.tsx
+++ b/packages/react-avatar/src/components/Avatar/Avatar.test.tsx
@@ -4,6 +4,7 @@ import { Avatar } from './Avatar';
 import * as renderer from 'react-test-renderer';
 import { ReactWrapper } from 'enzyme';
 import { render } from '@testing-library/react';
+import { getInitials } from '../../utils/getInitials';
 
 describe('Avatar', () => {
   let wrapper: ReactWrapper | undefined;
@@ -112,43 +113,36 @@ describe('Avatar', () => {
 
   it('does not set name on the native element', () => {
     const result = render(<Avatar name="First Last" data-testid="root" />);
-    expect(result.getByTestId('root').getAttribute('name')).toBeFalsy();
+
+    const root = result.getByTestId('root');
+    expect(root.getAttribute('name')).toBeFalsy();
   });
 
-  it('sets the alt text on the image element, and aria-hidden on initials', () => {
+  it('sets the alt text on the image and aria-hidden on initials, when there is an image', () => {
     const name = 'First Last';
     const result = render(<Avatar name={name} image={{ src: 'avatar.png' }} />);
 
     const image = result.getByRole('img');
-    const initials = result.getByText('FL');
-    expect(image.getAttribute('alt')).toEqual(name);
+    const initials = result.getByText(getInitials(name, false));
+    expect(image).toBe(result.getByAltText(name));
     expect(initials.getAttribute('aria-hidden')).toEqual('true');
   });
 
-  it('sets role and aria-label on initials when there is no image', () => {
+  it('sets role and aria-label on initials, when there is no image', () => {
     const name = 'First Last';
     const initialsRef = React.createRef<HTMLSpanElement>();
     const result = render(<Avatar name={name} initials={{ ref: initialsRef }} />);
 
-    expect(result.getByRole('img')).toBe(initialsRef.current);
-    expect(initialsRef.current?.getAttribute('aria-label')).toEqual(name);
-    expect(initialsRef.current?.getAttribute('aria-hidden')).toBeNull();
+    expect(initialsRef.current).toBe(result.getByRole('img'));
+    expect(initialsRef.current).toBe(result.getByLabelText(name));
   });
 
-  it('sets role and aria-label on icon when there is no image or initials', () => {
+  it('sets role and aria-label on icon, when there is no image or initials', () => {
     const name = 'First Last';
     const iconRef = React.createRef<HTMLSpanElement>();
     const result = render(<Avatar name={name} initials="" icon={{ ref: iconRef }} />);
 
-    expect(result.getByRole('img')).toBe(iconRef.current);
-    expect(iconRef.current?.getAttribute('aria-label')).toEqual(name);
-    expect(iconRef.current?.getAttribute('aria-hidden')).toBeNull();
+    expect(iconRef.current).toBe(result.getByRole('img'));
+    expect(iconRef.current).toBe(result.getByLabelText(name));
   });
-
-  // it('sets alt on the image element', () => {
-  //   const name = 'First Last';
-  //   const result = render(<Avatar name={name} image={{ src: 'first-last.png' }} />);
-
-  //   expect(result.getByRole('img').getAttribute('alt')).toEqual(name);
-  // });
 });

--- a/packages/react-avatar/src/components/Avatar/Avatar.test.tsx
+++ b/packages/react-avatar/src/components/Avatar/Avatar.test.tsx
@@ -3,6 +3,7 @@ import { isConformant } from '../../common/isConformant';
 import { Avatar } from './Avatar';
 import * as renderer from 'react-test-renderer';
 import { ReactWrapper } from 'enzyme';
+import { render } from '@testing-library/react';
 
 describe('Avatar', () => {
   let wrapper: ReactWrapper | undefined;
@@ -64,10 +65,9 @@ describe('Avatar', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('displays custom initials via getInitials', () => {
-    const component = renderer.create(
-      <Avatar name="First Last" getInitials={name => (name[1] + name[7]).toUpperCase()} />,
-    );
+  it('displays custom initials', () => {
+    const name = 'First Last';
+    const component = renderer.create(<Avatar name={name} initials={(name[1] + name[7]).toUpperCase()} />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
@@ -109,4 +109,46 @@ describe('Avatar', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('does not set name on the native element', () => {
+    const result = render(<Avatar name="First Last" data-testid="root" />);
+    expect(result.getByTestId('root').getAttribute('name')).toBeFalsy();
+  });
+
+  it('sets the alt text on the image element, and aria-hidden on initials', () => {
+    const name = 'First Last';
+    const result = render(<Avatar name={name} image={{ src: 'avatar.png' }} />);
+
+    const image = result.getByRole('img');
+    const initials = result.getByText('FL');
+    expect(image.getAttribute('alt')).toEqual(name);
+    expect(initials.getAttribute('aria-hidden')).toEqual('true');
+  });
+
+  it('sets role and aria-label on initials when there is no image', () => {
+    const name = 'First Last';
+    const initialsRef = React.createRef<HTMLSpanElement>();
+    const result = render(<Avatar name={name} initials={{ ref: initialsRef }} />);
+
+    expect(result.getByRole('img')).toBe(initialsRef.current);
+    expect(initialsRef.current?.getAttribute('aria-label')).toEqual(name);
+    expect(initialsRef.current?.getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('sets role and aria-label on icon when there is no image or initials', () => {
+    const name = 'First Last';
+    const iconRef = React.createRef<HTMLSpanElement>();
+    const result = render(<Avatar name={name} initials="" icon={{ ref: iconRef }} />);
+
+    expect(result.getByRole('img')).toBe(iconRef.current);
+    expect(iconRef.current?.getAttribute('aria-label')).toEqual(name);
+    expect(iconRef.current?.getAttribute('aria-hidden')).toBeNull();
+  });
+
+  // it('sets alt on the image element', () => {
+  //   const name = 'First Last';
+  //   const result = render(<Avatar name={name} image={{ src: 'first-last.png' }} />);
+
+  //   expect(result.getByRole('img').getAttribute('alt')).toEqual(name);
+  // });
 });

--- a/packages/react-avatar/src/components/Avatar/Avatar.test.tsx
+++ b/packages/react-avatar/src/components/Avatar/Avatar.test.tsx
@@ -128,6 +128,13 @@ describe('Avatar', () => {
     expect(initials.getAttribute('aria-hidden')).toEqual('true');
   });
 
+  it('sets the alt text on the image to the initials, when there is no name', () => {
+    const result = render(<Avatar initials="FL" image={{ src: 'avatar.png' }} />);
+
+    const image = result.getByRole('img');
+    expect(image).toBe(result.getByAltText('FL'));
+  });
+
   it('sets role and aria-label on initials, when there is no image', () => {
     const name = 'First Last';
     const initialsRef = React.createRef<HTMLSpanElement>();

--- a/packages/react-avatar/src/components/Avatar/Avatar.test.tsx
+++ b/packages/react-avatar/src/components/Avatar/Avatar.test.tsx
@@ -138,9 +138,9 @@ describe('Avatar', () => {
   });
 
   it('sets role and aria-label on icon, when there is no image or initials', () => {
-    const name = 'First Last';
+    const name = '(111)-555-1234';
     const iconRef = React.createRef<HTMLSpanElement>();
-    const result = render(<Avatar name={name} initials="" icon={{ ref: iconRef }} />);
+    const result = render(<Avatar name={name} icon={{ ref: iconRef }} />);
 
     expect(iconRef.current).toBe(result.getByRole('img'));
     expect(iconRef.current).toBe(result.getByLabelText(name));

--- a/packages/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -25,7 +25,7 @@ export type AvatarSlots = {
   initials?: IntrinsicShorthandProps<'span'>;
 
   /**
-   * Icon to be displayed when the avatar doesn't have an image or name (or if getInitials returns an empty string).
+   * Icon to be displayed when the avatar doesn't have an image or initials.
    *
    * @defaultvalue `PersonRegular` (the default icon's size depends on the Avatar's size)
    */
@@ -44,7 +44,7 @@ export type AvatarCommons = Omit<React.HTMLAttributes<HTMLElement>, 'children'> 
    * The name will be used to determine the initials displayed when there is no icon, as well as provided to
    * accessibility tools.
    */
-  name: string;
+  name?: string;
 
   /**
    * Size of the avatar in pixels.

--- a/packages/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -20,7 +20,7 @@ export type AvatarSlots = {
   /**
    * (optional) Custom initials. By default, this will be derived from the `name` using `getInitials`.
    *
-   * The initials are only displayed if there is no image (as well as while the image is loading).
+   * The initials are displayed when there is no image (including while the image is loading).
    */
   initials?: IntrinsicShorthandProps<'span'>;
 

--- a/packages/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -18,14 +18,16 @@ export type AvatarSlots = {
   image?: IntrinsicShorthandProps<'img'>;
 
   /**
-   * The label shown when there's no image. Defaults to the initials derived from `name` using `getInitials`.
+   * (optional) Custom initials. By default, this will be derived from the `name` using `getInitials`.
+   *
+   * The initials are only displayed if there is no image (as well as while the image is loading).
    */
-  label?: IntrinsicShorthandProps<'span'>;
+  initials?: IntrinsicShorthandProps<'span'>;
 
   /**
    * Icon to be displayed when the avatar doesn't have an image or name (or if getInitials returns an empty string).
    *
-   * @defaultvalue `Person20Regular` (the default icon's size depends on the Avatar's size)
+   * @defaultvalue `PersonRegular` (the default icon's size depends on the Avatar's size)
    */
   icon?: IntrinsicShorthandProps<'span'>;
 
@@ -37,14 +39,12 @@ export type AvatarSlots = {
 
 export type AvatarCommons = Omit<React.HTMLAttributes<HTMLElement>, 'children'> & {
   /**
-   * The name used for displaying the initials of the avatar if the image is not provided
+   * The name of the person or entity represented by this Avatar. This should always be provided if it is available.
+   *
+   * The name will be used to determine the initials displayed when there is no icon, as well as provided to
+   * accessibility tools.
    */
   name: string;
-
-  /**
-   * Custom method for generating the initials from the name property, which is shown if no image is provided.
-   */
-  getInitials: (name: string, isRtl: boolean) => string;
 
   /**
    * Size of the avatar in pixels.

--- a/packages/react-avatar/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/react-avatar/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -3,10 +3,11 @@
 exports[`Avatar displays a badge 1`] = `
 <span
   className="fui-Avatar"
-  name="First Last"
 >
   <span
+    aria-label="First Last"
     className=""
+    role="img"
   >
     FL
   </span>
@@ -33,13 +34,14 @@ exports[`Avatar displays a badge 1`] = `
 </span>
 `;
 
-exports[`Avatar displays custom initials via getInitials 1`] = `
+exports[`Avatar displays custom initials 1`] = `
 <span
   className="fui-Avatar"
-  name="First Last"
 >
   <span
+    aria-label="First Last"
     className=""
+    role="img"
   >
     IA
   </span>
@@ -49,7 +51,6 @@ exports[`Avatar displays custom initials via getInitials 1`] = `
 exports[`Avatar handles customSize 1`] = `
 <span
   className="fui-Avatar"
-  name="First Last"
   style={
     Object {
       "height": "33px",
@@ -58,7 +59,9 @@ exports[`Avatar handles customSize 1`] = `
   }
 >
   <span
+    aria-label="First Last"
     className=""
+    role="img"
   >
     FL
   </span>
@@ -70,6 +73,7 @@ exports[`Avatar prioritizes image over icon 1`] = `
   className="fui-Avatar"
 >
   <span
+    aria-hidden={true}
     className=""
   >
     <span
@@ -86,14 +90,15 @@ exports[`Avatar prioritizes image over icon 1`] = `
 exports[`Avatar prioritizes image over initials 1`] = `
 <span
   className="fui-Avatar"
-  name="First Last"
 >
   <span
+    aria-hidden={true}
     className=""
   >
     FL
   </span>
   <img
+    alt="First Last"
     className=""
     src="i.png"
   />
@@ -103,14 +108,15 @@ exports[`Avatar prioritizes image over initials 1`] = `
 exports[`Avatar prioritizes image over initials and icon 1`] = `
 <span
   className="fui-Avatar"
-  name="First Last"
 >
   <span
+    aria-hidden={true}
     className=""
   >
     FL
   </span>
   <img
+    alt="First Last"
     className=""
     src="i.png"
   />
@@ -120,10 +126,11 @@ exports[`Avatar prioritizes image over initials and icon 1`] = `
 exports[`Avatar prioritizes initials over icon 1`] = `
 <span
   className="fui-Avatar"
-  name="First Last"
 >
   <span
+    aria-label="First Last"
     className=""
+    role="img"
   >
     FL
   </span>
@@ -133,10 +140,11 @@ exports[`Avatar prioritizes initials over icon 1`] = `
 exports[`Avatar renders 1 initial with a 1-word name 1`] = `
 <span
   className="fui-Avatar"
-  name="First"
 >
   <span
+    aria-label="First"
     className=""
+    role="img"
   >
     F
   </span>
@@ -146,10 +154,11 @@ exports[`Avatar renders 1 initial with a 1-word name 1`] = `
 exports[`Avatar renders 2 initials with a 2-word name 1`] = `
 <span
   className="fui-Avatar"
-  name="First Last"
 >
   <span
+    aria-label="First Last"
     className=""
+    role="img"
   >
     FL
   </span>
@@ -159,10 +168,11 @@ exports[`Avatar renders 2 initials with a 2-word name 1`] = `
 exports[`Avatar renders 2 initials with a 3-word name 1`] = `
 <span
   className="fui-Avatar"
-  name="First M. Last"
 >
   <span
+    aria-label="First M. Last"
     className=""
+    role="img"
   >
     FL
   </span>
@@ -175,6 +185,7 @@ exports[`Avatar renders a default state 1`] = `
 >
   <span
     className=""
+    role="img"
   >
     <svg
       aria-hidden={true}
@@ -202,6 +213,7 @@ exports[`Avatar renders an icon 1`] = `
 >
   <span
     className=""
+    role="img"
   >
     <span
       className="icon"
@@ -213,10 +225,11 @@ exports[`Avatar renders an icon 1`] = `
 exports[`Avatar renders an icon if the name is not alphabetic 1`] = `
 <span
   className="fui-Avatar"
-  name="(111)-555-1234"
 >
   <span
+    aria-label="(111)-555-1234"
     className=""
+    role="img"
   >
     <svg
       aria-hidden={true}
@@ -243,6 +256,7 @@ exports[`Avatar renders an image 1`] = `
   className="fui-Avatar"
 >
   <span
+    aria-hidden={true}
     className=""
   >
     <svg

--- a/packages/react-avatar/src/components/Avatar/renderAvatar.tsx
+++ b/packages/react-avatar/src/components/Avatar/renderAvatar.tsx
@@ -7,7 +7,7 @@ export const renderAvatar = (state: AvatarState) => {
 
   return (
     <slots.root {...slotProps.root}>
-      <slots.label {...slotProps.label} />
+      <slots.initials {...slotProps.initials} />
       <slots.icon {...slotProps.icon} />
       <slots.image {...slotProps.image} />
       <slots.badge {...slotProps.badge} />

--- a/packages/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
-import { getInitials as getInitialsDefault } from '../../utils/index';
+import { getInitials } from '../../utils/index';
 import type { AvatarNamedColor, AvatarProps, AvatarState } from './Avatar.types';
 import { PersonRegular } from '@fluentui/react-icons';
 import { PresenceBadge } from '@fluentui/react-badge';
@@ -8,15 +8,7 @@ import { useFluent } from '@fluentui/react-shared-contexts';
 
 export const useAvatar = (props: AvatarProps, ref: React.Ref<HTMLElement>): AvatarState => {
   const { dir } = useFluent();
-  const {
-    name = '',
-    size = 32,
-    shape = 'circular',
-    active = 'unset',
-    activeAppearance = 'ring',
-    idForColor,
-    getInitials = getInitialsDefault,
-  } = props;
+  const { name = '', size = 32, shape = 'circular', active = 'unset', activeAppearance = 'ring', idForColor } = props;
   let { color = 'neutral' } = props;
 
   // Resolve 'colorful' to a specific color name
@@ -32,19 +24,18 @@ export const useAvatar = (props: AvatarProps, ref: React.Ref<HTMLElement>): Avat
     activeAppearance,
     color,
     idForColor,
-    getInitials,
 
     components: {
       root: 'span',
-      label: 'span',
+      initials: 'span',
       icon: 'span',
       image: 'img',
       badge: PresenceBadge,
     },
 
     root: getNativeElementProps('span', { ...props, ref }),
-    label: resolveShorthand(props.label),
-    icon: undefined, // The icon will be resolved below if there is no label text
+    initials: resolveShorthand(props.initials),
+    icon: undefined, // The icon will be resolved below if initials is empty
     image: resolveShorthand(props.image),
     badge: resolveShorthand(props.badge, {
       defaultProps: { size: getBadgeSize(size) },
@@ -52,10 +43,10 @@ export const useAvatar = (props: AvatarProps, ref: React.Ref<HTMLElement>): Avat
   };
 
   // If a label was not provided, use the initials and fall back to the icon if initials aren't available
-  if (!state.label?.children) {
-    const initials = state.getInitials(state.name, dir === 'rtl');
+  if (!state.initials?.children) {
+    const initials = getInitials(state.name, dir === 'rtl');
     if (initials) {
-      state.label = { ...state.label, children: initials };
+      state.initials = { ...state.initials, children: initials };
     } else {
       state.icon = resolveShorthand(props.icon, {
         required: true,

--- a/packages/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -8,12 +8,12 @@ import { useFluent } from '@fluentui/react-shared-contexts';
 
 export const useAvatar = (props: AvatarProps, ref: React.Ref<HTMLElement>): AvatarState => {
   const { dir } = useFluent();
-  const { name = '', size = 32, shape = 'circular', active = 'unset', activeAppearance = 'ring', idForColor } = props;
+  const { name, size = 32, shape = 'circular', active = 'unset', activeAppearance = 'ring', idForColor } = props;
   let { color = 'neutral' } = props;
 
   // Resolve 'colorful' to a specific color name
   if (color === 'colorful') {
-    color = avatarColors[getHashCode(props.idForColor ?? props.name ?? '') % avatarColors.length];
+    color = avatarColors[getHashCode(idForColor ?? name ?? '') % avatarColors.length];
   }
 
   const state: AvatarState = {
@@ -42,9 +42,9 @@ export const useAvatar = (props: AvatarProps, ref: React.Ref<HTMLElement>): Avat
     }),
   };
 
-  // If a label was not provided, use the initials and fall back to the icon if initials aren't available
+  // If initials were not provided, get initials from the name, or fall back to the icon if initials aren't available
   if (!state.initials?.children) {
-    const initials = getInitials(state.name, dir === 'rtl');
+    const initials = getInitials(name, dir === 'rtl');
     if (initials) {
       state.initials = { ...state.initials, children: initials };
     } else {

--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -445,8 +445,8 @@ export const useAvatarStyles = (state: AvatarState): AvatarState => {
     state.image.className = mergeClasses(styles.image, state.image.className);
   }
 
-  if (state.label) {
-    state.label.className = mergeClasses(styles.iconLabel, state.label.className);
+  if (state.initials) {
+    state.initials.className = mergeClasses(styles.iconLabel, state.initials.className);
   }
 
   if (state.icon) {


### PR DESCRIPTION
## Current Behavior

* Avatar's `label` slot is confusingly named: its purpose is to display the initials, not a general purpose label
* Avatar doesn't have good accessibility

## New Behavior

* Remove Avatar's `getInitials` prop. Instead, the user can just set `initials={myCustomInitialsFunction(name)}`
* Default the image's `alt` attribute to the name
* Update aria props to the initials and icon slots:
   * Add `aria-hidden="true"` if the image is present
   * If there's no image, add `role="img" aria-label={name}` to make the avatar appear as an image to accessibility tools.
