### PR TITLE
chore: migrate react-text to use Griffel

### DIFF
--- a/change/@fluentui-react-text-deb16e3d-c089-4d90-ad84-7ef467f659c9.json
+++ b/change/@fluentui-react-text-deb16e3d-c089-4d90-ad84-7ef467f659c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use Griffel packages",
+  "packageName": "@fluentui/react-text",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-text/.babelrc.json
+++ b/packages/react-text/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-text/MIGRATION.md
+++ b/packages/react-text/MIGRATION.md
@@ -44,7 +44,7 @@ _This property suffered no changes and can be left as is._
 
 The `nowrap` property was changed to `wrap` and it is `true` by default. You can achieve the same result as `nowrap` by using:
 
-```
+```tsx
 <Text wrap={false}>Not wrapped</Text>
 ```
 
@@ -69,7 +69,7 @@ Variants are now represented with tokens that you can override on a theme level.
 
 You can use them with Text as such:
 
-```
+```tsx
 <Text size={300}>Text</Text>
 ```
 
@@ -88,8 +88,10 @@ _This property suffered no changes and can be left as is._
 
 To achieve the same result with the new `truncate` property, you'll need to do the following:
 
-```
-<Text block truncate wrap={false}>Not wrapped</Text>
+```tsx
+<Text block truncate wrap={false}>
+  Not wrapped
+</Text>
 ```
 
 This is due to `truncate` changing the CSS property `text-overflow` to `ellipsis`.
@@ -109,7 +111,7 @@ While the name remains the same, the values are now represented with integer tok
 
 You can use them with Text as such:
 
-```
+```tsx
 <Text size={300}>Text</Text>
 ```
 
