### PR TITLE
chore: migrate react-tooltip to use Griffel

### DIFF
--- a/change/@fluentui-react-tooltip-d6140e21-2c99-4913-826d-8075c45c6fd4.json
+++ b/change/@fluentui-react-tooltip-d6140e21-2c99-4913-826d-8075c45c6fd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use Griffel packages",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-d6140e21-2c99-4913-826d-8075c45c6fd4.json
+++ b/change/@fluentui-react-tooltip-d6140e21-2c99-4913-826d-8075c45c6fd4.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "use Griffel packages",
+  "comment": "Replace make-styles packages with griffel equivalents.",
   "packageName": "@fluentui/react-tooltip",
   "email": "olfedias@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-tooltip/.babelrc.json
+++ b/packages/react-tooltip/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-tooltip/jest.config.js
+++ b/packages/react-tooltip/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-tooltip/package.json
+++ b/packages/react-tooltip/package.json
@@ -26,11 +26,9 @@
     "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "9.0.0-beta.4",
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/jest-serializer-make-styles": "9.0.0-beta.4",
     "@fluentui/react-conformance": "*",
-    "@fluentui/react-conformance-make-styles": "9.0.0-beta.4",
+    "@fluentui/react-conformance-griffel": "9.0.0-beta.0",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
@@ -44,7 +42,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-portal": "9.0.0-beta.5",
     "@fluentui/react-positioning": "9.0.0-beta.4",
     "@fluentui/react-shared-contexts": "9.0.0-beta.4",

--- a/packages/react-tooltip/package.json
+++ b/packages/react-tooltip/package.json
@@ -42,12 +42,12 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@griffel/react": "1.0.0",
     "@fluentui/react-portal": "9.0.0-beta.5",
     "@fluentui/react-positioning": "9.0.0-beta.4",
     "@fluentui/react-shared-contexts": "9.0.0-beta.4",
     "@fluentui/react-theme": "9.0.0-beta.4",
     "@fluentui/react-utilities": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-tooltip/src/common/isConformant.ts
+++ b/packages/react-tooltip/src/common/isConformant.ts
@@ -1,6 +1,6 @@
 import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
 import type { IsConformantOptions, TestObject } from '@fluentui/react-conformance';
-import makeStylesTests from '@fluentui/react-conformance-make-styles';
+import griffelTests from '@fluentui/react-conformance-griffel';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
@@ -8,7 +8,7 @@ export function isConformant<TProps = {}>(
   const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
-    extraTests: makeStylesTests as TestObject<TProps>,
+    extraTests: griffelTests as TestObject<TProps>,
   };
 
   baseIsConformant(defaultOptions, testInfo);

--- a/packages/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
@@ -1,4 +1,4 @@
-import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
 import { createArrowStyles } from '@fluentui/react-positioning';
 import { tokens } from '@fluentui/react-theme';
 import { arrowHeight } from './private/constants';

--- a/packages/react-tooltip/src/stories/TooltipAria.stories.tsx
+++ b/packages/react-tooltip/src/stories/TooltipAria.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shorthands, makeStyles } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles } from '@griffel/react';
 
 import { Tooltip } from '../Tooltip';
 

--- a/packages/react-tooltip/src/stories/TooltipDefault.stories.tsx
+++ b/packages/react-tooltip/src/stories/TooltipDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shorthands, makeStyles } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles } from '@griffel/react';
 
 import { Tooltip } from '../Tooltip';
 

--- a/packages/react-tooltip/src/stories/TooltipPositioning.stories.tsx
+++ b/packages/react-tooltip/src/stories/TooltipPositioning.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shorthands, makeStyles } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles } from '@griffel/react';
 
 import { Tooltip } from '../Tooltip';
 


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-tooltip` package.

Following packages were replaced:

- `@fluentui/react-make-styles` => `@griffel/react`
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`
- `@fluentui/react-conformance-make-styles` => `@fluentui/react-conformance-griffel`

---

Note: check #21360 for more details about changes.