### PR TITLE
Remove usage of jasmine and deprecated jest APIs from tests

### DIFF
--- a/change/@fluentui-react-96940b77-cbb9-4e27-a121-52dde91fd023.json
+++ b/change/@fluentui-react-96940b77-cbb9-4e27-a121-52dde91fd023.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update tests to remove deprecated API usage",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
+++ b/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
@@ -74,6 +74,10 @@ const resolveStylesOptions = (options?: {
 };
 
 describe('resolveStyles', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('resolves styles', () => {
     const { resolvedStyles } = resolveStyles(resolveStylesOptions(), resolvedVariables);
 
@@ -81,7 +85,7 @@ describe('resolveStyles', () => {
   });
 
   test('caches resolved styles', () => {
-    spyOn(testComponentStyles, 'root').and.callThrough();
+    jest.spyOn(testComponentStyles, 'root');
     const { resolvedStyles } = resolveStyles(resolveStylesOptions(), resolvedVariables);
 
     expect(resolvedStyles.root).toMatchObject({ color: 'red' });
@@ -117,7 +121,7 @@ describe('resolveStyles', () => {
   });
 
   test('caches resolved styles for no props', () => {
-    spyOn(testComponentStyles, 'root').and.callThrough();
+    jest.spyOn(testComponentStyles, 'root');
     const options = resolveStylesOptions();
     const { resolvedStyles } = resolveStyles(options, resolvedVariables);
     const { resolvedStyles: secondResolvedStyles } = resolveStyles(options, resolvedVariables);
@@ -141,7 +145,7 @@ describe('resolveStyles', () => {
   });
 
   test('caches resolved styles for the same props', () => {
-    spyOn(testComponentStyles, 'root').and.callThrough();
+    jest.spyOn(testComponentStyles, 'root');
     const options = resolveStylesOptions({
       displayNames: ['Test2'],
       componentProps: { primary: true },
@@ -189,7 +193,7 @@ describe('resolveStyles', () => {
   });
 
   test('considers props when caching resolved styles', () => {
-    spyOn(testComponentStyles, 'root').and.callThrough();
+    jest.spyOn(testComponentStyles, 'root');
     const options = resolveStylesOptions({
       displayNames: ['Test4'],
       componentProps: { primary: true },
@@ -225,7 +229,7 @@ describe('resolveStyles', () => {
   });
 
   test('does not cache styles if caching is disabled', () => {
-    spyOn(testComponentStyles, 'root').and.callThrough();
+    jest.spyOn(testComponentStyles, 'root');
     const options = resolveStylesOptions({
       performance: { enableStylesCaching: false },
     });
@@ -253,7 +257,7 @@ describe('resolveStyles', () => {
   });
 
   test('does not cache styles if there are inline overrides', () => {
-    spyOn(testComponentStyles, 'root').and.callThrough();
+    jest.spyOn(testComponentStyles, 'root');
     const propsInlineOverrides: ResolveStylesOptions['inlineStylesProps'][] = [
       { styles: { fontSize: '10px' } },
       { design: { left: '10px' } },
@@ -369,7 +373,7 @@ describe('resolveStyles', () => {
     });
 
     test('avoids "styles" computation when enabled', () => {
-      spyOn(testComponentStyles, 'root').and.callThrough();
+      jest.spyOn(testComponentStyles, 'root');
       const options = resolveStylesOptions({
         inlineStylesProps: { variables: { isFoo: true, isBar: null, isBaz: undefined } },
         performance: { enableBooleanVariablesCaching: true },
@@ -391,7 +395,7 @@ describe('resolveStyles', () => {
     });
 
     test('when enabled only "variables" as plain objects can be cached', () => {
-      spyOn(testComponentStyles, 'root').and.callThrough();
+      jest.spyOn(testComponentStyles, 'root');
       const options = resolveStylesOptions({
         inlineStylesProps: { variables: () => {} },
         performance: { enableBooleanVariablesCaching: true },
@@ -403,7 +407,7 @@ describe('resolveStyles', () => {
     });
 
     test('when enabled only "variables" as boolean or nil properties can be cached', () => {
-      spyOn(testComponentStyles, 'root').and.callThrough();
+      jest.spyOn(testComponentStyles, 'root');
       const options = resolveStylesOptions({
         inlineStylesProps: { variables: { foo: 'bar' } },
         performance: { enableBooleanVariablesCaching: true },

--- a/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
+++ b/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
@@ -81,7 +81,7 @@ describe('resolveStyles', () => {
   });
 
   test('caches resolved styles', () => {
-    spyOn(testComponentStyles, 'root').and.callThrough();
+    jest.spyOn(testComponentStyles, 'root');
     const { resolvedStyles } = resolveStyles(resolveStylesOptions(), resolvedVariables);
 
     expect(resolvedStyles.root).toMatchObject({ color: 'red' });
@@ -117,7 +117,7 @@ describe('resolveStyles', () => {
   });
 
   test('caches resolved styles for no props', () => {
-    spyOn(testComponentStyles, 'root').and.callThrough();
+    jest.spyOn(testComponentStyles, 'root');
     const options = resolveStylesOptions();
     const { resolvedStyles } = resolveStyles(options, resolvedVariables);
     const { resolvedStyles: secondResolvedStyles } = resolveStyles(options, resolvedVariables);
@@ -141,7 +141,7 @@ describe('resolveStyles', () => {
   });
 
   test('caches resolved styles for the same props', () => {
-    spyOn(testComponentStyles, 'root').and.callThrough();
+    jest.spyOn(testComponentStyles, 'root');
     const options = resolveStylesOptions({
       displayNames: ['Test2'],
       componentProps: { primary: true },
@@ -189,7 +189,7 @@ describe('resolveStyles', () => {
   });
 
   test('considers props when caching resolved styles', () => {
-    spyOn(testComponentStyles, 'root').and.callThrough();
+    jest.spyOn(testComponentStyles, 'root');
     const options = resolveStylesOptions({
       displayNames: ['Test4'],
       componentProps: { primary: true },
@@ -225,7 +225,7 @@ describe('resolveStyles', () => {
   });
 
   test('does not cache styles if caching is disabled', () => {
-    spyOn(testComponentStyles, 'root').and.callThrough();
+    jest.spyOn(testComponentStyles, 'root');
     const options = resolveStylesOptions({
       performance: { enableStylesCaching: false },
     });
@@ -253,7 +253,7 @@ describe('resolveStyles', () => {
   });
 
   test('does not cache styles if there are inline overrides', () => {
-    spyOn(testComponentStyles, 'root').and.callThrough();
+    jest.spyOn(testComponentStyles, 'root');
     const propsInlineOverrides: ResolveStylesOptions['inlineStylesProps'][] = [
       { styles: { fontSize: '10px' } },
       { design: { left: '10px' } },
@@ -369,7 +369,7 @@ describe('resolveStyles', () => {
     });
 
     test('avoids "styles" computation when enabled', () => {
-      spyOn(testComponentStyles, 'root').and.callThrough();
+      jest.spyOn(testComponentStyles, 'root');
       const options = resolveStylesOptions({
         inlineStylesProps: { variables: { isFoo: true, isBar: null, isBaz: undefined } },
         performance: { enableBooleanVariablesCaching: true },
@@ -391,7 +391,7 @@ describe('resolveStyles', () => {
     });
 
     test('when enabled only "variables" as plain objects can be cached', () => {
-      spyOn(testComponentStyles, 'root').and.callThrough();
+      jest.spyOn(testComponentStyles, 'root');
       const options = resolveStylesOptions({
         inlineStylesProps: { variables: () => {} },
         performance: { enableBooleanVariablesCaching: true },
@@ -403,7 +403,7 @@ describe('resolveStyles', () => {
     });
 
     test('when enabled only "variables" as boolean or nil properties can be cached', () => {
-      spyOn(testComponentStyles, 'root').and.callThrough();
+      jest.spyOn(testComponentStyles, 'root');
       const options = resolveStylesOptions({
         inlineStylesProps: { variables: { foo: 'bar' } },
         performance: { enableBooleanVariablesCaching: true },

--- a/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
+++ b/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
@@ -74,10 +74,6 @@ const resolveStylesOptions = (options?: {
 };
 
 describe('resolveStyles', () => {
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
-
   test('resolves styles', () => {
     const { resolvedStyles } = resolveStyles(resolveStylesOptions(), resolvedVariables);
 
@@ -85,7 +81,7 @@ describe('resolveStyles', () => {
   });
 
   test('caches resolved styles', () => {
-    jest.spyOn(testComponentStyles, 'root');
+    spyOn(testComponentStyles, 'root').and.callThrough();
     const { resolvedStyles } = resolveStyles(resolveStylesOptions(), resolvedVariables);
 
     expect(resolvedStyles.root).toMatchObject({ color: 'red' });
@@ -121,7 +117,7 @@ describe('resolveStyles', () => {
   });
 
   test('caches resolved styles for no props', () => {
-    jest.spyOn(testComponentStyles, 'root');
+    spyOn(testComponentStyles, 'root').and.callThrough();
     const options = resolveStylesOptions();
     const { resolvedStyles } = resolveStyles(options, resolvedVariables);
     const { resolvedStyles: secondResolvedStyles } = resolveStyles(options, resolvedVariables);
@@ -145,7 +141,7 @@ describe('resolveStyles', () => {
   });
 
   test('caches resolved styles for the same props', () => {
-    jest.spyOn(testComponentStyles, 'root');
+    spyOn(testComponentStyles, 'root').and.callThrough();
     const options = resolveStylesOptions({
       displayNames: ['Test2'],
       componentProps: { primary: true },
@@ -193,7 +189,7 @@ describe('resolveStyles', () => {
   });
 
   test('considers props when caching resolved styles', () => {
-    jest.spyOn(testComponentStyles, 'root');
+    spyOn(testComponentStyles, 'root').and.callThrough();
     const options = resolveStylesOptions({
       displayNames: ['Test4'],
       componentProps: { primary: true },
@@ -229,7 +225,7 @@ describe('resolveStyles', () => {
   });
 
   test('does not cache styles if caching is disabled', () => {
-    jest.spyOn(testComponentStyles, 'root');
+    spyOn(testComponentStyles, 'root').and.callThrough();
     const options = resolveStylesOptions({
       performance: { enableStylesCaching: false },
     });
@@ -257,7 +253,7 @@ describe('resolveStyles', () => {
   });
 
   test('does not cache styles if there are inline overrides', () => {
-    jest.spyOn(testComponentStyles, 'root');
+    spyOn(testComponentStyles, 'root').and.callThrough();
     const propsInlineOverrides: ResolveStylesOptions['inlineStylesProps'][] = [
       { styles: { fontSize: '10px' } },
       { design: { left: '10px' } },
@@ -373,7 +369,7 @@ describe('resolveStyles', () => {
     });
 
     test('avoids "styles" computation when enabled', () => {
-      jest.spyOn(testComponentStyles, 'root');
+      spyOn(testComponentStyles, 'root').and.callThrough();
       const options = resolveStylesOptions({
         inlineStylesProps: { variables: { isFoo: true, isBar: null, isBaz: undefined } },
         performance: { enableBooleanVariablesCaching: true },
@@ -395,7 +391,7 @@ describe('resolveStyles', () => {
     });
 
     test('when enabled only "variables" as plain objects can be cached', () => {
-      jest.spyOn(testComponentStyles, 'root');
+      spyOn(testComponentStyles, 'root').and.callThrough();
       const options = resolveStylesOptions({
         inlineStylesProps: { variables: () => {} },
         performance: { enableBooleanVariablesCaching: true },
@@ -407,7 +403,7 @@ describe('resolveStyles', () => {
     });
 
     test('when enabled only "variables" as boolean or nil properties can be cached', () => {
-      jest.spyOn(testComponentStyles, 'root');
+      spyOn(testComponentStyles, 'root').and.callThrough();
       const options = resolveStylesOptions({
         inlineStylesProps: { variables: { foo: 'bar' } },
         performance: { enableBooleanVariablesCaching: true },

--- a/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
+++ b/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
@@ -74,6 +74,10 @@ const resolveStylesOptions = (options?: {
 };
 
 describe('resolveStyles', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   test('resolves styles', () => {
     const { resolvedStyles } = resolveStyles(resolveStylesOptions(), resolvedVariables);
 

--- a/packages/react/src/common/testUtilities.ts
+++ b/packages/react/src/common/testUtilities.ts
@@ -54,5 +54,5 @@ export function mockEvent(targetValue: string = ''): ReactTestUtils.SyntheticEve
  * https://github.com/facebook/jest/issues/2157#issuecomment-279171856
  */
 export function flushPromises() {
-  return new Promise<void>(resolve => setImmediate(resolve));
+  return new Promise<void>(resolve => setTimeout(resolve, 0));
 }

--- a/packages/react/src/common/testUtilities.ts
+++ b/packages/react/src/common/testUtilities.ts
@@ -54,5 +54,6 @@ export function mockEvent(targetValue: string = ''): ReactTestUtils.SyntheticEve
  * https://github.com/facebook/jest/issues/2157#issuecomment-279171856
  */
 export function flushPromises() {
-  return new Promise<void>(resolve => setTimeout(resolve, 0));
+  // TODO: in jest 27, change to `new Promise(process.nextTick)` per https://stackoverflow.com/a/51045733
+  return new Promise<void>(resolve => setImmediate(resolve));
 }

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -22,6 +22,7 @@ describe('DatePicker', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    jest.resetAllMocks();
   });
 
   it('renders default DatePicker correctly', () => {

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -142,7 +142,7 @@ describe('DatePicker', () => {
 
   it('should clear error message when required input has date text and allowTextInput is true', () => {
     // See https://github.com/facebook/react/issues/11565
-    spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
 
     safeCreate(<DatePickerBase isRequired={true} allowTextInput={true} />, datePicker => {
       const textfield = datePicker.root.findByType(TextField);
@@ -171,7 +171,7 @@ describe('DatePicker', () => {
 
   it('clears error message when required input has date selected from calendar and allowTextInput is true', () => {
     // See https://github.com/facebook/react/issues/11565
-    spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
 
     safeCreate(<DatePickerBase isRequired={true} allowTextInput={true} />, datePicker => {
       const textfield = datePicker.root.findByType(TextField);
@@ -201,7 +201,7 @@ describe('DatePicker', () => {
 
   it('should not clear initial error when datepicker is opened', () => {
     // See https://github.com/facebook/react/issues/11565
-    spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
 
     safeCreate(
       <DatePickerBase
@@ -253,7 +253,7 @@ describe('DatePicker', () => {
 
   it('should reset status message after selecting a valid date', () => {
     // See https://github.com/facebook/react/issues/11565
-    spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
 
     safeCreate(<DatePickerBase allowTextInput={true} initialPickerDate={new Date('2021-04-15')} />, datePicker => {
       const input = datePicker.root.findByType('input');
@@ -286,7 +286,7 @@ describe('DatePicker', () => {
   // @todo: usage of document.querySelector is incorrectly testing DOM mounted by previous tests and needs to be fixed.
   it('should call onSelectDate only once when allowTextInput is true and popup is used to select the value', () => {
     // See https://github.com/facebook/react/issues/11565
-    spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
     const onSelectDate = jest.fn();
 
     safeCreate(<DatePickerBase allowTextInput={true} onSelectDate={onSelectDate} />, datePicker => {
@@ -307,7 +307,7 @@ describe('DatePicker', () => {
 
   it('should set "Calendar" as the Callout\'s aria-label', () => {
     // See https://github.com/facebook/react/issues/11565
-    spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
 
     safeCreate(<DatePickerBase />, datePicker => {
       const input = datePicker.root.findAllByType('div')[5];
@@ -330,7 +330,7 @@ describe('DatePicker', () => {
     // that the datepicker opens on the correct month
 
     // See https://github.com/facebook/react/issues/11565
-    spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
 
     safeCreate(
       <DatePickerBase allowTextInput={true} today={today} initialPickerDate={initiallySelectedDate} />,
@@ -360,7 +360,7 @@ describe('DatePicker', () => {
     // that the datepicker opens on the correct month
 
     // See https://github.com/facebook/react/issues/11565
-    spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
 
     safeCreate(
       <DatePickerBase

--- a/packages/react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.test.tsx
@@ -70,7 +70,7 @@ describe('Dropdown', () => {
 
     it('Renders correctly when open', () => {
       // Mock createPortal so that the options list ends up inside the wrapper for snapshotting
-      jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+      spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
       // There's intermittent variation (maybe measurement-related) on different computers,
       // so use fake timers to make it more predictable even though we never advance the timers.
       jest.useFakeTimers();
@@ -509,7 +509,7 @@ describe('Dropdown', () => {
 
     it('Renders correctly when open', () => {
       // Mock createPortal so that the options list ends up inside the wrapper for snapshotting
-      jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+      spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
       // There's intermittent variation (maybe measurement-related) on different computers,
       // so use fake timers to make it more predictable even though we never advance the timers.
       jest.useFakeTimers();

--- a/packages/react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.test.tsx
@@ -70,7 +70,7 @@ describe('Dropdown', () => {
 
     it('Renders correctly when open', () => {
       // Mock createPortal so that the options list ends up inside the wrapper for snapshotting
-      spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+      jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
       // There's intermittent variation (maybe measurement-related) on different computers,
       // so use fake timers to make it more predictable even though we never advance the timers.
       jest.useFakeTimers();
@@ -509,7 +509,7 @@ describe('Dropdown', () => {
 
     it('Renders correctly when open', () => {
       // Mock createPortal so that the options list ends up inside the wrapper for snapshotting
-      spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+      jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
       // There's intermittent variation (maybe measurement-related) on different computers,
       // so use fake timers to make it more predictable even though we never advance the timers.
       jest.useFakeTimers();

--- a/packages/react/src/components/ExtendedPicker/BaseExtendedPicker.test.tsx
+++ b/packages/react/src/components/ExtendedPicker/BaseExtendedPicker.test.tsx
@@ -259,19 +259,19 @@ describe('Pickers', () => {
 
       // precondition check
       expect(picker.floatingPicker.current).toBeTruthy();
-      expect(picker.floatingPicker.current!.suggestions).toEqual([
-        jasmine.objectContaining({
-          item: jasmine.objectContaining({
+      expect(picker.floatingPicker.current!.suggestions).toMatchObject([
+        {
+          item: {
             name: 'black',
             key: 'black',
-          }),
-        }),
-        jasmine.objectContaining({
-          item: jasmine.objectContaining({
+          },
+        },
+        {
+          item: {
             name: 'blue',
             key: 'blue',
-          }),
-        }),
+          },
+        },
       ]);
 
       // act
@@ -279,10 +279,10 @@ describe('Pickers', () => {
 
       // assert
       expect(picker.items).toEqual([
-        jasmine.objectContaining({
+        {
           name: 'black',
           key: 'black',
-        }),
+        },
       ]);
     });
 

--- a/packages/utilities/src/getPropsWithDefaults.test.ts
+++ b/packages/utilities/src/getPropsWithDefaults.test.ts
@@ -24,7 +24,7 @@ describe('getPropsWithDefaults', () => {
       num: 0,
       bool: false,
       str: '',
-      fn: jasmine.createSpy('fn'),
+      fn: () => undefined,
       nul: null,
     };
 

--- a/packages/utilities/src/safeSetTimeout.test.tsx
+++ b/packages/utilities/src/safeSetTimeout.test.tsx
@@ -35,7 +35,7 @@ describe('safeSetTimeout', () => {
 
     expect(setTimeoutCalled).toEqual(false);
 
-    jest.runTimersToTime(100);
+    jest.advanceTimersByTime(100);
 
     expect(setTimeoutCalled).toEqual(true);
   });
@@ -47,7 +47,7 @@ describe('safeSetTimeout', () => {
 
     wrapper.unmount();
 
-    jest.runTimersToTime(100);
+    jest.advanceTimersByTime(100);
 
     expect(setTimeoutCalled).toEqual(false);
   });

--- a/packages/utilities/src/setFocusVisibility.test.tsx
+++ b/packages/utilities/src/setFocusVisibility.test.tsx
@@ -45,7 +45,7 @@ describe('setFocusVisibility', () => {
   };
 
   beforeEach(() => {
-    spyOn(getWindow, 'getWindow').and.returnValue(mockWindow);
+    jest.spyOn(getWindow, 'getWindow').mockReturnValue(mockWindow as Window);
     classNames = [];
 
     wrapper = mount(<FocusRects />);

--- a/scripts/debug-test.js
+++ b/scripts/debug-test.js
@@ -10,7 +10,7 @@ if (!configPath || !rootPath) {
     'Unable to find jest.config.js relative to currently opened file. Run debug-test from an open source file in a jest enabled project.',
   );
 } else {
-  const jestCli = require.resolve('jest-cli/bin/jest.js');
+  const jestCli = require.resolve('jest-cli/bin/jest');
   process.chdir(path.dirname(configPath));
   require(jestCli);
 }


### PR DESCRIPTION
## Current Behavior

A few tests are using either global jasmine APIs (such as *global* `spyOn`) which will stop working with [new defaults in jest 27](https://jestjs.io/blog/2021/05/25/jest-27#flipping-defaults), or deprecated jest APIs (`runTimersToTime`) that are removed in 27.

## New Behavior

Switch to alternative/newer APIs that are already available in jest 26.

I didn't add any lint rules to ban the old APIs, so it's possible that new usage could sneak in between now and whenever we actually upgrade to jest 27. However I'm not too concerned about this because the number of new instances (if any) should be small enough that it will be easy to fix.

## Related Issue(s)

Related to #18442