### PR TITLE
chore: update generator to use Griffel

### DIFF
--- a/change/@fluentui-react-provider-9a410062-0b56-435a-8468-9195cc7a448a.json
+++ b/change/@fluentui-react-provider-9a410062-0b56-435a-8468-9195cc7a448a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add @types/react-test-renderer to devDependencies",
+  "packageName": "@fluentui/react-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-provider/package.json
+++ b/packages/react-provider/package.json
@@ -34,6 +34,7 @@
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
+    "@types/react-test-renderer": "^16.0.0",
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",

--- a/scripts/create-component/plop-templates/src/common/isConformant.ts.hbs
+++ b/scripts/create-component/plop-templates/src/common/isConformant.ts.hbs
@@ -1,6 +1,6 @@
 import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
 import type { IsConformantOptions, TestObject } from '@fluentui/react-conformance';
-import makeStylesTests from '@fluentui/react-conformance-make-styles';
+import griffelTests from '@fluentui/react-conformance-griffel';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
@@ -8,7 +8,7 @@ export function isConformant<TProps = {}>(
   const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
-    extraTests: makeStylesTests as TestObject<TProps>,
+    extraTests: griffelTests as TestObject<TProps>,
   };
 
   baseIsConformant(defaultOptions, testInfo);

--- a/scripts/create-component/plop-templates/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs
+++ b/scripts/create-component/plop-templates/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { makeStyles, mergeClasses } from '@griffel/react';
 import type { {{componentName}}State } from './{{componentName}}.types';
 
 /**

--- a/scripts/create-package/plop-templates-react/.babelrc.json
+++ b/scripts/create-package/plop-templates-react/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/scripts/create-package/plop-templates-react/jest.config.js
+++ b/scripts/create-package/plop-templates-react/jest.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 });
 
 module.exports = config;

--- a/scripts/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/create-package/plop-templates-react/package.json.hbs
@@ -24,11 +24,9 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "",
     "@fluentui/eslint-plugin": "",
-    "@fluentui/jest-serializer-make-styles": "",
     "@fluentui/react-conformance": "",
-    "@fluentui/react-conformance-make-styles": "",
+    "@fluentui/react-conformance-griffel": "",
     "@fluentui/scripts": "",
     "@types/enzyme": "",
     "@types/enzyme-adapter-react-16": "",
@@ -42,9 +40,9 @@
     "react-test-renderer": ""
   },
   "dependencies": {
-    "@fluentui/react-make-styles": "",
     "@fluentui/react-theme": "",
     "@fluentui/react-utilities": "",
+    "@griffel/react": "",
     "tslib": ""
   },
   "peerDependencies": {

--- a/scripts/create-package/plopfile.ts
+++ b/scripts/create-package/plopfile.ts
@@ -16,7 +16,7 @@ const v8ReferencePackages = {
   node: ['codemods'],
 };
 const convergedReferencePackages = {
-  react: ['react-menu'],
+  react: ['react-provider'],
   node: ['babel-make-styles'],
 };
 

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -326,7 +326,6 @@ describe('migrate-converged-pkg generator', () => {
       expect(rootTsConfig.compilerOptions.paths).toEqual(
         expect.objectContaining({
           '@proj/react-dummy': ['packages/react-dummy/src/index.ts'],
-          '@proj/react-make-styles': ['packages/react-make-styles/src/index.ts'],
           '@proj/react-theme': ['packages/react-theme/src/index.ts'],
           '@proj/react-utilities': ['packages/react-utilities/src/index.ts'],
         }),
@@ -383,7 +382,7 @@ describe('migrate-converged-pkg generator', () => {
 
         const config = createConfig({
         setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
-        snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+        snapshotSerializers: ['@griffel/jest-serializer'],
         });
 
         module.exports = config;"
@@ -413,7 +412,7 @@ describe('migrate-converged-pkg generator', () => {
         },
         coverageDirectory: './coverage',
         setupFilesAfterEnv: ['./config/tests.js'],
-        snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+        snapshotSerializers: ['@griffel/jest-serializer'],
         };"
       `);
     });
@@ -421,8 +420,7 @@ describe('migrate-converged-pkg generator', () => {
     it(`should add 'snapshotSerializers' to jest.config.js only when needed`, async () => {
       const projectConfig = readProjectConfiguration(tree, options.name);
       function removePkgDependenciesThatTriggerSnapshotSerializersAddition() {
-        const workspaceConfig = readWorkspaceConfiguration(tree);
-        const packagesThatTriggerAddingSnapshots = [`@${workspaceConfig.npmScope}/react-make-styles`];
+        const packagesThatTriggerAddingSnapshots = ['@griffel/react'];
 
         updateJson(tree, `${projectConfig.root}/package.json`, (json: PackageJson) => {
           packagesThatTriggerAddingSnapshots.forEach(pkgName => {
@@ -958,94 +956,61 @@ describe('migrate-converged-pkg generator', () => {
     }
 
     it(`should setup .babelrc.json`, async () => {
-      const babelMakeStylesPkg = getScopedPkgName(tree, 'babel-make-styles');
       const projectConfig = readProjectConfiguration(tree, options.name);
 
-      let packageJson = getPackageJson(projectConfig);
-      let devDeps = packageJson.devDependencies || {};
-      expect(devDeps[babelMakeStylesPkg]).toBe(undefined);
-
       await generator(tree, options);
-
       let babelConfig = getBabelConfig(projectConfig);
 
       expect(babelConfig).toEqual({
-        plugins: [
-          'module:@fluentui/babel-make-styles',
-          'annotate-pure-calls',
-          '@babel/transform-react-pure-annotations',
-        ],
+        presets: ['@griffel'],
+        plugins: ['annotate-pure-calls', '@babel/transform-react-pure-annotations'],
       });
 
       tree.delete(`${projectConfig.root}/.babelrc.json`);
 
       await generator(tree, options);
-
       babelConfig = getBabelConfig(projectConfig);
-      packageJson = getPackageJson(projectConfig);
-      devDeps = packageJson.devDependencies || {};
 
       expect(babelConfig).toEqual({
-        plugins: [
-          'module:@fluentui/babel-make-styles',
-          'annotate-pure-calls',
-          '@babel/transform-react-pure-annotations',
-        ],
+        presets: ['@griffel'],
+        plugins: ['annotate-pure-calls', '@babel/transform-react-pure-annotations'],
       });
-      expect(devDeps[babelMakeStylesPkg]).toBe('9.0.0-alpha.0');
     });
 
-    it(`should add @fluentui/babel-make-styles plugin only if needed`, async () => {
+    it(`should add @griffel/babel-preset only if needed`, async () => {
       let projectConfig = readProjectConfiguration(tree, options.name);
-      const babelMakeStylesPkg = getScopedPkgName(tree, 'babel-make-styles');
 
       updateJson(tree, `${projectConfig.root}/package.json`, (json: PackageJson) => {
         if (json.dependencies) {
-          delete json.dependencies[getScopedPkgName(tree, 'react-make-styles')];
-          delete json.dependencies[getScopedPkgName(tree, 'make-styles')];
+          delete json.dependencies['@griffel/react'];
         }
-
-        json.devDependencies = json.devDependencies || {};
-        json.devDependencies[babelMakeStylesPkg] = '^9.0.0-alpha.0';
 
         return json;
       });
 
       let babelConfig = getBabelConfig(projectConfig);
-      let packageJson = getPackageJson(projectConfig);
-      let devDeps = packageJson.devDependencies || {};
 
       expect(babelConfig).toEqual({
-        plugins: [
-          'module:@fluentui/babel-make-styles',
-          'annotate-pure-calls',
-          '@babel/transform-react-pure-annotations',
-        ],
-      });
-      expect(devDeps[babelMakeStylesPkg]).toBe('^9.0.0-alpha.0');
-
-      await generator(tree, options);
-
-      babelConfig = getBabelConfig(projectConfig);
-      packageJson = getPackageJson(projectConfig);
-      devDeps = packageJson.devDependencies || {};
-
-      expect(babelConfig).toEqual({
+        presets: ['@griffel'],
         plugins: ['annotate-pure-calls', '@babel/transform-react-pure-annotations'],
       });
-      expect(devDeps[babelMakeStylesPkg]).toBe(undefined);
+
+      await generator(tree, options);
+      babelConfig = getBabelConfig(projectConfig);
+
+      expect(babelConfig).toEqual({
+        presets: [],
+        plugins: ['annotate-pure-calls', '@babel/transform-react-pure-annotations'],
+      });
 
       projectConfig = readProjectConfiguration(tree, '@proj/babel-make-styles');
       await generator(tree, { name: '@proj/babel-make-styles' });
-
       babelConfig = getBabelConfig(projectConfig);
-      packageJson = getPackageJson(projectConfig);
-      devDeps = packageJson.devDependencies || {};
 
       expect(babelConfig).toEqual({
+        presets: [],
         plugins: ['annotate-pure-calls', '@babel/transform-react-pure-annotations'],
       });
-      expect(devDeps[babelMakeStylesPkg]).toBe(undefined);
     });
   });
 
@@ -1219,14 +1184,15 @@ function setupDummyPackage(
   const defaults = {
     version: '9.0.0-alpha.40',
     dependencies: {
-      [`@${workspaceConfig.npmScope}/react-make-styles`]: '^9.0.0-alpha.38',
+      [`@griffel/react`]: '^9.0.0-alpha.38',
       [`@${workspaceConfig.npmScope}/react-theme`]: '^9.0.0-alpha.13',
       [`@${workspaceConfig.npmScope}/react-utilities`]: '^9.0.0-alpha.25',
       tslib: '^2.1.0',
       someThirdPartyDep: '^11.1.2',
     },
     babelConfig: {
-      plugins: ['module:@fluentui/babel-make-styles', 'annotate-pure-calls', '@babel/transform-react-pure-annotations'],
+      presets: ['@griffel'],
+      plugins: ['annotate-pure-calls', '@babel/transform-react-pure-annotations'],
     },
     tsConfig: { compilerOptions: { baseUrl: '.', typeRoots: ['../../node_modules/@types', '../../typings'] } },
   };
@@ -1265,7 +1231,7 @@ function setupDummyPackage(
 
       const config = createConfig({
         setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
-        snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+        snapshotSerializers: ['@griffel/jest-serializer'],
       });
 
       module.exports = config;

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -1184,7 +1184,7 @@ function setupDummyPackage(
   const defaults = {
     version: '9.0.0-alpha.40',
     dependencies: {
-      [`@griffel/react`]: '^9.0.0-alpha.38',
+      [`@griffel/react`]: '1.0.0',
       [`@${workspaceConfig.npmScope}/react-theme`]: '^9.0.0-alpha.13',
       [`@${workspaceConfig.npmScope}/react-utilities`]: '^9.0.0-alpha.25',
       tslib: '^2.1.0',


### PR DESCRIPTION
## PR changes

This PR updates `create-package` script & templates and Nx generator use Griffel packages.
Changes that are applied to generator are matching changes in #21360.

Note: This PR does not implement migration from `make-styles` to Griffel.