### PR TITLE
divider: minimum line length

### DIFF
--- a/change/@fluentui-react-divider-02ac1b84-8ea4-482b-b277-223375b8e172.json
+++ b/change/@fluentui-react-divider-02ac1b84-8ea4-482b-b277-223375b8e172.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "set minimum line length based on a11y review",
+  "packageName": "@fluentui/react-divider",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-divider/src/components/Divider/useDividerStyles.ts
+++ b/packages/react-divider/src/components/Divider/useDividerStyles.ts
@@ -6,8 +6,8 @@ export const dividerClassName = 'fui-Divider';
 
 const contentSpacing = '12px';
 const insetSpacing = '12px';
-const startEndMaxHeight = '8px';
-const minLineSegmentLength = '32px;';
+const maxStartEndLength = '8px';
+const minStartEndLength = '8px;';
 
 const useBaseStyles = makeStyles({
   // Base styles
@@ -115,13 +115,13 @@ const useHorizontalStyles = makeStyles({
     ':before': {
       borderTopStyle: 'solid',
       borderTopWidth: tokens.strokeWidthThin,
-      minWidth: minLineSegmentLength,
+      minWidth: minStartEndLength,
     },
 
     ':after': {
       borderTopStyle: 'solid',
       borderTopWidth: tokens.strokeWidthThin,
-      minWidth: minLineSegmentLength,
+      minWidth: minStartEndLength,
     },
   },
 
@@ -136,7 +136,7 @@ const useHorizontalStyles = makeStyles({
     ':before': {
       content: '""',
       marginRight: contentSpacing,
-      maxWidth: startEndMaxHeight,
+      maxWidth: maxStartEndLength,
     },
 
     ':after': {
@@ -158,7 +158,7 @@ const useHorizontalStyles = makeStyles({
     ':after': {
       content: '""',
       marginLeft: contentSpacing,
-      maxWidth: startEndMaxHeight,
+      maxWidth: maxStartEndLength,
     },
   },
 });
@@ -172,13 +172,13 @@ const useVerticalStyles = makeStyles({
     ':before': {
       borderRightStyle: 'solid',
       borderRightWidth: tokens.strokeWidthThin,
-      minHeight: minLineSegmentLength,
+      minHeight: minStartEndLength,
     },
 
     ':after': {
       borderRightStyle: 'solid',
       borderRightWidth: tokens.strokeWidthThin,
-      minHeight: minLineSegmentLength,
+      minHeight: minStartEndLength,
     },
   },
 
@@ -198,7 +198,7 @@ const useVerticalStyles = makeStyles({
     ':before': {
       content: '""',
       marginBottom: contentSpacing,
-      maxHeight: startEndMaxHeight,
+      maxHeight: maxStartEndLength,
     },
 
     ':after': {
@@ -220,7 +220,7 @@ const useVerticalStyles = makeStyles({
     ':after': {
       content: '""',
       marginTop: contentSpacing,
-      maxHeight: startEndMaxHeight,
+      maxHeight: maxStartEndLength,
     },
   },
 });

--- a/packages/react-divider/src/components/Divider/useDividerStyles.ts
+++ b/packages/react-divider/src/components/Divider/useDividerStyles.ts
@@ -7,6 +7,7 @@ export const dividerClassName = 'fui-Divider';
 const contentSpacing = '12px';
 const insetSpacing = '12px';
 const startEndMaxHeight = '8px';
+const minLineSegmentLength = '32px;';
 
 const useBaseStyles = makeStyles({
   // Base styles
@@ -22,6 +23,7 @@ const useBaseStyles = makeStyles({
     fontSize: tokens.fontSizeBase200,
     fontWeight: tokens.fontWeightRegular,
     lineHeight: tokens.lineHeightBase200,
+    textAlign: 'center',
 
     color: tokens.colorNeutralForeground2,
 
@@ -29,7 +31,6 @@ const useBaseStyles = makeStyles({
       boxSizing: 'border-box',
       display: 'flex',
       flexGrow: 1,
-
       ...shorthands.borderColor(tokens.colorNeutralStroke2),
     },
 
@@ -37,7 +38,6 @@ const useBaseStyles = makeStyles({
       boxSizing: 'border-box',
       display: 'flex',
       flexGrow: 1,
-
       ...shorthands.borderColor(tokens.colorNeutralStroke2),
     },
   },
@@ -115,11 +115,13 @@ const useHorizontalStyles = makeStyles({
     ':before': {
       borderTopStyle: 'solid',
       borderTopWidth: tokens.strokeWidthThin,
+      minWidth: minLineSegmentLength,
     },
 
     ':after': {
       borderTopStyle: 'solid',
       borderTopWidth: tokens.strokeWidthThin,
+      minWidth: minLineSegmentLength,
     },
   },
 
@@ -170,11 +172,13 @@ const useVerticalStyles = makeStyles({
     ':before': {
       borderRightStyle: 'solid',
       borderRightWidth: tokens.strokeWidthThin,
+      minHeight: minLineSegmentLength,
     },
 
     ':after': {
       borderRightStyle: 'solid',
       borderRightWidth: tokens.strokeWidthThin,
+      minHeight: minLineSegmentLength,
     },
   },
 


### PR DESCRIPTION
## Current Behavior

When the divider has a very long string as the content, it will take up all the available room before it wraps.
This causes the line to be pushed to zero width and hides the line.

## New Behavior

The line segments on either side have a minimum width of 32px (based on recommendation from designer)
The content text alignment is set to centered (otherwise the line min width cause a left-aligned text which looks incorrect)

## Related Issue(s)

Related to #21105
