### PR TITLE
Slider story layoyut updates

### DIFF
--- a/packages/react-slider/src/components/Slider/Slider.stories.tsx
+++ b/packages/react-slider/src/components/Slider/Slider.stories.tsx
@@ -17,6 +17,7 @@ export default {
     Story => (
       <div
         style={{
+          // These stories use grid layout due to Safari bug noted in PR https://github.com/microsoft/fluentui/pull/21479
           display: 'grid',
           gridTemplateRows: 'repeat(1fr)',
           rowGap: '1em',

--- a/packages/react-slider/src/components/Slider/Slider.stories.tsx
+++ b/packages/react-slider/src/components/Slider/Slider.stories.tsx
@@ -15,7 +15,15 @@ export default {
   component: Slider,
   decorators: [
     Story => (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '1em', alignItems: 'flex-start', padding: 20 }}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateRows: 'repeat(1fr)',
+          rowGap: '1em',
+          justifyItems: 'start',
+          padding: 20,
+        }}
+      >
         <Story />
       </div>
     ),


### PR DESCRIPTION
Flex layout was causing issues in Safari. Grid layout is more predictable.  

Bug we're trying to avoid is being addressed by w3c right now. Looks like it could also be solved by giving the flex items an explicit flex basis (which we don't do due to how the story wrapper works)

https://github.com/w3c/csswg-drafts/issues/6822

Here is a repro of the bug when using a % height inside of a flexbox https://codepen.io/micahgodbolt/pen/oNogGVo