### PR TITLE
fix(Textfield): include prefix/suffix in accessible name

### DIFF
--- a/change/@fluentui-react-6ab3ca9f-7a9a-46a4-b405-457d482d3d4f.json
+++ b/change/@fluentui-react-6ab3ca9f-7a9a-46a4-b405-457d482d3d4f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix Textfield to include prefix/suffix in the accessible name",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react-focus/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/react-examples/src/react-focus/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -536,7 +536,7 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                     margin-right: 4px;
                     margin-top: 0;
                   }
-              id="id__10"
+              id="id__12"
             >
               Button 3
             </span>
@@ -653,7 +653,7 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                 margin-right: 4px;
                 margin-top: 0;
               }
-          id="id__13"
+          id="id__15"
         >
           Tabbable Element 1
         </span>
@@ -666,7 +666,7 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone16"
+    data-focuszone-id="FocusZone18"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -804,7 +804,7 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                     margin-right: 4px;
                     margin-top: 0;
                   }
-              id="id__17"
+              id="id__19"
             >
               Button 1
             </span>
@@ -919,7 +919,7 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                     margin-right: 4px;
                     margin-top: 0;
                   }
-              id="id__20"
+              id="id__22"
             >
               Button 2
             </span>
@@ -1054,7 +1054,7 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                 color: GrayText;
               }
-          id="TextField23"
+          id="TextField25"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}

--- a/packages/react-examples/src/react-focus/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/react-examples/src/react-focus/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -655,7 +655,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField6"
+                id="TextField8"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -758,7 +758,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           flex-shrink: 0;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone10"
+    data-focuszone-id="FocusZone14"
     data-is-focusable={true}
     data-item-index={1}
     data-selection-index={1}
@@ -1133,7 +1133,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField11"
+                id="TextField15"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1326,7 +1326,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField14"
+                id="TextField20"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1429,7 +1429,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           flex-shrink: 0;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone18"
+    data-focuszone-id="FocusZone26"
     data-is-focusable={true}
     data-item-index={2}
     data-selection-index={2}
@@ -1804,7 +1804,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField19"
+                id="TextField27"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1997,7 +1997,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField22"
+                id="TextField32"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -2100,7 +2100,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           flex-shrink: 0;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone26"
+    data-focuszone-id="FocusZone38"
     data-is-focusable={true}
     data-item-index={3}
     data-selection-index={3}
@@ -2475,7 +2475,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField27"
+                id="TextField39"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -2668,7 +2668,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField30"
+                id="TextField44"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -2771,7 +2771,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           flex-shrink: 0;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone34"
+    data-focuszone-id="FocusZone50"
     data-is-focusable={true}
     data-item-index={4}
     data-selection-index={4}
@@ -3146,7 +3146,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField35"
+                id="TextField51"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -3339,7 +3339,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField38"
+                id="TextField56"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -3442,7 +3442,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           flex-shrink: 0;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone42"
+    data-focuszone-id="FocusZone62"
     data-is-focusable={true}
     data-item-index={5}
     data-selection-index={5}
@@ -3817,7 +3817,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField43"
+                id="TextField63"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -4010,7 +4010,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField46"
+                id="TextField68"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -4113,7 +4113,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           flex-shrink: 0;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone50"
+    data-focuszone-id="FocusZone74"
     data-is-focusable={true}
     data-item-index={6}
     data-selection-index={6}
@@ -4488,7 +4488,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField51"
+                id="TextField75"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -4681,7 +4681,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField54"
+                id="TextField80"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -4784,7 +4784,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           flex-shrink: 0;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone58"
+    data-focuszone-id="FocusZone86"
     data-is-focusable={true}
     data-item-index={7}
     data-selection-index={7}
@@ -5159,7 +5159,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField59"
+                id="TextField87"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -5352,7 +5352,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField62"
+                id="TextField92"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -5455,7 +5455,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           flex-shrink: 0;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone66"
+    data-focuszone-id="FocusZone98"
     data-is-focusable={true}
     data-item-index={8}
     data-selection-index={8}
@@ -5830,7 +5830,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField67"
+                id="TextField99"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -6023,7 +6023,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField70"
+                id="TextField104"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -6126,7 +6126,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           flex-shrink: 0;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone74"
+    data-focuszone-id="FocusZone110"
     data-is-focusable={true}
     data-item-index={9}
     data-selection-index={9}
@@ -6501,7 +6501,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField75"
+                id="TextField111"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -6694,7 +6694,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                       color: GrayText;
                     }
-                id="TextField78"
+                id="TextField116"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}

--- a/packages/react-examples/src/react-focus/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/react-examples/src/react-focus/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -536,7 +536,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     margin-right: 4px;
                     margin-top: 0;
                   }
-              id="id__10"
+              id="id__12"
             >
               Button 3
             </span>
@@ -741,7 +741,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                         margin-right: 4px;
                         margin-top: 0;
                       }
-                  id="id__13"
+                  id="id__15"
                 >
                   Create account
                 </span>
@@ -891,7 +891,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone19"
+    data-focuszone-id="FocusZone21"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -1029,7 +1029,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     margin-right: 4px;
                     margin-top: 0;
                   }
-              id="id__20"
+              id="id__22"
             >
               Button 1
             </span>
@@ -1144,7 +1144,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     margin-right: 4px;
                     margin-top: 0;
                   }
-              id="id__23"
+              id="id__25"
             >
               Button 2
             </span>
@@ -1278,7 +1278,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                     color: GrayText;
                   }
-              id="TextField26"
+              id="TextField28"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -1398,7 +1398,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     margin-right: 4px;
                     margin-top: 0;
                   }
-              id="id__29"
+              id="id__33"
             >
               Button 3
             </span>

--- a/packages/react-examples/src/react/TextField/TextField.PrefixAndSuffix.Example.tsx
+++ b/packages/react-examples/src/react/TextField/TextField.PrefixAndSuffix.Example.tsx
@@ -17,13 +17,11 @@ export const TextFieldPrefixAndSuffixExample: React.FunctionComponent = () => {
         <TextField // prettier-ignore
           label="With prefix"
           prefix="https://"
-          ariaLabel="Example text field with https:// prefix"
         />
         <TextField // prettier-ignore
           label="Disabled with prefix"
           prefix="https://"
           disabled
-          ariaLabel="Example text field with https:// prefix"
         />
       </Stack>
 
@@ -31,15 +29,9 @@ export const TextFieldPrefixAndSuffixExample: React.FunctionComponent = () => {
         <TextField // prettier-ignore
           label="With suffix"
           suffix=".com"
-          ariaLabel="Example text field with .com suffix"
         />
 
-        <TextField
-          label="With prefix and suffix"
-          prefix="https://"
-          suffix=".com"
-          ariaLabel="Example text field with https:// prefix and .com suffix"
-        />
+        <TextField label="With prefix and suffix" prefix="https://" suffix=".com" />
       </Stack>
     </Stack>
   );

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -707,7 +707,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
-                        id="TextField6"
+                        id="TextField8"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -877,7 +877,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
-                        id="TextField10"
+                        id="TextField14"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -1047,7 +1047,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
-                        id="TextField14"
+                        id="TextField20"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -1217,7 +1217,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
-                        id="TextField18"
+                        id="TextField26"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -1282,8 +1282,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               padding-top: 5px;
               word-wrap: break-word;
             }
-        htmlFor="Toggle21"
-        id="Toggle21-label"
+        htmlFor="Toggle31"
+        id="Toggle31-label"
       >
         Show preview box
       </label>
@@ -1297,7 +1297,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       >
         <button
           aria-checked={true}
-          aria-labelledby="Toggle21-label"
+          aria-labelledby="Toggle31-label"
           checked={true}
           className=
               ms-Toggle-background
@@ -1351,7 +1351,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               }
           data-is-focusable={true}
           data-ktp-target={true}
-          id="Toggle21"
+          id="Toggle31"
           onChange={[Function]}
           onClick={[Function]}
           role="switch"
@@ -1393,7 +1393,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
           }
     >
       <div
