### PR TITLE
chore: make-styles devDependencies in react-components

### DIFF
--- a/change/@fluentui-react-components-03c79370-75d3-4a56-84bf-8fb29626fb8e.json
+++ b/change/@fluentui-react-components-03c79370-75d3-4a56-84bf-8fb29626fb8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove make-styles dev packages",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-components-03c79370-75d3-4a56-84bf-8fb29626fb8e.json
+++ b/change/@fluentui-react-components-03c79370-75d3-4a56-84bf-8fb29626fb8e.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Remove make-styles dev packages",
+  "comment": "Replace make-styles dev packages with griffel equivalents",
   "packageName": "@fluentui/react-components",
   "email": "olfedias@microsoft.com",
   "dependentChangeType": "none"

--- a/packages/react-components/.babelrc.json
+++ b/packages/react-components/.babelrc.json
@@ -1,0 +1,4 @@
+{
+  "presets": ["@griffel"],
+  "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
+}

--- a/packages/react-components/.babelrc.json
+++ b/packages/react-components/.babelrc.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["module:@fluentui/babel-make-styles", "annotate-pure-calls", "@babel/transform-react-pure-annotations"]
-}

--- a/packages/react-components/jest.config.js
+++ b/packages/react-components/jest.config.js
@@ -17,5 +17,4 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@fluentui/jest-serializer-make-styles'],
 };

--- a/packages/react-components/jest.config.js
+++ b/packages/react-components/jest.config.js
@@ -17,4 +17,5 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -35,8 +35,7 @@
     "@types/react": "16.9.42",
     "@types/react-dom": "16.9.10",
     "react": "16.8.6",
-    "react-dom": "16.8.6",
-    "@fluentui/babel-make-styles": "9.0.0-beta.4"
+    "react-dom": "16.8.6"
   },
   "dependencies": {
     "@fluentui/react-accordion": "9.0.0-beta.5",


### PR DESCRIPTION
## PR changes

This PR replaces `@fluentui/*-make-styles` `devDependencies` with `@griffel/*` in `@fluentui/react-components` package.

Following packages were replaced (**only** `devDependencies`):
- `@fluentui/babel-make-styles` => `@griffel/babel-preset`
- `@fluentui/jest-serializer-make-styles` => `@griffel/jest-serializer`

This solves build issue that happened in (#21470):

![image](https://user-images.githubusercontent.com/14183168/151350854-6d99e412-517d-49ed-91cf-d9f1beea4b61.png)

- `packages/react-components/jest.config.js` has `@fluentui/jest-serializer-make-styles`
- `@fluentui/react-components` does not have `@fluentui/jest-serializer-make-styles` in `devDependencies`
- nothing builds `@fluentui/jest-serializer-make-styles`, build fails 💥