### PR TITLE
fix(scripts): update create-component generator to adhere to latest changes

### DIFF
--- a/scripts/create-component/plop-templates/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs
+++ b/scripts/create-component/plop-templates/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs
@@ -1,6 +1,8 @@
 import { makeStyles, mergeClasses } from '@griffel/react';
 import type { {{componentName}}State } from './{{componentName}}.types';
 
+
+export const {{componentNames.propertyName}}ClassName = 'fui-{{componentName}}'
 /**
  * Styles for the root slot
  */
@@ -17,7 +19,7 @@ const useStyles = makeStyles({
  */
 export const use{{componentName}}Styles_unstable = (state: {{componentName}}State): {{componentName}}State => {
   const styles = useStyles();
-  state.root.className = mergeClasses(styles.root, state.root.className);
+  state.root.className = mergeClasses({{componentNames.propertyName}}ClassName, styles.root, state.root.className);
 
   // TODO Add class names to slots, for example:
   // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);

--- a/scripts/create-component/plop-templates/src/components/{{componentName}}/{{componentName}}.tsx.hbs
+++ b/scripts/create-component/plop-templates/src/components/{{componentName}}/{{componentName}}.tsx.hbs
@@ -6,7 +6,7 @@ import type { {{componentName}}Props } from './{{componentName}}.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 
 /**
- * {{componentName}} component
+ * {{componentName}} component - TODO: add more docs
  */
 export const {{componentName}}: ForwardRefComponent<{{componentName}}Props> = React.forwardRef((props, ref) => {
   const state = use{{componentName}}_unstable(props, ref);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- generator produces invalid code ( type check fails, tests fail )
- generator asks if user wants to run post-processing. if user opts out he will get invalid code
- post-processing invokes unnecessary build chain

## New Behavior

-  no asking if user want's to run post-processing
- component/package is updated and ready to go after generator run

**🎬 DEMO:**


https://user-images.githubusercontent.com/1223799/151839581-0b938baa-83b4-494d-9b5f-d4d65e7b527c.mov



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20960