-        aria-labelledby="ChoiceGroupLabel23"
+        aria-labelledby="ChoiceGroupLabel33"
         onFocus={[Function]}
         role="radiogroup"
       >
@@ -1421,7 +1421,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
-          id="ChoiceGroupLabel23"
+          id="ChoiceGroupLabel33"
         >
           Alpha slider type
         </label>
@@ -1470,8 +1470,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       top: 0px;
                       width: 100%;
                     }
-                id="ChoiceGroup22-alpha"
-                name="ChoiceGroup22"
+                id="ChoiceGroup32-alpha"
+                name="ChoiceGroup32"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1557,11 +1557,11 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       border-color: Highlight;
                       forced-color-adjust: none;
                     }
-                htmlFor="ChoiceGroup22-alpha"
+                htmlFor="ChoiceGroup32-alpha"
               >
                 <span
                   className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel23-alpha"
+                  id="ChoiceGroupLabel33-alpha"
                 >
                   Alpha
                 </span>
@@ -1610,8 +1610,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       top: 0px;
                       width: 100%;
                     }
-                id="ChoiceGroup22-transparency"
-                name="ChoiceGroup22"
+                id="ChoiceGroup32-transparency"
+                name="ChoiceGroup32"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1691,11 +1691,11 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 0px;
                     }
-                htmlFor="ChoiceGroup22-transparency"
+                htmlFor="ChoiceGroup32-transparency"
               >
                 <span
                   className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel23-transparency"
+                  id="ChoiceGroupLabel33-transparency"
                 >
                   Transparency
                 </span>
@@ -1744,8 +1744,8 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       top: 0px;
                       width: 100%;
                     }
-                id="ChoiceGroup22-none"
-                name="ChoiceGroup22"
+                id="ChoiceGroup32-none"
+                name="ChoiceGroup32"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1825,11 +1825,11 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 0px;
                     }
-                htmlFor="ChoiceGroup22-none"
+                htmlFor="ChoiceGroup32-none"
               >
                 <span
                   className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel23-none"
+                  id="ChoiceGroupLabel33-none"
                 >
                   None
                 </span>

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -293,7 +293,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                     display: block;
                   }
               data-automationid="DetailsHeader"
-              data-focuszone-id="FocusZone5"
+              data-focuszone-id="FocusZone7"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
@@ -302,7 +302,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
             >
               <div
                 aria-colindex={1}
-                aria-labelledby="header4-checkTooltip"
+                aria-labelledby="header6-checkTooltip"
                 className=
                     ms-DetailsHeader-cell
                     ms-DetailsHeader-cellIsCheck
@@ -409,7 +409,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                     data-automationid="DetailsRowCheck"
                     data-is-focusable={true}
                     data-selection-toggle={true}
-                    id="header4-check"
+                    id="header6-check"
                     role="checkbox"
                     tabIndex={-1}
                   >
@@ -566,13 +566,13 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                       white-space: nowrap;
                       width: 1px;
                     }
-                id="header4-checkTooltip"
+                id="header6-checkTooltip"
               >
                 Toggle selection for all items
               </label>
               <div
                 aria-colindex={2}
-                aria-labelledby="header4-column1-name"
+                aria-labelledby="header6-column1-name"
                 aria-sort="none"
                 className=
                     ms-DetailsHeader-cell
@@ -682,7 +682,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           top: 1px;
                           z-index: 1;
                         }
-                    id="header4-column1"
+                    id="header6-column1"
                     onClick={[Function]}
                     onContextMenu={[Function]}
                   >
@@ -696,7 +696,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             overflow: hidden;
                             text-overflow: ellipsis;
                           }
-                      id="header4-column1-name"
+                      id="header6-column1-name"
                     >
                       Name
                     </span>
@@ -761,7 +761,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
               />
               <div
                 aria-colindex={3}
-                aria-labelledby="header4-column2-name"
+                aria-labelledby="header6-column2-name"
                 aria-sort="none"
                 className=
                     ms-DetailsHeader-cell
@@ -871,7 +871,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                           top: 1px;
                           z-index: 1;
                         }
-                    id="header4-column2"
+                    id="header6-column2"
                     onClick={[Function]}
                     onContextMenu={[Function]}
                   >
@@ -885,7 +885,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             overflow: hidden;
                             text-overflow: ellipsis;
                           }
-                      id="header4-column2-name"
+                      id="header6-column2-name"
                     >
                       Value
                     </span>
@@ -978,7 +978,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                       min-height: 1px;
                       min-width: 100%;
                     }
-                data-focuszone-id="FocusZone6"
+                data-focuszone-id="FocusZone8"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -1080,12 +1080,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone8"
+                          data-focuszone-id="FocusZone10"
                           data-is-focusable={true}
                           data-item-index={0}
                           data-selection-index={0}
                           data-selection-touch-invoke={true}
-                          id="row3-0"
+                          id="row5-0"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -1148,7 +1148,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-0-checkbox row3-0-header"
+                              aria-labelledby="row5-0-checkbox row5-0-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1197,7 +1197,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-0-checkbox"
+                              id="row5-0-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -1558,12 +1558,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone10"
+                          data-focuszone-id="FocusZone12"
                           data-is-focusable={true}
                           data-item-index={1}
                           data-selection-index={1}
                           data-selection-touch-invoke={true}
-                          id="row3-1"
+                          id="row5-1"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -1626,7 +1626,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-1-checkbox row3-1-header"
+                              aria-labelledby="row5-1-checkbox row5-1-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1675,7 +1675,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-1-checkbox"
+                              id="row5-1-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -2036,12 +2036,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone12"
+                          data-focuszone-id="FocusZone14"
                           data-is-focusable={true}
                           data-item-index={2}
                           data-selection-index={2}
                           data-selection-touch-invoke={true}
-                          id="row3-2"
+                          id="row5-2"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -2104,7 +2104,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-2-checkbox row3-2-header"
+                              aria-labelledby="row5-2-checkbox row5-2-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2153,7 +2153,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-2-checkbox"
+                              id="row5-2-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -2514,12 +2514,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone14"
+                          data-focuszone-id="FocusZone16"
                           data-is-focusable={true}
                           data-item-index={3}
                           data-selection-index={3}
                           data-selection-touch-invoke={true}
-                          id="row3-3"
+                          id="row5-3"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -2582,7 +2582,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-3-checkbox row3-3-header"
+                              aria-labelledby="row5-3-checkbox row5-3-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2631,7 +2631,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-3-checkbox"
+                              id="row5-3-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -2992,12 +2992,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone16"
+                          data-focuszone-id="FocusZone18"
                           data-is-focusable={true}
                           data-item-index={4}
                           data-selection-index={4}
                           data-selection-touch-invoke={true}
-                          id="row3-4"
+                          id="row5-4"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3060,7 +3060,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-4-checkbox row3-4-header"
+                              aria-labelledby="row5-4-checkbox row5-4-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3109,7 +3109,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-4-checkbox"
+                              id="row5-4-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -3470,12 +3470,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone18"
+                          data-focuszone-id="FocusZone20"
                           data-is-focusable={true}
                           data-item-index={5}
                           data-selection-index={5}
                           data-selection-touch-invoke={true}
-                          id="row3-5"
+                          id="row5-5"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3538,7 +3538,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-5-checkbox row3-5-header"
+                              aria-labelledby="row5-5-checkbox row5-5-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3587,7 +3587,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-5-checkbox"
+                              id="row5-5-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -3948,12 +3948,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone20"
+                          data-focuszone-id="FocusZone22"
                           data-is-focusable={true}
                           data-item-index={6}
                           data-selection-index={6}
                           data-selection-touch-invoke={true}
-                          id="row3-6"
+                          id="row5-6"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -4016,7 +4016,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-6-checkbox row3-6-header"
+                              aria-labelledby="row5-6-checkbox row5-6-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4065,7 +4065,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-6-checkbox"
+                              id="row5-6-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -4426,12 +4426,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone22"
+                          data-focuszone-id="FocusZone24"
                           data-is-focusable={true}
                           data-item-index={7}
                           data-selection-index={7}
                           data-selection-touch-invoke={true}
