### PR TITLE
[6.0] Add Debug verbosity to ManifestGeneratorTask

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -118,6 +118,7 @@ steps:
     displayName: 📒 Generate Manifest
     inputs:
       BuildDropPath: $(System.DefaultWorkingDirectory)
+      Verbosity: Debug
 
   - task: PublishPipelineArtifact@1
     displayName: 📒 Publish Manifest


### PR DESCRIPTION
## Current Behavior

The Default verbosity is warning. 

## New Behavior
Setting to Debug to analyze why the task is hanging...

