### PR TITLE
positioningContainer to include changes in v8

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.styles.ts
@@ -1,5 +1,6 @@
 import { memoizeFunction } from '../../../Utilities';
-import { mergeStyleSets, focusClear, IStyle, HighContrastSelector } from '../../../Styling';
+import { mergeStyleSets, focusClear, HighContrastSelector } from '../../../Styling';
+import type { IStyle } from '../../../Styling';
 
 export interface IPositioningContainerStyles {
   /**

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
@@ -1,438 +1,395 @@
 import * as React from 'react';
-import { IPositioningContainerProps } from './PositioningContainer.types';
 import { getClassNames } from './PositioningContainer.styles';
+import { ZIndexes } from '../../../Styling';
 import { Layer } from '../../../Layer';
 
 // Utilites/Helpers
 import { DirectionalHint } from '../../../common/DirectionalHint';
-import {
-  Point,
-  IRectangle,
-  css,
-  elementContains,
-  focusFirstChild,
-  getWindow,
-  getDocument,
-  initializeComponentRef,
-  Async,
-  EventGroup,
-} from '../../../Utilities';
+import { css, elementContains, focusFirstChild, EventGroup, getPropsWithDefaults } from '../../../Utilities';
 
-import {
-  getMaxHeight,
-  positionElement,
-  IPositionedData,
-  IPositionProps,
-  IPosition,
-  RectangleEdge,
-} from '../../../utilities/positioning';
+import { getMaxHeight, positionElement, RectangleEdge } from '../../../Positioning';
 
 import { AnimationClassNames, mergeStyles } from '../../../Styling';
+import { useMergedRefs, useAsync, useTarget } from '@fluentui/react-hooks';
+import type { IPositioningContainerProps } from './PositioningContainer.types';
+import type { Point, IRectangle } from '../../../Utilities';
+import type { IPositionedData, IPositionProps, IPosition } from '../../../Positioning';
 
 const OFF_SCREEN_STYLE = { opacity: 0 };
 
-// In order for some of the max height logic to work
-// properly we need to set the border.
-// The value is abitrary.
+// In order for some of the max height logic to work properly we need to set the border.
+// The value is arbitrary.
 const BORDER_WIDTH = 1;
-const SLIDE_ANIMATIONS: { [key: number]: string } = {
+const SLIDE_ANIMATIONS = {
   [RectangleEdge.top]: 'slideUpIn20',
   [RectangleEdge.bottom]: 'slideDownIn20',
   [RectangleEdge.left]: 'slideLeftIn20',
   [RectangleEdge.right]: 'slideRightIn20',
+} as const;
+
+const DEFAULT_PROPS = {
+  preventDismissOnScroll: false,
+  offsetFromTarget: 0,
+  minPagePadding: 8,
+  directionalHint: DirectionalHint.bottomAutoEdge,
 };
 
-export interface IPositioningContainerState {
-  /**
-   * Current set of calcualted positions for the outermost parent container.
-   */
-  positions?: IPositionedData;
+function useCachedBounds(props: IPositioningContainerProps, targetWindow: Window | undefined) {
+  /** The bounds used when determining if and where the PositioningContainer should be placed. */
+  const positioningBounds = React.useRef<IRectangle>();
 
-  /**
-   * Tracks the current height offset and updates during
-   * the height animation when props.finalHeight is specified.
-   */
-  heightOffset?: number;
-}
-
-export class PositioningContainer extends React.Component<IPositioningContainerProps, IPositioningContainerState>
-  implements PositioningContainer {
-  public static defaultProps: IPositioningContainerProps = {
-    preventDismissOnScroll: false,
-    offsetFromTarget: 0,
-    minPagePadding: 8,
-    directionalHint: DirectionalHint.bottomAutoEdge,
-  };
-
-  private _didSetInitialFocus: boolean;
-
-  /**
-   * The primary positioned div.
-   */
-  private _positionedHost = React.createRef<HTMLDivElement>();
-
-  // @TODO rename to reflect the name of this class
-  private _contentHost = React.createRef<HTMLDivElement>();
-
-  /**
-   * Stores an instance of Window, used to check
-   * for server side rendering and if focus was lost.
-   */
-  private _targetWindow: Window;
-
-  /**
-   * The bounds used when determing if and where the
-   * PositioningContainer should be placed.
-   */
-  private _positioningBounds: IRectangle;
-
-  /**
-   * The maximum height the PositioningContainer can grow to
-   * without going being the window or target bounds
-   */
-  private _maxHeight: number | undefined;
-  private _positionAttempts: number;
-  private _target: HTMLElement | MouseEvent | Point | null;
-  private _setHeightOffsetTimer: number;
-  private _async: Async;
-  private _events: EventGroup;
-
-  constructor(props: IPositioningContainerProps) {
-    super(props);
-
-    initializeComponentRef(this);
-    this._async = new Async(this);
-    this._events = new EventGroup(this);
-
-    this._didSetInitialFocus = false;
-    this.state = {
-      positions: undefined,
-      heightOffset: 0,
-    };
-    this._positionAttempts = 0;
-  }
-
-  public UNSAFE_componentWillMount(): void {
-    this._setTargetWindowAndElement(this._getTarget());
-  }
-
-  public componentDidMount(): void {
-    this._onComponentDidMount();
-  }
-
-  public componentDidUpdate(): void {
-    this._setInitialFocus();
-    this._updateAsyncPosition();
-  }
-
-  public UNSAFE_componentWillUpdate(newProps: IPositioningContainerProps): void {
-    // If the target element changed, find the new one. If we are tracking
-    // target with class name, always find element because we do not know if
-    // fabric has rendered a new element and disposed the old element.
-    const newTarget = this._getTarget(newProps);
-    const oldTarget = this._getTarget();
-    if (newTarget !== oldTarget || typeof newTarget === 'string' || newTarget instanceof String) {
-      this._maxHeight = undefined;
-      this._setTargetWindowAndElement(newTarget!);
-    }
-
-    if (newProps.offsetFromTarget !== this.props.offsetFromTarget) {
-      this._maxHeight = undefined;
-    }
-
-    if (newProps.finalHeight !== this.props.finalHeight) {
-      this._setHeightOffsetEveryFrame();
-    }
-  }
-
-  public componentWillUnmount(): void {
-    this._async.dispose();
-    this._events.dispose();
-  }
-
-  public render(): JSX.Element | null {
-    // If there is no target window then we are likely in server side rendering and we should not render anything.
-    if (!this._targetWindow) {
-      return null;
-    }
-
-    const { className, positioningContainerWidth, positioningContainerMaxHeight, children } = this.props;
-    const { positions } = this.state;
-
-    const styles = getClassNames();
-
-    const directionalClassName =
-      positions && positions.targetEdge ? (AnimationClassNames as any)[SLIDE_ANIMATIONS[positions.targetEdge]] : '';
-
-    const getContentMaxHeight: number = this._getMaxHeight() + this.state.heightOffset!;
-    const contentMaxHeight: number =
-      positioningContainerMaxHeight! && positioningContainerMaxHeight! > getContentMaxHeight
-        ? getContentMaxHeight
-        : positioningContainerMaxHeight!;
-    const content = (
-      <div ref={this._positionedHost} className={css('ms-PositioningContainer', styles.container)}>
-        <div
-          className={mergeStyles(
-            'ms-PositioningContainer-layerHost',
-            styles.root,
-            className,
-            directionalClassName,
-            !!positioningContainerWidth && { width: positioningContainerWidth },
-          )}
-          style={positions ? positions.elementPosition : OFF_SCREEN_STYLE}
-          // Safari and Firefox on Mac OS requires this to back-stop click events so focus remains in the Callout.
-          // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-          tabIndex={-1}
-          ref={this._contentHost}
-        >
-          {children}
-          {
-            // @TODO apply to the content container
-            contentMaxHeight
-          }
-        </div>
-      </div>
-    );
-
-    return this.props.doNotLayer ? content : <Layer>{content}</Layer>;
-  }
-
-  /**
-   * Deprecated, use `onResize` instead.
-   * @deprecated Use `onResize` instead.
-   */
-  public dismiss = (ev?: Event | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>): void => {
-    this.onResize(ev);
-  };
-
-  public onResize = (ev?: Event | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>): void => {
-    const { onDismiss } = this.props;
-    if (onDismiss) {
-      onDismiss(ev);
-    } else {
-      this._updateAsyncPosition();
-    }
-  };
-
-  protected _dismissOnScroll(ev: Event): void {
-    const { preventDismissOnScroll } = this.props;
-    if (this.state.positions && !preventDismissOnScroll) {
-      this._dismissOnLostFocus(ev);
-    }
-  }
-
-  protected _dismissOnLostFocus(ev: Event): void {
-    const target = ev.target as HTMLElement;
-    const clickedOutsideCallout =
-      this._positionedHost.current && !elementContains(this._positionedHost.current, target);
-
-    if (
-      (!this._target && clickedOutsideCallout) ||
-      (ev.target !== this._targetWindow &&
-        clickedOutsideCallout &&
-        ((this._target as MouseEvent).stopPropagation ||
-          !this._target ||
-          (target !== this._target && !elementContains(this._target as HTMLElement, target))))
-    ) {
-      this.onResize(ev);
-    }
-  }
-
-  protected _setInitialFocus = (): void => {
-    if (this._contentHost.current && this.props.setInitialFocus && !this._didSetInitialFocus && this.state.positions) {
-      this._didSetInitialFocus = true;
-      focusFirstChild(this._contentHost.current);
-    }
-  };
-
-  protected _onComponentDidMount = (): void => {
-    // This is added so the positioningContainer will dismiss when the window is scrolled
-    // but not when something inside the positioningContainer is scrolled. The delay seems
-    // to be required to avoid React firing an async focus event in IE from
-    // the target changing focus quickly prior to rendering the positioningContainer.
-    this._async.setTimeout(() => {
-      this._events.on(this._targetWindow, 'scroll', this._async.throttle(this._dismissOnScroll, 10), true);
-      this._events.on(this._targetWindow, 'resize', this._async.throttle(this.onResize, 10), true);
-      this._events.on(this._targetWindow.document.body, 'focus', this._dismissOnLostFocus, true);
-      this._events.on(this._targetWindow.document.body, 'click', this._dismissOnLostFocus, true);
-    }, 0);
-
-    if (this.props.onLayerMounted) {
-      this.props.onLayerMounted();
-    }
-
-    this._updateAsyncPosition();
-    this._setHeightOffsetEveryFrame();
-  };
-
-  private _updateAsyncPosition(): void {
-    this._async.requestAnimationFrame(() => this._updatePosition());
-  }
-
-  private _updatePosition(): void {
-    const { positions } = this.state;
-    const { offsetFromTarget, onPositioned } = this.props;
-
-    const hostElement = this._positionedHost.current;
-    const positioningContainerElement = this._contentHost.current;
-
-    if (hostElement && positioningContainerElement) {
-      const currentProps: IPositionProps = { ...(this.props as any) };
-      currentProps.bounds = this._getBounds();
-      currentProps.target = this._target!;
-      if (document.body.contains(currentProps.target as Node)) {
-        currentProps.gapSpace = offsetFromTarget;
-        const newPositions: IPositionedData = positionElement(currentProps, hostElement, positioningContainerElement);
-        // Set the new position only when the positions are not exists or one of the new positioningContainer positions
-        // are different. The position should not change if the position is within 2 decimal places.
-        if (
-          (!positions && newPositions) ||
-          (positions && newPositions && !this._arePositionsEqual(positions, newPositions) && this._positionAttempts < 5)
-        ) {
-          // We should not reposition the positioningContainer more than a few times, if it is then the content is
-          // likely resizing and we should stop trying to reposition to prevent a stack overflow.
-          this._positionAttempts++;
-          this.setState(
-            {
-              positions: newPositions,
-            },
-            () => {
-              if (onPositioned) {
-                onPositioned(newPositions);
-              }
-            },
-          );
-        } else {
-          this._positionAttempts = 0;
-          if (onPositioned) {
-            onPositioned(newPositions);
-          }
-        }
-      } else if (positions !== undefined) {
-        this.setState({
-          positions: undefined,
-        });
-      }
-    }
-  }
-
-  private _getBounds(): IRectangle {
-    if (!this._positioningBounds) {
-      let currentBounds = this.props.bounds;
+  const getCachedBounds = (): IRectangle => {
+    if (!positioningBounds.current) {
+      let currentBounds = props.bounds;
 
       if (!currentBounds) {
         currentBounds = {
-          top: 0 + this.props.minPagePadding!,
-          left: 0 + this.props.minPagePadding!,
-          right: this._targetWindow.innerWidth - this.props.minPagePadding!,
-          bottom: this._targetWindow.innerHeight - this.props.minPagePadding!,
-          width: this._targetWindow.innerWidth - this.props.minPagePadding! * 2,
-          height: this._targetWindow.innerHeight - this.props.minPagePadding! * 2,
+          top: 0 + props.minPagePadding!,
+          left: 0 + props.minPagePadding!,
+          right: targetWindow!.innerWidth - props.minPagePadding!,
+          bottom: targetWindow!.innerHeight - props.minPagePadding!,
+          width: targetWindow!.innerWidth - props.minPagePadding! * 2,
+          height: targetWindow!.innerHeight - props.minPagePadding! * 2,
         };
       }
-      this._positioningBounds = currentBounds;
+      positioningBounds.current = currentBounds;
     }
-    return this._positioningBounds;
+    return positioningBounds.current;
+  };
+
+  return getCachedBounds;
+}
+
+function usePositionState(
+  props: IPositioningContainerProps,
+  positionedHost: React.RefObject<HTMLDivElement | null>,
+  contentHost: React.RefObject<HTMLDivElement | null>,
+  targetRef: React.RefObject<Element | MouseEvent | Point | null>,
+  getCachedBounds: () => IRectangle,
+) {
+  const async = useAsync();
+  /**
+   * Current set of calculated positions for the outermost parent container.
+   */
+  const [positions, setPositions] = React.useState<IPositionedData>();
+  const positionAttempts = React.useRef(0);
+
+  const updateAsyncPosition = (): void => {
+    async.requestAnimationFrame(() => updatePosition());
+  };
+
+  const updatePosition = (): void => {
+    const { offsetFromTarget, onPositioned } = props;
+    const hostElement = positionedHost.current;
+    const positioningContainerElement = contentHost.current;
+
+    if (hostElement && positioningContainerElement) {
+      const currentProps: IPositionProps = { ...props } as IPositionProps;
+      currentProps!.bounds = getCachedBounds();
+      currentProps!.target = targetRef.current!;
+      const { target } = currentProps;
+
+      if (target) {
+        // Check if the target is an Element or a MouseEvent and the document contains it
+        // or don't check anything else if the target is a Point or Rectangle
+        if (
+          (!(target as Element).getBoundingClientRect && !(target as MouseEvent).preventDefault) ||
+          document.body.contains(target as Node)
+        ) {
+          currentProps!.gapSpace = offsetFromTarget;
+          const newPositions: IPositionedData = positionElement(
+            currentProps!,
+            hostElement,
+            positioningContainerElement,
+          );
+          // Set the new position only when the positions are not exists or one of the new positioningContainer
+          // positions are different. The position should not change if the position is within 2 decimal places.
+          if (
+            (!positions && newPositions) ||
+            (positions && newPositions && !arePositionsEqual(positions, newPositions) && positionAttempts.current < 5)
+          ) {
+            // We should not reposition the positioningContainer more than a few times, if it is then the content is
+            // likely resizing and we should stop trying to reposition to prevent a stack overflow.
+            positionAttempts.current++;
+            setPositions(newPositions);
+            onPositioned?.(newPositions);
+          } else {
+            positionAttempts.current = 0;
+            onPositioned?.(newPositions);
+          }
+        } else if (positions !== undefined) {
+          setPositions(undefined);
+        }
+      } else if (positions !== undefined) {
+        setPositions(undefined);
+      }
+    }
+  };
+
+  React.useEffect(updateAsyncPosition);
+
+  return [positions, updateAsyncPosition] as const;
+}
+
+function useSetInitialFocus(
+  { setInitialFocus }: IPositioningContainerProps,
+  contentHost: React.RefObject<HTMLDivElement | null>,
+  positions: IPositionedData | undefined,
+) {
+  const didSetInitialFocus = React.useRef(false);
+
+  React.useEffect((): void => {
+    if (!didSetInitialFocus.current && contentHost.current && setInitialFocus && positions) {
+      didSetInitialFocus.current = true;
+      focusFirstChild(contentHost.current);
+    }
+  });
+}
+
+function useMaxHeight(
+  { directionalHintFixed, offsetFromTarget, directionalHint, target }: IPositioningContainerProps,
+  targetRef: React.RefObject<Element | MouseEvent | Point | null>,
+  getCachedBounds: () => IRectangle,
+) {
+  /**
+   * The maximum height the PositioningContainer can grow to
+   * without going beyond the window or target bounds
+   */
+  const maxHeight = React.useRef<number | undefined>();
+
+  // If the target element changed, reset the max height. If we are tracking
+  // target with class name, always reset because we do not know if
+  // fabric has rendered a new element and disposed the old element.
+  if (typeof target === 'string') {
+    maxHeight.current = undefined;
   }
+  React.useEffect(() => {
+    maxHeight.current = undefined;
+  }, [target, offsetFromTarget]);
 
   /**
    * Return the maximum height the container can grow to
    * without going out of the specified bounds
    */
-  private _getMaxHeight(): number {
-    const { directionalHintFixed, offsetFromTarget, directionalHint } = this.props;
-
-    if (!this._maxHeight) {
-      if (directionalHintFixed && this._target) {
+  const getCachedMaxHeight = (): number => {
+    if (!maxHeight.current) {
+      if (directionalHintFixed && targetRef.current) {
         const gapSpace = offsetFromTarget ? offsetFromTarget : 0;
-        this._maxHeight = getMaxHeight(this._target, directionalHint!, gapSpace, this._getBounds());
+        maxHeight.current = getMaxHeight(targetRef.current, directionalHint!, gapSpace, getCachedBounds());
       } else {
-        this._maxHeight = this._getBounds().height! - BORDER_WIDTH * 2;
+        maxHeight.current = getCachedBounds().height! - BORDER_WIDTH * 2;
       }
     }
-    return this._maxHeight!;
-  }
+    return maxHeight.current!;
+  };
 
-  private _arePositionsEqual(positions: IPositionedData, newPosition: IPositionedData): boolean {
-    return this._comparePositions(positions.elementPosition, newPosition.elementPosition);
-  }
+  return getCachedMaxHeight;
+}
 
-  private _comparePositions(oldPositions: IPosition, newPositions: IPosition): boolean {
-    for (const key in newPositions) {
-      if (newPositions.hasOwnProperty(key)) {
-        const oldPositionEdge = oldPositions[key];
-        const newPositionEdge = newPositions[key];
+function useAutoDismissEvents(
+  { onDismiss, preventDismissOnScroll }: IPositioningContainerProps,
+  positionedHost: React.RefObject<HTMLDivElement | null>,
+  targetWindow: Window | undefined,
+  targetRef: React.RefObject<Element | MouseEvent | Point | null>,
+  positions: IPositionedData | undefined,
+  updateAsyncPosition: () => void,
+) {
+  const async = useAsync();
 
-        if (oldPositionEdge && newPositionEdge) {
-          if (oldPositionEdge.toFixed(2) !== newPositionEdge.toFixed(2)) {
-            return false;
-          }
-        }
+  const onResize = React.useCallback(
+    (ev?: Event | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>): void => {
+      if (onDismiss) {
+        onDismiss(ev);
+      } else {
+        updateAsyncPosition();
       }
-    }
-    return true;
-  }
+    },
+    [onDismiss, updateAsyncPosition],
+  );
 
-  private _setTargetWindowAndElement(target: HTMLElement | string | MouseEvent | Point | null): void {
-    const currentElement = this._positionedHost.current;
+  const dismissOnLostFocus = React.useCallback(
+    (ev: Event): void => {
+      const target = ev.target as HTMLElement;
+      const clickedOutsideCallout = positionedHost.current && !elementContains(positionedHost.current, target);
 
-    if (target) {
-      if (typeof target === 'string') {
-        const currentDoc: Document = getDocument()!;
-        this._target = currentDoc ? (currentDoc.querySelector(target) as HTMLElement) : null;
-        this._targetWindow = getWindow(currentElement)!;
-        // Cast to any prevents error about stopPropagation always existing
-      } else if ((target as any).stopPropagation) {
-        this._targetWindow = getWindow((target as MouseEvent).target as HTMLElement)!;
-        this._target = target;
-      } else if (
-        // eslint-disable-next-line deprecation/deprecation
-        ((target as Point).left !== undefined || (target as Point).x !== undefined) &&
-        // eslint-disable-next-line deprecation/deprecation
-        ((target as Point).top !== undefined || (target as Point).y !== undefined)
+      if (
+        (!targetRef.current && clickedOutsideCallout) ||
+        (ev.target !== targetWindow &&
+          clickedOutsideCallout &&
+          ((targetRef.current as MouseEvent).stopPropagation ||
+            !targetRef.current ||
+            (target !== targetRef.current && !elementContains(targetRef.current as HTMLElement, target))))
       ) {
-        this._targetWindow = getWindow(currentElement)!;
-        this._target = target;
-      } else {
-        const targetElement: HTMLElement = target as HTMLElement;
-        this._targetWindow = getWindow(targetElement)!;
-        this._target = target;
+        onResize(ev);
       }
-    } else {
-      this._targetWindow = getWindow(currentElement)!;
-    }
-  }
+    },
+    [onResize, positionedHost, targetRef, targetWindow],
+  );
 
+  const dismissOnScroll = React.useCallback(
+    (ev: Event): void => {
+      if (positions && !preventDismissOnScroll) {
+        dismissOnLostFocus(ev);
+      }
+    },
+    [dismissOnLostFocus, positions, preventDismissOnScroll],
+  );
+
+  React.useEffect(() => {
+    const events = new EventGroup({});
+    // This is added so the positioningContainer will dismiss when the window is scrolled
+    // but not when something inside the positioningContainer is scrolled. The delay seems
+    // to be required to avoid React firing an async focus event in IE from
+    // the target changing focus quickly prior to rendering the positioningContainer.
+    async.setTimeout(() => {
+      events.on(targetWindow, 'scroll', async.throttle(dismissOnScroll, 10), true);
+      events.on(targetWindow, 'resize', async.throttle(onResize, 10), true);
+      events.on(targetWindow?.document?.body, 'focus', dismissOnLostFocus, true);
+      events.on(targetWindow?.document?.body, 'click', dismissOnLostFocus, true);
+    }, 0);
+
+    return () => events.dispose();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on mount
+  }, [dismissOnScroll]);
+}
+
+export function useHeightOffset(
+  { finalHeight }: IPositioningContainerProps,
+  contentHost: React.RefObject<HTMLDivElement | null>,
+) {
   /**
-   * Animates the height if finalHeight was given.
+   * Tracks the current height offset and updates during
+   * the height animation when props.finalHeight is specified.
    */
-  private _setHeightOffsetEveryFrame(): void {
-    if (this._contentHost && this.props.finalHeight) {
-      this._setHeightOffsetTimer = this._async.requestAnimationFrame(() => {
-        if (!this._contentHost.current) {
+  const [heightOffset, setHeightOffset] = React.useState<number>(0);
+  const async = useAsync();
+  const setHeightOffsetTimer = React.useRef<number>(0);
+
+  /** Animates the height if finalHeight was given. */
+  const setHeightOffsetEveryFrame = (): void => {
+    if (contentHost && finalHeight) {
+      setHeightOffsetTimer.current = async.requestAnimationFrame(() => {
+        if (!contentHost.current) {
           return;
         }
 
-        const positioningContainerMainElem = this._contentHost.current.lastChild as HTMLElement;
+        const positioningContainerMainElem = contentHost.current.lastChild as HTMLElement;
         const cardScrollHeight: number = positioningContainerMainElem.scrollHeight;
         const cardCurrHeight: number = positioningContainerMainElem.offsetHeight;
         const scrollDiff: number = cardScrollHeight - cardCurrHeight;
 
-        this.setState({
-          heightOffset: this.state.heightOffset! + scrollDiff,
-        });
+        setHeightOffset(heightOffset + scrollDiff);
 
-        if (positioningContainerMainElem.offsetHeight < this.props.finalHeight!) {
-          this._setHeightOffsetEveryFrame();
+        if (positioningContainerMainElem.offsetHeight < finalHeight) {
+          setHeightOffsetEveryFrame();
         } else {
-          this._async.cancelAnimationFrame(this._setHeightOffsetTimer);
+          async.cancelAnimationFrame(setHeightOffsetTimer.current);
         }
       });
     }
+  };
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- should only re-run if finalHeight changes
+  React.useEffect(setHeightOffsetEveryFrame, [finalHeight]);
+
+  return heightOffset;
+}
+
+export const PositioningContainer: React.FunctionComponent<IPositioningContainerProps> = React.forwardRef<
+  HTMLDivElement,
+  IPositioningContainerProps
+>((propsWithoutDefaults, forwardedRef) => {
+  const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
+
+  // @TODO rename to reflect the name of this class
+  const contentHost = React.useRef<HTMLDivElement>(null);
+  /**
+   * The primary positioned div.
+   */
+  const positionedHost = React.useRef<HTMLDivElement>(null);
+  const rootRef = useMergedRefs(forwardedRef, positionedHost);
+
+  const [targetRef, targetWindow] = useTarget(props.target, positionedHost);
+  const getCachedBounds = useCachedBounds(props, targetWindow);
+  const [positions, updateAsyncPosition] = usePositionState(
+    props,
+    positionedHost,
+    contentHost,
+    targetRef,
+    getCachedBounds,
+  );
+  const getCachedMaxHeight = useMaxHeight(props, targetRef, getCachedBounds);
+  const heightOffset = useHeightOffset(props, contentHost);
+
+  useSetInitialFocus(props, contentHost, positions);
+  useAutoDismissEvents(props, positionedHost, targetWindow, targetRef, positions, updateAsyncPosition);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on initial render
+  React.useEffect(() => props.onLayerMounted?.(), []);
+
+  // If there is no target window then we are likely in server side rendering and we should not render anything.
+  if (!targetWindow) {
+    return null;
   }
 
-  private _getTarget(props: IPositioningContainerProps = this.props): HTMLElement | string | MouseEvent | Point | null {
-    const { target } = props;
-    return target!;
+  const { className, doNotLayer, positioningContainerWidth, positioningContainerMaxHeight, children } = props;
+
+  const styles = getClassNames();
+
+  const directionalClassName =
+    positions && positions.targetEdge ? AnimationClassNames[SLIDE_ANIMATIONS[positions.targetEdge]] : '';
+
+  const getContentMaxHeight: number = getCachedMaxHeight() + heightOffset!;
+  const contentMaxHeight: number =
+    positioningContainerMaxHeight! && positioningContainerMaxHeight! > getContentMaxHeight
+      ? getContentMaxHeight
+      : positioningContainerMaxHeight!;
+  const content = (
+    <div ref={rootRef} className={css('ms-PositioningContainer', styles.container)}>
+      <div
+        className={mergeStyles(
+          'ms-PositioningContainer-layerHost',
+          styles.root,
+          className,
+          directionalClassName,
+          !!positioningContainerWidth && { width: positioningContainerWidth },
+          doNotLayer && { zIndex: ZIndexes.Layer },
+        )}
+        style={positions ? positions.elementPosition : OFF_SCREEN_STYLE}
+        // Safari and Firefox on Mac OS requires this to back-stop click events so focus remains in the Callout.
+        // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+        tabIndex={-1}
+        ref={contentHost}
+      >
+        {children}
+        {
+          // @TODO apply to the content container
+          contentMaxHeight
+        }
+      </div>
+    </div>
+  );
+
+  return doNotLayer ? content : <Layer>{content}</Layer>;
+});
+PositioningContainer.displayName = 'PositioningContainer';
+
+function arePositionsEqual(positions: IPositionedData, newPosition: IPositionedData): boolean {
+  return comparePositions(positions.elementPosition, newPosition.elementPosition);
+}
+
+function comparePositions(oldPositions: IPosition, newPositions: IPosition): boolean {
+  for (const key in newPositions) {
+    if (newPositions.hasOwnProperty(key)) {
+      const oldPositionEdge = oldPositions[key];
+      const newPositionEdge = newPositions[key];
+
+      if (oldPositionEdge && newPositionEdge) {
+        if (oldPositionEdge.toFixed(2) !== newPositionEdge.toFixed(2)) {
+          return false;
+        }
+      }
+    }
   }
+  return true;
 }

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.types.ts
@@ -1,6 +1,9 @@
+import * as React from 'react';
 import { DirectionalHint } from '../../../common/DirectionalHint';
-import { IRefObject, IBaseProps, Point, IRectangle } from '../../../Utilities';
-import { IPositionedData } from '../../../utilities/positioning';
+import type { IRefObject, IBaseProps, Point, IRectangle } from '../../../Utilities';
+import type { IPositionedData } from '../../../Positioning';
+import type { ReactNode } from 'react';
+import type { Target } from '@fluentui/react-hooks';
 
 /**
  * {@docCategory Coachmark}
@@ -10,17 +13,20 @@ export interface IPositioningContainer {}
 /**
  * {@docCategory Coachmark}
  */
-export interface IPositioningContainerProps extends IBaseProps<IPositioningContainer> {
+export interface IPositioningContainerProps
+  extends IBaseProps<IPositioningContainer>,
+    React.RefAttributes<HTMLDivElement> {
   /**
    * All props for your component are to be defined here.
    */
   componentRef?: IRefObject<IPositioningContainer>;
+
   /**
    * The target that the positioningContainer should try to position itself based on.
    * It can be either an HTMLElement a querySelector string of a valid HTMLElement
    * or a MouseEvent. If MouseEvent is given then the origin point of the event will be used.
    */
-  target?: HTMLElement | string | MouseEvent | Point | null;
+  target?: Target;
 
   /**
    * How the element should be positioned
@@ -165,6 +171,11 @@ export interface IPositioningContainerProps extends IBaseProps<IPositioningConta
    * When not set the positioningContainer will expand with contents up to the bottom of the screen
    */
   positioningContainerMaxHeight?: number;
+
+  /**
+   * Child nodes to render
+   */
+  children?: ReactNode;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X ] Code is up-to-date with the `master` branch
* [X ] Your changes are covered by tests (if possible)
* [ X] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
Target moves on scroll; if coachmark is in dialog, and dialog body string is too long, the target of the coachmark moves
## New Behavior
behavior in v8. target does not move. coachmark positions to correct target
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