-                          id="row3-7"
+                          id="row5-7"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -4494,7 +4494,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-7-checkbox row3-7-header"
+                              aria-labelledby="row5-7-checkbox row5-7-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4543,7 +4543,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-7-checkbox"
+                              id="row5-7-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -4904,12 +4904,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone24"
+                          data-focuszone-id="FocusZone26"
                           data-is-focusable={true}
                           data-item-index={8}
                           data-selection-index={8}
                           data-selection-touch-invoke={true}
-                          id="row3-8"
+                          id="row5-8"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -4972,7 +4972,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-8-checkbox row3-8-header"
+                              aria-labelledby="row5-8-checkbox row5-8-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5021,7 +5021,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-8-checkbox"
+                              id="row5-8-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -5382,12 +5382,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone26"
+                          data-focuszone-id="FocusZone28"
                           data-is-focusable={true}
                           data-item-index={9}
                           data-selection-index={9}
                           data-selection-touch-invoke={true}
-                          id="row3-9"
+                          id="row5-9"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -5450,7 +5450,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-9-checkbox row3-9-header"
+                              aria-labelledby="row5-9-checkbox row5-9-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5499,7 +5499,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-9-checkbox"
+                              id="row5-9-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -277,7 +277,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                     display: block;
                   }
               data-automationid="DetailsHeader"
-              data-focuszone-id="FocusZone5"
+              data-focuszone-id="FocusZone7"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
@@ -286,7 +286,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
             >
               <div
                 aria-colindex={1}
-                aria-labelledby="header4-checkTooltip"
+                aria-labelledby="header6-checkTooltip"
                 className=
                     ms-DetailsHeader-cell
                     ms-DetailsHeader-cellIsCheck
@@ -393,7 +393,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                     data-automationid="DetailsRowCheck"
                     data-is-focusable={true}
                     data-selection-toggle={true}
-                    id="header4-check"
+                    id="header6-check"
                     role="checkbox"
                     tabIndex={-1}
                   >
@@ -550,13 +550,13 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                       white-space: nowrap;
                       width: 1px;
                     }
-                id="header4-checkTooltip"
+                id="header6-checkTooltip"
               >
                 Toggle selection for all items
               </label>
               <div
                 aria-colindex={2}
-                aria-labelledby="header4-column1-name"
+                aria-labelledby="header6-column1-name"
                 aria-sort="none"
                 className=
                     ms-DetailsHeader-cell
@@ -666,7 +666,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           top: 1px;
                           z-index: 1;
                         }
-                    id="header4-column1"
+                    id="header6-column1"
                     onClick={[Function]}
                     onContextMenu={[Function]}
                   >
@@ -680,7 +680,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             overflow: hidden;
                             text-overflow: ellipsis;
                           }
-                      id="header4-column1-name"
+                      id="header6-column1-name"
                     >
                       Name
                     </span>
@@ -745,7 +745,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
               />
               <div
                 aria-colindex={3}
-                aria-labelledby="header4-column2-name"
+                aria-labelledby="header6-column2-name"
                 aria-sort="none"
                 className=
                     ms-DetailsHeader-cell
@@ -855,7 +855,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                           top: 1px;
                           z-index: 1;
                         }
-                    id="header4-column2"
+                    id="header6-column2"
                     onClick={[Function]}
                     onContextMenu={[Function]}
                   >
@@ -869,7 +869,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             overflow: hidden;
                             text-overflow: ellipsis;
                           }
-                      id="header4-column2-name"
+                      id="header6-column2-name"
                     >
                       Value
                     </span>
@@ -962,7 +962,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                       min-height: 1px;
                       min-width: 100%;
                     }
-                data-focuszone-id="FocusZone6"
+                data-focuszone-id="FocusZone8"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -1065,12 +1065,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone8"
+                          data-focuszone-id="FocusZone10"
                           data-is-focusable={true}
                           data-item-index={0}
                           data-selection-index={0}
                           data-selection-touch-invoke={true}
-                          id="row3-0"
+                          id="row5-0"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -1133,7 +1133,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-0-checkbox row3-0-header"
+                              aria-labelledby="row5-0-checkbox row5-0-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1182,7 +1182,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-0-checkbox"
+                              id="row5-0-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -1544,12 +1544,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone10"
+                          data-focuszone-id="FocusZone12"
                           data-is-focusable={true}
                           data-item-index={1}
                           data-selection-index={1}
                           data-selection-touch-invoke={true}
-                          id="row3-1"
+                          id="row5-1"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -1612,7 +1612,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-1-checkbox row3-1-header"
+                              aria-labelledby="row5-1-checkbox row5-1-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -1661,7 +1661,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-1-checkbox"
+                              id="row5-1-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -2023,12 +2023,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone12"
+                          data-focuszone-id="FocusZone14"
                           data-is-focusable={true}
                           data-item-index={2}
                           data-selection-index={2}
                           data-selection-touch-invoke={true}
-                          id="row3-2"
+                          id="row5-2"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -2091,7 +2091,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-2-checkbox row3-2-header"
+                              aria-labelledby="row5-2-checkbox row5-2-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2140,7 +2140,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-2-checkbox"
+                              id="row5-2-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -2502,12 +2502,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone14"
+                          data-focuszone-id="FocusZone16"
                           data-is-focusable={true}
                           data-item-index={3}
                           data-selection-index={3}
                           data-selection-touch-invoke={true}
-                          id="row3-3"
+                          id="row5-3"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -2570,7 +2570,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-3-checkbox row3-3-header"
+                              aria-labelledby="row5-3-checkbox row5-3-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -2619,7 +2619,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-3-checkbox"
+                              id="row5-3-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -2981,12 +2981,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone16"
+                          data-focuszone-id="FocusZone18"
                           data-is-focusable={true}
                           data-item-index={4}
                           data-selection-index={4}
                           data-selection-touch-invoke={true}
-                          id="row3-4"
+                          id="row5-4"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3049,7 +3049,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-4-checkbox row3-4-header"
+                              aria-labelledby="row5-4-checkbox row5-4-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3098,7 +3098,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-4-checkbox"
+                              id="row5-4-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -3460,12 +3460,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone18"
+                          data-focuszone-id="FocusZone20"
                           data-is-focusable={true}
                           data-item-index={5}
                           data-selection-index={5}
                           data-selection-touch-invoke={true}
-                          id="row3-5"
+                          id="row5-5"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -3528,7 +3528,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-5-checkbox row3-5-header"
+                              aria-labelledby="row5-5-checkbox row5-5-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -3577,7 +3577,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-5-checkbox"
+                              id="row5-5-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -3939,12 +3939,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone20"
+                          data-focuszone-id="FocusZone22"
                           data-is-focusable={true}
                           data-item-index={6}
                           data-selection-index={6}
                           data-selection-touch-invoke={true}
-                          id="row3-6"
+                          id="row5-6"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -4007,7 +4007,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-6-checkbox row3-6-header"
+                              aria-labelledby="row5-6-checkbox row5-6-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4056,7 +4056,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-6-checkbox"
+                              id="row5-6-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -4418,12 +4418,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone22"
+                          data-focuszone-id="FocusZone24"
                           data-is-focusable={true}
                           data-item-index={7}
                           data-selection-index={7}
                           data-selection-touch-invoke={true}
-                          id="row3-7"
+                          id="row5-7"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -4486,7 +4486,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-7-checkbox row3-7-header"
+                              aria-labelledby="row5-7-checkbox row5-7-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -4535,7 +4535,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-7-checkbox"
+                              id="row5-7-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -4897,12 +4897,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone24"
+                          data-focuszone-id="FocusZone26"
                           data-is-focusable={true}
                           data-item-index={8}
                           data-selection-index={8}
                           data-selection-touch-invoke={true}
-                          id="row3-8"
+                          id="row5-8"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -4965,7 +4965,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-8-checkbox row3-8-header"
+                              aria-labelledby="row5-8-checkbox row5-8-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5014,7 +5014,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-8-checkbox"
+                              id="row5-8-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >
@@ -5376,12 +5376,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                 flex-shrink: 0;
                               }
                           data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone26"