@@ -129,18 +131,20 @@ Northstar design tokens:
 
 - Color: `siteVariables.colors.brand[600]`
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   root: {
-     color: 'rgb(98, 100, 167)'
+    color: 'rgb(98, 100, 167)',
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 ##### **teamsDarkTheme**
@@ -149,18 +153,20 @@ Northstar design tokens:
 
 - Color: `siteVariables.colors.brand[400]`
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   root: {
-     color: 'rgb(166, 167, 220)'
+    color: 'rgb(166, 167, 220)',
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 ##### **teamsHighContrastTheme**
@@ -169,18 +175,20 @@ Northstar design tokens:
 
 - Color: `siteVariables.accessibleYellow`
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   root: {
-     color: 'rgb(255, 255, 1)'
+    color: 'rgb(255, 255, 1)',
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 #### Using `atMention="me"`
@@ -192,19 +200,21 @@ Northstar design tokens:
 - Color: `siteVariables.colors.orange[400]`
 - Font weight: `siteVariables.fontWeightBold`
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   root: {
-     color: 'rgb(204, 74, 49)',
-     fontWeight: 700
+    color: 'rgb(204, 74, 49)',
+    fontWeight: 700,
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 ##### **teamsDarkTheme**
@@ -214,19 +224,21 @@ Northstar design tokens:
 - Color: `siteVariables.colors.orange[300]`
 - Font weight: `siteVariables.fontWeightBold`
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   root: {
-     color: 'rgb(233, 117, 72)',
-     fontWeight: 700
+    color: 'rgb(233, 117, 72)',
+    fontWeight: 700,
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 ##### **teamsHighContrastTheme**
@@ -236,37 +248,41 @@ Northstar design tokens:
 - Color: `siteVariables.accessibleYellow`
 - Font weight: `siteVariables.fontWeightBold`
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   root: {
-     color: 'rgb(255, 255, 1)',
-     fontWeight: 700
+    color: 'rgb(255, 255, 1)',
+    fontWeight: 700,
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 ### color
 
 This property was deprecated. Below is a simple example on how to achieve the same result:
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   root: {
-    color: //Your color here
+    color: '__ put your color there __',
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 _Read more about the CSS prop: [color](https://developer.mozilla.org/en-US/docs/Web/CSS/color)_
@@ -276,13 +292,13 @@ _Read more about the CSS prop: [color](https://developer.mozilla.org/en-US/docs/
 The `content` prop works the same way as the native `children` prop in React.
 You can either use:
 
-```
+```tsx
 <Text children="Hello World!" />
 ```
 
 Or the common and recomended way:
 
-```
+```tsx
 <Text>Hello World!</Text>
 ```
 
@@ -297,6 +313,8 @@ Northstar design tokens:
 - Color: `siteVariables.colors.grey[250]`
 
 ```
+import { makeStyles, Text } from '@fluentui/react-components';
+
 const useStyles = makeStyles(theme => ({
   root: {
      color: 'rgb(200, 198, 196)'
@@ -317,6 +335,8 @@ Northstar design tokens:
 - Color: `siteVariables.colors.grey[450]`
 
 ```
+import { makeStyles, Text } from '@fluentui/react-components';
+
 const useStyles = makeStyles(theme => ({
   root: {
      color: 'rgb(96, 94, 92)'
@@ -337,6 +357,8 @@ Northstar design tokens:
 - Color: `siteVariables.accessibleGreen`
 
 ```
+import { makeStyles, Text } from '@fluentui/react-components';
+
 const useStyles = makeStyles(theme => ({
   root: {
      color: 'rgb(63, 242, 63)'
@@ -361,6 +383,8 @@ Northstar design tokens:
 - Color: `siteVariables.colorScheme.red.foreground`
 
 ```
+import { makeStyles, Text } from '@fluentui/react-components';
+
 const useStyles = makeStyles(theme => ({
   root: {
      color: 'rgb(196, 49, 75)'
@@ -381,6 +405,8 @@ Northstar design tokens:
 - Color: `siteVariables.colors.red[300]`
 
 ```
+import { makeStyles, Text } from '@fluentui/react-components';
+
 const useStyles = makeStyles(theme => ({
   root: {
      color: 'rgb(231, 53, 80)'
@@ -401,6 +427,8 @@ Northstar design tokens:
 - Color: `siteVariables.red`
 
 ```
+import { makeStyles, Text } from '@fluentui/react-components';
+
 const useStyles = makeStyles(theme => ({
   root: {
      color: 'rgb(255, 0, 0)'
@@ -426,6 +454,8 @@ Northstar design tokens:
 - Font weight: `siteVariables.fontWeightBold`
 
 ```
+import { makeStyles, Text } from '@fluentui/react-components';
+
 const useStyles = makeStyles(theme => ({
   root: {
      color: 'rgb(196, 49, 75)',
@@ -448,6 +478,8 @@ Northstar design tokens:
 - Font weight: `siteVariables.fontWeightBold`
 
 ```
+import { makeStyles, Text } from '@fluentui/react-components';
+
 const useStyles = makeStyles(theme => ({
   root: {
      color: 'rgb(231, 53, 80)',
@@ -470,6 +502,8 @@ Northstar design tokens:
 - Font weight: `siteVariables.fontWeightBold`
 
 ```
+import { makeStyles, Text } from '@fluentui/react-components';
+
 const useStyles = makeStyles(theme => ({
   root: {
      color: 'rgb(255, 0, 0)',
@@ -495,6 +529,8 @@ Northstar design tokens:
 - Color: `siteVariables.colors.green[600]`
 
 ```
+import { makeStyles, Text } from '@fluentui/react-components';
+
 const useStyles = makeStyles(theme => ({
   root: {
      color: 'rgb(35, 123, 75)'
@@ -515,6 +551,8 @@ Northstar design tokens:
 - Color: `siteVariables.colors.green[200]`
 
 ```
+import { makeStyles, Text } from '@fluentui/react-components';
+
 const useStyles = makeStyles(theme => ({
   root: {
      color: 'rgb(146, 195, 83)'
@@ -534,36 +572,40 @@ Northstar design tokens:
 
 - Color: `siteVariables.colors.green[200]`
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   root: {
-     color: 'rgb(146, 195, 83)'
+    color: 'rgb(146, 195, 83)',
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 ### temporary [DEPRECATED]
 
 This property was deprecated. Given that this property depends on the applied style, you can find below examples on how to achieve the same results in the default, dark and high contrast themes:
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   root: {
-     fontStyle: 'italic'
+    fontStyle: 'italic',
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 ### timestamp [DEPRECATED]
@@ -576,18 +618,20 @@ Northstar design tokens:
 
 - Color: `siteVariables.colorScheme.default.foreground1`
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   root: {
-     color: 'rgb(72, 70, 68)'
+    color: 'rgb(72, 70, 68)',
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 #### **teamsDarkTheme**
@@ -596,18 +640,20 @@ Northstar design tokens:
 
 - Color: `siteVariables.colorScheme.default.foreground1`
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   root: {
-     color: 'rgb(138, 136, 134)'
+    color: 'rgb(138, 136, 134)',
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 #### **teamsHighContrastTheme**
@@ -616,23 +662,25 @@ Northstar design tokens:
 
 - Color: `siteVariables.colors.white`
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   root: {
-     color: 'rgb(255, 255, 255)'
+    color: 'rgb(255, 255, 255)',
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 ### variables [DEPRECATED]
 
-For v9, this feature is no longer supported. The alternative is to apply styles through `make-styles`. Below is an example of a migration:
+For v9, this feature is no longer supported. The alternative is to apply styles through `makeStyles()` (see [Griffel](https://github.com/microsoft/griffel) docs for more details). Below is an example of a migration:
 
 #### v0 (Northstar) implementation
 
@@ -644,18 +692,20 @@ const MyComponent = () => {
 
 #### v9 (Fluent UI) implementation
 
-```
-const useStyles = makeStyles(theme => ({
+```tsx
+import { makeStyles, Text } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
   red: {
-     color: 'red'
+    color: 'red',
   },
-})
+});
 
 const MyComponent = () => {
-    const styles = useStyles()
+  const styles = useStyles();
 
-    return <Text className={styles.root}>{...}</Text>
-}
+  return <Text className={styles.root}>{/* ... */}</Text>;
+};
 ```
 
 ### weight
@@ -677,4 +727,4 @@ _This property suffered no changes and can be left as is._
 
 ### styles
 
-_This property suffered no changes and can be used as is. However, we highly recommend that you migrate to a `make-styles` styling solution for performance reasons._
+_This property suffered no changes and can be used as is. However, we highly recommend that you migrate to `makeStyles()` (a [Griffel](https://github.com/microsoft/griffel) styling solution) for performance reasons._

--- a/packages/react-text/jest.config.js
+++ b/packages/react-text/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-text/package.json
+++ b/packages/react-text/package.json
@@ -26,11 +26,9 @@
     "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "9.0.0-beta.4",
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/jest-serializer-make-styles": "9.0.0-beta.4",
     "@fluentui/react-conformance": "*",
-    "@fluentui/react-conformance-make-styles": "9.0.0-beta.4",
+    "@fluentui/react-conformance-griffel": "9.0.0-beta.0",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
@@ -44,7 +42,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-utilities": "9.0.0-beta.4",
     "tslib": "^2.1.0"
   },

--- a/packages/react-text/src/common/isConformant.ts
+++ b/packages/react-text/src/common/isConformant.ts
@@ -1,6 +1,6 @@
 import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
 import type { IsConformantOptions, TestObject } from '@fluentui/react-conformance';
-import makeStylesTests from '@fluentui/react-conformance-make-styles';
+import griffelTests from '@fluentui/react-conformance-griffel';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
@@ -8,7 +8,7 @@ export function isConformant<TProps = {}>(
   const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
-    extraTests: makeStylesTests as TestObject<TProps>,
+    extraTests: griffelTests as TestObject<TProps>,
     testOptions: {
       'make-styles-overrides-win': {
         callCount: 2,

--- a/packages/react-text/src/components/Body/Body.tsx
+++ b/packages/react-text/src/components/Body/Body.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { typographyStyles } from '../../typographyStyles/index';
 import { createWrapper, TextWrapperProps } from '../wrapper';
 

--- a/packages/react-text/src/components/Caption/Caption.tsx
+++ b/packages/react-text/src/components/Caption/Caption.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { typographyStyles } from '../../typographyStyles/index';
 import { createWrapper, TextWrapperProps } from '../wrapper';
 

--- a/packages/react-text/src/components/Display/Display.tsx
+++ b/packages/react-text/src/components/Display/Display.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { typographyStyles } from '../../typographyStyles/index';
 import { createWrapper, TextWrapperProps } from '../wrapper';
 

--- a/packages/react-text/src/components/Headline/Headline.tsx
+++ b/packages/react-text/src/components/Headline/Headline.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { typographyStyles } from '../../typographyStyles/index';
 import { createWrapper, TextWrapperProps } from '../wrapper';
 

--- a/packages/react-text/src/components/LargeTitle/LargeTitle.tsx
+++ b/packages/react-text/src/components/LargeTitle/LargeTitle.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { typographyStyles } from '../../typographyStyles/index';
 import { createWrapper, TextWrapperProps } from '../wrapper';
 

--- a/packages/react-text/src/components/Subheadline/Subheadline.tsx
+++ b/packages/react-text/src/components/Subheadline/Subheadline.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { typographyStyles } from '../../typographyStyles/index';
 import { createWrapper, TextWrapperProps } from '../wrapper';
 

--- a/packages/react-text/src/components/Text/useTextStyles.ts
+++ b/packages/react-text/src/components/Text/useTextStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import type { TextState } from './Text.types';
 

--- a/packages/react-text/src/components/Title1/Title1.tsx
+++ b/packages/react-text/src/components/Title1/Title1.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { typographyStyles } from '../../typographyStyles/index';
 import { createWrapper, TextWrapperProps } from '../wrapper';
 

--- a/packages/react-text/src/components/Title2/Title2.tsx
+++ b/packages/react-text/src/components/Title2/Title2.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { typographyStyles } from '../../typographyStyles/index';
 import { createWrapper, TextWrapperProps } from '../wrapper';
 

--- a/packages/react-text/src/components/Title3/Title3.tsx
+++ b/packages/react-text/src/components/Title3/Title3.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { typographyStyles } from '../../typographyStyles/index';
 import { createWrapper, TextWrapperProps } from '../wrapper';
 

--- a/packages/react-text/src/components/wrapper.tsx
+++ b/packages/react-text/src/components/wrapper.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mergeClasses } from '@fluentui/react-make-styles';
+import { mergeClasses } from '@griffel/react';
 import { renderText_unstable, useText_unstable, useTextStyles_unstable } from '../Text';
 import type { TextProps } from '../Text';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';

--- a/packages/react-text/src/stories/Default.stories.tsx
+++ b/packages/react-text/src/stories/Default.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { Text } from '../Text';
 import type { TextProps } from '../Text';
 

--- a/packages/react-text/src/typographyStyles/typographyStyles.ts
+++ b/packages/react-text/src/typographyStyles/typographyStyles.ts
@@ -1,58 +1,58 @@
 import { tokens } from '@fluentui/react-theme';
-import type { MakeStylesStyle } from '@fluentui/react-make-styles';
+import type { GriffelStyle } from '@griffel/react';
 
 /**
  * Make-styles rules for the typography variants
  */
-export const caption: MakeStylesStyle = {
+export const caption: GriffelStyle = {
   fontFamily: tokens.fontFamilyBase,
   fontSize: tokens.fontSizeBase200,
   lineHeight: tokens.lineHeightBase200,
   fontWeight: tokens.fontWeightRegular,
 };
-export const body: MakeStylesStyle = {
+export const body: GriffelStyle = {
   fontFamily: tokens.fontFamilyBase,
   fontSize: tokens.fontSizeBase300,
   lineHeight: tokens.lineHeightBase300,
   fontWeight: tokens.fontWeightRegular,
 };
-export const subheadline: MakeStylesStyle = {
+export const subheadline: GriffelStyle = {
   fontFamily: tokens.fontFamilyBase,
   fontSize: tokens.fontSizeBase400,
   lineHeight: tokens.lineHeightBase400,
   fontWeight: tokens.fontWeightSemibold,
 };
-export const headline: MakeStylesStyle = {
+export const headline: GriffelStyle = {
   fontFamily: tokens.fontFamilyBase,
   fontSize: tokens.fontSizeBase500,
   lineHeight: tokens.lineHeightBase500,
   fontWeight: tokens.fontWeightSemibold,
 };
-export const title3: MakeStylesStyle = {
+export const title3: GriffelStyle = {
   fontFamily: tokens.fontFamilyBase,
   fontSize: tokens.fontSizeBase600,
   lineHeight: tokens.lineHeightBase600,
   fontWeight: tokens.fontWeightSemibold,
 };
-export const title2: MakeStylesStyle = {
+export const title2: GriffelStyle = {
   fontFamily: tokens.fontFamilyBase,
   fontSize: tokens.fontSizeHero700,
   lineHeight: tokens.lineHeightHero700,
   fontWeight: tokens.fontWeightSemibold,
 };
-export const title1: MakeStylesStyle = {
+export const title1: GriffelStyle = {
   fontFamily: tokens.fontFamilyBase,
   fontSize: tokens.fontSizeHero800,
   lineHeight: tokens.lineHeightHero800,
   fontWeight: tokens.fontWeightSemibold,
 };
-export const largeTitle: MakeStylesStyle = {
+export const largeTitle: GriffelStyle = {
   fontFamily: tokens.fontFamilyBase,
   fontSize: tokens.fontSizeHero900,
   lineHeight: tokens.lineHeightHero900,
   fontWeight: tokens.fontWeightSemibold,
 };
-export const display: MakeStylesStyle = {
+export const display: GriffelStyle = {
   fontFamily: tokens.fontFamilyBase,
   fontSize: tokens.fontSizeHero1000,
   lineHeight: tokens.lineHeightHero1000,


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-text` package.

Following packages were replaced:

- `@fluentui/react-make-styles` => `@griffel/react`
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`
- `@fluentui/react-conformance-make-styles` => `@fluentui/react-conformance-griffel`

---

Note: check #21360 for more details about changes.