### PR TITLE
Hide Avatar's image if it is a broken link

### DIFF
--- a/apps/vr-tests/src/stories/AvatarConverged.stories.tsx
+++ b/apps/vr-tests/src/stories/AvatarConverged.stories.tsx
@@ -244,4 +244,7 @@ storiesOf('Avatar Converged', module)
       );
     },
     { includeHighContrast: true, includeDarkMode: true },
-  );
+  )
+  .addStory('image-broken', () => (
+    <Avatar name="Broken Image" image={{ src: `${imageRoot}/broken_image_url.jpg` }} />
+  ));

--- a/apps/vr-tests/src/stories/AvatarConverged.stories.tsx
+++ b/apps/vr-tests/src/stories/AvatarConverged.stories.tsx
@@ -245,6 +245,6 @@ storiesOf('Avatar Converged', module)
     },
     { includeHighContrast: true, includeDarkMode: true },
   )
-  .addStory('image-broken', () => (
-    <Avatar name="Broken Image" image={{ src: `${imageRoot}/broken_image_url.jpg` }} />
+  .addStory('image-bad-url', () => (
+    <Avatar name="Broken Image" image={{ src: `${imageRoot}/bad_image_url.jpg` }} />
   ));

--- a/change/@fluentui-react-avatar-20d08826-ae0b-4d61-918b-47123a5a8f7c.json
+++ b/change/@fluentui-react-avatar-20d08826-ae0b-4d61-918b-47123a5a8f7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Hide Avatar's image if it is a broken link",
+  "packageName": "@fluentui/react-avatar",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -5,6 +5,7 @@ import type { AvatarNamedColor, AvatarProps, AvatarState } from './Avatar.types'
 import { PersonRegular } from '@fluentui/react-icons';
 import { PresenceBadge } from '@fluentui/react-badge';
 import { useFluent } from '@fluentui/react-shared-contexts';
+import { useMergedEventCallbacks } from '@fluentui/react-utilities';
 
 export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElement>): AvatarState => {
   const { dir } = useFluent();
@@ -53,13 +54,23 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
     });
   }
 
+  const [imageHidden, setImageHidden] = React.useState<true | undefined>(undefined);
   const image: AvatarState['image'] = resolveShorthand(props.image, {
     defaultProps: {
       alt: '',
       role: 'presentation',
       'aria-hidden': true,
+      hidden: imageHidden,
     },
   });
+
+  // Hide the image if it fails to load and restore it on a successful load
+  const imageOnError = useMergedEventCallbacks(image?.onError, () => setImageHidden(true));
+  const imageOnLoad = useMergedEventCallbacks(image?.onLoad, () => setImageHidden(undefined));
+  if (image) {
+    image.onError = imageOnError;
+    image.onLoad = imageOnLoad;
+  }
 
   const badge: AvatarState['badge'] = resolveShorthand(props.badge, {
     defaultProps: {


### PR DESCRIPTION
## Current Behavior

When an Avatar has a broken image link, the broken image icon shows on top of the Avatar:
![image](https://user-images.githubusercontent.com/48106640/152900503-79a1a117-15dd-4164-88c7-21b742c3cd6c.png)

## New Behavior

Add `hidden` to the image slot if it fails to load. The Avatar still displays the initials or icon when there is no image:
![image](https://user-images.githubusercontent.com/48106640/152900902-2daaeb3f-f8c4-4384-91cd-555fb477bb6e.png)

This should not affect accessibility: the root slot (not the image slot) has the role of img, and aria-label for its alt text (user name). The image slot is aria-hidden regardless of whether the image loads or not.

## Related Issue(s)

* Fixes #20128
