### PR TITLE
Only render aria properties when there is a valid value

### DIFF
--- a/change/@fluentui-react-bf05c92a-5865-4168-8b1c-6bc30f245748.json
+++ b/change/@fluentui-react-bf05c92a-5865-4168-8b1c-6bc30f245748.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "do not render area attributes without valid values",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -246,7 +246,9 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
   public render(): JSX.Element {
     const { suggestedDisplayValue, isFocused, items } = this.state;
     const { className, inputProps, disabled, selectionAriaLabel, selectionRole = 'list', theme, styles } = this.props;
-    const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : undefined;
+
+    const suggestionsVisible = !!this.state.suggestionsVisible;
+    const suggestionsAvailable = suggestionsVisible ? this._ariaMap.suggestionList : undefined;
     // TODO
     // Clean this up by leaving only the first part after removing support for SASS.
     // Currently we can not remove the SASS styles from BasePicker class because it
@@ -314,10 +316,10 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
                 onBlur={this.onInputBlur}
                 onInputValueChange={this.onInputChange}
                 suggestedDisplayValue={suggestedDisplayValue}
-                aria-activedescendant={this.getActiveDescendant()}
+                aria-activedescendant={suggestionsVisible ? this.getActiveDescendant() : undefined}
                 aria-controls={suggestionsAvailable}
                 aria-describedby={items.length > 0 ? this._ariaMap.selectedItems : undefined}
-                aria-expanded={!!this.state.suggestionsVisible}
+                aria-expanded={suggestionsVisible}
                 aria-haspopup="listbox"
                 aria-label={comboLabel}
                 role="combobox"
@@ -1039,9 +1041,9 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
     const { suggestedDisplayValue, isFocused } = this.state;
     const { className, inputProps, disabled, selectionAriaLabel, selectionRole = 'list', theme, styles } = this.props;
 
-    const suggestionsAvailable: string | undefined = this.state.suggestionsVisible
-      ? this._ariaMap.suggestionList
-      : undefined;
+    const suggestionsVisible = !!this.state.suggestionsVisible;
+
+    const suggestionsAvailable: string | undefined = suggestionsVisible ? this._ariaMap.suggestionList : undefined;
     // TODO
     // Clean this up by leaving only the first part after removing support for SASS.
     // Currently we can not remove the SASS styles from BasePicker class because it
@@ -1087,9 +1089,9 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
               onClick={this.onClick}
               onInputValueChange={this.onInputChange}
               suggestedDisplayValue={suggestedDisplayValue}
-              aria-activedescendant={this.getActiveDescendant()}
+              aria-activedescendant={suggestionsVisible ? this.getActiveDescendant() : undefined}
               aria-controls={suggestionsAvailable}
-              aria-expanded={!!this.state.suggestionsVisible}
+              aria-expanded={suggestionsVisible}
               aria-haspopup="listbox"
               aria-label={comboLabel}
               role="combobox"

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -246,7 +246,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
   public render(): JSX.Element {
     const { suggestedDisplayValue, isFocused, items } = this.state;
     const { className, inputProps, disabled, selectionAriaLabel, selectionRole = 'list', theme, styles } = this.props;
-    const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
+    const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : undefined;
     // TODO
     // Clean this up by leaving only the first part after removing support for SASS.
     // Currently we can not remove the SASS styles from BasePicker class because it
@@ -1039,7 +1039,9 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
     const { suggestedDisplayValue, isFocused } = this.state;
     const { className, inputProps, disabled, selectionAriaLabel, selectionRole = 'list', theme, styles } = this.props;
 
-    const suggestionsAvailable: string | undefined = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
+    const suggestionsAvailable: string | undefined = this.state.suggestionsVisible
+      ? this._ariaMap.suggestionList
+      : undefined;
     // TODO
     // Clean this up by leaving only the first part after removing support for SASS.
     // Currently we can not remove the SASS styles from BasePicker class because it
@@ -1075,7 +1077,7 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
       <div ref={this.root} onBlur={this.onBlur} onFocus={this.onFocus}>
         <div className={classNames.root} onKeyDown={this.onKeyDown}>
           {this.renderCustomAlert(classNames.screenReaderText)}
-          <div className={classNames.text} aria-owns={suggestionsAvailable || undefined}>
+          <div className={classNames.text} aria-owns={suggestionsAvailable}>
             <Autofill
               {...(inputProps as any)}
               className={classNames.input}
@@ -1086,7 +1088,7 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
               onInputValueChange={this.onInputChange}
               suggestedDisplayValue={suggestedDisplayValue}
               aria-activedescendant={this.getActiveDescendant()}
-              aria-controls={suggestionsAvailable || undefined}
+              aria-controls={suggestionsAvailable}
               aria-expanded={!!this.state.suggestionsVisible}
               aria-haspopup="listbox"
               aria-label={comboLabel}

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`PeoplePicker renders correctly 1`] = `
     role="presentation"
   >
     <div
-      aria-owns=""
       className=
           ms-BasePicker-text
           {
@@ -67,9 +66,7 @@ exports[`PeoplePicker renders correctly 1`] = `
           }
     >
       <input
