### PR TITLE
feat(react-theme): Add colorNeutralForeground1Static token

### DIFF
--- a/change/@fluentui-react-theme-1c0d1c53-1dfc-49b9-aa9d-b0786f2b51f3.json
+++ b/change/@fluentui-react-theme-1c0d1c53-1dfc-49b9-aa9d-b0786f2b51f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat(react-theme): Add colorNeutralForeground1Static token",
+  "packageName": "@fluentui/react-theme",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-theme/etc/react-theme.api.md
+++ b/packages/react-theme/etc/react-theme.api.md
@@ -202,6 +202,7 @@ export type ColorTokens = {
     colorCompoundBrandForeground1Pressed: string;
     colorBrandForeground1: string;
     colorBrandForeground2: string;
+    colorNeutralForeground1Static: string;
     colorNeutralForegroundInverted: string;
     colorNeutralForegroundInvertedHover: string;
     colorNeutralForegroundInvertedPressed: string;

--- a/packages/react-theme/src/alias/dark.ts
+++ b/packages/react-theme/src/alias/dark.ts
@@ -32,6 +32,7 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorCompoundBrandForeground1Pressed: brand[80], // #0078d4 Global.Color.Brand.80
   colorBrandForeground1: brand[100], // #2899f5 Global.Color.Brand.100
   colorBrandForeground2: brand[110], // #3aa0f3 Global.Color.Brand.110
+  colorNeutralForeground1Static: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInverted: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedHover: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedPressed: white, // #ffffff Global.Color.White
@@ -87,8 +88,8 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorTransparentBackgroundSelected: 'transparent', // transparent undefined
   colorNeutralBackgroundDisabled: grey[8], // #141414 Global.Color.Grey.8
   colorNeutralBackgroundInvertedDisabled: whiteAlpha[10], // rgba(255, 255, 255, 0.1) Global.Color.WhiteAlpha.10
-  colorNeutralStencil1: grey[20], // #333333 Global.Color.Grey.20
-  colorNeutralStencil2: grey[34], // #575757 Global.Color.Grey.34
+  colorNeutralStencil1: grey[34], // #575757 Global.Color.Grey.34
+  colorNeutralStencil2: grey[20], // #333333 Global.Color.Grey.20
   colorBrandBackground: brand[70], // #106ebe Global.Color.Brand.70
   colorBrandBackgroundHover: brand[80], // #0078d4 Global.Color.Brand.80
   colorBrandBackgroundPressed: brand[40], // #004578 Global.Color.Brand.40

--- a/packages/react-theme/src/alias/highContrast.ts
+++ b/packages/react-theme/src/alias/highContrast.ts
@@ -1,5 +1,4 @@
 import {
-  grey,
   hcButtonFace,
   hcButtonText,
   hcCanvas,
@@ -45,6 +44,7 @@ export const generateColorTokens = (): ColorTokens => ({
   colorCompoundBrandForeground1Pressed: hcHighlight, // #1aebff Global.Color.hcHighlight
   colorBrandForeground1: hcCanvasText, // #ffffff Global.Color.hcCanvasText
   colorBrandForeground2: hcButtonText, // #000000 Global.Color.hcButtonText
+  colorNeutralForeground1Static: hcCanvas, // #000000 Global.Color.hcCanvas
   colorNeutralForegroundInverted: hcCanvasText, // #ffffff Global.Color.hcCanvasText
   colorNeutralForegroundInvertedHover: hcHighlightText, // #000000 Global.Color.hcHighlightText
   colorNeutralForegroundInvertedPressed: hcHighlightText, // #000000 Global.Color.hcHighlightText
@@ -100,8 +100,8 @@ export const generateColorTokens = (): ColorTokens => ({
   colorTransparentBackgroundSelected: hcHighlight, // #1aebff Global.Color.hcHighlight
   colorNeutralBackgroundDisabled: hcCanvas, // #000000 Global.Color.hcCanvas
   colorNeutralBackgroundInvertedDisabled: hcCanvas, // #000000 Global.Color.hcCanvas
-  colorNeutralStencil1: grey[8], // #141414 Global.Color.Grey.8
-  colorNeutralStencil2: grey[52], // #858585 Global.Color.Grey.52
+  colorNeutralStencil1: hcCanvasText, // #ffffff Global.Color.hcCanvasText
+  colorNeutralStencil2: hcCanvasText, // #ffffff Global.Color.hcCanvasText
   colorBrandBackground: hcButtonFace, // #ffffff Global.Color.hcButtonFace
   colorBrandBackgroundHover: hcHighlight, // #1aebff Global.Color.hcHighlight
   colorBrandBackgroundPressed: hcHighlight, // #1aebff Global.Color.hcHighlight

--- a/packages/react-theme/src/alias/light.ts
+++ b/packages/react-theme/src/alias/light.ts
@@ -32,6 +32,7 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorCompoundBrandForeground1Pressed: brand[60], // #005a9e Global.Color.Brand.60
   colorBrandForeground1: brand[80], // #0078d4 Global.Color.Brand.80
   colorBrandForeground2: brand[70], // #106ebe Global.Color.Brand.70
+  colorNeutralForeground1Static: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInverted: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedHover: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedPressed: white, // #ffffff Global.Color.White
@@ -69,7 +70,7 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorNeutralBackground5Pressed: grey[94], // #f0f0f0 Global.Color.Grey.94
   colorNeutralBackground5Selected: grey[98], // #fafafa Global.Color.Grey.98
   colorNeutralBackground6: grey[90], // #e6e6e6 Global.Color.Grey.90
-  colorNeutralBackgroundInverted: grey[20], // #333333 Global.Color.Grey.20
+  colorNeutralBackgroundInverted: grey[38], // #616161 Global.Color.Grey.38
   colorSubtleBackground: 'transparent', // transparent undefined
   colorSubtleBackgroundHover: grey[96], // #f5f5f5 Global.Color.Grey.96
   colorSubtleBackgroundPressed: grey[88], // #e0e0e0 Global.Color.Grey.88

--- a/packages/react-theme/src/alias/teamsDark.ts
+++ b/packages/react-theme/src/alias/teamsDark.ts
@@ -32,6 +32,7 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorCompoundBrandForeground1Pressed: brand[80], // #0078d4 Global.Color.Brand.80
   colorBrandForeground1: brand[100], // #2899f5 Global.Color.Brand.100
   colorBrandForeground2: brand[110], // #3aa0f3 Global.Color.Brand.110
+  colorNeutralForeground1Static: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInverted: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedHover: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedPressed: white, // #ffffff Global.Color.White
@@ -87,8 +88,8 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorTransparentBackgroundSelected: 'transparent', // transparent undefined
   colorNeutralBackgroundDisabled: grey[8], // #141414 Global.Color.Grey.8
   colorNeutralBackgroundInvertedDisabled: whiteAlpha[10], // rgba(255, 255, 255, 0.1) Global.Color.WhiteAlpha.10
-  colorNeutralStencil1: grey[20], // #333333 Global.Color.Grey.20
-  colorNeutralStencil2: grey[34], // #575757 Global.Color.Grey.34
+  colorNeutralStencil1: grey[34], // #575757 Global.Color.Grey.34
+  colorNeutralStencil2: grey[20], // #333333 Global.Color.Grey.20
   colorBrandBackground: brand[70], // #106ebe Global.Color.Brand.70
   colorBrandBackgroundHover: brand[80], // #0078d4 Global.Color.Brand.80
   colorBrandBackgroundPressed: brand[40], // #004578 Global.Color.Brand.40

--- a/packages/react-theme/src/tokens.ts
+++ b/packages/react-theme/src/tokens.ts
@@ -41,6 +41,7 @@ export const tokens: Record<keyof Theme, string> = {
   colorNeutralForegroundInvertedDisabled: 'var(--colorNeutralForegroundInvertedDisabled)',
   colorBrandForeground1: 'var(--colorBrandForeground1)',
   colorBrandForeground2: 'var(--colorBrandForeground2)',
+  colorNeutralForeground1Static: 'var(--colorNeutralForeground1Static)',
   colorBrandForegroundInverted: 'var(--colorBrandForegroundInverted)',
   colorBrandForegroundInvertedHover: 'var(--colorBrandForegroundInvertedHover)',
   colorBrandForegroundInvertedPressed: 'var(--colorBrandForegroundInvertedPressed)',

--- a/packages/react-theme/src/types.ts
+++ b/packages/react-theme/src/types.ts
@@ -32,6 +32,7 @@ export type ColorTokens = {
   colorCompoundBrandForeground1Pressed: string;
   colorBrandForeground1: string;
   colorBrandForeground2: string;
+  colorNeutralForeground1Static: string;
   colorNeutralForegroundInverted: string;
   colorNeutralForegroundInvertedHover: string;
   colorNeutralForegroundInvertedPressed: string;


### PR DESCRIPTION
1. add `colorNeutralForeground1Static` token
2. update `colorNeutralBackgroundInverted` token values
3. update `neutralStencil1` and `neutralStencil2` token values

## Old Behavior (columns - light, dark, teamsDark, highContrast)
![image](https://user-images.githubusercontent.com/9615899/150758337-131d3206-9cf8-4f52-b4a6-53fa7befebfc.png)
![image](https://user-images.githubusercontent.com/9615899/150758377-beb66a8d-e5f6-4c06-a2ca-c5ba9be32c71.png)

## Spec (columns - light, dark, highContrast, teamsDark)
![image](https://user-images.githubusercontent.com/9615899/150757526-de501a51-70ee-426a-b81f-c48ad964ea2f.png)
![image](https://user-images.githubusercontent.com/9615899/150757581-84c3598f-5755-40df-9256-0c1f465405a9.png)
![image](https://user-images.githubusercontent.com/9615899/150757612-c25f3d18-0b38-49c2-b75e-50f3c2a60b74.png)

## New Behavior (columns - light, dark, teamsDark, highContrast)
![image](https://user-images.githubusercontent.com/9615899/150757798-eaeb8367-3661-476f-92a1-73034380351d.png)
![image](https://user-images.githubusercontent.com/9615899/150757832-d2bd580c-24d3-4ef8-9b73-a6bd74307506.png)
![image](https://user-images.githubusercontent.com/9615899/150757875-31cbadfe-1b10-46b3-9d3b-2a1e27ce823c.png)

_Note: There is a difference between spec (#e5e5e5) and impl (#e6e6e6) for Grey.90, which is known._