### PR TITLE
Dropdown: Headers and Dividers marked as hidden are no longer visible

### DIFF
--- a/change/@fluentui-react-45e4bf9b-adec-4695-b025-ccafe5d633b8.json
+++ b/change/@fluentui-react-45e4bf9b-adec-4695-b025-ccafe5d633b8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: Headers and Dividers marked as hidden are now actually hidden.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -5431,9 +5431,11 @@ export interface IDropdownStyles {
     caretDownWrapper: IStyle;
     dropdown: IStyle;
     dropdownDivider: IStyle;
+    dropdownDividerHidden: IStyle;
     dropdownItem: IStyle;
     dropdownItemDisabled: IStyle;
     dropdownItemHeader: IStyle;
+    dropdownItemHeaderHidden: IStyle;
     dropdownItemHidden: IStyle;
     dropdownItems: IStyle;
     dropdownItemSelected: IStyle;

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -738,8 +738,9 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
   private _renderSeparator(item: IDropdownOption): JSX.Element | null {
     const { index, key } = item;
+    const separatorClassName = item.hidden ? this._classNames.dropdownDividerHidden : this._classNames.dropdownDivider;
     if (index! > 0) {
-      return <div role="separator" key={key} className={this._classNames.dropdownDivider} />;
+      return <div role="separator" key={key} className={separatorClassName} />;
     }
     return null;
   }
@@ -747,8 +748,12 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
   private _renderHeader(item: IDropdownOption): JSX.Element {
     const { onRenderOption = this._onRenderOption } = this.props;
     const { key, id } = item;
+    const headerClassName = item.hidden
+      ? this._classNames.dropdownItemHeaderHidden
+      : this._classNames.dropdownItemHeader;
+
     return (
-      <div id={id} key={key} className={this._classNames.dropdownItemHeader}>
+      <div id={id} key={key} className={headerClassName}>
         {onRenderOption(item, this._onRenderOption)}
       </div>
     );

--- a/packages/react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.styles.ts
@@ -122,6 +122,30 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
     },
   ];
 
+  const dropdownHeaderStyle: IStyle = [
+    globalClassnames.dropdownItemHeader,
+    {
+      ...fonts.medium,
+      fontWeight: FontWeights.semibold,
+      color: semanticColors.menuHeader,
+      background: 'none',
+      backgroundColor: 'transparent',
+      border: 'none',
+      height: DROPDOWN_ITEM_HEIGHT,
+      lineHeight: DROPDOWN_ITEM_HEIGHT,
+      cursor: 'default',
+      padding: '0 8px',
+      userSelect: 'none',
+      textAlign: 'left',
+      selectors: {
+        [HighContrastSelector]: {
+          color: 'GrayText',
+          ...getHighContrastNoAdjustStyle(),
+        },
+      },
+    },
+  ];
+
   const selectedItemBackgroundColor = semanticColors.menuItemBackgroundPressed;
 
   const itemSelectors = (isSelected: boolean = false) => {
@@ -366,6 +390,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
     dropdownItemSelectedAndDisabled: [dropdownItemSelected, dropdownItemDisabled, { backgroundColor: 'transparent' }],
     dropdownItemHidden: [...dropdownItemStyle, { display: 'none' }],
     dropdownDivider: [globalClassnames.dropdownDivider, { height: 1, backgroundColor: semanticColors.bodyDivider }],
+    dropdownDividerHidden: [globalClassnames.dropdownDivider, { display: 'none' }],
     dropdownOptionText: [
       globalClassnames.dropdownOptionText,
       {
@@ -379,29 +404,8 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
         margin: '1px',
       },
     ],
-    dropdownItemHeader: [
-      globalClassnames.dropdownItemHeader,
-      {
-        ...fonts.medium,
-        fontWeight: FontWeights.semibold,
-        color: semanticColors.menuHeader,
-        background: 'none',
-        backgroundColor: 'transparent',
-        border: 'none',
-        height: DROPDOWN_ITEM_HEIGHT,
-        lineHeight: DROPDOWN_ITEM_HEIGHT,
-        cursor: 'default',
-        padding: '0 8px',
-        userSelect: 'none',
-        textAlign: 'left',
-        selectors: {
-          [HighContrastSelector]: {
-            color: 'GrayText',
-            ...getHighContrastNoAdjustStyle(),
-          },
-        },
-      },
-    ],
+    dropdownItemHeader: [...dropdownHeaderStyle],
+    dropdownItemHeaderHidden: [...dropdownHeaderStyle, { display: 'none' }],
     subComponentStyles: {
       label: { root: { display: 'inline-block' } },
       multiSelectItem: {

--- a/packages/react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.styles.ts
@@ -404,7 +404,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
         margin: '1px',
       },
     ],
-    dropdownItemHeader: [...dropdownHeaderStyle],
+    dropdownItemHeader: dropdownHeaderStyle,
     dropdownItemHeaderHidden: [...dropdownHeaderStyle, { display: 'none' }],
     subComponentStyles: {
       label: { root: { display: 'inline-block' } },

--- a/packages/react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.types.ts
@@ -245,8 +245,14 @@ export interface IDropdownStyles {
   /** Refers to the dropdown separator. */
   dropdownDivider: IStyle;
 
+  /** Style for dropdown separator when hidden. */
+  dropdownDividerHidden: IStyle;
+
   /** Refers to the individual dropdown items that are being rendered as a header. */
   dropdownItemHeader: IStyle;
+
+  /** Style for dropdown header when hidden. */
+  dropdownItemHeaderHidden: IStyle;
 
   /**
    * Refers to the panel that hosts the Dropdown options in small viewports.


### PR DESCRIPTION


Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


## Current Behavior

<!-- This is the behavior we have today -->
- When an option item for a `Dropdown` are either a `header` or `divider` and given the `hidden:true` property, they are still visible:
![image](https://user-images.githubusercontent.com/8649804/152073322-77ac1dee-312e-4235-a39d-ed2906acfc49.png)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- `header` and `divider` `Dropdown` options are no longer visible when marked as `hidden`
![image](https://user-images.githubusercontent.com/8649804/152073384-e5d88827-1327-4ad6-9104-9d582ee54ffe.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19909
