### PR TITLE
fix: Conformance tests should unmount components

### DIFF
--- a/change/@fluentui-react-conformance-51ab0364-5e41-409e-87b4-bc07c09fac6d.json
+++ b/change/@fluentui-react-conformance-51ab0364-5e41-409e-87b4-bc07c09fac6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Conformance tests should unmount components",
+  "packageName": "@fluentui/react-conformance",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -3,7 +3,8 @@ import { defaultErrorMessages } from './defaultErrorMessages';
 import { ComponentDoc } from 'react-docgen-typescript';
 import { getComponent } from './utils/getComponent';
 import { getCallbackArguments } from './utils/getCallbackArguments';
-import { mount, ReactWrapper } from 'enzyme';
+import { ReactWrapper } from 'enzyme';
+import { mount } from './utils/mountWithCleanup';
 import { act } from 'react-dom/test-utils';
 import parseDocblock from './utils/parseDocblock';
 import { validateCallbackArguments } from './utils/validateCallbackArguments';
@@ -254,6 +255,7 @@ export const defaultTests: TestObject = {
       const defaultEl = customMount(<Component {...requiredProps} />);
       const defaultComponent = getComponent(defaultEl, helperComponents, wrapperComponent);
       const defaultClassNames = defaultComponent.getDOMNode().getAttribute('class')?.split(' ') || [];
+      defaultEl.unmount();
 
       const el = customMount(<Component {...mergedProps} />);
       const component = getComponent(el, helperComponents, wrapperComponent);

--- a/packages/react-conformance/src/isConformant.ts
+++ b/packages/react-conformance/src/isConformant.ts
@@ -5,12 +5,15 @@ import { defaultTests } from './defaultTests';
 import { merge } from './utils/merge';
 import { createTsProgram } from './utils/createTsProgram';
 import { getComponentDoc } from './utils/getComponentDoc';
+import { cleanup } from './utils/mountWithCleanup';
 
 export function isConformant<TProps = {}>(...testInfo: Partial<IsConformantOptions<TProps>>[]) {
   const mergedOptions = merge<IsConformantOptions>(...testInfo);
   const { componentPath, displayName, disabledTests = [], extraTests, tsconfigDir } = mergedOptions;
 
   describe('isConformant', () => {
+    afterEach(cleanup);
+
     if (!fs.existsSync(componentPath)) {
       throw new Error(`Path ${componentPath} does not exist`);
     }

--- a/packages/react-conformance/src/utils/mountWithCleanup.ts
+++ b/packages/react-conformance/src/utils/mountWithCleanup.ts
@@ -1,0 +1,29 @@
+import { mount as enzymeMount, ReactWrapper } from 'enzyme';
+
+let wrapper: ReactWrapper | undefined;
+
+/**
+ * A wrapper around enzyme's mount that helps with unmounting and cleanup
+ * This is an approach that's adopted by quite a few users of enzyme.
+ * https://github.com/enzymejs/enzyme/issues/911
+ * @returns Enzyme wrapper
+ */
+export const mount = (...args: Parameters<typeof enzymeMount>) => {
+  const enzymeWrapper = enzymeMount(...args);
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  wrapper = enzymeWrapper;
+  return enzymeWrapper;
+};
+
+export const cleanup = () => {
+  if (wrapper) {
+    try {
+      wrapper.unmount();
+    } catch {
+      console.error('failed to unmount');
+    }
+  }
+
+  wrapper = undefined;
+};

--- a/packages/react-conformance/src/utils/mountWithCleanup.ts
+++ b/packages/react-conformance/src/utils/mountWithCleanup.ts
@@ -18,11 +18,7 @@ export const mount = (...args: Parameters<typeof enzymeMount>) => {
 
 export const cleanup = () => {
   if (wrapper) {
-    try {
-      wrapper.unmount();
-    } catch {
-      console.error('failed to unmount');
-    }
+    wrapper.unmount();
   }
 
   wrapper = undefined;


### PR DESCRIPTION
Enzyme does not unmount automatically at the end of a test
test suite which leads to cryptic bugs when queryselectors return
multiple elements, or the wrong element.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Conformance tests leave DOM elements in the document after test

## New Behavior

Conformance tests don't leave DOM elements in the document after test

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
