### PR TITLE
chore: migrate react-portal to use Griffel

### DIFF
--- a/change/@fluentui-react-portal-a4b331c9-24db-4100-808c-a711f9e7eeca.json
+++ b/change/@fluentui-react-portal-a4b331c9-24db-4100-808c-a711f9e7eeca.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove unused dependency on Griffel",
+  "packageName": "@fluentui/react-portal",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@fluentui/react-icons": "^2.0.154-beta.5",
     "@griffel/babel-preset": "1.0.0",
     "@griffel/jest-serializer": "1.0.0",
+    "@griffel/react": "1.0.0",
     "@linaria/babel-preset": "3.0.0-beta.14",
     "@microsoft/api-extractor": "7.18.1",
     "@nrwl/cli": "13.4.5",

--- a/packages/react-portal/.babelrc.json
+++ b/packages/react-portal/.babelrc.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-portal/jest.config.js
+++ b/packages/react-portal/jest.config.js
@@ -17,5 +17,4 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 };

--- a/packages/react-portal/package.json
+++ b/packages/react-portal/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/jest-serializer-make-styles": "9.0.0-beta.4",
     "@fluentui/react-conformance": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
@@ -39,11 +38,9 @@
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-test-renderer": "^16.3.0",
-    "@fluentui/babel-make-styles": "9.0.0-beta.4"
+    "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
     "@fluentui/react-shared-contexts": "9.0.0-beta.4",
     "@fluentui/react-tabster": "9.0.0-beta.5",
     "@fluentui/react-utilities": "9.0.0-beta.4",

--- a/packages/react-portal/package.json
+++ b/packages/react-portal/package.json
@@ -29,7 +29,6 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/scripts": "^1.0.0",
-    "@griffel/react": "1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/react": "16.9.42",

--- a/packages/react-portal/package.json
+++ b/packages/react-portal/package.json
@@ -29,6 +29,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/scripts": "^1.0.0",
+    "@griffel/react": "1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/react": "16.9.42",

--- a/packages/react-portal/src/stories/PortalDefault.stories.tsx
+++ b/packages/react-portal/src/stories/PortalDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 
 import { Portal } from '../Portal';

--- a/packages/react-portal/src/stories/PortalNested.stories.tsx
+++ b/packages/react-portal/src/stories/PortalNested.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 
 import { Portal } from '../Portal';


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-portal` package.

Following packages were replaced:
- `@fluentui/react-make-styles` => `@griffel/react` (only in stories)

As Griffel is not used as dependency in this package, `make-styles` packages were removed from configs.

---

Note: check #21360 for more details about changes.