### PR TITLE
chore: migrate react-checkbox to use Griffel

### DIFF
--- a/change/@fluentui-react-checkbox-54181b52-9a19-48e5-8cc3-c2cea765d706.json
+++ b/change/@fluentui-react-checkbox-54181b52-9a19-48e5-8cc3-c2cea765d706.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use Griffel packages",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-54181b52-9a19-48e5-8cc3-c2cea765d706.json
+++ b/change/@fluentui-react-checkbox-54181b52-9a19-48e5-8cc3-c2cea765d706.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "use Griffel packages",
+  "comment": "Replace make-styles packages with griffel equivalents.",
   "packageName": "@fluentui/react-checkbox",
   "email": "olfedias@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-checkbox/.babelrc.json
+++ b/packages/react-checkbox/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-checkbox/jest.config.js
+++ b/packages/react-checkbox/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-checkbox/package.json
+++ b/packages/react-checkbox/package.json
@@ -43,9 +43,9 @@
   "dependencies": {
     "@fluentui/react-icons": "^2.0.154-beta.5",
     "@fluentui/react-label": "9.0.0-beta.4",
-    "@griffel/react": "1.0.0",
     "@fluentui/react-tabster": "9.0.0-beta.5",
     "@fluentui/react-utilities": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-checkbox/package.json
+++ b/packages/react-checkbox/package.json
@@ -26,9 +26,8 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/jest-serializer-make-styles": "9.0.0-beta.4",
     "@fluentui/react-conformance": "*",
-    "@fluentui/react-conformance-make-styles": "9.0.0-beta.4",
+    "@fluentui/react-conformance-griffel": "9.0.0-beta.0",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
@@ -39,13 +38,12 @@
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-test-renderer": "^16.3.0",
-    "@fluentui/babel-make-styles": "9.0.0-beta.4"
+    "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
     "@fluentui/react-icons": "^2.0.154-beta.5",
     "@fluentui/react-label": "9.0.0-beta.4",
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-tabster": "9.0.0-beta.5",
     "@fluentui/react-utilities": "9.0.0-beta.4",
     "tslib": "^2.1.0"

--- a/packages/react-checkbox/src/common/isConformant.ts
+++ b/packages/react-checkbox/src/common/isConformant.ts
@@ -1,5 +1,5 @@
 import { isConformant as baseIsConformant, IsConformantOptions, TestObject } from '@fluentui/react-conformance';
-import makeStylesTests from '@fluentui/react-conformance-make-styles';
+import griffelTests from '@fluentui/react-conformance-griffel';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
@@ -7,7 +7,7 @@ export function isConformant<TProps = {}>(
   const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
-    extraTests: makeStylesTests as TestObject<TProps>,
+    extraTests: griffelTests as TestObject<TProps>,
     skipAsPropTests: true,
   };
 

--- a/packages/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -1,4 +1,4 @@
-import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import { tokens } from '@fluentui/react-theme';
 import { CheckboxState } from './Checkbox.types';


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-checkbox` package.

Following packages were replaced:

- `@fluentui/react-make-styles` => `@griffel/react`
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`
- `@fluentui/react-conformance-make-styles` => `@fluentui/react-conformance-griffel`

---

Note: check #21360 for more details about changes.