### PR TITLE
bugfix (react-accordion): solve wrong behavior on Accordion `multiple` mode

### DIFF
--- a/change/@fluentui-react-accordion-3be4a964-94a5-4976-9db3-c6531f3964d5.json
+++ b/change/@fluentui-react-accordion-3be4a964-94a5-4976-9db3-c6531f3964d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updates initial open items value to be empty on every case",
+  "packageName": "@fluentui/react-accordion",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-accordion/src/components/Accordion/useAccordion.test.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordion.test.ts
@@ -16,17 +16,14 @@ describe('useAccordion_unstable', () => {
     expect(result.current.openItems.includes(1)).toBeTruthy();
   });
 
-  // TODO: fix this state, right now we can't ensure collapsible on first render
   it('should respect "multiple" behavior', () => {
     const { result } = renderHook(() => useAccordion_unstable({ multiple: true }, React.createRef()));
 
-    expect(result.current.openItems.length).toEqual(1);
-    expect(result.current.openItems.includes(0)).toBeTruthy();
+    expect(result.current.openItems.length).toEqual(0);
 
     act(() => result.current.requestToggle(undefined!, { value: 1 }));
 
-    expect(result.current.openItems.length).toEqual(2);
-    expect(result.current.openItems.includes(0)).toBeTruthy();
+    expect(result.current.openItems.length).toEqual(1);
     expect(result.current.openItems.includes(1)).toBeTruthy();
   });
 

--- a/packages/react-accordion/src/components/Accordion/useAccordion.test.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordion.test.ts
@@ -16,48 +16,55 @@ describe('useAccordion_unstable', () => {
     expect(result.current.openItems.includes(1)).toBeTruthy();
   });
 
