### PR TITLE
doc (react-aria): Add documentation for lack of semantic heading element on `AccordionHeader` 

### DIFF
--- a/change/@fluentui-react-accordion-ae14316f-52fa-48d7-b29f-6c7d7e47cdd6.json
+++ b/change/@fluentui-react-accordion-ae14316f-52fa-48d7-b29f-6c7d7e47cdd6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updates spec and story to add warning about heading level",
+  "packageName": "@fluentui/react-accordion",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-accordion/Spec.md
+++ b/packages/react-accordion/Spec.md
@@ -420,13 +420,13 @@ As described on [WAI-ARIA Roles, States, and Properties](https://www.w3.org/TR/w
 
 > Each accordion header button is wrapped in an element with role heading that has a value set for aria-level that is appropriate for the information architecture of the page.
 
-Every `AccordionHeader` should have as it's root an element with `role="heading"` and a proper `aria-level` attribute (or be a semantic heading element: `h1`, `h2`, `h3`, `h4`, `h5` or `h6`). This behavior is not implemented by default on `AccordionHeader` as it's impossible to predict which heading level will be required by the user. Requiring manual addition of such ARIA requirement.
+Every `AccordionHeader` should have as its root a semantic heading element: `h1`, `h2`, `h3`, `h4`, `h5` or `h6`. Alternatively `role="heading"` and a proper `aria-level` attribute. This behavior is not implemented by default on `AccordionHeader` as it's impossible to predict which heading level will be required by the user. Requiring manual addition of such ARIA requirement.
 
 ```tsx
 {/* No heading level by default */}
 <AccordionHeader>This is a header</AccordionHeader>
 {/* Generated html */}
-<div> {/* ⚠️ This is wrong according to WAI-ARIA specification ⚠️*/}
+<div>
   <button>This is a header</button>
 </div>
 

--- a/packages/react-accordion/Spec.md
+++ b/packages/react-accordion/Spec.md
@@ -410,6 +410,37 @@ As a general rule, once the accordion is closed the focus should return to the h
 | Keyboard | Home       | Moves Focus | Moves focus to the first panel heading                      |
 | Keyboard | End        | Moves Focus | Moves focus to the last panel heading                       |
 
-## Accessibiltiy
+## Accessibility
 
-Accessibility behaviour is built into the spec as much as possible. This section addresses specific issues that don't fit well with the standard definition of the component.
+Accessibility behavior is built into the spec as much as possible. This section addresses specific issues that don't fit well with the standard definition of the component.
+
+### No heading level on `AccordionHeader` by default
+
+As described on [WAI-ARIA Roles, States, and Properties](https://www.w3.org/TR/wai-aria-practices/#wai-aria-roles-states-and-properties) documentation for accordion:
+
+> Each accordion header button is wrapped in an element with role heading that has a value set for aria-level that is appropriate for the information architecture of the page.
+
+Every `AccordionHeader` should have as it's root an element with `role="heading"` and a proper `aria-level` attribute (or be a semantic heading element: `h1`, `h2`, `h3`, `h4`, `h5` or `h6`). This behavior is not implemented by default on `AccordionHeader` as it's impossible to predict which heading level will be required by the user. Requiring manual addition of such ARIA requirement.
+
+```tsx
+{/* No heading level by default */}
+<AccordionHeader>This is a header</AccordionHeader>
+{/* Generated html */}
+<div> {/* ⚠️ This is wrong according to WAI-ARIA specification ⚠️*/}
+  <button>This is a header</button>
+</div>
+
+{/* as semantic heading */}
+<AccordionHeader as="h4">This is a header</AccordionHeader>
+{/* Generated html */}
+<h4>
+  <button>This is a header</button>
+</h4>
+
+{/* if no semantic heading can be used */}
+<AccordionHeader role="heading" aria-level="4">This is a header</AccordionHeader>
+{/* Generated html */}
+<div role="heading" aria-level="4">
+  <button>This is a header</button>
+</h4>
+```

--- a/packages/react-accordion/src/stories/AccordionHeaders.stories.tsx
+++ b/packages/react-accordion/src/stories/AccordionHeaders.stories.tsx
@@ -34,7 +34,7 @@ HeadingLevels.parameters = {
   docs: {
     description: {
       story:
-        'An accordion header is a `<div>` by default, but according to [WAI-ARIA specification](https://www.w3.org/TR/wai-aria-practices/#wai-aria-roles-states-and-properties), it should be marked up as a proper heading of any level.',
+        'An accordion header is a `<div>` by default, but according to [WAI-ARIA specification](https://www.w3.org/TR/wai-aria-practices/#wai-aria-roles-states-and-properties), we recommend using a proper heading of any level in markup.',
     },
   },
 };

--- a/packages/react-accordion/src/stories/AccordionHeaders.stories.tsx
+++ b/packages/react-accordion/src/stories/AccordionHeaders.stories.tsx
@@ -33,7 +33,8 @@ export const HeadingLevels = () => (
 HeadingLevels.parameters = {
   docs: {
     description: {
-      story: 'An accordion header is a `<div>` by default, but can be marked up as a heading of any level.',
+      story:
+        'An accordion header is a `<div>` by default, but according to [WAI-ARIA specification](https://www.w3.org/TR/wai-aria-practices/#wai-aria-roles-states-and-properties), it should be marked up as a proper heading of any level.',
     },
   },
 };


### PR DESCRIPTION
## New Behavior

Adds warnings about lack of semantic heading element on `AccordionHeader` component by default on Storybook and Spec

## Related Issue(s)

Fixes #21120
