### PR TITLE
(web-components) aligned "plus 2" type ramp line height size

### DIFF
--- a/change/@fluentui-web-components-b1b8280a-99df-489f-b694-bbdeddb48dd0.json
+++ b/change/@fluentui-web-components-b1b8280a-99df-489f-b694-bbdeddb48dd0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Aligned \"plus 2\" type ramp line height size",
+  "packageName": "@fluentui/web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/design-tokens.ts
+++ b/packages/web-components/src/design-tokens.ts
@@ -100,7 +100,7 @@ export const typeRampPlus1LineHeight = create<string>('type-ramp-plus-1-line-hei
 /** @public */
 export const typeRampPlus2FontSize = create<string>('type-ramp-plus-2-font-size').withDefault('20px');
 /** @public */
-export const typeRampPlus2LineHeight = create<string>('type-ramp-plus-2-line-height').withDefault('28px');
+export const typeRampPlus2LineHeight = create<string>('type-ramp-plus-2-line-height').withDefault('26px');
 /** @public */
 export const typeRampPlus3FontSize = create<string>('type-ramp-plus-3-font-size').withDefault('24px');
 /** @public */


### PR DESCRIPTION
## Current Behavior

"Plus 2"" type ramp line height size was not aligned with Fluent Design.

## New Behavior

Adjusts the line height by reducing 2px.