### PR TITLE
Document how to import preview components

### DIFF
--- a/change/@fluentui-react-card-a126bdd2-10f8-4154-aac7-5cbf9f35fee7.json
+++ b/change/@fluentui-react-card-a126bdd2-10f8-4154-aac7-5cbf9f35fee7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "document how to import preview components",
+  "packageName": "@fluentui/react-card",
+  "email": "me@levithomason.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-input-34332062-0f6d-4d2a-aef7-b3e9c1e904cd.json
+++ b/change/@fluentui-react-input-34332062-0f6d-4d2a-aef7-b3e9c1e904cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "document how to import preview components",
+  "packageName": "@fluentui/react-input",
+  "email": "me@levithomason.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-slider-52f80686-998d-4779-a397-1d083bb23670.json
+++ b/change/@fluentui-react-slider-52f80686-998d-4779-a397-1d083bb23670.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "document how to import preview components",
+  "packageName": "@fluentui/react-slider",
+  "email": "me@levithomason.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-card/src/CardDescription.md
+++ b/packages/react-card/src/CardDescription.md
@@ -1,7 +1,11 @@
+<!-- Don't allow prettier to collapse code block into single line -->
+<!-- prettier-ignore -->
 > **⚠️ Preview components are considered unstable:**
 >
 > ```jsx
+>
 > import { Card } from '@fluentui/react-components/unstable';
+>
 > ```
 >
 > - Features and APIs may change before final release

--- a/packages/react-card/src/CardDescription.md
+++ b/packages/react-card/src/CardDescription.md
@@ -1,4 +1,8 @@
 > **⚠️ Preview components are considered unstable:**
 >
+> ```jsx
+> import { Card } from '@fluentui/react-components/unstable';
+> ```
+>
 > - Features and APIs may change before final release
 > - Please contact us if you intend to use this in your product

--- a/packages/react-input/src/stories/InputDescription.md
+++ b/packages/react-input/src/stories/InputDescription.md
@@ -1,7 +1,11 @@
+<!-- Don't allow prettier to collapse code block into single line -->
+<!-- prettier-ignore -->
 > **⚠️ Preview components are considered unstable:**
 >
 > ```jsx
+> 
 > import { Input } from '@fluentui/react-components/unstable';
+> 
 > ```
 >
 > - Features and APIs may change before final release

--- a/packages/react-input/src/stories/InputDescription.md
+++ b/packages/react-input/src/stories/InputDescription.md
@@ -1,4 +1,8 @@
 > **⚠️ Preview components are considered unstable:**
 >
+> ```jsx
+> import { Input } from '@fluentui/react-components/unstable';
+> ```
+>
 > - Features and APIs may change before final release
 > - Please contact us if you intend to use this in your product

--- a/packages/react-slider/src/components/Slider/SliderDescription.md
+++ b/packages/react-slider/src/components/Slider/SliderDescription.md
@@ -1,7 +1,11 @@
+<!-- Don't allow prettier to collapse code block into single line -->
+<!-- prettier-ignore -->
 > **⚠️ Preview components are considered unstable:**
 >
 > ```jsx
+> 
 > import { Slider } from '@fluentui/react-components/unstable';
+> 
 > ```
 >
 > - Features and APIs may change before final release

--- a/packages/react-slider/src/components/Slider/SliderDescription.md
+++ b/packages/react-slider/src/components/Slider/SliderDescription.md
@@ -1,4 +1,8 @@
 > **⚠️ Preview components are considered unstable:**
 >
+> ```jsx
+> import { Slider } from '@fluentui/react-components/unstable';
+> ```
+>
 > - Features and APIs may change before final release
 > - Please contact us if you intend to use this in your product


### PR DESCRIPTION
## Current Behavior

We do not document how to import `unstable` preview components

## New Behavior

We now show a code block with the import statement for unstable components.

![image](https://user-images.githubusercontent.com/5067638/152407540-bc7c2a54-5234-4148-ae7b-c91c9792939f.png)
