### PR TITLE
Make Avatar's initials be un-selectable text

### DIFF
--- a/change/@fluentui-react-avatar-0f282257-9138-4521-a526-519d53e53065.json
+++ b/change/@fluentui-react-avatar-0f282257-9138-4521-a526-519d53e53065.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make Avatar's initials be un-selectable text",
+  "packageName": "@fluentui/react-avatar",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -191,6 +191,7 @@ const useStyles = makeStyles({
     justifyContent: 'center',
     verticalAlign: 'center',
     textAlign: 'center',
+    userSelect: 'none',
     ...shorthands.borderRadius('inherit'),
   },
 


### PR DESCRIPTION
## Current Behavior

The text cursor changes to an I-bar over the Avatar's initials, and the text is selectable.

## New Behavior

Add `user-select: none` to the initials text.

## Related Issue(s)

* Fixes #20130
