### PR TITLE
temp fix: Add react-make-styles as devDep to fix perf test pipeline

### DIFF
--- a/apps/perf-test/package.json
+++ b/apps/perf-test/package.json
@@ -19,6 +19,7 @@
     "@fluentui/react": "^8.51.0",
     "@fluentui/react-avatar": "9.0.0-beta.4",
     "@fluentui/react-button": "9.0.0-beta.5",
+    "@fluentui/react-make-styles": "9.0.0-beta.4",
     "@fluentui/react-provider": "9.0.0-beta.5",
     "@fluentui/react-theme": "9.0.0-beta.4",
     "@fluentui/scripts": "^1.0.0",

--- a/packages/fluentui/perf-test/package.json
+++ b/packages/fluentui/perf-test/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@fluentui/digest": "^0.60.1",
     "@fluentui/react": "^8.0.0",
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
     "@fluentui/react-northstar": "^0.60.1",
     "@fluentui/react-northstar-prototypes": "^0.60.1",
     "@types/react": "16.9.42",

--- a/packages/fluentui/perf-test/package.json
+++ b/packages/fluentui/perf-test/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@fluentui/digest": "^0.60.1",
     "@fluentui/react": "^8.0.0",
+    "@fluentui/react-make-styles": "9.0.0-beta.4",
     "@fluentui/react-northstar": "^0.60.1",
     "@fluentui/react-northstar-prototypes": "^0.60.1",
     "@types/react": "16.9.42",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- Perf-test CI pipeline is failing since `react-icons` (which lives in another repo) is still using `react-make-styles` and has yet to migrate to Griffel. No packages in our repo trigger `react-make-styles` build anymore which is causing the error.
 ![image](https://user-images.githubusercontent.com/8649804/151072684-769129d0-7e14-4a7e-9138-100e4084bafc.png)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Temporarily adds `react-make-styles` as a dependency of the `perf-test` package. Should be removed once [PR ](https://github.com/microsoft/fluentui-system-icons/pull/393)to migrate `react-icons` to Griffel is merged. 
## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
