### PR TITLE
Avatar: Export the default getInitials implementation

### DIFF
--- a/change/@fluentui-react-avatar-56b839c4-963b-40e9-a27c-6002a17750c8.json
+++ b/change/@fluentui-react-avatar-56b839c4-963b-40e9-a27c-6002a17750c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Export the default getInitials implementation",
+  "packageName": "@fluentui/react-avatar",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-avatar/etc/react-avatar.api.md
@@ -56,6 +56,9 @@ export type AvatarState = ComponentState<AvatarSlots> & AvatarCommons & {
     color: Exclude<AvatarCommons['color'], 'colorful'>;
 };
 
+// @public
+export function getInitials(displayName: string | undefined | null, isRtl: boolean, allowPhoneInitials?: boolean): string;
+
 // @public (undocumented)
 export const renderAvatar_unstable: (state: AvatarState) => JSX.Element;
 

--- a/packages/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -18,7 +18,10 @@ export type AvatarSlots = {
   image?: IntrinsicShorthandProps<'img'>;
 
   /**
-   * (optional) Custom initials. By default, this will be derived from the `name` using `getInitials`.
+   * (optional) Custom initials.
+   *
+   * It is usually not necessary to specify custom initials; by default they will be derived from the `name` prop,
+   * using the `getInitials` function.
    *
    * The initials are displayed when there is no image (including while the image is loading).
    */

--- a/packages/react-avatar/src/index.ts
+++ b/packages/react-avatar/src/index.ts
@@ -1,2 +1,2 @@
 export * from './Avatar';
-export * from './utils';
+export * from './utils/index';

--- a/packages/react-avatar/src/index.ts
+++ b/packages/react-avatar/src/index.ts
@@ -1,1 +1,2 @@
 export * from './Avatar';
+export * from './utils';

--- a/packages/react-avatar/src/utils/getInitials.ts
+++ b/packages/react-avatar/src/utils/getInitials.ts
@@ -68,7 +68,12 @@ function cleanupDisplayName(displayName: string): string {
 /**
  * Get (up to 2 characters) initials based on display name of the persona.
  *
- * @public
+ * @param displayName - The full name of the person or entity
+ * @param isRtl - Whether the display is in RTL
+ * @param allowPhoneInitials - Should initials be generated from phone numbers (default false)
+ *
+ * @returns The 1 or 2 character initials based on the name. Or an empty string if no initials
+ * could be derived from the name.
  */
 export function getInitials(
   displayName: string | undefined | null,


### PR DESCRIPTION
Export the `getInitials` function from `@fluentui/react-avatar` so users can optionally use it in their implementation

## Related Issue(s)

This is a follow-up from a comment on another PR for Avatar: https://github.com/microsoft/fluentui/pull/21346#discussion_r791924699
