### PR TITLE
Prevent Tooltip from overriding any aria-label, etc. props on its child

### DIFF
--- a/change/@fluentui-react-tooltip-29b9f81e-0e54-4234-a8c6-b983ebba7116.json
+++ b/change/@fluentui-react-tooltip-29b9f81e-0e54-4234-a8c6-b983ebba7116.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Prevent Tooltip from overriding any aria-label, etc. props on its child",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.test.tsx
@@ -105,4 +105,40 @@ describe('Tooltip', () => {
     expect(target.hasAttribute('aria-description')).toBe(false);
     expect(target.hasAttribute('aria-describedby')).toBe(false);
   });
+
+  it("doesn't override trigger's aria-label", () => {
+    const result = render(
+      <Tooltip content="Label tooltip" relationship="label">
+        <button aria-label="test-label" />
+      </Tooltip>,
+    );
+
+    const target = result.getByRole('button');
+    expect(target.getAttribute('aria-label')).toBe('test-label');
+    expect(target.getAttribute('aria-labelledby')).toBe(null);
+  });
+
+  it("doesn't override trigger's aria-labelledby", () => {
+    const result = render(
+      <Tooltip content="Label tooltip" relationship="label">
+        <button aria-labelledby="test-labelledby" />
+      </Tooltip>,
+    );
+
+    const target = result.getByRole('button');
+    expect(target.getAttribute('aria-label')).toBe(null);
+    expect(target.getAttribute('aria-labelledby')).toBe('test-labelledby');
+  });
+
+  it("doesn't override trigger's aria-describedby", () => {
+    const result = render(
+      <Tooltip content="Description tooltip" relationship="description">
+        <button aria-describedby="test-describedby" />
+      </Tooltip>,
+    );
+
+    const target = result.getByRole('button');
+    expect(target.getAttribute('aria-description')).toBe(null);
+    expect(target.getAttribute('aria-describedby')).toBe('test-describedby');
+  });
 });

--- a/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -203,16 +203,20 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
   }
 
   if (relationship === 'label') {
-    // aria-label only works if the content is a string. Otherwise, need to use aria-labelledby.
-    if (typeof state.content.children === 'string') {
-      triggerProps['aria-label'] = state.content.children;
-    } else if (!isServerSideRender) {
-      triggerProps['aria-labelledby'] = state.content.id;
-      // Always render the tooltip even if hidden, so that aria-labelledby refers to a valid element
-      state.shouldRenderTooltip = true;
+    const hasLabel = child?.props && ('aria-label' in child.props || 'aria-labelledby' in child.props);
+    if (!hasLabel) {
+      // aria-label only works if the content is a string. Otherwise, need to use aria-labelledby.
+      if (typeof state.content.children === 'string') {
+        triggerProps['aria-label'] = state.content.children;
+      } else if (!isServerSideRender) {
+        triggerProps['aria-labelledby'] = state.content.id;
+        // Always render the tooltip even if hidden, so that aria-labelledby refers to a valid element
+        state.shouldRenderTooltip = true;
+      }
     }
   } else if (relationship === 'description') {
-    if (!isServerSideRender) {
+    const hasDescription = child?.props && ('aria-description' in child.props || 'aria-describedby' in child.props);
+    if (!hasDescription && !isServerSideRender) {
       triggerProps['aria-describedby'] = state.content.id;
       // Always render the tooltip even if hidden, so that aria-describedby refers to a valid element
       state.shouldRenderTooltip = true;


### PR DESCRIPTION
## Current Behavior

Tooltip currently overrides aria props set on their child component. For example, the Button ends up with `aria-label="Foo"` in this scenario:
```jsx
<Tooltip content="Foo" relationship="label">
  <Button aria-label="Bar">...</Button>
</Tooltip>
```

## New Behavior

Have tooltip check for the existence of `aria-label`/`aria-labelledby` before setting either prop. Likewise, check for `aria-description`/`aria-describedby` before setting a description.

## Related Issue(s)

* This is a follow up to a comment on this PR: https://github.com/microsoft/fluentui/pull/21495#discussion_r795619711
