### PR TITLE
react-badge: Updated best practices for long text

### DIFF
--- a/change/@fluentui-react-badge-d43aec0f-403d-43e0-a257-d246681911bf.json
+++ b/change/@fluentui-react-badge-d43aec0f-403d-43e0-a257-d246681911bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated best practices for long text",
+  "packageName": "@fluentui/react-badge",
+  "email": "tkrasniqi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-badge/src/BadgeBestPractices.md
+++ b/packages/react-badge/src/BadgeBestPractices.md
@@ -16,4 +16,8 @@
 ### Badge shouldn't rely only on color information
 
 - Include meaningful descriptions when using color to represent meaning in a badge. If relying on color only [unread dot] ensure that non-visual information is included using aria-describedby
+
+### Text on Badge
+
+- Badges are intented to have short text, small numerical values or status information. Long text is not supported and should not be used within a Badge.
 </details>


### PR DESCRIPTION
## Current Behavior
Badges should not have long text, they are intended for short text or small numerical values. If a long text is added to a Badge it will result into a broken UI especially in zoom. 

This PR adds this information to the best practices so that it is explicitly mention how it should be used.
## New Behavior
No change to the Badge functionality.

## Related Issue(s)

Fixes #21130
