### PR TITLE
Enable cypress for v8

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
   },
   // Configure glob patterns for excluding files and folders in searches. Inherits all glob patterns from the file.exclude setting.
   "search.exclude": {
+    ".yarn/releases": true,
     "common/temp": true,
     "**/node_modules": true,
     "**/lib": true,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,9 +103,9 @@ jobs:
           # This MUST have a trailing slash, or the links to PR deploy site assets won't work
           githubTargetLink: $(deployUrl)/
 
-      # only run e2e tests when converged storybook is published by scoping to the converged suite package
+      # only run e2e tests when the appropriate storybook is published by scoping to relevant packages
       - script: |
-          yarn e2e $(sinceArg) --scope @fluentui/react-components
+          yarn e2e $(sinceArg) --scope @fluentui/react-components --scope @fluentui/react
         displayName: Cypress E2E tests
 
       - template: .devops/templates/cleanup.yml

--- a/change/@fluentui-eslint-plugin-b9154030-4181-4675-b110-63c62d547695.json
+++ b/change/@fluentui-eslint-plugin-b9154030-4181-4675-b110-63c62d547695.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add ./e2e to list of files allowing devDependencies",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-01f47d41-d589-464a-ada7-4ae8b9d47604.json
+++ b/change/@fluentui-react-01f47d41-d589-464a-ada7-4ae8b9d47604.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add command to run e2e tests",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/src/utils/configHelpers.js
+++ b/packages/eslint-plugin/src/utils/configHelpers.js
@@ -9,6 +9,7 @@ const testFiles = [
   '**/{test,tests}/**',
   '**/testUtilities.{ts,tsx}',
   '**/common/{isConformant,snapshotSerializers}.{ts,tsx}',
+  './e2e/**',
 ];
 
 const docsFiles = ['**/*Page.tsx', '**/{docs,demo}/**', '**/*.doc.{ts,tsx}'];

--- a/packages/react-examples/e2e/support.js
+++ b/packages/react-examples/e2e/support.js
@@ -1,0 +1,2 @@
+// workaround for https://github.com/cypress-io/cypress/issues/8599
+import '@fluentui/scripts/cypress/support';

--- a/packages/react-examples/src/react/FocusTrapZone/e2e/FocusTrapZone.TabWrappingMultiFocusZone.stories.tsx
+++ b/packages/react-examples/src/react/FocusTrapZone/e2e/FocusTrapZone.TabWrappingMultiFocusZone.stories.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { FocusZone, FocusTrapZone, FocusZoneDirection, mergeStyles } from '@fluentui/react';
+
+const rootClass = mergeStyles({
+  position: 'relative',
+  button: { position: 'absolute', height: 30, width: 30 },
+  '#a': { top: 0, left: 0 },
+  '#b': { top: 0, left: 30 },
+  '#c': { top: 0, left: 60 },
+  '#d': { top: 30, left: 0 },
+  '#e': { top: 30, left: 30 },
+  '#f': { top: 30, left: 60 },
+});
+
+/**
+ * Tab and shift-tab wrap at extreme ends of the FTZ:
+ *
+ * can tab across FocusZones with different button structures
+ */
+export const TabWrappingMultiFocusZone = () => {
+  return (
+    <div className={rootClass}>
+      <FocusTrapZone forceFocusInsideTrap={false}>
+        <FocusZone direction={FocusZoneDirection.horizontal}>
+          <div>
+            <button id="a">a</button>
+          </div>
+          <div>
+            <button id="b">b</button>
+          </div>
+          <div>
+            <button id="c">c</button>
+          </div>
+        </FocusZone>
+        <FocusZone direction={FocusZoneDirection.horizontal}>
+          <div>
+            <div>
+              <button id="d">d</button>
+              <button id="e">e</button>
+              <button id="f">f</button>
+            </div>
+          </div>
+        </FocusZone>
+      </FocusTrapZone>
+    </div>
+  );
+};

--- a/packages/react-examples/src/react/FocusTrapZone/e2e/FocusTrapZone.e2e.ts
+++ b/packages/react-examples/src/react/FocusTrapZone/e2e/FocusTrapZone.e2e.ts
@@ -20,44 +20,5 @@ describe('FocusTrapZone', () => {
       cy.realPress('Tab');
       cy.focused().should('have.id', 'a');
     });
-
-    it('can tab across a FocusZone with different button structures', () => {
-      cy.loadStory(ftzStoriesTitle, 'TabWrappingFocusZone');
-
-      cy.get('#x').focus();
-      cy.focused().should('have.id', 'x');
-
-      // shift+tab to focus first bumper
-      cy.realPress(['Shift', 'Tab']);
-      cy.focused().should('have.id', 'a');
-
-      // tab to focus last bumper
-      cy.realPress('Tab');
-      cy.focused().should('have.id', 'x');
-    });
-
-    it(
-      'can trap focus when FTZ bookmark elements are FocusZones, ' +
-        'and those elements have inner elements focused that are not the first inner element',
-      () => {
-        cy.loadStory(ftzStoriesTitle, 'TabWrappingFocusZoneBumpers');
-
-        // Focus the middle button in the first FZ.
-        cy.get('#a').focus().realPress('ArrowRight');
-        cy.focused().should('have.id', 'b');
-
-        // Focus the middle button in the second FZ.
-        cy.get('#e').focus().realPress('ArrowRight');
-        cy.focused().should('have.id', 'f');
-
-        // tab to focus last bumper
-        cy.realPress('Tab');
-        cy.focused().should('have.id', 'b');
-
-        // shift+tab to focus first bumper
-        cy.realPress(['Shift', 'Tab']);
-        cy.focused().should('have.id', 'f');
-      },
-    );
   });
 });

