### PR TITLE
chore: migrate react-tabster to use Griffel

### DIFF
--- a/change/@fluentui-react-tabster-7b7fc54e-8f57-4f49-92c5-1e26e6e9ad90.json
+++ b/change/@fluentui-react-tabster-7b7fc54e-8f57-4f49-92c5-1e26e6e9ad90.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use Griffel packages",
+  "packageName": "@fluentui/react-tabster",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tabster/.babelrc.json
+++ b/packages/react-tabster/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-tabster/etc/react-tabster.api.md
@@ -4,12 +4,12 @@
 
 ```ts
 
-import type { MakeStylesStyle } from '@fluentui/react-make-styles';
+import type { GriffelStyle } from '@griffel/react';
 import type { RefObject } from 'react';
 import { Types } from 'tabster';
 
 // @public
-export const createCustomFocusIndicatorStyle: (style: MakeStylesStyle, options?: CreateFocusIndicatorStyleRuleOptions) => MakeStylesStyle;
+export const createCustomFocusIndicatorStyle: (style: GriffelStyle, options?: CreateFocusIndicatorStyleRuleOptions) => GriffelStyle;
 
 // @public (undocumented)
 export interface CreateFocusIndicatorStyleRuleOptions {
@@ -20,7 +20,7 @@ export interface CreateFocusIndicatorStyleRuleOptions {
 // @public
 export const createFocusOutlineStyle: (options?: {
     style: Partial<FocusOutlineStyleOptions>;
-} & CreateFocusIndicatorStyleRuleOptions) => MakeStylesStyle;
+} & CreateFocusIndicatorStyleRuleOptions) => GriffelStyle;
 
 // @public (undocumented)
 export type FocusOutlineOffset = Record<'top' | 'bottom' | 'left' | 'right', string>;

--- a/packages/react-tabster/jest.config.js
+++ b/packages/react-tabster/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-tabster/package.json
+++ b/packages/react-tabster/package.json
@@ -32,11 +32,10 @@
     "@types/react-test-renderer": "^16.0.0",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-test-renderer": "^16.3.0",
-    "@fluentui/babel-make-styles": "9.0.0-beta.4"
+    "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-shared-contexts": "9.0.0-beta.4",
     "@fluentui/react-utilities": "9.0.0-beta.4",
     "keyborg": "^1.1.0",

--- a/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/hooks/useFocusIndicatorStyle.ts
@@ -1,6 +1,6 @@
 import { tokens } from '@fluentui/react-theme';
 import { KEYBOARD_NAV_SELECTOR } from '../symbols';
-import type { MakeStylesStyle } from '@fluentui/react-make-styles';
+import type { GriffelStyle } from '@griffel/react';
 
 export type FocusOutlineOffset = Record<'top' | 'bottom' | 'left' | 'right', string>;
 export type FocusOutlineStyleOptions = {
@@ -71,7 +71,7 @@ export const createFocusOutlineStyle = (
   options: {
     style: Partial<FocusOutlineStyleOptions>;
   } & CreateFocusIndicatorStyleRuleOptions = { style: {}, ...defaultOptions },
-): MakeStylesStyle => ({
+): GriffelStyle => ({
   ':focus-visible': {
     outlineStyle: 'none',
   },
@@ -91,9 +91,9 @@ export const createFocusOutlineStyle = (
  * @param style - styling applied on focus, defaults to @see getDefaultFocusOutlineStyes
  */
 export const createCustomFocusIndicatorStyle = (
-  style: MakeStylesStyle,
+  style: GriffelStyle,
   options: CreateFocusIndicatorStyleRuleOptions = defaultOptions,
-): MakeStylesStyle => ({
+): GriffelStyle => ({
   ':focus-visible': {
     outlineStyle: 'none',
   },


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-tabster` package.

Following packages were replaced:

- `@fluentui/react-make-styles` => `@griffel/react`
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`
- `@fluentui/react-conformance-make-styles` => `@fluentui/react-conformance-griffel`

---

Note: check #21360 for more details about changes.