### PR TITLE
chore: move "yarn checkchange" to Github Action

### DIFF
--- a/.github/workflows/check-change.yml
+++ b/.github/workflows/check-change.yml
@@ -1,0 +1,30 @@
+name: Check change
+on:
+  pull_request:
+
+jobs:
+  check-change:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const beachballVersion = require('./package.json').devDependencies.beachball;
+            if (typeof beachballVersion !== 'string') {
+              core.setFailed("Please check 'package.json', it should include 'beachball' in 'devDependencies'")
+            } else {
+              console.log(`Using beachball@${beachballVersion}...`)
+              await exec.exec('yarn', ['global', 'add', `beachball@${beachballVersion}`]);
+            }
+
+      - run: |
+          cp scripts/beachball/.beachballrc.base.json .beachballrc.json
+          yarn checkchange

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,10 +29,6 @@ jobs:
         displayName: yarn (install packages)
 
       - script: |
-          yarn checkchange
-        displayName: verify change files
-
-      - script: |
           yarn nx workspace-lint
         displayName: nx:workspace-lint
 

--- a/scripts/beachball/.beachballrc.base.json
+++ b/scripts/beachball/.beachballrc.base.json
@@ -1,0 +1,17 @@
+{
+  "disallowedChangeTypes": ["major", "prerelease"],
+  "tag": "latest",
+  "generateChangelog": true,
+  "ignorePatterns": [
+    "**/*.{shot,snap}",
+    "**/*.{test,spec}.{ts,tsx}",
+    "**/*.stories.tsx",
+    "**/.eslintrc.*",
+    "**/__fixtures__/**",
+    "**/__mocks__/**",
+    "**/common/isConformant.ts",
+    "**/jest.config.js",
+    "**/SPEC*.md",
+    "**/tests/**"
+  ]
+}

--- a/scripts/beachball/index.ts
+++ b/scripts/beachball/index.ts
@@ -1,24 +1,15 @@
-import { BeachballConfig } from 'beachball';
+import type { BeachballConfig } from 'beachball';
+import * as fs from 'fs';
+import * as path from 'path';
+
 import { renderHeader, renderEntry } from './customRenderers';
 import { getScopes } from './getScopes';
 import { getVNextChangelogGroups } from './getVNextChangelogGroups';
 
+const baseConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, '.beachballrc.base.json'), { encoding: 'utf8' }));
+
 export const config: BeachballConfig = {
-  disallowedChangeTypes: ['major', 'prerelease'],
-  tag: 'latest',
-  generateChangelog: true,
-  ignorePatterns: [
-    '**/*.{shot,snap}',
-    '**/*.{test,spec}.{ts,tsx}',
-    '**/*.stories.tsx',
-    '**/.eslintrc.*',
-    '**/__fixtures__/**',
-    '**/__mocks__/**',
-    '**/common/isConformant.ts',
-    '**/jest.config.js',
-    '**/SPEC*.md',
-    '**/tests/**',
-  ],
+  ...baseConfig,
   scope: getScopes(),
   changelog: {
     customRenderers: {


### PR DESCRIPTION
## Current Behavior

We ran `yarn checkchange` in the main pipeline that runs build.

This might be my personal problem, but I keep forgetting to add changelog files ¯\_(ツ)_/¯

 From my POV there are following issues:
- it takes around 3-5 minutes before CI will reach `yarn checkchange` step
- if the step fails nothing after it will run

_This looks like a punishment to contributors_ 😁

## New Behavior

`yarn checkchange` is moved out to a separate workflow.

- This workflow is blazing fast as it does not install packages (overall run is less than a minute) => fast check ⏱
- This workflow does not break the build pipeline => if you forgot to push change files you don't need to wait 5 minutes to see failing CI 👌

---

**New Github workflow should be marked as the required check.**