--- a/packages/react-examples/src/react/FocusTrapZone/e2e/FocusTrapZone.e2e.ts
+++ b/packages/react-examples/src/react/FocusTrapZone/e2e/FocusTrapZone.e2e.ts
@@ -1,0 +1,63 @@
+const ftzStoriesTitle = 'Components/FocusTrapZone/e2e';
+
+describe('FocusTrapZone', () => {
+  before(() => {
+    cy.visitStorybook({ qs: { e2e: '1' } });
+  });
+
+  describe('Tab and shift-tab wrap at extreme ends of the FTZ', () => {
+    it('can tab across FocusZones with different button structures', () => {
+      cy.loadStory(ftzStoriesTitle, 'TabWrappingMultiFocusZone');
+
+      cy.get('#a').focus();
+      cy.focused().should('have.id', 'a');
+
+      // shift+tab to focus first bumper
+      cy.realPress(['Shift', 'Tab']);
+      cy.focused().should('have.id', 'd');
+
+      // tab to focus last bumper
+      cy.realPress('Tab');
+      cy.focused().should('have.id', 'a');
+    });
+
+    it('can tab across a FocusZone with different button structures', () => {
+      cy.loadStory(ftzStoriesTitle, 'TabWrappingFocusZone');
+
+      cy.get('#x').focus();
+      cy.focused().should('have.id', 'x');
+
+      // shift+tab to focus first bumper
+      cy.realPress(['Shift', 'Tab']);
+      cy.focused().should('have.id', 'a');
+
+      // tab to focus last bumper
+      cy.realPress('Tab');
+      cy.focused().should('have.id', 'x');
+    });
+
+    it(
+      'can trap focus when FTZ bookmark elements are FocusZones, ' +
+        'and those elements have inner elements focused that are not the first inner element',
+      () => {
+        cy.loadStory(ftzStoriesTitle, 'TabWrappingFocusZoneBumpers');
+
+        // Focus the middle button in the first FZ.
+        cy.get('#a').focus().realPress('ArrowRight');
+        cy.focused().should('have.id', 'b');
+
+        // Focus the middle button in the second FZ.
+        cy.get('#e').focus().realPress('ArrowRight');
+        cy.focused().should('have.id', 'f');
+
+        // tab to focus last bumper
+        cy.realPress('Tab');
+        cy.focused().should('have.id', 'b');
+
+        // shift+tab to focus first bumper
+        cy.realPress(['Shift', 'Tab']);
+        cy.focused().should('have.id', 'f');
+      },
+    );
+  });
+});

