### PR TITLE
For point/circle custom radius, only active point/circle will be visible in area chart 

### DIFF
--- a/change/@fluentui-react-charting-a6d89901-e651-461a-ae5b-4072c54bbc39.json
+++ b/change/@fluentui-react-charting-a6d89901-e651-461a-ae5b-4072c54bbc39.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "only active circle will be visible when custom radius is passed",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-scharde@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -566,6 +566,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
       );
     });
 
+    const circleRadius = pointOptions && pointOptions.r ? Number(pointOptions.r) : 8;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this._stackedData.forEach((singleStackedData: Array<any>, index: number) => {
       if (points.length === index) {
@@ -584,7 +585,6 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
                 data-is-focusable={true}
                 cx={xScale(singlePoint.xVal)}
                 cy={yScale(singlePoint.values[1])}
-                r={this._getCircleRadius(xDataPoint)}
                 stroke={lineColor}
                 strokeWidth={3}
                 visibility={this.state.nearestCircleToHighlight ? 'visibility' : 'hidden'}
@@ -593,6 +593,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
                 onMouseOver={this._onRectMouseMove}
                 onClick={this._onDataPointClick.bind(this, points[index]!.data[pointIndex].onDataPointClick!)}
                 {...pointOptions}
+                r={this._getCircleRadius(xDataPoint, circleRadius)}
               />
             );
           })}
@@ -642,12 +643,12 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     return graph;
   };
 
-  private _getCircleRadius = (xDataPoint: number): number => {
+  private _getCircleRadius = (xDataPoint: number, circleRadius: number): number => {
     const { isCircleClicked, nearestCircleToHighlight } = this.state;
     if (isCircleClicked && nearestCircleToHighlight === xDataPoint) {
       return 1;
     } else if (nearestCircleToHighlight === xDataPoint) {
-      return 8;
+      return circleRadius;
     } else {
       return 0;
     }

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.Styled.Example.tsx
@@ -102,7 +102,7 @@ export class AreaChartStyledExample extends React.Component<{}, IAreaChartBasicS
     const chartData = {
       chartTitle: 'Area chart styled example',
       lineChartData: chartPoints,
-      pointOptions: { radius: 8, strokeWidth: 3, opacity: 1, stroke: DefaultPalette.blueDark },
+      pointOptions: { r: 10, strokeWidth: 3, opacity: 1, stroke: DefaultPalette.blueDark },
       pointLineOptions: { strokeWidth: 2, strokeDasharray: '10 10', stroke: DefaultPalette.blueDark },
     };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

When user pass custom radius for circle point, on hover all the circle are visible, here only active circle should visible. 

## New Behavior

Only active circle will be visible even if user pass the custom radius for area chart point. 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->


**Before Change:**

https://user-images.githubusercontent.com/29042635/151368668-2188441c-891c-45f3-b4d3-ed52879d8be0.mp4



**After Change:**

https://user-images.githubusercontent.com/29042635/151368697-fa893fcb-c149-440d-9c09-bf25b58b05e5.mp4





Fixes #
