### PR TITLE
chore: remove make-styles packages react-aria

### DIFF
--- a/change/@fluentui-react-aria-443b8afb-6d3e-45e1-a381-75ab044f5c67.json
+++ b/change/@fluentui-react-aria-443b8afb-6d3e-45e1-a381-75ab044f5c67.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove Griffel packages",
+  "packageName": "@fluentui/react-aria",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-aria/.babelrc.json
+++ b/packages/react-aria/.babelrc.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-aria/jest.config.js
+++ b/packages/react-aria/jest.config.js
@@ -17,5 +17,4 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 };

--- a/packages/react-aria/package.json
+++ b/packages/react-aria/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/jest-serializer-make-styles": "9.0.0-beta.4",
     "@fluentui/react-conformance": "*",
     "@fluentui/scripts": "^1.0.0",
     "@types/enzyme": "3.10.3",
@@ -38,12 +37,10 @@
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "react-test-renderer": "^16.3.0",
-    "@fluentui/babel-make-styles": "9.0.0-beta.4"
+    "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "9.0.0-beta.1",
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
     "@fluentui/react-utilities": "9.0.0-beta.4",
     "tslib": "^2.1.0"
   },


### PR DESCRIPTION
## PR changes

This PR remove `@fluentui/*-make-styles` packages from `@fluentui/react-aria` as they are not used.