### PR TITLE
feat: Imperative `setTarget` for `usePopper` and `positioning`

### DIFF
--- a/change/@fluentui-react-positioning-9b11f0e0-fafc-464e-88ac-ef746c87965f.json
+++ b/change/@fluentui-react-positioning-9b11f0e0-fafc-464e-88ac-ef746c87965f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Imperative `setTarget` for `usePopper` and `positioning`",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/Concepts/Positioning/PositioningPopperImperativeHandle.stories.tsx
+++ b/packages/react-components/src/Concepts/Positioning/PositioningPopperImperativeHandle.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { Popover, PopoverTrigger, PopoverSurface, PopoverProps } from '@fluentui/react-popover';
 import { Button } from '@fluentui/react-button';
-import { PositioningProps } from '@fluentui/react-positioning';
+import { PopperRefHandle } from '@fluentui/react-positioning';
 
 export const PopperImperativeHandle = () => {
   const [loading, setLoading] = React.useState(true);
-  const popperRef: PositioningProps['popperRef'] = React.useRef(null);
+  const popperRef = React.useRef<PopperRefHandle>(null);
   const timeoutRef = React.useRef(0);
 
   const onOpenChange: PopoverProps['onOpenChange'] = (e, data) => {

--- a/packages/react-components/src/Concepts/Positioning/PositioningPopperImperativeHandle.stories.tsx
+++ b/packages/react-components/src/Concepts/Positioning/PositioningPopperImperativeHandle.stories.tsx
@@ -5,7 +5,7 @@ import { PositioningProps } from '@fluentui/react-positioning';
 
 export const PopperImperativeHandle = () => {
   const [loading, setLoading] = React.useState(true);
-  const popperRef: PositioningProps['popperRef'] = React.useRef({ updatePosition: () => null });
+  const popperRef: PositioningProps['popperRef'] = React.useRef(null);
   const timeoutRef = React.useRef(0);
 
   const onOpenChange: PopoverProps['onOpenChange'] = (e, data) => {

--- a/packages/react-menu/src/stories/MenuAnchorToTarget.stories.tsx
+++ b/packages/react-menu/src/stories/MenuAnchorToTarget.stories.tsx
@@ -19,17 +19,6 @@ export const AnchorToCustomTarget = () => {
     }
   }, [buttonRef, popperRef]);
 
-  // A callback ref can be used, but the component the ref is attached to
-  // must be rendered after the `Menu` component so that `popperRef` is resolved
-  // Most likely won't work if there's any kind of async loading
-  // const callbackRef = React.useCallback(
-  //   (el: HTMLButtonElement) => {
-  //     console.log(popperRef.current, el);
-  //     popperRef.current?.setTarget(el);
-  //   },
-  //   [popperRef],
-  // );
-
   return (
     <>
       <Button onClick={() => setOpen(s => !s)}>Open menu</Button>

--- a/packages/react-menu/src/stories/MenuAnchorToTarget.stories.tsx
+++ b/packages/react-menu/src/stories/MenuAnchorToTarget.stories.tsx
@@ -3,23 +3,29 @@ import * as React from 'react';
 import { Menu, MenuList, MenuItem, MenuPopover, MenuProps } from '../index';
 
 import { Button } from '@fluentui/react-button';
+import { PopperRefHandle } from '@fluentui/react-positioning';
 
 export const AnchorToCustomTarget = () => {
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const popperRef = React.useRef<PopperRefHandle>(null);
   const [open, setOpen] = React.useState(false);
-  const [target, setTarget] = React.useState<HTMLElement | null>(null);
   const onOpenChange: MenuProps['onOpenChange'] = (e, data) => {
     setOpen(data.open);
   };
 
+  React.useEffect(() => {
+    if (buttonRef.current) {
+      popperRef.current?.setTarget(buttonRef.current);
+    }
+  }, [buttonRef, popperRef]);
+
   return (
     <>
-      <Button ref={setTarget} onClick={() => setOpen(s => !s)}>
-        Open menu
-      </Button>
-      <Button ref={setTarget} onClick={() => setOpen(s => !s)}>
+      <Button onClick={() => setOpen(s => !s)}>Open menu</Button>
+      <Button ref={buttonRef} onClick={() => setOpen(s => !s)}>
         Custom target
       </Button>
-      <Menu open={open} onOpenChange={onOpenChange} positioning={{ target }}>
+      <Menu open={open} onOpenChange={onOpenChange} positioning={{ popperRef }}>
         <MenuPopover>
           <MenuList>
             <MenuItem>New </MenuItem>

--- a/packages/react-menu/src/stories/MenuAnchorToTarget.stories.tsx
+++ b/packages/react-menu/src/stories/MenuAnchorToTarget.stories.tsx
@@ -19,6 +19,17 @@ export const AnchorToCustomTarget = () => {
     }
   }, [buttonRef, popperRef]);
 
+  // A callback ref can be used, but the component the ref is attached to
+  // must be rendered after the `Menu` component so that `popperRef` is resolved
+  // Most likely won't work if there's any kind of async loading
+  // const callbackRef = React.useCallback(
+  //   (el: HTMLButtonElement) => {
+  //     console.log(popperRef.current, el);
+  //     popperRef.current?.setTarget(el);
+  //   },
+  //   [popperRef],
+  // );
+
   return (
     <>
       <Button onClick={() => setOpen(s => !s)}>Open menu</Button>

--- a/packages/react-popover/src/stories/PopoverAnchorToCustomTarget.stories.tsx
+++ b/packages/react-popover/src/stories/PopoverAnchorToCustomTarget.stories.tsx
@@ -3,6 +3,7 @@ import { Button } from '@fluentui/react-button';
 import { makeStyles, shorthands } from '@griffel/react';
 
 import { Popover, PopoverTrigger, PopoverSurface } from '../index';
+import { PopperRefHandle } from '@fluentui/react-positioning';
 
 const useStyles = makeStyles({
   container: {
@@ -27,12 +28,19 @@ const ExampleContent = () => {
 };
 
 export const AnchorToCustomTarget = () => {
-  const [target, setTarget] = React.useState<HTMLElement | null>();
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const popperRef = React.useRef<PopperRefHandle>(null);
   const styles = useStyles();
+
+  React.useEffect(() => {
+    if (buttonRef.current) {
+      popperRef.current?.setTarget(buttonRef.current);
+    }
+  }, [buttonRef, popperRef]);
 
   return (
     <div className={styles.container}>
-      <Popover positioning={{ target }}>
+      <Popover positioning={{ popperRef }}>
         <PopoverTrigger>
           <Button>Popover trigger</Button>
         </PopoverTrigger>
@@ -42,7 +50,7 @@ export const AnchorToCustomTarget = () => {
         </PopoverSurface>
       </Popover>
 
-      <Button ref={setTarget}>Custom target</Button>
+      <Button ref={buttonRef}>Custom target</Button>
     </div>
   );
 };

--- a/packages/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-positioning/etc/react-positioning.api.md
@@ -54,6 +54,21 @@ export type OffsetFunctionParam = {
 };
 
 // @public (undocumented)
+export interface PopperOptions {
+    align?: Alignment;
+    arrowPadding?: number;
+    autoSize?: AutoSize;
+    coverTarget?: boolean;
+    flipBoundary?: Boundary;
+    offset?: Offset;
+    overflowBoundary?: Boundary;
+    pinned?: boolean;
+    position?: Position;
+    positionFixed?: boolean;
+    unstable_disableTether?: boolean | 'all';
+}
+
+// @public (undocumented)
 export type PopperRefHandle = {
     updatePosition: () => void;
     setTarget: (target: HTMLElement) => void;
@@ -66,17 +81,8 @@ export type PopperVirtualElement = PopperJs.VirtualElement;
 export type Position = 'above' | 'below' | 'before' | 'after';
 
 // @public (undocumented)
-export interface PositioningProps {
-    align?: Alignment;
-    arrowPadding?: number;
-    autoSize?: AutoSize;
-    coverTarget?: boolean;
-    flipBoundary?: Boundary;
-    offset?: Offset;
-    overflowBoundary?: Boundary;
-    pinned?: boolean;
+export interface PositioningProps extends Omit<PopperOptions, 'positionFixed' | 'unstable_disableTether'> {
     popperRef?: React_2.Ref<PopperRefHandle>;
-    position?: Position;
     target?: HTMLElement | PopperVirtualElement | null;
 }
 
@@ -89,10 +95,10 @@ export type PositioningShorthandValue = 'above' | 'above-start' | 'above-end' | 
 // @public (undocumented)
 export function resolvePositioningShorthand(shorthand: PositioningShorthand | undefined | null): Readonly<PositioningProps>;
 
-// Warning: (ae-forgotten-export) The symbol "PopperOptions" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "UsePopperOptions" needs to be exported by the entry point index.d.ts
 //
 // @public
-export function usePopper(options?: PopperOptions): {
+export function usePopper(options?: UsePopperOptions): {
     targetRef: React_2.MutableRefObject<any>;
     containerRef: React_2.MutableRefObject<any>;
     arrowRef: React_2.MutableRefObject<any>;

--- a/packages/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-positioning/etc/react-positioning.api.md
@@ -56,6 +56,7 @@ export type OffsetFunctionParam = {
 // @public (undocumented)
 export type PopperRefHandle = {
     updatePosition: () => void;
+    setTarget: (target: HTMLElement) => void;
 };
 
 // @public (undocumented)

--- a/packages/react-positioning/src/types.ts
+++ b/packages/react-positioning/src/types.ts
@@ -34,7 +34,7 @@ export type PopperRefHandle = {
 
 export type PopperVirtualElement = PopperJs.VirtualElement;
 
-export interface PositioningProps {
+export interface PopperOptions {
   /** Alignment for the component. Only has an effect if used with the @see position option */
   align?: Alignment;
 
@@ -44,9 +44,6 @@ export interface PositioningProps {
   /** The element which will define the boundaries of the popper position for the overflow behavior. */
   overflowBoundary?: Boundary;
 
-  /** An imperative handle to Popper methods. */
-  popperRef?: React.Ref<PopperRefHandle>;
-
   /**
    * Position for the component. Position has higher priority than align. If position is vertical ('above' | 'below')
    * and align is also vertical ('top' | 'bottom') or if both position and align are horizontal ('before' | 'after'
@@ -54,6 +51,12 @@ export interface PositioningProps {
    * then provided value for 'align' will be ignored and 'center' will be used instead.
    */
   position?: Position;
+
+  /**
+   * Enables the Popper box to position itself in 'fixed' mode (default value is position: 'absolute')
+   * @default false
+   */
+  positionFixed?: boolean;
 
   /**
    * Lets you displace a popper element from its reference element.
@@ -78,11 +81,6 @@ export interface PositioningProps {
   autoSize?: AutoSize;
 
   /**
-   * Manual override for popper target. Useful for scenarios where a component accepts user prop to override target
-   */
-  target?: HTMLElement | PopperVirtualElement | null;
-
-  /**
    * Modifies position and alignment to cover the target
    */
   coverTarget?: boolean;
@@ -92,6 +90,25 @@ export interface PositioningProps {
    * `position` props, regardless of the size of the component, the reference element or the viewport.
    */
   pinned?: boolean;
+
+  /**
+   * When the reference element or the viewport is outside viewport allows a popper element to be fully in viewport.
+   * "all" enables this behavior for all axis.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  unstable_disableTether?: boolean | 'all';
+}
+
+export interface PositioningProps
+  // "positionFixed" & "unstable_disableTether" are not exported as public API (yet)
+  extends Omit<PopperOptions, 'positionFixed' | 'unstable_disableTether'> {
+  /** An imperative handle to Popper methods. */
+  popperRef?: React.Ref<PopperRefHandle>;
+
+  /**
+   * Manual override for popper target. Useful for scenarios where a component accepts user prop to override target
+   */
+  target?: HTMLElement | PopperVirtualElement | null;
 }
 
 export type PositioningShorthandValue =

--- a/packages/react-positioning/src/types.ts
+++ b/packages/react-positioning/src/types.ts
@@ -18,7 +18,19 @@ export type AutoSize = 'height' | 'height-always' | 'width' | 'width-always' | '
 
 export type Boundary = PopperJs.Boundary | 'scrollParent' | 'window';
 
-export type PopperRefHandle = { updatePosition: () => void };
+export type PopperRefHandle = {
+  /**
+   * Updates the position of the popper imperatively.
+   * Useful when the position of the target changes from other factors than scrolling of window resize.
+   */
+  updatePosition: () => void;
+
+  /**
+   * Sets the target and updates positioning imperatively.
+   * Useful for avoiding double renders with the target option.
+   */
+  setTarget: (target: HTMLElement) => void;
+};
 
 export type PopperVirtualElement = PopperJs.VirtualElement;
 

--- a/packages/react-positioning/src/usePopper.ts
+++ b/packages/react-positioning/src/usePopper.ts
@@ -12,7 +12,7 @@ import {
   useCallbackRef,
   getBasePlacement,
 } from './utils/index';
-import { PopperVirtualElement, PopperOptions, PositioningProps } from './types';
+import type { PopperVirtualElement, PopperOptions, PositioningProps } from './types';
 
 type PopperInstance = PopperJs.Instance & { isFirstRun?: boolean };
 

--- a/packages/react-positioning/src/usePopper.ts
+++ b/packages/react-positioning/src/usePopper.ts
@@ -74,6 +74,7 @@ function hasAutofocusFilter(node: Node) {
  */
 function usePopperOptions(options: PopperOptions, popperOriginalPositionRef: React.MutableRefObject<string>) {
   const {
+    align,
     arrowPadding,
     autoSize,
     coverTarget,
@@ -81,14 +82,16 @@ function usePopperOptions(options: PopperOptions, popperOriginalPositionRef: Rea
     offset,
     onStateUpdate,
     overflowBoundary,
+    pinned,
+    position,
+    positionFixed,
     // eslint-disable-next-line @typescript-eslint/naming-convention
     unstable_disableTether,
-    pinned,
   } = options;
 
   const isRtl = useFluent().dir === 'rtl';
-  const placement = getPlacement(options.align, options.position, isRtl);
-  const strategy = options.positionFixed ? 'fixed' : 'absolute';
+  const placement = getPlacement(align, position, isRtl);
+  const strategy = positionFixed ? 'fixed' : 'absolute';
 
   const handleStateUpdate = useEventCallback(({ state }: { state: Partial<PopperJs.State> }) => {
     if (onStateUpdate) {
@@ -334,7 +337,7 @@ export function usePopper(
     popperInstanceRef.current?.destroy();
     popperInstanceRef.current = null;
 
-    const target = externalTargetRef.current ?? targetRef.current;
+    const target = overrideTargetRef.current ?? targetRef.current;
 
     let popperInstance: PopperInstance | null = null;
 
@@ -394,7 +397,7 @@ export function usePopper(
   const arrowRef = useCallbackRef<HTMLElement | null>(null, handlePopperUpdate, true);
 
   // Stores external target from options.target or setTarget
-  const externalTargetRef = useCallbackRef<HTMLElement | PopperVirtualElement | null>(null, handlePopperUpdate, true);
+  const overrideTargetRef = useCallbackRef<HTMLElement | PopperVirtualElement | null>(null, handlePopperUpdate, true);
 
   React.useImperativeHandle(
     options.popperRef,
@@ -410,7 +413,8 @@ export function usePopper(
           // eslint-disable-next-line no-console
           console.warn(err.stack);
         }
-        externalTargetRef.current = target;
+
+        overrideTargetRef.current = target;
       },
     }),
     // Missing deps:
@@ -422,9 +426,9 @@ export function usePopper(
 
   useIsomorphicLayoutEffect(() => {
     if (options.target) {
-      externalTargetRef.current = options.target;
+      overrideTargetRef.current = options.target;
     }
-  }, [options.target, externalTargetRef]);
+  }, [options.target, overrideTargetRef]);
   useIsomorphicLayoutEffect(() => {
     handlePopperUpdate();
 
@@ -437,7 +441,7 @@ export function usePopper(
     () => {
       if (!isFirstMount) {
         popperInstanceRef.current?.setOptions(
-          resolvePopperOptions(externalTargetRef.current ?? targetRef.current, containerRef.current, arrowRef.current),
+          resolvePopperOptions(overrideTargetRef.current ?? targetRef.current, containerRef.current, arrowRef.current),
         );
       }
     },


### PR DESCRIPTION
## Current Behavior

Using `<Menu positioning={{ target }} />` requires `React.useState()` (to get refs as DOM elements) call to force a double render.

## New Behavior

Adds a `setTarget` imperative call to the `popperRef` imperative handle.

This allows users to set their own target **without** forcing a double render with `React.useState()`. `setTarget()` can be called inside `React.useEffect()` hooks, for example. The modified stories all use effects to call this API.

`onStateUpdate()` was removed `usePopper()`, as we don't it publicly it's not a breaking change. Types (`PopperOptions`, `PositioningOptions`) were also refactored to better show boundaries  between the hook and options themselves. No breaking changes in these interfaces.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
