### PR TITLE
chore: migrate react-components to use Griffel

### DIFF
--- a/change/@fluentui-react-components-05f4886b-95c5-4d2b-b774-d070055353cb.json
+++ b/change/@fluentui-react-components-05f4886b-95c5-4d2b-b774-d070055353cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Replace make-styles packages with griffel equivalents",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/etc/react-components.api.md
+++ b/packages/react-components/etc/react-components.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { __styles } from '@fluentui/react-make-styles';
+import { __styles } from '@griffel/react';
 import { Accordion } from '@fluentui/react-accordion';
 import { accordionClassName } from '@fluentui/react-accordion';
 import { AccordionContext } from '@fluentui/react-accordion';
@@ -75,7 +75,7 @@ import { counterBadgeClassName } from '@fluentui/react-badge';
 import { CounterBadgeProps } from '@fluentui/react-badge';
 import { CounterBadgeState } from '@fluentui/react-badge';
 import { createDarkTheme } from '@fluentui/react-theme';
-import { createDOMRenderer } from '@fluentui/react-make-styles';
+import { createDOMRenderer } from '@griffel/react';
 import { createHighContrastTheme } from '@fluentui/react-theme';
 import { createLightTheme } from '@fluentui/react-theme';
 import { createTeamsDarkTheme } from '@fluentui/react-theme';
@@ -116,8 +116,8 @@ import { linkClassName } from '@fluentui/react-link';
 import { LinkProps } from '@fluentui/react-link';
 import { LinkSlots } from '@fluentui/react-link';
 import { LinkState } from '@fluentui/react-link';
-import { makeStaticStyles } from '@fluentui/react-make-styles';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStaticStyles } from '@griffel/react';
+import { makeStyles } from '@griffel/react';
 import { Menu } from '@fluentui/react-menu';
 import { MenuButton } from '@fluentui/react-button';
 import { menuButtonClassName } from '@fluentui/react-button';
@@ -187,7 +187,7 @@ import { MenuTriggerChildProps } from '@fluentui/react-menu';
 import { MenuTriggerContextProvider } from '@fluentui/react-menu';
 import { MenuTriggerProps } from '@fluentui/react-menu';
 import { MenuTriggerState } from '@fluentui/react-menu';
-import { mergeClasses } from '@fluentui/react-make-styles';
+import { mergeClasses } from '@griffel/react';
 import { OnOpenChangeData } from '@fluentui/react-popover';
 import { OnVisibleChangeData } from '@fluentui/react-tooltip';
 import { OpenPopoverEvents } from '@fluentui/react-popover';
@@ -223,9 +223,7 @@ import { renderBadge_unstable } from '@fluentui/react-badge';
 import { renderButton_unstable } from '@fluentui/react-button';
 import { renderCompoundButton_unstable } from '@fluentui/react-button';
 import { renderDivider_unstable } from '@fluentui/react-divider';
-import { RendererContext } from '@fluentui/react-make-styles';
-import { RendererProvider } from '@fluentui/react-make-styles';
-import { RendererProviderProps } from '@fluentui/react-make-styles';
+import { RendererProvider } from '@griffel/react';
 import { renderFluentProvider_unstable } from '@fluentui/react-provider';
 import { renderImage_unstable } from '@fluentui/react-image';
 import { renderLabel_unstable } from '@fluentui/react-label';
@@ -249,12 +247,12 @@ import { renderSplitButton_unstable } from '@fluentui/react-button';
 import { renderText_unstable } from '@fluentui/react-text';
 import { renderToggleButton_unstable } from '@fluentui/react-button';
 import { renderTooltip_unstable } from '@fluentui/react-tooltip';
-import { renderToStyleElements } from '@fluentui/react-make-styles';
+import { renderToStyleElements } from '@griffel/react';
 import { SelectableHandler } from '@fluentui/react-menu';
 import { setVirtualParent } from '@fluentui/react-portal';
 import { ShadowBrandTokens } from '@fluentui/react-theme';
 import { ShadowTokens } from '@fluentui/react-theme';
-import { shorthands } from '@fluentui/react-make-styles';
+import { shorthands } from '@griffel/react';
 import { SplitButton } from '@fluentui/react-button';
 import { splitButtonClassName } from '@fluentui/react-button';
 import { SplitButtonProps } from '@fluentui/react-button';
