### PR TITLE
Combobox: remove default title attribute applied to options.

### DIFF
--- a/change/@fluentui-react-249e5fdc-e376-4786-8ac6-ef8519937ca0.json
+++ b/change/@fluentui-react-249e5fdc-e376-4786-8ac6-ef8519937ca0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Combobox: Title attribute is no longer applied to ",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-249e5fdc-e376-4786-8ac6-ef8519937ca0.json
+++ b/change/@fluentui-react-249e5fdc-e376-4786-8ac6-ef8519937ca0.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Combobox: Title attribute is no longer applied to ",
+  "comment": "Combobox: remove default title attribute added to options.",
   "packageName": "@fluentui/react",
   "email": "tristan.watanabe@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1461,7 +1461,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const isIndeterminate: boolean = this._isOptionIndeterminate(item.index);
     const optionStyles = this._getCurrentOptionStyles(item);
     const optionClassNames = getComboBoxOptionClassNames(this._getCurrentOptionStyles(item));
-    const title = item.title ?? undefined;
+    const title = item.title;
 
     const onRenderCheckboxLabel = () => onRenderOption(item, this._onRenderOptionContent);
 

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1461,7 +1461,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const isIndeterminate: boolean = this._isOptionIndeterminate(item.index);
     const optionStyles = this._getCurrentOptionStyles(item);
     const optionClassNames = getComboBoxOptionClassNames(this._getCurrentOptionStyles(item));
-    const title = item.title ?? getPreviewText(item);
+    const title = item.title ?? undefined;
 
     const onRenderCheckboxLabel = () => onRenderOption(item, this._onRenderOptionContent);
 

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -923,7 +923,6 @@ exports[`ComboBox Renders correctly when open 1`] = `
                     data-is-focusable="true"
                     id="ComboBox0-list1"
                     role="option"
-                    title="Option 1"
                     type="button"
                   >
                     <span
@@ -1085,7 +1084,6 @@ exports[`ComboBox Renders correctly when open 1`] = `
                   data-is-focusable="true"
                   id="ComboBox0-list3"
                   role="option"
-                  title="Option 2"
                   type="button"
                 >
                   <span
@@ -1665,7 +1663,6 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                         & .ms-Checkbox-label {
                           width: 100%;
                         }
-                    title="Option 1"
                   >
                     <input
                       aria-selected="false"
@@ -1688,7 +1685,6 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                       data-ktp-execute-target="true"
                       id="ComboBox0-list1"
                       role="option"
-                      title="Option 1"
                       type="checkbox"
                     />
                     <label
@@ -1880,7 +1876,6 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                       & .ms-Checkbox-label {
                         width: 100%;
                       }
-                  title="Option 2"
                 >
                   <input
                     aria-selected="true"
@@ -1904,7 +1899,6 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                     data-ktp-execute-target="true"
                     id="ComboBox0-list3"
                     role="option"
-                    title="Option 2"
                     type="checkbox"
                   />
                   <label


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

- `Combobox` automatically applies a `title` attribute to each option item which causes an NVDA issue where the option item’s name is announced twice. 

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- `Combobox` will only apply the `title` attribute to the option item only if the option item explicitly passes a `title` prop.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes [10748](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10748)
