### PR TITLE
Combobox native aria support for labelledby and describedby

### DIFF
--- a/change/@fluentui-react-b84d6012-6cba-47a0-bf2f-063e18ea34ab.json
+++ b/change/@fluentui-react-b84d6012-6cba-47a0-bf2f-063e18ea34ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Combobox now supports aria-describedby and aria-labelledby properly",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -1025,30 +1025,34 @@ describe('ComboBox', () => {
     });
   });
 
-  it('allows adding a custom aria-describedby id to the input', () => {
-    safeMount(<ComboBox options={DEFAULT_OPTIONS} ariaDescribedBy={'customAriaDescriptionId'} />, wrapper => {
-      const inputElement = wrapper.find('input').getDOMNode();
-      expect(inputElement.getAttribute('aria-describedby')).toBe('customAriaDescriptionId');
-    });
+  it('defaults to ariaDescribedBy prop when passing id to input', () => {
+    const ariaId = 'customAriaDescriptionId';
+    safeMount(
+      <ComboBox options={DEFAULT_OPTIONS} ariaDescribedBy={ariaId} aria-describedby="usePropInstead" />,
+      wrapper => {
+        const inputElement = wrapper.find('input').getDOMNode();
+        expect(inputElement.getAttribute('aria-describedby')).toBe(ariaId);
+      },
+    );
   });
 
-  it('correctly handles (aria-labelledby) when no label prop is provided', () => {
-    safeMount(<ComboBox options={RENDER_OPTIONS} aria-labelledby={'customAriaLabel'} />, wrapper => {
+  it('allows adding a custom aria-describedby id to the input via an attribute', () => {
+    const ariaId = 'customAriaDescriptionId';
+    safeMount(<ComboBox options={DEFAULT_OPTIONS} aria-describedby={ariaId} />, wrapper => {
       const inputElement = wrapper.find('input').getDOMNode();
-
-      expect(inputElement.getAttribute('aria-labelledby')).toBeNull();
+      expect(inputElement.getAttribute('aria-describedby')).toBe(ariaId);
     });
   });
 
   it('correctly handles (aria-labelledby) when label prop is provided', () => {
-    safeMount(
-      <ComboBox options={DEFAULT_OPTIONS} label="hello world" aria-labelledby={'customAriaLabel'} />,
-      wrapper => {
-        const inputElement = wrapper.find('input').getDOMNode();
+    const labelId = 'customAriaLabelledById';
+    safeMount(<ComboBox options={DEFAULT_OPTIONS} label="hello world" aria-labelledby={labelId} />, wrapper => {
+      const labelElement = wrapper.find('label').getDOMNode();
+      expect(labelElement.getAttribute('id')).toBe(labelId);
 
-        expect(inputElement.getAttribute('aria-labelledby')).toBe('ComboBox0-label');
-      },
-    );
+      const inputElement = wrapper.find('input').getDOMNode();
+      expect(inputElement.getAttribute('aria-labelledby')).toBe(labelId);
+    });
   });
 
   it('sets ariaLabel on both the input and the dropdown list', () => {

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -1044,14 +1044,14 @@ describe('ComboBox', () => {
     });
   });
 
-  it('correctly handles (aria-labelledby) when label prop is provided', () => {
-    const labelId = 'customAriaLabelledById';
-    safeMount(<ComboBox options={DEFAULT_OPTIONS} label="hello world" aria-labelledby={labelId} />, wrapper => {
+  it('correctly handles (aria-labelledby) when label is also provided', () => {
+    const customId = 'customAriaLabelledById';
+    safeMount(<ComboBox options={DEFAULT_OPTIONS} label="hello world" aria-labelledby={customId} />, wrapper => {
       const labelElement = wrapper.find('label').getDOMNode();
-      expect(labelElement.getAttribute('id')).toBe(labelId);
+      const labelId = labelElement.getAttribute('id');
 
       const inputElement = wrapper.find('input').getDOMNode();
-      expect(inputElement.getAttribute('aria-labelledby')).toBe(labelId);
+      expect(inputElement.getAttribute('aria-labelledby')).toBe(customId + ' ' + labelId);
     });
   });
 

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1327,7 +1327,12 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
     if (label) {
       return (
-        <Label id={this._id + '-label'} disabled={disabled} required={required} className={this._classNames.label}>
+        <Label
+          id={this.props['aria-labelledby'] || this._id + '-label'}
+          disabled={disabled}
+          required={required}
+          className={this._classNames.label}
+        >
           {label}
           {onRenderLabelProps.multiselectAccessibleText && (
             <span className={this._classNames.screenReaderText}>{onRenderLabelProps.multiselectAccessibleText}</span>

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -570,6 +570,8 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         ? multiselectAccessibleText
         : placeholderProp;
 
+    const labelledBy = [this.props['aria-labelledby'], label && this._id + '-label'].join(' ').trim();
+
     return (
       <div
         data-ktp-target={true}
@@ -596,7 +598,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           aria-autocomplete={this._getAriaAutoCompleteValue()}
           role="combobox"
           readOnly={disabled}
-          aria-labelledby={this.props['aria-labelledby'] || (label && this._id + '-label')}
+          aria-labelledby={labelledBy ? labelledBy : undefined}
           aria-label={ariaLabel && !label ? ariaLabel : undefined}
           aria-describedby={
             errorMessage !== undefined ? mergeAriaAttributeValues(ariaDescribedBy, errorMessageId) : ariaDescribedBy
@@ -1327,12 +1329,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
     if (label) {
       return (
-        <Label
-          id={this.props['aria-labelledby'] || this._id + '-label'}
-          disabled={disabled}
-          required={required}
-          className={this._classNames.label}
-        >
+        <Label id={this._id + '-label'} disabled={disabled} required={required} className={this._classNames.label}>
           {label}
           {onRenderLabelProps.multiselectAccessibleText && (
             <span className={this._classNames.screenReaderText}>{onRenderLabelProps.multiselectAccessibleText}</span>

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -420,6 +420,8 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, [
       'onChange',
       'value',
+      'aria-describedby',
+      'aria-labelledby',
     ]);
 
     const hasErrorMessage = errorMessage && errorMessage.length > 0 ? true : false;
@@ -544,7 +546,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       label,
       disabled,
       ariaLabel,
-      ariaDescribedBy,
+      ariaDescribedBy = this.props['aria-describedby'],
       required,
       errorMessage,
       buttonIconProps,
@@ -594,7 +596,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           aria-autocomplete={this._getAriaAutoCompleteValue()}
           role="combobox"
           readOnly={disabled}
-          aria-labelledby={label && this._id + '-label'}
+          aria-labelledby={this.props['aria-labelledby'] || (label && this._id + '-label')}
           aria-label={ariaLabel && !label ? ariaLabel : undefined}
           aria-describedby={
             errorMessage !== undefined ? mergeAriaAttributeValues(ariaDescribedBy, errorMessageId) : ariaDescribedBy


### PR DESCRIPTION
## Current Behavior

aria-describedby and aria-labeledby were being outputed onto the container div instead of onto the internal input

## New Behavior

aria-describedby and aria-labeledby are now skipped over when grabbing props for the outer div, and are logically rendered by the input when provided. 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21520
