### PR TITLE
fix: Set correct url for cancel screener job API call

### DIFF
--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -117,7 +117,7 @@ export async function cancelScreenerRun(
 
   await notifyIntegration({
     commit,
-    url: '',
+    url: 'https://screener.io/',
     status: 'completed',
     project: screenerConfig.projectRepo,
     conclusion,


### PR DESCRIPTION
Github API client will fail if the url field does not contain a valid
url with `http` or `https` scheme

