### PR TITLE
bugfix(react-accordion): Fix navigable not working

### DIFF
--- a/change/@fluentui-react-accordion-da606dee-fa35-47c7-9d15-6c0f29d721af.json
+++ b/change/@fluentui-react-accordion-da606dee-fa35-47c7-9d15-6c0f29d721af.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds linear as option for navigable",
+  "packageName": "@fluentui/react-accordion",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-accordion-da606dee-fa35-47c7-9d15-6c0f29d721af.json
+++ b/change/@fluentui-react-accordion-da606dee-fa35-47c7-9d15-6c0f29d721af.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Adds linear as option for navigable",
+  "comment": "Breaking change: navigable becomes navigation",
   "packageName": "@fluentui/react-accordion",
   "email": "bsunderhus@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-accordion/Spec.md
+++ b/packages/react-accordion/Spec.md
@@ -37,9 +37,10 @@ The root level component serves context and common API between all children.
 export type AccordionProps = ComponentProps &
   React.HTMLAttributes<HTMLElement> & {
     /**
-     * Indicates if keyboard navigation is available
+     * Indicates if keyboard navigation is available and gives two options,
+     * linear or circular navigation
      */
-    navigable?: boolean;
+    navigation?: 'linear' | 'circular';
     /**
      * Indicates if Accordion support multiple Panels opened at the same time
      */

--- a/packages/react-accordion/src/components/Accordion/Accordion.types.ts
+++ b/packages/react-accordion/src/components/Accordion/Accordion.types.ts
@@ -10,13 +10,10 @@ export type AccordionToggleEventHandler = (event: AccordionToggleEvent, data: Ac
 
 type AccordionCommons = {
   /**
-   * Indicates if keyboard navigation is available
-   * By default circular navigation is available,
-   * if 'linear' is provided than there's no circular navigation
-   *
-   * @default false
+   * Indicates if keyboard navigation is available and gives two options,
+   * linear or circular navigation
    */
-  navigable: boolean | 'linear';
+  navigation?: 'linear' | 'circular';
   /**
    * Indicates if Accordion support multiple Panels opened at the same time
    */

--- a/packages/react-accordion/src/components/Accordion/Accordion.types.ts
+++ b/packages/react-accordion/src/components/Accordion/Accordion.types.ts
@@ -11,8 +11,12 @@ export type AccordionToggleEventHandler = (event: AccordionToggleEvent, data: Ac
 type AccordionCommons = {
   /**
    * Indicates if keyboard navigation is available
+   * By default circular navigation is available,
+   * if 'linear' is provided than there's no circular navigation
+   *
+   * @default false
    */
-  navigable: boolean;
+  navigable: boolean | 'linear';
   /**
    * Indicates if Accordion support multiple Panels opened at the same time
    */

--- a/packages/react-accordion/src/components/Accordion/AccordionContext.ts
+++ b/packages/react-accordion/src/components/Accordion/AccordionContext.ts
@@ -4,7 +4,6 @@ import type { AccordionContextValue } from './Accordion.types';
 
 export const AccordionContext: Context<AccordionContextValue> = createContext<AccordionContextValue>({
   openItems: [],
-  navigable: false,
   collapsible: false,
   requestToggle() {
     /* noop */

--- a/packages/react-accordion/src/components/Accordion/useAccordion.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordion.ts
@@ -16,7 +16,7 @@ export const useAccordion_unstable = (props: AccordionProps, ref: React.Ref<HTML
     multiple = false,
     collapsible = false,
     onToggle,
-    navigable = false,
+    navigation,
   } = props;
   const [openItems, setOpenItems] = useControllableState({
     state: React.useMemo(() => normalizeValues(controlledOpenItems), [controlledOpenItems]),
@@ -25,7 +25,7 @@ export const useAccordion_unstable = (props: AccordionProps, ref: React.Ref<HTML
   });
 
   const arrowNavigationProps = useArrowNavigationGroup({
-    circular: navigable === 'linear' ? false : navigable,
+    circular: navigation === 'circular',
   });
 
   const requestToggle = useEventCallback((event: AccordionToggleEvent, data: AccordionToggleData) => {
@@ -41,7 +41,7 @@ export const useAccordion_unstable = (props: AccordionProps, ref: React.Ref<HTML
   return {
     multiple,
     collapsible,
-    navigable,
+    navigation,
     openItems,
     requestToggle,
     components: {
@@ -49,7 +49,7 @@ export const useAccordion_unstable = (props: AccordionProps, ref: React.Ref<HTML
     },
     root: getNativeElementProps('div', {
       ...props,
-      ...(navigable ? arrowNavigationProps : {}),
+      ...(navigation ? arrowNavigationProps : {}),
       ref,
     }),
   };

--- a/packages/react-accordion/src/components/Accordion/useAccordion.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordion.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { getNativeElementProps, useControllableState, useEventCallback } from '@fluentui/react-utilities';
 import type { AccordionProps, AccordionState, AccordionToggleData, AccordionToggleEvent } from './Accordion.types';
 import type { AccordionItemValue } from '../AccordionItem/AccordionItem.types';
+import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 
 /**
  * Returns the props and state required to render the component
@@ -22,6 +23,8 @@ export const useAccordion_unstable = (props: AccordionProps, ref: React.Ref<HTML
     defaultState: () => initializeUncontrolledOpenItems({ defaultOpenItems, multiple }),
     initialState: [],
   });
+
+  const arrowNavigationProps = useArrowNavigationGroup();
 
   const requestToggle = useEventCallback((event: AccordionToggleEvent, data: AccordionToggleData) => {
     onToggle?.(event, data);
@@ -44,6 +47,7 @@ export const useAccordion_unstable = (props: AccordionProps, ref: React.Ref<HTML
     },
     root: getNativeElementProps('div', {
       ...props,
+      ...(navigable ? arrowNavigationProps : {}),
       ref,
     }),
   };

--- a/packages/react-accordion/src/components/Accordion/useAccordion.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordion.ts
@@ -24,7 +24,9 @@ export const useAccordion_unstable = (props: AccordionProps, ref: React.Ref<HTML
     initialState: [],
   });
 
-  const arrowNavigationProps = useArrowNavigationGroup();
+  const arrowNavigationProps = useArrowNavigationGroup({
+    circular: navigable === 'linear' ? false : navigable,
+  });
 
   const requestToggle = useEventCallback((event: AccordionToggleEvent, data: AccordionToggleData) => {
     onToggle?.(event, data);

--- a/packages/react-accordion/src/components/Accordion/useAccordionContextValues.test.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordionContextValues.test.ts
@@ -7,13 +7,13 @@ import { useAccordionContextValues_unstable } from './useAccordionContextValues'
 describe('useAccordionContextValues_unstable', () => {
   it('should return a value for "accordion"', () => {
     const { result } = renderHook(() => {
-      const state = useAccordion_unstable({ navigable: false }, React.createRef());
+      const state = useAccordion_unstable({}, React.createRef());
 
       return useAccordionContextValues_unstable(state);
     });
 
     expect(result.current.accordion).toBeDefined();
-    expect(result.current.accordion.navigable).toBe(false);
+    expect(result.current.accordion.navigation).toBe(undefined);
     expect(result.current.accordion.openItems).toBeInstanceOf(Array);
     expect(result.current.accordion.requestToggle).toBeInstanceOf(Function);
   });

--- a/packages/react-accordion/src/components/Accordion/useAccordionContextValues.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordionContextValues.ts
@@ -1,11 +1,11 @@
 import type { AccordionContextValue, AccordionContextValues, AccordionState } from './Accordion.types';
 
 export function useAccordionContextValues_unstable(state: AccordionState): AccordionContextValues {
-  const { navigable, openItems, requestToggle, collapsible } = state;
+  const { navigation, openItems, requestToggle, collapsible } = state;
 
   // This context is created with "@fluentui/react-context-selector", these is no sense to memoize it
   const accordion: AccordionContextValue = {
-    navigable,
+    navigation,
     openItems,
     requestToggle,
     collapsible,

--- a/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.test.tsx
+++ b/packages/react-accordion/src/components/AccordionHeader/useAccordionHeader.test.tsx
@@ -12,7 +12,6 @@ describe('useAccordionHeader_unstable', () => {
       <AccordionContext.Provider
         value={{
           collapsible: false,
-          navigable: false,
           openItems: [1],
           requestToggle: () => {
             /* ... */

--- a/packages/react-accordion/src/components/AccordionItem/useAccordionItem.ts
+++ b/packages/react-accordion/src/components/AccordionItem/useAccordionItem.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { getNativeElementProps } from '@fluentui/react-utilities';
-import { useTabsterAttributes } from '@fluentui/react-tabster';
+import { useFocusableGroup } from '@fluentui/react-tabster';
 import { useContextSelector } from '@fluentui/react-context-selector';
 import { AccordionContext } from '../Accordion/AccordionContext';
 import type { AccordionItemProps, AccordionItemState } from './AccordionItem.types';
@@ -17,9 +17,7 @@ export const useAccordionItem_unstable = (
 ): AccordionItemState => {
   const { value, disabled = false } = props;
   const navigable = useContextSelector(AccordionContext, ctx => ctx.navigable);
-  const tabsterAttributes = useTabsterAttributes({
-    groupper: {},
-  });
+  const focusableProps = useFocusableGroup();
 
   const requestToggle = useContextSelector(AccordionContext, ctx => ctx.requestToggle);
   const open = useContextSelector(AccordionContext, ctx => ctx.openItems.includes(value));
@@ -38,8 +36,8 @@ export const useAccordionItem_unstable = (
     },
     root: getNativeElementProps('div', {
       ref: ref,
-      ...(navigable ? tabsterAttributes : {}),
       ...props,
+      ...(navigable && focusableProps),
     }),
   };
 };

--- a/packages/react-accordion/src/components/AccordionItem/useAccordionItem.ts
+++ b/packages/react-accordion/src/components/AccordionItem/useAccordionItem.ts
@@ -16,7 +16,7 @@ export const useAccordionItem_unstable = (
   ref: React.Ref<HTMLElement>,
 ): AccordionItemState => {
   const { value, disabled = false } = props;
-  const navigable = useContextSelector(AccordionContext, ctx => ctx.navigable);
+  const navigation = useContextSelector(AccordionContext, ctx => ctx.navigation);
   const focusableProps = useFocusableGroup();
 
   const requestToggle = useContextSelector(AccordionContext, ctx => ctx.requestToggle);
@@ -37,7 +37,7 @@ export const useAccordionItem_unstable = (
     root: getNativeElementProps('div', {
       ref: ref,
       ...props,
-      ...(navigable && focusableProps),
+      ...(navigation && focusableProps),
     }),
   };
 };

--- a/packages/react-accordion/src/stories/AccordionNavigable.stories.tsx
+++ b/packages/react-accordion/src/stories/AccordionNavigable.stories.tsx
@@ -6,19 +6,19 @@ export const Navigable = (args: AccordionProps) => (
     <AccordionItem value="1">
       <AccordionHeader>Accordion Header 1</AccordionHeader>
       <AccordionPanel>
-        <div>Accordion Panel 1</div>
+        <button>Accordion Panel 1</button>
       </AccordionPanel>
     </AccordionItem>
     <AccordionItem value="2">
       <AccordionHeader>Accordion Header 2</AccordionHeader>
       <AccordionPanel>
-        <div>Accordion Panel 2</div>
+        <button>Accordion Panel 2</button>
       </AccordionPanel>
     </AccordionItem>
     <AccordionItem value="3">
       <AccordionHeader>Accordion Header 3</AccordionHeader>
       <AccordionPanel>
-        <div>Accordion Panel 3</div>
+        <button>Accordion Panel 3</button>
       </AccordionPanel>
     </AccordionItem>
   </Accordion>


### PR DESCRIPTION
## Current Behavior

Accordion `navigable` props is not working properly, it should allow keyboard navigation when property is set.

## New Behavior

1. Accordion `navigable` props is working _"properly"_, it should allow keyboard navigation when property is set.
2. Adds circular navigation by default and linear as optional.


## Related Issue(s)

Apparently right now we're having problems reproducing the exact [WAI-ARIA behavior from Accordion specification](https://www.w3.org/TR/wai-aria-practices/#accordion) with tabster https://github.com/microsoft/tabster/issues/111

Fixes #21725
