### PR TITLE
chore: migrate react-divider to use Griffel

### DIFF
--- a/change/@fluentui-react-divider-de1f0901-ef09-4ac0-8399-2584219ca5c6.json
+++ b/change/@fluentui-react-divider-de1f0901-ef09-4ac0-8399-2584219ca5c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use Griffel packages",
+  "packageName": "@fluentui/react-divider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-de1f0901-ef09-4ac0-8399-2584219ca5c6.json
+++ b/change/@fluentui-react-divider-de1f0901-ef09-4ac0-8399-2584219ca5c6.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "use Griffel packages",
+  "comment": "Replace make-styles packages with griffel equivalents.",
   "packageName": "@fluentui/react-divider",
   "email": "olfedias@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-divider/.babelrc.json
+++ b/packages/react-divider/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-divider/jest.config.js
+++ b/packages/react-divider/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-divider/package.json
+++ b/packages/react-divider/package.json
@@ -26,11 +26,9 @@
     "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "9.0.0-beta.4",
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/jest-serializer-make-styles": "9.0.0-beta.4",
     "@fluentui/react-conformance": "*",
-    "@fluentui/react-conformance-make-styles": "9.0.0-beta.4",
+    "@fluentui/react-conformance-griffel": "9.0.0-beta.0",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
@@ -44,7 +42,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-utilities": "9.0.0-beta.4",
     "tslib": "^2.1.0"
   },

--- a/packages/react-divider/src/common/isConformant.ts
+++ b/packages/react-divider/src/common/isConformant.ts
@@ -1,5 +1,5 @@
 import { isConformant as baseIsConformant, IsConformantOptions, TestObject } from '@fluentui/react-conformance';
-import makeStylesTests from '@fluentui/react-conformance-make-styles';
+import griffelTests from '@fluentui/react-conformance-griffel';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
@@ -7,7 +7,7 @@ export function isConformant<TProps = {}>(
   const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
-    extraTests: makeStylesTests as TestObject<TProps>,
+    extraTests: griffelTests as TestObject<TProps>,
   };
 
   baseIsConformant(defaultOptions, testInfo);

--- a/packages/react-divider/src/components/Divider/useDividerStyles.ts
+++ b/packages/react-divider/src/components/Divider/useDividerStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses, shorthands, makeStyles } from '@fluentui/react-make-styles';
+import { mergeClasses, shorthands, makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import { DividerState } from './Divider.types';
 

--- a/packages/react-divider/src/stories/DividerAlignContent.stories.tsx
+++ b/packages/react-divider/src/stories/DividerAlignContent.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import { Divider } from '../Divider';
 

--- a/packages/react-divider/src/stories/DividerAppearance.stories.tsx
+++ b/packages/react-divider/src/stories/DividerAppearance.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import { Divider } from '../Divider';
 

--- a/packages/react-divider/src/stories/DividerCustomStyles.stories.tsx
+++ b/packages/react-divider/src/stories/DividerCustomStyles.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shorthands, makeStyles } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import { Divider } from '../Divider';
 

--- a/packages/react-divider/src/stories/DividerDefault.stories.tsx
+++ b/packages/react-divider/src/stories/DividerDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import { Divider } from '../Divider';
 

--- a/packages/react-divider/src/stories/DividerInset.stories.tsx
+++ b/packages/react-divider/src/stories/DividerInset.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import { Divider } from '../Divider';
 

--- a/packages/react-divider/src/stories/DividerVertical.stories.tsx
+++ b/packages/react-divider/src/stories/DividerVertical.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import { Divider } from '../Divider';
 


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-divider` package.

Following packages were replaced:

- `@fluentui/react-make-styles` => `@griffel/react`
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`
- `@fluentui/react-conformance-make-styles` => `@fluentui/react-conformance-griffel`

---

Note: check #21360 for more details about changes.