### PR TITLE
Callout, Dialog, Modal: convert tests to use testing-library

### DIFF
--- a/change/@fluentui-react-conformance-8f7a5ab5-539c-4cbb-be77-0b1e9e42a5fa.json
+++ b/change/@fluentui-react-conformance-8f7a5ab5-539c-4cbb-be77-0b1e9e42a5fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Clear document.body after each test to avoid interference between tests",
+  "packageName": "@fluentui/react-conformance",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-conformance/src/isConformant.ts
+++ b/packages/react-conformance/src/isConformant.ts
@@ -11,6 +11,11 @@ export function isConformant<TProps = {}>(...testInfo: Partial<IsConformantOptio
   const { componentPath, displayName, disabledTests = [], extraTests, tsconfigDir } = mergedOptions;
 
   describe('isConformant', () => {
+    afterEach(() => {
+      // TODO: remove this once cleanup is properly implemented or after moving to testing-library
+      document.body.innerHTML = '';
+    });
+
     if (!fs.existsSync(componentPath)) {
       throw new Error(`Path ${componentPath} does not exist`);
     }

--- a/packages/react/src/components/Callout/Callout.test.tsx
+++ b/packages/react/src/components/Callout/Callout.test.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import * as ReactTestUtils from 'react-dom/test-utils';
-import { render } from '@testing-library/react';
-import { safeCreate } from '@fluentui/test-utilities';
+import { render, act } from '@testing-library/react';
 import { isConformant } from '../../common/isConformant';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { resetIds } from '../../Utilities';
@@ -13,14 +10,10 @@ import { expectNoHiddenParents } from '../../common/testUtilities';
 
 describe('Callout', () => {
   beforeEach(() => {
-    realDom = document.createElement('div');
-    document.body.appendChild(realDom);
     resetIds();
   });
 
   afterEach(() => {
-    ReactDOM.unmountComponentAtNode(realDom);
-    document.body.removeChild(realDom);
     jest.useRealTimers();
     jest.resetAllMocks();
   });
@@ -28,8 +21,6 @@ describe('Callout', () => {
   afterAll(() => {
     resetIds();
   });
-
-  let realDom: HTMLDivElement;
 
   isConformant({
     Component: Callout,
@@ -40,167 +31,117 @@ describe('Callout', () => {
   });
 
   it('renders Callout correctly', () => {
-    safeCreate(<CalloutContent>Content</CalloutContent>, component => {
-      const tree = component.toJSON();
-      expect(tree).toMatchSnapshot();
-    });
+    const { container } = render(<CalloutContent>Content</CalloutContent>);
+    expect(container).toMatchSnapshot();
   });
 
-  it('target id strings does not throw exception', () => {
-    let threwException = false;
-    try {
-      ReactTestUtils.renderIntoDocument<HTMLDivElement>(
+  it('does not throw with target id string', () => {
+    expect(() => {
+      render(
         <div>
           <button id="target" style={{ top: '10px', left: '10px', height: '0', width: '0px' }}>
-            {' '}
-            target{' '}
+            target
           </button>
           <Callout target="#target" directionalHint={DirectionalHint.topLeftEdge}>
             <div>Content</div>
           </Callout>
         </div>,
       );
-    } catch (e) {
-      threwException = true;
-    }
-
-    expect(threwException).toEqual(false);
+    }).not.toThrow();
   });
 
-  it('target MouseEvents does not throw exception', () => {
+  it('does not throw with target MouseEvent', () => {
     const mouseEvent = document.createEvent('MouseEvent');
     const eventTarget = document.createElement('div');
     mouseEvent.initMouseEvent('click', false, false, window, 0, 0, 0, 0, 0, false, false, false, false, 1, eventTarget);
-    let threwException = false;
-    try {
-      ReactTestUtils.renderIntoDocument<HTMLDivElement>(
+
+    expect(() => {
+      render(
         <div>
           <Callout target={eventTarget} directionalHint={DirectionalHint.topLeftEdge}>
             <div>Content</div>
           </Callout>
         </div>,
       );
-    } catch (e) {
-      threwException = true;
-    }
-
-    expect(threwException).toEqual(false);
+    }).not.toThrow();
   });
 
-  it('target Elements does not throw exception', () => {
+  it('does not throw with target Element', () => {
     const targetElement = document.createElement('div');
     document.body.appendChild(targetElement);
-    let threwException = false;
-    try {
-      ReactTestUtils.renderIntoDocument<HTMLDivElement>(
+
+    expect(() => {
+      render(
         <div>
           <Callout target={targetElement} directionalHint={DirectionalHint.topLeftEdge}>
             <div>Content</div>
           </Callout>
         </div>,
       );
-    } catch (e) {
-      threwException = true;
-    }
-
-    expect(threwException).toEqual(false);
+    }).not.toThrow();
   });
 
-  it('without target does not throw exception', () => {
-    let threwException = false;
-    try {
-      ReactTestUtils.renderIntoDocument<HTMLDivElement>(
+  it('does not throw without target', () => {
+    expect(() => {
+      render(
         <div>
           <Callout directionalHint={DirectionalHint.topLeftEdge}>
             <div>Content</div>
           </Callout>
         </div>,
       );
-    } catch (e) {
-      threwException = true;
-    }
-    expect(threwException).toEqual(false);
+    }).not.toThrow();
   });
 
   it('passes event to onDismiss prop', () => {
     jest.useFakeTimers();
-    let threwException = false;
-    let gotEvent = false;
-    const onDismiss = (ev?: unknown) => {
-      if (ev) {
-        gotEvent = true;
-      }
-    };
+    const onDismiss = jest.fn();
 
-    // In order to have eventlisteners that have been added to the window to be called the JSX needs
-    // to be rendered into the real dom rather than the testutil simulated dom.
+    const { getByText } = render(
+      <div>
+        <button>button</button>
+        <button id="target" style={{ top: '10px', left: '10px', height: '0', width: '0px' }}>
+          target
+        </button>
+        <Callout target="#target" directionalHint={DirectionalHint.topLeftEdge} onDismiss={onDismiss}>
+          <div>Content</div>
+        </Callout>
+      </div>,
+    );
 
-    try {
-      ReactTestUtils.act(() => {
-        ReactDOM.render<HTMLDivElement>(
-          <div>
-            <button id="focustarget"> button </button>
-            <button id="target" style={{ top: '10px', left: '10px', height: '0', width: '0px' }}>
-              {' '}
-              target{' '}
-            </button>
-            <Callout target="#target" directionalHint={DirectionalHint.topLeftEdge} onDismiss={onDismiss}>
-              <div>Content</div>
-            </Callout>
-          </div>,
-          realDom,
-        );
-      });
-    } catch (e) {
-      threwException = true;
-    }
-    expect(threwException).toEqual(false);
-
-    ReactTestUtils.act(() => {
-      const focusTarget = document.querySelector('#focustarget') as HTMLButtonElement;
-
+    act(() => {
       // Move focus
       jest.runAllTimers();
-
-      focusTarget.focus();
-
-      expect(gotEvent).toEqual(true);
     });
+
+    getByText('button').focus();
+
+    // ensure event is passed to callback
+    expect(onDismiss).toHaveBeenCalledWith(expect.objectContaining({ type: 'focus' }));
   });
 
   it('prevents dismiss when preventDismissOnEvent is passed', () => {
     jest.useFakeTimers();
-    let threwException = false;
     const onDismiss = jest.fn();
     const preventAllDismiss = () => true;
 
-    try {
-      ReactTestUtils.act(() => {
-        ReactDOM.render<HTMLDivElement>(
-          <div>
-            <button id="focustarget"> button </button>
-            <Callout target="#target" preventDismissOnEvent={preventAllDismiss} onDismiss={onDismiss}>
-              <div>Content</div>
-            </Callout>
-          </div>,
-          realDom,
-        );
-      });
-    } catch (e) {
-      threwException = true;
-    }
-    expect(threwException).toEqual(false);
+    const { getByText, queryByText } = render(
+      <div>
+        <button>button</button>
+        <Callout target="#target" preventDismissOnEvent={preventAllDismiss} onDismiss={onDismiss}>
+          <div>Content</div>
+        </Callout>
+      </div>,
+    );
 
-    ReactTestUtils.act(() => {
-      const focusTarget = document.querySelector('#focustarget') as HTMLButtonElement;
-
+    act(() => {
       // Move focus
       jest.runAllTimers();
-
-      focusTarget.focus();
-
-      expect(onDismiss.mock.calls.length).toEqual(0);
     });
+    getByText('button').focus();
+
+    expect(queryByText('Content')).toBeTruthy();
+    expect(onDismiss).not.toHaveBeenCalled();
   });
 
   it('will correctly return focus to element that spawned it', () => {
@@ -211,59 +152,41 @@ describe('Callout', () => {
     // Callout/popup checks active element to get what currently has focus
     // to know what to return focus to. By mocking the return value we can be sure
     // that it will have something "focused" when mounted
-    const b = jest.spyOn(window.document, 'activeElement', 'get');
-    b.mockReturnValue(focusedElement as Element);
+    jest.spyOn(window.document, 'activeElement', 'get').mockReturnValue(focusedElement as Element);
 
-    let threwException = false;
-    let previousFocusElement;
-    let isFocused;
-    let restoreCalled = false;
-    const onRestoreFocus = (options: IPopupRestoreFocusParams) => {
-      previousFocusElement = options.originalElement;
-      isFocused = options.containsFocus;
-      restoreCalled = true;
-    };
+    const onRestoreFocus = jest.fn();
     // In order to have eventlisteners that have been added to the window to be called the JSX needs
     // to be rendered into the real dom rather than the testutil simulated dom.
-    try {
-      ReactTestUtils.act(() => {
-        ReactDOM.render<HTMLDivElement>(
-          <div>
-            <button id="target" style={{ top: '10px', left: '10px', height: '0', width: '0px' }}>
-              target
-            </button>
-            <Callout target="#target" directionalHint={DirectionalHint.topLeftEdge} onRestoreFocus={onRestoreFocus}>
-              {/* must be a button to be focusable for the test*/}
-              <button id={'inner'}>Content</button>
-            </Callout>
-          </div>,
-          realDom,
-        );
-      });
-    } catch (e) {
-      threwException = true;
-    }
-    expect(threwException).toEqual(false);
+    const { getByText, unmount } = render(
+      <div>
+        <button id="target" style={{ top: '10px', left: '10px', height: '0', width: '0px' }}>
+          target
+        </button>
+        <Callout target="#target" directionalHint={DirectionalHint.topLeftEdge} onRestoreFocus={onRestoreFocus}>
+          {/* must be a button to be focusable for the test*/}
+          <button id="inner">Content</button>
+        </Callout>
+      </div>,
+    );
 
-    ReactTestUtils.act(() => {
-      const focusTarget = document.querySelector('#inner') as HTMLDivElement;
-
+    act(() => {
       jest.runAllTimers();
-      // Make sure that focus is in the callout
-      focusTarget.focus();
     });
 
-    // Unmounting everything is the same as dismissing the Callout. As
-    // the tree is unmounted, popup will get unmounted first and the
-    // onRestoreFocus method will get called
-    ReactDOM.unmountComponentAtNode(realDom);
+    // Make sure that focus is in the callout
+    getByText('Content').focus();
 
-    expect(restoreCalled).toEqual(true);
-    expect(isFocused).toEqual(true);
+    // Unmounting everything is the same as dismissing the Callout.
+    // As the tree is unmounted, popup will get unmounted first and onRestoreFocus will get called.
+    unmount();
 
-    // Just to make sure that both elements are not undefined
-    expect(previousFocusElement).not.toBeFalsy();
-    expect(previousFocusElement).toEqual(focusedElement);
+    expect(onRestoreFocus).toHaveBeenCalledTimes(1);
+    expect(onRestoreFocus).toHaveBeenLastCalledWith(
+      expect.objectContaining<Partial<IPopupRestoreFocusParams>>({
+        originalElement: focusedElement,
+        containsFocus: true,
+      }),
+    );
   });
 
   // This behavior could be changed in the future

--- a/packages/react/src/components/Callout/Callout.test.tsx
+++ b/packages/react/src/components/Callout/Callout.test.tsx
@@ -51,14 +51,13 @@ describe('Callout', () => {
   });
 
   it('does not throw with target MouseEvent', () => {
-    const mouseEvent = document.createEvent('MouseEvent');
     const eventTarget = document.createElement('div');
-    mouseEvent.initMouseEvent('click', false, false, window, 0, 0, 0, 0, 0, false, false, false, false, 1, eventTarget);
+    const mouseEvent = new MouseEvent('click', { relatedTarget: eventTarget });
 
     expect(() => {
       render(
         <div>
-          <Callout target={eventTarget} directionalHint={DirectionalHint.topLeftEdge}>
+          <Callout target={mouseEvent} directionalHint={DirectionalHint.topLeftEdge}>
             <div>Content</div>
           </Callout>
         </div>,
@@ -155,8 +154,7 @@ describe('Callout', () => {
     jest.spyOn(window.document, 'activeElement', 'get').mockReturnValue(focusedElement as Element);
 
     const onRestoreFocus = jest.fn();
-    // In order to have eventlisteners that have been added to the window to be called the JSX needs
-    // to be rendered into the real dom rather than the testutil simulated dom.
+
     const { getByText, unmount } = render(
       <div>
         <button id="target" style={{ top: '10px', left: '10px', height: '0', width: '0px' }}>

--- a/packages/react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
+++ b/packages/react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
@@ -1,69 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Callout renders Callout correctly 1`] = `
-<div
-  className=
-      ms-Callout-container
-      {
-        position: relative;
-      }
->
+<div>
   <div
-    className=
-        ms-Callout
+    class=
+        ms-Callout-container
         {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          border-radius: 2px;
-          box-shadow: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108);
-          box-sizing: border-box;
-          display: flex;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          outline: transparent;
-          position: absolute;
+          position: relative;
         }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-          border-color: WindowText;
-          border-style: solid;
-          border-width: 1px;
-        }
-        &::-moz-focus-inner {
-          border: 0px;
-        }
-    style={
-      Object {
-        "filter": "opacity(0)",
-        "opacity": 0,
-        "pointerEvents": "none",
-      }
-    }
-    tabIndex={-1}
   >
     <div
-      className=
-          ms-Callout-main
+      class=
+          ms-Callout
           {
-            background-color: #ffffff;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
             border-radius: 2px;
-            overflow-x: hidden;
-            overflow-y: auto;
-            position: relative;
-            width: 100%;
+            box-shadow: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108);
+            box-sizing: border-box;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            outline: transparent;
+            position: absolute;
           }
-      onKeyDown={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-      style={
-        Object {
-          "maxHeight": "100%",
-          "outline": "none",
-          "overflowY": undefined,
-        }
-      }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            border-color: WindowText;
+            border-style: solid;
+            border-width: 1px;
+          }
+          &::-moz-focus-inner {
+            border: 0px;
+          }
+      style="opacity: 0; filter: opacity(0); pointer-events: none;"
+      tabindex="-1"
     >
-      Content
+      <div
+        class=
+            ms-Callout-main
+            {
+              background-color: #ffffff;
+              border-radius: 2px;
+              overflow-x: hidden;
+              overflow-y: auto;
+              position: relative;
+              width: 100%;
+            }
+        style="outline: none; max-height: 100%;"
+      >
+        Content
+      </div>
     </div>
   </div>
 </div>

--- a/packages/react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react/src/components/Dialog/Dialog.test.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react';
-import * as renderer from 'react-test-renderer';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 
-import { mount } from 'enzyme';
 import { Dialog } from './Dialog';
 import { DialogBase } from './Dialog.base';
 import { DialogContent } from './DialogContent';
 import { DialogType } from './DialogContent.types'; // for express fluent assertions
 import { resetIds, setWarningCallback } from '@fluentui/utilities';
-import { act } from 'react-dom/test-utils';
 import { isConformant } from '../../common/isConformant';
 import { expectNoHiddenParents } from '../../common/testUtilities';
 
@@ -17,22 +14,28 @@ describe('Dialog', () => {
     resetIds();
   });
 
+  afterEach(() => {
+    setWarningCallback();
+    jest.useRealTimers();
+  });
+
   afterAll(() => {
     resetIds();
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
+  isConformant({
+    Component: Dialog,
+    displayName: 'Dialog',
+    disabledTests: ['component-handles-ref', 'component-has-root-ref', 'component-handles-classname'],
   });
 
-  it('renders Dialog correctly', () => {
-    const component = renderer.create(<DialogContent />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+  it('renders DialogContent correctly', () => {
+    const { container } = render(<DialogContent />);
+    expect(container).toMatchSnapshot();
   });
 
-  it('renders Dialog with a jsx title', () => {
-    const component = renderer.create(
+  it('respects a jsx title', () => {
+    const { queryByText } = render(
       <DialogContent
         type={DialogType.normal}
         title={
@@ -43,12 +46,13 @@ describe('Dialog', () => {
         }
       />,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(queryByText('I am span 1')).toBeTruthy();
+    expect(queryByText('I am span 2')).toBeTruthy();
   });
 
-  it('renders DialogContent with titleProps', () => {
-    const component = renderer.create(
+  it('respects titleProps', () => {
+    const { getByTitle } = render(
       <DialogContent
         type={DialogType.normal}
         title="sample title"
@@ -60,220 +64,165 @@ describe('Dialog', () => {
         }}
       />,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-  });
 
-  isConformant({
-    Component: Dialog,
-    displayName: 'Dialog',
-    disabledTests: ['component-handles-ref', 'component-has-root-ref', 'component-handles-classname'],
+    const title = getByTitle('tooltip');
+    expect(title.getAttribute('aria-level')).toBe('3');
+    expect(title.className).toMatch(/\btitle_class\b/);
   });
 
   it('Fires dismissed after closing', () => {
-    act(() => {
-      jest.useFakeTimers();
-    });
-    let dismissedCalled = false;
+    jest.useFakeTimers();
+    const onDismissed = jest.fn();
 
-    const handleDismissed = () => {
-      dismissedCalled = true;
-    };
+    const { queryByRole, rerender } = render(<DialogBase hidden={false} modalProps={{ onDismissed }} />);
 
-    const wrapper = mount(<DialogBase hidden={false} modalProps={{ onDismissed: handleDismissed }} />);
+    expect(queryByRole('dialog')).toBeTruthy();
 
-    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
-    act(() => {
-      wrapper.setProps({ hidden: true });
-      wrapper.update();
-    });
+    rerender(<DialogBase hidden modalProps={{ onDismissed }} />);
 
     act(() => {
       jest.runAllTimers();
     });
-    expect(document.querySelector('[role="dialog"]')).toBeNull();
-    expect(dismissedCalled).toEqual(true);
-    wrapper.unmount();
+
+    expect(queryByRole('dialog')).toBeFalsy();
+    expect(onDismissed).toHaveBeenCalledTimes(1);
   });
 
   it('deprecated isOpen controls open state of the dialog', () => {
-    setWarningCallback(() => {
-      /* suppress deprecation warning as error */
-    });
+    // suppress deprecation warning as error
+    setWarningCallback(() => undefined);
+    jest.useFakeTimers();
+    const onDismissed = jest.fn();
 
-    act(() => {
-      jest.useFakeTimers();
-    });
-    let dismissedCalled = false;
+    const { queryByRole, rerender } = render(<DialogBase isOpen modalProps={{ onDismissed }} />);
 
-    const handleDismissed = () => {
-      dismissedCalled = true;
-    };
-    const wrapper = mount(<DialogBase isOpen={true} modalProps={{ onDismissed: handleDismissed }} />);
+    expect(queryByRole('dialog')).toBeTruthy();
 
-    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
-    act(() => {
-      wrapper.setProps({ isOpen: false });
-      wrapper.update();
-    });
+    rerender(<DialogBase isOpen={false} modalProps={{ onDismissed }} />);
 
     act(() => {
       jest.runAllTimers();
     });
-    expect(document.querySelector('[role="dialog"]')).toBeNull();
-    expect(dismissedCalled).toEqual(true);
-    act(() => {
-      wrapper.unmount();
-    });
-    setWarningCallback();
+
+    expect(queryByRole('dialog')).toBeFalsy();
+    expect(onDismissed).toHaveBeenCalledTimes(1);
   });
 
   it('Properly attaches auto-generated aria attributes IDs', () => {
-    const wrapper = mount(
+    const { getByRole } = render(
       <DialogBase
         hidden={false}
-        modalProps={{
-          onDismissed: () => {
-            /* no-op */
-          },
-        }}
         dialogContentProps={{
-          type: DialogType.normal,
           title: 'sample title',
           subText: 'Sample subtext',
-          titleProps: { 'aria-level': 3 },
         }}
       />,
     );
 
-    const dialogHTML = document.querySelector('[role="dialog"]');
-    expect(dialogHTML).not.toBeNull();
+    const dialogHTML = getByRole('dialog');
 
-    const labelledby = dialogHTML!.getAttribute('aria-labelledby');
-    expect(labelledby).toMatch(/Dialog[\d+]+-title/);
-    expect(document.getElementById(labelledby!)).not.toBeNull();
+    const labelledby = dialogHTML.getAttribute('aria-labelledby')!;
+    expect(labelledby).toMatch(/Dialog\d+-title/);
+    expect(document.getElementById(labelledby)).not.toBeNull();
 
-    expect(dialogHTML!.getAttribute('aria-describedby')).toMatch(/Dialog[\d+]+-subText/);
-    wrapper.unmount();
+    expect(dialogHTML.getAttribute('aria-describedby')).toMatch(/Dialog\d+-subText/);
   });
 
   it('Properly attaches IDs when aria-describedby is passed', () => {
     const subTextAriaId = 'subtextariaid';
-    const wrapper = mount(
+    const { getByRole } = render(
       <DialogBase
         hidden={false}
         modalProps={{
-          onDismissed: () => {
-            /* no-op */
-          },
           subtitleAriaId: subTextAriaId,
         }}
         dialogContentProps={{
-          type: DialogType.normal,
           title: 'sample title',
           subText: 'Sample subtext',
         }}
       />,
     );
 
-    const dialogHTML = document.querySelector('[role="dialog"]');
-    expect(dialogHTML).not.toBeNull();
-    expect(dialogHTML!.getAttribute('aria-labelledby')).toMatch(/Dialog[\d+]+-title/);
-    expect(dialogHTML!.getAttribute('aria-describedby')).toEqual(subTextAriaId);
-    wrapper.unmount();
+    const dialogHTML = getByRole('dialog');
+    expect(dialogHTML.getAttribute('aria-labelledby')).toMatch(/Dialog\d+-title/);
+    expect(dialogHTML.getAttribute('aria-describedby')).toEqual(subTextAriaId);
   });
 
   it('Properly attaches IDs when aria-labelledby is passed', () => {
     const titleAriaId = 'titleariaid';
-    const wrapper = mount(
+    const { getByRole } = render(
       <DialogBase
         hidden={false}
         modalProps={{
-          onDismissed: () => {
-            /* no-op */
-          },
           titleAriaId: titleAriaId,
         }}
         dialogContentProps={{
-          type: DialogType.normal,
           title: 'sample title',
           subText: 'Sample subtext',
         }}
       />,
     );
 
-    const dialogHTML = document.querySelector('[role="dialog"]');
-    expect(dialogHTML).not.toBeNull();
-    expect(dialogHTML!.getAttribute('aria-labelledby')).toEqual(titleAriaId);
-    expect(dialogHTML!.getAttribute('aria-describedby')).toMatch(/Dialog[\d+]+-subText/);
-    wrapper.unmount();
+    const dialogHTML = getByRole('dialog');
+    expect(dialogHTML.getAttribute('aria-labelledby')).toEqual(titleAriaId);
+    expect(dialogHTML.getAttribute('aria-describedby')).toMatch(/Dialog\d+-subText/);
   });
 
-  describe('Dialog Title Id', () => {
-    beforeEach(() => {
-      // Prevent warn deprecations from failing test
-      setWarningCallback(() => {
-        /* no-op */
-      });
-    });
+  it('deprecated titleId prop should be used if titleProps.id is not passed', () => {
+    // Prevent warn deprecations from failing test
+    setWarningCallback(() => undefined);
 
-    afterEach(() => setWarningCallback());
+    const titleId = 'title_id';
+    render(
+      <DialogBase
+        hidden={false}
+        dialogContentProps={{
+          titleId,
+          title: 'sample title',
+        }}
+      />,
+    );
 
-    it('deprecated titleId prop should be set if titleProps.id is not passed', () => {
-      const titleId = 'title_id';
-      const wrapper = mount(
-        <DialogBase
-          hidden={false}
-          dialogContentProps={{
-            titleId,
-            type: DialogType.normal,
-            title: 'sample title',
-          }}
-        />,
-      );
+    const dialogTitle = document.getElementById(titleId);
+    expect(dialogTitle).toBeTruthy();
+  });
 
-      const dialogTitle = document.getElementById(titleId);
-      expect(dialogTitle).not.toBeNull();
-      wrapper.unmount();
-    });
+  it('deprecated titleId prop should not be used if titleProps.id is undefined', () => {
+    setWarningCallback(() => undefined);
 
-    it('deprecated titleId prop should not be set if titleProps.id is undefined', () => {
-      const titleId = 'title_id';
-      const wrapper = mount(
-        <DialogBase
-          hidden={false}
-          dialogContentProps={{
-            titleId,
-            type: DialogType.normal,
-            title: 'sample title',
-            titleProps: { id: undefined },
-          }}
-        />,
-      );
+    const titleId = 'title_id';
+    render(
+      <DialogBase
+        hidden={false}
+        dialogContentProps={{
+          titleId,
+          title: 'sample title',
+          titleProps: { id: undefined },
+        }}
+      />,
+    );
 
-      const dialogTitle = document.getElementById(titleId);
-      expect(dialogTitle).toBeNull();
-      wrapper.unmount();
-    });
+    const dialogTitle = document.getElementById(titleId);
+    expect(dialogTitle).toBeFalsy();
+  });
 
-    it('titleProps.id should be set if deprecated titleId is also passed', () => {
-      const titleId = 'title_id';
-      const wrapper = mount(
-        <DialogBase
-          hidden={false}
-          dialogContentProps={{
-            titleId: `${titleId}_deprecated`,
-            type: DialogType.normal,
-            title: 'sample title',
-            titleProps: { id: titleId },
-          }}
-        />,
-      );
+  it('titleProps.id should be used if deprecated titleId is also passed', () => {
+    setWarningCallback(() => undefined);
 
-      const dialogTitle = document.getElementById(titleId);
-      expect(dialogTitle).not.toBeNull();
-      wrapper.unmount();
-    });
+    const titleId = 'title_id';
+    render(
+      <DialogBase
+        hidden={false}
+        dialogContentProps={{
+          titleId: `${titleId}_deprecated`,
+          title: 'sample title',
+          titleProps: { id: titleId },
+        }}
+      />,
+    );
+
+    const dialogTitle = document.getElementById(titleId);
+    expect(dialogTitle).toBeTruthy();
   });
 
   describe('enableAriaHiddenSiblings', () => {

--- a/packages/react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -1,361 +1,111 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dialog renders Dialog correctly 1`] = `
-<div
-  className=
-
-      {
-        flex-grow: 1;
-        overflow-y: hidden;
-      }
->
+exports[`Dialog renders DialogContent correctly 1`] = `
+<div>
   <div
-    className=
-        ms-Dialog-header
+    class=
+
         {
-          box-sizing: border-box;
-          position: relative;
-          width: 100%;
+          flex-grow: 1;
+          overflow-y: hidden;
         }
   >
     <div
-      aria-level={1}
-      className=
-          ms-Dialog-title
+      class=
+          ms-Dialog-header
           {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #323130;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 20px;
-            font-weight: 600;
-            line-height: normal;
-            margin-bottom: 0;
-            margin-left: 0;
-            margin-right: 0;
-            margin-top: 0;
-            min-height: 20px;
-            padding-bottom: 20px;
-            padding-left: 24px;
-            padding-right: 46px;
-            padding-top: 16px;
-          }
-          @media (min-width: 320px) and (max-width: 479px){& {
-            padding-bottom: 16px;
-            padding-left: 16px;
-            padding-right: 46px;
-            padding-top: 16px;
-          }
-      role="heading"
-    />
-    <div
-      className=
-
-          {
-            display: flex;
-            flex-direction: row;
-            flex-wrap: nowrap;
-            padding-bottom: 0;
-            padding-left: 0;
-            padding-right: 15px;
-            padding-top: 15px;
-            position: absolute;
-            right: 0;
-            top: 0;
-          }
-          & > * {
-            flex: 0 0 auto;
-          }
-          & .ms-Dialog-button {
-            color: #323130;
-          }
-          & .ms-Dialog-button:hover {
-            border-radius: 2px;
-            color: #201f1e;
-          }
-          @media (min-width: 320px) and (max-width: 479px){& {
-            padding-bottom: 0;
-            padding-left: 0;
-            padding-right: 8px;
-            padding-top: 15px;
-          }
-    />
-  </div>
-  <div
-    className=
-        ms-Dialog-inner
-        {
-          padding-bottom: 24px;
-          padding-left: 24px;
-          padding-right: 24px;
-          padding-top: 0;
-        }
-        @media (min-width: 320px) and (max-width: 479px){& {
-          padding-bottom: 16px;
-          padding-left: 16px;
-          padding-right: 16px;
-          padding-top: 0;
-        }
-  >
-    <div
-      className=
-          ms-Dialog-content
-          {
-            position: relative;
-            width: 100%;
-          }
-    />
-  </div>
-</div>
-`;
-
-exports[`Dialog renders Dialog with a jsx title 1`] = `
-<div
-  className=
-
-      {
-        flex-grow: 1;
-        overflow-y: hidden;
-      }
->
-  <div
-    className=
-        ms-Dialog-header
-        {
-          box-sizing: border-box;
-          position: relative;
-          width: 100%;
-        }
-  >
-    <div
-      aria-level={1}
-      className=
-          ms-Dialog-title
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #323130;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 20px;
-            font-weight: 600;
-            line-height: normal;
-            margin-bottom: 0;
-            margin-left: 0;
-            margin-right: 0;
-            margin-top: 0;
-            min-height: 20px;
-            padding-bottom: 20px;
-            padding-left: 24px;
-            padding-right: 46px;
-            padding-top: 16px;
-          }
-          @media (min-width: 320px) and (max-width: 479px){& {
-            padding-bottom: 16px;
-            padding-left: 16px;
-            padding-right: 46px;
-            padding-top: 16px;
-          }
-      role="heading"
-    >
-      <div>
-        <span>
-          I am span 1
-        </span>
-        <span>
-          I am span 2
-        </span>
-      </div>
-    </div>
-    <div
-      className=
-
-          {
-            display: flex;
-            flex-direction: row;
-            flex-wrap: nowrap;
-            padding-bottom: 0;
-            padding-left: 0;
-            padding-right: 15px;
-            padding-top: 15px;
-            position: absolute;
-            right: 0;
-            top: 0;
-          }
-          & > * {
-            flex: 0 0 auto;
-          }
-          & .ms-Dialog-button {
-            color: #323130;
-          }
-          & .ms-Dialog-button:hover {
-            border-radius: 2px;
-            color: #201f1e;
-          }
-          @media (min-width: 320px) and (max-width: 479px){& {
-            padding-bottom: 0;
-            padding-left: 0;
-            padding-right: 8px;
-            padding-top: 15px;
-          }
-    />
-  </div>
-  <div
-    className=
-        ms-Dialog-inner
-        {
-          padding-bottom: 24px;
-          padding-left: 24px;
-          padding-right: 24px;
-          padding-top: 0;
-        }
-        @media (min-width: 320px) and (max-width: 479px){& {
-          padding-bottom: 16px;
-          padding-left: 16px;
-          padding-right: 16px;
-          padding-top: 0;
-        }
-  >
-    <div
-      className=
-          ms-Dialog-content
-          {
-            position: relative;
-            width: 100%;
-          }
-    />
-  </div>
-</div>
-`;
-
-exports[`Dialog renders DialogContent with titleProps 1`] = `
-<div
-  className=
-
-      {
-        flex-grow: 1;
-        overflow-y: hidden;
-      }
->
-  <div
-    className=
-        ms-Dialog-header
-        {
-          box-sizing: border-box;
-          position: relative;
-          width: 100%;
-        }
-  >
-    <div
-      aria-level={3}
-      className=
-          ms-Dialog-title
-          title_class
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #323130;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 20px;
-            font-weight: 600;
-            line-height: normal;
-            margin-bottom: 0;
-            margin-left: 0;
-            margin-right: 0;
-            margin-top: 0;
-            min-height: 20px;
-            padding-bottom: 20px;
-            padding-left: 24px;
-            padding-right: 46px;
-            padding-top: 16px;
-          }
-          @media (min-width: 320px) and (max-width: 479px){& {
-            padding-bottom: 16px;
-            padding-left: 16px;
-            padding-right: 46px;
-            padding-top: 16px;
-          }
-      role="heading"
-      title="tooltip"
-    >
-      sample title
-    </div>
-    <div
-      className=
-
-          {
-            display: flex;
-            flex-direction: row;
-            flex-wrap: nowrap;
-            padding-bottom: 0;
-            padding-left: 0;
-            padding-right: 15px;
-            padding-top: 15px;
-            position: absolute;
-            right: 0;
-            top: 0;
-          }
-          & > * {
-            flex: 0 0 auto;
-          }
-          & .ms-Dialog-button {
-            color: #323130;
-          }
-          & .ms-Dialog-button:hover {
-            border-radius: 2px;
-            color: #201f1e;
-          }
-          @media (min-width: 320px) and (max-width: 479px){& {
-            padding-bottom: 0;
-            padding-left: 0;
-            padding-right: 8px;
-            padding-top: 15px;
-          }
-    />
-  </div>
-  <div
-    className=
-        ms-Dialog-inner
-        {
-          padding-bottom: 24px;
-          padding-left: 24px;
-          padding-right: 24px;
-          padding-top: 0;
-        }
-        @media (min-width: 320px) and (max-width: 479px){& {
-          padding-bottom: 16px;
-          padding-left: 16px;
-          padding-right: 16px;
-          padding-top: 0;
-        }
-  >
-    <div
-      className=
-          ms-Dialog-content
-          {
+            box-sizing: border-box;
             position: relative;
             width: 100%;
           }
     >
-      <p
-        className=
-            ms-Dialog-subText
+      <div
+        aria-level="1"
+        class=
+            ms-Dialog-title
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              color: #605e5c;
+              color: #323130;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              line-height: 1.5;
-              margin-bottom: 24px;
+              font-size: 20px;
+              font-weight: 600;
+              line-height: normal;
+              margin-bottom: 0;
               margin-left: 0;
               margin-right: 0;
               margin-top: 0;
-              word-wrap: break-word;
+              min-height: 20px;
+              padding-bottom: 20px;
+              padding-left: 24px;
+              padding-right: 46px;
+              padding-top: 16px;
             }
-      >
-        Sample subtext
-      </p>
+            @media (min-width: 320px) and (max-width: 479px){& {
+              padding-bottom: 16px;
+              padding-left: 16px;
+              padding-right: 46px;
+              padding-top: 16px;
+            }
+        role="heading"
+      />
+      <div
+        class=
+
+            {
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 15px;
+              padding-top: 15px;
+              position: absolute;
+              right: 0;
+              top: 0;
+            }
+            & > * {
+              flex: 0 0 auto;
+            }
+            & .ms-Dialog-button {
+              color: #323130;
+            }
+            & .ms-Dialog-button:hover {
+              border-radius: 2px;
+              color: #201f1e;
+            }
+            @media (min-width: 320px) and (max-width: 479px){& {
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 8px;
+              padding-top: 15px;
+            }
+      />
+    </div>
+    <div
+      class=
+          ms-Dialog-inner
+          {
+            padding-bottom: 24px;
+            padding-left: 24px;
+            padding-right: 24px;
+            padding-top: 0;
+          }
+          @media (min-width: 320px) and (max-width: 479px){& {
+            padding-bottom: 16px;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+          }
+    >
+      <div
+        class=
+            ms-Dialog-content
+            {
+              position: relative;
+              width: 100%;
+            }
+      />
     </div>
   </div>
 </div>

--- a/packages/react/src/components/Modal/Modal.test.tsx
+++ b/packages/react/src/components/Modal/Modal.test.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
+import { render, act } from '@testing-library/react';
 import { Modal } from './Modal';
 import { ContextualMenu } from '../../ContextualMenu';
 import * as path from 'path';
 import { isConformant } from '../../common/isConformant';
-import { safeCreate } from '@fluentui/test-utilities';
-import { render, act } from '@testing-library/react';
-import { resetIds } from '../../Utilities';
-import { Popup } from '../Popup/Popup';
 import { expectNoHiddenParents } from '../../common/testUtilities';
+import { resetIds } from '../../Utilities';
 
 describe('Modal', () => {
   beforeEach(() => {
@@ -30,58 +28,36 @@ describe('Modal', () => {
   });
 
   it('renders Modal correctly', () => {
-    // Mock createPortal to capture its component hierarchy in snapshot output.
-    const ReactDOM = require('react-dom');
-    ReactDOM.createPortal = jest.fn(element => {
-      return element;
-    });
-
-    safeCreate(
-      <Modal isOpen={true} className={'test-className'} containerClassName={'test-containerClassName'}>
+    const { queryByText } = render(
+      <Modal isOpen className="test-className" containerClassName="test-containerClassName">
         Test Content
       </Modal>,
-      component => {
-        expect(component.toJSON()).toMatchSnapshot();
-        ReactDOM.createPortal.mockClear();
-      },
     );
+
+    expect(queryByText('Test Content')).toBeTruthy();
+
+    expect(document.body).toMatchSnapshot();
   });
 
   it('renders Modeless Modal correctly', () => {
-    // Mock createPortal to capture its component hierarchy in snapshot output.
-    const ReactDOM = require('react-dom');
-    ReactDOM.createPortal = jest.fn(element => {
-      return element;
-    });
-    safeCreate(
-      <Modal
-        isOpen={true}
-        isModeless={true}
-        className={'test-className'}
-        containerClassName={'test-containerClassName'}
-      >
+    const { queryByText } = render(
+      <Modal isOpen isModeless className="test-className" containerClassName="test-containerClassName">
         Test Content
       </Modal>,
-      component => {
-        expect(component!.toJSON()).toMatchSnapshot();
-        ReactDOM.createPortal.mockClear();
-      },
     );
+
+    expect(queryByText('Test Content')).toBeTruthy();
+
+    expect(document.body).toMatchSnapshot();
   });
 
   it('renders Draggable Modal correctly', () => {
-    // Mock createPortal to capture its component hierarchy in snapshot output.
-    const ReactDOM = require('react-dom');
-    ReactDOM.createPortal = jest.fn(element => {
-      return element;
-    });
-
-    safeCreate(
+    render(
       <Modal
-        isOpen={true}
-        isModeless={true}
-        className={'test-className'}
-        containerClassName={'test-containerClassName'}
+        isOpen
+        isModeless
+        className="test-className"
+        containerClassName="test-containerClassName"
         dragOptions={{
           moveMenuItemText: 'Move',
           closeMenuItemText: 'Close',
@@ -90,105 +66,44 @@ describe('Modal', () => {
       >
         Test Content
       </Modal>,
-      component => {
-        expect(component!.toJSON()).toMatchSnapshot();
-        ReactDOM.createPortal.mockClear();
-      },
     );
+    expect(document.body).toMatchSnapshot();
   });
 
-  it('renders a Modal with ARIA role alertDialog when isAlert is true ', () => {
-    // Mock createPortal to capture its component hierarchy in snapshot output.
-    const ReactDOM = require('react-dom');
-    ReactDOM.createPortal = jest.fn(element => {
-      return element;
-    });
-
-    safeCreate(
-      <Modal isOpen={true} isAlert={true} className={'test-className'} containerClassName={'test-containerClassName'}>
+  it('uses ARIA role alertdialog when isAlert is true ', () => {
+    const { queryByRole } = render(
+      <Modal isOpen isAlert>
         Test Content
       </Modal>,
-      component => {
-        const componentInstance = component.root;
-        expect(componentInstance.findByType(Popup).props.role).toBe('alertdialog');
-        ReactDOM.createPortal.mockClear();
-      },
     );
+    expect(queryByRole('alertdialog')).toBeTruthy();
   });
 
-  it('renders Modal with ARIA role dialog when isModeless and isBlocking are set to true', () => {
-    // Mock createPortal to capture its component hierarchy in snapshot output.
-    const ReactDOM = require('react-dom');
-    ReactDOM.createPortal = jest.fn(element => {
-      return element;
-    });
-
-    safeCreate(
-      <Modal
-        isOpen={true}
-        isAlert={false}
-        isModeless={true}
-        isBlocking={true}
-        className={'test-className'}
-        containerClassName={'test-containerClassName'}
-      >
+  it('uses ARIA role dialog when isModeless and isBlocking are true', () => {
+    const { queryByRole } = render(
+      <Modal isOpen isAlert={false} isModeless isBlocking>
         Test Content
       </Modal>,
-      component => {
-        const componentInstance = component.root;
-        expect(componentInstance.findByType(Popup).props.role).toBe('dialog');
-        ReactDOM.createPortal.mockClear();
-      },
     );
+    expect(queryByRole('dialog')).toBeTruthy();
   });
 
-  it('renders Modal with ARIA role dialog when isAlert is false', () => {
-    // Mock createPortal to capture its component hierarchy in snapshot output.
-    const ReactDOM = require('react-dom');
-    ReactDOM.createPortal = jest.fn(element => {
-      return element;
-    });
-
-    safeCreate(
-      <Modal
-        isOpen={true}
-        isAlert={false}
-        isBlocking={true}
-        className={'test-className'}
-        containerClassName={'test-containerClassName'}
-      >
+  it('uses ARIA role dialog when isAlert is false', () => {
+    const { queryByRole } = render(
+      <Modal isOpen isAlert={false} isBlocking>
         Test Content
       </Modal>,
-      component => {
-        const componentInstance = component.root;
-        expect(componentInstance.findByType(Popup).props.role).toBe('dialog');
-        ReactDOM.createPortal.mockClear();
-      },
     );
+    expect(queryByRole('dialog')).toBeTruthy();
   });
 
-  it('renders Modal with ARIA role alertdialog when isBlocking is true', () => {
-    // Mock createPortal to capture its component hierarchy in snapshot output.
-    const ReactDOM = require('react-dom');
-    ReactDOM.createPortal = jest.fn(element => {
-      return element;
-    });
-
-    safeCreate(
-      <Modal
-        isOpen={true}
-        isBlocking={true}
-        className={'test-className'}
-        containerClassName={'test-containerClassName'}
-      >
+  it('uses ARIA role alertdialog when isBlocking is true', () => {
+    const { queryByRole } = render(
+      <Modal isOpen isBlocking>
         Test Content
       </Modal>,
-      component => {
-        const componentInstance = component.root;
-        expect(componentInstance.findByType(Popup).props.role).toBe('alertdialog');
-        ReactDOM.createPortal.mockClear();
-      },
     );
+    expect(queryByRole('alertdialog')).toBeTruthy();
   });
 
   describe('enableAriaHiddenSiblings', () => {

--- a/packages/react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -1,514 +1,464 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Modal renders Draggable Modal correctly 1`] = `
-<span
-  className="ms-layer"
->
-  <div
-    className=
-        ms-Fabric
-        ms-Layer-content
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          color: #323130;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          visibility: visible;
-        }
-        & button {
-          font-family: inherit;
-        }
-        & input {
-          font-family: inherit;
-        }
-        & textarea {
-          font-family: inherit;
-        }
-    onBlur={[Function]}
-    onChange={[Function]}
-    onClick={[Function]}
-    onContextMenu={[Function]}
-    onDoubleClick={[Function]}
-    onDrag={[Function]}
-    onDragEnd={[Function]}
-    onDragEnter={[Function]}
-    onDragExit={[Function]}
-    onDragLeave={[Function]}
-    onDragOver={[Function]}
-    onDragStart={[Function]}
-    onDrop={[Function]}
-    onFocus={[Function]}
-    onInput={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseMove={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
-    onMouseUp={[Function]}
-    onSubmit={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-  >
-    <div
-      aria-modal={false}
-      onKeyDown={[Function]}
-      role="dialog"
-      style={
-        Object {
-          "outline": "none",
-          "overflowY": undefined,
-        }
-      }
-    >
-      <div
-        className=
-            ms-Modal
-            is-open
-            test-className
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              align-items: center;
-              background-color: transparent;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 100%;
-              justify-content: center;
-              opacity: 1;
-              pointer-events: auto;
-              position: absolute;
-              transition: opacity 0.267s;
-              width: 100%;
-            }
-      >
-        <div
-          className=
-              ms-Dialog-main
-              test-containerClassName
-              {
-                background-color: #ffffff;
-                border-radius: 2px;
-                box-shadow: 0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18);
-                box-sizing: border-box;
-                cursor: move;
-                max-height: calc(100% - 32px);
-                max-width: calc(100% - 32px);
-                min-height: 176px;
-                min-width: 288px;
-                outline: 3px solid transparent;
-                overflow-y: auto;
-                position: relative;
-                text-align: left;
-                z-index: 1000000;
-              }
-          id="ModalFocusTrapZone0"
-          onBlurCapture={[Function]}
-          onFocusCapture={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchStart={[Function]}
-          style={
-            Object {
-              "transform": "translate(0px, 0px)",
-            }
-          }
-        >
-          <div
-            aria-hidden={true}
-            data-is-focus-trap-zone-bumper={true}
-            data-is-visible={true}
-            style={
-              Object {
-                "pointerEvents": "none",
-                "position": "fixed",
-              }
-            }
-            tabIndex={0}
-          />
-          <div
-            className=
-                ms-Modal-scrollableContent
-                {
-                  flex-grow: 1;
-                  max-height: 100vh;
-                  overflow-y: auto;
-                }
-                @supports (-webkit-overflow-scrolling: touch){& {
-                  max-height: 768px;
-                }
-            data-is-scrollable={true}
-          >
-            Test Content
-          </div>
-          <div
-            aria-hidden={true}
-            data-is-focus-trap-zone-bumper={true}
-            data-is-visible={true}
-            style={
-              Object {
-                "pointerEvents": "none",
-                "position": "fixed",
-              }
-            }
-            tabIndex={0}
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-</span>
-`;
+<body
+  class=
 
-exports[`Modal renders Modal correctly 1`] = `
-<span
-  className="ms-layer"
+      {
+        overflow: hidden !important;
+      }
 >
   <div
-    className=
-        ms-Fabric
-        ms-Layer-content
+    class=
+        ms-Layer
+        ms-Layer--fixed
+        ms-Modal-Layer
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: #323130;
+          bottom: 0px;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
-          visibility: visible;
+          height: unset;
+          left: 0px;
+          position: static;
+          right: 0px;
+          top: 0px;
+          visibility: hidden;
+          width: unset;
+          z-index: 1000000;
         }
-        & button {
-          font-family: inherit;
-        }
-        & input {
-          font-family: inherit;
-        }
-        & textarea {
-          font-family: inherit;
-        }
-    onBlur={[Function]}
-    onChange={[Function]}
-    onClick={[Function]}
-    onContextMenu={[Function]}
-    onDoubleClick={[Function]}
-    onDrag={[Function]}
-    onDragEnd={[Function]}
-    onDragEnter={[Function]}
-    onDragExit={[Function]}
-    onDragLeave={[Function]}
-    onDragOver={[Function]}
-    onDragStart={[Function]}
-    onDrop={[Function]}
-    onFocus={[Function]}
-    onInput={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseMove={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
-    onMouseUp={[Function]}
-    onSubmit={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
+    data-portal-element="true"
   >
     <div
-      aria-modal={true}
-      onKeyDown={[Function]}
-      role="dialog"
-      style={
-        Object {
-          "outline": "none",
-          "overflowY": undefined,
-        }
-      }
+      class=
+          ms-Fabric
+          ms-Layer-content
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            visibility: visible;
+          }
+          & button {
+            font-family: inherit;
+          }
+          & input {
+            font-family: inherit;
+          }
+          & textarea {
+            font-family: inherit;
+          }
     >
       <div
-        className=
-            ms-Modal
-            is-open
-            test-className
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              align-items: center;
-              background-color: transparent;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 100%;
-              justify-content: center;
-              opacity: 1;
-              pointer-events: auto;
-              position: fixed;
-              transition: opacity 0.267s;
-              width: 100%;
-            }
-        role="document"
+        aria-modal="false"
+        role="dialog"
+        style="outline: none;"
       >
         <div
-          aria-hidden={true}
-          className=
-              ms-Overlay
-              ms-Overlay--dark
+          class=
+              ms-Modal
+              is-open
+              test-className
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: rgba(0,0,0,.4);
-                bottom: 0px;
+                align-items: center;
+                background-color: transparent;
+                display: flex;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                left: 0px;
+                height: 100%;
+                justify-content: center;
+                opacity: 1;
+                pointer-events: auto;
                 position: absolute;
-                right: 0px;
-                top: 0px;
+                transition: opacity 0.267s;
+                width: 100%;
               }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                border: 1px solid WindowText;
-                opacity: 0;
-              }
-        />
-        <div
-          className=
-              ms-Dialog-main
-              test-containerClassName
-              {
-                background-color: #ffffff;
-                border-radius: 2px;
-                box-shadow: 0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18);
-                box-sizing: border-box;
-                max-height: calc(100% - 32px);
-                max-width: calc(100% - 32px);
-                min-height: 176px;
-                min-width: 288px;
-                outline: 3px solid transparent;
-                overflow-y: auto;
-                position: relative;
-                text-align: left;
-              }
-          id="ModalFocusTrapZone0"
-          onBlurCapture={[Function]}
-          onFocusCapture={[Function]}
         >
           <div
-            aria-hidden={true}
-            data-is-focus-trap-zone-bumper={true}
-            data-is-visible={true}
-            style={
-              Object {
-                "pointerEvents": "none",
-                "position": "fixed",
-              }
-            }
-            tabIndex={0}
-          />
-          <div
-            className=
-                ms-Modal-scrollableContent
+            class=
+                ms-Dialog-main
+                test-containerClassName
                 {
-                  flex-grow: 1;
-                  max-height: 100vh;
+                  background-color: #ffffff;
+                  border-radius: 2px;
+                  box-shadow: 0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18);
+                  box-sizing: border-box;
+                  cursor: move;
+                  max-height: calc(100% - 32px);
+                  max-width: calc(100% - 32px);
+                  min-height: 176px;
+                  min-width: 288px;
+                  outline: 3px solid transparent;
                   overflow-y: auto;
+                  position: relative;
+                  text-align: left;
+                  z-index: 1000000;
                 }
-                @supports (-webkit-overflow-scrolling: touch){& {
-                  max-height: 768px;
-                }
-            data-is-scrollable={true}
+            id="ModalFocusTrapZone0"
+            style="transform: translate(0px, 0px);"
           >
-            Test Content
+            <div
+              aria-hidden="true"
+              data-is-focus-trap-zone-bumper="true"
+              data-is-visible="true"
+              style="pointer-events: none; position: fixed;"
+              tabindex="0"
+            />
+            <div
+              class=
+                  ms-Modal-scrollableContent
+                  {
+                    flex-grow: 1;
+                    max-height: 100vh;
+                    overflow-y: auto;
+                  }
+                  @supports (-webkit-overflow-scrolling: touch){& {
+                    max-height: 768px;
+                  }
+              data-is-scrollable="true"
+            >
+              Test Content
+            </div>
+            <div
+              aria-hidden="true"
+              data-is-focus-trap-zone-bumper="true"
+              data-is-visible="true"
+              style="pointer-events: none; position: fixed;"
+              tabindex="0"
+            />
           </div>
-          <div
-            aria-hidden={true}
-            data-is-focus-trap-zone-bumper={true}
-            data-is-visible={true}
-            style={
-              Object {
-                "pointerEvents": "none",
-                "position": "fixed",
-              }
-            }
-            tabIndex={0}
-          />
         </div>
       </div>
     </div>
   </div>
-</span>
+  <div
+    aria-hidden="true"
+  >
+    <span
+      class="ms-layer"
+    />
+  </div>
+</body>
 `;
 
-exports[`Modal renders Modeless Modal correctly 1`] = `
-<span
-  className="ms-layer"
+exports[`Modal renders Modal correctly 1`] = `
+<body
+  class=
+
+      {
+        overflow: hidden !important;
+      }
 >
   <div
-    className=
-        ms-Fabric
-        ms-Layer-content
+    aria-hidden="true"
+  >
+    <span
+      class="ms-layer"
+    />
+  </div>
+  <div
+    class=
+        ms-Layer
+        ms-Layer--fixed
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: #323130;
+          bottom: 0px;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
-          visibility: visible;
+          left: 0px;
+          position: fixed;
+          right: 0px;
+          top: 0px;
+          visibility: hidden;
+          z-index: 1000000;
         }
-        & button {
-          font-family: inherit;
-        }
-        & input {
-          font-family: inherit;
-        }
-        & textarea {
-          font-family: inherit;
-        }
-    onBlur={[Function]}
-    onChange={[Function]}
-    onClick={[Function]}
-    onContextMenu={[Function]}
-    onDoubleClick={[Function]}
-    onDrag={[Function]}
-    onDragEnd={[Function]}
-    onDragEnter={[Function]}
-    onDragExit={[Function]}
-    onDragLeave={[Function]}
-    onDragOver={[Function]}
-    onDragStart={[Function]}
-    onDrop={[Function]}
-    onFocus={[Function]}
-    onInput={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseMove={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
-    onMouseUp={[Function]}
-    onSubmit={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
+    data-portal-element="true"
   >
     <div
-      aria-modal={false}
-      onKeyDown={[Function]}
-      role="dialog"
-      style={
-        Object {
-          "outline": "none",
-          "overflowY": undefined,
-        }
-      }
+      class=
+          ms-Fabric
+          ms-Layer-content
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            visibility: visible;
+          }
+          & button {
+            font-family: inherit;
+          }
+          & input {
+            font-family: inherit;
+          }
+          & textarea {
+            font-family: inherit;
+          }
     >
       <div
-        className=
-            ms-Modal
-            is-open
-            test-className
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              align-items: center;
-              background-color: transparent;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 100%;
-              justify-content: center;
-              opacity: 1;
-              pointer-events: auto;
-              position: absolute;
-              transition: opacity 0.267s;
-              width: 100%;
-            }
+        aria-modal="true"
+        role="dialog"
+        style="outline: none;"
       >
         <div
-          className=
-              ms-Dialog-main
-              test-containerClassName
+          class=
+              ms-Modal
+              is-open
+              test-className
               {
-                background-color: #ffffff;
-                border-radius: 2px;
-                box-shadow: 0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18);
-                box-sizing: border-box;
-                max-height: calc(100% - 32px);
-                max-width: calc(100% - 32px);
-                min-height: 176px;
-                min-width: 288px;
-                outline: 3px solid transparent;
-                overflow-y: auto;
-                position: relative;
-                text-align: left;
-                z-index: 1000000;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                background-color: transparent;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 100%;
+                justify-content: center;
+                opacity: 1;
+                pointer-events: auto;
+                position: fixed;
+                transition: opacity 0.267s;
+                width: 100%;
               }
-          id="ModalFocusTrapZone0"
-          onBlurCapture={[Function]}
-          onFocusCapture={[Function]}
+          role="document"
         >
           <div
-            aria-hidden={true}
-            data-is-focus-trap-zone-bumper={true}
-            data-is-visible={true}
-            style={
-              Object {
-                "pointerEvents": "none",
-                "position": "fixed",
-              }
-            }
-            tabIndex={0}
-          />
-          <div
-            className=
-                ms-Modal-scrollableContent
+            aria-hidden="true"
+            class=
+                ms-Overlay
+                ms-Overlay--dark
                 {
-                  flex-grow: 1;
-                  max-height: 100vh;
-                  overflow-y: auto;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: rgba(0,0,0,.4);
+                  bottom: 0px;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  left: 0px;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
                 }
-                @supports (-webkit-overflow-scrolling: touch){& {
-                  max-height: 768px;
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border: 1px solid WindowText;
+                  opacity: 0;
                 }
-            data-is-scrollable={true}
-          >
-            Test Content
-          </div>
-          <div
-            aria-hidden={true}
-            data-is-focus-trap-zone-bumper={true}
-            data-is-visible={true}
-            style={
-              Object {
-                "pointerEvents": "none",
-                "position": "fixed",
-              }
-            }
-            tabIndex={0}
           />
+          <div
+            class=
+                ms-Dialog-main
+                test-containerClassName
+                {
+                  background-color: #ffffff;
+                  border-radius: 2px;
+                  box-shadow: 0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18);
+                  box-sizing: border-box;
+                  max-height: calc(100% - 32px);
+                  max-width: calc(100% - 32px);
+                  min-height: 176px;
+                  min-width: 288px;
+                  outline: 3px solid transparent;
+                  overflow-y: auto;
+                  position: relative;
+                  text-align: left;
+                }
+            id="ModalFocusTrapZone0"
+          >
+            <div
+              aria-hidden="true"
+              data-is-focus-trap-zone-bumper="true"
+              data-is-visible="true"
+              style="pointer-events: none; position: fixed;"
+              tabindex="0"
+            />
+            <div
+              class=
+                  ms-Modal-scrollableContent
+                  {
+                    flex-grow: 1;
+                    max-height: 100vh;
+                    overflow-y: auto;
+                  }
+                  @supports (-webkit-overflow-scrolling: touch){& {
+                    max-height: 768px;
+                  }
+              data-is-scrollable="true"
+            >
+              Test Content
+            </div>
+            <div
+              aria-hidden="true"
+              data-is-focus-trap-zone-bumper="true"
+              data-is-visible="true"
+              style="pointer-events: none; position: fixed;"
+              tabindex="0"
+            />
+          </div>
         </div>
       </div>
     </div>
   </div>
-</span>
+</body>
+`;
+
+exports[`Modal renders Modeless Modal correctly 1`] = `
+<body
+  class=
+
+      {
+        overflow: hidden !important;
+      }
+>
+  <div
+    class=
+        ms-Layer
+        ms-Layer--fixed
+        ms-Modal-Layer
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          bottom: 0px;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: unset;
+          left: 0px;
+          position: static;
+          right: 0px;
+          top: 0px;
+          visibility: hidden;
+          width: unset;
+          z-index: 1000000;
+        }
+    data-portal-element="true"
+  >
+    <div
+      class=
+          ms-Fabric
+          ms-Layer-content
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            visibility: visible;
+          }
+          & button {
+            font-family: inherit;
+          }
+          & input {
+            font-family: inherit;
+          }
+          & textarea {
+            font-family: inherit;
+          }
+    >
+      <div
+        aria-modal="false"
+        role="dialog"
+        style="outline: none;"
+      >
+        <div
+          class=
+              ms-Modal
+              is-open
+              test-className
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                background-color: transparent;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 100%;
+                justify-content: center;
+                opacity: 1;
+                pointer-events: auto;
+                position: absolute;
+                transition: opacity 0.267s;
+                width: 100%;
+              }
+        >
+          <div
+            class=
+                ms-Dialog-main
+                test-containerClassName
+                {
+                  background-color: #ffffff;
+                  border-radius: 2px;
+                  box-shadow: 0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18);
+                  box-sizing: border-box;
+                  max-height: calc(100% - 32px);
+                  max-width: calc(100% - 32px);
+                  min-height: 176px;
+                  min-width: 288px;
+                  outline: 3px solid transparent;
+                  overflow-y: auto;
+                  position: relative;
+                  text-align: left;
+                  z-index: 1000000;
+                }
+            id="ModalFocusTrapZone0"
+          >
+            <div
+              aria-hidden="true"
+              data-is-focus-trap-zone-bumper="true"
+              data-is-visible="true"
+              style="pointer-events: none; position: fixed;"
+              tabindex="0"
+            />
+            <div
+              class=
+                  ms-Modal-scrollableContent
+                  {
+                    flex-grow: 1;
+                    max-height: 100vh;
+                    overflow-y: auto;
+                  }
+                  @supports (-webkit-overflow-scrolling: touch){& {
+                    max-height: 768px;
+                  }
+              data-is-scrollable="true"
+            >
+              Test Content
+            </div>
+            <div
+              aria-hidden="true"
+              data-is-focus-trap-zone-bumper="true"
+              data-is-visible="true"
+              style="pointer-events: none; position: fixed;"
+              tabindex="0"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-hidden="true"
+  >
+    <span
+      class="ms-layer"
+    />
+  </div>
+</body>
 `;

--- a/packages/react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -139,9 +139,7 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <span
       class="ms-layer"
     />
@@ -453,9 +451,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <span
       class="ms-layer"
     />


### PR DESCRIPTION
## Current Behavior

Callout, Dialog, and Modal's tests use a mix of enzyme, react-test-renderer, and react-dom, along with assorted odd patterns such as unnecessary snapshot testing.

## New Behavior

Convert the tests to all use testing-library. In some cases I also tweaked what the tests were doing to be simpler or to test things more directly/effectively: for example, replacing some of the snapshot tests with direct tests of the relevant DOM.

**Please review snapshot updates with whitespace changes hidden!**

I noticed that some of the tests were having issues due to conformance tests not fully cleaning up. As a temporary workaround in react-conformance (until it's also converted to use testing-library), I added an `afterEach` which does `document.body.innerHTML = ''`.

## Related Issue(s)

Part of #21663