### PR TITLE
chore: Deploy vr-test site during CI run

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,7 +168,7 @@ jobs:
           BlobPrefix: $(deployBasePath)/react-screener
           CacheControl: 'public, max-age=600000'
           ContainerName: '$web'
-          SourcePath: 'packages/apps/vr-test/dist/storybook'
+          SourcePath: 'apps/vr-test/dist/storybook'
           storage: $(azureStorage)
 
       # Don't use lage here because it eats long output for reasons that are hard to debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,7 +168,7 @@ jobs:
           BlobPrefix: $(deployBasePath)/react-screener
           CacheControl: 'public, max-age=600000'
           ContainerName: '$web'
-          SourcePath: 'apps/vr-test/dist/storybook'
+          SourcePath: 'apps/vr-tests/dist/storybook'
           storage: $(azureStorage)
 
       # Don't use lage here because it eats long output for reasons that are hard to debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,7 +168,7 @@ jobs:
           BlobPrefix: $(deployBasePath)/react-screener
           CacheControl: 'public, max-age=600000'
           ContainerName: '$web'
-          SourcePath: 'packages/apps/vr-test/dist'
+          SourcePath: 'packages/apps/vr-test/dist/storybook'
           storage: $(azureStorage)
 
       # Don't use lage here because it eats long output for reasons that are hard to debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,6 +161,16 @@ jobs:
           yarn workspace @fluentui/vr-tests screener:build
         displayName: build vr-tests storybook
 
+      - task: AzureUpload@2
+        displayName: Upload @fluentui/react VR test site
+        inputs:
+          azureSubscription: $(azureSubscription)
+          BlobPrefix: $(deployBasePath)/react-screener
+          CacheControl: 'public, max-age=600000'
+          ContainerName: '$web'
+          SourcePath: 'packages/apps/vr-test/dist'
+          storage: $(azureStorage)
+
       # Don't use lage here because it eats long output for reasons that are hard to debug
       - script: |
           yarn workspace @fluentui/vr-tests screener


### PR DESCRIPTION
In preparation to use our screener proxy to run vr-tests, the vr-test
story book needs to be uploaded to Azure storage similar to what is
being done for Northstar.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

vr-tests storybook is not being deployed to azure in CI

## New Behavior

vr-tests storybook is being deployed to azure in CI

[LINK TO PR STORYBOOK](https://fluentuipr.z22.web.core.windows.net/pull/21668/react-screener/index.html)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
