### PR TITLE
fix: MenuTrigger should work correctly when `aria-disabled="true"`

### DIFF
--- a/change/@fluentui-react-menu-154a57c9-4439-40a0-8587-74adcfe20434.json
+++ b/change/@fluentui-react-menu-154a57c9-4439-40a0-8587-74adcfe20434.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: MenuTrigger should work correctly when `aria-disabled=\"true\"`",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
+++ b/packages/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import { MenuTrigger } from './MenuTrigger';
 import * as renderer from 'react-test-renderer';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { isConformant } from '../../common/isConformant';
+import { mockUseMenuContext } from '../../common/mockUseMenuContext';
+
+jest.mock('../../contexts/menuContext.ts');
 
 describe('MenuTrigger', () => {
+  beforeEach(() => mockUseMenuContext());
+
   isConformant({
     disabledTests: [
       // MenuTrigger does not render DOM elements
@@ -51,7 +56,7 @@ describe('MenuTrigger', () => {
       Array [
         <button
           aria-haspopup="menu"
-          id=""
+          id="id"
         >
           Trigger
         </button>,
@@ -81,11 +86,54 @@ describe('MenuTrigger', () => {
       Array [
         <button
           aria-haspopup="menu"
-          id=""
+          id="id"
         >
           Trigger
         </button>,
       ]
     `);
+  });
+
+  it('should not open menu when aria-disabled is true', () => {
+    const setOpen = jest.fn();
+    mockUseMenuContext({ setOpen });
+
+    const { getByRole } = render(
+      <MenuTrigger>
+        <button aria-disabled>trigger</button>
+      </MenuTrigger>,
+    );
+    fireEvent.click(getByRole('button'));
+
+    expect(setOpen).toBeCalledTimes(0);
+  });
+
+  it('should open menu when aria-disabled is false', () => {
+    const setOpen = jest.fn();
+    mockUseMenuContext({ setOpen });
+
+    const { getByRole } = render(
+      <MenuTrigger>
+        <button aria-disabled={false}>trigger</button>
+      </MenuTrigger>,
+    );
+    fireEvent.click(getByRole('button'));
+
+    expect(setOpen).toBeCalledTimes(1);
+    expect(setOpen).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ open: true }));
+  });
+
+  it('should open menu when trigger is disabled', () => {
+    const setOpen = jest.fn();
+    mockUseMenuContext({ setOpen });
+
+    const { getByRole } = render(
+      <MenuTrigger>
+        <button disabled>trigger</button>
+      </MenuTrigger>,
+    );
+    fireEvent.click(getByRole('button'));
+
+    expect(setOpen).toBeCalledTimes(0);
   });
 });

--- a/packages/react-menu/src/components/MenuTrigger/__snapshots__/MenuTrigger.test.tsx.snap
+++ b/packages/react-menu/src/components/MenuTrigger/__snapshots__/MenuTrigger.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MenuTrigger renders a default state 1`] = `
 <button
   aria-haspopup="menu"
-  id=""
+  id="id"
   onClick={[Function]}
   onContextMenu={[Function]}
   onKeyDown={[Function]}

--- a/packages/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
@@ -148,7 +148,8 @@ export const useMenuTrigger = (props: MenuTriggerProps, ref: React.Ref<HTMLEleme
 };
 
 const isTargetDisabled = (e: React.SyntheticEvent | Event) => {
-  const isDisabled = (el: HTMLElement) => el.hasAttribute('disabled') || el.hasAttribute('aria-disabled');
+  const isDisabled = (el: HTMLElement) =>
+    el.hasAttribute('disabled') || (el.hasAttribute('aria-disabled') && el.getAttribute('aria-disabled') === 'true');
   if (e.target instanceof HTMLElement && isDisabled(e.target)) {
     return true;
   }


### PR DESCRIPTION
Adds a check to `isTargetDisabled` to not only check the presence of
`aria-disabled` but its value

## Current Behavior

`SplitButton` is broken since `aria-disabled` will always be present on the trigger with `true` and `false` values. Since existing `MenuTrigger` only checks the presence of the attribute, the menu will never open.

## New Behavior

`SplitButton` will open the menu correctly

## Related Issue(s)

Fixes #21350
