### PR TITLE
chore: migrate react-positioning to use Griffel

### DIFF
--- a/change/@fluentui-react-positioning-9a291fd5-6056-4028-900c-ae4734eb3e77.json
+++ b/change/@fluentui-react-positioning-9a291fd5-6056-4028-900c-ae4734eb3e77.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use Griffel packages",
+  "packageName": "@fluentui/react-positioning",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-positioning/.babelrc.json
+++ b/packages/react-positioning/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-positioning/etc/react-positioning.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import type { MakeStylesStyle } from '@fluentui/react-make-styles';
+import type { GriffelStyle } from '@griffel/react';
 import * as PopperJs from '@popperjs/core';
 import * as React_2 from 'react';
 
@@ -24,14 +24,14 @@ export function createArrowHeightStyles(arrowHeight: number): {
 };
 
 // @public
-export function createArrowStyles(options: CreateArrowStylesOptions): MakeStylesStyle;
+export function createArrowStyles(options: CreateArrowStylesOptions): GriffelStyle;
 
 // @public
 export type CreateArrowStylesOptions = {
     arrowHeight: number | undefined;
-    borderWidth?: MakeStylesStyle['borderBottomWidth'];
-    borderStyle?: MakeStylesStyle['borderBottomStyle'];
-    borderColor?: MakeStylesStyle['borderBottomColor'];
+    borderWidth?: GriffelStyle['borderBottomWidth'];
+    borderStyle?: GriffelStyle['borderBottomStyle'];
+    borderColor?: GriffelStyle['borderBottomColor'];
 };
 
 // @public

--- a/packages/react-positioning/jest.config.js
+++ b/packages/react-positioning/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-positioning/package.json
+++ b/packages/react-positioning/package.json
@@ -29,11 +29,10 @@
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "react": "16.8.6",
-    "react-dom": "16.8.6",
-    "@fluentui/babel-make-styles": "9.0.0-beta.4"
+    "react-dom": "16.8.6"
   },
   "dependencies": {
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-shared-contexts": "9.0.0-beta.4",
     "@fluentui/react-utilities": "9.0.0-beta.4",
     "@popperjs/core": "~2.4.3",

--- a/packages/react-positioning/src/createArrowStyles.ts
+++ b/packages/react-positioning/src/createArrowStyles.ts
@@ -1,6 +1,6 @@
-import { shorthands } from '@fluentui/react-make-styles';
+import { shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
-import type { MakeStylesStyle } from '@fluentui/react-make-styles';
+import type { GriffelStyle } from '@griffel/react';
 
 /**
  * Options parameter for the createArrowStyles function
@@ -19,21 +19,21 @@ export type CreateArrowStylesOptions = {
    *
    * @defaultvalue 1px
    */
-  borderWidth?: MakeStylesStyle['borderBottomWidth'];
+  borderWidth?: GriffelStyle['borderBottomWidth'];
 
   /**
    * The borderStyle for the arrow. Should be the same borderStyle as the parent element.
    *
    * @defaultvalue solid
    */
-  borderStyle?: MakeStylesStyle['borderBottomStyle'];
+  borderStyle?: GriffelStyle['borderBottomStyle'];
 
   /**
    * The borderColor of the arrow. Should be the same borderColor as the parent element.
    *
    * @defaultvalue tokens.colorTransparentStroke
    */
-  borderColor?: MakeStylesStyle['borderBottomColor'];
+  borderColor?: GriffelStyle['borderBottomColor'];
 };
 
 /**
@@ -58,7 +58,7 @@ export type CreateArrowStylesOptions = {
  *   )
  * ```
  */
-export function createArrowStyles(options: CreateArrowStylesOptions): MakeStylesStyle {
+export function createArrowStyles(options: CreateArrowStylesOptions): GriffelStyle {
   const {
     arrowHeight,
     borderWidth = '1px',


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-positioning` package.

Following packages were replaced:

- `@fluentui/react-make-styles` => `@griffel/react`
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`
- `@fluentui/react-conformance-make-styles` => `@fluentui/react-conformance-griffel`

---

Note: check #21360 for more details about changes.