### PR TITLE
chore: migrate react-tabs to use Griffel

### DIFF
--- a/packages/react-tabs/.babelrc.json
+++ b/packages/react-tabs/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-tabs/jest.config.js
+++ b/packages/react-tabs/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-tabs/package.json
+++ b/packages/react-tabs/package.json
@@ -26,11 +26,9 @@
     "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "9.0.0-beta.4",
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/jest-serializer-make-styles": "9.0.0-beta.4",
     "@fluentui/react-conformance": "*",
-    "@fluentui/react-conformance-make-styles": "9.0.0-beta.4",
+    "@fluentui/react-conformance-griffel": "9.0.0-beta.0",
     "@fluentui/react-context-selector": "9.0.0-beta.4",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
@@ -45,7 +43,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-tabster": "9.0.0-beta.5",
     "@fluentui/react-utilities": "9.0.0-beta.4",
     "tslib": "^2.1.0"

--- a/packages/react-tabs/src/common/isConformant.ts
+++ b/packages/react-tabs/src/common/isConformant.ts
@@ -1,6 +1,6 @@
 import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
 import type { IsConformantOptions, TestObject } from '@fluentui/react-conformance';
-import makeStylesTests from '@fluentui/react-conformance-make-styles';
+import griffelTests from '@fluentui/react-conformance-griffel';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
@@ -8,7 +8,7 @@ export function isConformant<TProps = {}>(
   const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
-    extraTests: makeStylesTests as TestObject<TProps>,
+    extraTests: griffelTests as TestObject<TProps>,
   };
 
   baseIsConformant(defaultOptions, testInfo);

--- a/packages/react-tabs/src/components/Tab/useTabStyles.ts
+++ b/packages/react-tabs/src/components/Tab/useTabStyles.ts
@@ -1,6 +1,6 @@
 import type { TabState } from './Tab.types';
 
-import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import { tokens } from '@fluentui/react-theme';
 

--- a/packages/react-tabs/src/components/TabList/useTabListStyles.ts
+++ b/packages/react-tabs/src/components/TabList/useTabListStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { makeStyles, mergeClasses } from '@griffel/react';
 import type { TabListState } from './TabList.types';
 
 export const tabListClassName = 'fui-TabList';

--- a/packages/react-tabs/src/stories/TabListAppearance.stories.tsx
+++ b/packages/react-tabs/src/stories/TabListAppearance.stories.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
 import { Tab, TabList, TabProps } from '../index';
 

--- a/packages/react-tabs/src/stories/TabListDefault.stories.tsx
+++ b/packages/react-tabs/src/stories/TabListDefault.stories.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
 import { Tab, TabList, TabProps } from '../index';
 

--- a/packages/react-tabs/src/stories/TabListSizeMedium.stories.tsx
+++ b/packages/react-tabs/src/stories/TabListSizeMedium.stories.tsx
@@ -1,5 +1,5 @@
 import { CalendarMonthRegular } from '@fluentui/react-icons';
-import { makeStyles, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
 import { Tab, TabList } from '../index';
 

--- a/packages/react-tabs/src/stories/TabListSizeSmall.stories.tsx
+++ b/packages/react-tabs/src/stories/TabListSizeSmall.stories.tsx
@@ -1,5 +1,5 @@
 import { CalendarMonthRegular } from '@fluentui/react-icons';
-import { makeStyles, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
 import { Tab, TabList, TabProps } from '../index';
 

--- a/packages/react-tabs/src/stories/TabListVertical.stories.tsx
+++ b/packages/react-tabs/src/stories/TabListVertical.stories.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
 import { Tab, TabList, TabProps } from '../index';
 

--- a/packages/react-tabs/src/stories/TabListWithIcon.stories.tsx
+++ b/packages/react-tabs/src/stories/TabListWithIcon.stories.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
 import { Tab, TabList, TabProps } from '../index';
 import { CalendarMonthRegular } from '@fluentui/react-icons';


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-tabs` package.

Following packages were replaced:

- `@fluentui/react-make-styles` => `@griffel/react`
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`
- `@fluentui/react-conformance-make-styles` => `@fluentui/react-conformance-griffel`

---

Note: check #21360 for more details about changes.