### PR TITLE
cra-template: temporarily add resolution for babel to work around bug

### DIFF
--- a/change/@fluentui-cra-template-a130326a-e7ca-434d-bb78-5c568d837747.json
+++ b/change/@fluentui-cra-template-a130326a-e7ca-434d-bb78-5c568d837747.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Temporarily add resolution for `@babel/core` to work around bug",
+  "packageName": "@fluentui/cra-template",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -12,6 +12,9 @@
       "typescript": "^4.1.2",
       "web-vitals": "^1.0.1"
     },
+    "resolutions": {
+      "@babel/core": "7.16.12"
+    },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]
     }

--- a/packages/fluentui/projects-test/src/createReactApp.ts
+++ b/packages/fluentui/projects-test/src/createReactApp.ts
@@ -30,6 +30,14 @@ export async function createReactApp() {
 
   await prepareCreateReactApp(tempPaths, 'typescript');
   const testAppPath = config.paths.withRootAt(tempPaths.testApp);
+
+  // TODO: remove once babel issue is fixed (tracked by https://github.com/microsoft/fluentui/issues/21546)
+  logger('Add resolution to work around @babel/core issue');
+  const packageJson = fs.readJSONSync(testAppPath('package.json'));
+  packageJson.resolutions = { '@babel/core': '7.16.12' };
+  fs.writeJSONSync(testAppPath('package.json'), packageJson, { spaces: 2 });
+  await shEcho('yarn', testAppPath());
+
   logger(`Test React project is successfully created: ${testAppPath()}`);
 
   logger('STEP 2. Add Fluent UI dependency to test project..');


### PR DESCRIPTION
## Current Behavior

All builds are failing on `@fluentui/cra-template test` (northstar CRA projects-test will have a similar error):
```
TypeError: /tmp/cra-template--23641-701XsZoyanlh/test-app/node_modules/@fluentui/date-time-utilities/lib/dateFormatting/dateFormatting.types.js: Cannot read property 'originalPositionFor' of undefined
```

This also happens when create a new app using the published version of the template+packages, meaning it's an issue with some newly-released version of a `react-scripts` dependency, not an issue with our code.

Based on [this issue comment](https://github.com/aws-amplify/amplify-ui/issues/1242#issuecomment-1028471472) it seems to be some issue with the newly-released `@babel/core@7.17.0`. 

The full stack of the error (which you can see by creating an app with the template locally and running `yarn start`) includes `@ampproject/remapping`, meaning the issue was introduced by https://github.com/babel/babel/pull/14209 which switched to using that package for merging source maps.

## New Behavior

Add resolution in template to use `@babel/core@7.16.12`. Will also try and get a smaller repro to file an issue with babel, but we need this temp fix to unblock builds, as well as any consumer usage of the template.

The same resolution is needed for northstar's CRA projects-test, it's just added to the test app after creation because that test uses the default typescript template.

Tracking work to revert this fix later in #21546.