### PR TITLE
fix: perf reporting for Northstar

### DIFF
--- a/apps/perf-test/tasks/fluentPerfRegressions.ts
+++ b/apps/perf-test/tasks/fluentPerfRegressions.ts
@@ -109,7 +109,7 @@ const checkPerfRegressions = (reporter: Reporter) => {
   reporter.markdown('## Perf Analysis (`@fluentui/react-northstar`)');
 
   try {
-    perfCounts = require(config.paths.packageDist('perf-test', 'perfCounts.json'));
+    perfCounts = require(config.paths.packageDist('perf-test-northstar', 'perfCounts.json'));
   } catch {
     reporter.warn('No perf measurements available');
     return;


### PR DESCRIPTION
## Current Behavior

#21490 renamed packages, perf reporting is broken:

![image](https://user-images.githubusercontent.com/14183168/153577060-16bb2828-c4be-4716-b059-2994141a5dd1.png)


## New Behavior

![image](https://user-images.githubusercontent.com/14183168/153603784-3b19b790-5dac-4219-8bad-a9eeffff1c0e.png)