### PR TITLE
Add logical margins CSS properties to IRawStyleBase, resolves #21321

### DIFF
--- a/change/@fluentui-merge-styles-311979b9-ac34-4eab-9d7c-7e8a3b61f638.json
+++ b/change/@fluentui-merge-styles-311979b9-ac34-4eab-9d7c-7e8a3b61f638.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add logical margins CSS properties to IRawStyleBase",
+  "packageName": "@fluentui/merge-styles",
+  "email": "beavi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -251,7 +251,11 @@ export interface IRawStyleBase extends IRawFontStyle {
     listStylePosition?: ICSSRule | string;
     listStyleType?: ICSSRule | string;
     margin?: ICSSRule | ICSSPixelUnitRule;
+    marginBlockEnd?: ICSSRule | ICSSPixelUnitRule;
+    marginBlockStart?: ICSSRule | ICSSPixelUnitRule;
     marginBottom?: ICSSRule | ICSSPixelUnitRule;
+    marginInlineEnd?: ICSSRule | ICSSPixelUnitRule;
+    marginInlineStart?: ICSSRule | ICSSPixelUnitRule;
     marginLeft?: ICSSRule | ICSSPixelUnitRule;
     marginRight?: ICSSRule | ICSSPixelUnitRule;
     marginTop?: ICSSRule | ICSSPixelUnitRule;

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -1268,9 +1268,37 @@ export interface IRawStyleBase extends IRawFontStyle {
   margin?: ICSSRule | ICSSPixelUnitRule;
 
   /**
+   * The margin-block-end CSS property defines the logical block end margin of an element, which maps to a physical
+   * margin depending on the element's writing mode, directionality, and text orientation.
+   */
+  marginBlockEnd?: ICSSRule | ICSSPixelUnitRule;
+
+  /**
+   * The margin-block-start CSS property defines the logical block start margin of an element, which maps to a physical
+   * margin depending on the element's writing mode, directionality, and text orientation.
+   */
+  marginBlockStart?: ICSSRule | ICSSPixelUnitRule;
+
+  /**
    * margin-bottom sets the bottom margin of an element.
    */
   marginBottom?: ICSSRule | ICSSPixelUnitRule;
+
+  /**
+   * The margin-inline-end CSS property defines the logical inline end margin of an element, which maps to a physical
+   * margin depending on the element's writing mode, directionality, and text orientation. In other words, it
+   * corresponds to the margin-top, margin-right, margin-bottom or margin-left property depending on the values defined
+   * for writing-mode, direction, and text-orientation.
+   */
+  marginInlineEnd?: ICSSRule | ICSSPixelUnitRule;
+
+  /**
+   * The margin-inline-start CSS property defines the logical inline start margin of an element, which maps to a
+   * physical margin depending on the element's writing mode, directionality, and text orientation. It corresponds to
+   * the margin-top, margin-right, margin-bottom, or margin-left property depending on the values defined for
+   * writing-mode, direction, and text-orientation.
+   */
+  marginInlineStart?: ICSSRule | ICSSPixelUnitRule;
 
   /**
    * margin-left sets the left margin of an element.

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -1269,13 +1269,17 @@ export interface IRawStyleBase extends IRawFontStyle {
 
   /**
    * The margin-block-end CSS property defines the logical block end margin of an element, which maps to a physical
-   * margin depending on the element's writing mode, directionality, and text orientation.
+   * margin depending on the element's writing mode, directionality, and text orientation. It corresponds to the
+   * margin-top, margin-right, margin-bottom or margin-left property depending on the values defined for writing-mode,
+   * direction, and text-orientation.
    */
   marginBlockEnd?: ICSSRule | ICSSPixelUnitRule;
 
   /**
    * The margin-block-start CSS property defines the logical block start margin of an element, which maps to a physical
-   * margin depending on the element's writing mode, directionality, and text orientation.
+   * margin depending on the element's writing mode, directionality, and text orientation. It corresponds to the
+   * margin-top, margin-right, margin-bottom or margin-left property depending on the values defined for writing-mode,
+   * direction, and text-orientation.
    */
   marginBlockStart?: ICSSRule | ICSSPixelUnitRule;
 
@@ -1286,9 +1290,9 @@ export interface IRawStyleBase extends IRawFontStyle {
 
   /**
    * The margin-inline-end CSS property defines the logical inline end margin of an element, which maps to a physical
-   * margin depending on the element's writing mode, directionality, and text orientation. In other words, it
-   * corresponds to the margin-top, margin-right, margin-bottom or margin-left property depending on the values defined
-   * for writing-mode, direction, and text-orientation.
+   * margin depending on the element's writing mode, directionality, and text orientation. It corresponds to the
+   * margin-top, margin-right, margin-bottom or margin-left property depending on the values defined for writing-mode,
+   * direction, and text-orientation.
    */
   marginInlineEnd?: ICSSRule | ICSSPixelUnitRule;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

I have followed other commits that add CSS properties like https://github.com/microsoft/fluentui/commit/50a43b5d1e13e6d507ab15477316bb5742fa6dbb, https://github.com/microsoft/fluentui/commit/dedb9ae121ac9fb983e35877fe4dbb6512fd8235 and https://github.com/microsoft/fluentui/commit/1959808480faf783fd56f51294f58467371538ad. Please, let me know if some more work is needed.

## Current Behavior

It is not possible to use logical margins CSS properties, e.g.
<Text styles={{ root: { marginInlineStart: '12px' } }}>

## New Behavior

It should be possible to use logical margins CSS properties.

## Related Issue(s)

https://github.com/microsoft/fluentui/issues/21321

Fixes #21321 
