### PR TITLE
chore: migrate react-card to use Griffel

### DIFF
--- a/change/@fluentui-react-card-85862361-6d0b-4c7e-8e71-6dba14d096fa.json
+++ b/change/@fluentui-react-card-85862361-6d0b-4c7e-8e71-6dba14d096fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use Griffel packages",
+  "packageName": "@fluentui/react-card",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-card/.babelrc.json
+++ b/packages/react-card/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-card/jest.config.js
+++ b/packages/react-card/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-card/package.json
+++ b/packages/react-card/package.json
@@ -27,11 +27,9 @@
     "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "9.0.0-beta.4",
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/jest-serializer-make-styles": "9.0.0-beta.4",
     "@fluentui/react-conformance": "*",
-    "@fluentui/react-conformance-make-styles": "9.0.0-beta.4",
+    "@fluentui/react-conformance-griffel": "9.0.0-beta.0",
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/react-text": "9.0.0-beta.4",
     "@fluentui/react-button": "9.0.0-beta.5",
@@ -47,7 +45,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-utilities": "9.0.0-beta.4",
     "@fluentui/react-tabster": "9.0.0-beta.5",
     "tslib": "^2.1.0"

--- a/packages/react-card/src/common/isConformant.ts
+++ b/packages/react-card/src/common/isConformant.ts
@@ -1,6 +1,6 @@
 import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
 import type { IsConformantOptions, TestObject } from '@fluentui/react-conformance';
-import makeStylesTests from '@fluentui/react-conformance-make-styles';
+import griffelTests from '@fluentui/react-conformance-griffel';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
@@ -8,7 +8,7 @@ export function isConformant<TProps = {}>(
   const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
-    extraTests: makeStylesTests as TestObject<TProps>,
+    extraTests: griffelTests as TestObject<TProps>,
   };
 
   baseIsConformant(defaultOptions, testInfo);

--- a/packages/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-card/src/components/Card/useCardStyles.ts
@@ -1,4 +1,4 @@
-import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import { cardPreviewClassName } from '../CardPreview/index';
 import type { CardState } from './Card.types';

--- a/packages/react-card/src/components/CardFooter/useCardFooterStyles.ts
+++ b/packages/react-card/src/components/CardFooter/useCardFooterStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { CardFooterState } from './CardFooter.types';
 
 export const cardFooterClassName = 'fui-CardFooter';

--- a/packages/react-card/src/components/CardHeader/useCardHeaderStyles.ts
+++ b/packages/react-card/src/components/CardHeader/useCardHeaderStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { CardHeaderState } from './CardHeader.types';
 
 export const cardHeaderClassName = 'fui-CardHeader';

--- a/packages/react-card/src/components/CardPreview/useCardPreviewStyles.ts
+++ b/packages/react-card/src/components/CardPreview/useCardPreviewStyles.ts
@@ -1,4 +1,4 @@
-import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
 import type { CardPreviewState } from './CardPreview.types';
 
 export const cardPreviewClassName = 'fui-CardPreview';


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-card` package.

Following packages were replaced:

- `@fluentui/react-make-styles` => `@griffel/react`
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`
- `@fluentui/react-conformance-make-styles` => `@fluentui/react-conformance-griffel`

---

Note: check #21360 for more details about changes.