+                          data-focuszone-id="FocusZone28"
                           data-is-focusable={true}
                           data-item-index={9}
                           data-selection-index={9}
                           data-selection-touch-invoke={true}
-                          id="row3-9"
+                          id="row5-9"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
@@ -5444,7 +5444,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             <div
                               aria-checked={false}
                               aria-label="select row"
-                              aria-labelledby="row3-9-checkbox row3-9-header"
+                              aria-labelledby="row5-9-checkbox row5-9-header"
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
@@ -5493,7 +5493,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   }
                               data-automationid="DetailsRowCheck"
                               data-selection-toggle={true}
-                              id="row3-9-checkbox"
+                              id="row5-9-checkbox"
                               role="checkbox"
                               tabIndex={-1}
                             >

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -625,7 +625,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                   display: block;
                 }
             data-automationid="DetailsHeader"
-            data-focuszone-id="FocusZone7"
+            data-focuszone-id="FocusZone9"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}
@@ -712,7 +712,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     }
               >
                 <span
-                  aria-describedby="header6-column1-tooltip"
+                  aria-describedby="header8-column1-tooltip"
                   aria-label="File Type"
                   className=
                       ms-DetailsHeader-cellTitle
@@ -748,7 +748,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         z-index: 1;
                       }
                   data-is-focusable="true"
-                  id="header6-column1"
+                  id="header8-column1"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                   role="button"
@@ -766,7 +766,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         & .ms-DetailsColumn-nearIcon {
                           padding-left: 0px;
                         }
-                    id="header6-column1-name"
+                    id="header8-column1-name"
                   >
                     <i
                       aria-hidden={true}
@@ -846,7 +846,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     white-space: nowrap;
                     width: 1px;
                   }
-              id="header6-column1-tooltip"
+              id="header8-column1-tooltip"
             >
               Column operations for File type, Press to sort on File type
             </label>
@@ -931,8 +931,8 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     }
               >
                 <span
-                  aria-describedby="header6-column2-tooltip"
-                  aria-labelledby="header6-column2-name"
+                  aria-describedby="header8-column2-tooltip"
+                  aria-labelledby="header8-column2-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -964,7 +964,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         z-index: 1;
                       }
                   data-is-focusable="true"
-                  id="header6-column2"
+                  id="header8-column2"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                   role="button"
@@ -979,7 +979,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           overflow: hidden;
                           text-overflow: ellipsis;
                         }
-                    id="header6-column2-name"
+                    id="header8-column2-name"
                   >
                     Name
                   </span>
@@ -1036,7 +1036,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     white-space: nowrap;
                     width: 1px;
                   }
-              id="header6-column2-tooltip"
+              id="header8-column2-tooltip"
             >
               Sorted A to Z
             </label>
@@ -1176,7 +1176,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     }
               >
                 <span
-                  aria-labelledby="header6-column3-name"
+                  aria-labelledby="header8-column3-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1208,7 +1208,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         z-index: 1;
                       }
                   data-is-focusable="true"
-                  id="header6-column3"
+                  id="header8-column3"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                   role="button"
@@ -1223,7 +1223,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           overflow: hidden;
                           text-overflow: ellipsis;
                         }
-                    id="header6-column3-name"
+                    id="header8-column3-name"
                   >
                     Date Modified
                   </span>
@@ -1366,7 +1366,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     }
               >
                 <span
-                  aria-labelledby="header6-column4-name"
+                  aria-labelledby="header8-column4-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1398,7 +1398,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         z-index: 1;
                       }
                   data-is-focusable="true"
-                  id="header6-column4"
+                  id="header8-column4"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                   role="button"
@@ -1413,7 +1413,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           overflow: hidden;
                           text-overflow: ellipsis;
                         }
-                    id="header6-column4-name"
+                    id="header8-column4-name"
                   >
                     Modified By
                   </span>
@@ -1556,7 +1556,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     }
               >
                 <span
-                  aria-labelledby="header6-column5-name"
+                  aria-labelledby="header8-column5-name"
                   className=
                       ms-DetailsHeader-cellTitle
                       {
@@ -1588,7 +1588,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         z-index: 1;
                       }
                   data-is-focusable="true"
-                  id="header6-column5"
+                  id="header8-column5"
                   onClick={[Function]}
                   onContextMenu={[Function]}
                   role="button"
@@ -1603,7 +1603,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           overflow: hidden;
                           text-overflow: ellipsis;
                         }
-                    id="header6-column5-name"
+                    id="header8-column5-name"
                   >
                     File Size
                   </span>
@@ -1696,7 +1696,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     min-height: 1px;
                     min-width: 100%;
                   }
-              data-focuszone-id="FocusZone8"
+              data-focuszone-id="FocusZone10"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -1794,12 +1794,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone10"
+                        data-focuszone-id="FocusZone12"
                         data-is-focusable={true}
                         data-item-index={0}
                         data-selection-index={0}
                         data-selection-touch-invoke={true}
