### PR TITLE
DetailsList :Add prop to selectionZone to disable default behavior that clears selection when clicking on non-toggle surface 

### DIFF
--- a/change/@fluentui-react-d53d8331-0a23-4d37-aecb-25b73686be1c.json
+++ b/change/@fluentui-react-d53d8331-0a23-4d37-aecb-25b73686be1c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "SelectionZone: Add prop to disable default behavior that clears selection when clicking on non-toggle surface.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -8031,6 +8031,7 @@ export interface ISelectionZoneProps extends React_2.ClassAttributes<SelectionZo
     onItemContextMenu?: (item?: any, index?: number, ev?: Event) => void | boolean;
     onItemInvoked?: (item?: IObjectWithKey, index?: number, ev?: Event) => void;
     selection: ISelection;
+    selectionClearedOnSurfaceClick?: boolean;
     selectionMode?: SelectionMode_2;
     selectionPreservedOnEmptyClick?: boolean;
 }

--- a/packages/react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.tsx
@@ -98,6 +98,13 @@ export interface ISelectionZoneProps extends React.ClassAttributes<SelectionZone
    */
   isSelectedOnFocus?: boolean;
   /**
+   * Determines if elements within the selection zone that DO NOT have the 'data-selection-toggle' or
+   * 'data-selection-all-toggle' attribute are clickable and can alter the selection.
+   *
+   * @defaultvalue true
+   */
+  selectionClearedOnSurfaceClick?: boolean;
+  /**
    * Optional callback for when an item is
    * invoked via ENTER or double-click.
    */
@@ -680,10 +687,10 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
   }
 
   private _clearAndSelectIndex(index: number): void {
-    const { selection } = this.props;
+    const { selection, selectionClearedOnSurfaceClick = true } = this.props;
     const isAlreadySingleSelected = selection.getSelectedCount() === 1 && selection.isIndexSelected(index);
 
-    if (!isAlreadySingleSelected) {
+    if (!isAlreadySingleSelected && selectionClearedOnSurfaceClick) {
       const isModal = selection.isModal && selection.isModal();
       selection.setChangeEvents(false);
       selection.setAllSelected(false);


### PR DESCRIPTION
Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


## Current Behavior

- When a user clicks on any part of the  `DetailsList`, that row is immediately marked as selected. However this behavior presents issues when there are already multiple rows already selected as clicking on any part of the `DetailsList` that's not the checkbox clears the previously selected rows and selects that lone clicked row.
- ### Clicking any non-checkbox part of a row clears the selection and selects that one row only:
  - ![DetailsListIssue](https://user-images.githubusercontent.com/8649804/152933676-9e25cf35-f279-4216-9806-1b45d6ecdc46.gif)


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- Adds a new prop called `selectionClearedOnSurfaceClick` to `SelectionZone` so now when a non-toggle element is clicked, nothing will get selected or unselected. The default behavior will have this default to `true` to preserve current behavior but this option gives consumers a way to opt out by passing `selectionZoneProps={{ selectionClearedOnSurfaceClick: false }}` to `DetailsList`. 

- ### Only clicking the checkbox will actually toggle selection:
  - ![DetailsListFix](https://user-images.githubusercontent.com/8649804/152932861-fbb3eee4-4316-42d8-ba7c-62047c54a2a7.gif)

- **Codesandbox**: https://codesandbox.io/s/pr-21641-detaislist-6g4ry?file=/src/App.tsx


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21185
