### PR TITLE
removed dup dependency in react-components

### DIFF
--- a/change/@fluentui-react-components-137f8d72-db14-423b-8057-44b1dfa7857c.json
+++ b/change/@fluentui-react-components-137f8d72-db14-423b-8057-44b1dfa7857c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "removed dup dependency",
+  "packageName": "@fluentui/react-components",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -48,7 +48,6 @@
     "@fluentui/react-input": "9.0.0-beta.0",
     "@fluentui/react-label": "9.0.0-beta.4",
     "@fluentui/react-link": "9.0.0-beta.5",
-    "@griffel/react": "1.0.0",
     "@fluentui/react-menu": "9.0.0-beta.5",
     "@fluentui/react-popover": "9.0.0-beta.5",
     "@fluentui/react-portal": "9.0.0-beta.5",


### PR DESCRIPTION
seems we capture two griffels during some merge conflicts. 