### PR TITLE
chore: migrate react-avatar to use Griffel

### DIFF
--- a/change/@fluentui-react-avatar-40747d70-5829-4f5d-8a6d-da1153e4b710.json
+++ b/change/@fluentui-react-avatar-40747d70-5829-4f5d-8a6d-da1153e4b710.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use Griffel packages",
+  "packageName": "@fluentui/react-avatar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-40747d70-5829-4f5d-8a6d-da1153e4b710.json
+++ b/change/@fluentui-react-avatar-40747d70-5829-4f5d-8a6d-da1153e4b710.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "use Griffel packages",
+  "comment": "Replace make-styles packages with griffel equivalents.",
   "packageName": "@fluentui/react-avatar",
   "email": "olfedias@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-avatar/.babelrc.json
+++ b/packages/react-avatar/.babelrc.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-avatar/jest.config.js
+++ b/packages/react-avatar/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -47,7 +47,7 @@
     "@fluentui/react-icons": "^2.0.154-beta.5",
     "@fluentui/react-theme": "9.0.0-beta.4",
     "@fluentui/react-utilities": "9.0.0-beta.4",
-     "@griffel/react": "1.0.0",
+    "@griffel/react": "1.0.0",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -45,9 +45,9 @@
   "dependencies": {
     "@fluentui/react-badge": "9.0.0-beta.4",
     "@fluentui/react-icons": "^2.0.154-beta.5",
-    "@griffel/react": "1.0.0",
     "@fluentui/react-theme": "9.0.0-beta.4",
     "@fluentui/react-utilities": "9.0.0-beta.4",
+     "@griffel/react": "1.0.0",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -26,11 +26,9 @@
     "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
-    "@fluentui/babel-make-styles": "9.0.0-beta.4",
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/jest-serializer-make-styles": "9.0.0-beta.4",
     "@fluentui/react-conformance": "*",
-    "@fluentui/react-conformance-make-styles": "9.0.0-beta.4",
+    "@fluentui/react-conformance-griffel": "9.0.0-beta.0",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
@@ -47,7 +45,7 @@
   "dependencies": {
     "@fluentui/react-badge": "9.0.0-beta.4",
     "@fluentui/react-icons": "^2.0.154-beta.5",
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-theme": "9.0.0-beta.4",
     "@fluentui/react-utilities": "9.0.0-beta.4",
     "tslib": "^2.1.0"

--- a/packages/react-avatar/src/common/isConformant.ts
+++ b/packages/react-avatar/src/common/isConformant.ts
@@ -1,5 +1,5 @@
 import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
-import makeStylesTests from '@fluentui/react-conformance-make-styles';
+import griffelTests from '@fluentui/react-conformance-griffel';
 import type { IsConformantOptions, TestObject } from '@fluentui/react-conformance';
 
 export function isConformant<TProps = {}>(
@@ -9,7 +9,7 @@ export function isConformant<TProps = {}>(
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
     disabledTests: ['has-docblock'],
-    extraTests: makeStylesTests as TestObject<TProps>,
+    extraTests: griffelTests as TestObject<TProps>,
   };
 
   baseIsConformant(defaultOptions, testInfo);

--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses, makeStyles, shorthands } from '@fluentui/react-make-styles';
+import { mergeClasses, makeStyles, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import type { AvatarState } from './Avatar.types';
 


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/core` and related packages in `@fluentui/react-avatar` package.

Following packages were replaced:

- `@fluentui/react-make-styles` => `@griffel/react`
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`
- `@fluentui/react-conformance-make-styles` => `@fluentui/react-conformance-griffel`

---

Note: check #21360 for more details about changes.