### PR TITLE
Revert cra-template workaround

### DIFF
--- a/change/@fluentui-cra-template-a130326a-e7ca-434d-bb78-5c568d837747.json
+++ b/change/@fluentui-cra-template-a130326a-e7ca-434d-bb78-5c568d837747.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Temporarily add resolution for `@babel/core` to work around bug",
-  "packageName": "@fluentui/cra-template",
-  "email": "elcraig@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-cra-template-f19ad23e-0c38-418c-b102-834d12de9304.json
+++ b/change/@fluentui-cra-template-f19ad23e-0c38-418c-b102-834d12de9304.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert adding resolution for babel because bug is fixed",
+  "packageName": "@fluentui/cra-template",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -12,9 +12,6 @@
       "typescript": "^4.1.2",
       "web-vitals": "^1.0.1"
     },
-    "resolutions": {
-      "@babel/core": "7.16.12"
-    },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]
     }

--- a/packages/fluentui/projects-test/src/createReactApp.ts
+++ b/packages/fluentui/projects-test/src/createReactApp.ts
@@ -30,14 +30,6 @@ export async function createReactApp() {
 
   await prepareCreateReactApp(tempPaths, 'typescript');
   const testAppPath = config.paths.withRootAt(tempPaths.testApp);
-
-  // TODO: remove once babel issue is fixed (tracked by https://github.com/microsoft/fluentui/issues/21546)
-  logger('Add resolution to work around @babel/core issue');
-  const packageJson = fs.readJSONSync(testAppPath('package.json'));
-  packageJson.resolutions = { '@babel/core': '7.16.12' };
-  fs.writeJSONSync(testAppPath('package.json'), packageJson, { spaces: 2 });
-  await shEcho('yarn', testAppPath());
-
   logger(`Test React project is successfully created: ${testAppPath()}`);
 
   logger('STEP 2. Add Fluent UI dependency to test project..');


### PR DESCRIPTION
## Current Behavior

#21545 added a workaround for an issue causing our tests that use create-react-app to fail. (see old PR description for details)

## New Behavior

Issue is fixed per https://github.com/facebook/create-react-app/issues/12017#issuecomment-1028615390 / https://github.com/babel/babel/issues/14229#issuecomment-1028610186. Revert workaround.

Fixes #21546