### PR TITLE
Panel: Header now properly inherits background color from main

### DIFF
--- a/change/@fluentui-react-91884cdd-2d97-41a6-827b-09f555e1032b.json
+++ b/change/@fluentui-react-91884cdd-2d97-41a6-827b-09f555e1032b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Panel fix: Header now inherits backgroundColor from parent.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -259,6 +259,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       classNames.commands,
       {
         marginTop: 18,
+        //Ensures that the stickied header always has a background to prevent overlaps on scroll.
         background: 'inherit',
         selectors: {
           [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -259,9 +259,9 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       classNames.commands,
       {
         marginTop: 18,
+        background: 'inherit',
         selectors: {
           [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
-            backgroundColor: semanticColors.bodyBackground,
             position: 'sticky',
             top: 0,
             zIndex: 1,
@@ -289,6 +289,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         flexDirection: 'column',
         flexGrow: 1,
         overflowY: 'hidden',
+        background: 'inherit',
       },
     ],
     header: [
@@ -323,6 +324,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       classNames.scrollableContent,
       {
         overflowY: 'auto',
+        background: 'inherit',
       },
       isFooterAtBottom && {
         flexGrow: 1,
@@ -353,7 +355,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         transition: `opacity ${AnimationVariables.durationValue3} ${AnimationVariables.easeFunction2}`,
         selectors: {
           [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
-            background: semanticColors.bodyBackground,
             position: 'sticky',
             bottom: 0,
           },

--- a/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -168,6 +168,7 @@ exports[`Panel allows the consumer to pass through popup props 1`] = `
             className=
                 ms-Panel-contentInner
                 {
+                  background: inherit;
                   display: flex;
                   flex-direction: column;
                   flex-grow: 1;
@@ -178,6 +179,7 @@ exports[`Panel allows the consumer to pass through popup props 1`] = `
               className=
                   ms-Panel-scrollableContent
                   {
+                    background: inherit;
                     overflow-y: auto;
                   }
               data-is-scrollable={true}
@@ -186,10 +188,10 @@ exports[`Panel allows the consumer to pass through popup props 1`] = `
                 className=
                     ms-Panel-commands
                     {
+                      background: inherit;
                       margin-top: 18px;
                     }
                     @media (min-height: 480px){& {
-                      background-color: #ffffff;
                       position: sticky;
                       top: 0px;
                       z-index: 1;
@@ -571,6 +573,7 @@ exports[`Panel renders Panel correctly 1`] = `
             className=
                 ms-Panel-contentInner
                 {
+                  background: inherit;
                   display: flex;
                   flex-direction: column;
                   flex-grow: 1;
@@ -581,6 +584,7 @@ exports[`Panel renders Panel correctly 1`] = `
               className=
                   ms-Panel-scrollableContent
                   {
+                    background: inherit;
                     overflow-y: auto;
                   }
               data-is-scrollable={true}
@@ -589,10 +593,10 @@ exports[`Panel renders Panel correctly 1`] = `
                 className=
                     ms-Panel-commands
                     {
+                      background: inherit;
                       margin-top: 18px;
                     }
                     @media (min-height: 480px){& {
-                      background-color: #ffffff;
                       position: sticky;
                       top: 0px;
                       z-index: 1;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

- Currently, the `header` of the `Panel` has a hardcoded `background-color` when it meets the height based media query. This was added to prevent the `content` from overlapping with the stickied `header` when scrolling down (see screenshot below) since by default, the `header`'s background color is **transparent**. However, this caused an issue where consumers get inconsistent background colors when they directly customize the `header` or the `main` root.

**`content` overlaps with `header` on scroll since `header` has a transparent background by default:**
![image](https://user-images.githubusercontent.com/8649804/151294859-e0399c6d-260d-45b8-874d-ad9f2daf93cf.png)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- The `header` will now **inherit** its `background` from its parent. If its parent does not have a background color specified, it will directly inherit its background from `main`. This ensures that there's always a `background-color` to prevent the overlap issue above while at the same time giving consumers a predictable custom styling experience.
- Removes unnecessary backgroundColor for the footer.

**New behavior with no custom styling, `content` does not overlap with `header` on scroll:**

![PanelHeaderFix2](https://user-images.githubusercontent.com/8649804/151297306-cacfdd24-d190-444b-be44-c33f08abc332.gif)


**New Behavior: when adding a red background-color to `main` , `header` now inherits it:**

![PanelHeaderFix](https://user-images.githubusercontent.com/8649804/151296721-b0aa7724-7cb7-4a7a-bc94-5a9a18ca9654.gif)




## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20643
