### PR TITLE
Tooltip: align API with other components that use triggers

### DIFF
--- a/change/@fluentui-react-tooltip-c42cbf2b-b2cc-41d6-ad2e-623d5f5bdd7c.json
+++ b/change/@fluentui-react-tooltip-c42cbf2b-b2cc-41d6-ad2e-623d5f5bdd7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "BREAKING: implement `content` slot",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tooltip/etc/react-tooltip.api.md
+++ b/packages/react-tooltip/etc/react-tooltip.api.md
@@ -37,10 +37,10 @@ export type TooltipCommons = {
 };
 
 // @public
-export type TooltipProps = ComponentProps<TooltipSlots> & Partial<Omit<TooltipCommons, 'relationship'>> & Pick<TooltipCommons, 'relationship'> & {
+export type TooltipProps = Omit<ComponentProps<TooltipSlots>, 'content'> & Required<Pick<ComponentProps<TooltipSlots>, 'content'>> & Partial<Omit<TooltipCommons, 'relationship'>> & Pick<TooltipCommons, 'relationship'> & {
     children?: (React_2.ReactElement & {
         ref?: React_2.Ref<unknown>;
-    }) | ((props: TooltipTriggerProps) => React_2.ReactNode);
+    }) | ((props: TooltipTriggerProps) => React_2.ReactNode) | null;
 };
 
 // @public

--- a/packages/react-tooltip/etc/react-tooltip.api.md
+++ b/packages/react-tooltip/etc/react-tooltip.api.md
@@ -9,8 +9,6 @@ import type { ComponentState } from '@fluentui/react-utilities';
 import type { IntrinsicShorthandProps } from '@fluentui/react-utilities';
 import type { PositioningShorthand } from '@fluentui/react-positioning';
 import * as React_2 from 'react';
