### PR TITLE
fix(Detailslist): link high contrast selector specificity

### DIFF
--- a/change/@fluentui-react-cca25cf7-0a9d-4d36-8d45-ff8e0a2411da.json
+++ b/change/@fluentui-react-cca25cf7-0a9d-4d36-8d45-ff8e0a2411da.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix DetailsList high contrast link selector hierarchy",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/react/src/components/DetailsList/DetailsRow.styles.ts
@@ -142,6 +142,11 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
 
         [`.${classNames.cell} > .${LinkGlobalClassNames.root}`]: {
           color: focusedLinkColor,
+          selectors: {
+            [HighContrastSelector]: {
+              color: 'HighlightText',
+            },
+          },
         },
 
         // Selected State hover
@@ -150,10 +155,14 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
           color: colors.selectedHoverMetaText,
           selectors: {
             // Selected State hover meta cell
-            [`.${classNames.cell} ${HighContrastSelector}`]: {
-              color: 'HighlightText',
+            [HighContrastSelector]: {
+              background: 'Highlight',
               selectors: {
-                '> a': {
+                [`.${classNames.cell}`]: {
+                  color: 'HighlightText',
+                },
+                [`.${classNames.cell} > .${LinkGlobalClassNames.root}`]: {
+                  forcedColorAdjust: 'none',
                   color: 'HighlightText',
                 },
               },
@@ -167,11 +176,6 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
                   color: 'HighlightText',
                 },
               },
-            },
-
-            // Ensure high-contrast mode overrides default hover background
-            [HighContrastSelector]: {
-              background: 'Highlight',
             },
           },
         },
@@ -281,11 +285,6 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
           background: 'Highlight',
           color: 'HighlightText',
           ...getHighContrastNoAdjustStyle(),
-          selectors: {
-            a: {
-              color: 'HighlightText',
-            },
-          },
         },
       },
     },


### PR DESCRIPTION
Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally

In Windows high contrast mode, the link color on selected DetailsList rows was incorrect because of a mismatch of selector specificity between non-HCM and HCM styles. This fixes the high contrast selector specificity.

Fixes [10836](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/10836

Visual change:
![screenshot of links before the change on a selected detailslist row. The link in this contrast theme is blue on a purple background](https://user-images.githubusercontent.com/3819570/151839999-6dc9e18f-6072-4467-bc5a-a51f21878eed.png)
to
![screenshot of links before the change on a selected detailslist row. The link now matches text color on selected rows, and has adequate text contrast](https://user-images.githubusercontent.com/3819570/151840160-6dcdcefa-3a7e-493e-b606-adb3694fbb42.png)
