### PR TITLE
Fix v9 switch bug in renderedPosition

### DIFF
--- a/change/@fluentui-react-switch-7506c328-082e-4b5c-a8ba-667ebff4c77b.json
+++ b/change/@fluentui-react-switch-7506c328-082e-4b5c-a8ba-667ebff4c77b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix visual display of controlled switches",
+  "packageName": "@fluentui/react-switch",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-switch/src/Switch.stories.tsx
+++ b/packages/react-switch/src/Switch.stories.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
 
 export const BasicSwitchExample = (props: SwitchProps) => {
   const styles = useStyles();
-  const [switchValue, setSwitchValue] = React.useState(false);
+  const [switchValue, setSwitchValue] = React.useState(true);
 
   const switchOnChange = (
     ev: React.PointerEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>,
@@ -27,6 +27,7 @@ export const BasicSwitchExample = (props: SwitchProps) => {
       <Label>Basic Example</Label>
       <Switch />
       <Label>Controlled Example</Label>
+      <Switch checked={switchValue} onChange={switchOnChange} />
       <Switch checked={switchValue} onChange={switchOnChange} />
       <Label>Disabled Example</Label>
       <Switch disabled defaultChecked={true} />

--- a/packages/react-switch/src/Switch.stories.tsx
+++ b/packages/react-switch/src/Switch.stories.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
 
 export const BasicSwitchExample = (props: SwitchProps) => {
   const styles = useStyles();
-  const [switchValue, setSwitchValue] = React.useState(true);
+  const [switchValue, setSwitchValue] = React.useState(false);
 
   const switchOnChange = (
     ev: React.PointerEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>,
@@ -27,7 +27,6 @@ export const BasicSwitchExample = (props: SwitchProps) => {
       <Label>Basic Example</Label>
       <Switch />
       <Label>Controlled Example</Label>
-      <Switch checked={switchValue} onChange={switchOnChange} />
       <Switch checked={switchValue} onChange={switchOnChange} />
       <Label>Disabled Example</Label>
       <Switch disabled defaultChecked={true} />

--- a/packages/react-switch/src/components/Switch/useSwitchState.ts
+++ b/packages/react-switch/src/components/Switch/useSwitchState.ts
@@ -46,7 +46,7 @@ export const useSwitchState = (state: SwitchState) => {
     initialState: false,
   });
   const [thumbAnimation, { setTrue: showThumbAnimation, setFalse: hideThumbAnimation }] = useBoolean(true);
-  const [renderedPosition, setRenderedPosition] = React.useState<number | undefined>(currentValue === true ? 100 : 0);
+  const [renderedPosition, setRenderedPosition] = React.useState<number | undefined>(undefined);
 
   const setChecked = useEventCallback(
     (ev: React.PointerEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>, incomingValue: boolean) => {


### PR DESCRIPTION
Bug in controlled switches where renderedPosition does not change if state change only comes from state (not a click/enter)

In switch logic renderedPosition is set to undefined on `setChecked`, which then allows `currentPosition` to be based off of `checked` value vs `renderedPosition` value. With default value of `renderedPosition` at 0 or 100, incoming state changes can never affect the `currentPosition`, and it stays at that default value.

This is a bit of a bandaid as we'll probably do some major changes to the control before actual release. 

fixes #21699 