-        aria-activedescendant="sug-noResultsFound"
         aria-autocomplete="both"
-        aria-controls=""
         aria-expanded={false}
         aria-haspopup="listbox"
         autoCapitalize="off"
@@ -207,7 +204,6 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
     role="presentation"
   >
     <div
-      aria-owns=""
       className=
           ms-BasePicker-text
           {
@@ -698,9 +694,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
         </div>
       </span>
       <input
-        aria-activedescendant="sug-noResultsFound"
         aria-autocomplete="both"
-        aria-controls=""
         aria-describedby="selected-items-id__0"
         aria-expanded={false}
         aria-haspopup="listbox"

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`TagPicker renders correctly 1`] = `
     role="presentation"
   >
     <div
-      aria-owns=""
       className=
           ms-BasePicker-text
           {
@@ -298,9 +297,7 @@ exports[`TagPicker renders correctly 1`] = `
         </div>
       </span>
       <input
-        aria-activedescendant="sug-noResultsFound"
         aria-autocomplete="both"
-        aria-controls=""
         aria-describedby="selected-items-id__0"
         aria-expanded={false}
         aria-haspopup="listbox"
@@ -439,7 +436,6 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
     role="presentation"
   >
     <div
-      aria-owns=""
       className=
           ms-BasePicker-text
           {
@@ -689,9 +685,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
         </div>
       </span>
       <input
-        aria-activedescendant="sug-noResultsFound"
         aria-autocomplete="both"
-        aria-controls=""
         aria-describedby="selected-items-id__0"
         aria-expanded={false}
         aria-haspopup="listbox"

--- a/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -30,13 +30,10 @@ exports[`BasePicker renders correctly 1`] = `
     role="presentation"
   >
     <div
-      aria-owns=""
       className="ms-BasePicker-text"
     >
       <input
-        aria-activedescendant="sug-noResultsFound"
         aria-autocomplete="both"
-        aria-controls=""
         aria-expanded={false}
         aria-haspopup="listbox"
         autoCapitalize="off"
@@ -97,13 +94,10 @@ exports[`BasePicker renders with inputProps supply classnames correctly 1`] = `
     role="presentation"
   >
     <div
-      aria-owns=""
       className="ms-BasePicker-text"
     >
       <input
-        aria-activedescendant="sug-noResultsFound"
         aria-autocomplete="both"
-        aria-controls=""
         aria-expanded={false}
         aria-haspopup="listbox"
         autoCapitalize="off"


### PR DESCRIPTION
Fixes #21656

`aria-owns` and `aria-controls` were being rendered even when there was no valid value. No impact to end users, but it causes a lot of noise in testing to the point of partners needing to turn a11y validation off. 

New behavior, aria attributes only display when they have a valid value

 
![picker](https://user-images.githubusercontent.com/1434956/153037139-21d9cc45-1e24-4fe7-90df-8c41cde2d702.gif)

