### PR TITLE
Move v9 Label to unstable

### DIFF
--- a/change/@fluentui-react-components-7702cb80-2bd9-4a3b-bb4d-28a95695e9e0.json
+++ b/change/@fluentui-react-components-7702cb80-2bd9-4a3b-bb4d-28a95695e9e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Move Label to unstable",
+  "packageName": "@fluentui/react-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-d0f89daf-4f48-4c36-9887-d46eaa221d1d.json
+++ b/change/@fluentui-react-input-d0f89daf-4f48-4c36-9887-d46eaa221d1d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update docs description",
+  "packageName": "@fluentui/react-input",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-8a94cbc7-e9d0-4f47-8729-14895fba88b5.json
+++ b/change/@fluentui-react-label-8a94cbc7-e9d0-4f47-8729-14895fba88b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update docs description",
+  "packageName": "@fluentui/react-label",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/etc/react-components.api.md
+++ b/packages/react-components/etc/react-components.api.md
@@ -103,11 +103,6 @@ import { imageClassName } from '@fluentui/react-image';
 import { ImageProps } from '@fluentui/react-image';
 import { ImageSlots } from '@fluentui/react-image';
 import { ImageState } from '@fluentui/react-image';
-import { Label } from '@fluentui/react-label';
-import { labelClassName } from '@fluentui/react-label';
-import { LabelProps } from '@fluentui/react-label';
-import { LabelSlots } from '@fluentui/react-label';
-import { LabelState } from '@fluentui/react-label';
 import { LargeTitle } from '@fluentui/react-text';
 import { largeTitleClassName } from '@fluentui/react-text';
 import { LineHeightTokens } from '@fluentui/react-theme';
@@ -226,7 +221,6 @@ import { renderDivider_unstable } from '@fluentui/react-divider';
 import { RendererProvider } from '@griffel/react';
 import { renderFluentProvider_unstable } from '@fluentui/react-provider';
 import { renderImage_unstable } from '@fluentui/react-image';
-import { renderLabel_unstable } from '@fluentui/react-label';
 import { renderLink_unstable } from '@fluentui/react-link';
 import { renderMenu_unstable } from '@fluentui/react-menu';
 import { renderMenuButton_unstable } from '@fluentui/react-button';
@@ -321,8 +315,6 @@ import { useFluentProviderContextValues_unstable } from '@fluentui/react-provide
 import { useFluentProviderStyles_unstable } from '@fluentui/react-provider';
 import { useImage_unstable } from '@fluentui/react-image';
 import { useImageStyles_unstable } from '@fluentui/react-image';
-import { useLabel_unstable } from '@fluentui/react-label';
-import { useLabelStyles_unstable } from '@fluentui/react-label';
 import { useLink_unstable } from '@fluentui/react-link';
 import { useLinkState_unstable } from '@fluentui/react-link';
 import { useLinkStyles_unstable } from '@fluentui/react-link';
@@ -570,16 +562,6 @@ export { ImageSlots }
 
 export { ImageState }
 
-export { Label }
-
-export { labelClassName }
-
-export { LabelProps }
-
-export { LabelSlots }
-
-export { LabelState }
-
 export { LargeTitle }
 
 export { largeTitleClassName }
@@ -816,8 +798,6 @@ export { renderFluentProvider_unstable }
 
 export { renderImage_unstable }
 
-export { renderLabel_unstable }
-
 export { renderLink_unstable }
 
 export { renderMenu_unstable }
@@ -1005,10 +985,6 @@ export { useFluentProviderStyles_unstable }
 export { useImage_unstable }
 
 export { useImageStyles_unstable }
