### PR TITLE
Explicit theme exports

### DIFF
--- a/change/@fluentui-react-92314f9d-9f20-4914-8d87-3eee3731abe8.json
+++ b/change/@fluentui-react-92314f9d-9f20-4914-8d87-3eee3731abe8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove duplicate export names caused by export star.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -81,7 +81,6 @@ export * from './SwatchColorPicker';
 export * from './TeachingBubble';
 export * from './Text';
 export * from './TextField';
-export * from './Theme';
 export * from './ThemeGenerator';
 export * from './TimePicker';
 export * from './Toggle';
@@ -89,5 +88,26 @@ export * from './Tooltip';
 export * from './Utilities';
 export * from './WeeklyDayPicker';
 export * from './WindowProvider';
+/**
+ * Styles and Theme both exported the same variables which causes conflicting
+ * star exports with webpack5. See here: https://github.com/microsoft/fluentui/issues/21601
+ * Now explicitly declaring Theme exports that are NOT also being exported from Styles.
+ */
+export * from './utilities/ThemeProvider/index';
+export {
+  CommunicationColors,
+  DefaultSpacing,
+  Depths,
+  FluentTheme,
+  LocalizedFontFamilies,
+  LocalizedFontNames,
+  mergeThemes,
+  MotionDurations,
+  MotionTimings,
+  MotionAnimations,
+  NeutralColors,
+  SharedColors,
+} from './Theme';
+export type { ComponentStyles, ComponentsStyles, PartialTheme, Theme } from './Theme';
 
 import './version';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -89,7 +89,7 @@ export * from './Utilities';
 export * from './WeeklyDayPicker';
 export * from './WindowProvider';
 /**
- * Styles and Theme both exported the same variables which causes conflicting
+ * Styles and Theme both exported the same name which causes conflicting
  * star exports with webpack5. See here: https://github.com/microsoft/fluentui/issues/21601
  * Now explicitly declaring Theme exports that are NOT also being exported from Styles.
  */

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -89,7 +89,7 @@ export * from './Utilities';
 export * from './WeeklyDayPicker';
 export * from './WindowProvider';
 /**
- * Styles and Theme both exported the same name which causes conflicting
+ * Styles and Theme both exported the same names which causes conflicting
  * star exports with webpack5. See here: https://github.com/microsoft/fluentui/issues/21601
  * Now explicitly declaring Theme exports that are NOT also being exported from Styles.
  */


### PR DESCRIPTION

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


## Current Behavior

<!-- This is the behavior we have today -->
- `Styling.ts` and `Theme.ts` have duplicated names being exported from them which are surfaced when we're exporting `*` from both in  `react/src/index.ts`. This is causing conflicting star export compilation issues for consumers using webpack5.  

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- Explicitly exports names from `Theme.ts` that are NOT already being exported from `Styling.ts`.

-  Ideally it should be the other way around since the duplicated names come from `@fluentui/theme` which is where `Theme.ts` is already exporting from; but doing that causes a lot of churn when using the API extractor which ultimately leads to duplicated exports in the API file (see screenshots):

1) ![image](https://user-images.githubusercontent.com/8649804/152459086-281c3bcf-1f8c-4f4b-aec6-2919111d95ea.png)
2) ![image](https://user-images.githubusercontent.com/8649804/152459102-dbae93bd-7cf6-49b0-8d09-771f8bf76736.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21601
