### PR TITLE
Button: Changing border radius of small button to borderRadiusMedium

### DIFF
--- a/change/@fluentui-react-button-159dc420-be08-4472-9dbb-634db2fd56ca.json
+++ b/change/@fluentui-react-button-159dc420-be08-4472-9dbb-634db2fd56ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Button: Changing border radius of small button to borderRadiusMedium.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-159dc420-be08-4472-9dbb-634db2fd56ca.json
+++ b/change/@fluentui-react-button-159dc420-be08-4472-9dbb-634db2fd56ca.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Button: Changing border radius of small button to borderRadiusMedium.",
+  "comment": "Button: Changing border radius of small button to borderRadiusMedium from borderRadiusSmall.",
   "packageName": "@fluentui/react-button",
   "email": "Humberto.Morimoto@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -146,7 +146,7 @@ const useRootStyles = makeStyles({
     height: '24px',
     minWidth: '64px',
 
-    ...shorthands.borderRadius(tokens.borderRadiusSmall),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
 
     fontSize: tokens.fontSizeBase200,
     fontWeight: tokens.fontWeightRegular,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The `Button` components have a border radius of `2px` (`borderRadiusSmall` token) when they are passed in `size="small"`.

## New Behavior

This PR changes this value to `4px` (`borderRadiusMedium` token) in accordance with changes made in the design specification for the `Button` component.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20991