-                        id="row5-0"
+                        id="row7-0"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -1968,7 +1968,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
-                            id="row5-0-header"
+                            id="row7-0-header"
                             role="rowheader"
                             style={
                               Object {
@@ -2258,12 +2258,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone13"
+                        data-focuszone-id="FocusZone15"
                         data-is-focusable={true}
                         data-item-index={1}
                         data-selection-index={1}
                         data-selection-touch-invoke={true}
-                        id="row5-1"
+                        id="row7-1"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2432,7 +2432,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
-                            id="row5-1-header"
+                            id="row7-1-header"
                             role="rowheader"
                             style={
                               Object {
@@ -2722,12 +2722,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone16"
+                        data-focuszone-id="FocusZone18"
                         data-is-focusable={true}
                         data-item-index={2}
                         data-selection-index={2}
                         data-selection-touch-invoke={true}
-                        id="row5-2"
+                        id="row7-2"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -2896,7 +2896,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
-                            id="row5-2-header"
+                            id="row7-2-header"
                             role="rowheader"
                             style={
                               Object {
@@ -3186,12 +3186,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone19"
+                        data-focuszone-id="FocusZone21"
                         data-is-focusable={true}
                         data-item-index={3}
                         data-selection-index={3}
                         data-selection-touch-invoke={true}
-                        id="row5-3"
+                        id="row7-3"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -3360,7 +3360,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
-                            id="row5-3-header"
+                            id="row7-3-header"
                             role="rowheader"
                             style={
                               Object {
@@ -3650,12 +3650,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone22"
+                        data-focuszone-id="FocusZone24"
                         data-is-focusable={true}
                         data-item-index={4}
                         data-selection-index={4}
                         data-selection-touch-invoke={true}
-                        id="row5-4"
+                        id="row7-4"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -3824,7 +3824,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
-                            id="row5-4-header"
+                            id="row7-4-header"
                             role="rowheader"
                             style={
                               Object {
@@ -4114,12 +4114,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone25"
+                        data-focuszone-id="FocusZone27"
                         data-is-focusable={true}
                         data-item-index={5}
                         data-selection-index={5}
                         data-selection-touch-invoke={true}
-                        id="row5-5"
+                        id="row7-5"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -4288,7 +4288,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
-                            id="row5-5-header"
+                            id="row7-5-header"
                             role="rowheader"
                             style={
                               Object {
@@ -4578,12 +4578,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone28"
+                        data-focuszone-id="FocusZone30"
                         data-is-focusable={true}
                         data-item-index={6}
                         data-selection-index={6}
                         data-selection-touch-invoke={true}
-                        id="row5-6"
+                        id="row7-6"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -4752,7 +4752,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
-                            id="row5-6-header"
+                            id="row7-6-header"
                             role="rowheader"
                             style={
                               Object {
@@ -5042,12 +5042,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone31"
+                        data-focuszone-id="FocusZone33"
                         data-is-focusable={true}
                         data-item-index={7}
                         data-selection-index={7}
                         data-selection-touch-invoke={true}
-                        id="row5-7"
+                        id="row7-7"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -5216,7 +5216,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
-                            id="row5-7-header"
+                            id="row7-7-header"
                             role="rowheader"
                             style={
                               Object {
@@ -5506,12 +5506,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone34"
+                        data-focuszone-id="FocusZone36"
                         data-is-focusable={true}
                         data-item-index={8}
                         data-selection-index={8}
                         data-selection-touch-invoke={true}
-                        id="row5-8"
+                        id="row7-8"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -5680,7 +5680,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
-                            id="row5-8-header"
+                            id="row7-8-header"
                             role="rowheader"
                             style={
                               Object {
@@ -5970,12 +5970,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               flex-shrink: 0;
                             }
                         data-automationid="DetailsRow"
-                        data-focuszone-id="FocusZone37"
+                        data-focuszone-id="FocusZone39"
                         data-is-focusable={true}
                         data-item-index={9}
                         data-selection-index={9}
                         data-selection-touch-invoke={true}
-                        id="row5-9"
+                        id="row7-9"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
@@ -6144,7 +6144,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
-                            id="row5-9-header"
+                            id="row7-9-header"
                             role="rowheader"
                             style={
                               Object {

--- a/packages/react-examples/src/react/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -264,8 +264,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 color: GrayText;
                 forced-color-adjust: none;
               }
-          htmlFor="TextField3"
-          id="TextFieldLabel5"
+          htmlFor="TextField5"
+          id="TextFieldLabel7"
         >
           Disabled
         </label>
@@ -302,7 +302,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
         >
           <input
             aria-invalid={false}
-            aria-labelledby="TextFieldLabel5"
+            aria-labelledby="TextFieldLabel7"
             className=
                 ms-TextField-field
                 {
@@ -370,7 +370,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   color: GrayText;
                 }
             disabled={true}
-            id="TextField3"
+            id="TextField5"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -430,8 +430,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
-          htmlFor="TextField6"
-          id="TextFieldLabel8"
+          htmlFor="TextField10"
+          id="TextFieldLabel12"
         >
           Read-only
         </label>
@@ -470,7 +470,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
         >
           <input
             aria-invalid={false}
-            aria-labelledby="TextFieldLabel8"
+            aria-labelledby="TextFieldLabel12"
             className=
                 ms-TextField-field
                 {
@@ -536,7 +536,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                   color: GrayText;
                 }
-            id="TextField6"
+            id="TextField10"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -603,8 +603,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 content: ' *';
                 padding-right: 12px;
               }
-          htmlFor="TextField9"
-          id="TextFieldLabel11"
+          htmlFor="TextField15"
+          id="TextFieldLabel17"
         >
           Required 
         </label>
@@ -643,7 +643,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
         >
           <input
             aria-invalid={false}
-            aria-labelledby="TextFieldLabel11"
+            aria-labelledby="TextFieldLabel17"
             className=
                 ms-TextField-field
                 {
@@ -709,7 +709,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                   color: GrayText;
                 }
-            id="TextField9"
+            id="TextField15"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -859,7 +859,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                   color: GrayText;
                 }
-            id="TextField12"
+            id="TextField20"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -920,8 +920,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
-          htmlFor="TextField15"
-          id="TextFieldLabel17"
+          htmlFor="TextField25"
+          id="TextFieldLabel27"
         >
           With error message
         </label>
@@ -960,9 +960,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               }
         >
           <input
-            aria-describedby="TextFieldDescription16"
+            aria-describedby="TextFieldDescription26"
             aria-invalid={true}
-            aria-labelledby="TextFieldLabel17"
+            aria-labelledby="TextFieldLabel27"
             className=
                 ms-TextField-field
                 {
@@ -1028,7 +1028,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                   color: GrayText;
                 }
-            id="TextField15"
+            id="TextField25"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -1039,7 +1039,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
         </div>
       </div>
       <span
-        id="TextFieldDescription16"
+        id="TextFieldDescription26"
       >
         <div
           role="alert"
@@ -1117,711 +1117,10 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
-          htmlFor="TextField18"
-          id="TextFieldLabel20"
-        >
-          With input mask
-        </label>
-        <div
-          className=
-              ms-TextField-fieldGroup
-              {
-                align-items: stretch;
-                background: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #605e5c;
-                box-shadow: none;
-                box-sizing: border-box;
-                cursor: text;
-                display: flex;
-                flex-direction: row;
-                height: 32px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                padding-bottom: 0px;
-                padding-left: 0px;
-                padding-right: 0px;
-                padding-top: 0px;
-                position: relative;
-              }
-              &:hover {
-                border-color: #323130;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                -ms-high-contrast-adjust: none;
-                border-color: Highlight;
-                forced-color-adjust: none;
-              }
-        >
-          <input
-            aria-invalid={false}
-            aria-labelledby="TextFieldLabel20"
-            className=
-                ms-TextField-field
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: none;
-                  border-radius: 0px;
-                  border: none;
-                  box-shadow: none;
-                  box-sizing: border-box;
-                  color: #323130;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  min-width: 0px;
-                  outline: 0px;
-                  padding-bottom: 0;
-                  padding-left: 8px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  text-overflow: ellipsis;
-                  width: 100%;
-                }
-                &:active {
-                  outline: 0px;
-                }
-                &:focus {
-                  outline: 0px;
-                }
-                &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                  background: Window;
-                  color: WindowText;
-                }
-                &::placeholder {
-                  color: #605e5c;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                  color: GrayText;
-                }
-                &:-ms-input-placeholder {
-                  color: #605e5c;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                  color: GrayText;
-                }
-                &::-ms-input-placeholder {
-                  color: #605e5c;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                  color: GrayText;
-                }
-            id="TextField18"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            onPaste={[Function]}
-            title="A 10 digit number"
-            type="text"
-            value="mask: (___) ___ - ____"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      className=
-          ms-TextField
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-          }
-    >
-      <div
-        className="ms-TextField-wrapper"
-      >
-        <label
-          className=
-              ms-Label
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                box-shadow: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 600;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                overflow-wrap: break-word;
-                padding-bottom: 5px;
-                padding-left: 0;
-                padding-right: 0;
-                padding-top: 5px;
-                word-wrap: break-word;
-              }
-          htmlFor="TextField21"
-          id="TextFieldLabel23"
-        >
-          With an icon
-        </label>
-        <div
-          className=
-              ms-TextField-fieldGroup
-              {
-                align-items: stretch;
-                background: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #605e5c;
-                box-shadow: none;
-                box-sizing: border-box;
-                cursor: text;
-                display: flex;
-                flex-direction: row;
-                height: 32px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                padding-bottom: 0px;
-                padding-left: 0px;
-                padding-right: 0px;
-                padding-top: 0px;
-                position: relative;
-              }
-              &:hover {
-                border-color: #323130;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                -ms-high-contrast-adjust: none;
-                border-color: Highlight;
-                forced-color-adjust: none;
-              }
-        >
-          <input
-            aria-invalid={false}
-            aria-labelledby="TextFieldLabel23"
-            className=
-                ms-TextField-field
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: none;
-                  border-radius: 0px;
-                  border: none;
-                  box-shadow: none;
-                  box-sizing: border-box;
-                  color: #323130;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  min-width: 0px;
-                  outline: 0px;
-                  padding-bottom: 0;
-                  padding-left: 8px;
-                  padding-right: 24px;
-                  padding-top: 0;
-                  text-overflow: ellipsis;
-                  width: 100%;
-                }
-                &:active {
-                  outline: 0px;
-                }
-                &:focus {
-                  outline: 0px;
-                }
-                &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                  background: Window;
-                  color: WindowText;
-                }
-                &::placeholder {
-                  color: #605e5c;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                  color: GrayText;
-                }
-                &:-ms-input-placeholder {
-                  color: #605e5c;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                  color: GrayText;
-                }
-                &::-ms-input-placeholder {
-                  color: #605e5c;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                  color: GrayText;
-                }
-            id="TextField21"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            type="text"
-            value=""
-          />
-          <i
-            aria-hidden={true}
-            className=
-
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  bottom: 6px;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons";
-                  font-size: 16px;
-                  font-style: normal;
-                  font-weight: normal;
-                  line-height: 18px;
-                  pointer-events: none;
-                  position: absolute;
-                  right: 8px;
-                  speak: none;
-                  top: auto;
-                }
-            data-icon-name="Calendar"
-          >
-            
-          </i>
-        </div>
-      </div>
-    </div>
-    <div
-      className=
-          ms-TextField
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-          }
-    >
-      <div
-        className="ms-TextField-wrapper"
-      >
-        <label
-          className=
-              ms-Label
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                box-shadow: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 600;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                overflow-wrap: break-word;
-                padding-bottom: 5px;
-                padding-left: 0;
-                padding-right: 0;
-                padding-top: 5px;
-                word-wrap: break-word;
-              }
-          htmlFor="TextField24"
-          id="TextFieldLabel26"
-        >
-          With placeholder
-        </label>
-        <div
-          className=
-              ms-TextField-fieldGroup
-              {
-                align-items: stretch;
-                background: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #605e5c;
-                box-shadow: none;
-                box-sizing: border-box;
-                cursor: text;
-                display: flex;
-                flex-direction: row;
-                height: 32px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                padding-bottom: 0px;
-                padding-left: 0px;
-                padding-right: 0px;
-                padding-top: 0px;
-                position: relative;
-              }
-              &:hover {
-                border-color: #323130;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                -ms-high-contrast-adjust: none;
-                border-color: Highlight;
-                forced-color-adjust: none;
-              }
-        >
-          <input
-            aria-invalid={false}
-            aria-labelledby="TextFieldLabel26"
-            className=
-                ms-TextField-field
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: none;
-                  border-radius: 0px;
-                  border: none;
-                  box-shadow: none;
-                  box-sizing: border-box;
-                  color: #323130;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  min-width: 0px;
-                  outline: 0px;
-                  padding-bottom: 0;
-                  padding-left: 8px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  text-overflow: ellipsis;
-                  width: 100%;
-                }
-                &:active {
-                  outline: 0px;
-                }
-                &:focus {
-                  outline: 0px;
-                }
-                &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                  background: Window;
-                  color: WindowText;
-                }
-                &::placeholder {
-                  color: #605e5c;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                  color: GrayText;
-                }
-                &:-ms-input-placeholder {
-                  color: #605e5c;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                  color: GrayText;
-                }
-                &::-ms-input-placeholder {
-                  color: #605e5c;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                  color: GrayText;
-                }
-            id="TextField24"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder="Please enter text here"
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      className=
-          ms-TextField
-          is-disabled
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-          }
-    >
-      <div
-        className="ms-TextField-wrapper"
-      >
-        <label
-          className=
-              ms-Label
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                box-shadow: none;
-                box-sizing: border-box;
-                color: #a19f9d;
-                display: block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 600;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                overflow-wrap: break-word;
-                padding-bottom: 5px;
-                padding-left: 0;
-                padding-right: 0;
-                padding-top: 5px;
-                word-wrap: break-word;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                -ms-high-contrast-adjust: none;
-                color: GrayText;
-                forced-color-adjust: none;
-              }
-          htmlFor="TextField27"
-          id="TextFieldLabel29"
-        >
-          Disabled with placeholder
-        </label>
-        <div
-          className=
-              ms-TextField-fieldGroup
-              {
-                align-items: stretch;
-                background: #ffffff;
-                border-color: #f3f2f1;
-                border-radius: 2px;
-                border: 1px solid #605e5c;
-                box-shadow: none;
-                box-sizing: border-box;
-                cursor: default;
-                display: flex;
-                flex-direction: row;
-                height: 32px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                padding-bottom: 0px;
-                padding-left: 0px;
-                padding-right: 0px;
-                padding-top: 0px;
-                position: relative;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                -ms-high-contrast-adjust: none;
-                border-color: GrayText;
-                forced-color-adjust: none;
-              }
-        >
-          <input
-            aria-invalid={false}
-            aria-labelledby="TextFieldLabel29"
-            className=
-                ms-TextField-field
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: #f3f2f1;
-                  background: none;
-                  border-color: #f3f2f1;
-                  border-radius: 0px;
-                  border: none;
-                  box-shadow: none;
-                  box-sizing: border-box;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  min-width: 0px;
-                  outline: 0px;
-                  padding-bottom: 0;
-                  padding-left: 8px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  text-overflow: ellipsis;
-                  width: 100%;
-                }
-                &:active {
-                  outline: 0px;
-                }
-                &:focus {
-                  outline: 0px;
-                }
-                &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                  background: Window;
-                  color: GrayText;
-                }
-                &::placeholder {
-                  color: #a19f9d;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                  color: GrayText;
-                }
-                &:-ms-input-placeholder {
-                  color: #a19f9d;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                  color: GrayText;
-                }
-                &::-ms-input-placeholder {
-                  color: #a19f9d;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                  color: GrayText;
-                }
-            disabled={true}
-            id="TextField27"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder="I am disabled"
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      className=
-          ms-TextField
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-          }
-    >
-      <div
-        className="ms-TextField-wrapper"
-      >
-        <label
-          className=
-              ms-Label
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                box-shadow: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 600;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                overflow-wrap: break-word;
-                padding-bottom: 5px;
-                padding-left: 0;
-                padding-right: 0;
-                padding-top: 5px;
-                word-wrap: break-word;
-              }
           htmlFor="TextField30"
           id="TextFieldLabel32"
         >
