### PR TITLE
Fix Storybook Publish

### DIFF
--- a/change/@fluentui-react-components-dba1069e-ed3c-4ca1-9128-7d9a7e928bcb.json
+++ b/change/@fluentui-react-components-dba1069e-ed3c-4ca1-9128-7d9a7e928bcb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Upgrade chromatic to latest",
+  "packageName": "@fluentui/react-components",
+  "email": "me@levithomason.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "just-scripts build",
     "bundle-size": "bundle-size measure",
-    "chromatic": "npx chromatic@5.6.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name build-storybook",
+    "chromatic": "npx chromatic@6.4.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name build-storybook",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",


### PR DESCRIPTION
## Current Behavior

🚨 `yarn chromatic` fails to build Storybook.

## New Behavior

 ✅  `yarn chromatic` builds and releases Storybook. The `npx` script was using an outdated `chromatic` package.