-
-export { useLabel_unstable }
-
-export { useLabelStyles_unstable }
 
 export { useLink_unstable }
 

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -203,14 +203,6 @@ export {
 } from '@fluentui/react-image';
 export type { ImageProps, ImageSlots, ImageState } from '@fluentui/react-image';
 export {
-  Label,
-  labelClassName,
-  renderLabel_unstable,
-  useLabel_unstable,
-  useLabelStyles_unstable,
-} from '@fluentui/react-label';
-export type { LabelProps, LabelSlots, LabelState } from '@fluentui/react-label';
-export {
   Link,
   linkClassName,
   renderLink_unstable,

--- a/packages/react-components/src/unstable/index.ts
+++ b/packages/react-components/src/unstable/index.ts
@@ -36,6 +36,7 @@ export type {
   CardSlots,
   CardState,
 } from '@fluentui/react-card';
+
 export {
   Input,
   inputClassName,
@@ -44,6 +45,15 @@ export {
   useInputStyles_unstable,
 } from '@fluentui/react-input';
 export type { InputOnChangeData, InputProps, InputSlots, InputState } from '@fluentui/react-input';
+
+export {
+  Label,
+  labelClassName,
+  renderLabel_unstable,
+  useLabel_unstable,
+  useLabelStyles_unstable,
+} from '@fluentui/react-label';
+export type { LabelProps, LabelSlots, LabelState } from '@fluentui/react-label';
 
 export {
   Slider,

--- a/packages/react-input/src/stories/Input.stories.tsx
+++ b/packages/react-input/src/stories/Input.stories.tsx
@@ -19,11 +19,8 @@ const meta: Meta = {
   component: Input,
   parameters: {
     docs: {
-      // The provided typing is wrong, ignore it
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       description: {
-        component: [descriptionMd].join('\n'),
+        component: descriptionMd,
       },
     },
   },

--- a/packages/react-input/src/stories/InputDescription.md
+++ b/packages/react-input/src/stories/InputDescription.md
@@ -1,11 +1,13 @@
+Input allows the user to enter and edit text.
+
 <!-- Don't allow prettier to collapse code block into single line -->
 <!-- prettier-ignore -->
 > **⚠️ Preview components are considered unstable:**
 >
 > ```jsx
-> 
+>
 > import { Input } from '@fluentui/react-components/unstable';
-> 
+>
 > ```
 >
 > - Features and APIs may change before final release

--- a/packages/react-label/src/stories/Label.stories.tsx
+++ b/packages/react-label/src/stories/Label.stories.tsx
@@ -2,19 +2,20 @@ import * as React from 'react';
 import { Meta } from '@storybook/react';
 import { Label } from '../index';
 
+import descriptionMd from './LabelDescription.md';
 export { Default } from './LabelDefault.stories';
 export { Size } from './LabelSize.stories';
 export { Strong } from './LabelStrong.stories';
 export { Disabled } from './LabelDisabled.stories';
 export { Required } from './LabelRequired.stories';
 
-export default {
-  title: 'Components/Label',
+const meta: Meta = {
+  title: 'Preview Components/Label',
   component: Label,
   parameters: {
     docs: {
       description: {
-        component: 'A label component provides a title or name to a component.',
+        component: descriptionMd,
       },
     },
   },
@@ -32,4 +33,6 @@ export default {
       </div>
     ),
   ],
-} as Meta;
+};
+
+export default meta;

--- a/packages/react-label/src/stories/LabelDescription.md
+++ b/packages/react-label/src/stories/LabelDescription.md
@@ -1,0 +1,10 @@
+A label provides a name or title for an input.
+
+> **⚠️ Preview components are considered unstable:**
+>
+> ```jsx
+> import { Label } from '@fluentui/react-components/unstable';
+> ```
+>
+> - Features and APIs may change before final release
+> - Please contact us if you intend to use this in your product

--- a/typings/storybook__addons/index.d.ts
+++ b/typings/storybook__addons/index.d.ts
@@ -1,8 +1,5 @@
 // Type definitions extension for @storybook/addons 6.0.18
-// Project: https://github.com/storybookjs/storybook/tree/next/lib/addons
-// Definitions by: Martin Hochel
-// Definitions: N/A
-// TypeScript Version: 3.1
+// Project: https://github.com/storybookjs/storybook/tree/main/lib/addons
 
 import { ViewMode } from '@storybook/addons';
 import * as React from 'react';
@@ -21,45 +18,52 @@ declare module '@storybook/addons' {
      * Note that this behaviour is rather confusing and will work only after 1st user interaction click
      * on particular menu item. On initial render canvas will be always rendered.
      *
-     * @see https://github.com/storybookjs/storybook/blob/next/addons/docs/docs/recipes.md#controlling-a-storys-view-mode
+     * @see https://github.com/storybookjs/storybook/blob/main/addons/docs/docs/recipes.md#controlling-a-storys-view-mode
      */
     viewMode?: ViewMode;
     /**
      * configure Storybook's preview tabs
-     * @see https://github.com/storybookjs/storybook/blob/next/addons/docs/docs/recipes.md#reordering-docs-tab-first
+     * @see https://github.com/storybookjs/storybook/blob/main/addons/docs/docs/recipes.md#reordering-docs-tab-first
      */
-    previewTabs?: Record<'storybook/docs/panel' | 'canvas', Partial<{ index: number; hidden: boolean }>>;
-    docs?: Partial<{
-      source: {
+    previewTabs?: Record<'storybook/docs/panel' | 'canvas', { index?: number; hidden?: boolean }>;
+    docs?: {
+      description?: {
+        /** Description for a whole component */
+        component?: string;
+        /** Description for an individual story */
+        story?: string;
+      };
+
+      source?: {
         /**
          * enable/disable rendering decorators in Docs mode
          */
         excludeDecorators: boolean;
       };
 
-      container: React.ComponentType<any>;
-      page: React.ComponentType<any>;
+      container?: React.ComponentType<any>;
+      page?: React.ComponentType<any>;
 
       /**
-       * https://github.com/storybookjs/storybook/tree/next/addons/docs/react#inline-stories
+       * https://github.com/storybookjs/storybook/tree/main/addons/docs/react#inline-stories
        */
-      inlineStories: boolean;
-    }>;
+      inlineStories?: boolean;
+    };
     /**
      * @see https://github.com/microsoft/fluentui-storybook-addons
      */
-    exportToCodeSandbox?: Partial<AddonExportToCodesandboxParameters>;
+    exportToCodeSandbox?: AddonExportToCodesandboxParameters;
   }
 
   interface AddonExportToCodesandboxParameters {
     /**
      * Dependencies that should be included with every story
      */
-    requiredDependencies: Record<string, string>;
+    requiredDependencies?: Record<string, string>;
     /**
      * Content of index.tsx in CodeSandbox
      */
-    indexTsx: string;
+    indexTsx?: string;
   }
 
   interface ControlsParameters {


### PR DESCRIPTION
## Current Behavior

Label is exported from `@fluentui/react-components` as almost-RC but all the input components are still unstable or not exported

## New Behavior

Move Label to `/unstable` and update its docs description accordingly.

Update Input's docs description to include an actual explanation of the component, not just an unstable notice.

Update custom `@storybook/addons` typings to include proper typings for `docs.description.component` to get rid of the need for a cast in Input and Label stories