-          Password with reveal button
+          With input mask
         </label>
         <div
           className=
@@ -1925,6 +1224,707 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   color: GrayText;
                 }
             id="TextField30"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onPaste={[Function]}
+            title="A 10 digit number"
+            type="text"
+            value="mask: (___) ___ - ____"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-TextField
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+    >
+      <div
+        className="ms-TextField-wrapper"
+      >
+        <label
+          className=
+              ms-Label
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 600;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
+          htmlFor="TextField35"
+          id="TextFieldLabel37"
+        >
+          With an icon
+        </label>
+        <div
+          className=
+              ms-TextField-fieldGroup
+              {
+                align-items: stretch;
+                background: #ffffff;
+                border-radius: 2px;
+                border: 1px solid #605e5c;
+                box-shadow: none;
+                box-sizing: border-box;
+                cursor: text;
+                display: flex;
+                flex-direction: row;
+                height: 32px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              &:hover {
+                border-color: #323130;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
+                border-color: Highlight;
+                forced-color-adjust: none;
+              }
+        >
+          <input
+            aria-invalid={false}
+            aria-labelledby="TextFieldLabel37"
+            className=
+                ms-TextField-field
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  background: none;
+                  border-radius: 0px;
+                  border: none;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-width: 0px;
+                  outline: 0px;
+                  padding-bottom: 0;
+                  padding-left: 8px;
+                  padding-right: 24px;
+                  padding-top: 0;
+                  text-overflow: ellipsis;
+                  width: 100%;
+                }
+                &:active {
+                  outline: 0px;
+                }
+                &:focus {
+                  outline: 0px;
+                }
+                &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                  color: GrayText;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                  color: GrayText;
+                }
+            id="TextField35"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            type="text"
+            value=""
+          />
+          <i
+            aria-hidden={true}
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  bottom: 6px;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  line-height: 18px;
+                  pointer-events: none;
+                  position: absolute;
+                  right: 8px;
+                  speak: none;
+                  top: auto;
+                }
+            data-icon-name="Calendar"
+          >
+            
+          </i>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-TextField
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+    >
+      <div
+        className="ms-TextField-wrapper"
+      >
+        <label
+          className=
+              ms-Label
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 600;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
+          htmlFor="TextField40"
+          id="TextFieldLabel42"
+        >
+          With placeholder
+        </label>
+        <div
+          className=
+              ms-TextField-fieldGroup
+              {
+                align-items: stretch;
+                background: #ffffff;
+                border-radius: 2px;
+                border: 1px solid #605e5c;
+                box-shadow: none;
+                box-sizing: border-box;
+                cursor: text;
+                display: flex;
+                flex-direction: row;
+                height: 32px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              &:hover {
+                border-color: #323130;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
+                border-color: Highlight;
+                forced-color-adjust: none;
+              }
+        >
+          <input
+            aria-invalid={false}
+            aria-labelledby="TextFieldLabel42"
+            className=
+                ms-TextField-field
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  background: none;
+                  border-radius: 0px;
+                  border: none;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-width: 0px;
+                  outline: 0px;
+                  padding-bottom: 0;
+                  padding-left: 8px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  text-overflow: ellipsis;
+                  width: 100%;
+                }
+                &:active {
+                  outline: 0px;
+                }
+                &:focus {
+                  outline: 0px;
+                }
+                &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                  color: GrayText;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                  color: GrayText;
+                }
+            id="TextField40"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder="Please enter text here"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-TextField
+          is-disabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+    >
+      <div
+        className="ms-TextField-wrapper"
+      >
+        <label
+          className=
+              ms-Label
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #a19f9d;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 600;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                color: GrayText;
+                forced-color-adjust: none;
+              }
+          htmlFor="TextField45"
+          id="TextFieldLabel47"
+        >
+          Disabled with placeholder
+        </label>
+        <div
+          className=
+              ms-TextField-fieldGroup
+              {
+                align-items: stretch;
+                background: #ffffff;
+                border-color: #f3f2f1;
+                border-radius: 2px;
+                border: 1px solid #605e5c;
+                box-shadow: none;
+                box-sizing: border-box;
+                cursor: default;
+                display: flex;
+                flex-direction: row;
+                height: 32px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                -ms-high-contrast-adjust: none;
+                border-color: GrayText;
+                forced-color-adjust: none;
+              }
+        >
+          <input
+            aria-invalid={false}
+            aria-labelledby="TextFieldLabel47"
+            className=
+                ms-TextField-field
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f3f2f1;
+                  background: none;
+                  border-color: #f3f2f1;
+                  border-radius: 0px;
+                  border: none;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-width: 0px;
+                  outline: 0px;
+                  padding-bottom: 0;
+                  padding-left: 8px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  text-overflow: ellipsis;
+                  width: 100%;
+                }
+                &:active {
+                  outline: 0px;
+                }
+                &:focus {
+                  outline: 0px;
+                }
+                &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  background: Window;
+                  color: GrayText;
+                }
+                &::placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                  color: GrayText;
+                }
+                &:-ms-input-placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
+                &::-ms-input-placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                  color: GrayText;
+                }
+            disabled={true}
+            id="TextField45"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder="I am disabled"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-TextField
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+    >
+      <div
+        className="ms-TextField-wrapper"
+      >
+        <label
+          className=
+              ms-Label
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 600;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
+          htmlFor="TextField50"
+          id="TextFieldLabel52"
+        >
+          Password with reveal button
+        </label>
+        <div
+          className=
+              ms-TextField-fieldGroup
+              {
+                align-items: stretch;
+                background: #ffffff;
+                border-radius: 2px;
+                border: 1px solid #605e5c;
+                box-shadow: none;
+                box-sizing: border-box;
+                cursor: text;
+                display: flex;
+                flex-direction: row;
+                height: 32px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              &:hover {
+                border-color: #323130;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                -ms-high-contrast-adjust: none;
+                border-color: Highlight;
+                forced-color-adjust: none;
+              }
+        >
+          <input
+            aria-invalid={false}
+            aria-labelledby="TextFieldLabel52"
+            className=
+                ms-TextField-field
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  background: none;
+                  border-radius: 0px;
+                  border: none;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-width: 0px;
+                  outline: 0px;
+                  padding-bottom: 0;
+                  padding-left: 8px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  text-overflow: ellipsis;
+                  width: 100%;
+                }
+                &:active {
+                  outline: 0px;
+                }
+                &:focus {
+                  outline: 0px;
+                }
+                &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                  color: GrayText;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                  color: GrayText;
+                }
+            id="TextField50"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -299,8 +299,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 color: GrayText;
                 forced-color-adjust: none;
               }
