### PR TITLE
chore: remove "nohoist" for make-styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,8 +258,6 @@
       "typings"
     ],
     "nohoist": [
-      "@fluentui/make-styles/@types/stylis",
-      "@fluentui/make-styles/stylis",
       "@fluentui/react-northstar-fela-renderer/stylis",
       "@fluentui/react-northstar-emotion-renderer/@types/stylis",
       "@fluentui/react-northstar-emotion-renderer/stylis",


### PR DESCRIPTION
## PR Changes

It was required to have `nohoist` settings for `@fluentui/make-styles` package. But as `@fluentui/make-styles` was moved out to `@griffel/core` and no longer present in out repo, these settings can be removed.
