### PR TITLE
chore: migrate react-popover to use Griffel

### DIFF
--- a/change/@fluentui-react-popover-a0804144-1806-4af5-bb61-8aaae1bb96f3.json
+++ b/change/@fluentui-react-popover-a0804144-1806-4af5-bb61-8aaae1bb96f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use Griffel packages",
+  "packageName": "@fluentui/react-popover",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-popover/.babelrc.json
+++ b/packages/react-popover/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-popover/jest.config.js
+++ b/packages/react-popover/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-popover/package.json
+++ b/packages/react-popover/package.json
@@ -27,11 +27,9 @@
     "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "9.0.0-beta.4",
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/jest-serializer-make-styles": "9.0.0-beta.4",
     "@fluentui/react-conformance": "*",
-    "@fluentui/react-conformance-make-styles": "9.0.0-beta.4",
+    "@fluentui/react-conformance-griffel": "9.0.0-beta.0",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
@@ -46,7 +44,7 @@
   },
   "dependencies": {
     "@fluentui/react-context-selector": "9.0.0-beta.4",
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-portal": "9.0.0-beta.5",
     "@fluentui/react-positioning": "9.0.0-beta.4",
     "@fluentui/react-shared-contexts": "9.0.0-beta.4",

--- a/packages/react-popover/src/common/isConformant.ts
+++ b/packages/react-popover/src/common/isConformant.ts
@@ -1,6 +1,6 @@
 import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
 import type { IsConformantOptions, TestObject } from '@fluentui/react-conformance';
-import makeStylesTests from '@fluentui/react-conformance-make-styles';
+import griffelTests from '@fluentui/react-conformance-griffel';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
@@ -10,7 +10,7 @@ export function isConformant<TProps = {}>(
     componentPath: module!.parent!.filename.replace('.test', ''),
     // TODO // https://github.com/microsoft/fluentui/issues/19522
     skipAsPropTests: true,
-    extraTests: makeStylesTests as TestObject<TProps>,
+    extraTests: griffelTests as TestObject<TProps>,
   };
 
   baseIsConformant(defaultOptions, testInfo);

--- a/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
+++ b/packages/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
@@ -1,4 +1,4 @@
-import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
 import { createArrowHeightStyles, createArrowStyles } from '@fluentui/react-positioning';
 import { tokens } from '@fluentui/react-theme';
 import type { PopoverSize } from '../Popover/Popover.types';

--- a/packages/react-popover/src/stories/PopoverAnchorToCustomTarget.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverAnchorToCustomTarget.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@fluentui/react-button';
-import { makeStyles, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@griffel/react';
 
 import { Popover, PopoverTrigger, PopoverSurface } from '../index';
 

--- a/packages/react-popover/src/stories/PopoverControllingOpenAndClose.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverControllingOpenAndClose.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@fluentui/react-button';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 
 import { PopoverProps, Popover, PopoverTrigger, PopoverSurface } from '../index';
 

--- a/packages/react-popover/src/stories/PopoverCustomTrigger.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverCustomTrigger.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@fluentui/react-button';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 
 import { Popover, PopoverProps, PopoverSurface } from '../index';
 

--- a/packages/react-popover/src/stories/PopoverDefault.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverDefault.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@fluentui/react-button';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 
 import { Popover, PopoverTrigger, PopoverSurface, PopoverProps } from '../index';
 

--- a/packages/react-popover/src/stories/PopoverInternalUpdateContent.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverInternalUpdateContent.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@fluentui/react-button';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 
 import { Popover, PopoverProps, PopoverTrigger, PopoverSurface } from '../index';
 

--- a/packages/react-popover/src/stories/PopoverNestedPopovers.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverNestedPopovers.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@fluentui/react-button';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 
 import { Popover, PopoverTrigger, PopoverSurface } from '../index';
 

--- a/packages/react-popover/src/stories/PopoverTrappingFocus.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverTrappingFocus.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@fluentui/react-button';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 
 import { Popover, PopoverTrigger, PopoverSurface } from '../index';
 


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-popover` package.

Following packages were replaced:

- `@fluentui/react-make-styles` => `@griffel/react`
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`
- `@fluentui/react-conformance-make-styles` => `@fluentui/react-conformance-griffel`

---

Note: check #21360 for more details about changes.