### PR TITLE
Remove commons export at component root

### DIFF
--- a/apps/vr-tests/src/stories/Badge.stories.tsx
+++ b/apps/vr-tests/src/stories/Badge.stories.tsx
@@ -5,7 +5,7 @@ import { CircleRegular } from '@fluentui/react-icons';
 import { mergeClasses, makeStyles, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 
-const badgeColors: BadgeProps['color'][] = [
+const badgeColors: Required<BadgeProps>['color'][] = [
   'brand',
   'danger',
   'important',
@@ -16,7 +16,12 @@ const badgeColors: BadgeProps['color'][] = [
   'warning',
 ];
 
-const badgeAppearances: BadgeProps['appearance'][] = ['filled', 'outline', 'tint', 'ghost'];
+const badgeAppearances: Required<BadgeProps>['appearance'][] = [
+  'filled',
+  'outline',
+  'tint',
+  'ghost',
+];
 
 const useStyles = makeStyles({
   container: {
@@ -40,14 +45,10 @@ const useStyles = makeStyles({
   },
 });
 
-const BadgeAppearanceTemplate: React.FC<{ appearance: BadgeProps['appearance'] }> = ({
+const BadgeAppearanceTemplate: React.FC<{ appearance: Required<BadgeProps>['appearance'] }> = ({
   appearance,
 }) => {
   const styles = useStyles();
-
-  if (!appearance) {
-    return <></>;
-  }
 
   const badges = new Map<BadgeProps['color'], JSX.Element[]>();
   badges.set('brand', []);
@@ -135,7 +136,7 @@ const appearanceStories = storiesOf('Badge Converged', module);
 
 badgeAppearances.forEach(appearance => {
   appearanceStories.addStory(
-    appearance as string,
+    appearance,
     () => <BadgeAppearanceTemplate appearance={appearance} />,
     { includeRtl: true, includeHighContrast: true, includeDarkMode: true },
   );

--- a/apps/vr-tests/src/stories/Badge.stories.tsx
+++ b/apps/vr-tests/src/stories/Badge.stories.tsx
@@ -1,11 +1,11 @@
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-import { Badge, BadgeCommons } from '@fluentui/react-badge';
+import { Badge, BadgeProps } from '@fluentui/react-badge';
 import { CircleRegular } from '@fluentui/react-icons';
 import { mergeClasses, makeStyles, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 
-const badgeColors: BadgeCommons['color'][] = [
+const badgeColors: BadgeProps['color'][] = [
   'brand',
   'danger',
   'important',
@@ -16,7 +16,7 @@ const badgeColors: BadgeCommons['color'][] = [
   'warning',
 ];
 
-const badgeAppearances: BadgeCommons['appearance'][] = ['filled', 'outline', 'tint', 'ghost'];
+const badgeAppearances: BadgeProps['appearance'][] = ['filled', 'outline', 'tint', 'ghost'];
 
 const useStyles = makeStyles({
   container: {
@@ -40,12 +40,16 @@ const useStyles = makeStyles({
   },
 });
 
-const BadgeAppearanceTemplate: React.FC<{ appearance: BadgeCommons['appearance'] }> = ({
+const BadgeAppearanceTemplate: React.FC<{ appearance: BadgeProps['appearance'] }> = ({
   appearance,
 }) => {
   const styles = useStyles();
 
-  const badges = new Map<BadgeCommons['color'], JSX.Element[]>();
+  if (!appearance) {
+    return <></>;
+  }
+
+  const badges = new Map<BadgeProps['color'], JSX.Element[]>();
   badges.set('brand', []);
   badges.set('danger', []);
   badges.set('severe', []);
@@ -109,7 +113,7 @@ const BadgeAppearanceTemplate: React.FC<{ appearance: BadgeCommons['appearance']
 
   return (
     <div>
-      {Array.from(badges.keys()).map((color: BadgeCommons['color'], i) => (
+      {Array.from(badges.keys()).map((color: BadgeProps['color'], i) => (
         <div key={i} className={styles.container}>
           <div
             className={mergeClasses(
@@ -131,7 +135,7 @@ const appearanceStories = storiesOf('Badge Converged', module);
 
 badgeAppearances.forEach(appearance => {
   appearanceStories.addStory(
-    appearance,
+    appearance as string,
     () => <BadgeAppearanceTemplate appearance={appearance} />,
     { includeRtl: true, includeHighContrast: true, includeDarkMode: true },
   );
@@ -148,7 +152,7 @@ storiesOf('Badge Converged - sizes', module).addStory(
         'medium',
         'large',
         'extra-large',
-      ] as BadgeCommons['size'][]).map(size => (
+      ] as BadgeProps['size'][]).map(size => (
         <Badge key={size} size={size} />
       ))}
     </div>

--- a/change/@fluentui-react-accordion-213d1c37-aede-492e-8350-13d8d57c021a.json
+++ b/change/@fluentui-react-accordion-213d1c37-aede-492e-8350-13d8d57c021a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-accordion",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-630c6199-fc67-4215-94e7-d4f05989c008.json
+++ b/change/@fluentui-react-avatar-630c6199-fc67-4215-94e7-d4f05989c008.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-avatar",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-84d44dcd-ccfc-4e6f-9ace-0de612e5d7d1.json
+++ b/change/@fluentui-react-badge-84d44dcd-ccfc-4e6f-9ace-0de612e5d7d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-badge",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-5896a55b-1432-499e-b009-6e9709119e82.json
+++ b/change/@fluentui-react-button-5896a55b-1432-499e-b009-6e9709119e82.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-button",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-4bf86cb5-d8e6-4edc-a549-ddce3fafa704.json
+++ b/change/@fluentui-react-checkbox-4bf86cb5-d8e6-4edc-a549-ddce3fafa704.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-45196c24-fa05-4c84-8362-e1b242450e57.json
+++ b/change/@fluentui-react-divider-45196c24-fa05-4c84-8362-e1b242450e57.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-divider",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-17c04505-80f6-4a90-b16f-d11a5973f8e8.json
+++ b/change/@fluentui-react-image-17c04505-80f6-4a90-b16f-d11a5973f8e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-image",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-3cae5b0c-a6f1-4ffc-8045-cf744cc9a0df.json
+++ b/change/@fluentui-react-label-3cae5b0c-a6f1-4ffc-8045-cf744cc9a0df.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-label",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-2a925535-c25c-4d65-ac2f-c9bd94f03117.json
+++ b/change/@fluentui-react-link-2a925535-c25c-4d65-ac2f-c9bd94f03117.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-link",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-dee8faca-d7b9-479a-8fff-b5ac485c286a.json
+++ b/change/@fluentui-react-menu-dee8faca-d7b9-479a-8fff-b5ac485c286a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-menu",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-3e873696-4df2-4945-9d49-961ba43d5849.json
+++ b/change/@fluentui-react-popover-3e873696-4df2-4945-9d49-961ba43d5849.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-popover",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-7309bf1f-3ff7-4845-af75-164971755321.json
+++ b/change/@fluentui-react-portal-7309bf1f-3ff7-4845-af75-164971755321.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-portal",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-0c926b4c-9ea9-44ab-8c63-ad44b430e9e4.json
+++ b/change/@fluentui-react-provider-0c926b4c-9ea9-44ab-8c63-ad44b430e9e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-provider",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-4241a358-b23a-4876-8cf2-d1c63b55137f.json
+++ b/change/@fluentui-react-slider-4241a358-b23a-4876-8cf2-d1c63b55137f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-slider",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-4b6941e2-b421-4545-87df-12bab7815bdc.json
+++ b/change/@fluentui-react-switch-4b6941e2-b421-4545-87df-12bab7815bdc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-switch",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-94dce346-4b5a-4320-b35f-a4e0cdca4823.json
+++ b/change/@fluentui-react-text-94dce346-4b5a-4320-b35f-a4e0cdca4823.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-text",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-fb4cc9df-c23a-486c-9dc3-8d4fb3ebe15a.json
+++ b/change/@fluentui-react-tooltip-fb4cc9df-c23a-486c-9dc3-8d4fb3ebe15a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove export of commons types",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-accordion/etc/react-accordion.api.md
@@ -19,15 +19,10 @@ export const Accordion: ForwardRefComponent<AccordionProps>;
 export const accordionClassName = "fui-Accordion";
 
 // @public (undocumented)
-export type AccordionCommons = {
-    navigable: boolean;
-    multiple: boolean;
-    collapsible: boolean;
-};
-
-// @public (undocumented)
 export const AccordionContext: Context<AccordionContextValue>;
 
+// Warning: (ae-forgotten-export) The symbol "AccordionCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type AccordionContextValue = Omit<AccordionCommons, 'multiple'> & {
     openItems: AccordionItemValue[];
@@ -46,13 +41,6 @@ export const AccordionHeader: ForwardRefComponent<AccordionHeaderProps>;
 export const accordionHeaderClassName = "fui-AccordionHeader";
 
 // @public (undocumented)
-export type AccordionHeaderCommons = {
-    size: AccordionHeaderSize;
-    expandIconPosition: AccordionHeaderExpandIconPosition;
-    inline: boolean;
-};
-
-// @public (undocumented)
 export type AccordionHeaderContextValue = {
     disabled: boolean;
     open: boolean;
@@ -68,6 +56,8 @@ export type AccordionHeaderContextValues = {
 // @public (undocumented)
 export type AccordionHeaderExpandIconPosition = 'start' | 'end';
 
+// Warning: (ae-forgotten-export) The symbol "AccordionHeaderCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type AccordionHeaderProps = ComponentProps<Partial<AccordionHeaderSlots>> & Partial<AccordionHeaderCommons>;
 
@@ -95,14 +85,10 @@ export const AccordionItem: ForwardRefComponent<AccordionItemProps>;
 export const accordionItemClassName = "fui-AccordionItem";
 
 // @public (undocumented)
-export type AccordionItemCommons = {
-    disabled: boolean;
-    value: AccordionItemValue;
-};
-
-// @public (undocumented)
 export const AccordionItemContext: React_2.Context<AccordionItemContextValue>;
 
+// Warning: (ae-forgotten-export) The symbol "AccordionItemCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type AccordionItemContextValue = Omit<AccordionItemCommons, 'value'> & {
     open: boolean;

--- a/packages/react-accordion/src/components/Accordion/Accordion.types.ts
+++ b/packages/react-accordion/src/components/Accordion/Accordion.types.ts
@@ -8,7 +8,7 @@ export type AccordionToggleEvent<E = HTMLElement> = React.MouseEvent<E> | React.
 
 export type AccordionToggleEventHandler = (event: AccordionToggleEvent, data: AccordionToggleData) => void;
 
-export type AccordionCommons = {
+type AccordionCommons = {
   /**
    * Indicates if keyboard navigation is available
    */

--- a/packages/react-accordion/src/components/AccordionHeader/AccordionHeader.types.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/AccordionHeader.types.ts
@@ -34,7 +34,7 @@ export type AccordionHeaderSlots = {
   icon?: Slot<'div'>;
 };
 
-export type AccordionHeaderCommons = {
+type AccordionHeaderCommons = {
   /**
    * Size of spacing in the heading
    */

--- a/packages/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
+++ b/packages/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
@@ -14,7 +14,7 @@ export type AccordionItemSlots = {
   root: Slot<'div'>;
 };
 
-export type AccordionItemCommons = {
+type AccordionItemCommons = {
   /**
    * Disables opening/closing of panel
    */

--- a/packages/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-avatar/etc/react-avatar.api.md
@@ -17,20 +17,11 @@ export const Avatar: ForwardRefComponent<AvatarProps>;
 // @public (undocumented)
 export const avatarClassName = "fui-Avatar";
 
-// @public (undocumented)
-export type AvatarCommons = {
-    name?: string;
-    size: 20 | 24 | 28 | 32 | 36 | 40 | 48 | 56 | 64 | 72 | 96 | 120 | 128;
-    shape: 'circular' | 'square';
-    active: 'active' | 'inactive' | 'unset';
-    activeAppearance: 'ring' | 'shadow' | 'ring-shadow';
-    color: 'neutral' | 'brand' | 'colorful' | AvatarNamedColor;
-    idForColor: string | undefined;
-};
-
 // @public
 export type AvatarNamedColor = 'darkRed' | 'cranberry' | 'red' | 'pumpkin' | 'peach' | 'marigold' | 'gold' | 'brass' | 'brown' | 'forest' | 'seafoam' | 'darkGreen' | 'lightTeal' | 'teal' | 'steel' | 'blue' | 'royalBlue' | 'cornflower' | 'navy' | 'lavender' | 'purple' | 'grape' | 'lilac' | 'pink' | 'magenta' | 'plum' | 'beige' | 'mink' | 'platinum' | 'anchor';
 
+// Warning: (ae-forgotten-export) The symbol "AvatarCommons" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & Partial<AvatarCommons>;
 

--- a/packages/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -34,7 +34,7 @@ export type AvatarSlots = {
   badge?: Slot<typeof PresenceBadge>;
 };
 
-export type AvatarCommons = {
+type AvatarCommons = {
   /**
    * The name of the person or entity represented by this Avatar. This should always be provided if it is available.
    *

--- a/packages/react-badge/etc/react-badge.api.md
+++ b/packages/react-badge/etc/react-badge.api.md
@@ -16,15 +16,8 @@ export const Badge: ForwardRefComponent<BadgeProps>;
 // @public (undocumented)
 export const badgeClassName = "fui-Badge";
 
-// @public (undocumented)
-export type BadgeCommons = {
-    appearance: 'filled' | 'ghost' | 'outline' | 'tint';
-    color: 'brand' | 'danger' | 'important' | 'informative' | 'severe' | 'subtle' | 'success' | 'warning';
-    iconPosition: 'before' | 'after';
-    shape: 'circular' | 'rounded' | 'square';
-    size: 'tiny' | 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large';
-};
-
+// Warning: (ae-forgotten-export) The symbol "BadgeCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type BadgeProps = Omit<ComponentProps<BadgeSlots>, 'color'> & Partial<BadgeCommons>;
 
@@ -43,17 +36,8 @@ export const CounterBadge: ForwardRefComponent<CounterBadgeProps>;
 // @public (undocumented)
 export const counterBadgeClassName = "fui-CounterBadge";
 
-// @public (undocumented)
-export type CounterBadgeCommons = {
-    overflowCount: number;
-    count: number;
-    showZero: boolean;
-    dot: boolean;
-    shape: 'circular' | 'rounded';
-    appearance: 'filled' | 'ghost';
-    color: Extract<BadgeProps['color'], 'brand' | 'danger' | 'important' | 'informative'>;
-};
-
+// Warning: (ae-forgotten-export) The symbol "CounterBadgeCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type CounterBadgeProps = Omit<BadgeProps, 'appearance' | 'shape' | 'color'> & Partial<CounterBadgeCommons>;
 
@@ -66,12 +50,8 @@ export const PresenceBadge: ForwardRefComponent<PresenceBadgeProps>;
 // @public (undocumented)
 export const presenceBadgeClassName = "fui-PresenceBadge";
 
-// @public (undocumented)
-export type PresenceBadgeCommons = {
-    status: PresenceBadgeStatus;
-    outOfOffice: boolean;
-} & BadgeCommons;
-
+// Warning: (ae-forgotten-export) The symbol "PresenceBadgeCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type PresenceBadgeProps = Omit<ComponentProps<Pick<BadgeSlots, 'root'>>, 'color'> & Partial<Pick<PresenceBadgeCommons, 'status' | 'outOfOffice' | 'size'>>;
 

--- a/packages/react-badge/src/components/Badge/index.ts
+++ b/packages/react-badge/src/components/Badge/index.ts
@@ -1,5 +1,6 @@
 export * from './Badge';
-export * from './Badge.types';
+// Explicit exports to omit BadgeCommons
+export type { BadgeProps, BadgeSlots, BadgeState } from './Badge.types';
 export * from './renderBadge';
 export * from './useBadge';
 export * from './useBadgeStyles';

--- a/packages/react-badge/src/components/CounterBadge/CounterBadge.types.ts
+++ b/packages/react-badge/src/components/CounterBadge/CounterBadge.types.ts
@@ -1,6 +1,6 @@
 import type { BadgeProps, BadgeState } from '../Badge/index';
 
-export type CounterBadgeCommons = {
+type CounterBadgeCommons = {
   /**
    * Max number to be displayed
    * @default 99

--- a/packages/react-badge/src/components/PresenceBadge/PresenceBadge.types.ts
+++ b/packages/react-badge/src/components/PresenceBadge/PresenceBadge.types.ts
@@ -1,9 +1,9 @@
 import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
-import type { BadgeCommons, BadgeSlots } from '../Badge/index';
+import type { BadgeCommons, BadgeSlots } from '../Badge/Badge.types';
 
 export type PresenceBadgeStatus = 'busy' | 'outOfOffice' | 'away' | 'available' | 'offline' | 'doNotDisturb';
 
-export type PresenceBadgeCommons = {
+type PresenceBadgeCommons = {
   /**
    * Represents several status
    * @default available

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -17,17 +17,8 @@ export const Button: ForwardRefComponent<ButtonProps>;
 // @public (undocumented)
 export const buttonClassName = "fui-Button";
 
-// @public (undocumented)
-export type ButtonCommons = {
-    appearance?: 'primary' | 'outline' | 'subtle' | 'transparent';
-    block: boolean;
-    disabledFocusable: boolean;
-    disabled: boolean;
-    iconPosition?: 'before' | 'after';
-    shape: 'rounded' | 'circular' | 'square';
-    size: 'small' | 'medium' | 'large';
-};
-
+// Warning: (ae-forgotten-export) The symbol "ButtonCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type ButtonProps = ComponentProps<ButtonSlots> & Partial<ButtonCommons>;
 
@@ -116,11 +107,8 @@ export const ToggleButton: ForwardRefComponent<ToggleButtonProps>;
 // @public (undocumented)
 export const toggleButtonClassName = "fui-ToggleButton";
 
-// @public (undocumented)
-export type ToggleButtonCommons = {
-    checked: boolean;
-};
-
+// Warning: (ae-forgotten-export) The symbol "ToggleButtonCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type ToggleButtonProps = ButtonProps & Partial<ToggleButtonCommons> & {
     defaultChecked?: boolean;

--- a/packages/react-button/src/components/Button/index.ts
+++ b/packages/react-button/src/components/Button/index.ts
@@ -1,5 +1,6 @@
 export * from './Button';
-export * from './Button.types';
+// Explicit exports to omit ButtonCommons
+export type { ButtonProps, ButtonSlots, ButtonState } from './Button.types';
 export * from './renderButton';
 export * from './useButton';
 export { buttonClassName, useButtonStyles_unstable } from './useButtonStyles';

--- a/packages/react-button/src/components/ToggleButton/ToggleButton.types.ts
+++ b/packages/react-button/src/components/ToggleButton/ToggleButton.types.ts
@@ -1,6 +1,6 @@
 import type { ButtonProps, ButtonState } from '../Button/Button.types';
 
-export type ToggleButtonCommons = {
+type ToggleButtonCommons = {
   /**
    * Defines the controlled checked state of the `ToggleButton`.
    * If passed, `ToggleButton` ignores the `defaultChecked` property.

--- a/packages/react-checkbox/etc/react-checkbox.api.md
+++ b/packages/react-checkbox/etc/react-checkbox.api.md
@@ -17,20 +17,14 @@ export const Checkbox: ForwardRefComponent<CheckboxProps>;
 // @public (undocumented)
 export const checkboxClassName = "fui-Checkbox";
 
-// @public (undocumented)
-export interface CheckboxCommons {
-    checked: 'mixed' | boolean;
-    circular: boolean;
-    labelPosition: 'before' | 'after';
-    size: 'medium' | 'large';
-}
-
 // @public
 export interface CheckboxOnChangeData {
     // (undocumented)
     checked: 'mixed' | boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "CheckboxCommons" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type CheckboxProps = Omit<ComponentProps<Partial<CheckboxSlots>, 'input'>, 'size' | 'checked' | 'defaultChecked' | 'onChange'> & Partial<CheckboxCommons> & {
     children?: never;

--- a/packages/react-checkbox/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react-checkbox/src/components/Checkbox/Checkbox.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Label } from '@fluentui/react-label';
 import { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
-export interface CheckboxCommons {
+interface CheckboxCommons {
   /**
    * Whether to render the checkbox in a circular shape instead of square.
    * This variant is only recommended to be used in a tasks-style UI (checklist),

--- a/packages/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-dialog/etc/react-dialog.api.md
@@ -16,9 +16,8 @@ export const Dialog: ForwardRefComponent<DialogProps>;
 // @public (undocumented)
 export const dialogClassName = "fui-Dialog";
 
-// @public (undocumented)
-export type DialogCommons = {};
-
+// Warning: (ae-forgotten-export) The symbol "DialogCommons" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type DialogProps = ComponentProps<DialogSlots> & DialogCommons;
 

--- a/packages/react-dialog/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-dialog/src/components/Dialog/Dialog.types.ts
@@ -4,7 +4,7 @@ export type DialogSlots = {
   root: Slot<'div'>;
 };
 
-export type DialogCommons = {
+type DialogCommons = {
   // TODO Add things shared between props and state here
 };
 

--- a/packages/react-divider/etc/react-divider.api.md
+++ b/packages/react-divider/etc/react-divider.api.md
@@ -16,14 +16,8 @@ export const Divider: ForwardRefComponent<DividerProps>;
 // @public (undocumented)
 export const dividerClassName = "fui-Divider";
 
-// @public (undocumented)
-export type DividerCommons = {
-    alignContent: 'start' | 'center' | 'end';
-    appearance?: 'brand' | 'strong' | 'subtle';
-    inset: boolean;
-    vertical: boolean;
-};
-
+// Warning: (ae-forgotten-export) The symbol "DividerCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type DividerProps = ComponentProps<Partial<DividerSlots>> & Partial<DividerCommons>;
 

--- a/packages/react-divider/src/components/Divider/Divider.types.ts
+++ b/packages/react-divider/src/components/Divider/Divider.types.ts
@@ -12,7 +12,7 @@ export type DividerSlots = {
   wrapper: Slot<'div'>;
 };
 
-export type DividerCommons = {
+type DividerCommons = {
   /**
    * Determines the alignment of the content within the divider.
    * @defaultvalue 'center'

--- a/packages/react-image/etc/react-image.api.md
+++ b/packages/react-image/etc/react-image.api.md
@@ -17,15 +17,8 @@ export { Image_2 as Image }
 // @public (undocumented)
 export const imageClassName = "fui-Image";
 
-// @public (undocumented)
-export type ImageCommons = {
-    bordered?: boolean;
-    fit?: 'none' | 'center' | 'contain' | 'cover';
-    block?: boolean;
-    shape?: 'square' | 'circular' | 'rounded';
-    shadow?: boolean;
-};
-
+// Warning: (ae-forgotten-export) The symbol "ImageCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type ImageProps = ComponentProps<ImageSlots> & Partial<ImageCommons>;
 

--- a/packages/react-image/src/components/Image/Image.types.ts
+++ b/packages/react-image/src/components/Image/Image.types.ts
@@ -4,7 +4,7 @@ export type ImageSlots = {
   root: Slot<'img'>;
 };
 
-export type ImageCommons = {
+type ImageCommons = {
   /**
    * An image can appear with rectangular border.
    */

--- a/packages/react-label/etc/react-label.api.md
+++ b/packages/react-label/etc/react-label.api.md
@@ -16,13 +16,8 @@ export const Label: ForwardRefComponent<LabelProps>;
 // @public (undocumented)
 export const labelClassName = "fui-Label";
 
-// @public (undocumented)
-export type LabelCommons = {
-    disabled: boolean;
-    size: 'small' | 'medium' | 'large';
-    strong: boolean;
-};
-
+// Warning: (ae-forgotten-export) The symbol "LabelCommons" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> & Partial<LabelCommons> & {
     required?: boolean | Slot<'span'>;

--- a/packages/react-label/src/components/Label/Label.types.ts
+++ b/packages/react-label/src/components/Label/Label.types.ts
@@ -1,6 +1,6 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
-export type LabelCommons = {
+type LabelCommons = {
   /**
    * Renders the label as disabled
    * @defaultvalue false

--- a/packages/react-link/etc/react-link.api.md
+++ b/packages/react-link/etc/react-link.api.md
@@ -16,14 +16,8 @@ export const Link: ForwardRefComponent<LinkProps>;
 // @public (undocumented)
 export const linkClassName = "fui-Link";
 
-// @public (undocumented)
-export type LinkCommons = {
-    appearance?: 'subtle';
-    disabled?: boolean;
-    disabledFocusable?: boolean;
-    inline?: boolean;
-};
-
+// Warning: (ae-forgotten-export) The symbol "LinkCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type LinkProps = ComponentProps<LinkSlots> & LinkCommons;
 

--- a/packages/react-link/src/components/Link/Link.types.ts
+++ b/packages/react-link/src/components/Link/Link.types.ts
@@ -7,7 +7,7 @@ export type LinkSlots = {
   root: Slot<'a', 'button'>;
 };
 
-export type LinkCommons = {
+type LinkCommons = {
   /**
    * A link can appear either with its default style or subtle.
    * If not specified, the link appears with its default styling.

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -175,15 +175,6 @@ export const MenuList: ForwardRefComponent<MenuListProps>;
 export const menuListClassName = "fui-MenuList";
 
 // @public (undocumented)
-export type MenuListCommons = {
-    onCheckedValueChange?: (e: MenuCheckedValueChangeEvent, data: MenuCheckedValueChangeData) => void;
-    checkedValues: Record<string, string[]>;
-    defaultCheckedValues?: Record<string, string[]>;
-    hasIcons?: boolean;
-    hasCheckmarks?: boolean;
-};
-
-// @public (undocumented)
 export const MenuListContext: Context<MenuListContextValue>;
 
 // @public
@@ -198,6 +189,8 @@ export type MenuListContextValues = {
     menuList: MenuListContextValue;
 };
 
+// Warning: (ae-forgotten-export) The symbol "MenuListCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type MenuListProps = ComponentProps<MenuListSlots> & Partial<MenuListCommons>;
 
@@ -265,9 +258,8 @@ export const MenuSplitGroup: ForwardRefComponent<MenuSplitGroupProps>;
 // @public (undocumented)
 export const menuSplitGroupClassName = "fui-MenuSplitGroup";
 
-// @public (undocumented)
-export type MenuSplitGroupCommons = {};
-
+// Warning: (ae-forgotten-export) The symbol "MenuSplitGroupCommons" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type MenuSplitGroupProps = ComponentProps<MenuSplitGroupSlots> & MenuSplitGroupCommons;
 

--- a/packages/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-menu/src/components/Menu/Menu.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
 import { usePopperMouseTarget, PositioningShorthand } from '@fluentui/react-positioning';
-import { MenuListCommons } from '../MenuList/index';
+import { MenuListCommons } from '../MenuList/MenuList.types';
 import { MenuContextValue } from '../../contexts/menuContext';
 
 type MenuCommons = MenuListCommons & {

--- a/packages/react-menu/src/components/MenuList/index.ts
+++ b/packages/react-menu/src/components/MenuList/index.ts
@@ -1,5 +1,14 @@
 export * from './MenuList';
-export * from './MenuList.types';
+// Explicit exports to omit MenuListCommons
+export type {
+  MenuCheckedValueChangeData,
+  MenuCheckedValueChangeEvent,
+  MenuListContextValues,
+  MenuListProps,
+  MenuListSlots,
+  MenuListState,
+  UninitializedMenuListState,
+} from './MenuList.types';
 export * from './renderMenuList';
 export * from './useMenuList';
 export * from './useMenuListStyles';

--- a/packages/react-menu/src/components/MenuSplitGroup/MenuSplitGroup.types.ts
+++ b/packages/react-menu/src/components/MenuSplitGroup/MenuSplitGroup.types.ts
@@ -4,7 +4,7 @@ export type MenuSplitGroupSlots = {
   root: Slot<'div'>;
 };
 
-export type MenuSplitGroupCommons = {};
+type MenuSplitGroupCommons = {};
 
 /**
  * MenuSplitGroup Props

--- a/packages/react-popover/etc/react-popover.api.md
+++ b/packages/react-popover/etc/react-popover.api.md
@@ -34,25 +34,13 @@ export type OpenPopoverEvents = MouseEvent | TouchEvent | React_2.MouseEvent<HTM
 export const Popover: React_2.FC<PopoverProps>;
 
 // @public (undocumented)
-export type PopoverCommons = Pick<PortalProps, 'mountNode'> & {
-    open: boolean;
-    defaultOpen?: boolean;
-    onOpenChange?: (e: OpenPopoverEvents, data: OnOpenChangeData) => void;
-    openOnHover?: boolean;
-    openOnContext?: boolean;
-    noArrow?: boolean;
-    size?: PopoverSize;
-    appearance?: 'brand' | 'inverted';
-    trapFocus?: boolean;
-    positioning?: PositioningShorthand;
-};
-
-// @public (undocumented)
 export const PopoverContext: Context<PopoverContextValue>;
 
 // @public
 export type PopoverContextValue = Pick<PopoverState, 'open' | 'setOpen' | 'triggerRef' | 'contentRef' | 'openOnHover' | 'openOnContext' | 'mountNode' | 'noArrow' | 'arrowRef' | 'size' | 'appearance' | 'trapFocus'>;
 
+// Warning: (ae-forgotten-export) The symbol "PopoverCommons" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type PopoverProps = Partial<PopoverCommons> & {
     children: [JSX.Element, JSX.Element] | JSX.Element;

--- a/packages/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-popover/src/components/Popover/Popover.types.ts
@@ -7,7 +7,7 @@ import type { PortalProps } from '@fluentui/react-portal';
  */
 export type PopoverSize = 'small' | 'medium' | 'large';
 
-export type PopoverCommons = Pick<PortalProps, 'mountNode'> & {
+type PopoverCommons = Pick<PortalProps, 'mountNode'> & {
   /**
    * Controls the opening of the Popover
    */

--- a/packages/react-portal/etc/react-portal.api.md
+++ b/packages/react-portal/etc/react-portal.api.md
@@ -12,12 +12,8 @@ export function elementContains(parent: HTMLElement | null, child: HTMLElement |
 // @public
 export const Portal: React_2.FC<PortalProps>;
 
-// @public (undocumented)
-export type PortalCommons = {
-    children: React_2.ReactNode;
-    mountNode: HTMLDivElement | undefined;
-};
-
+// Warning: (ae-forgotten-export) The symbol "PortalCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type PortalProps = Partial<PortalCommons>;
 

--- a/packages/react-portal/src/components/Portal/Portal.types.ts
+++ b/packages/react-portal/src/components/Portal/Portal.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export type PortalCommons = {
+type PortalCommons = {
   /**
    * React children
    */

--- a/packages/react-provider/etc/react-provider.api.md
+++ b/packages/react-provider/etc/react-provider.api.md
@@ -23,12 +23,6 @@ export const FluentProvider: React_2.ForwardRefExoticComponent<FluentProviderPro
 export const fluentProviderClassName = "fui-FluentProvider";
 
 // @public (undocumented)
-export interface FluentProviderCommons {
-    dir: 'ltr' | 'rtl';
-    targetDocument: Document | undefined;
-}
-
-// @public (undocumented)
 export interface FluentProviderContextValues extends Pick<FluentProviderState, 'theme'> {
     // (undocumented)
     provider: ProviderContextValue;
@@ -40,6 +34,8 @@ export interface FluentProviderContextValues extends Pick<FluentProviderState, '
     tooltip: TooltipContextType;
 }
 
+// Warning: (ae-forgotten-export) The symbol "FluentProviderCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export interface FluentProviderProps extends Omit<ComponentProps<FluentProviderSlots>, 'dir'>, Partial<FluentProviderCommons> {
     // (undocumented)

--- a/packages/react-provider/src/components/FluentProvider/FluentProvider.types.ts
+++ b/packages/react-provider/src/components/FluentProvider/FluentProvider.types.ts
@@ -10,7 +10,7 @@ export type FluentProviderSlots = {
   root: Slot<'div'>;
 };
 
-export interface FluentProviderCommons {
+interface FluentProviderCommons {
   /** Sets the direction of text & generated styles. */
   dir: 'ltr' | 'rtl';
 

--- a/packages/react-slider/etc/react-slider.api.md
+++ b/packages/react-slider/etc/react-slider.api.md
@@ -20,25 +20,12 @@ export const Slider: ForwardRefComponent<SliderProps>;
 export const sliderClassName = "fui-Slider";
 
 // @public (undocumented)
-export type SliderCommons = {
-    defaultValue?: number;
-    value?: number;
-    min?: number;
-    max?: number;
-    step?: number;
-    disabled?: boolean;
-    vertical?: boolean;
-    origin?: number;
-    size?: 'small' | 'medium';
-    onChange?: (ev: React_2.ChangeEvent<HTMLInputElement>, data: SliderOnChangeData) => void;
-    getAriaValueText?: (value: number) => string;
-};
-
-// @public (undocumented)
 export type SliderOnChangeData = {
     value: number;
 };
 
+// Warning: (ae-forgotten-export) The symbol "SliderCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type SliderProps = Omit<ComponentProps<Partial<SliderSlots>, 'input'>, 'defaultValue' | 'onChange' | 'size' | 'value'> & SliderCommons;
 

--- a/packages/react-slider/src/components/Slider/Slider.types.ts
+++ b/packages/react-slider/src/components/Slider/Slider.types.ts
@@ -37,7 +37,7 @@ export type SliderSlots = {
   };
 };
 
-export type SliderCommons = {
+type SliderCommons = {
   /**
    * The starting value for an uncontrolled Slider.
    * Mutually exclusive with `value` prop.

--- a/packages/react-spinbutton/etc/react-spinbutton.api.md
+++ b/packages/react-spinbutton/etc/react-spinbutton.api.md
@@ -19,9 +19,8 @@ export const SpinButton: ForwardRefComponent<SpinButtonProps>;
 // @public (undocumented)
 export const spinButtonClassName = "fui-SpinButton";
 
-// @public (undocumented)
-export type SpinButtonCommons = {};
-
+// Warning: (ae-forgotten-export) The symbol "SpinButtonCommons" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type SpinButtonProps = ComponentProps<SpinButtonSlots> & SpinButtonCommons;
 

--- a/packages/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
@@ -4,7 +4,7 @@ export type SpinButtonSlots = {
   root: Slot<'div'>;
 };
 
-export type SpinButtonCommons = {
+type SpinButtonCommons = {
   // TODO Add things shared between props and state here
 };
 

--- a/packages/react-spinner/etc/react-spinner.api.md
+++ b/packages/react-spinner/etc/react-spinner.api.md
@@ -19,9 +19,8 @@ export const Spinner: ForwardRefComponent<SpinnerProps>;
 // @public (undocumented)
 export const spinnerClassName = "fui-Spinner";
 
-// @public (undocumented)
-export type SpinnerCommons = {};
-
+// Warning: (ae-forgotten-export) The symbol "SpinnerCommons" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type SpinnerProps = ComponentProps<SpinnerSlots> & SpinnerCommons;
 

--- a/packages/react-spinner/src/components/Spinner/Spinner.types.ts
+++ b/packages/react-spinner/src/components/Spinner/Spinner.types.ts
@@ -4,7 +4,7 @@ export type SpinnerSlots = {
   root: Slot<'div'>;
 };
 
-export type SpinnerCommons = {
+type SpinnerCommons = {
   // TODO Add things shared between props and state here
 };
 

--- a/packages/react-switch/etc/react-switch.api.md
+++ b/packages/react-switch/etc/react-switch.api.md
@@ -19,16 +19,8 @@ export const Switch: ForwardRefComponent<SwitchProps>;
 // @public (undocumented)
 export const switchClassName = "fui-Switch";
 
-// @public (undocumented)
-export interface SwitchCommons {
-    checked?: boolean;
-    defaultChecked?: boolean;
-    disabled?: boolean;
-    onChange?: (ev: React_2.PointerEvent<HTMLDivElement> | React_2.KeyboardEvent<HTMLDivElement>, data: {
-        checked: boolean;
-    }) => void;
-}
-
+// Warning: (ae-forgotten-export) The symbol "SwitchCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export interface SwitchProps extends Omit<ComponentProps<Partial<SwitchSlots>>, 'onChange'>, SwitchCommons {
 }

--- a/packages/react-switch/src/components/Switch/Switch.types.ts
+++ b/packages/react-switch/src/components/Switch/Switch.types.ts
@@ -33,7 +33,7 @@ export type SwitchSlots = {
   activeRail: NonNullable<Slot<'div'>>;
 };
 
-export interface SwitchCommons {
+interface SwitchCommons {
   /**
    * The starting value for a uncontrolled Switch. If `true` then the Switch will be enabled.
    * Mutually exclusive with `checked` prop.

--- a/packages/react-tabs/etc/react-tabs.api.md
+++ b/packages/react-tabs/etc/react-tabs.api.md
@@ -48,11 +48,6 @@ export const Tab: ForwardRefComponent<TabProps>;
 // @public (undocumented)
 export const tabClassName = "fui-Tab";
 
-// @public (undocumented)
-export type TabCommons = {
-    value: TabValue;
-};
-
 // @public
 export type TabContentRect = {
     x: number;
@@ -67,15 +62,8 @@ export const TabList: ForwardRefComponent<TabListProps>;
 // @public (undocumented)
 export const tabListClassName = "fui-TabList";
 
-// @public (undocumented)
-export type TabListCommons = {
-    appearance?: 'transparent' | 'subtle';
-    onTabSelect?: SelectTabEventHandler;
-    selectedValue?: TabValue;
-    size?: 'small' | 'medium';
-    vertical?: boolean;
-};
-
+// Warning: (ae-forgotten-export) The symbol "TabListCommons" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type TabListContextValue = Pick<TabListCommons, 'onTabSelect' | 'selectedValue'> & Required<Pick<TabListCommons, 'appearance' | 'size' | 'vertical'>> & {
     onRegister: RegisterTabEventHandler;
@@ -106,6 +94,8 @@ export type TabListState = ComponentState<Required<TabListSlots>> & TabListConte
     selectedTabRect?: TabContentRect;
 };
 
+// Warning: (ae-forgotten-export) The symbol "TabCommons" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type TabProps = ComponentProps<Partial<TabSlots>> & TabCommons;
 

--- a/packages/react-tabs/src/components/Tab/Tab.types.ts
+++ b/packages/react-tabs/src/components/Tab/Tab.types.ts
@@ -23,7 +23,7 @@ export type TabSlots = {
   content: NonNullable<Slot<'span'>>;
 };
 
-export type TabCommons = {
+type TabCommons = {
   /**
    * The value that identifies this tab when selected.
    */

--- a/packages/react-tabs/src/components/TabList/TabList.types.ts
+++ b/packages/react-tabs/src/components/TabList/TabList.types.ts
@@ -31,7 +31,7 @@ export type TabListSlots = {
   root: Slot<'div'>;
 };
 
-export type TabListCommons = {
+type TabListCommons = {
   /**
    * A tab list can supports 'transparent' and 'subtle' appearance.
    *- 'subtle': Minimizes emphasis to blend into the background until hovered or focused.

--- a/packages/react-text/etc/react-text.api.md
+++ b/packages/react-text/etc/react-text.api.md
@@ -60,20 +60,8 @@ export { Text_2 as Text }
 // @public (undocumented)
 export const textClassName = "fui-Text";
 
-// @public (undocumented)
-export type TextCommons = {
-    wrap: boolean;
-    truncate: boolean;
-    block: boolean;
-    italic: boolean;
-    underline: boolean;
-    strikethrough: boolean;
-    size: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
-    font: 'base' | 'monospace' | 'numeric';
-    weight: 'regular' | 'medium' | 'semibold';
-    align: 'start' | 'center' | 'end' | 'justify';
-};
-
+// Warning: (ae-forgotten-export) The symbol "TextCommons" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type TextProps = ComponentProps<TextSlots> & Partial<TextCommons>;
 

--- a/packages/react-text/src/components/Text/Text.types.ts
+++ b/packages/react-text/src/components/Text/Text.types.ts
@@ -7,7 +7,7 @@ export type TextSlots = {
   root: Slot<'span', 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'pre'>;
 };
 
-export type TextCommons = {
+type TextCommons = {
   /**
    * Wraps the text content on white spaces.
    *

--- a/packages/react-tooltip/etc/react-tooltip.api.md
+++ b/packages/react-tooltip/etc/react-tooltip.api.md
@@ -25,18 +25,8 @@ export const Tooltip: React_2.FC<TooltipProps> & FluentTriggerComponent;
 // @public (undocumented)
 export const tooltipClassName = "fui-Tooltip";
 
-// @public
-export type TooltipCommons = {
-    appearance?: 'normal' | 'inverted';
-    withArrow?: boolean;
-    positioning?: PositioningShorthand;
-    visible?: boolean;
-    onVisibleChange?: (event: React_2.PointerEvent<HTMLElement> | React_2.FocusEvent<HTMLElement> | undefined, data: OnVisibleChangeData) => void;
-    relationship: 'label' | 'description' | 'inaccessible';
-    showDelay: number;
-    hideDelay: number;
-};
-
+// Warning: (ae-forgotten-export) The symbol "TooltipCommons" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type TooltipProps = ComponentProps<TooltipSlots> & Partial<Omit<TooltipCommons, 'relationship'>> & Pick<TooltipCommons, 'relationship'> & {
     children?: (React_2.ReactElement & {

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.types.ts
@@ -12,7 +12,7 @@ export type TooltipSlots = {
 /**
  * Properties and state for Tooltip
  */
-export type TooltipCommons = {
+type TooltipCommons = {
   /**
    * The tooltip's visual appearance.
    * * `normal` - Uses the theme's background and text colors.

--- a/scripts/create-component/plop-templates/src/components/{{componentName}}/{{componentName}}.types.ts.hbs
+++ b/scripts/create-component/plop-templates/src/components/{{componentName}}/{{componentName}}.types.ts.hbs
@@ -4,7 +4,7 @@ export type {{componentName}}Slots = {
   root: Slot<'div'>;
 };
 
-export type {{componentName}}Commons = {
+type {{componentName}}Commons = {
   // TODO Add things shared between props and state here
 };
 


### PR DESCRIPTION
## Current Behavior
Commons types are exported from the root of each component, and could be taken on as a dependency if you imported directly from the component. We want to eventually remove the common types, and don't want anyone taking dependencies on them.

## New Behavior
This PR removes the exporting of most Commons types, and changes the template for future components. For those that require sharing Commons between components, the Commons type is omitted from the top level export.

## Related Issue(s)

This is a replacement for #21607

Fixes #
