### PR TITLE
Wrap icon in a button

### DIFF
--- a/packages/react-examples/src/react/Toggle/Toggle.CustomLabel.Example.tsx
+++ b/packages/react-examples/src/react/Toggle/Toggle.CustomLabel.Example.tsx
@@ -3,35 +3,39 @@ import { Icon } from '@fluentui/react/lib/Icon';
 import { Stack, IStackTokens } from '@fluentui/react/lib/Stack';
 import { Toggle } from '@fluentui/react/lib/Toggle';
 import { TooltipHost } from '@fluentui/react/lib/Tooltip';
+import { useId } from '@fluentui/react-hooks';
 
 const stackTokens: IStackTokens = { childrenGap: 10 };
+const buttonStyles = {
+  background: 'transparent',
+  border: 'none',
+};
 
 export const ToggleCustomLabelExample: React.FunctionComponent = () => {
+  const [showTooltip, setShowTooltip] = React.useState(false);
+  const tooltipId = useId('tooltipId');
+
+  const iconWithTooltip = (
+    <>
+      <TooltipHost content={showTooltip ? 'Info tooltip' : undefined} id={tooltipId}>
+        <button
+          style={buttonStyles}
+          aria-label={showTooltip ? 'Close Tooltip' : 'Open Tooltip'}
+          onClick={() => setShowTooltip(!showTooltip)}
+          aria-describedby={showTooltip ? tooltipId : undefined}
+        >
+          <Icon iconName="Info" />
+        </button>
+      </TooltipHost>
+    </>
+  );
+
   return (
     <Stack tokens={stackTokens}>
-      <Toggle
-        label={
-          <div>
-            Custom label{' '}
-            <TooltipHost content="Info tooltip">
-              <Icon iconName="Info" aria-label="Info tooltip" />
-            </TooltipHost>
-          </div>
-        }
-        onText="On"
-        offText="Off"
-        onChange={_onChange}
-      />
+      <Toggle label={<div>Custom label {iconWithTooltip}</div>} onText="On" offText="Off" onChange={_onChange} />
 
       <Toggle
-        label={
-          <div>
-            Custom inline label{' '}
-            <TooltipHost content="Info tooltip">
-              <Icon iconName="Info" aria-label="Info tooltip" />
-            </TooltipHost>
-          </div>
-        }
+        label={<div>Custom inline label {iconWithTooltip}</div>}
         inlineLabel
         onText="On"
         offText="Off"

--- a/packages/react-examples/src/react/Toggle/Toggle.CustomLabel.Example.tsx
+++ b/packages/react-examples/src/react/Toggle/Toggle.CustomLabel.Example.tsx
@@ -19,10 +19,10 @@ export const ToggleCustomLabelExample: React.FunctionComponent = () => {
     <>
       <TooltipHost content={showTooltip ? 'Info tooltip' : undefined} id={tooltipId}>
         <button
-          style={buttonStyles}
           aria-label={showTooltip ? 'Close Tooltip' : 'Open Tooltip'}
-          onClick={() => setShowTooltip(!showTooltip)}
           aria-describedby={showTooltip ? tooltipId : undefined}
+          onClick={() => setShowTooltip(!showTooltip)}
+          style={buttonStyles}
         >
           <Icon iconName="Info" />
         </button>


### PR DESCRIPTION


Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally



## Current Behavior

<!-- This is the behavior we have today -->
- Tooltip content that wraps the `Icon` is inaccessible to keyboard users.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- `Icon` is now wrapped in a `button` which also acts as a trigger to show/hide the tooltip.
- **New behavior when using screen reader:**

https://user-images.githubusercontent.com/8649804/153311420-fb881ff2-c84b-4c47-939f-9d7d0c988629.mp4


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes ADO [bug ](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/13285)
