### PR TITLE
Export global values from @fluentui/react-theme

### DIFF
--- a/change/@fluentui-react-theme-499b7869-0e7b-49d9-b0a6-34f0f89d0132.json
+++ b/change/@fluentui-react-theme-499b7869-0e7b-49d9-b0a6-34f0f89d0132.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Exporting global values as part of the react-theme package.",
+  "packageName": "@fluentui/react-theme",
+  "email": "omprieto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-theme/etc/react-theme.api.md
+++ b/packages/react-theme/etc/react-theme.api.md
@@ -5,6 +5,17 @@
 ```ts
 
 // @public (undocumented)
+export const black = "#000000";
+
+// Warning: (ae-forgotten-export) The symbol "AlphaColors" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export const blackAlpha: Record<AlphaColors, string>;
+
+// @public (undocumented)
+export const borderRadius: BorderRadiusTokens;
+
+// @public (undocumented)
 export type BorderRadiusTokens = {
     borderRadiusNone: string;
     borderRadiusSmall: string;
@@ -15,10 +26,19 @@ export type BorderRadiusTokens = {
 };
 
 // @public (undocumented)
+export const brandOffice: BrandVariants;
+
+// @public (undocumented)
 export type Brands = 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100 | 110 | 120 | 130 | 140 | 150 | 160;
 
 // @public (undocumented)
+export const brandTeams: BrandVariants;
+
+// @public (undocumented)
 export type BrandVariants = Record<Brands, string>;
+
+// @public (undocumented)
+export const brandWeb: BrandVariants;
 
 // @public (undocumented)
 export type ColorPaletteAnchor = 'colorPaletteAnchorBackground1' | 'colorPaletteAnchorBackground2' | 'colorPaletteAnchorBackground3' | 'colorPaletteAnchorForeground1' | 'colorPaletteAnchorForeground2' | 'colorPaletteAnchorForeground3' | 'colorPaletteAnchorBorderActive' | 'colorPaletteAnchorBorder1' | 'colorPaletteAnchorBorder2';
@@ -323,11 +343,17 @@ export const createLightTheme: (brand: BrandVariants) => Theme;
 export const createTeamsDarkTheme: (brand: BrandVariants) => Theme;
 
 // @public (undocumented)
+export const fontFamilies: FontFamilyTokens;
+
+// @public (undocumented)
 export type FontFamilyTokens = {
     fontFamilyBase: string;
     fontFamilyMonospace: string;
     fontFamilyNumeric: string;
 };
+
+// @public (undocumented)
+export const fontSizes: FontSizeTokens;
 
 // @public (undocumented)
 export type FontSizeTokens = {
@@ -344,11 +370,46 @@ export type FontSizeTokens = {
 };
 
 // @public (undocumented)
+export const fontWeights: FontWeightTokens;
+
+// @public (undocumented)
 export type FontWeightTokens = {
     fontWeightRegular: number;
     fontWeightMedium: number;
     fontWeightSemibold: number;
 };
+
+// Warning: (ae-forgotten-export) The symbol "Greys" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export const grey: Record<Greys, string>;
+
+// @public (undocumented)
+export const hcButtonFace = "#ffffff";
+
+// @public (undocumented)
+export const hcButtonText = "#000000";
+
+// @public (undocumented)
+export const hcCanvas = "#000000";
+
+// @public (undocumented)
+export const hcCanvasText = "#ffffff";
+
+// @public (undocumented)
+export const hcDisabled = "#3ff23f";
+
+// @public (undocumented)
+export const hcHighlight = "#1aebff";
+
+// @public (undocumented)
+export const hcHighlightText = "#000000";
+
+// @public (undocumented)
+export const hcHyperlink = "#ffff00";
+
+// @public (undocumented)
+export const lineHeights: LineHeightTokens;
 
 // @public (undocumented)
 export type LineHeightTokens = {
@@ -387,6 +448,14 @@ export type ShadowTokens = {
     shadow64: string;
 };
 
+// Warning: (ae-forgotten-export) The symbol "GlobalSharedColors" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export const sharedColors: GlobalSharedColors;
+
+// @public (undocumented)
+export const strokeWidths: StrokeWidthTokens;
+
 // @public (undocumented)
 export type StrokeWidthTokens = {
     strokeWidthThin: string;
@@ -421,6 +490,12 @@ export const webHighContrastTheme: Theme;
 
 // @public (undocumented)
 export const webLightTheme: Theme;
+
+// @public (undocumented)
+export const white = "#ffffff";
+
+// @public (undocumented)
+export const whiteAlpha: Record<AlphaColors, string>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-theme/etc/react-theme.api.md
+++ b/packages/react-theme/etc/react-theme.api.md
@@ -5,15 +5,15 @@
 ```ts
 
 // @public (undocumented)
