### PR TITLE
fix(menuButtonBehavior): do not set aria attributes when they are undefined

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Use shadow8 for better contrast of `Tooltip` @jurokapsiar ([#21316](https://github.com/microsoft/fluentui/pull/21316))
 - `FocusTrapZone`: add handleRef method instead of function to prevent calling it on each re-render @annabratseiko ([#21337](https://github.com/microsoft/fluentui/pull/21337))
 - Fix color slot titles in docsite @notandrew ([#21378](https://github.com/microsoft/fluentui/pull/21378))
+- Fix `menuButtonBehavior` to not set undefined aria attributes @yuanboxue-amber ([#21610](https://github.com/microsoft/fluentui/pull/21610))
 
 ### Features
 - Add new Popup prop `closeOnScroll` to close popup when scroll happens outside of the popover element @yuanboxue-amber ([#21453](https://github.com/microsoft/fluentui/pull/21453))

--- a/packages/fluentui/accessibility/src/behaviors/MenuButton/menuButtonBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/MenuButton/menuButtonBehavior.ts
@@ -14,9 +14,9 @@ export const menuButtonBehavior: Accessibility<MenuButtonBehaviorProps> = props 
   return _.merge(behavior, {
     attributes: {
       trigger: {
-        'aria-controls': props.open ? props.menuId : undefined,
-        'aria-expanded': (props.open && !props.contextMenu) || undefined,
-        'aria-haspopup': props.contextMenu ? undefined : 'true',
+        ...(props.open && { 'aria-controls': props.menuId }),
+        ...(props.open && !props.contextMenu && { 'aria-expanded': 'true' }),
+        ...(!props.contextMenu && { 'aria-haspopup': 'true' }),
         id: props.triggerId,
         ...(!props.contextMenu && props.open && { tabIndex: -1 }),
       },


### PR DESCRIPTION
 
## Current Behavior

`menuButtonBehavior` can set aria attributes to undefined value. When MenuButton is used with another component, user prop is not able to override the undefined aria attributes.
In this example: https://codesandbox.io/s/fluent-ui-example-forked-nbrh2?file=/example.tsx MenuButton is added as a contextMenu on a TreeItem, with TreeItem being the trigger. This is a very common use case. But MenuButton forces undefined aria attributes (including aria-expanded) on TreeItem, so TreeItem loses its `aria-expanded` attribute:
<img width="699" alt="Screenshot 2022-02-04 at 11 05 55" src="https://user-images.githubusercontent.com/28751745/152511354-4d735750-79ab-43c8-ba69-fd2ee3c1861e.png">
This is not overridable from user prop, unless user gives MenuButton a custom accessibility behavior.

## New Behavior

This PR updates `menuButtonBehavior` to never set any aria attributes to undefined.

 