--- a/packages/react-examples/tsconfig.json
+++ b/packages/react-examples/tsconfig.json
@@ -18,7 +18,7 @@
     "skipLibCheck": true,
     "lib": ["es5", "dom", "es2015.promise"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["webpack-env", "custom-global", "node"],
+    "types": ["webpack-env", "custom-global", "node", "cypress", "cypress-storybook/cypress", "cypress-real-events"],
     "paths": {
       "@fluentui/react-examples/lib/*": ["./src/*"],
       "@fluentui/react-examples": ["./src"]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,6 +21,7 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "codepen": "node ../../scripts/local-codepen.js",
+    "e2e": "yarn workspace @fluentui/react-examples e2e --package react",
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "cross-env NODE_OPTIONS=--max-old-space-size=3072 just-scripts dev:storybook",

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -5,7 +5,7 @@ const path = require('path');
 /**
  * Script that run/opens cypress, since cypress does not support easy config extension.
  * Can be removed in favour of native CLI once cypress supports path-based config extension.
- * https://github.com/cypress-io/cypress/issues/5674
+ * https://github.com/cypress-io/cypress/issues/5218
  *
  * To debug cypress tests locally, run the following in your package folder in *separate terminals*:
  * - `yarn start` and make a note of the port
@@ -18,9 +18,10 @@ const argv = require('yargs')
     choices: ['run', 'open'],
   })
   .option('package', {
-    describe: 'Package to load the deployed storybook for (used by PR runs only)',
+    describe: 'Unscoped package name to load the deployed storybook for (used by PR runs only)',
     default: 'react-components',
-    type: 'string',
+    type: 'option',
+    choices: ['react-components', 'react'],
   })
   .option('port', {
     describe: 'Port number storybook is running on (used by local runs only)',

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -3,9 +3,13 @@ const cypress = require('cypress');
 const path = require('path');
 
 /**
- * Script that run/opens cypress, since cypress does not support easy config extension
- * Can be removed in favour of native CLI once cypress supports path based config extension
+ * Script that run/opens cypress, since cypress does not support easy config extension.
+ * Can be removed in favour of native CLI once cypress supports path-based config extension.
  * https://github.com/cypress-io/cypress/issues/5674
+ *
+ * To debug cypress tests locally, run the following in your package folder in *separate terminals*:
+ * - `yarn start` and make a note of the port
+ * - `yarn e2e --mode open --port ####`
  */
 
 const argv = require('yargs')

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -13,8 +13,13 @@ const argv = require('yargs')
     describe: 'Choose a mode to run cypress',
     choices: ['run', 'open'],
   })
+  .option('package', {
+    describe: 'Package to load the deployed storybook for (used by PR runs only)',
+    default: 'react-components',
+    type: 'string',
+  })
   .option('port', {
-    describe: 'Port number storybook is running on',
+    describe: 'Port number storybook is running on (used by local runs only)',
     default: 3000,
     type: 'number',
   })
@@ -22,8 +27,7 @@ const argv = require('yargs')
 
 const baseConfig = {
   baseUrl: process.env.DEPLOYURL
-    ? // Base path hard coded for converged for now, can be modified to be configurable if required to other projects
-      `${process.env.DEPLOYURL}/react-components/storybook`
+    ? `${process.env.DEPLOYURL}/${argv.package}/storybook`
     : `http://localhost:${argv.port}`,
   fixturesFolder: path.join(__dirname, 'cypress/fixtures'),
   integrationFolder: '.',


### PR DESCRIPTION
## Current Behavior

In v9 we can use cypress to run interactive tests in a real browser. This isn't possible today in v8. 

Running tests in a real browser is desirable for testing related to interactive features such as focus that aren't realistically simulated in jsdom.

## New Behavior

Enable cypress tests for v8 and add one test for FocusTrapZone as an example.

Our cypress wrapper (`scripts/cypress.js`) was hardcoded to always load the `react-components` storybook in PR builds, so I added a `--package` option.

Since the storybook for v8 is in `react-examples`, it's easiest to also have the e2e tests and e2e-specific stories live there. Longer-term once v8 is migrated to the new build system, the e2e tests and stories could potentially be relocated to the `react` package itself.

To facilitate having e2e-only stories that don't show up on the doc site, I updated `react-examples/.storybook/preview.js` to look for a `e2e=1` query parameter which determines whether to show stories with `/e2e/` in their path. (Storybook appears to preserve any user-provided query parameters when changing stories.)

## Related Issue(s)

Fixes #21662
