### PR TITLE
ContextualMenu: Add prop that allows users to wrap a custom tooltip around each menu item button

### DIFF
--- a/change/@fluentui-react-0871327a-3a79-40e3-a43a-e99c4c35bb64.json
+++ b/change/@fluentui-react-0871327a-3a79-40e3-a43a-e99c4c35bb64.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "ContextualMenu: Add prop that allows users to wrap a custom tooltip around each menu item button.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -4099,7 +4099,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, React
     onItemClick?: (ev?: React_2.MouseEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
     onMenuDismissed?: (contextualMenu?: IContextualMenuProps) => void;
     onMenuOpened?: (contextualMenu?: IContextualMenuProps) => void;
-    onRenderContextualMenuItemWrapper?: IRenderFunction<IContextualMenuItem>;
+    onRenderContextualMenuItem?: IRenderFunction<IContextualMenuItem>;
     onRenderMenuList?: IRenderFunction<IContextualMenuListProps>;
     onRenderSubMenu?: IRenderFunction<IContextualMenuProps>;
     onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -4099,6 +4099,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, React
     onItemClick?: (ev?: React_2.MouseEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
     onMenuDismissed?: (contextualMenu?: IContextualMenuProps) => void;
     onMenuOpened?: (contextualMenu?: IContextualMenuProps) => void;
+    onRenderContextualMenuItemWrapper?: IRenderFunction<IContextualMenuItem>;
     onRenderMenuList?: IRenderFunction<IContextualMenuListProps>;
     onRenderSubMenu?: IRenderFunction<IContextualMenuProps>;
     onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -865,15 +865,20 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
           renderedItems.push(renderSectionItem(item, itemClassNames, menuClassNames, index, hasCheckmarks, hasIcons));
           break;
         default:
-          const menuItem = renderNormalItem(
-            item,
-            itemClassNames,
-            index,
-            focusableElementIndex,
-            totalItemCount,
-            hasCheckmarks,
-            hasIcons,
-          );
+          const defaultRenderNormalItem = () =>
+            renderNormalItem(
+              item,
+              itemClassNames,
+              index,
+              focusableElementIndex,
+              totalItemCount,
+              hasCheckmarks,
+              hasIcons,
+            ) as JSX.Element;
+
+          const menuItem = props.onRenderContextualMenuItemWrapper
+            ? props.onRenderContextualMenuItemWrapper(item, defaultRenderNormalItem)
+            : defaultRenderNormalItem();
           renderedItems.push(renderListItem(menuItem, item.key || index, itemClassNames, item.title));
           break;
       }

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -876,8 +876,8 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
               hasIcons,
             ) as JSX.Element;
 
-          const menuItem = props.onRenderContextualMenuItemWrapper
-            ? props.onRenderContextualMenuItemWrapper(item, defaultRenderNormalItem)
+          const menuItem = props.onRenderContextualMenuItem
+            ? props.onRenderContextualMenuItem(item, defaultRenderNormalItem)
             : defaultRenderNormalItem();
           renderedItems.push(renderListItem(menuItem, item.key || index, itemClassNames, item.title));
           break;

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -235,6 +235,12 @@ export interface IContextualMenuProps
   onRenderMenuList?: IRenderFunction<IContextualMenuListProps>;
 
   /**
+   * Method to wrap menu items. Gives the ability to wrap a custom
+   * tooltip to each menu item button.
+   */
+  onRenderContextualMenuItemWrapper?: IRenderFunction<IContextualMenuItem>;
+
+  /**
    * Delay (in milliseconds) to wait before expanding / dismissing a submenu on mouseEnter or mouseLeave
    */
   subMenuHoverDelay?: number;

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -238,7 +238,7 @@ export interface IContextualMenuProps
    * Method to wrap menu items. Gives the ability to wrap a custom
    * tooltip to each menu item button.
    */
-  onRenderContextualMenuItemWrapper?: IRenderFunction<IContextualMenuItem>;
+  onRenderContextualMenuItem?: IRenderFunction<IContextualMenuItem>;
 
   /**
    * Delay (in milliseconds) to wait before expanding / dismissing a submenu on mouseEnter or mouseLeave


### PR DESCRIPTION
Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


## Current Behavior

- There's currently no appropriate way to wrap each menu item in a `ContextualMenu` in a custom tooltip. Using the current `contextualMenuItemAs` prop overrides the children of the menu item button and doesn't include the button itself. This results in the tooltip not rendering when a menu item button receives keyboard focus. 

- ### Tooltip doesnt render on keyboard focus: 
![ContextualMenuTooltipBefore](https://user-images.githubusercontent.com/8649804/153532900-f1953725-34d4-4f28-b3ac-a6a530e0e8fa.gif)

## New Behavior:
- A new prop called `onRenderContextualMenuItem` is now added to enable consumers to wrap the contextual menu item button in a tooltip. Now, when a menu item receives keyboard focus, the tooltip is rendered appropriately.

- ### Tooltip now renders on keyboard focus: 
![ContextualMenuTooltipAfter](https://user-images.githubusercontent.com/8649804/153532931-5788db84-940a-49d2-9306-fb5e41518bcb.gif)

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19862
