### PR TITLE
fix(Calendar): re-remove aria-readonly on grid cells

### DIFF
--- a/change/@fluentui-react-98c7b050-b677-41f4-8303-36efc8bbfee7.json
+++ b/change/@fluentui-react-98c7b050-b677-41f4-8303-36efc8bbfee7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix aria-readonly regression in Calendar",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -236,7 +236,6 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
       onKeyDown={!ariaHidden ? onDayKeyDown : undefined}
       role="gridcell"
       tabIndex={isNavigatedDate ? 0 : undefined}
-      aria-readonly="true"
       aria-current={day.isSelected ? 'date' : undefined}
       aria-selected={day.isInBounds ? day.isSelected : undefined}
       data-is-focusable={!ariaHidden && (allFocusable || (day.isInBounds ? true : undefined))}

--- a/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
+++ b/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
@@ -593,7 +593,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -707,7 +706,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -821,7 +819,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -935,7 +932,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -1049,7 +1045,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -1163,7 +1158,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -1277,7 +1271,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -1396,7 +1389,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
         >
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -1538,7 +1530,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -1680,7 +1671,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -1822,7 +1812,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -1965,7 +1954,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-current="date"
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={true}
             className=
                 ms-CalendarDay-daySelected
@@ -2157,7 +2145,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -2295,7 +2282,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -2449,7 +2435,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -2559,7 +2544,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -2669,7 +2653,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -2779,7 +2762,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -2889,7 +2871,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -2999,7 +2980,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -3109,7 +3089,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -3907,7 +3886,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4021,7 +3999,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4135,7 +4112,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4249,7 +4225,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4363,7 +4338,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4477,7 +4451,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4591,7 +4564,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4710,7 +4682,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
         >
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4852,7 +4823,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4995,7 +4965,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-current="date"
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={true}
             className=
                 ms-CalendarDay-daySelected
@@ -5187,7 +5156,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -5325,7 +5293,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -5463,7 +5430,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -5601,7 +5567,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -5755,7 +5720,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -5865,7 +5829,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -5975,7 +5938,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -6085,7 +6047,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -6195,7 +6156,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -6305,7 +6265,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -6415,7 +6374,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 


### PR DESCRIPTION
Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally

I unintentionally un-did the `CalendarDayGridCell` `aria-readonly` fix from this PR: #20324 in a simultaneous calendar fix PR. This re-fixes the original fix.
