### PR TITLE
fix: Run production build before publish

### DIFF
--- a/azure-pipelines.release-vnext.yml
+++ b/azure-pipelines.release-vnext.yml
@@ -44,16 +44,16 @@ steps:
     displayName: yarn
 
   - script: |
-      yarn run:published build --production --no-cache
-    displayName: yarn build
-
-  - script: |
       yarn run:published test
     displayName: yarn test
 
   - script: |
       yarn run:published lint
     displayName: yarn lint
+
+  - script: |
+      yarn run:published build --production --no-cache
+    displayName: yarn build
 
   - script: |
       yarn publish:beachball -n $(npmToken)


### PR DESCRIPTION
## Current Behavior

Production build is overriden by `test` and `lint` stages so development build is published

## New Behavior

Production build is run right before publish step

## Related Issue(s)


Fixes partially #21686
