### PR TITLE
feat(Popup): new prop `closeOnScroll` close popup when scroll outside of it

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
@@ -131,6 +131,9 @@ export interface PopupProps
 
   /** Controls whether or not auto focus should be applied, using boolean or AutoFocusZoneProps type value. */
   autoFocus?: boolean | AutoFocusZoneProps;
+
+  /** Close the popup when scroll happens outside of Popup */
+  closeOnScroll?: boolean;
 }
 
 export const popupClassName = 'ui-popup';
@@ -170,6 +173,7 @@ export const Popup: React.FC<PopupProps> &
     unstable_disableTether,
     unstable_pinned,
     autoSize,
+    closeOnScroll,
   } = props;
 
   const [open, setOpen] = useAutoControlled({
@@ -477,7 +481,7 @@ export const Popup: React.FC<PopupProps> &
                   capture
                 />
 
-                {isOpenedByRightClick && (
+                {(isOpenedByRightClick || closeOnScroll) && (
                   <>
                     <EventListener listener={dismissOnScroll} target={context.target} type="wheel" capture />
                     <EventListener listener={dismissOnScroll} target={context.target} type="touchmove" capture />
@@ -685,6 +689,7 @@ Popup.propTypes = {
   contentRef: customPropTypes.ref,
   trapFocus: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
   autoFocus: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
+  closeOnScroll: PropTypes.bool,
 };
 Popup.defaultProps = {
   accessibility: popupBehavior,


### PR DESCRIPTION
When popup's trigger is rendered outside of a scrollable container, popperjs is not able to find the scrollable parent of the trigger element, and it can cause the trigger to detach from popup itself:
https://codesandbox.io/s/fluent-ui-example-forked-yxmwv?file=/example.js:0-1198
![image](https://user-images.githubusercontent.com/28751745/151161236-e052c187-b74c-417f-b702-f67caf7ad777.png)

For cases like this, a new prop `closeOnScroll` is added to Popup, so when the scroll happens in the container, the popup can be dismissed.
