### PR TITLE
Fix tooltip arrow's high contrast border in RTL

### DIFF
--- a/change/@fluentui-react-positioning-8bf7e435-add2-4059-8c21-b1f66706a1d9.json
+++ b/change/@fluentui-react-positioning-8bf7e435-add2-4059-8c21-b1f66706a1d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix tooltip arrow's high contrast border in RTL",
+  "packageName": "@fluentui/react-positioning",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-positioning/src/createArrowStyles.ts
+++ b/packages/react-positioning/src/createArrowStyles.ts
@@ -82,7 +82,11 @@ export function createArrowStyles(options: CreateArrowStylesOptions): MakeStyles
       width: 'inherit',
       height: 'inherit',
       backgroundColor: 'inherit',
-      ...shorthands.borderRight(borderWidth, borderStyle, borderColor),
+      ...shorthands.borderRight(
+        `${borderWidth} /* @noflip */`,
+        `${borderStyle} /* @noflip */`,
+        `${borderColor} /* @noflip */`,
+      ),
       ...shorthands.borderBottom(borderWidth, borderStyle, borderColor),
       borderBottomRightRadius: tokens.borderRadiusSmall,
       transform: 'rotate(var(--angle)) translate(0, 50%) rotate(45deg)',


### PR DESCRIPTION
## Current Behavior

The high contrast arrow border for tooltip is wrong in RTL:
![image](https://user-images.githubusercontent.com/48106640/150338046-0adc7eae-ffba-4bfb-893b-787e29c46025.png)

## New Behavior

Don't flip the border's side for RTL, since RTL is already handled by popper.

![image](https://user-images.githubusercontent.com/48106640/150338590-a5e276b1-d1bf-4e10-aa2c-3669f83f5df7.png)
