### PR TITLE
Fix Avatar high contrast border on Windows

### DIFF
--- a/change/@fluentui-react-avatar-909b616c-7314-42aa-b2f5-aecabfdd5b95.json
+++ b/change/@fluentui-react-avatar-909b616c-7314-42aa-b2f5-aecabfdd5b95.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Avatar's high contrast border on Windows",
+  "packageName": "@fluentui/react-avatar",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -193,7 +193,6 @@ const useStyles = makeStyles({
     justifyContent: 'center',
     verticalAlign: 'center',
     textAlign: 'center',
-    userSelect: 'none',
   },
 
   icon16: { fontSize: '16px' },

--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -185,7 +185,6 @@ const useStyles = makeStyles({
     width: '100%',
     height: '100%',
     lineHeight: '1',
-    ...shorthands.borderRadius('inherit'),
     ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStroke),
 
     display: 'flex',
@@ -193,6 +192,7 @@ const useStyles = makeStyles({
     justifyContent: 'center',
     verticalAlign: 'center',
     textAlign: 'center',
+    ...shorthands.borderRadius('inherit'),
   },
 
   icon16: { fontSize: '16px' },

--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -61,7 +61,6 @@ const useStyles = makeStyles({
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
     fontFamily: tokens.fontFamilyBase,
     fontWeight: tokens.fontWeightSemibold,
-    boxShadow: `0 0 0 ${tokens.strokeWidthThin} ${tokens.colorTransparentStroke} inset`,
   },
 
   textCaption2: {
@@ -178,20 +177,22 @@ const useStyles = makeStyles({
     verticalAlign: 'top',
   },
 
-  iconLabel: {
+  iconInitials: {
     position: 'absolute',
+    boxSizing: 'border-box',
     top: 0,
     left: 0,
     width: '100%',
     height: '100%',
     lineHeight: '1',
+    ...shorthands.borderRadius('inherit'),
+    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStroke),
 
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     verticalAlign: 'center',
     textAlign: 'center',
-    ...shorthands.borderRadius('inherit'),
   },
 
   icon16: { fontSize: '16px' },
@@ -428,7 +429,7 @@ export const useAvatarStyles_unstable = (state: AvatarState): AvatarState => {
   }
 
   if (state.initials) {
-    state.initials.className = mergeClasses(styles.iconLabel, state.initials.className);
+    state.initials.className = mergeClasses(styles.iconInitials, state.initials.className);
   }
 
   if (state.icon) {
@@ -447,7 +448,7 @@ export const useAvatarStyles_unstable = (state: AvatarState): AvatarState => {
       iconSizeClass = styles.icon48;
     }
 
-    state.icon.className = mergeClasses(styles.iconLabel, iconSizeClass, state.icon.className);
+    state.icon.className = mergeClasses(styles.iconInitials, iconSizeClass, state.icon.className);
   }
 
   return state;

--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -193,6 +193,7 @@ const useStyles = makeStyles({
     justifyContent: 'center',
     verticalAlign: 'center',
     textAlign: 'center',
+    userSelect: 'none',
   },
 
   icon16: { fontSize: '16px' },


### PR DESCRIPTION
## Current Behavior

Avatar uses a box-shadow to draw its high contrast border, which works ok with the high contrast color theme, but doesn't work with Windows/Edge high contrast mode, which hides box-shadows.
![image](https://user-images.githubusercontent.com/48106640/152902406-147a56d0-bf98-4917-b426-6ee0d893129f.png)

## New Behavior

Use a border on the initials/icon slot, rather than a box-shadow. Windows high contrast mode always renders borders.
![image](https://user-images.githubusercontent.com/48106640/152902358-ac3a2a82-3542-4096-948f-8e5a26dff1e4.png)

## Related Issue(s)

* Fixes #21355
