### PR TITLE
docs: Interactive popover stories should use aria-labelledby

### DIFF
--- a/packages/react-popover/src/stories/PopoverNestedPopovers.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverNestedPopovers.stories.tsx
@@ -10,46 +10,57 @@ const useStyles = makeStyles({
   },
 });
 
-const ExampleContent = () => {
+const FirstNestedPopover = () => {
   const styles = useStyles();
+  const id = 'first';
   return (
-    <div>
-      <h3 className={styles.contentHeader}>Popover content</h3>
+    <Popover trapFocus>
+      <PopoverTrigger>
+        <Button>First nested trigger</Button>
+      </PopoverTrigger>
 
-      <div>This is some popover content</div>
-    </div>
+      <PopoverSurface aria-labelledby={id}>
+        <div>
+          <h3 id={id} className={styles.contentHeader}>
+            Popover content
+          </h3>
+
+          <div>This is some popover content</div>
+        </div>
+        <Button>First nested button</Button>
+        <SecondNestedPopover />
+        <SecondNestedPopover />
+      </PopoverSurface>
+    </Popover>
   );
 };
 
-const FirstNestedPopover = () => (
-  <Popover trapFocus>
-    <PopoverTrigger>
-      <Button>First nested trigger</Button>
-    </PopoverTrigger>
+const SecondNestedPopover = () => {
+  const styles = useStyles();
+  const id = 'second';
+  return (
+    <Popover trapFocus>
+      <PopoverTrigger>
+        <Button>Second nested trigger</Button>
+      </PopoverTrigger>
 
-    <PopoverSurface>
-      <ExampleContent />
-      <Button>First nested button</Button>
-      <SecondNestedPopover />
-      <SecondNestedPopover />
-    </PopoverSurface>
-  </Popover>
-);
+      <PopoverSurface aria-labelledby={id}>
+        <div>
+          <h3 id={id} className={styles.contentHeader}>
+            Popover content
+          </h3>
 
-const SecondNestedPopover = () => (
-  <Popover trapFocus>
-    <PopoverTrigger>
-      <Button>Second nested trigger</Button>
-    </PopoverTrigger>
-
-    <PopoverSurface>
-      <ExampleContent />
-      <Button>Second nested button</Button>
-    </PopoverSurface>
-  </Popover>
-);
+          <div>This is some popover content</div>
+        </div>
+        <Button>Second nested button</Button>
+      </PopoverSurface>
+    </Popover>
+  );
+};
 
 export const NestedPopovers = () => {
+  const id = 'root';
+  const styles = useStyles();
   return (
     <Popover trapFocus>
       <PopoverTrigger>
@@ -57,7 +68,13 @@ export const NestedPopovers = () => {
       </PopoverTrigger>
 
       <PopoverSurface>
-        <ExampleContent />
+        <div>
+          <h3 id={id} className={styles.contentHeader}>
+            Popover content
+          </h3>
+
+          <div>This is some popover content</div>
+        </div>
         <Button>Root button</Button>
         <FirstNestedPopover />
       </PopoverSurface>

--- a/packages/react-popover/src/stories/PopoverTrappingFocus.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverTrappingFocus.stories.tsx
@@ -10,33 +10,32 @@ const useStyles = makeStyles({
   },
 });
 
-const ExampleContent = () => {
+export const TrappingFocus = () => {
   const styles = useStyles();
+  const id = 'heading';
   return (
-    <div>
-      <h3 className={styles.contentHeader}>Popover content</h3>
+    <Popover trapFocus>
+      <PopoverTrigger>
+        <Button>Popover trigger</Button>
+      </PopoverTrigger>
 
-      <div>This is some popover content</div>
-    </div>
+      <PopoverSurface aria-labelledby={id}>
+        <div>
+          <h3 id={id} className={styles.contentHeader}>
+            Popover content
+          </h3>
+
+          <div>This is some popover content</div>
+        </div>
+
+        <div>
+          <Button>Action</Button>
+          <Button>Action</Button>
+        </div>
+      </PopoverSurface>
+    </Popover>
   );
 };
-
-export const TrappingFocus = () => (
-  <Popover trapFocus>
-    <PopoverTrigger>
-      <Button>Popover trigger</Button>
-    </PopoverTrigger>
-
-    <PopoverSurface>
-      <ExampleContent />
-
-      <div>
-        <Button>Action</Button>
-        <Button>Action</Button>
-      </div>
-    </PopoverSurface>
-  </Popover>
-);
 
 TrappingFocus.parameters = {
   docs: {


### PR DESCRIPTION
Interactive popovers should follow the WAI dialog pattern, so
`aria-labelledby` should be present so that the dialog is labelled by
the heading of the content.

Addressed by: #21107