### PR TITLE
chore: migrate react-accordion to use Griffel

### DIFF
--- a/change/@fluentui-react-accordion-87c44b26-f9b8-4819-b689-92307876b78b.json
+++ b/change/@fluentui-react-accordion-87c44b26-f9b8-4819-b689-92307876b78b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use Griffel packages",
+  "packageName": "@fluentui/react-accordion",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-accordion/.babelrc.json
+++ b/packages/react-accordion/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-accordion/jest.config.js
+++ b/packages/react-accordion/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-accordion/package.json
+++ b/packages/react-accordion/package.json
@@ -26,11 +26,9 @@
     "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "9.0.0-beta.4",
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/jest-serializer-make-styles": "9.0.0-beta.4",
     "@fluentui/react-conformance": "*",
-    "@fluentui/react-conformance-make-styles": "9.0.0-beta.4",
+    "@fluentui/react-conformance-griffel": "9.0.0-beta.0",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
@@ -47,7 +45,7 @@
     "@fluentui/react-aria": "9.0.0-beta.4",
     "@fluentui/react-context-selector": "9.0.0-beta.4",
     "@fluentui/react-icons": "^2.0.154-beta.5",
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-tabster": "9.0.0-beta.5",
     "@fluentui/react-theme": "9.0.0-beta.4",
     "@fluentui/react-utilities": "9.0.0-beta.4",

--- a/packages/react-accordion/src/common/isConformant.ts
+++ b/packages/react-accordion/src/common/isConformant.ts
@@ -1,5 +1,5 @@
 import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
-import makeStylesTests from '@fluentui/react-conformance-make-styles';
+import griffelTests from '@fluentui/react-conformance-griffel';
 import type { IsConformantOptions, TestObject } from '@fluentui/react-conformance';
 
 export function isConformant<TProps = {}>(
@@ -9,7 +9,7 @@ export function isConformant<TProps = {}>(
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
     skipAsPropTests: true,
-    extraTests: makeStylesTests as TestObject<TProps>,
+    extraTests: griffelTests as TestObject<TProps>,
   };
 
   baseIsConformant(defaultOptions, testInfo);

--- a/packages/react-accordion/src/components/Accordion/useAccordionStyles.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordionStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses } from '@fluentui/react-make-styles';
+import { mergeClasses } from '@griffel/react';
 import type { AccordionState } from './Accordion.types';
 
 export const accordionClassName = 'fui-Accordion';

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
@@ -1,4 +1,4 @@
-import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import { tokens } from '@fluentui/react-theme';
 import type { AccordionHeaderState } from './AccordionHeader.types';

--- a/packages/react-accordion/src/components/AccordionItem/useAccordionItemStyles.ts
+++ b/packages/react-accordion/src/components/AccordionItem/useAccordionItemStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses } from '@fluentui/react-make-styles';
+import { mergeClasses } from '@griffel/react';
 import type { AccordionItemState } from './AccordionItem.types';
 
 export const accordionItemClassName = 'fui-AccordionItem';

--- a/packages/react-accordion/src/components/AccordionPanel/useAccordionPanelStyles.ts
+++ b/packages/react-accordion/src/components/AccordionPanel/useAccordionPanelStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { makeStyles, mergeClasses } from '@griffel/react';
 import type { AccordionPanelState } from './AccordionPanel.types';
 
 export const accordionPanelClassName = 'fui-AccordionPanel';


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-accordion` package.

Following packages were replaced:

- `@fluentui/react-make-styles` => `@griffel/react`
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`
- `@fluentui/react-conformance-make-styles` => `@fluentui/react-conformance-griffel`

---

Note: check #21360 for more details about changes.