### PR TITLE
Fix failing "yarn" commands on Windows

### DIFF
--- a/scripts/use-yarn-please.js
+++ b/scripts/use-yarn-please.js
@@ -8,9 +8,9 @@ const COMMAND_PREFIX = `\x1B[36m>\x1B[39m \x1B[7m\x1B[1m\x1B[36m PACKAGE MANAGER
 const Strings = {
   useYarnInstead: `
 - 🚨 Looks like you are trying to run "npm install". This repository has migrated to use Yarn as its package manager.
-- 📜 Please install the latest stable version of Yarn@1 following the instructions at https://yarnpkg.com/getting-started/install or by running "npm install -g yarn@1
+- 📜 Please install the latest stable version of Yarn@1 following the instructions at https://classic.yarnpkg.com/en/docs/install or by running "npm install -g yarn@1
 `,
-  installYarn: `You currently do not have an installation of Yarn in your PATH. Please install the latest stable version of Yarn@1 following the instructions at https://yarnpkg.com/getting-started/install or by running "npm install -g yarn@1".
+  installYarn: `You currently do not have an installation of Yarn in your PATH. Please install the latest stable version of Yarn@1 following the instructions at https://classic.yarnpkg.com/en/docs/install or by running "npm install -g yarn@1".
 `,
 };
 

--- a/scripts/use-yarn-please.js
+++ b/scripts/use-yarn-please.js
@@ -40,6 +40,6 @@ function userInvokedNpmInstall() {
 }
 
 function detectYarnInstallation() {
-  const yarnResult = spawnSync('yarn', ['--version'], { shell: true });
+  const yarnResult = spawnSync('yarn', ['--version'], { shell: true }); // Need to execute this in a sheel for Windows:  https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows
   return { exists: yarnResult.status === 0, version: yarnResult.stdout };
 }

--- a/scripts/use-yarn-please.js
+++ b/scripts/use-yarn-please.js
@@ -40,6 +40,6 @@ function userInvokedNpmInstall() {
 }
 
 function detectYarnInstallation() {
-  const yarnResult = spawnSync('yarn', ['--version']);
+  const yarnResult = spawnSync('yarn', ['--version'], { shell: true });
   return { exists: yarnResult.status === 0, version: yarnResult.stdout };
 }

--- a/scripts/use-yarn-please.js
+++ b/scripts/use-yarn-please.js
@@ -40,6 +40,6 @@ function userInvokedNpmInstall() {
 }
 
 function detectYarnInstallation() {
-  const yarnResult = spawnSync('yarn', ['--version'], { shell: true }); // Need to execute this in a sheel for Windows:  https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows
+  const yarnResult = spawnSync('yarn', ['--version'], { shell: true }); // Need to execute this in a shell for Windows:  https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows
   return { exists: yarnResult.status === 0, version: yarnResult.stdout };
 }


### PR DESCRIPTION
Please verify that:
* [X] Code is up-to-date with the `master` branch
* [X] You've run `yarn change` locally

<!--
PR flow tips:
* [X] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Running `yarn ...` commands on Windows fails.

## New Behavior

Running `yarn ...` commands on Windows works.

The change updates the `spawnSync` command to [spawn in a shell which allows `cmd` files to be executed on Windows](https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows) (`yarn` invokes a file called `yarn.cmd` on Windows)

Additionally, links to Yarn documentation in `use-yarn-please.js` have been updated to point to `https://classic.yarnpkg.com/...` as this is the docs site for Yarn 1.x and this project is using Yarn 1.x.

## Related Issue(s)

It appears a change in #17196 surfaced this issue.