@@ -361,7 +359,6 @@ import { usePopoverSurfaceStyles_unstable } from '@fluentui/react-popover';
 import { usePopoverTrigger_unstable } from '@fluentui/react-popover';
 import { usePortal_unstable } from '@fluentui/react-portal';
 import { usePresenceBadge_unstable } from '@fluentui/react-badge';
-import { useRenderer } from '@fluentui/react-make-styles';
 import { useSplitButton_unstable } from '@fluentui/react-button';
 import { useSplitButtonStyles_unstable } from '@fluentui/react-button';
 import { useText_unstable } from '@fluentui/react-text';
@@ -812,11 +809,7 @@ export { renderCompoundButton_unstable }
 
 export { renderDivider_unstable }
 
-export { RendererContext }
-
 export { RendererProvider }
-
-export { RendererProviderProps }
 
 export { renderFluentProvider_unstable }
 
@@ -1087,8 +1080,6 @@ export { usePopoverTrigger_unstable }
 export { usePortal_unstable }
 
 export { usePresenceBadge_unstable }
-
-export { useRenderer }
 
 export { useSplitButton_unstable }
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -48,7 +48,7 @@
     "@fluentui/react-input": "9.0.0-beta.0",
     "@fluentui/react-label": "9.0.0-beta.4",
     "@fluentui/react-link": "9.0.0-beta.5",
-    "@fluentui/react-make-styles": "9.0.0-beta.4",
+    "@griffel/react": "1.0.0",
     "@fluentui/react-menu": "9.0.0-beta.5",
     "@fluentui/react-popover": "9.0.0-beta.5",
     "@fluentui/react-portal": "9.0.0-beta.5",

--- a/packages/react-components/src/Concepts/Positioning/PositioningCoverTarget.stories.tsx
+++ b/packages/react-components/src/Concepts/Positioning/PositioningCoverTarget.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
 import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
 import { Button } from '@fluentui/react-button';
 import { PositioningShorthand } from '@fluentui/react-positioning';

--- a/packages/react-components/src/Concepts/Positioning/PositioningShorthandPositions.stories.tsx
+++ b/packages/react-components/src/Concepts/Positioning/PositioningShorthandPositions.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shorthands, makeStyles, mergeClasses } from '@fluentui/react-make-styles';
+import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
 import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
 import { Button } from '@fluentui/react-button';
 import { PositioningShorthand } from '@fluentui/react-positioning';

--- a/packages/react-components/src/DocsComponents/FluentDocsPage.stories.tsx
+++ b/packages/react-components/src/DocsComponents/FluentDocsPage.stories.tsx
@@ -10,7 +10,7 @@ import {
   PRIMARY_STORY,
   Stories,
 } from '@storybook/addon-docs';
-import { makeStyles, shorthands } from '@fluentui/react-make-styles';
+import { makeStyles, shorthands } from '@griffel/react';
 
 import { Toc, nameToHash } from './Toc.stories';
 

--- a/packages/react-components/src/Migrations/utils.stories.tsx
+++ b/packages/react-components/src/Migrations/utils.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Source } from '@storybook/addon-docs';
-import { makeStyles } from '@fluentui/react-make-styles';
+import { makeStyles } from '@griffel/react';
 
 const useCodeComparisonStyles = makeStyles({
   root: {

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -1,6 +1,5 @@
 // Utilities
 export {
-  RendererContext,
   RendererProvider,
   __styles,
   createDOMRenderer,
@@ -9,9 +8,7 @@ export {
   mergeClasses,
   renderToStyleElements,
   shorthands,
-  useRenderer,
-} from '@fluentui/react-make-styles';
-export type { RendererProviderProps } from '@fluentui/react-make-styles';
+} from '@griffel/react';
 export {
   FluentProvider,
   fluentProviderClassName,


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/react-make-styles` with `@griffel/react` in `@fluentui/react-components` package.

## Export changes

- `RenderProvider`, `RendererProviderProps` and `useRenderer` are not exported anymore. These APIs are internal to Griffel and should not be exposed to customers.

---

Note: check #21360 for more details about changes.