### PR TITLE
Fix lage args in release builds

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -25,7 +25,7 @@ jobs:
         displayName: yarn
 
       - script: |
-          yarn lage bundle-size --no-cache --verbose $(sinceArg)
+          yarn lage bundle-size --verbose $(sinceArg)
         displayName: build packages & create reports
 
       - script: |
@@ -66,7 +66,7 @@ jobs:
           filePath: yarn-ci.sh
         displayName: yarn
 
-      - script: yarn build --to @fluentui/react @fluentui/keyboard-key --no-cache
+      - script: yarn build --to @fluentui/react @fluentui/keyboard-key
         displayName: yarn build to @fluentui/react
 
       - script: yarn workspace @fluentui/test-bundles bundle:size
@@ -104,7 +104,7 @@ jobs:
           filePath: yarn-ci.sh
         displayName: yarn
 
-      - script: yarn build --to @fluentui/react-northstar --no-cache
+      - script: yarn build --to @fluentui/react-northstar
         displayName: yarn build to @fluentui/react-northstar
 
       - script: yarn workspace @fluentui/test-bundles bundle:size

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -23,7 +23,7 @@ steps:
 
   # @fluentui/perf-test-northstar needs build and bundle steps
   - script: |
-      yarn lage build --to @fluentui/perf-test-northstar --to perf-test --verbose --no-cache
+      yarn lage build --to @fluentui/perf-test-northstar --to perf-test --verbose
     displayName: build to perf-test
 
   # Fluent perf-test must run before Fabric perf-test until they are consolidated.

--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -45,9 +45,11 @@ steps:
     displayName: 'Bump and commit nightly versions'
 
   - script: |
-      yarn run:published build --production --no-cache
+      yarn run:published build --production
     displayName: yarn build
 
+  # --only makes it only run tests (otherwise due to the missing --production arg, lage would re-run the build)
+  # https://github.com/microsoft/fluentui/issues/21686
   - script: |
       yarn run:published test
     displayName: yarn test

--- a/azure-pipelines.release-vnext.yml
+++ b/azure-pipelines.release-vnext.yml
@@ -44,16 +44,18 @@ steps:
     displayName: yarn
 
   - script: |
-      yarn run:published test
+      yarn run:published build --production
+    displayName: yarn build
+
+  # --only makes it only run tests (otherwise due to the missing --production arg, lage would re-run the build)
+  # https://github.com/microsoft/fluentui/issues/21686
+  - script: |
+      yarn run:published test --only
     displayName: yarn test
 
   - script: |
-      yarn run:published lint
+      yarn run:published lint --only
     displayName: yarn lint
-
-  - script: |
-      yarn run:published build --production --no-cache
-    displayName: yarn build
 
   - script: |
       yarn publish:beachball -n $(npmToken)

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -45,20 +45,21 @@ steps:
     displayName: Generate version files
 
   - script: |
-      yarn run:published build --production --no-cache
+      yarn run:published build --production
     displayName: yarn build
 
-  # test, lint, bundle using lage cached build from previous step (omit --no-cache)
+  # --only makes it only run tests (otherwise due to the missing --production arg, lage would re-run the build)
+  # https://github.com/microsoft/fluentui/issues/21686
   - script: |
-      yarn run:published test
+      yarn run:published test --only
     displayName: yarn test
 
   - script: |
-      yarn run:published lint
+      yarn run:published lint --only
     displayName: yarn lint
 
   - script: |
-      yarn run:published bundle --production
+      yarn run:published bundle --only --production
     displayName: yarn bundle
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: $(DANGER_GITHUB_API_TOKEN)
 
       - script: |
-          yarn buildci --no-cache $(sinceArg)
+          yarn buildci  $(sinceArg)
         displayName: build, test, lint
 
       - template: .devops/templates/cleanup.yml
@@ -72,11 +72,11 @@ jobs:
 
       # this also builds FUI N* docs if appropriate
       - script: |
-          yarn bundle --no-cache $(sinceArg)
+          yarn bundle  $(sinceArg)
         displayName: bundle
 
       - script: |
-          yarn lage build-storybook --no-cache --verbose $(sinceArg)
+          yarn lage build-storybook  --verbose $(sinceArg)
         displayName: build Storybooks
 
       ## This runs regardless of scope, the app will adapt to the scope as well


### PR DESCRIPTION
## Current Behavior

We run `lage` with the `--no-cache` arg in some of our pipelines. This appears to be a carry-over from when we were initially going to try enabling caching in blob storage but is not actually needed now, and it can cause steps to be re-run unnecessarily.

Even with that arg removed, release builds were still re-running `build` during the `test` and `lint` steps due to different args (`--production` or not)--see #21686 for more background.

## New Behavior

Remove `--no-cache` from the pipelines.

To work around the issue in #21686 while only building once, keep the `build` step first but add [`--only`](https://microsoft.github.io/lage/guide/cli.html#only) to the `test` and `lint` steps to prevent it from re-running the build.

## Related Issue(s)

#21686