### PR TITLE
MenuButton: Updating types so it properly supports ref

### DIFF
--- a/change/@fluentui-react-button-cb98f8c3-450b-4c40-9613-e980b1357b50.json
+++ b/change/@fluentui-react-button-cb98f8c3-450b-4c40-9613-e980b1357b50.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "MenuButton: Updating types so it properly supports ref.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -67,10 +67,8 @@ export const MenuButton: ForwardRefComponent<MenuButtonProps>;
 // @public (undocumented)
 export const menuButtonClassName = "fui-MenuButton";
 
-// Warning: (ae-forgotten-export) The symbol "MenuTriggerChildProps" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export type MenuButtonProps = ComponentProps<MenuButtonSlots> & Partial<Omit<ButtonCommons, 'iconPosition'>> & Partial<MenuTriggerChildProps>;
+export type MenuButtonProps = ComponentProps<MenuButtonSlots> & Partial<Omit<ButtonCommons, 'iconPosition'>>;
 
 // @public (undocumented)
 export type MenuButtonSlots = ButtonSlots & {

--- a/packages/react-button/src/components/MenuButton/MenuButton.types.ts
+++ b/packages/react-button/src/components/MenuButton/MenuButton.types.ts
@@ -1,16 +1,5 @@
-import * as React from 'react';
 import type { ComponentProps, ComponentState, IntrinsicSlotProps } from '@fluentui/react-utilities';
 import type { ButtonCommons, ButtonSlots, ButtonState } from '../Button/Button.types';
-
-// This type mimics the interface found in MenuTrigger.types.ts to allow MenuButton and Menu to play correctly with each
-// other without having to tightly couple them.
-// https://github.com/microsoft/fluentui/blob/master/packages/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
-type MenuTriggerChildProps = Pick<
-  React.HTMLAttributes<HTMLElement>,
-  'onClick' | 'onMouseEnter' | 'onMouseLeave' | 'onContextMenu' | 'onKeyDown' | 'aria-haspopup' | 'aria-expanded' | 'id'
-> & {
-  ref?: React.Ref<never>;
-};
 
 export type MenuButtonSlots = ButtonSlots & {
   /**
@@ -19,9 +8,7 @@ export type MenuButtonSlots = ButtonSlots & {
   menuIcon?: IntrinsicSlotProps<'span'>;
 };
 
-export type MenuButtonProps = ComponentProps<MenuButtonSlots> &
-  Partial<Omit<ButtonCommons, 'iconPosition'>> &
-  Partial<MenuTriggerChildProps>;
+export type MenuButtonProps = ComponentProps<MenuButtonSlots> & Partial<Omit<ButtonCommons, 'iconPosition'>>;
 
 export type MenuButtonState = ComponentState<MenuButtonSlots> &
   Omit<ButtonState, keyof ButtonSlots | 'components' | 'iconPosition'>;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

`MenuButton` currently accepts a `ref` that is typed as `Ref<never> & Ref<HTMLButtonElement | HTMLAnchorElement>` which makes it impossible to satisfy with type-safety (i.e. need to type as `any`).

## New Behavior

Thir PR fixes the issue by correctly typing `MenuButton` by removing the `MenuTriggerChildProps` type from its definition, as `MenuButton` already supports the attributes that type indicates while also removing the `Ref<never>` type that is screwing up the usage of `ref`.

You can try it out by doing:

```tsx
const ref = React.useRef<HTMLButtonElement | HTMLAnchorElement>(null);

...

<MenuButton ref={ref}>This is a Menu Button</MenuButton>
```

Which will complain before the changes in this PR, whilst working correctly after those changes.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21484