-  it('should respect "multiple" behavior', () => {
-    const { result } = renderHook(() => useAccordion_unstable({ multiple: true }, React.createRef()));
+  describe('multiple', () => {
+    it('should only have zero open items before having any items', () => {
+      const { result } = renderHook(() => useAccordion_unstable({ multiple: true }, React.createRef()));
+      expect(result.current.openItems.length).toEqual(0);
+      act(() => result.current.requestToggle(undefined!, { value: 0 }));
+      expect(result.current.openItems.length).toEqual(1);
+      act(() => result.current.requestToggle(undefined!, { value: 0 }));
+      expect(result.current.openItems.length).toEqual(1);
+    });
+    it('should not have less than 1 open item', () => {
+      const { result } = renderHook(() =>
+        useAccordion_unstable({ multiple: true, defaultOpenItems: [0] }, React.createRef()),
+      );
 
-    expect(result.current.openItems.length).toEqual(0);
+      expect(result.current.openItems.length).toEqual(1);
 
-    act(() => result.current.requestToggle(undefined!, { value: 1 }));
-
-    expect(result.current.openItems.length).toEqual(1);
-    expect(result.current.openItems.includes(1)).toBeTruthy();
+      act(() => result.current.requestToggle(undefined!, { value: 0 }));
+      expect(result.current.openItems.length).toEqual(1);
+      expect(result.current.openItems.includes(0)).toBeTruthy();
+    });
+    it('should open multiple panels', () => {
+      const { result } = renderHook(() => useAccordion_unstable({ multiple: true }, React.createRef()));
+      expect(result.current.openItems.length).toEqual(0);
+      act(() => result.current.requestToggle(undefined!, { value: 0 }));
+      expect(result.current.openItems.includes(0)).toBeTruthy();
+      act(() => result.current.requestToggle(undefined!, { value: 1 }));
+      expect(result.current.openItems.includes(1)).toBeTruthy();
+      expect(result.current.openItems.length).toEqual(2);
+    });
   });
-
-  it('should respect collapsible behavior', () => {
-    const { result } = renderHook(() => useAccordion_unstable({ collapsible: true }, React.createRef()));
-
-    expect(result.current.openItems.length).toEqual(0);
-
-    act(() => result.current.requestToggle(undefined!, { value: 0 }));
-
-    expect(result.current.openItems.length).toEqual(1);
-    expect(result.current.openItems.includes(0)).toBeTruthy();
-
-    act(() => result.current.requestToggle(undefined!, { value: 1 }));
-
-    expect(result.current.openItems.length).toEqual(1);
-    expect(result.current.openItems.includes(1)).toBeTruthy();
-  });
-  it('should respect collapsible and multiple behavior', () => {
-    const { result } = renderHook(() =>
-      useAccordion_unstable({ multiple: true, collapsible: true }, React.createRef()),
-    );
-
-    expect(result.current.openItems.length).toEqual(0);
-
-    act(() => result.current.requestToggle(undefined!, { value: 0 }));
-
-    expect(result.current.openItems.length).toEqual(1);
-    expect(result.current.openItems.includes(0)).toBeTruthy();
-
-    act(() => result.current.requestToggle(undefined!, { value: 1 }));
-
-    expect(result.current.openItems.length).toEqual(2);
-    expect(result.current.openItems.includes(0)).toBeTruthy();
-    expect(result.current.openItems.includes(1)).toBeTruthy();
+  describe('collapsible', () => {
+    it('should have zero panels opened', () => {
+      const { result } = renderHook(() => useAccordion_unstable({ collapsible: true }, React.createRef()));
+      expect(result.current.openItems.length).toEqual(0);
+      act(() => result.current.requestToggle(undefined!, { value: 0 }));
+      expect(result.current.openItems.length).toEqual(1);
+      act(() => result.current.requestToggle(undefined!, { value: 0 }));
+      expect(result.current.openItems.length).toEqual(0);
+    });
+    it('should not open more than one panel', () => {
+      const { result } = renderHook(() => useAccordion_unstable({ collapsible: true }, React.createRef()));
+      expect(result.current.openItems.length).toEqual(0);
+      act(() => result.current.requestToggle(undefined!, { value: 0 }));
+      expect(result.current.openItems.length).toEqual(1);
+      expect(result.current.openItems.includes(0)).toBeTruthy();
+      act(() => result.current.requestToggle(undefined!, { value: 1 }));
+      expect(result.current.openItems.length).toEqual(1);
+      expect(result.current.openItems.includes(1)).toBeTruthy();
+      expect(result.current.openItems.includes(0)).toBeFalsy();
+    });
   });
 });

--- a/packages/react-accordion/src/components/Accordion/useAccordion.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordion.ts
@@ -19,18 +19,18 @@ export const useAccordion_unstable = (props: AccordionProps, ref: React.Ref<HTML
   } = props;
   const [openItems, setOpenItems] = useControllableState({
     state: React.useMemo(() => normalizeValues(controlledOpenItems), [controlledOpenItems]),
-    defaultState: () => initializeUncontrolledOpenItems({ collapsible, defaultOpenItems, multiple }),
+    defaultState: () => initializeUncontrolledOpenItems({ defaultOpenItems, multiple }),
     initialState: [],
   });
 
   const requestToggle = useEventCallback((event: AccordionToggleEvent, data: AccordionToggleData) => {
     onToggle?.(event, data);
-    setOpenItems(previousOpenItems => {
-      return updateOpenItems(data.value, previousOpenItems, {
+    setOpenItems(previousOpenItems =>
+      updateOpenItems(data.value, previousOpenItems, {
         collapsible,
         multiple,
-      });
-    });
+      }),
+    );
   });
 
   return {
@@ -55,20 +55,14 @@ export const useAccordion_unstable = (props: AccordionProps, ref: React.Ref<HTML
 function initializeUncontrolledOpenItems({
   defaultOpenItems,
   multiple,
-  collapsible,
-}: Pick<AccordionProps, 'defaultOpenItems' | 'multiple' | 'collapsible'>): AccordionItemValue[] {
+}: Pick<AccordionProps, 'defaultOpenItems' | 'multiple'>): AccordionItemValue[] {
   if (defaultOpenItems !== undefined) {
     if (Array.isArray(defaultOpenItems)) {
       return multiple ? defaultOpenItems : [defaultOpenItems[0]];
     }
     return [defaultOpenItems];
   }
-  /**
-   * TODO: since the dropping of descendants API due to performance issues,
-   * the default behavior of Accordion has been compromised and [0] makes no sense
-   * indexes are not used anymore to ensure the position of the element which should be opened by default
-   */
-  return collapsible ? [] : [0];
+  return [];
 }
 
 /**

--- a/packages/react-accordion/src/stories/AccordionMultiple.stories.tsx
+++ b/packages/react-accordion/src/stories/AccordionMultiple.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { AccordionItem, AccordionHeader, AccordionPanel, Accordion, AccordionProps } from '../index';
 
 export const Multiple = (args: AccordionProps) => (
-  <Accordion defaultOpenItems="1" {...args}>
+  <Accordion {...args}>
     <AccordionItem value="1">
       <AccordionHeader>Accordion Header 1</AccordionHeader>
       <AccordionPanel>

--- a/packages/react-accordion/src/stories/AccordionMultiple.stories.tsx
+++ b/packages/react-accordion/src/stories/AccordionMultiple.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { AccordionItem, AccordionHeader, AccordionPanel, Accordion, AccordionProps } from '../index';
 
 export const Multiple = (args: AccordionProps) => (
-  <Accordion {...args}>
+  <Accordion defaultOpenItems="1" {...args}>
     <AccordionItem value="1">
       <AccordionHeader>Accordion Header 1</AccordionHeader>
       <AccordionPanel>

--- a/packages/react-accordion/src/stories/AccordionMultiple.stories.tsx
+++ b/packages/react-accordion/src/stories/AccordionMultiple.stories.tsx
@@ -31,7 +31,9 @@ Multiple.args = {
 Multiple.parameters = {
   docs: {
     description: {
-      story: 'An accordion supports multiple panels expanded simultaneously.',
+      story:
+        // eslint-disable-next-line @fluentui/max-len
+        "An accordion supports multiple panels expanded simultaneously. Since it's not simple to determine which panel will be opened by default, `multiple` will also be collapsed by default on the first render",
     },
   },
 };

--- a/packages/react-accordion/src/stories/AccordionOpenItems.stories.tsx
+++ b/packages/react-accordion/src/stories/AccordionOpenItems.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { AccordionItem, AccordionHeader, AccordionPanel, Accordion, AccordionProps } from '../index';
 
 export const OpenItems = (args: AccordionProps) => (
-  <Accordion {...args}>
+  <Accordion defaultOpenItems="1" {...args}>
     <AccordionItem value="1">
       <AccordionHeader>Accordion Header 1</AccordionHeader>
       <AccordionPanel>
@@ -31,7 +31,8 @@ OpenItems.args = {
 OpenItems.parameters = {
   docs: {
     description: {
-      story: 'An accordion can have defined open items.',
+      story:
+        'An accordion can have defined open items. If no open item is present, all panels will be closed by default',
     },
   },
 };


### PR DESCRIPTION
## Current Behavior

If `Accordion` property `multiple` is set to true, `Accordion` is allowing multiple panels to be opened as well as no panel to be opened

## New Behavior

If `Accordion` property `multiple` is set to true, `Accordion` is allowing multiple panels to be opened but always at least one panel should be opened.

## Related Issue(s)

Fixes #21724
