### PR TITLE
Avatar: Remove `glow` and `ring-glow` from activeAppearance, as their visuals are not yet finalized

### DIFF
--- a/apps/vr-tests/src/stories/AvatarConverged.stories.tsx
+++ b/apps/vr-tests/src/stories/AvatarConverged.stories.tsx
@@ -59,7 +59,7 @@ const examples = {
     { status: 'offline', outOfOffice: true },
     { status: 'outOfOffice', outOfOffice: true },
   ],
-  activeDisplay: ['ring', 'ring-shadow', 'ring-glow', 'shadow', 'glow'],
+  activeDisplay: ['ring', 'ring-shadow', 'shadow'],
   color: ['neutral', 'brand', 'colorful'],
   namedColors: [
     'darkRed',
@@ -211,14 +211,8 @@ storiesOf('Avatar Converged', module)
   .addStory('size+active+shadow', () => (
     <AvatarList images={examples.image} active="active" activeAppearance="shadow" />
   ))
-  .addStory('size+active+glow', () => (
-    <AvatarList images={examples.image} active="active" activeAppearance="glow" />
-  ))
   .addStory('size+active+ring-shadow', () => (
     <AvatarList images={examples.image} active="active" activeAppearance="ring-shadow" />
-  ))
-  .addStory('size+active+ring-glow', () => (
-    <AvatarList images={examples.image} active="active" activeAppearance="ring-glow" />
   ))
   .addStory('customSize+image', () => <AvatarCustomSizeList images={examples.image} />)
   .addStory('customSize+name+badge', () => (

--- a/change/@fluentui-react-avatar-c14f3a02-b7da-4d44-8f3b-83c101e3bc45.json
+++ b/change/@fluentui-react-avatar-c14f3a02-b7da-4d44-8f3b-83c101e3bc45.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Temporarily remove `glow` and `ring-glow` from activeAppearance, as their visuals are not yet finalized",
+  "packageName": "@fluentui/react-avatar",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-c14f3a02-b7da-4d44-8f3b-83c101e3bc45.json
+++ b/change/@fluentui-react-avatar-c14f3a02-b7da-4d44-8f3b-83c101e3bc45.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Temporarily remove `glow` and `ring-glow` from activeAppearance, as their visuals are not yet finalized",
+  "comment": "Remove `glow` and `ring-glow` from activeAppearance, as their visuals are not yet finalized.",
   "packageName": "@fluentui/react-avatar",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-avatar/etc/react-avatar.api.md
@@ -25,7 +25,7 @@ export type AvatarCommons = Omit<React_2.HTMLAttributes<HTMLElement>, 'children'
     size: 20 | 24 | 28 | 32 | 36 | 40 | 48 | 56 | 64 | 72 | 96 | 120 | 128;
     shape: 'circular' | 'square';
     active: 'active' | 'inactive' | 'unset';
-    activeAppearance: 'ring' | 'shadow' | 'glow' | 'ring-shadow' | 'ring-glow';
+    activeAppearance: 'ring' | 'shadow' | 'ring-shadow';
     color: 'neutral' | 'brand' | 'colorful' | AvatarNamedColor;
     idForColor: string | undefined;
 };

--- a/packages/react-avatar/src/AvatarActiveAppearance.stories.tsx
+++ b/packages/react-avatar/src/AvatarActiveAppearance.stories.tsx
@@ -5,9 +5,7 @@ export const ActiveAppearance = (props: Partial<AvatarProps>) => (
   <div style={{ display: 'flex', gap: '32px' }}>
     <Avatar {...props} active="active" activeAppearance="ring" />
     <Avatar {...props} active="active" activeAppearance="shadow" />
-    <Avatar {...props} active="active" activeAppearance="glow" />
     <Avatar {...props} active="active" activeAppearance="ring-shadow" />
-    <Avatar {...props} active="active" activeAppearance="ring-glow" />
   </div>
 );
 
@@ -16,7 +14,7 @@ ActiveAppearance.parameters = {
     description: {
       story:
         'An avatar can have different appearances when active.' +
-        ' Avatar supports `ring`, `shadow`, `glow`, `ring-shadow`, and `ring-glow`.' +
+        ' Avatar supports `ring`, `shadow`, `ring-shadow`.' +
         ' The default is `ring`.',
     },
   },

--- a/packages/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -83,7 +83,7 @@ export type AvatarCommons = Omit<React.HTMLAttributes<HTMLElement>, 'children'> 
    *
    * @defaultvalue ring
    */
-  activeAppearance: 'ring' | 'shadow' | 'glow' | 'ring-shadow' | 'ring-glow';
+  activeAppearance: 'ring' | 'shadow' | 'ring-shadow';
 
   /**
    * The color when displaying either an icon or initials.

--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -138,12 +138,6 @@ const useStyles = makeStyles({
   shadow16: { ':before': { boxShadow: tokens.shadow16 } },
   shadow28: { ':before': { boxShadow: tokens.shadow28 } },
 
-  // TODO: use proper tokens instead of "rgba(0,120,212,0.3)"
-  glow4: { ':before': { boxShadow: `${tokens.shadow4}, 0 0 4px 2px rgba(0,120,212,0.3)` } },
-  glow8: { ':before': { boxShadow: `${tokens.shadow8}, 0 0 8px 2px rgba(0,120,212,0.3)` } },
-  glow16: { ':before': { boxShadow: `${tokens.shadow16}, 0 0 8px 2px rgba(0,120,212,0.3)` } },
-  glow28: { ':before': { boxShadow: `${tokens.shadow28}, 0 0 28px 4px rgba(0,120,212,0.3)` } },
-
   inactive: {
     opacity: '0.8',
     transform: 'scale(0.875)',
@@ -393,7 +387,7 @@ export const useAvatarStyles_unstable = (state: AvatarState): AvatarState => {
   if (active === 'active' || active === 'inactive') {
     rootClasses.push(styles.activeOrInactive);
 
-    if (activeAppearance.includes('ring')) {
+    if (activeAppearance === 'ring' || activeAppearance === 'ring-shadow') {
       rootClasses.push(styles.ring);
 
       if (size <= 48) {
@@ -405,7 +399,7 @@ export const useAvatarStyles_unstable = (state: AvatarState): AvatarState => {
       }
     }
 
-    if (activeAppearance.includes('shadow')) {
+    if (activeAppearance === 'shadow' || activeAppearance === 'ring-shadow') {
       if (size <= 28) {
         rootClasses.push(styles.shadow4);
       } else if (size <= 48) {
@@ -414,18 +408,6 @@ export const useAvatarStyles_unstable = (state: AvatarState): AvatarState => {
         rootClasses.push(styles.shadow16);
       } else {
         rootClasses.push(styles.shadow28);
-      }
-    }
-
-    if (activeAppearance.includes('glow')) {
-      if (size <= 28) {
-        rootClasses.push(styles.glow4);
-      } else if (size <= 48) {
-        rootClasses.push(styles.glow8);
-      } else if (size <= 64) {
-        rootClasses.push(styles.glow16);
-      } else {
-        rootClasses.push(styles.glow28);
       }
     }
 


### PR DESCRIPTION
## Current Behavior

Avatar's `glow` and `ring-glow` activeAppearances are currently using temporary styles, as their visuals have not been finalized by design yet.

## New Behavior

Remove `glow` and `ring-glow` for now. They will be added back later, once we have final visuals for them.

## Issue

Fixes #21351