### PR TITLE
[v7] DetailsList :Add prop to selectionZone to disable default behavior that clears selection when clicking on non-toggle surface

### DIFF
--- a/change/office-ui-fabric-react-d25edab7-544c-4ad9-b9bb-2a4bbbc4317c.json
+++ b/change/office-ui-fabric-react-d25edab7-544c-4ad9-b9bb-2a4bbbc4317c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "SelectionZone: Add prop to disable default behavior that clears selection when clicking on non-toggle surface.",
+  "packageName": "office-ui-fabric-react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7314,6 +7314,7 @@ export interface ISelectionZoneProps extends React.ClassAttributes<SelectionZone
     onItemContextMenu?: (item?: any, index?: number, ev?: Event) => void | boolean;
     onItemInvoked?: (item?: IObjectWithKey, index?: number, ev?: Event) => void;
     selection: ISelection;
+    selectionClearedOnSurfaceClick?: boolean;
     selectionMode?: SelectionMode;
     selectionPreservedOnEmptyClick?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -98,7 +98,7 @@ export interface ISelectionZoneProps extends React.ClassAttributes<SelectionZone
   isSelectedOnFocus?: boolean;
   /**
    * Determines if elements within the selection zone that DO NOT have the 'data-selection-toggle' or
-   * 'data-selection-all-toggle' attribute are clickable and can alter the selection.
+   * 'data-selection-all-toggle' attribute are clickable and can alter the selection .
    *
    * @defaultvalue true
    */

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -97,6 +97,13 @@ export interface ISelectionZoneProps extends React.ClassAttributes<SelectionZone
    */
   isSelectedOnFocus?: boolean;
   /**
+   * Determines if elements within the selection zone that DO NOT have the 'data-selection-toggle' or
+   * 'data-selection-all-toggle' attribute are clickable and can alter the selection.
+   *
+   * @defaultvalue true
+   */
+  selectionClearedOnSurfaceClick?: boolean;
+  /**
    * Optional callback for when an item is
    * invoked via ENTER or double-click.
    */
@@ -674,10 +681,10 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
   }
 
   private _clearAndSelectIndex(index: number): void {
-    const { selection } = this.props;
+    const { selection, selectionClearedOnSurfaceClick = true } = this.props;
     const isAlreadySingleSelected = selection.getSelectedCount() === 1 && selection.isIndexSelected(index);
 
-    if (!isAlreadySingleSelected) {
+    if (!isAlreadySingleSelected && selectionClearedOnSurfaceClick) {
       const isModal = selection.isModal && selection.isModal();
       selection.setChangeEvents(false);
       selection.setAllSelected(false);

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -98,7 +98,7 @@ export interface ISelectionZoneProps extends React.ClassAttributes<SelectionZone
   isSelectedOnFocus?: boolean;
   /**
    * Determines if elements within the selection zone that DO NOT have the 'data-selection-toggle' or
-   * 'data-selection-all-toggle' attribute are clickable and can alter the selection .
+   * 'data-selection-all-toggle' attribute are clickable and can alter the selection.
    *
    * @defaultvalue true
    */


### PR DESCRIPTION
cherry-pick of #21641

---

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


## Current Behavior

- When a user clicks on any part of the  `DetailsList`, that row is immediately marked as selected. However this behavior presents issues when there are already multiple rows already selected as clicking on any part of the `DetailsList` that's not the checkbox clears the previously selected rows and selects that lone clicked row.
- ### Clicking any non-checkbox part of a row clears the selection and selects that one row only:
  - ![DetailsListIssue](https://user-images.githubusercontent.com/8649804/152933676-9e25cf35-f279-4216-9806-1b45d6ecdc46.gif)


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- Adds a new prop called `selectionClearedOnSurfaceClick` to `SelectionZone` so now when a non-toggle element is clicked, nothing will get selected or unselected. The default behavior will have this default to `true` to preserve current behavior but this option gives consumers a way to opt out by passing `selectionZoneProps={{ selectionClearedOnSurfaceClick: false }}` to `DetailsList`. 

- ### Only clicking the checkbox will actually toggle selection:
  - ![DetailsListFix](https://user-images.githubusercontent.com/8649804/152932861-fbb3eee4-4316-42d8-ba7c-62047c54a2a7.gif)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21185