-          htmlFor="TextField3"
-          id="TextFieldLabel5"
+          htmlFor="TextField5"
+          id="TextFieldLabel7"
         >
           Disabled:
         </label>
@@ -340,7 +340,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
         >
           <input
             aria-invalid={false}
-            aria-labelledby="TextFieldLabel5"
+            aria-labelledby="TextFieldLabel7"
             className=
                 ms-TextField-field
                 {
@@ -409,7 +409,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   color: GrayText;
                 }
             disabled={true}
-            id="TextField3"
+            id="TextField5"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -492,8 +492,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 content: ' *';
                 padding-right: 12px;
               }
-          htmlFor="TextField6"
-          id="TextFieldLabel8"
+          htmlFor="TextField10"
+          id="TextFieldLabel12"
         >
           Required:
         </label>
@@ -534,7 +534,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
         >
           <input
             aria-invalid={false}
-            aria-labelledby="TextFieldLabel8"
+            aria-labelledby="TextFieldLabel12"
             className=
                 ms-TextField-field
                 {
@@ -601,7 +601,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                   color: GrayText;
                 }
-            id="TextField6"
+            id="TextField10"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -686,8 +686,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 padding-top: 5px;
                 word-wrap: break-word;
               }
-          htmlFor="TextField9"
-          id="TextFieldLabel11"
+          htmlFor="TextField15"
+          id="TextFieldLabel17"
         >
           Borderless single-line TextField
         </label>
@@ -726,7 +726,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
         >
           <input
             aria-invalid={false}
-            aria-labelledby="TextFieldLabel11"
+            aria-labelledby="TextFieldLabel17"
             className=
                 ms-TextField-field
                 {
@@ -792,7 +792,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                   color: GrayText;
                 }
-            id="TextField9"
+            id="TextField15"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -855,8 +855,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 padding-top: 5px;
                 word-wrap: break-word;
               }
-          htmlFor="TextField12"
-          id="TextFieldLabel14"
+          htmlFor="TextField20"
+          id="TextFieldLabel22"
         >
           Borderless multi-line TextField
         </label>
@@ -896,7 +896,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
         >
           <textarea
             aria-invalid={false}
-            aria-labelledby="TextFieldLabel14"
+            aria-labelledby="TextFieldLabel22"
             className=
                 ms-TextField-field
                 {
@@ -966,7 +966,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                   color: GrayText;
                 }
-            id="TextField12"
+            id="TextField20"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/TextField.Controlled.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TextField.Controlled.Example.tsx.shot
@@ -238,8 +238,8 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
               padding-top: 5px;
               word-wrap: break-word;
             }
-        htmlFor="TextField3"
-        id="TextFieldLabel5"
+        htmlFor="TextField5"
+        id="TextFieldLabel7"
       >
         Controlled TextField limiting length of value to 5
       </label>
@@ -279,7 +279,7 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
       >
         <input
           aria-invalid={false}
-          aria-labelledby="TextFieldLabel5"
+          aria-labelledby="TextFieldLabel7"
           className=
               ms-TextField-field
               {
@@ -345,7 +345,7 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                 color: GrayText;
               }
-          id="TextField3"
+          id="TextField5"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}

--- a/packages/react-examples/src/react/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -146,7 +146,7 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 color: #005a9e;
               }
           data-is-focusable={true}
-          id="iconButton5"
+          id="iconButton7"
           onClick={[Function]}
           onKeyDown={[Function]}
           onKeyPress={[Function]}
@@ -408,8 +408,8 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                   padding-top: 5px;
                   word-wrap: break-word;
                 }
-            htmlFor="TextField9"
-            id="TextFieldLabel11"
+            htmlFor="TextField11"
+            id="TextFieldLabel13"
           >
             Wrapping default label renderer
           </label>
@@ -470,7 +470,7 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
       >
         <input
           aria-invalid={false}
-          aria-labelledby="TextFieldLabel11"
+          aria-labelledby="TextFieldLabel13"
           className=
               ms-TextField-field
               {
@@ -536,7 +536,7 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                 color: GrayText;
               }
-          id="TextField9"
+          id="TextField11"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -596,8 +596,8 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               padding-top: 5px;
               word-wrap: break-word;
             }
-        htmlFor="TextField12"
-        id="TextFieldLabel14"
+        htmlFor="TextField16"
+        id="TextFieldLabel18"
       >
         Custom description rendering
       </label>
@@ -635,9 +635,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
             }
       >
         <input
-          aria-describedby="TextFieldDescription13"
+          aria-describedby="TextFieldDescription17"
           aria-invalid={false}
