### PR TITLE
chore: migrate react-input to use Griffel

### DIFF
--- a/change/@fluentui-react-input-9bef86de-9038-4127-8e8e-81f0881cb6da.json
+++ b/change/@fluentui-react-input-9bef86de-9038-4127-8e8e-81f0881cb6da.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use Griffel packages",
+  "packageName": "@fluentui/react-input",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-9bef86de-9038-4127-8e8e-81f0881cb6da.json
+++ b/change/@fluentui-react-input-9bef86de-9038-4127-8e8e-81f0881cb6da.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "use Griffel packages",
+  "comment": "Replace make-styles packages with griffel equivalents.",
   "packageName": "@fluentui/react-input",
   "email": "olfedias@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-input/.babelrc.json
+++ b/packages/react-input/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-input/jest.config.js
+++ b/packages/react-input/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-input/package.json
+++ b/packages/react-input/package.json
@@ -26,11 +26,9 @@
     "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "9.0.0-beta.4",
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/jest-serializer-make-styles": "9.0.0-beta.4",
     "@fluentui/react-conformance": "*",
-    "@fluentui/react-conformance-make-styles": "9.0.0-beta.4",
+    "@fluentui/react-conformance-griffel": "9.0.0-beta.0",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
@@ -44,7 +42,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-utilities": "9.0.0-beta.4",
     "tslib": "^2.1.0"
   },

--- a/packages/react-input/package.json
+++ b/packages/react-input/package.json
@@ -42,8 +42,8 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@griffel/react": "1.0.0",
     "@fluentui/react-utilities": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-input/src/common/isConformant.ts
+++ b/packages/react-input/src/common/isConformant.ts
@@ -1,6 +1,6 @@
 import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
 import type { IsConformantOptions, TestObject } from '@fluentui/react-conformance';
-import makeStylesTests from '@fluentui/react-conformance-make-styles';
+import griffelTests from '@fluentui/react-conformance-griffel';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
@@ -10,7 +10,7 @@ export function isConformant<TProps = {}>(
     componentPath: module!.parent!.filename.replace('.test', ''),
     disabledTests: ['has-docblock'],
     skipAsPropTests: true,
-    extraTests: makeStylesTests as TestObject<TProps>,
+    extraTests: griffelTests as TestObject<TProps>,
   };
 
   baseIsConformant(defaultOptions, testInfo);

--- a/packages/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-input/src/components/Input/useInputStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import type { InputState } from './Input.types';
 

--- a/packages/react-input/src/stories/InputAppearance.stories.tsx
+++ b/packages/react-input/src/stories/InputAppearance.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import { Input } from '../index';
 

--- a/packages/react-input/src/stories/InputContentBeforeAfter.stories.tsx
+++ b/packages/react-input/src/stories/InputContentBeforeAfter.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { SearchRegular, DismissRegular } from '@fluentui/react-icons';
 import { Input } from '../index';
 

--- a/packages/react-input/src/stories/InputSize.stories.tsx
+++ b/packages/react-input/src/stories/InputSize.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { Input } from '../index';
 
 const useStyles = makeStyles({

--- a/packages/react-input/src/stories/InputType.stories.tsx
+++ b/packages/react-input/src/stories/InputType.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { Input } from '../index';
 
 const useStyles = makeStyles({


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-input` package.

Following packages were replaced:

- `@fluentui/react-make-styles` => `@griffel/react`
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`
- `@fluentui/react-conformance-make-styles` => `@fluentui/react-conformance-griffel`

---

Note: check #21360 for more details about changes.