### PR TITLE
chore: use Griffel webpack loader

### DIFF
--- a/apps/vr-tests/.storybook/main.js
+++ b/apps/vr-tests/.storybook/main.js
@@ -26,7 +26,7 @@ module.exports = {
 
     config.module.rules.unshift({
       test: /\.(ts|tsx)$/,
-      use: [{ loader: '@fluentui/make-styles-webpack-loader' }],
+      use: [{ loader: '@griffel/webpack-loader' }],
     });
 
     return custom(config);

--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -15,8 +15,7 @@
     "start": "just-scripts dev:storybook"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/make-styles-webpack-loader": "9.0.0-beta.4"
+    "@fluentui/eslint-plugin": "*"
   },
   "dependencies": {
     "@fluentui/babel-make-styles": "9.0.0-beta.4",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -158,10 +158,6 @@ jobs:
         displayName: yarn
 
       - script: |
-          yarn build --to @fluentui/make-styles-webpack-loader --verbose --no-cache
-        displayName: build Webpack loader
-
-      - script: |
           yarn workspace vr-tests screener:build
         displayName: build vr-tests storybook
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@griffel/babel-preset": "1.0.0",
     "@griffel/jest-serializer": "1.0.0",
     "@griffel/react": "1.0.0",
+    "@griffel/webpack-loader": "2.0.0",
     "@linaria/babel-preset": "3.0.0-beta.14",
     "@microsoft/api-extractor": "7.18.1",
     "@nrwl/cli": "13.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1704,6 +1704,18 @@
   dependencies:
     "@griffel/core" "1.0.7"
 
+"@griffel/webpack-loader@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@griffel/webpack-loader/-/webpack-loader-2.0.0.tgz#4c0597e30431d8e8177bdb9e9b4ffabb0cd521ab"
+  integrity sha512-Y7CRUm1OcMr5B2xqQpZ2edGmEfyN7DQz+apYfT5+G7zy4zIPaoWtLPW17rgzjpesrt+65OPiTcVcDki/0hDehw==
+  dependencies:
+    "@babel/core" "^7.12.13"
+    "@griffel/babel-preset" "1.0.0"
+    "@linaria/babel-preset" "^3.0.0-beta.14"
+    enhanced-resolve "^5.8.2"
+    loader-utils "^2.0.0"
+    schema-utils "^3.1.1"
+
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz#1e6fe5d8027b1f285dc0d31762f566bccd73d5a9"


### PR DESCRIPTION
## PR changes

This PR replaces usage of `@fluentui/make-styles-webpack-loader` with `@griffel/webpack-loader` in `vr-tests` package.

#### What will happen with `@fluentui/make-styles-webpack-loader`?

It will be deprecated and removed from Fluent codebase in a separate PR.

#### Does it work?

Yes ⬇️

![image](https://user-images.githubusercontent.com/14183168/151373973-c70222c9-e74f-4864-bdf1-2ec76e287c9e.png)
