### PR TITLE
Update wording in check for modified files script to reduce confusion

### DIFF
--- a/packages/fluentui/test-a-feature.md
+++ b/packages/fluentui/test-a-feature.md
@@ -13,7 +13,6 @@
   - [Running tests](#running-tests)
 - [Screener Tests](#screener-tests)
   - [Tests with Steps API](#tests-with-steps-api)
-    - [Example for a test file](#example-for-a-test-file)
     - [Important mentions](#important-mentions)
   - [Run Screener tests](#run-screener-tests)
     - [Local run command](#local-run-command)

--- a/packages/fluentui/test-a-feature.md
+++ b/packages/fluentui/test-a-feature.md
@@ -13,6 +13,7 @@
   - [Running tests](#running-tests)
 - [Screener Tests](#screener-tests)
   - [Tests with Steps API](#tests-with-steps-api)
+    - [Example for a test file](#example-for-a-test-file)
     - [Important mentions](#important-mentions)
   - [Run Screener tests](#run-screener-tests)
     - [Local run command](#local-run-command)
@@ -259,7 +260,7 @@ Performance tests will measure performance, set a baseline for performance and h
 
 ### Adding a Perf Test
 
-- To add a perf test, simply add a file with `.perf.` in its naming. (As of writing, `.perf.` files in `packages/fluentui/docs/src` and `packages/fluentui/perf-test` are automatically consumed.)
+- To add a perf test, simply add a file with `.perf.` in its naming. (As of writing, `.perf.` files in `packages/fluentui/docs/src` and `packages/fluentui/perf-test-northstar` are automatically consumed.)
 - Formatting follows [Storybook CSF convention](https://storybook.js.org/docs/formats/component-story-format/) with special support for `iterations` metadata which tells the performance testing package how many iterations of your component to render:
 
 ```tsx
@@ -282,9 +283,9 @@ Run test and watch:
 yarn perf:test
 ```
 
-After running `perf:test`, results can be viewed in the `packages/fluentui/perf-test/dist` folder with the main entry file being `packages/fluentui/perf-test/dist/perfCounts.html`.
+After running `perf:test`, results can be viewed in the `packages/fluentui/perf-test-northstar/dist` folder with the main entry file being `packages/fluentui/perf-test-northstar/dist/perfCounts.html`.
 
-There are more detailed commands as well (these must be run from `packages/fluentui/perf-test` directory):
+There are more detailed commands as well (these must be run from `packages/fluentui/perf-test-northstar` directory):
 
 | Command                      | Description                                                             |
 | ---------------------------- | ----------------------------------------------------------------------- |

--- a/scripts/tasks/check-for-modified-files.ts
+++ b/scripts/tasks/check-for-modified-files.ts
@@ -17,6 +17,7 @@ export function checkForModifiedFiles() {
     // Diffing against HEAD will include both unstaged and staged files
     // (some scripts, such as gulp build:docs:toc, automatically stage the modified files)
     execSync('git diff HEAD', { stdio: 'inherit' });
+    logger.error('');
 
     throw new Error('Found modified files');
   }

--- a/scripts/tasks/check-for-modified-files.ts
+++ b/scripts/tasks/check-for-modified-files.ts
@@ -3,7 +3,7 @@ import { EOL } from 'os';
 import { execSync } from 'child_process';
 
 export function checkForModifiedFiles() {
-  const notEmpty = value => value.trim() !== '';
+  const notEmpty = (value: string) => value.trim() !== '';
 
   const gitStatusOutput = execSync('git status -s --untracked-files=no').toString('utf8');
   const hasChangedFiles = gitStatusOutput.split(EOL).filter(notEmpty).length > 0;
@@ -14,8 +14,8 @@ export function checkForModifiedFiles() {
     logger.error('Most likely you committed your files with --no-verify.');
     logger.error(gitStatusOutput);
 
-    execSync('git diff', { stdio: 'inherit' });
+    execSync('git --no-pager diff', { stdio: 'inherit' });
 
-    throw new Error('change file is required');
+    throw new Error('Found modified files');
   }
 }

--- a/scripts/tasks/check-for-modified-files.ts
+++ b/scripts/tasks/check-for-modified-files.ts
@@ -9,9 +9,9 @@ export function checkForModifiedFiles() {
   const hasChangedFiles = gitStatusOutput.split(EOL).filter(notEmpty).length > 0;
 
   if (hasChangedFiles) {
-    logger.error('This build has files that are tracked by git that resulted in changed files.');
-    logger.error('Check the following output and resolve the problem that caused these files to change');
-    logger.error('Most likely you committed your files with --no-verify');
+    logger.error('This build has files that are tracked by git that resulted in modified files.');
+    logger.error('Check the following output and resolve the problem that caused these files to change.');
+    logger.error('Most likely you committed your files with --no-verify.');
     logger.error(gitStatusOutput);
 
     execSync('git diff', { stdio: 'inherit' });

--- a/scripts/tasks/check-for-modified-files.ts
+++ b/scripts/tasks/check-for-modified-files.ts
@@ -10,11 +10,13 @@ export function checkForModifiedFiles() {
 
   if (hasChangedFiles) {
     logger.error('This build has files that are tracked by git that resulted in modified files.');
-    logger.error('Check the following output and resolve the problem that caused these files to change.');
+    logger.error('Check the following output and resolve the problem that caused these files to change .');
     logger.error('Most likely you committed your files with --no-verify.');
     logger.error(gitStatusOutput);
 
-    execSync('git --no-pager diff', { stdio: 'inherit' });
+    // Diffing against HEAD will include both unstaged and staged files
+    // (some scripts, such as gulp build:docs:toc, automatically stage the modified files)
+    execSync('git diff HEAD', { stdio: 'inherit' });
 
     throw new Error('Found modified files');
   }


### PR DESCRIPTION
## Current Behavior

I previously updated the name of the "check for modified files" step to remove the word "change" and reduce confusion with missing beachball change files.

But the error message itself still says "changed files," and at least in [this build](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=234781&view=logs&j=e04f516c-d41f-56c0-01f7-6f5ba91e652f&t=343794f6-bec6-56c0-7ec6-a9e0b3d94ab5&l=22), the diff was missing (the blank line is supposed to be a diff).

```
[7:23:06 PM] x This build has files that are tracked by git that resulted in changed files.
[7:23:06 PM] x Check the following output and resolve the problem that caused these files to change
[7:23:06 PM] x Most likely you committed your files with --no-verify
[7:23:06 PM] x M  ../packages/fluentui/test-a-feature.md

[7:23:06 PM] x Error detected while running 'check-for-modified-files'
[7:23:06 PM] x ------------------------------------
[7:23:06 PM] x Error: change file is required
```

## New Behavior

Update the message to say "modified files" and add `--no-pager` option to hopefully fix the diff.

```
[7:23:06 PM] x This build has files that are tracked by git that resulted in modified files.
[7:23:06 PM] x Check the following output and resolve the problem that caused these files to change.
[7:23:06 PM] x Most likely you committed your files with --no-verify.
[7:23:06 PM] x M  ../packages/fluentui/test-a-feature.md
<full diff will be here>
[7:23:06 PM] x Error detected while running 'check-for-modified-files'
[7:23:06 PM] x ------------------------------------
[7:23:06 PM] x Error: Found modified files
```

## Testing

Temporarily add a file with incorrect TOC to the PR, verify build fails helpfully