-          aria-labelledby="TextFieldLabel14"
+          aria-labelledby="TextFieldLabel18"
           className=
               ms-TextField-field
               {
@@ -703,7 +703,7 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                 color: GrayText;
               }
-          id="TextField12"
+          id="TextField16"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -714,7 +714,7 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
       </div>
     </div>
     <span
-      id="TextFieldDescription13"
+      id="TextFieldDescription17"
     >
       <span
         className=

--- a/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -671,7 +671,7 @@ exports[`ColorPicker renders correctly 1`] = `
                           @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                             color: GrayText;
                           }
-                      id="TextField6"
+                      id="TextField8"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -841,7 +841,7 @@ exports[`ColorPicker renders correctly 1`] = `
                           @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                             color: GrayText;
                           }
-                      id="TextField10"
+                      id="TextField14"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -1011,7 +1011,7 @@ exports[`ColorPicker renders correctly 1`] = `
                           @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                             color: GrayText;
                           }
-                      id="TextField14"
+                      id="TextField20"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -1181,7 +1181,7 @@ exports[`ColorPicker renders correctly 1`] = `
                           @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                             color: GrayText;
                           }
-                      id="TextField18"
+                      id="TextField26"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -1900,7 +1900,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                           @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                             color: GrayText;
                           }
-                      id="TextField6"
+                      id="TextField8"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -2070,7 +2070,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                           @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                             color: GrayText;
                           }
-                      id="TextField10"
+                      id="TextField14"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -2240,7 +2240,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                           @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                             color: GrayText;
                           }
-                      id="TextField14"
+                      id="TextField20"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -2410,7 +2410,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                           @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                             color: GrayText;
                           }
-                      id="TextField18"
+                      id="TextField26"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -3106,7 +3106,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                           @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                             color: GrayText;
                           }
-                      id="TextField6"
+                      id="TextField8"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -3276,7 +3276,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                           @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                             color: GrayText;
                           }
-                      id="TextField10"
+                      id="TextField14"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -3446,7 +3446,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                           @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                             color: GrayText;
                           }
-                      id="TextField14"
+                      id="TextField20"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -3616,7 +3616,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                           @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
                             color: GrayText;
                           }
-                      id="TextField18"
+                      id="TextField26"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}

--- a/packages/react/src/components/TextField/TextField.base.tsx
+++ b/packages/react/src/components/TextField/TextField.base.tsx
@@ -73,6 +73,8 @@ export class TextFieldBase
   private _fallbackId: string;
   private _descriptionId: string;
   private _labelId: string;
+  private _prefixId: string;
+  private _suffixId: string;
   private _delayedValidate: (value: string | undefined) => void;
   private _lastValidation: number;
   private _latestValidateValue: string | undefined;
@@ -98,6 +100,8 @@ export class TextFieldBase
     this._fallbackId = getId(COMPONENT_NAME);
     this._descriptionId = getId(COMPONENT_NAME + 'Description');
     this._labelId = getId(COMPONENT_NAME + 'Label');
+    this._prefixId = getId(COMPONENT_NAME + 'Prefix');
+    this._suffixId = getId(COMPONENT_NAME + 'Suffix');
 
     this._warnControlledUsage();
 
@@ -247,7 +251,9 @@ export class TextFieldBase
           {onRenderLabel(this.props, this._onRenderLabel)}
           <div className={classNames.fieldGroup}>
             {(prefix !== undefined || this.props.onRenderPrefix) && (
-              <div className={classNames.prefix}>{onRenderPrefix(this.props, this._onRenderPrefix)}</div>
+              <div className={classNames.prefix} id={this._prefixId}>
+                {onRenderPrefix(this.props, this._onRenderPrefix)}
+              </div>
             )}
             {multiline ? this._renderTextArea() : this._renderInput()}
             {iconProps && <Icon className={classNames.icon} {...iconProps} />}
@@ -269,7 +275,9 @@ export class TextFieldBase
               </button>
             )}
             {(suffix !== undefined || this.props.onRenderSuffix) && (
-              <div className={classNames.suffix}>{onRenderSuffix(this.props, this._onRenderSuffix)}</div>
+              <div className={classNames.suffix} id={this._suffixId}>
+                {onRenderSuffix(this.props, this._onRenderSuffix)}
+              </div>
             )}
           </div>
         </div>
@@ -517,12 +525,28 @@ export class TextFieldBase
   }
 
   private _renderInput(): JSX.Element | null {
-    const { ariaLabel, invalid = !!this._errorMessage, type = 'text', label } = this.props;
+    const {
+      ariaLabel,
+      invalid = !!this._errorMessage,
+      onRenderPrefix,
+      onRenderSuffix,
+      prefix,
+      suffix,
+      type = 'text',
+      label,
+    } = this.props;
+
+    // build aria-labelledby list from label, prefix, and suffix
+    const labelIds = [];
+    label && labelIds.push(this._labelId);
+    (prefix !== undefined || onRenderPrefix) && labelIds.push(this._prefixId);
+    (suffix !== undefined || onRenderSuffix) && labelIds.push(this._suffixId);
+
     const inputProps: React.InputHTMLAttributes<HTMLInputElement> & React.RefAttributes<HTMLInputElement> = {
       type: this.state.isRevealingPassword ? 'text' : type,
       id: this._id,
       ...getNativeProps(this.props, inputProperties, ['defaultValue', 'type']),
-      'aria-labelledby': this.props['aria-labelledby'] || (label ? this._labelId : undefined),
+      'aria-labelledby': this.props['aria-labelledby'] || (labelIds.length > 0 ? labelIds.join(' ') : undefined),
       ref: this._textElement as React.RefObject<HTMLInputElement>,
       value: this.value || '',
       onInput: this._onInputChange,

--- a/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -298,6 +298,7 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               background: Window;
               color: WindowText;
             }
+        id="TextFieldPrefix3"
       >
         <span
           style={
@@ -312,7 +313,7 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
       <input
         aria-describedby="TextFieldDescription1"
         aria-invalid={true}
-        aria-labelledby="TextFieldLabel2"
+        aria-labelledby="TextFieldLabel2 TextFieldPrefix3 TextFieldSuffix4"
         className=
             ms-TextField-field
             {
@@ -407,6 +408,7 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               background: Window;
               color: WindowText;
             }
+        id="TextFieldSuffix4"
       >
         <span
           style={
@@ -557,6 +559,7 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               background: Window;
               color: WindowText;
             }
+        id="TextFieldPrefix3"
       >
         <span
           style={
@@ -571,7 +574,7 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
       <input
         aria-describedby="TextFieldDescription1"
         aria-invalid={true}
-        aria-labelledby="TextFieldLabel2"
+        aria-labelledby="TextFieldLabel2 TextFieldPrefix3 TextFieldSuffix4"
         className=
             ms-TextField-field
             {
@@ -666,6 +669,7 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               background: Window;
               color: WindowText;
             }
+        id="TextFieldSuffix4"
       >
         <span
           style={
@@ -1568,6 +1572,7 @@ exports[`TextField snapshots should respect user component and subcomponent styl
               background: Window;
               color: WindowText;
             }
+        id="TextFieldPrefix3"
       >
         <span
           style={
@@ -1582,7 +1587,7 @@ exports[`TextField snapshots should respect user component and subcomponent styl
       <input
         aria-describedby="TextFieldDescription1"
         aria-invalid={true}
-        aria-labelledby="TextFieldLabel2"
+        aria-labelledby="TextFieldLabel2 TextFieldPrefix3 TextFieldSuffix4"
         className=
             ms-TextField-field
             {
@@ -1677,6 +1682,7 @@ exports[`TextField snapshots should respect user component and subcomponent styl
               background: Window;
               color: WindowText;
             }
+        id="TextFieldSuffix4"
       >
         <span
           style={


### PR DESCRIPTION
Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally

The Textfield prefix/suffix was not included in the accessible name or description of the input. This PR updates Textfield to build `aria-labelledby` to include prefix/suffix elements (if they exist), in addition to the label. It also removes the `ariaLabel` prop from the examples, where it was overridden by `aria-labelledby` in any case.

Fixes [13169](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/13169)