-export const black = "#000000";
+const black = "#000000";
 
 // Warning: (ae-forgotten-export) The symbol "AlphaColors" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const blackAlpha: Record<AlphaColors, string>;
+const blackAlpha: Record<AlphaColors, string>;
 
 // @public (undocumented)
-export const borderRadius: BorderRadiusTokens;
+const borderRadius_2: BorderRadiusTokens;
 
 // @public (undocumented)
 export type BorderRadiusTokens = {
@@ -26,19 +26,19 @@ export type BorderRadiusTokens = {
 };
 
 // @public (undocumented)
-export const brandOffice: BrandVariants;
+const brandOffice: BrandVariants;
 
 // @public (undocumented)
 export type Brands = 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100 | 110 | 120 | 130 | 140 | 150 | 160;
 
 // @public (undocumented)
-export const brandTeams: BrandVariants;
+const brandTeams: BrandVariants;
 
 // @public (undocumented)
 export type BrandVariants = Record<Brands, string>;
 
 // @public (undocumented)
-export const brandWeb: BrandVariants;
+const brandWeb: BrandVariants;
 
 // @public (undocumented)
 export type ColorPaletteAnchor = 'colorPaletteAnchorBackground1' | 'colorPaletteAnchorBackground2' | 'colorPaletteAnchorBackground3' | 'colorPaletteAnchorForeground1' | 'colorPaletteAnchorForeground2' | 'colorPaletteAnchorForeground3' | 'colorPaletteAnchorBorderActive' | 'colorPaletteAnchorBorder1' | 'colorPaletteAnchorBorder2';
@@ -343,7 +343,7 @@ export const createLightTheme: (brand: BrandVariants) => Theme;
 export const createTeamsDarkTheme: (brand: BrandVariants) => Theme;
 
 // @public (undocumented)
-export const fontFamilies: FontFamilyTokens;
+const fontFamilies: FontFamilyTokens;
 
 // @public (undocumented)
 export type FontFamilyTokens = {
@@ -353,7 +353,7 @@ export type FontFamilyTokens = {
 };
 
 // @public (undocumented)
-export const fontSizes: FontSizeTokens;
+const fontSizes: FontSizeTokens;
 
 // @public (undocumented)
 export type FontSizeTokens = {
@@ -370,7 +370,7 @@ export type FontSizeTokens = {
 };
 
 // @public (undocumented)
-export const fontWeights: FontWeightTokens;
+const fontWeights: FontWeightTokens;
 
 // @public (undocumented)
 export type FontWeightTokens = {
@@ -379,37 +379,46 @@ export type FontWeightTokens = {
     fontWeightSemibold: number;
 };
 
+// @public (undocumented)
+export const globals: {
+    colors: typeof colors;
+    fonts: typeof fonts;
+    strokeWidths: typeof strokeWidths;
+    borderRadius: typeof borderRadius;
+    brandColors: typeof brandColors;
+};
+
 // Warning: (ae-forgotten-export) The symbol "Greys" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const grey: Record<Greys, string>;
+const grey: Record<Greys, string>;
 
 // @public (undocumented)
-export const hcButtonFace = "#ffffff";
+const hcButtonFace = "#ffffff";
 
 // @public (undocumented)
-export const hcButtonText = "#000000";
+const hcButtonText = "#000000";
 
 // @public (undocumented)
-export const hcCanvas = "#000000";
+const hcCanvas = "#000000";
 
 // @public (undocumented)
-export const hcCanvasText = "#ffffff";
+const hcCanvasText = "#ffffff";
 
 // @public (undocumented)
-export const hcDisabled = "#3ff23f";
+const hcDisabled = "#3ff23f";
 
 // @public (undocumented)
-export const hcHighlight = "#1aebff";
+const hcHighlight = "#1aebff";
 
 // @public (undocumented)
-export const hcHighlightText = "#000000";
+const hcHighlightText = "#000000";
 
 // @public (undocumented)
-export const hcHyperlink = "#ffff00";
+const hcHyperlink = "#ffff00";
 
 // @public (undocumented)
-export const lineHeights: LineHeightTokens;
+const lineHeights: LineHeightTokens;
 
 // @public (undocumented)
 export type LineHeightTokens = {
@@ -451,10 +460,10 @@ export type ShadowTokens = {
 // Warning: (ae-forgotten-export) The symbol "GlobalSharedColors" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const sharedColors: GlobalSharedColors;
+const sharedColors: GlobalSharedColors;
 
 // @public (undocumented)
-export const strokeWidths: StrokeWidthTokens;
+const strokeWidths_2: StrokeWidthTokens;
 
 // @public (undocumented)
 export type StrokeWidthTokens = {
@@ -492,10 +501,18 @@ export const webHighContrastTheme: Theme;
 export const webLightTheme: Theme;
 
 // @public (undocumented)
-export const white = "#ffffff";
+const white = "#ffffff";
 
 // @public (undocumented)
-export const whiteAlpha: Record<AlphaColors, string>;
+const whiteAlpha: Record<AlphaColors, string>;
+
+// Warnings were encountered during analysis:
+//
+// lib/global/index.d.ts:7:5 - (ae-forgotten-export) The symbol "colors" needs to be exported by the entry point index.d.ts
+// lib/global/index.d.ts:8:5 - (ae-forgotten-export) The symbol "fonts" needs to be exported by the entry point index.d.ts
+// lib/global/index.d.ts:9:5 - (ae-forgotten-export) The symbol "strokeWidths" needs to be exported by the entry point index.d.ts
+// lib/global/index.d.ts:10:5 - (ae-forgotten-export) The symbol "borderRadius" needs to be exported by the entry point index.d.ts
+// lib/global/index.d.ts:11:5 - (ae-forgotten-export) The symbol "brandColors" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-theme/src/global/index.ts
+++ b/packages/react-theme/src/global/index.ts
@@ -2,3 +2,4 @@ export * from './colors';
 export * from './fonts';
 export * from './strokeWidths';
 export * from './borderRadius';
+export * from './brandColors';

--- a/packages/react-theme/src/global/index.ts
+++ b/packages/react-theme/src/global/index.ts
@@ -1,3 +1,17 @@
+import * as colors from './colors';
+import * as fonts from './fonts';
+import * as strokeWidths from './strokeWidths';
+import * as borderRadius from './borderRadius';
+import * as brandColors from './brandColors';
+
+export const globals = {
+  colors,
+  fonts,
+  strokeWidths,
+  borderRadius,
+  brandColors,
+};
+
 export * from './colors';
 export * from './fonts';
 export * from './strokeWidths';

--- a/packages/react-theme/src/index.ts
+++ b/packages/react-theme/src/index.ts
@@ -1,5 +1,6 @@
 export * from './themes/index';
 export * from './utils/index';
+export * from './global/index';
 
 export { themeToTokensObject } from './themeToTokensObject';
 export { tokens } from './tokens';

--- a/packages/react-theme/src/index.ts
+++ b/packages/react-theme/src/index.ts
@@ -1,9 +1,9 @@
 export * from './themes/index';
 export * from './utils/index';
-export * as globals from './global/index';
 
 export { themeToTokensObject } from './themeToTokensObject';
 export { tokens } from './tokens';
+export { globals } from './global';
 
 export type {
   Brands,

--- a/packages/react-theme/src/index.ts
+++ b/packages/react-theme/src/index.ts
@@ -1,6 +1,6 @@
 export * from './themes/index';
 export * from './utils/index';
-export * from './global/index';
+export * as globals from './global/index';
 
 export { themeToTokensObject } from './themeToTokensObject';
 export { tokens } from './tokens';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `master` branch
* [X] Your changes are covered by tests (if possible)
* [X] You've run `yarn change` locally


PR flow tips:
* [X] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The global values of @fluientui/react-theme are not exported out of the package.

## New Behavior

The global values are now exported.

## Related Issue(s)

I've been looking at some integration with the @fluentui/react-theme package and I'd like to access the `brandOffice` object that lives under https://github.com/microsoft/fluentui/blob/master/packages/react-theme/src/global/brandColors.ts to use as part of the default palette that we offer.