### PR TITLE
fix: update add-to-milestone to support pull_request_target

### DIFF
--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign to latest milestone
-        uses: andrefcdias/add-to-milestone@v1.2.0
+        uses: andrefcdias/add-to-milestone@v1.2.2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           use-expression: true


### PR DESCRIPTION
## Current Behavior

Version 1.2.0 had a bug where `pull_request` was the only acceptable target.

## New Behavior

Version 1.2.2 has this issue fixed.
https://github.com/andrefcdias/add-to-milestone/pull/67