### PR TITLE
ContextualMenu: delayUpdateFocusOnHover is now working correctly so menu items are no longer focused on mouse hover

### DIFF
--- a/change/@fluentui-react-25b07909-5295-43bd-b7ff-749c29477562.json
+++ b/change/@fluentui-react-25b07909-5295-43bd-b7ff-749c29477562.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: delayUpdateFocusOnHover is now working correctly so menu items are no longer focused on mouse hover.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -236,7 +236,7 @@ function useShouldUpdateFocusOnMouseMove({ delayUpdateFocusOnHover, hidden }: IC
 
   const onMenuFocusCapture = React.useCallback(() => {
     if (delayUpdateFocusOnHover) {
-      shouldUpdateFocusOnMouseEvent.current = true;
+      shouldUpdateFocusOnMouseEvent.current = false;
     }
   }, [delayUpdateFocusOnHover]);
 


### PR DESCRIPTION
Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally



## Current Behavior

<!-- This is the behavior we have today -->
- The default behavior of a `ContextualMenu` is to have menu items focused on hover. The `delayUpdateFocusOnHover` prop is supposed to be a flag that prevents that behavior. However, passing that prop to `ContextualMenu` currently does not do anything. Seems like `shouldUpdateFocusOnMouseEvent` was being incorrectly set to true when `delayUpdateFocusOnHover` is `true` which resulted in the prop not working.

### Focus is initially on searchbox but hovering over menu items moves focus to those items: 
![ContextualMenuHoverBefore](https://user-images.githubusercontent.com/8649804/152104324-d120155e-7317-49ef-a3e8-e92b40c66d3c.gif)


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- Passing `delayUpdateFocusOnHover` to the `ContextualMenu` now correctly prevents focus from going to the hovered menu items. 
### Focus now stays with searchbox even when menu items are hovered: 
![ContextualMenuHoverFIxed](https://user-images.githubusercontent.com/8649804/152104329-7e634da8-918a-4ed8-b469-aaf77464e9f7.gif)

**CodeSandbox to demonstrate new behavior:** https://codesandbox.io/s/pr-21528-contextualmenu-hover-9ue42


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes ##20552
