### PR TITLE
Allow React 17 in peer dependencies of react-accordion, react-badge and react-context-selector

### DIFF
--- a/change/@fluentui-react-accordion-560e7f50-7089-47a8-b265-63dcba83ec0c.json
+++ b/change/@fluentui-react-accordion-560e7f50-7089-47a8-b265-63dcba83ec0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow React 17 in peerDependencies.",
+  "packageName": "@fluentui/react-accordion",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-77d2f110-6723-44f9-8608-f6aa56a27406.json
+++ b/change/@fluentui-react-badge-77d2f110-6723-44f9-8608-f6aa56a27406.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow React 17 in peerDependencies.",
+  "packageName": "@fluentui/react-badge",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-context-selector-dd47074d-5d40-4183-bc4a-721cb52a9678.json
+++ b/change/@fluentui-react-context-selector-dd47074d-5d40-4183-bc4a-721cb52a9678.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow React 17 in peerDependencies.",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-accordion/package.json
+++ b/packages/react-accordion/package.json
@@ -52,10 +52,10 @@
     "tslib": "^2.1.0"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
-    "react": ">=16.8.0 <17.0.0",
-    "react-dom": ">=16.8.0 <17.0.0"
+    "@types/react": ">=16.8.0 <18.0.0",
+    "@types/react-dom": ">=16.8.0 <18.0.0",
+    "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-badge/package.json
+++ b/packages/react-badge/package.json
@@ -49,10 +49,10 @@
     "tslib": "^2.1.0"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
-    "react": ">=16.8.0 <17.0.0",
-    "react-dom": ">=16.8.0 <17.0.0"
+    "@types/react": ">=16.8.0 <18.0.0",
+    "@types/react-dom": ">=16.8.0 <18.0.0",
+    "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-context-selector/package.json
+++ b/packages/react-context-selector/package.json
@@ -40,10 +40,10 @@
     "tslib": "^2.1.0"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
-    "react": ">=16.8.0 <17.0.0",
-    "react-dom": ">=16.8.0 <17.0.0"
+    "@types/react": ">=16.8.0 <18.0.0",
+    "@types/react-dom": ">=16.8.0 <18.0.0",
+    "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally

## Current Behavior

<!-- This is the behavior we have today -->
- The `react-accordion`, `react-badge` and `react-context-selector` were missed when we allowed React 17 via peer dependencies for v8 and converged (#17048) which causes issues for consumers who use React 17+ and installs `@fluentui/react-components`.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- Peer dependency ranges for `react-accordion`, `react-badge` and `react-context-selector` have been updated to allow React 17.
## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21543
