### PR TITLE
ToggleButton: Stopping aria-pressed from changing when ToggleButton is disabledFocusable

### DIFF
--- a/change/@fluentui-react-button-6c840806-b17d-4402-85d5-cbc963eb57dd.json
+++ b/change/@fluentui-react-button-6c840806-b17d-4402-85d5-cbc963eb57dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "ToggleButton: Stopping aria-pressed from changing when ToggleButton is disabledFocusable.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/components/ToggleButton/ToggleButton.test.tsx
+++ b/packages/react-button/src/components/ToggleButton/ToggleButton.test.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
+import { fireEvent, render } from '@testing-library/react';
 import { validateBehavior, ComponentTestFacade, toggleButtonBehaviorDefinition } from '@fluentui/a11y-testing';
 import { isConformant } from '../../common/isConformant';
 import { ToggleButton } from './ToggleButton';
 import { ToggleButtonProps } from './ToggleButton.types';
 
 describe('ToggleButton', () => {
+  beforeAll(() => {
+    // Reset body after behavioral checks are done
+    document.body.innerHTML = '';
+  });
+
   isConformant({
     Component: ToggleButton as React.FunctionComponent<ToggleButtonProps>,
     displayName: 'ToggleButton',
@@ -14,5 +20,43 @@ describe('ToggleButton', () => {
     const testFacade = new ComponentTestFacade(ToggleButton, {});
     const errors = validateBehavior(toggleButtonBehaviorDefinition, testFacade);
     expect(errors).toEqual([]);
+  });
+
+  it('triggers a change in `aria-pressed` when clicked if it is uncontrolled', () => {
+    const result = render(<ToggleButton>This is a toggle button</ToggleButton>);
+    const toggleButton = result.getByRole('button');
+
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(toggleButton);
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('true');
+    fireEvent.click(toggleButton);
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('does not trigger a change in `aria-pressed` when clicked if it is controlled', () => {
+    const result = render(<ToggleButton checked>This is a toggle button</ToggleButton>);
+    const toggleButton = result.getByRole('button');
+
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('true');
+    fireEvent.click(toggleButton);
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('does not trigger a change in `aria-pressed` when clicked if it is disabled', () => {
+    const result = render(<ToggleButton disabled>This is a toggle button</ToggleButton>);
+    const toggleButton = result.getByRole('button');
+
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(toggleButton);
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('does not trigger a change in `aria-pressed` when clicked if it is disabledFocusable', () => {
+    const result = render(<ToggleButton disabledFocusable>This is a toggle button</ToggleButton>);
+    const toggleButton = result.getByRole('button');
+
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(toggleButton);
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('false');
   });
 });

--- a/packages/react-button/src/components/ToggleButton/useToggleButton.ts
+++ b/packages/react-button/src/components/ToggleButton/useToggleButton.ts
@@ -13,6 +13,7 @@ export const useToggleButton_unstable = (
   { checked, defaultChecked, ...props }: ToggleButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ToggleButtonState => {
+  const { disabled, disabledFocusable } = props;
   const buttonState = useButton_unstable(props, ref);
   const { role, onClick } = buttonState.root;
 
@@ -34,7 +35,7 @@ export const useToggleButton_unstable = (
     // Slots definition
     root: {
       ...buttonState.root,
-      [isCheckboxTypeRole ? 'aria-checked' : 'aria-pressed']: !!checkedValue,
+      [isCheckboxTypeRole ? 'aria-checked' : 'aria-pressed']: !disabled && !disabledFocusable && checkedValue,
       onClick: React.useCallback(
         ev => {
           if (onClick) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

When `ToggleButton` was `disabledFocusable`, clicking it still triggered a change in `aria-pressed`.

## New Behavior

After this PR, clicking on a `disabledFocusable` `ToggleButton` does no longer trigger a change in `aria-pressed`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21407