-import { ShorthandProps } from '@fluentui/react-utilities';
-import { ShorthandRenderFunction } from '@fluentui/react-utilities';
 
 // @public
 export type OnVisibleChangeData = {
@@ -21,21 +19,7 @@ export type OnVisibleChangeData = {
 export const renderTooltip_unstable: (state: TooltipState) => JSX.Element;
 
 // @public
-export const Tooltip: React_2.ForwardRefExoticComponent<Omit<{
-    content?: ShorthandProps<    {
-    as?: "div" | undefined;
-    } & Pick<React_2.DetailedHTMLProps<React_2.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof React_2.HTMLAttributes<HTMLDivElement>> & {
-    ref?: ((instance: HTMLDivElement | null) => void) | React_2.RefObject<HTMLDivElement> | null | undefined;
-    } & {
-    children?: React_2.ReactNode | ShorthandRenderFunction<Pick<React_2.DetailedHTMLProps<React_2.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof React_2.HTMLAttributes<HTMLDivElement>> & {
-    ref?: ((instance: HTMLDivElement | null) => void) | React_2.RefObject<HTMLDivElement> | null | undefined;
-    }>;
-    }>;
-}, "root"> & Partial<Omit<TooltipCommons, "relationship">> & Pick<TooltipCommons, "relationship"> & {
-    children?: (React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> & {
-        ref?: React_2.Ref<unknown> | undefined;
-    }) | ((props: TooltipTriggerProps) => React_2.ReactNode) | undefined;
-} & React_2.RefAttributes<HTMLElement>>;
+export const Tooltip: React_2.FC<TooltipProps>;
 
 // @public (undocumented)
 export const tooltipClassName = "fui-Tooltip";
@@ -78,7 +62,7 @@ export type TooltipTriggerProps = {
 } & Pick<React_2.HTMLAttributes<HTMLElement>, 'onPointerEnter' | 'onPointerLeave' | 'onFocus' | 'onBlur' | 'aria-describedby' | 'aria-labelledby' | 'aria-label'>;
 
 // @public
-export const useTooltip_unstable: (props: TooltipProps, ref: React_2.Ref<HTMLElement>) => TooltipState;
+export const useTooltip_unstable: (props: TooltipProps) => TooltipState;
 
 // @public
 export const useTooltipStyles_unstable: (state: TooltipState) => TooltipState;

--- a/packages/react-tooltip/etc/react-tooltip.api.md
+++ b/packages/react-tooltip/etc/react-tooltip.api.md
@@ -6,10 +6,11 @@
 
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
-import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { IntrinsicShorthandProps } from '@fluentui/react-utilities';
 import type { PositioningShorthand } from '@fluentui/react-positioning';
 import * as React_2 from 'react';
+import { ShorthandProps } from '@fluentui/react-utilities';
+import { ShorthandRenderFunction } from '@fluentui/react-utilities';
 
 // @public
 export type OnVisibleChangeData = {
@@ -20,7 +21,21 @@ export type OnVisibleChangeData = {
 export const renderTooltip_unstable: (state: TooltipState) => JSX.Element;
 
 // @public
-export const Tooltip: ForwardRefComponent<TooltipProps>;
+export const Tooltip: React_2.ForwardRefExoticComponent<Omit<{
+    content?: ShorthandProps<    {
+    as?: "div" | undefined;
+    } & Pick<React_2.DetailedHTMLProps<React_2.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof React_2.HTMLAttributes<HTMLDivElement>> & {
+    ref?: ((instance: HTMLDivElement | null) => void) | React_2.RefObject<HTMLDivElement> | null | undefined;
+    } & {
+    children?: React_2.ReactNode | ShorthandRenderFunction<Pick<React_2.DetailedHTMLProps<React_2.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof React_2.HTMLAttributes<HTMLDivElement>> & {
+    ref?: ((instance: HTMLDivElement | null) => void) | React_2.RefObject<HTMLDivElement> | null | undefined;
+    }>;
+    }>;
+}, "root"> & Partial<Omit<TooltipCommons, "relationship">> & Pick<TooltipCommons, "relationship"> & {
+    children?: (React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> & {
+        ref?: React_2.Ref<unknown> | undefined;
+    }) | ((props: TooltipTriggerProps) => React_2.ReactNode) | undefined;
+} & React_2.RefAttributes<HTMLElement>>;
 
 // @public (undocumented)
 export const tooltipClassName = "fui-Tooltip";
@@ -28,7 +43,6 @@ export const tooltipClassName = "fui-Tooltip";
 // @public
 export type TooltipCommons = {
     appearance?: 'normal' | 'inverted';
-    content: React_2.ReactNode;
     withArrow?: boolean;
     positioning?: PositioningShorthand;
     visible?: boolean;
@@ -39,19 +53,20 @@ export type TooltipCommons = {
 };
 
 // @public
-export type TooltipProps = ComponentProps<TooltipSlots> & Partial<Omit<TooltipCommons, 'content' | 'relationship'>> & Pick<TooltipCommons, 'content' | 'relationship'>;
+export type TooltipProps = ComponentProps<TooltipSlots> & Partial<Omit<TooltipCommons, 'relationship'>> & Pick<TooltipCommons, 'relationship'> & {
+    children?: (React_2.ReactElement & {
+        ref?: React_2.Ref<unknown>;
+    }) | ((props: TooltipTriggerProps) => React_2.ReactNode);
+};
 
 // @public
 export type TooltipSlots = {
-    root: Omit<IntrinsicShorthandProps<'div'>, 'children'> & {
-        children?: (React_2.ReactElement<React_2.HTMLAttributes<HTMLElement>> & {
-            ref?: React_2.Ref<unknown>;
-        }) | ((props: TooltipTriggerProps) => React_2.ReactNode) | null;
-    };
+    content: IntrinsicShorthandProps<'div'>;
 };
 
 // @public
 export type TooltipState = ComponentState<TooltipSlots> & TooltipCommons & {
+    children?: React_2.ReactNode;
     shouldRenderTooltip?: boolean;
     arrowRef?: React_2.Ref<HTMLDivElement>;
     arrowClassName?: string;
@@ -63,7 +78,7 @@ export type TooltipTriggerProps = {
 } & Pick<React_2.HTMLAttributes<HTMLElement>, 'onPointerEnter' | 'onPointerLeave' | 'onFocus' | 'onBlur' | 'aria-describedby' | 'aria-labelledby' | 'aria-label'>;
 
 // @public
-export const useTooltip_unstable: (props: TooltipProps, ref: React_2.Ref<HTMLDivElement>) => TooltipState;
+export const useTooltip_unstable: (props: TooltipProps, ref: React_2.Ref<HTMLElement>) => TooltipState;
 
 // @public
 export const useTooltipStyles_unstable: (state: TooltipState) => TooltipState;

--- a/packages/react-tooltip/src/common/isConformant.ts
+++ b/packages/react-tooltip/src/common/isConformant.ts
@@ -1,6 +1,5 @@
 import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
-import type { IsConformantOptions, TestObject } from '@fluentui/react-conformance';
-import griffelTests from '@fluentui/react-conformance-griffel';
+import type { IsConformantOptions } from '@fluentui/react-conformance';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
@@ -8,7 +7,6 @@ export function isConformant<TProps = {}>(
   const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     asPropHandlesRef: true,
     componentPath: module!.parent!.filename.replace('.test', ''),
-    extraTests: griffelTests as TestObject<TProps>,
   };
 
   baseIsConformant(defaultOptions, testInfo);

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.test.tsx
@@ -60,13 +60,15 @@ describe('Tooltip', () => {
   it('renders the content of a nontrivial label tooltip', () => {
     const result = render(
       <Tooltip
-        id="the-tooltip-id"
         relationship="label"
-        content={
-          <span>
-            This is a <strong>formatted</strong> tooltip
-          </span>
-        }
+        content={{
+          children: (
+            <span>
+              This is a <strong>formatted</strong> tooltip
+            </span>
+          ),
+          id: 'the-tooltip-id',
+        }}
       >
         <button />
       </Tooltip>,

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.tsx
@@ -7,11 +7,11 @@ import type { TooltipProps } from './Tooltip.types';
 /**
  * A tooltip provides light weight contextual information on top of its target element.
  */
-export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>((props, ref) => {
-  const state = useTooltip_unstable(props, ref);
+export const Tooltip: React.FC<TooltipProps> = props => {
+  const state = useTooltip_unstable(props);
 
   useTooltipStyles_unstable(state);
   return renderTooltip_unstable(state);
-});
+};
 
 Tooltip.displayName = 'Tooltip';

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.tsx
@@ -3,12 +3,11 @@ import { useTooltip_unstable } from './useTooltip';
 import { renderTooltip_unstable } from './renderTooltip';
 import { useTooltipStyles_unstable } from './useTooltipStyles';
 import type { TooltipProps } from './Tooltip.types';
-import type { ForwardRefComponent } from '@fluentui/react-utilities';
 
 /**
  * A tooltip provides light weight contextual information on top of its target element.
  */
-export const Tooltip: ForwardRefComponent<TooltipProps> = React.forwardRef((props, ref) => {
+export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>((props, ref) => {
   const state = useTooltip_unstable(props, ref);
 
   useTooltipStyles_unstable(state);

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
@@ -6,18 +6,7 @@ import type { ComponentProps, ComponentState, IntrinsicShorthandProps } from '@f
  * Slot properties for Tooltip
  */
 export type TooltipSlots = {
-  root: Omit<IntrinsicShorthandProps<'div'>, 'children'> & {
-    /**
-     * The child is the element that triggers the Tooltip. It will have additional properties added,
-     * including events and aria properties.
-     * Alternatively, children can be a render function that takes the props and adds
-     * them to the appropriate elements.
-     */
-    children?:
-      | (React.ReactElement<React.HTMLAttributes<HTMLElement>> & { ref?: React.Ref<unknown> })
-      | ((props: TooltipTriggerProps) => React.ReactNode)
-      | null;
-  };
+  content: IntrinsicShorthandProps<'div'>;
 };
 
 /**
@@ -32,11 +21,6 @@ export type TooltipCommons = {
    * @defaultvalue normal
    */
   appearance?: 'normal' | 'inverted';
-
-  /**
-   * The content displayed inside the tooltip.
-   */
-  content: React.ReactNode;
 
   /**
    * Render an arrow pointing to the target element
@@ -117,14 +101,18 @@ export type OnVisibleChangeData = {
  * Properties for Tooltip
  */
 export type TooltipProps = ComponentProps<TooltipSlots> &
-  Partial<Omit<TooltipCommons, 'content' | 'relationship'>> &
-  Pick<TooltipCommons, 'content' | 'relationship'>;
+  Partial<Omit<TooltipCommons, 'relationship'>> &
+  Pick<TooltipCommons, 'relationship'> & {
+    children?: (React.ReactElement & { ref?: React.Ref<unknown> }) | ((props: TooltipTriggerProps) => React.ReactNode);
+  };
 
 /**
  * State used in rendering Tooltip
  */
 export type TooltipState = ComponentState<TooltipSlots> &
   TooltipCommons & {
+    children?: React.ReactNode;
+
     /**
      * Whether the tooltip should be rendered to the DOM.
      */

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
@@ -100,10 +100,14 @@ export type OnVisibleChangeData = {
 /**
  * Properties for Tooltip
  */
-export type TooltipProps = ComponentProps<TooltipSlots> &
+export type TooltipProps = Omit<ComponentProps<TooltipSlots>, 'content'> &
+  Required<Pick<ComponentProps<TooltipSlots>, 'content'>> &
   Partial<Omit<TooltipCommons, 'relationship'>> &
   Pick<TooltipCommons, 'relationship'> & {
-    children?: (React.ReactElement & { ref?: React.Ref<unknown> }) | ((props: TooltipTriggerProps) => React.ReactNode) | null;
+    children?:
+      | (React.ReactElement & { ref?: React.Ref<unknown> })
+      | ((props: TooltipTriggerProps) => React.ReactNode)
+      | null;
   };
 
 /**

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
@@ -103,7 +103,7 @@ export type OnVisibleChangeData = {
 export type TooltipProps = ComponentProps<TooltipSlots> &
   Partial<Omit<TooltipCommons, 'relationship'>> &
   Pick<TooltipCommons, 'relationship'> & {
-    children?: (React.ReactElement & { ref?: React.Ref<unknown> }) | ((props: TooltipTriggerProps) => React.ReactNode);
+    children?: (React.ReactElement & { ref?: React.Ref<unknown> }) | ((props: TooltipTriggerProps) => React.ReactNode) | null;
   };
 
 /**

--- a/packages/react-tooltip/src/components/Tooltip/renderTooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/renderTooltip.tsx
@@ -11,13 +11,13 @@ export const renderTooltip_unstable = (state: TooltipState) => {
 
   return (
     <>
-      {state.root.children}
+      {state.children}
       {state.shouldRenderTooltip && (
         <Portal>
-          <slots.root {...slotProps.root}>
+          <slots.content {...slotProps.content}>
             {state.withArrow && <div ref={state.arrowRef} className={state.arrowClassName} />}
-            {state.content}
-          </slots.root>
+            {state.content.children}
+          </slots.content>
         </Portal>
       )}
     </>

--- a/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -21,9 +21,8 @@ import { arrowHeight, tooltipBorderRadius } from './private/constants';
  * before being passed to renderTooltip_unstable.
  *
  * @param props - props from this instance of Tooltip
- * @param ref - reference to root HTMLElement of Tooltip
  */
-export const useTooltip_unstable = (props: TooltipProps, ref: React.Ref<HTMLElement>): TooltipState => {
+export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
   const context = React.useContext(TooltipContext);
   const isServerSideRender = useIsSSR();
   const { targetDocument } = useFluent();

--- a/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -3,7 +3,7 @@ import { mergeArrowOffset, resolvePositioningShorthand, usePopper } from '@fluen
 import { TooltipContext, useFluent } from '@fluentui/react-shared-contexts';
 import {
   applyTriggerPropsToChildren,
-  getNativeElementProps,
+  resolveShorthand,
   useControllableState,
   useId,
   useIsomorphicLayoutEffect,
@@ -23,15 +23,16 @@ import { arrowHeight, tooltipBorderRadius } from './private/constants';
  * @param props - props from this instance of Tooltip
  * @param ref - reference to root HTMLElement of Tooltip
  */
-export const useTooltip_unstable = (props: TooltipProps, ref: React.Ref<HTMLDivElement>): TooltipState => {
+export const useTooltip_unstable = (props: TooltipProps, ref: React.Ref<HTMLElement>): TooltipState => {
   const context = React.useContext(TooltipContext);
   const isServerSideRender = useIsSSR();
   const { targetDocument } = useFluent();
   const [setDelayTimeout, clearDelayTimeout] = useTimeout();
 
   const {
-    content,
     appearance,
+    children,
+    content,
     withArrow,
     positioning,
     onVisibleChange,
@@ -55,7 +56,6 @@ export const useTooltip_unstable = (props: TooltipProps, ref: React.Ref<HTMLDivE
   );
 
   const state: TooltipState = {
-    content,
     withArrow,
     positioning,
     showDelay,
@@ -67,15 +67,17 @@ export const useTooltip_unstable = (props: TooltipProps, ref: React.Ref<HTMLDivE
 
     // Slots
     components: {
-      root: 'div',
+      content: 'div',
     },
-    root: getNativeElementProps('div', {
-      role: 'tooltip',
-      ...props,
-      ref,
-      id: useId('tooltip-', props.id),
+    content: resolveShorthand(content, {
+      defaultProps: {
+        role: 'tooltip',
+      },
+      required: true,
     }),
   };
+
+  state.content.id = useId('tooltip-', state.content.id);
 
   const popperOptions = {
     enabled: state.visible,
@@ -100,7 +102,7 @@ export const useTooltip_unstable = (props: TooltipProps, ref: React.Ref<HTMLDivE
     arrowRef: React.MutableRefObject<HTMLDivElement>;
   } = usePopper(popperOptions);
 
-  state.root.ref = useMergedRefs(state.root.ref, containerRef);
+  state.content.ref = useMergedRefs(state.content.ref, containerRef);
   state.arrowRef = arrowRef;
 
   // When this tooltip is visible, hide any other tooltips, and register it
@@ -181,10 +183,10 @@ export const useTooltip_unstable = (props: TooltipProps, ref: React.Ref<HTMLDivE
 
   // Cancel the hide timer when the pointer enters the tooltip, and restart it when the mouse leaves.
   // This keeps the tooltip visible when the pointer is moved over it.
-  state.root.onPointerEnter = useMergedCallbacks(state.root.onPointerEnter, clearDelayTimeout);
-  state.root.onPointerLeave = useMergedCallbacks(state.root.onPointerLeave, onLeaveTrigger);
+  state.content.onPointerEnter = useMergedCallbacks(state.content.onPointerEnter, clearDelayTimeout);
+  state.content.onPointerLeave = useMergedCallbacks(state.content.onPointerLeave, onLeaveTrigger);
 
-  const child = React.isValidElement(state.root.children) ? state.root.children : undefined;
+  const child = React.isValidElement(children) ? children : undefined;
 
   // The props to add to the trigger element (child)
   const triggerProps: TooltipTriggerProps = {
@@ -203,23 +205,23 @@ export const useTooltip_unstable = (props: TooltipProps, ref: React.Ref<HTMLDivE
 
   if (relationship === 'label') {
     // aria-label only works if the content is a string. Otherwise, need to use aria-labelledby.
-    if (typeof state.content === 'string') {
-      triggerProps['aria-label'] = state.content;
+    if (typeof state.content.children === 'string') {
+      triggerProps['aria-label'] = state.content.children;
     } else if (!isServerSideRender) {
-      triggerProps['aria-labelledby'] = state.root.id;
+      triggerProps['aria-labelledby'] = state.content.id;
       // Always render the tooltip even if hidden, so that aria-labelledby refers to a valid element
       state.shouldRenderTooltip = true;
     }
   } else if (relationship === 'description') {
     if (!isServerSideRender) {
-      triggerProps['aria-describedby'] = state.root.id;
+      triggerProps['aria-describedby'] = state.content.id;
       // Always render the tooltip even if hidden, so that aria-describedby refers to a valid element
       state.shouldRenderTooltip = true;
     }
   }
 
   // Apply the trigger props to the child, either by calling the render function, or cloning with the new props
-  state.root.children = applyTriggerPropsToChildren(state.root.children, triggerProps) as React.ReactElement;
+  state.children = applyTriggerPropsToChildren(children, triggerProps);
   return state;
 };
 

--- a/packages/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
@@ -49,12 +49,12 @@ const useStyles = makeStyles({
 export const useTooltipStyles_unstable = (state: TooltipState): TooltipState => {
   const styles = useStyles();
 
-  state.root.className = mergeClasses(
+  state.content.className = mergeClasses(
     tooltipClassName,
     styles.root,
     state.appearance === 'inverted' && styles.inverted,
     state.visible && styles.visible,
-    state.root.className,
+    state.content.className,
   );
 
   state.arrowClassName = styles.arrow;


### PR DESCRIPTION
# BREAKING CHANGES 🚨

This PR implements #21261 and aligns API of `Tooltip` component with other components that use Trigger pattern. `content` on `Tooltip` becomes a real slot.

### Before

```tsx
function App() {
  return (
    <>
      <Tooltip content="Foo" />
      <Tooltip
        content="Foo"
        className="bar"
        id="foo"
        onClick={() => {
          console.log("baz");
        }}
      />
    </>
  );
}
```

### After

```tsx
function App() {
  return (
    <>
      <Tooltip content="Foo" />
      <Tooltip
        content={{
          children: "Foo",
          className: "bar",
          // 👆 if "className" will passed to "Tooltip" directly you will get a TS error
          id: "foo",
          onClick: () => {
            console.log("baz");
          }
        }}
      />
    </>
  );
}
```