### PR TITLE
Callout: Remove enableAriaHiddenSiblings (for now) and fix bug with data props

### DIFF
--- a/change/@fluentui-react-0d393c1e-1683-4e57-8df8-d9f87d796800.json
+++ b/change/@fluentui-react-0d393c1e-1683-4e57-8df8-d9f87d796800.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Callout: prevent data props from being used twice",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-97e0499f-f249-4df8-9c42-b7fdb65f7f85.json
+++ b/change/@fluentui-react-97e0499f-f249-4df8-9c42-b7fdb65f7f85.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add enableAriaHiddenSiblings to Popup, Callout, Dialog and respect it in Popup",
+  "comment": "Add enableAriaHiddenSiblings to Popup and Dialog and respect it in Modal",
   "packageName": "@fluentui/react",
   "email": "stefhan@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3028,8 +3028,6 @@ export interface ICalloutProps extends React_2.HTMLAttributes<HTMLDivElement>, R
     directionalHintForRTL?: DirectionalHint;
     dismissOnTargetClick?: boolean;
     doNotLayer?: boolean;
-    // @deprecated
-    enableAriaHiddenSiblings?: boolean;
     finalHeight?: number;
     gapSpace?: number;
     hidden?: boolean;

--- a/packages/react/src/components/Callout/Callout.types.ts
+++ b/packages/react/src/components/Callout/Callout.types.ts
@@ -278,14 +278,6 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
    * focus will not be restored automatically, and you'll need to call `params.originalElement.focus()`.
    */
   onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;
-
-  /**
-   * Puts aria-hidden=true on all non-ancestors of the current callout, for screen readers.
-   * @defaultvalue true
-   * @deprecated Setting this to `false` is deprecated since it breaks modal behavior for some screen readers.
-   * It will not be supported in future versions of the library.
-   */
-  enableAriaHiddenSiblings?: boolean;
 }
 
 /**

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -421,8 +421,6 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
       target,
       hidden,
       onLayerMounted,
-      // eslint-disable-next-line deprecation/deprecation
-      enableAriaHiddenSiblings = true,
     } = props;
 
     const hostElement = React.useRef<HTMLDivElement>(null);
@@ -509,7 +507,10 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
           {beakVisible && <div className={classNames.beak} style={getBeakPosition(positions)} />}
           {beakVisible && <div className={classNames.beakCurtain} />}
           <Popup
-            {...getNativeProps(props, ARIA_ROLE_ATTRIBUTES)}
+            // don't use getNativeElementProps for role and roledescription because it will also
+            // pass through data-* props (resulting in them being used in two places)
+            role={props.role}
+            aria-roledescription={props['aria-roledescription']}
             ariaDescribedBy={ariaDescribedBy}
             ariaLabel={ariaLabel}
             ariaLabelledBy={ariaLabelledBy}
@@ -521,7 +522,6 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
             onScroll={onScroll}
             shouldRestoreFocus={shouldRestoreFocus}
             style={overflowStyle}
-            enableAriaHiddenSiblings={enableAriaHiddenSiblings}
           >
             {children}
           </Popup>


### PR DESCRIPTION
## Current Behavior

#21110 added `enableAriaHiddenSiblings` in several components including Callout. However, upon trying to write a test for this (after the PR was merged...oops) I noticed it wasn't being respected--this condition in Popup checks for `aria-modal`, which Callout doesn't currently pass through:
https://github.com/microsoft/fluentui/blob/3082edf3477a37c493d28f246b5217752a14b7ba/packages/react/src/components/Popup/Popup.tsx#L124-L132

I asked @smhigley about this and we decided more discussion is needed about the "right" behavior here (whether Callout should pass `aria-modal`, what the appropriate default is for `enableAriaHiddenSiblings` in that component, etc).

While writing the test I also noticed a bug where `data-*` props are being used on two different elements within Callout due to the behavior of `getNativeElementProps` (it passes through any `data-*` and `aria-*` props in addition to things in the allowed props list).

## New Behavior

Remove `enableAriaHiddenSiblings` from Callout *for now* (it could be added back later after discussion about details of the behavior). This is NOT a breaking change since #21110 isn't in a published version yet.

For the duplicate `data-*` props bug, directly set the desired props on Callout's Popup instead of using `getNativeElementProps`.

## Related Issue(s)

#21091