### PR TITLE
chore: Create VR test project for react-components

### DIFF
--- a/apps/vr-tests-react-components/.eslintrc.json
+++ b/apps/vr-tests-react-components/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
+  "root": true,
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/jsx-no-bind": "off",
+    "deprecation/deprecation": "off",
+    "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../.."] }]
+  }
+}

--- a/apps/vr-tests-react-components/.eslintrc.json
+++ b/apps/vr-tests-react-components/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
+  "extends": ["plugin:@fluentui/eslint-plugin/react"],
   "root": true,
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",

--- a/apps/vr-tests-react-components/.storybook/main.js
+++ b/apps/vr-tests-react-components/.storybook/main.js
@@ -1,0 +1,30 @@
+const path = require('path');
+const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
+
+module.exports = {
+  stories: ['../src/**/*.stories.tsx'],
+  core: {
+    builder: 'webpack5',
+  },
+  babel: {},
+  typescript: {
+    // disable react-docgen-typescript (totally not needed here, slows things down a lot)
+    reactDocgen: false,
+  },
+  webpackFinal: config => {
+    const tsPaths = new TsconfigPathsPlugin({
+      configFile: path.resolve(__dirname, '../../../tsconfig.base.json'),
+    });
+
+    if (config.resolve) {
+      config.resolve.plugins ? config.resolve.plugins.push(tsPaths) : (config.resolve.plugins = [tsPaths]);
+    }
+
+    config.module.rules.unshift({
+      test: /\.(ts|tsx)$/,
+      use: [{ loader: '@griffel/webpack-loader' }],
+    });
+
+    return config;
+  },
+};

--- a/apps/vr-tests-react-components/.storybook/manager.js
+++ b/apps/vr-tests-react-components/.storybook/manager.js
@@ -1,0 +1,9 @@
+import { addons } from '@storybook/addons';
+import { create } from '@storybook/theming';
+
+addons.setConfig({
+  theme: create({
+    base: 'light',
+    brandTitle: 'Fabric',
+  }),
+});

--- a/apps/vr-tests-react-components/.storybook/preview.js
+++ b/apps/vr-tests-react-components/.storybook/preview.js
@@ -1,0 +1,60 @@
+// @ts-check
+import * as React from 'react';
+import { setAddon } from '@storybook/react';
+import { webLightTheme, webHighContrastTheme, webDarkTheme } from '@fluentui/react-theme';
+import { FluentProvider } from '@fluentui/react-provider';
+
+/**
+ * @deprecated https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-setaddon
+ *
+ * TODO: rework this to be conformant with Component Story Format
+ *
+ * Via this addon, we INVENT a new API that automatically adds several
+ * stories for you when you call addStory() that adds variants (like RTL)
+ *
+ * addStory() is not an official Storybook API
+ *
+ * Adds a story with different configuration options.
+ * By default, only adds a story in LTR.
+ * The config parameter can be used to add the story RTL in addition to LTR.
+ * In future, this can add a story with additional configurations such as theming.
+ */
+setAddon({
+  /**
+   * @type {import('../src/utilities/types').ExtendedStoryApi['addStory']}
+   * @this {import('../src/utilities/types').ExtendedStoryApi}
+   */
+  addStory(storyName, storyFn, config = {}) {
+    this.add(storyName, context => {
+      return <FluentProvider theme={webLightTheme}>{storyFn(context)}</FluentProvider>;
+    });
+    if (config.includeRtl) {
+      this.add(storyName + ' - RTL', context => {
+        return (
+          <FluentProvider theme={webLightTheme} dir="rtl">
+            {storyFn(context)}
+          </FluentProvider>
+        );
+      });
+    }
+    if (config.includeDarkMode) {
+      this.add(storyName + ' - Dark Mode', context => {
+        return <FluentProvider theme={webDarkTheme}>{storyFn(context)}</FluentProvider>;
+      });
+    }
+    if (config.includeHighContrast) {
+      this.add(storyName + ' - High Contrast', context => {
+        return <FluentProvider theme={webHighContrastTheme}>{storyFn(context)}</FluentProvider>;
+      });
+    }
+
+    return this;
+  },
+});
+
+export const parameters = { layout: 'none' };
+
+// For static storybook per https://github.com/screener-io/screener-storybook#testing-with-static-storybook-app
+if (typeof window === 'object') {
+  /** @type {*} */ (window).__screener_storybook__ = require('@storybook/react').getStorybook;
+}

--- a/apps/vr-tests-react-components/just.config.ts
+++ b/apps/vr-tests-react-components/just.config.ts
@@ -1,0 +1,5 @@
+import { preset, task } from '@fluentui/scripts';
+
+preset();
+
+task('build', 'build:node-lib').cached();

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@fluentui/vr-tests-react-components",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Visual regression tests for @fluentui/react-components",
+  "scripts": {
+    "build": "just-scripts build",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "just": "just-scripts",
+    "lint": "just-scripts lint",
+    "screener:build": "cross-env NODE_OPTIONS=--max-old-space-size=3072 just-scripts storybook:build",
+    "start": "just-scripts dev:storybook"
+  },
+  "devDependencies": {
+    "@fluentui/eslint-plugin": "*"
+  },
+  "dependencies": {
+    "@fluentui/react-accordion": "9.0.0-rc.1",
+    "@fluentui/react-avatar": "9.0.0-rc.1",
+    "@fluentui/react-badge": "9.0.0-rc.1",
+    "@fluentui/react-button": "9.0.0-rc.1",
+    "@fluentui/react-card": "9.0.0-beta.6",
+    "@fluentui/react-checkbox": "^9.0.0-beta.6",
+    "@fluentui/react-divider": "9.0.0-rc.1",
+    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-image": "9.0.0-rc.1",
+    "@fluentui/react-input": "9.0.0-beta.1",
+    "@fluentui/react-label": "9.0.0-beta.5",
+    "@fluentui/react-link": "9.0.0-rc.1",
+    "@fluentui/react-menu": "9.0.0-rc.1",
+    "@fluentui/react-popover": "9.0.0-rc.1",
+    "@fluentui/react-provider": "9.0.0-rc.1",
+    "@fluentui/react-slider": "9.0.0-beta.6",
+    "@fluentui/react-switch": "9.0.0-rc.1",
+    "@fluentui/react-tabs": "9.0.0-beta.4",
+    "@fluentui/react-text": "9.0.0-rc.1",
+    "@fluentui/react-theme": "9.0.0-rc.1",
+    "@fluentui/react-tooltip": "9.0.0-rc.1",
+    "@fluentui/scripts": "^1.0.0",
+    "@griffel/react": "1.0.0",
+    "@types/react": "16.9.42",
+    "@types/react-dom": "16.9.10",
+    "react": "16.8.6",
+    "react-dom": "16.8.6",
+    "screener-storybook": "0.21.2",
+    "tslib": "^2.1.0"
+  }
+}

--- a/apps/vr-tests-react-components/screener.config.js
+++ b/apps/vr-tests-react-components/screener.config.js
@@ -33,9 +33,6 @@ const baseBranch = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
 
 // https://github.com/screener-io/screener-storybook#additional-configuration-options
 const config = {
-  fluentInternal: {
-    baseUrl: `${process.env.DEPLOYURL}/react-components-screener/iframe.html`,
-  },
   projectRepo: 'microsoft/fluentui/react-components',
   storybookStaticBuildDir: 'dist/storybook',
   storybookConfigDir: '.storybook',

--- a/apps/vr-tests-react-components/screener.config.js
+++ b/apps/vr-tests-react-components/screener.config.js
@@ -1,0 +1,50 @@
+// @ts-check
+
+const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+if (!fs.existsSync(path.join(__dirname, 'dist/storybook'))) {
+  console.error('You must run `yarn screener:build` before `yarn screener`');
+  process.exit(1);
+}
+
+function getCurrentHash() {
+  try {
+    const buffer = cp.execSync('git rev-list --parents -n 1 HEAD', {
+      stdio: ['pipe', 'pipe', process.stderr],
+    });
+
+    if (buffer) {
+      // The command returns a list of hashes, the last one is the one we want
+      return buffer.toString().trim().split(' ').pop();
+    }
+  } catch (e) {
+    console.error('Cannot get current git hash');
+    process.exit(1);
+  }
+
+  return '';
+}
+
+const baseBranch = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
+  ? process.env.SYSTEM_PULLREQUEST_TARGETBRANCH.replace(/^refs\/heads\//, '')
+  : 'master';
+
+// https://github.com/screener-io/screener-storybook#additional-configuration-options
+const config = {
+  projectRepo: 'microsoft/fluentui/react-components',
+  storybookStaticBuildDir: 'dist/storybook',
+  storybookConfigDir: '.storybook',
+  apiKey: process.env.SCREENER_API_KEY,
+  resolution: '1024x768',
+  baseBranch,
+  failureExitCode: 0,
+  alwaysAcceptBaseBranch: true,
+  ...(process.env.BUILD_SOURCEBRANCH && process.env.BUILD_SOURCEBRANCH.indexOf('refs/pull') > -1
+    ? { commit: getCurrentHash() }
+    : null),
+};
+console.log('Screener config: ' + JSON.stringify({ ...config, apiKey: '...' }, null, 2));
+
+module.exports = config;

--- a/apps/vr-tests-react-components/screener.config.js
+++ b/apps/vr-tests-react-components/screener.config.js
@@ -33,6 +33,9 @@ const baseBranch = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
 
 // https://github.com/screener-io/screener-storybook#additional-configuration-options
 const config = {
+  fluentInternal: {
+    baseUrl: `${process.env.DEPLOYURL}/react-components-screener/iframe.html`,
+  },
   projectRepo: 'microsoft/fluentui/react-components',
   storybookStaticBuildDir: 'dist/storybook',
   storybookConfigDir: '.storybook',

--- a/apps/vr-tests-react-components/src/stories/Accordion.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Accordion.stories.tsx
@@ -1,0 +1,161 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import Screener from 'screener-storybook/src/screener';
+import { Accordion, AccordionItem, AccordionHeader, AccordionPanel } from '@fluentui/react-accordion';
+import { CircleRegular } from '@fluentui/react-icons';
+
+storiesOf('Accordion Converged', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('normal', { cropTo: '.testWrapper' })
+        .focus('#opened-btn')
+        .snapshot('focus opened', { cropTo: '.testWrapper' })
+        .focus('#closed-btn')
+        .snapshot('focus closed', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      <div className="testWrapper" style={{ width: '300px' }}>
+        {story()}
+      </div>
+    </Screener>
+  ))
+
+  .addStory(
+    'visibility+focus',
+    () => (
+      <Accordion openItems={[0]}>
+        <AccordionItem value={0}>
+          <AccordionHeader button={{ id: 'opened-btn' }}>Opened</AccordionHeader>
+          <AccordionPanel>Opened Panel</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value={1}>
+          <AccordionHeader button={{ id: 'closed-btn' }}>Closed</AccordionHeader>
+          <AccordionPanel>Closed Panel</AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    ),
+    { includeRtl: true, includeHighContrast: true, includeDarkMode: true },
+  );
+
+storiesOf('Accordion Converged', module)
+  .addDecorator(story => (
+    <Screener steps={new Screener.Steps().snapshot('normal', { cropTo: '.testWrapper' }).end()}>
+      <div className="testWrapper" style={{ width: '300px' }}>
+        {story()}
+      </div>
+    </Screener>
+  ))
+
+  .addStory(
+    'size',
+    () => (
+      <Accordion openItems={[0, 1, 2, 3]}>
+        <AccordionItem value={0}>
+          <AccordionHeader size="small">Small</AccordionHeader>
+          <AccordionPanel>Small Panel</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value={1}>
+          <AccordionHeader size="medium">Medium</AccordionHeader>
+          <AccordionPanel>Medium Panel</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value={2}>
+          <AccordionHeader size="large">Large</AccordionHeader>
+          <AccordionPanel>Large Panel</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value={3}>
+          <AccordionHeader size="extra-large">Extra Large</AccordionHeader>
+          <AccordionPanel>Extra Large Panel</AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    ),
+    { includeRtl: true },
+  )
+  .addStory(
+    'expandIconPosition="end"',
+    () => (
+      <Accordion openItems={[0]}>
+        <AccordionItem value={0}>
+          <AccordionHeader expandIconPosition="end">Opened</AccordionHeader>
+          <AccordionPanel>Visible Panel</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value={1}>
+          <AccordionHeader expandIconPosition="end">Closed</AccordionHeader>
+          <AccordionPanel>Hidden Panel</AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    ),
+    { includeRtl: true },
+  )
+  .addStory(
+    'expandIcon="<Icon/>"',
+    () => (
+      <Accordion openItems={[]}>
+        <AccordionItem value={0}>
+          <AccordionHeader expandIcon={<CircleRegular />} expandIconPosition="start">
+            Expand Icon Start
+          </AccordionHeader>
+          <AccordionPanel>Expand Icon Start Panel</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value={1}>
+          <AccordionHeader expandIcon={<CircleRegular />} expandIconPosition="end">
+            Expand Icon End
+          </AccordionHeader>
+          <AccordionPanel>Expand Icon End Panel</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value={2}>
+          <AccordionHeader inline expandIcon={<CircleRegular />} expandIconPosition="end">
+            Expand Icon Inline End
+          </AccordionHeader>
+          <AccordionPanel>Expand Icon Inline End Panel</AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    ),
+    { includeRtl: true, includeHighContrast: true, includeDarkMode: true },
+  )
+  .addStory(
+    'icon="<Icon/>"',
+    () => (
+      <Accordion openItems={[]}>
+        <AccordionItem value={0}>
+          <AccordionHeader icon={<CircleRegular />} expandIconPosition="start">
+            Icon Start
+          </AccordionHeader>
+          <AccordionPanel>Icon Start Panel</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value={1}>
+          <AccordionHeader icon={<CircleRegular />} expandIconPosition="end">
+            Icon End
+          </AccordionHeader>
+          <AccordionPanel>Icon End Panel</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value={2}>
+          <AccordionHeader inline icon={<CircleRegular />} expandIconPosition="end">
+            Icon Inline End
+          </AccordionHeader>
+          <AccordionPanel>Icon Inline End Panel</AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    ),
+    { includeRtl: true },
+  )
+  .addStory(
+    'disabled',
+    () => (
+      <Accordion openItems={[]}>
+        <AccordionItem value={0} disabled>
+          <AccordionHeader>Disabled Item Opened</AccordionHeader>
+          <AccordionPanel>Disabled Item Opened Panel</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value={1} disabled>
+          <AccordionHeader>Disabled Item Closed</AccordionHeader>
+          <AccordionPanel>Disabled Item Closed Panel</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value={2} disabled>
+          <AccordionHeader inline>Disabled Item ClosedInline</AccordionHeader>
+          <AccordionPanel>Disabled Item ClosedInline Panel</AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    ),
+    { includeHighContrast: true, includeDarkMode: true },
+  );

--- a/apps/vr-tests-react-components/src/stories/Avatar.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Avatar.stories.tsx
@@ -1,0 +1,238 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import Screener from 'screener-storybook/src/screener';
+import { Avatar, AvatarProps } from '@fluentui/react-avatar';
+import { PeopleRegular, PersonCallRegular } from '@fluentui/react-icons';
+
+const imageRoot = 'http://fabricweb.azureedge.net/fabric-website/assets/images/avatar';
+
+/** Sample names and images for use in Avatar examples */
+const nameAndImage = [
+  { name: 'Katri Athokas', image: `${imageRoot}/KatriAthokas.jpg` },
+  { name: 'Elvia Atkins', image: `${imageRoot}/ElviaAtkins.jpg` },
+  { name: 'Mauricio August', image: `${imageRoot}/MauricioAugust.jpg` },
+  { name: 'Colin Ballinger', image: `${imageRoot}/ColinBallinger.jpg` },
+  { name: 'Lydia Bauer', image: `${imageRoot}/LydiaBauer.jpg` },
+  { name: 'Amanda Brady', image: `${imageRoot}/AmandaBrady.jpg` },
+  { name: 'Henry Brill', image: `${imageRoot}/HenryBrill.jpg` },
+  { name: 'Celeste Burton', image: `${imageRoot}/CelesteBurton.jpg` },
+  { name: 'Robin Counts', image: `${imageRoot}/RobinCounts.jpg` },
+  { name: 'Tim Deboer', image: `${imageRoot}/TimDeboer.jpg` },
+  { name: 'Cameron Evans', image: `${imageRoot}/CameronEvans.jpg` },
+  { name: 'Isaac Fielder', image: `${imageRoot}/IsaacFielder.jpg` },
+  { name: 'Cecil Folk', image: `${imageRoot}/CecilFolk.jpg` },
+  { name: 'Miguel Garcia', image: `${imageRoot}/MiguelGarcia.jpg` },
+  { name: 'Wanda Howard', image: `${imageRoot}/WandaHoward.jpg` },
+  { name: 'Mona Kane', image: `${imageRoot}/MonaKane.jpg` },
+  { name: 'Kat Larsson', image: `${imageRoot}/KatLarsson.jpg` },
+  { name: 'Ashley McCarthy', image: `${imageRoot}/AshleyMcCarthy.jpg` },
+  { name: 'Johnie McConnell', image: `${imageRoot}/JohnieMcConnell.jpg` },
+  { name: 'Allan Munger', image: `${imageRoot}/AllanMunger.jpg` },
+  { name: 'Erik Nason', image: `${imageRoot}/ErikNason.jpg` },
+  { name: 'Kristin Patterson', image: `${imageRoot}/KristinPatterson.jpg` },
+  { name: 'Daisy Phillips', image: `${imageRoot}/DaisyPhillips.jpg` },
+  { name: 'Carole Poland', image: `${imageRoot}/CarolePoland.jpg` },
+  { name: 'Carlos Slattery', image: `${imageRoot}/CarlosSlattery.jpg` },
+  { name: 'Robert Tolbert', image: `${imageRoot}/RobertTolbert.jpg` },
+  { name: 'Kevin Sturgis', image: `${imageRoot}/KevinSturgis.jpg` },
+  { name: 'Charlotte Waltson', image: `${imageRoot}/CharlotteWaltson.jpg` },
+  { name: 'Elliot Woodward', image: `${imageRoot}/ElliotWoodward.jpg` },
+];
+
+/** Arrays of example values for each Avatar prop */
+const examples = {
+  size: [20, 24, 28, 32, 36, 40, 48, 56, 64, 72, 96, 120, 128],
+  nameAndImage: nameAndImage,
+  name: nameAndImage.map(p => p.name),
+  image: nameAndImage.map(p => p.image),
+  badge: [
+    { status: 'available' },
+    { status: 'away' },
+    { status: 'busy' },
+    { status: 'doNotDisturb' },
+    { status: 'offline' },
+    { status: 'outOfOffice' },
+    { status: 'available', outOfOffice: true },
+    { status: 'away', outOfOffice: true },
+    { status: 'busy', outOfOffice: true },
+    { status: 'doNotDisturb', outOfOffice: true },
+    { status: 'offline', outOfOffice: true },
+    { status: 'outOfOffice', outOfOffice: true },
+  ],
+  activeDisplay: ['ring', 'ring-shadow', 'shadow'],
+  color: ['neutral', 'brand', 'colorful'],
+  namedColors: [
+    'darkRed',
+    'cranberry',
+    'red',
+    'pumpkin',
+    'peach',
+    'marigold',
+    'gold',
+    'brass',
+    'brown',
+    'forest',
+    'seafoam',
+    'darkGreen',
+    'lightTeal',
+    'teal',
+    'steel',
+    'blue',
+    'royalBlue',
+    'cornflower',
+    'navy',
+    'lavender',
+    'purple',
+    'grape',
+    'lilac',
+    'pink',
+    'magenta',
+    'plum',
+    'beige',
+    'mink',
+    'platinum',
+    'anchor',
+  ],
+  /** A SVG hexagon data URL used by the CustomShape example */
+  hexagon:
+    'data:image/svg+xml;utf8,' +
+    '<svg width="36" height="32" viewBox="0 0 36 32" fill="none" xmlns="http://www.w3.org/2000/svg">' +
+    '<path fill="rgb(232,232,232)" d="M0.407926 17.528C-0.135976 16.5859 -0.135975 15.4141 0.407926 14.472' +
+    'L7.91541 1.46793C8.44076 0.557947 9.39444 0 10.4245 0H25.5755C26.6056 0 27.5592 0.557951 28.0846 1.46793' +
+    'L35.5921 14.472C36.136 15.4141 36.136 16.5859 35.5921 17.528L28.0846 30.5321' +
+    'C27.5592 31.4421 26.6056 32 25.5755 32H10.4245C9.39443 32 8.44076 31.4421 7.91541 30.5321L0.407926 17.528Z"/>' +
+    '</svg>',
+} as const;
+
+/** Renders an Avatar at every standard size */
+const AvatarList: React.FC<
+  AvatarProps & {
+    names?: readonly string[];
+    images?: readonly string[];
+  }
+> = props => {
+  const { names, images, ...restOfProps } = props;
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '48px', padding: '24px' }}>
+      {examples.size.map((size, i) => (
+        <Avatar
+          key={size}
+          size={size}
+          name={names && names[i % names.length]}
+          image={images ? { src: images[i % images.length] } : undefined}
+          {...restOfProps}
+        />
+      ))}
+    </div>
+  );
+};
+
+const customSizes: { baseSize: AvatarProps['size']; customSize: string }[] = [
+  { baseSize: 20, customSize: '13px' },
+  { baseSize: 20, customSize: '21px' },
+  { baseSize: 32, customSize: '34px' },
+  { baseSize: 48, customSize: '55px' },
+  { baseSize: 72, customSize: '89px' },
+  { baseSize: 128, customSize: '144px' },
+];
+
+/** Renders an Avatar at a few custom sizes */
+const AvatarCustomSizeList: React.FC<
+  AvatarProps & {
+    names?: readonly string[];
+    images?: readonly string[];
+  }
+> = props => {
+  const { names, images, ...restOfProps } = props;
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '48px', padding: '24px' }}>
+      {customSizes.map(({ baseSize, customSize }, i) => (
+        <Avatar
+          key={customSize}
+          size={baseSize}
+          style={{ width: customSize, height: customSize }}
+          name={names && names[names.length - (i % names.length) - 1]}
+          image={images ? { src: images[images.length - (i % images.length) - 1] } : undefined}
+          {...restOfProps}
+        />
+      ))}
+    </div>
+  );
+};
+
+storiesOf('Avatar Converged', module)
+  .addDecorator(story => (
+    <div style={{ display: 'flex' }}>
+      <div className="testWrapper" style={{ maxWidth: '750px' }}>
+        {story()}
+      </div>
+    </div>
+  ))
+  .addDecorator(story => (
+    <Screener steps={new Screener.Steps().snapshot('normal', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>
+  ))
+  .addStory(
+    'basic',
+    () => (
+      <div style={{ display: 'flex', gap: '24px', padding: '24px' }}>
+        <Avatar />
+        <Avatar name="First Last" />
+        <Avatar name="Three Word Name" />
+        <Avatar name="One" />
+        <Avatar name="(111)-555-1234" icon={<PersonCallRegular />} />
+        <Avatar icon={<PeopleRegular />} shape="square" />
+        <Avatar name="Group" icon={<PeopleRegular />} shape="square" />
+        <Avatar image={{ src: examples.image[14] }} badge={{ status: 'away' }} />
+        <Avatar name={examples.name[7]} image={{ src: examples.image[7] }} badge={{ status: 'available' }} />
+      </div>
+    ),
+    { includeRtl: true, includeHighContrast: true, includeDarkMode: true },
+  )
+  .addStory('size+name', () => <AvatarList names={examples.name} />)
+  .addStory('size+icon+badge+square', () => <AvatarList badge={{ status: 'outOfOffice' }} shape="square" />)
+  .addStory('size+image+badge', () => <AvatarList images={examples.image} badge={{ status: 'doNotDisturb' }} />)
+  .addStory('size+inactive+badge', () => (
+    <AvatarList images={examples.image} active="inactive" badge={{ status: 'offline' }} />
+  ))
+  .addStory('size+active+badge', () => (
+    <AvatarList images={examples.image} active="active" badge={{ status: 'available' }} />
+  ))
+  .addStory('size+active+shadow', () => (
+    <AvatarList images={examples.image} active="active" activeAppearance="shadow" />
+  ))
+  .addStory('size+active+ring-shadow', () => (
+    <AvatarList images={examples.image} active="active" activeAppearance="ring-shadow" />
+  ))
+  .addStory('customSize+image', () => <AvatarCustomSizeList images={examples.image} />)
+  .addStory('customSize+name+badge', () => (
+    <AvatarCustomSizeList names={examples.name} badge={{ status: 'available' }} />
+  ))
+  .addStory('customSize+icon+active', () => <AvatarCustomSizeList active="active" />)
+  .addStory(
+    'color',
+    () => {
+      const rowStyles: React.CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: '8px' };
+
+      return (
+        <div style={{ display: 'flex', gap: '24px', flexDirection: 'row' }}>
+          <div style={rowStyles}>
+            <Avatar color="neutral" />
+            <Avatar color="brand" />
+          </div>
+          <div style={rowStyles}>
+            {examples.name.map(name => (
+              <Avatar color="colorful" name={name} key={name} />
+            ))}
+          </div>
+          <div style={rowStyles}>
+            {examples.namedColors.map(color => (
+              <Avatar color={color} key={color} />
+            ))}
+          </div>
+        </div>
+      );
+    },
+    { includeHighContrast: true, includeDarkMode: true },
+  )
+  .addStory('image-bad-url', () => <Avatar name="Broken Image" image={{ src: `${imageRoot}/bad_image_url.jpg` }} />);

--- a/apps/vr-tests-react-components/src/stories/Badge.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Badge.stories.tsx
@@ -1,0 +1,132 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { Badge, BadgeProps } from '@fluentui/react-badge';
+import { CircleRegular } from '@fluentui/react-icons';
+import { mergeClasses, makeStyles, shorthands } from '@griffel/react';
+import { tokens } from '@fluentui/react-theme';
+
+const badgeColors: Required<BadgeProps>['color'][] = [
+  'brand',
+  'danger',
+  'important',
+  'informative',
+  'severe',
+  'subtle',
+  'success',
+  'warning',
+];
+
+const badgeAppearances: Required<BadgeProps>['appearance'][] = ['filled', 'outline', 'tint', 'ghost'];
+
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+
+  badgeContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    ...shorthands.gap('5px'),
+    ...shorthands.padding('5px'),
+  },
+
+  label: {
+    marginLeft: '10px',
+  },
+
+  brandContainer: {
+    backgroundColor: tokens.colorBrandBackgroundStatic,
+  },
+});
+
+const BadgeAppearanceTemplate: React.FC<{ appearance: Required<BadgeProps>['appearance'] }> = ({ appearance }) => {
+  const styles = useStyles();
+
+  const badges = new Map<BadgeProps['color'], JSX.Element[]>();
+  badges.set('brand', []);
+  badges.set('danger', []);
+  badges.set('severe', []);
+  badges.set('warning', []);
+  badges.set('success', []);
+  badges.set('important', []);
+  badges.set('informative', []);
+  badges.set('subtle', []);
+
+  badgeColors.forEach(color => {
+    const circularWithText = (
+      <Badge color={color} appearance={appearance}>
+        1
+      </Badge>
+    );
+    const circularWithIcon = <Badge color={color} appearance={appearance} icon={<CircleRegular />} />;
+    const roundedWithIcon = <Badge color={color} appearance={appearance} shape="rounded" icon={<CircleRegular />} />;
+    const roundedWithText = (
+      <Badge color={color} appearance={appearance} shape="rounded">
+        {appearance.toUpperCase()}
+      </Badge>
+    );
+    const roundedWithTextAndIconBefore = (
+      <Badge color={color} appearance={appearance} shape="rounded" icon={<CircleRegular />} iconPosition="before">
+        {appearance.toUpperCase()}
+      </Badge>
+    );
+    const roundedWithTextAndIconAfter = (
+      <Badge color={color} appearance={appearance} shape="rounded" icon={<CircleRegular />} iconPosition="after">
+        {appearance.toUpperCase()}
+      </Badge>
+    );
+
+    badges
+      .get(color)!
+      .push(
+        circularWithText,
+        circularWithIcon,
+        roundedWithIcon,
+        roundedWithText,
+        roundedWithTextAndIconAfter,
+        roundedWithTextAndIconBefore,
+      );
+  });
+
+  return (
+    <div>
+      {Array.from(badges.keys()).map((color: BadgeProps['color'], i) => (
+        <div key={i} className={styles.container}>
+          <div
+            className={mergeClasses(
+              styles.badgeContainer,
+              color === 'subtle' && appearance === 'outline' && styles.brandContainer,
+              color === 'subtle' && appearance === 'ghost' && styles.brandContainer,
+            )}
+          >
+            {badges.get(color)}
+          </div>
+          <div className={styles.label}>{color}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const appearanceStories = storiesOf('Badge Converged', module);
+
+badgeAppearances.forEach(appearance => {
+  appearanceStories.addStory(appearance, () => <BadgeAppearanceTemplate appearance={appearance} />, {
+    includeRtl: true,
+    includeHighContrast: true,
+    includeDarkMode: true,
+  });
+});
+
+storiesOf('Badge Converged - sizes', module).addStory(
+  'default',
+  () => (
+    <div style={{ display: 'flex', gap: 10 }}>
+      {(['tiny', 'extra-small', 'small', 'medium', 'large', 'extra-large'] as BadgeProps['size'][]).map(size => (
+        <Badge key={size} size={size} />
+      ))}
+    </div>
+  ),
+  { includeRtl: true, includeHighContrast: true, includeDarkMode: true },
+);

--- a/apps/vr-tests-react-components/src/stories/Button.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Button.stories.tsx
@@ -1,0 +1,602 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import Screener from 'screener-storybook/src/screener';
+import { Button, CompoundButton, ToggleButton, MenuButton } from '@fluentui/react-button';
+
+storiesOf('Button Converged', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('button')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('button')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('button')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Default', () => <Button>Hello, world</Button>, {
+    includeRtl: true,
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Circular', () => <Button shape="circular">Hello, world</Button>)
+  .addStory('Outline', () => <Button appearance="outline">Hello, world</Button>)
+  .addStory('Primary', () => <Button appearance="primary">Hello, world</Button>, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Subtle', () => <Button appearance="subtle">Hello, world</Button>, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Transparent', () => <Button appearance="transparent">Hello, world</Button>, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Disabled', () => <Button disabled>Hello, world</Button>, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory(
+    'Outline Disabled',
+    () => (
+      <Button appearance="outline" disabled>
+        Hello, world
+      </Button>
+    ),
+    {
+      includeHighContrast: true,
+      includeDarkMode: true,
+    },
+  )
+  .addStory(
+    'Primary Disabled',
+    () => (
+      <Button appearance="primary" disabled>
+        Hello, world
+      </Button>
+    ),
+    { includeHighContrast: true, includeDarkMode: true },
+  )
+  .addStory(
+    'Subtle Disabled',
+    () => (
+      <Button appearance="subtle" disabled>
+        Hello, world
+      </Button>
+    ),
+    { includeHighContrast: true, includeDarkMode: true },
+  )
+  .addStory(
+    'Transparent Disabled',
+    () => (
+      <Button appearance="transparent" disabled>
+        Hello, world
+      </Button>
+    ),
+    { includeHighContrast: true, includeDarkMode: true },
+  )
+  .addStory('Size small', () => (
+    <Button icon="X" size="small">
+      Hello, world
+    </Button>
+  ))
+  .addStory('Size large', () => (
+    <Button icon="X" size="large">
+      Hello, world
+    </Button>
+  ))
+  .addStory('With icon before content', () => <Button icon="X">Hello, world</Button>, {
+    includeRtl: true,
+  })
+  .addStory(
+    'With icon after content',
+    () => (
+      <Button icon="X" iconPosition="after">
+        Hello, world
+      </Button>
+    ),
+    { includeRtl: true },
+  )
+  .addStory('Icon only', () => <Button icon="X" />)
+  .addStory('Circular and icon only', () => <Button shape="circular" icon="X" />, {
+    includeRtl: true,
+  });
+
+storiesOf('Button Block Converged', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('button')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('button')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('button')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Default', () => <Button block>Hello, world</Button>, { includeRtl: true })
+  .addStory('Circular', () => (
+    <Button block shape="circular">
+      Hello, world
+    </Button>
+  ))
+  .addStory('Outline', () => (
+    <Button block appearance="outline">
+      Hello, world
+    </Button>
+  ))
+  .addStory('Primary', () => (
+    <Button block appearance="primary">
+      Hello, world
+    </Button>
+  ))
+  .addStory('Subtle', () => (
+    <Button block appearance="subtle">
+      Hello, world
+    </Button>
+  ))
+  .addStory('Transparent', () => (
+    <Button block appearance="transparent">
+      Hello, world
+    </Button>
+  ))
+  .addStory('Disabled', () => (
+    <Button block disabled>
+      Hello, world
+    </Button>
+  ))
+  .addStory('Size small', () => (
+    <Button block icon="X" size="small">
+      Hello, world
+    </Button>
+  ))
+  .addStory('Size large', () => (
+    <Button block icon="X" size="large">
+      Hello, world
+    </Button>
+  ));
+
+storiesOf('CompoundButton Converged', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('button')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('button')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('button')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory(
+    'Default',
+    () => <CompoundButton secondaryContent="This is some secondary text">Hello, world</CompoundButton>,
+    { includeRtl: true },
+  )
+  .addStory('Circular', () => (
+    <CompoundButton shape="circular" secondaryContent="This is some secondary text">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Outline', () => (
+    <CompoundButton secondaryContent="This is some secondary text" appearance="outline">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Primary', () => (
+    <CompoundButton secondaryContent="This is some secondary text" appearance="primary">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Subtle', () => (
+    <CompoundButton secondaryContent="This is some secondary text" appearance="subtle">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Transparent', () => (
+    <CompoundButton secondaryContent="This is some secondary text" appearance="transparent">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Disabled', () => (
+    <CompoundButton secondaryContent="This is some secondary text" disabled>
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Outline Disabled', () => (
+    <CompoundButton secondaryContent="This is some secondary text" appearance="outline" disabled>
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Primary Disabled', () => (
+    <CompoundButton secondaryContent="This is some secondary text" appearance="primary" disabled>
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Subtle Disabled', () => (
+    <CompoundButton secondaryContent="This is some secondary text" appearance="subtle" disabled>
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Transparent Disabled', () => (
+    <CompoundButton secondaryContent="This is some secondary text" appearance="transparent" disabled>
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Size small', () => (
+    <CompoundButton secondaryContent="This is some secondary text" icon="X" size="small">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Size large', () => (
+    <CompoundButton secondaryContent="This is some secondary text" icon="X" size="large">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory(
+    'With icon before content',
+    () => (
+      <CompoundButton secondaryContent="This is some secondary text" icon="X">
+        Hello, world
+      </CompoundButton>
+    ),
+    { includeRtl: true },
+  )
+  .addStory(
+    'With icon after content',
+    () => (
+      <CompoundButton secondaryContent="This is some secondary text" icon="X" iconPosition="after">
+        Hello, world
+      </CompoundButton>
+    ),
+    { includeRtl: true },
+  )
+  .addStory('Icon only', () => <CompoundButton icon="X" />)
+  .addStory('Circular and icon only', () => <CompoundButton shape="circular" icon="X" />, {
+    includeRtl: true,
+  });
+
+storiesOf('CompoundButton Block Converged', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('button')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('button')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('button')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory(
+    'Default',
+    () => (
+      <CompoundButton block secondaryContent="This is some secondary text">
+        Hello, world
+      </CompoundButton>
+    ),
+    { includeRtl: true },
+  )
+  .addStory('Circular', () => (
+    <CompoundButton block secondaryContent="This is some secondary text" shape="circular">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Outline', () => (
+    <CompoundButton block secondaryContent="This is some secondary text" appearance="outline">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Primary', () => (
+    <CompoundButton block secondaryContent="This is some secondary text" appearance="primary">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Subtle', () => (
+    <CompoundButton block secondaryContent="This is some secondary text" appearance="subtle">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Transparent', () => (
+    <CompoundButton block secondaryContent="This is some secondary text" appearance="transparent">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Disabled', () => (
+    <CompoundButton block secondaryContent="This is some secondary text" disabled>
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Size small', () => (
+    <CompoundButton block secondaryContent="This is some secondary text" icon="X" size="small">
+      Hello, world
+    </CompoundButton>
+  ))
+  .addStory('Size large', () => (
+    <CompoundButton block secondaryContent="This is some secondary text" icon="X" size="large">
+      Hello, world
+    </CompoundButton>
+  ));
+
+storiesOf('ToggleButton Converged', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('button')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('button')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('button')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Default', () => <ToggleButton>Hello, world</ToggleButton>, {
+    includeRtl: true,
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Circular', () => <ToggleButton shape="circular">Hello, world</ToggleButton>)
+  .addStory('Outline', () => <ToggleButton appearance="outline">Hello, world</ToggleButton>)
+  .addStory('Primary', () => <ToggleButton appearance="primary">Hello, world</ToggleButton>, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Subtle', () => <ToggleButton appearance="subtle">Hello, world</ToggleButton>)
+  .addStory('Transparent', () => <ToggleButton appearance="transparent">Hello, world</ToggleButton>)
+  .addStory('Disabled', () => <ToggleButton disabled>Hello, world</ToggleButton>)
+  .addStory('Primary Disabled', () => (
+    <ToggleButton appearance="primary" disabled>
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Subtle Disabled', () => (
+    <ToggleButton appearance="subtle" disabled>
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Transparent Disabled', () => (
+    <ToggleButton appearance="transparent" disabled>
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Size small', () => (
+    <ToggleButton icon="X" size="small">
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Size large', () => (
+    <ToggleButton icon="X" size="large">
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('With icon before content', () => <ToggleButton icon="X">Hello, world</ToggleButton>)
+  .addStory('With icon after content', () => (
+    <ToggleButton icon="X" iconPosition="after">
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Icon only', () => <ToggleButton icon="X" />)
+  .addStory('Circular and icon only', () => <ToggleButton shape="circular" icon="X" />)
+  .addStory('Checked', () => <ToggleButton checked>Hello, world</ToggleButton>)
+  .addStory('Primary Checked', () => (
+    <ToggleButton appearance="primary" checked>
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Subtle Checked', () => (
+    <ToggleButton appearance="subtle" checked>
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Transparent Checked', () => (
+    <ToggleButton appearance="transparent" checked>
+      Hello, world
+    </ToggleButton>
+  ));
+
+storiesOf('ToggleButton Block Converged', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('button')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('button')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('button')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Default', () => <ToggleButton block>Hello, world</ToggleButton>, { includeRtl: true })
+  .addStory('Circular', () => (
+    <ToggleButton block shape="circular">
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Outline', () => (
+    <ToggleButton block appearance="primary">
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Primary', () => (
+    <ToggleButton block appearance="primary">
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Subtle', () => (
+    <ToggleButton block appearance="subtle">
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Transparent', () => (
+    <ToggleButton block appearance="transparent">
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Disabled', () => (
+    <ToggleButton block disabled>
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Size small', () => (
+    <ToggleButton block icon="X" size="small">
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Size large', () => (
+    <ToggleButton block icon="X" size="large">
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Checked', () => (
+    <ToggleButton block checked>
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Primary Checked', () => (
+    <ToggleButton block appearance="primary" checked>
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Subtle Checked', () => (
+    <ToggleButton block appearance="subtle" checked>
+      Hello, world
+    </ToggleButton>
+  ))
+  .addStory('Transparent Checked', () => (
+    <ToggleButton block appearance="transparent" checked>
+      Hello, world
+    </ToggleButton>
+  ));
+
+storiesOf('MenuButton Converged', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('button')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('button')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('button')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Default', () => <MenuButton>Hello, world</MenuButton>, { includeRtl: true })
+  .addStory('Circular', () => <MenuButton shape="circular">Hello, world</MenuButton>)
+  .addStory('Outline', () => <MenuButton appearance="outline">Hello, world</MenuButton>)
+  .addStory('Primary', () => <MenuButton appearance="primary">Hello, world</MenuButton>)
+  .addStory('Subtle', () => <MenuButton appearance="subtle">Hello, world</MenuButton>)
+  .addStory('Transparent', () => <MenuButton appearance="transparent">Hello, world</MenuButton>)
+  .addStory('Disabled', () => <MenuButton disabled>Hello, world</MenuButton>)
+  .addStory('Outline Disabled', () => (
+    <MenuButton appearance="outline" disabled>
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('Primary Disabled', () => (
+    <MenuButton appearance="primary" disabled>
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('Subtle Disabled', () => (
+    <MenuButton appearance="subtle" disabled>
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('Transparent Disabled', () => (
+    <MenuButton appearance="transparent" disabled>
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('Size small', () => (
+    <MenuButton icon="X" size="small">
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('Size large', () => (
+    <MenuButton icon="X" size="large">
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('With icon', () => <MenuButton icon="X">Hello, world</MenuButton>)
+  .addStory('Icon only', () => <MenuButton icon="X" />)
+  .addStory('Circular and icon only', () => <MenuButton shape="circular" icon="X" />);
+
+storiesOf('MenuButton Block Converged', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('button')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('button')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('button')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Default', () => <MenuButton block>Hello, world</MenuButton>, { includeRtl: true })
+  .addStory('Circular', () => (
+    <MenuButton block shape="circular">
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('Outline', () => (
+    <MenuButton block appearance="outline">
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('Primary', () => (
+    <MenuButton block appearance="primary">
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('Subtle', () => (
+    <MenuButton block appearance="subtle">
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('Transparent', () => (
+    <MenuButton block appearance="transparent">
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('Disabled', () => (
+    <MenuButton block disabled>
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('Size small', () => (
+    <MenuButton block icon="X" size="small">
+      Hello, world
+    </MenuButton>
+  ))
+  .addStory('Size large', () => (
+    <MenuButton block icon="X" size="large">
+      Hello, world
+    </MenuButton>
+  ));

--- a/apps/vr-tests-react-components/src/stories/Checkbox.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Checkbox.stories.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import Screener, { Steps } from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { Checkbox } from '@fluentui/react-checkbox';
+import { TestWrapperDecoratorFixedWidth } from '../utilities/TestWrapperDecorator';
+
+storiesOf('Checkbox Converged', module)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
+  .addDecorator(story => (
+    <Screener
+      steps={new Steps()
+        .snapshot('rest', { cropTo: '.testWrapper' })
+        .hover('input')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('input')
+        .snapshot('active', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('unchecked', () => <Checkbox label="Unchecked" />)
+  .addStory('checked', () => <Checkbox checked label="Checked" />)
+  .addStory('mixed', () => <Checkbox checked="mixed" label="Mixed" />)
+  .addStory('disabled', () => <Checkbox disabled label="Disabled" />);
+
+storiesOf('Checkbox Converged', module)
+  .addDecorator(story => (
+    <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>
+  ))
+  .addStory('disabled+checked', () => <Checkbox disabled checked label="Disabled checked" />)
+  .addStory('disabled+mixed', () => <Checkbox disabled checked="mixed" label="Disabled mixed" />)
+  .addStory('no-label', () => <Checkbox />)
+  .addStory('label-before', () => <Checkbox labelPosition="before" label="Label before" />)
+  .addStory('label-wrapping', () => (
+    <Checkbox
+      label={
+        <>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua
+        </>
+      }
+    />
+  ))
+  .addStory('required', () => <Checkbox required label="Required" />)
+  .addStory('required+label-before', () => (
+    <Checkbox required labelPosition="before" label="Required with label before" />
+  ))
+  .addStory('circular', () => <Checkbox circular label="Circular" />)
+  .addStory('circular+checked', () => <Checkbox circular checked label="Circular checked" />)
+  .addStory('circular+mixed', () => <Checkbox circular checked="mixed" label="Circular mixed" />)
+  //
+  // large variants
+  //
+  .addStory('large', () => <Checkbox size="large" label="Large" />)
+  .addStory('large+checked', () => <Checkbox size="large" checked label="Large checked" />)
+  .addStory('large+mixed', () => <Checkbox size="large" checked="mixed" label="Large mixed" />)
+  .addStory('large+circular', () => <Checkbox size="large" circular label="Large circular" />)
+  .addStory('large+circular+checked', () => <Checkbox size="large" circular checked label="Large circular checked" />)
+  .addStory('large+circular+mixed', () => (
+    <Checkbox size="large" circular checked="mixed" label="Large circular mixed" />
+  ))
+  .addStory('large+label-wrapping', () => (
+    <Checkbox
+      size="large"
+      label={
+        <>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua
+        </>
+      }
+    />
+  ));

--- a/apps/vr-tests-react-components/src/stories/CounterBadge.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/CounterBadge.stories.tsx
@@ -1,0 +1,15 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { CounterBadge } from '@fluentui/react-badge';
+
+storiesOf('CounterBadge Converged - colors', module).addStory(
+  'default',
+  () => (
+    <div style={{ display: 'flex', gap: 10 }}>
+      {(['brand', 'danger', 'important', 'informative'] as const).map(color => (
+        <CounterBadge count={5} appearance="filled" color={color} key={color} />
+      ))}
+    </div>
+  ),
+  { includeRtl: true },
+);

--- a/apps/vr-tests-react-components/src/stories/Divider.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Divider.stories.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import Screener, { Steps } from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { Divider } from '@fluentui/react-divider';
+import { TestWrapperDecorator, TestWrapperDecoratorFixedWidth } from '../utilities/index';
+
+storiesOf('Divider Converged - Horizontal', module)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
+  .addDecorator(story => (
+    <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>
+  ))
+  .addStory('without content', () => <Divider />, { includeRtl: true })
+  .addStory('with content', () => <Divider>Today</Divider>, {
+    includeRtl: true,
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Start Aligned', () => <Divider alignContent="start">Today</Divider>, {
+    includeRtl: true,
+  })
+  .addStory('End Aligned', () => <Divider alignContent="end">Today</Divider>, { includeRtl: true })
+  .addStory('Appearance subtle', () => <Divider appearance="subtle">Today</Divider>, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Appearance strong', () => <Divider appearance="strong">Today</Divider>, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Appearance brand', () => <Divider appearance="brand">Today</Divider>, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Inset', () => <Divider inset>Today</Divider>);
+
+storiesOf('Divider Converged - Vertical', module)
+  .addDecorator(TestWrapperDecorator)
+  .addDecorator(story => (
+    <div style={{ height: '200px' }}>
+      <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>
+    </div>
+  ))
+  .addStory('Center Aligned', () => <Divider vertical>Today</Divider>)
+  .addStory('Start Aligned', () => (
+    <Divider vertical alignContent="start">
+      Today
+    </Divider>
+  ))
+  .addStory('End Aligned', () => (
+    <Divider vertical alignContent="end">
+      Today
+    </Divider>
+  ))
+  .addStory('inset', () => (
+    <Divider inset vertical>
+      Today
+    </Divider>
+  ));

--- a/apps/vr-tests-react-components/src/stories/Image.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Image.stories.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import Screener from 'screener-storybook/src/screener';
+import { Image } from '@fluentui/react-image';
+
+const imageUrl = 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/AmandaBrady.jpg';
+
+storiesOf('Image Converged', module)
+  .addDecorator((story: () => React.ReactNode) => (
+    <Screener steps={new Screener.Steps().snapshot('normal', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>
+  ))
+  .addStory('Default', () => <Image src="https://via.placeholder.com/300x300" alt="Placeholder image" />)
+  .addStory('Image Shape', () => (
+    <>
+      <div>
+        <Image src={imageUrl} alt="Amanda's avatar default" height={200} width={200} />
+      </div>
+      <div>
+        <Image src={imageUrl} alt="Amanda's avatar rounded" height={200} width={200} shape="rounded" />
+      </div>
+      <div>
+        <Image src={imageUrl} alt="Amanda's avatar circular" height={200} width={200} shape="circular" />
+      </div>
+    </>
+  ))
+  .addStory('Image Variations Border', () => (
+    <>
+      <div>
+        <Image src={imageUrl} alt="Amanda's avatar bordered" height={200} width={200} bordered />
+      </div>
+      <div>
+        <Image
+          src={imageUrl}
+          alt="Amanda's avatar bordered and rounded"
+          height={200}
+          width={200}
+          bordered
+          shape="rounded"
+        />
+      </div>
+      <div>
+        <Image
+          src={imageUrl}
+          alt="Amanda's avatar bordered and circular"
+          height={200}
+          width={200}
+          bordered
+          shape="circular"
+        />
+      </div>
+    </>
+  ))
+  .addStory('Image Variations Fallback', () => (
+    <Image src="non-existent.jpg" alt="Non-existent image fallback" height={150} width={150} />
+  ))
+  .addStory('Image Layout Fit', () => (
+    <>
+      <div style={{ height: 300, width: 400 }}>
+        <Image src="https://via.placeholder.com/600x200" alt="Placeholder for fit none" fit="none" />
+      </div>
+      <div style={{ height: 300, width: 400 }}>
+        <Image src="https://via.placeholder.com/600x200" alt="Placeholder for fit center" fit="center" />
+      </div>
+      <div style={{ height: 300, width: 400 }}>
+        <Image src="https://via.placeholder.com/600x200" alt="Placeholder for fit contain" fit="contain" />
+      </div>
+      <div style={{ height: 300, width: 400 }}>
+        <Image src="https://via.placeholder.com/600x200" alt="Placeholder for fit cover" fit="cover" />
+      </div>
+    </>
+  ))
+  .addStory('Image Fluid', () => (
+    <>
+      <div>
+        <Image src="https://via.placeholder.com/900x50" block />
+      </div>
+      <div>
+        <Image src="https://via.placeholder.com/100x100" block />
+      </div>
+    </>
+  ))
+  .addStory('Image Shadow', () => <Image src="https://via.placeholder.com/900x50" shadow />);

--- a/apps/vr-tests-react-components/src/stories/Input.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Input.stories.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import Screener, { Steps } from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { Input } from '@fluentui/react-input';
+import { SearchRegular, DismissRegular } from '@fluentui/react-icons';
+import { TestWrapperDecoratorFixedWidth } from '../utilities/TestWrapperDecorator';
+
+storiesOf('Input Converged', module)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
+  .addDecorator(story => (
+    <Screener
+      steps={new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('input')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .click('input')
+        .wait(250) // let focus border animation finish
+        .snapshot('focused', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Appearance: outline (default)', () => <Input placeholder="Placeholder" />)
+  .addStory('Appearance: underline', () => <Input appearance="underline" placeholder="Placeholder" />)
+  .addStory('Appearance: filledDarker', () => <Input appearance="filledDarker" placeholder="Placeholder" />)
+  .addStory('Appearance: filledLighter', () => (
+    // filledLighter requires a background to show up (this is colorNeutralBackground3 in web light theme)
+    <div style={{ background: '#f5f5f5', padding: '10px' }}>
+      <Input appearance="filledLighter" placeholder="Placeholder" />
+    </div>
+  ))
+  .addStory('Disabled', () => <Input disabled />)
+  .addStory('With value', () => <Input defaultValue="Value!" />);
+
+// Non-interactive stories
+storiesOf('Input Converged', module)
+  // note: due to reused "Input Converged" story ID, TestWrapperDecoratorFixedWidth is also reused
+  .addDecorator(story => (
+    <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>
+  ))
+  .addStory('Size: small', () => <Input size="small" placeholder="Placeholder" />)
+  .addStory('Size: large', () => <Input size="large" placeholder="Placeholder" />)
+  .addStory('Inline', () => (
+    <p>
+      Some text with <Input inline placeholder="hello" style={{ width: '75px' }} /> inline input
+    </p>
+  ))
+  .addStory(
+    'contentBefore',
+    () => <Input contentBefore={<SearchRegular style={{ fontSize: '20px' }} />} placeholder="Placeholder" />,
+    { includeRtl: true },
+  )
+  .addStory(
+    'contentAfter',
+    () => <Input contentAfter={<DismissRegular style={{ fontSize: '20px' }} />} placeholder="Placeholder" />,
+    { includeRtl: true },
+  );

--- a/apps/vr-tests-react-components/src/stories/Label.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Label.stories.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import Screener from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { Label } from '@fluentui/react-label';
+
+storiesOf('Label Converged', module)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>,
+  )
+  .addStory('Root', () => <Label>I'm a label</Label>, {
+    includeRtl: true,
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Disabled', () => <Label disabled>I'm a disabled label</Label>, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Required', () => <Label required>I'm a required label</Label>, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Strong', () => <Label strong>I'm a strong label</Label>)
+  .addStory('Small', () => <Label size="small">I'm a small label</Label>)
+  .addStory('Large', () => <Label size="large">I'm a large label</Label>)
+  .addStory('CustomRequired', () => <Label required="**">I'm a label with custom required text</Label>, {
+    includeRtl: true,
+  })
+  .addStory(
+    'Multiline',
+    () => (
+      <div style={{ width: '200px' }}>
+        <Label required>Super long label to show overflow into multiple lines</Label>
+      </div>
+    ),
+    { includeRtl: true },
+  );

--- a/apps/vr-tests-react-components/src/stories/Link.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Link.stories.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import Screener, { Steps } from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { Link, LinkProps } from '@fluentui/react-link';
+
+const AnchorLink = (props: LinkProps & { as?: 'a' }) => <Link {...props} href="https://www.bing.com" />;
+const ButtonLink = (props: LinkProps) => <Link {...props} />;
+
+storiesOf('Link Converged - Rendered as anchor', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('a')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('a')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('a')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Stand-alone', () => <AnchorLink>Stand-alone link</AnchorLink>, {
+    includeRtl: true,
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Stand-alone Disabled', () => <AnchorLink disabled>Stand-alone disabled link</AnchorLink>)
+  .addStory(
+    'Stand-alone Disabled Focusable',
+    () => (
+      <AnchorLink disabled disabledFocusable>
+        Stand-alone disabled focusable link
+      </AnchorLink>
+    ),
+    { includeHighContrast: true, includeDarkMode: true },
+  )
+  .addStory(
+    'Inline',
+    () => (
+      <div>
+        This is <AnchorLink inline>a link</AnchorLink> used alongside other text content.
+      </div>
+    ),
+    { includeRtl: true },
+  )
+  .addStory('Inline Disabled', () => (
+    <div>
+      This is{' '}
+      <AnchorLink inline disabled>
+        a disabled link
+      </AnchorLink>{' '}
+      used alongside other text content.
+    </div>
+  ))
+  .addStory('Inline Disabled Focusable', () => (
+    <div>
+      This is{' '}
+      <AnchorLink inline disabled disabledFocusable>
+        a disabled focusable link
+      </AnchorLink>{' '}
+      used alongside other text content.
+    </div>
+  ));
+
+storiesOf('Link Converged - Rendered as button', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('button')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('button')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('button')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Stand-alone', () => <ButtonLink>Stand-alone link</ButtonLink>, { includeRtl: true })
+  .addStory('Stand-alone Disabled', () => <ButtonLink disabled>Stand-alone disabled link</ButtonLink>)
+  .addStory('Stand-alone Disabled Focusable', () => (
+    <ButtonLink disabled disabledFocusable>
+      Stand-alone disabled focusable link
+    </ButtonLink>
+  ))
+  .addStory(
+    'Inline',
+    () => (
+      <div>
+        This is <ButtonLink inline>a link</ButtonLink> used alongside other text content.
+      </div>
+    ),
+    { includeRtl: true },
+  )
+  .addStory('Inline Disabled', () => (
+    <div>
+      This is{' '}
+      <ButtonLink inline disabled>
+        a disabled link
+      </ButtonLink>{' '}
+      used alongside other text content.
+    </div>
+  ))
+  .addStory('Inline Disabled Focusable', () => (
+    <div>
+      This is{' '}
+      <ButtonLink inline disabled disabledFocusable>
+        a disabled focusable link
+      </ButtonLink>{' '}
+      used alongside other text content.
+    </div>
+  ));

--- a/apps/vr-tests-react-components/src/stories/MakeStyles.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/MakeStyles.stories.tsx
@@ -1,0 +1,214 @@
+import { shorthands, mergeClasses, makeStyles } from '@griffel/react';
+import { FluentProvider } from '@fluentui/react-provider';
+import { tokens, webLightTheme } from '@fluentui/react-theme';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import Screener, { Steps } from 'screener-storybook/src/screener';
+
+const useStyles = makeStyles({
+  box: {
+    ...shorthands.border('5px', 'solid', tokens.colorNeutralStroke1),
+    ...shorthands.borderLeft('20px', 'solid', tokens.colorPaletteBlueBorder2),
+
+    backgroundColor: tokens.colorNeutralBackground1,
+    color: tokens.colorNeutralForeground1,
+
+    ...shorthands.margin('5px'),
+    ...shorthands.padding('5px'),
+    paddingLeft: '50px',
+  },
+
+  container: {
+    ...shorthands.border('5px', 'solid', tokens.colorNeutralStroke1),
+    ...shorthands.borderLeft('20px', 'solid', tokens.colorPaletteBlueBorder2),
+
+    ...shorthands.margin('5px'),
+    ...shorthands.padding('5px'),
+  },
+  containerPrimary: {
+    borderLeftColor: tokens.colorPaletteDarkOrangeBorder2,
+  },
+
+  provider: {
+    marginLeft: '20px',
+  },
+});
+
+const useFocusStylesA = makeStyles({
+  root: {
+    ...shorthands.border('3px', 'solid', 'blue'),
+    ...shorthands.padding('10px'),
+
+    ':focus': {
+      color: 'red',
+    },
+    ':hover': {
+      color: 'blue',
+    },
+  },
+});
+const useFocusStylesB = makeStyles({
+  root: {
+    ...shorthands.border('3px', 'solid', 'orange'),
+    ...shorthands.padding('10px'),
+
+    ':hover': {
+      color: 'orange',
+    },
+    ':focus': {
+      color: 'green',
+    },
+  },
+});
+
+const Box: React.FC = props => {
+  const classes = useStyles();
+
+  return <div className={classes.box}>{props.children}</div>;
+};
+
+const BoxWithPseudo: React.FC = () => {
+  const classesA = useFocusStylesA();
+  const classesB = useFocusStylesB();
+
+  return (
+    <div style={{ display: 'flex', gap: '5px', flexDirection: 'column' }}>
+      <p>When element is focused & hovered - border color & text color should match</p>
+
+      <div className={classesA.root} id="boxA" tabIndex={0}>
+        A focusable element
+      </div>
+      <div className={classesB.root} id="boxB" tabIndex={0}>
+        A focusable element
+      </div>
+    </div>
+  );
+};
+
+const Container: React.FC<{ className?: string; primary?: boolean }> = props => {
+  const classes = useStyles();
+
+  return (
+    <div className={mergeClasses(classes.container, props.primary && classes.containerPrimary, props.className)}>
+      {props.children}
+    </div>
+  );
+};
+
+const ClassNameProvider: React.FC<{
+  children: (className: string) => React.ReactElement;
+}> = props => {
+  const classes = useStyles();
+
+  return props.children(classes.provider);
+};
+
+export const Nested = () => (
+  <>
+    <p>This scenario shows that it's possible to have nested components (LTR inside RTL).</p>
+
+    <FluentProvider dir="rtl" theme={webLightTheme}>
+      <Container primary>مرحبا بالعالم!</Container>
+
+      <FluentProvider dir="ltr">
+        <Container primary>Hello world!</Container>
+      </FluentProvider>
+    </FluentProvider>
+  </>
+);
+
+export const Propagation = () => (
+  <>
+    <p>
+      This scenario shows classes propagation between boundaries with "mergeClasses()" function: classes generated in
+      LTR context will be applied properly in RTL.
+    </p>
+
+    <FluentProvider theme={webLightTheme}>
+      <ClassNameProvider>
+        {className => (
+          <FluentProvider dir="rtl">
+            <Container className={className} primary>
+              مرحبا بالعالم!
+            </Container>
+          </FluentProvider>
+        )}
+      </ClassNameProvider>
+
+      <FluentProvider dir="rtl">
+        <ClassNameProvider>
+          {className => (
+            <FluentProvider dir="ltr">
+              <Container className={className} primary>
+                Hello world!
+              </Container>
+            </FluentProvider>
+          )}
+        </ClassNameProvider>
+      </FluentProvider>
+    </FluentProvider>
+  </>
+);
+
+// RTL stories
+// Check for details: packages/react-examples/src/react-make-styles/RTL/RTL.stories.tsx
+
+storiesOf('MakeStyles', module)
+  .addDecorator(story => (
+    <Screener steps={new Steps().snapshot('normal', { cropTo: '.testWrapper' }).end()}>
+      <div className="testWrapper" style={{ width: '300px' }}>
+        {story()}
+      </div>
+    </Screener>
+  ))
+  .addStory('RTL: two components in a single Provider', () => (
+    <FluentProvider dir="rtl" theme={webLightTheme}>
+      <Box>مرحبا بالعالم!</Box>
+      <Container>مرحبا بالعالم!</Container>
+    </FluentProvider>
+  ))
+  .addStory('RTL: two providers with different directions as siblings', () => (
+    <>
+      <FluentProvider theme={webLightTheme}>
+        <Box>Hello world!</Box>
+        <Container primary>Hello world!</Container>
+      </FluentProvider>
+
+      <FluentProvider dir="rtl" theme={webLightTheme}>
+        <Box>مرحبا بالعالم!</Box>
+        <Container primary>مرحبا بالعالم!</Container>
+      </FluentProvider>
+    </>
+  ))
+  .addStory('RTL: two providers with different directions as children', () => (
+    <FluentProvider dir="rtl" theme={webLightTheme}>
+      <Container primary>مرحبا بالعالم!</Container>
+
+      <FluentProvider dir="ltr">
+        <Container primary>Hello world!</Container>
+      </FluentProvider>
+    </FluentProvider>
+  ));
+
+// Pseudo selectors stories
+
+storiesOf('MakeStyles (pseudo)', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Steps()
+        .snapshot('normal', { cropTo: '.testWrapper' })
+        .focus('#boxA')
+        .snapshot('boxA, focus', { cropTo: '.testWrapper' })
+        .hover('#boxA')
+        .snapshot('boxA, focus+hover', { cropTo: '.testWrapper' })
+        .focus('#boxB')
+        .hover('#boxB')
+        .snapshot('boxB, focus+hover', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      <div className="testWrapper" style={{ width: '300px' }}>
+        {story()}
+      </div>
+    </Screener>
+  ))
+  .addStory('insertion is ordered', () => <BoxWithPseudo />);

--- a/apps/vr-tests-react-components/src/stories/Menu.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Menu.stories.tsx
@@ -1,0 +1,264 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import Screener from 'screener-storybook/src/screener';
+import {
+  Menu,
+  MenuTrigger,
+  MenuPopover,
+  MenuList,
+  MenuItem,
+  MenuItemCheckbox,
+  MenuItemRadio,
+  MenuGroup,
+  MenuGroupHeader,
+  MenuDivider,
+  MenuSplitGroup,
+} from '@fluentui/react-menu';
+import { CutRegular, EditRegular, ClipboardPasteRegular } from '@fluentui/react-icons';
+
+storiesOf('Menu Converged - basic', module)
+  .addDecorator(story => (
+    <Screener steps={new Screener.Steps().hover('[role="menuitem"]').snapshot('hover menuitem').end()}>
+      {story()}
+    </Screener>
+  ))
+  .addStory(
+    'default',
+    () => (
+      <Menu open>
+        <MenuTrigger>
+          <button>Toggle menu</button>
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <MenuItem icon={<CutRegular />}>Cut</MenuItem>
+            <MenuItem icon={<EditRegular />}>Edit</MenuItem>
+            <MenuItem icon={<ClipboardPasteRegular />}>Paste</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    ),
+    { includeRtl: true },
+  );
+
+storiesOf('Menu Converged - secondary content', module)
+  .addDecorator(story => (
+    <Screener steps={new Screener.Steps().hover('[role="menuitem"]').snapshot('hover menuitem').end()}>
+      {story()}
+    </Screener>
+  ))
+  .addStory(
+    'default',
+    () => (
+      <Menu open>
+        <MenuTrigger>
+          <button>Toggle menu</button>
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <MenuItem icon={<CutRegular />} secondaryContent="Ctrl+X">
+              Cut
+            </MenuItem>
+            <MenuItem icon={<EditRegular />}>Edit</MenuItem>
+            <MenuItem icon={<ClipboardPasteRegular />} secondaryContent="Ctrl+P">
+              Paste
+            </MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    ),
+    { includeRtl: true },
+  );
+
+storiesOf('Menu Converged - groups', module)
+  .addDecorator(story => <Screener>{story()}</Screener>)
+  .addStory(
+    'default',
+    () => (
+      <Menu open>
+        <MenuTrigger>
+          <button>Toggle menu</button>
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <MenuGroup>
+              <MenuGroupHeader>Section header</MenuGroupHeader>
+              <MenuItem icon={<CutRegular />}>Cut</MenuItem>
+              <MenuItem icon={<ClipboardPasteRegular />}>Paste</MenuItem>
+              <MenuItem icon={<EditRegular />}>Edit</MenuItem>
+            </MenuGroup>
+            <MenuDivider />
+            <MenuGroup>
+              <MenuGroupHeader>Section header</MenuGroupHeader>
+              <MenuItem icon={<CutRegular />}>Cut</MenuItem>
+              <MenuItem icon={<ClipboardPasteRegular />}>Paste</MenuItem>
+              <MenuItem icon={<EditRegular />}>Edit</MenuItem>
+            </MenuGroup>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    ),
+    { includeRtl: true, includeHighContrast: true, includeDarkMode: true },
+  );
+
+storiesOf('Menu Converged - selection', module)
+  .addDecorator(story => (
+    <Screener steps={new Screener.Steps().click('[role="menuitemcheckbox"]').snapshot('selected').end()}>
+      {story()}
+    </Screener>
+  ))
+  .addStory(
+    'checkbox',
+    () => (
+      <Menu open>
+        <MenuTrigger>
+          <button>Toggle menu</button>
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <MenuItemCheckbox icon={<CutRegular />} name="edit" value="cut">
+              Cut
+            </MenuItemCheckbox>
+            <MenuItemCheckbox icon={<ClipboardPasteRegular />} name="edit" value="paste">
+              Paste
+            </MenuItemCheckbox>
+            <MenuItemCheckbox icon={<EditRegular />} name="edit" value="edit">
+              Edit
+            </MenuItemCheckbox>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    ),
+    { includeRtl: true, includeHighContrast: true, includeDarkMode: true },
+  );
+
+storiesOf('Menu Converged - selection groups', module)
+  .addDecorator(story => (
+    <Screener steps={new Screener.Steps().click('[role="menuitemcheckbox"]').snapshot('selected').end()}>
+      {story()}
+    </Screener>
+  ))
+  .addStory(
+    'default',
+    () => (
+      <Menu open>
+        <MenuTrigger>
+          <button>Toggle menu</button>
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <MenuGroup>
+              <MenuGroupHeader>Checkbox group</MenuGroupHeader>
+              <MenuItemCheckbox icon={<CutRegular />} name="edit" value="cut">
+                Cut
+              </MenuItemCheckbox>
+              <MenuItemCheckbox icon={<ClipboardPasteRegular />} name="edit" value="paste">
+                Paste
+              </MenuItemCheckbox>
+              <MenuItemCheckbox icon={<EditRegular />} name="edit" value="edit">
+                Edit
+              </MenuItemCheckbox>
+            </MenuGroup>
+            <MenuDivider />
+            <MenuGroup>
+              <MenuGroupHeader>Radio group</MenuGroupHeader>
+              <MenuItemRadio icon={<CutRegular />} name="font" value="segoe">
+                Segoe
+              </MenuItemRadio>
+              <MenuItemRadio icon={<ClipboardPasteRegular />} name="font" value="calibri">
+                Caliri
+              </MenuItemRadio>
+              <MenuItemRadio icon={<EditRegular />} name="font" value="arial">
+                Arial
+              </MenuItemRadio>
+            </MenuGroup>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    ),
+    { includeRtl: true },
+  );
+
+storiesOf('Menu Converged - nested submenus', module)
+  .addDecorator(story => (
+    // https://github.com/microsoft/fluentui/issues/19782
+    <Screener steps={new Screener.Steps().click('#nestedTrigger').snapshot('all open').end()}>{story()}</Screener>
+  ))
+  .addStory(
+    'default',
+    () => (
+      <Menu open>
+        <MenuTrigger>
+          <button>Toggle menu</button>
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>New </MenuItem>
+            <MenuItem>New Window</MenuItem>
+            <MenuItem>Open Folder</MenuItem>
+            <Menu>
+              <MenuTrigger>
+                <MenuItem id="nestedTrigger">Preferences</MenuItem>
+              </MenuTrigger>
+
+              <MenuPopover>
+                <MenuList>
+                  <MenuItem>New </MenuItem>
+                  <MenuItem>New Window</MenuItem>
+                  <MenuItem>Open Folder</MenuItem>
+                </MenuList>
+              </MenuPopover>
+            </Menu>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    ),
+    { includeRtl: true },
+  );
+
+storiesOf('Menu Converged - split item', module)
+  .addDecorator(story => (
+    // https://github.com/microsoft/fluentui/issues/19782
+    <Screener steps={new Screener.Steps().click('#nestedTrigger').snapshot('submenu open').end()}>{story()}</Screener>
+  ))
+  .addStory(
+    'default',
+    () => (
+      <Menu open>
+        <MenuTrigger>
+          <button>Toggle menu</button>
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>New </MenuItem>
+            <MenuItem>New Window</MenuItem>
+            <MenuItem>Open Folder</MenuItem>
+            <Menu>
+              <MenuSplitGroup>
+                <MenuItem>Open</MenuItem>
+                <MenuTrigger>
+                  <MenuItem id="nestedTrigger" />
+                </MenuTrigger>
+              </MenuSplitGroup>
+
+              <MenuPopover>
+                <MenuList>
+                  <MenuItem>In browser</MenuItem>
+                  <MenuItem>In desktop app</MenuItem>
+                  <MenuItem>In mobile</MenuItem>
+                </MenuList>
+              </MenuPopover>
+            </Menu>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    ),
+    { includeRtl: true },
+  );

--- a/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
@@ -1,0 +1,51 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import Screener from 'screener-storybook/src/screener';
+import { Popover, PopoverTrigger, PopoverSurface, PopoverProps } from '@fluentui/react-popover';
+
+const ExampleContent = () => {
+  return (
+    <div>
+      <h3>Popover content</h3>
+
+      <div>This is some popover content</div>
+    </div>
+  );
+};
+
+const positions: NonNullable<PopoverProps['positioning']>[] = [
+  'above',
+  'above-end',
+  'above-start',
+  'below',
+  'below-end',
+  'below-start',
+  'before',
+  'before-bottom',
+  'before-top',
+  'after',
+  'after-bottom',
+  'after-top',
+];
+
+const stories = storiesOf('Popover Converged - positioning', module)
+  .addDecorator(story => <Screener>{story()}</Screener>)
+  .addDecorator(story => <div style={{ position: 'fixed', top: '50%', left: '50%' }}>{story()}</div>);
+
+positions.forEach(position => {
+  stories.addStory(
+    position as string,
+    () => (
+      <Popover open positioning={position}>
+        <PopoverTrigger>
+          <button>Toggle menu</button>
+        </PopoverTrigger>
+
+        <PopoverSurface>
+          <ExampleContent />
+        </PopoverSurface>
+      </Popover>
+    ),
+    { includeRtl: true },
+  );
+});

--- a/apps/vr-tests-react-components/src/stories/PresenceBadge.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/PresenceBadge.stories.tsx
@@ -1,0 +1,50 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { PresenceBadge, PresenceBadgeProps } from '@fluentui/react-badge';
+
+const statuses: PresenceBadgeProps['status'][] = [
+  'available',
+  'away',
+  'busy',
+  'doNotDisturb',
+  'offline',
+  'outOfOffice',
+];
+
+storiesOf('PresenceBadge Converged - status', module).addStory(
+  'default',
+  () => (
+    <div style={{ display: 'flex', gap: 10 }}>
+      {statuses.map(status => (
+        <PresenceBadge status={status} key={status} />
+      ))}
+    </div>
+  ),
+  { includeRtl: true },
+);
+
+storiesOf('PresenceBadge Converged - OOF status', module).addStory(
+  'default',
+  () => (
+    <div style={{ display: 'flex', gap: 10 }}>
+      {statuses.map(status => (
+        <PresenceBadge status={status} key={status} outOfOffice />
+      ))}
+    </div>
+  ),
+  { includeRtl: true },
+);
+
+storiesOf('PresenceBadge Converged - sizes', module).addStory(
+  'default',
+  () => (
+    <div style={{ display: 'flex', gap: 10 }}>
+      {(['tiny', 'extra-small', 'small', 'medium', 'large', 'extra-large'] as PresenceBadgeProps['size'][]).map(
+        size => (
+          <PresenceBadge status="available" key={size} size={size} />
+        ),
+      )}
+    </div>
+  ),
+  { includeRtl: true },
+);

--- a/apps/vr-tests-react-components/src/stories/Slider.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Slider.stories.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import Screener, { Steps } from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { Slider } from '@fluentui/react-slider';
+
+storiesOf('Slider Converged', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('.test-class')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('.test-class')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('.test-class')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Root', () => <Slider className="test-class" defaultValue={30} />, {
+    includeRtl: true,
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Vertical', () => <Slider className="test-class" vertical defaultValue={30} />, {
+    includeRtl: true,
+  })
+  .addStory('Disabled', () => <Slider className="test-class" disabled defaultValue={30} />, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Disabled Vertical', () => <Slider className="test-class" disabled vertical defaultValue={30} />)
+  .addStory('Origin', () => <Slider className="test-class" origin={30} />, { includeRtl: true })
+  .addStory('Origin Vertical', () => <Slider className="test-class" vertical origin={30} />, {
+    includeRtl: true,
+  })
+  .addStory('Origin (min)', () => <Slider className="test-class" min={0} origin={0} />)
+  .addStory('Origin Vertical (min)', () => <Slider className="test-class" min={0} vertical origin={0} />)
+  .addStory('Origin (max)', () => <Slider className="test-class" max={10} origin={10} />)
+  .addStory('Origin Vertical (max)', () => <Slider className="test-class" min={10} vertical origin={10} />);

--- a/apps/vr-tests-react-components/src/stories/Switch.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Switch.stories.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import Screener, { Steps } from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { Switch } from '@fluentui/react-switch';
+
+storiesOf('Switch Converged', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('.test-class')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('.test-class')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('.test-class')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Root (unchecked)', () => <Switch className="test-class" defaultChecked={false} />, {
+    includeRtl: true,
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Root (checked)', () => <Switch className="test-class" defaultChecked={true} />, {
+    includeRtl: true,
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Disabled (unchecked)', () => <Switch className="test-class" disabled defaultChecked={false} />, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  })
+  .addStory('Disabled (checked)', () => <Switch className="test-class" disabled defaultChecked={true} />, {
+    includeHighContrast: true,
+    includeDarkMode: true,
+  });

--- a/apps/vr-tests-react-components/src/stories/Tabs.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tabs.stories.tsx
@@ -1,0 +1,190 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import Screener from 'screener-storybook/src/screener';
+import { TabList, Tab } from '@fluentui/react-tabs';
+
+storiesOf('TabList and Tab Converged', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('.mouse-target')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('.mouse-target')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('.mouse-target')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory(
+    'Default',
+    () => (
+      <TabList>
+        <Tab value="1">First</Tab>
+        <Tab className="mouse-target" value="2">
+          Second
+        </Tab>
+        <Tab value="3">Third</Tab>
+      </TabList>
+    ),
+    {
+      includeRtl: true,
+      includeHighContrast: true,
+      includeDarkMode: true,
+    },
+  )
+  .addStory('Vertical', () => (
+    <TabList vertical>
+      <Tab value="1">First</Tab>
+      <Tab className="mouse-target" value="2">
+        Second
+      </Tab>
+      <Tab value="3">Third</Tab>
+    </TabList>
+  ))
+  .addStory(
+    'Subtle appearance',
+    () => (
+      <TabList appearance="subtle">
+        <Tab value="1">First</Tab>
+        <Tab className="mouse-target" value="2">
+          Second
+        </Tab>
+        <Tab value="3">Third</Tab>
+      </TabList>
+    ),
+    {
+      includeHighContrast: true,
+      includeDarkMode: true,
+    },
+  )
+  .addStory(
+    'Small size',
+    () => (
+      <TabList size="small">
+        <Tab value="1">First</Tab>
+        <Tab className="mouse-target" value="2">
+          Second
+        </Tab>
+        <Tab value="3">Third</Tab>
+      </TabList>
+    ),
+    {
+      includeHighContrast: true,
+      includeDarkMode: true,
+    },
+  )
+  .addStory(
+    'Vertical and small size',
+    () => (
+      <TabList size="small" vertical>
+        <Tab value="1">First</Tab>
+        <Tab className="mouse-target" value="2">
+          Second
+        </Tab>
+        <Tab value="3">Third</Tab>
+      </TabList>
+    ),
+    {
+      includeHighContrast: true,
+      includeDarkMode: true,
+    },
+  )
+  .addStory(
+    'Tab Selected (default)',
+    () => (
+      <TabList defaultSelectedValue="2">
+        <Tab value="1">First</Tab>
+        <Tab className="mouse-target" value="2">
+          Second
+        </Tab>
+        <Tab value="3">Third</Tab>
+      </TabList>
+    ),
+    {
+      includeHighContrast: true,
+      includeDarkMode: true,
+    },
+  )
+  .addStory(
+    'Tab Selected',
+    () => (
+      <TabList selectedValue="2">
+        <Tab value="1">First</Tab>
+        <Tab className="mouse-target" value="2">
+          Second
+        </Tab>
+        <Tab value="3">Third</Tab>
+      </TabList>
+    ),
+    {
+      includeHighContrast: true,
+      includeDarkMode: true,
+    },
+  )
+  .addStory(
+    'With icon',
+    () => (
+      <TabList>
+        <Tab icon="A" value="1">
+          First
+        </Tab>
+        <Tab icon="B" className="mouse-target" value="2">
+          Second
+        </Tab>
+        <Tab icon="C" value="3">
+          Third
+        </Tab>
+      </TabList>
+    ),
+    {
+      includeRtl: true,
+    },
+  )
+  .addStory(
+    'With icon and vertical',
+    () => (
+      <TabList vertical>
+        <Tab icon="A" value="1">
+          First
+        </Tab>
+        <Tab icon="B" className="mouse-target" value="2">
+          Second
+        </Tab>
+        <Tab icon="C" value="3">
+          Third
+        </Tab>
+      </TabList>
+    ),
+    {
+      includeRtl: true,
+    },
+  )
+  .addStory(
+    'With icon only',
+    () => (
+      <TabList>
+        <Tab icon="A" value="1" />
+        <Tab icon="B" className="mouse-target" value="2" />
+        <Tab icon="C" value="3" />
+      </TabList>
+    ),
+    {
+      includeRtl: false,
+    },
+  )
+  .addStory(
+    'With icon only and vertical',
+    () => (
+      <TabList vertical>
+        <Tab icon="A" value="1" />
+        <Tab icon="B" className="mouse-target" value="2" />
+        <Tab icon="C" value="3" />
+      </TabList>
+    ),
+    {
+      includeRtl: false,
+    },
+  );

--- a/apps/vr-tests-react-components/src/stories/Text.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Text.stories.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import Screener from 'screener-storybook/src/screener';
+import {
+  Body,
+  Caption,
+  Display,
+  Headline,
+  LargeTitle,
+  Subheadline,
+  Text,
+  Title1,
+  Title2,
+  Title3,
+} from '@fluentui/react-text';
+
+storiesOf('Text Converged', module)
+  .addDecorator((story: () => React.ReactNode) => (
+    <Screener steps={new Screener.Steps().snapshot('normal', { cropTo: '.testWrapper' }).end()}>
+      <div className="testWrapper" style={{ width: '250px' }}>
+        {story()}
+      </div>
+    </Screener>
+  ))
+  .addStory(
+    'Default',
+    () => (
+      <>
+        <p>
+          <Title3 block>Default</Title3>
+          <Text>Lorem ipsum dolor sit amet, nullam rhoncus tristique tellus in Portucale.</Text>
+        </p>
+        <p>
+          <Title3 block>No wrapping</Title3>
+          <Text block wrap={false}>
+            Lorem ipsum dolor sit amet, nullam rhoncus tristique tellus in Portucale.
+          </Text>
+        </p>
+        <p>
+          <Title3 block>Truncate</Title3>
+          <Text block wrap={false} truncate>
+            Lorem ipsum dolor sit amet, nullam rhoncus tristique tellus in Portucale.
+          </Text>
+        </p>
+        <p>
+          <Title3 block>Italic</Title3>
+          <Text block italic>
+            Hello, world
+          </Text>
+        </p>
+        <p>
+          <Title3 block>Underline</Title3>
+          <Text block underline>
+            Hello, world
+          </Text>
+        </p>
+        <p>
+          <Title3 block>Strikethrough</Title3>
+          <Text block strikethrough>
+            Hello, world
+          </Text>
+        </p>
+        <p>
+          <Title3 block>Sizes</Title3>
+          <Text block size={100}>
+            100
+          </Text>
+          <Text block size={200}>
+            200
+          </Text>
+          <Text block size={300}>
+            300
+          </Text>
+          <Text block size={400}>
+            400
+          </Text>
+          <Text block size={500}>
+            500
+          </Text>
+          <Text block size={600}>
+            600
+          </Text>
+          <Text block size={700}>
+            700
+          </Text>
+          <Text block size={800}>
+            800
+          </Text>
+          <Text block size={900}>
+            900
+          </Text>
+          <Text block size={1000}>
+            1000
+          </Text>
+        </p>
+        <p>
+          <Title3 block>Fonts</Title3>
+          <Text block font="base">
+            Base
+          </Text>
+          <Text block font="monospace">
+            Monospace
+          </Text>
+          <Text block font="numeric">
+            Numeric
+          </Text>
+        </p>
+        <p>
+          <Title3 block>Weights</Title3>
+          <Text block weight="regular">
+            Regular
+          </Text>
+          <Text block weight="medium">
+            Medium
+          </Text>
+          <Text block weight="semibold">
+            Semibold
+          </Text>
+        </p>
+        <p>
+          <Title3 block>Alignments</Title3>
+          <Text block align="start">
+            Start
+          </Text>
+          <Text block align="center">
+            Center
+          </Text>
+          <Text block align="end">
+            End
+          </Text>
+          <Text block align="justify">
+            Justified lorem ipsum dolor sit amet, nullam rhoncus tristique tellus in Portucale.
+          </Text>
+        </p>
+      </>
+    ),
+    { includeRtl: true, includeHighContrast: true, includeDarkMode: true },
+  )
+  .addStory(
+    'Display',
+    () => (
+      <>
+        <Display block>Display</Display>
+        <LargeTitle block>LargeTitle</LargeTitle>
+        <Title1 block>Title1</Title1>
+        <Title2 block>Title2</Title2>
+        <Title3 block>Title3</Title3>
+        <Headline block>Headline</Headline>
+        <Subheadline block>Subheadline</Subheadline>
+        <Body block>Body</Body>
+        <Caption block>Caption</Caption>
+      </>
+    ),
+    { includeRtl: true },
+  );

--- a/apps/vr-tests-react-components/src/stories/Tooltip.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Tooltip } from '@fluentui/react-tooltip';
-import { TestWrapperDecorator } from '../utilities';
+import { TestWrapperDecorator } from '../utilities/index';
 import { makeStyles, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 

--- a/apps/vr-tests-react-components/src/stories/Tooltip.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tooltip.stories.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Tooltip } from '@fluentui/react-tooltip';
+import { TestWrapperDecorator } from '../utilities';
+import { makeStyles, shorthands } from '@griffel/react';
+import { tokens } from '@fluentui/react-theme';
+
+const useStyles = makeStyles({
+  wrapper: {
+    display: 'flex',
+    ...shorthands.gap('5px'),
+    ...shorthands.padding('50px', '120px'),
+    backgroundColor: tokens.colorNeutralBackground1,
+
+    '& button, & .target': {
+      color: tokens.colorNeutralForeground1,
+      backgroundColor: tokens.colorNeutralBackground1,
+      ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke1),
+    },
+  },
+});
+
+storiesOf('Tooltip Converged', module)
+  .addDecorator(TestWrapperDecorator)
+  .addStory(
+    'basic',
+    () => (
+      <div className={useStyles().wrapper}>
+        <Tooltip visible content="This is a tooltip" relationship="description">
+          <button>Target</button>
+        </Tooltip>
+      </div>
+    ),
+    { includeDarkMode: true, includeHighContrast: true },
+  )
+  .addStory(
+    'inverted',
+    () => (
+      <div className={useStyles().wrapper}>
+        <Tooltip visible appearance="inverted" content="Inverted tooltip" relationship="description">
+          <button>Target</button>
+        </Tooltip>
+      </div>
+    ),
+    { includeDarkMode: true },
+  )
+  .addStory(
+    'withArrow',
+    () => (
+      <div className={useStyles().wrapper}>
+        <Tooltip visible withArrow content="Tooltip with an arrow" relationship="description">
+          <button>Target</button>
+        </Tooltip>
+      </div>
+    ),
+    { includeDarkMode: true, includeHighContrast: true },
+  )
+  .addStory(
+    'inverted withArrow',
+    () => (
+      <div className={useStyles().wrapper}>
+        <Tooltip
+          visible
+          appearance="inverted"
+          withArrow
+          content="Inverted tooltip with an arrow"
+          relationship="description"
+        >
+          <button>Target</button>
+        </Tooltip>
+      </div>
+    ),
+    { includeDarkMode: true },
+  )
+  .addStory('text-wrapping', () => (
+    <div className={useStyles().wrapper}>
+      <Tooltip visible content="This tooltip's text is long enough to wrap to a new line" relationship="description">
+        <button>Target</button>
+      </Tooltip>
+    </div>
+  ))
+  .addStory(
+    'positioning',
+    () => {
+      const positions = [
+        ['above', 'start'],
+        ['above', 'center'],
+        ['above', 'end'],
+        ['below', 'start'],
+        ['below', 'center'],
+        ['below', 'end'],
+        ['before', 'top'],
+        ['before', 'center'],
+        ['before', 'bottom'],
+        ['after', 'top'],
+        ['after', 'center'],
+        ['after', 'bottom'],
+      ] as const;
+      const [target, setTarget] = React.useState<HTMLDivElement | null>(null);
+      return (
+        <div className={useStyles().wrapper}>
+          <div ref={setTarget} className="target" style={{ width: '300px', height: '150px' }}>
+            {positions.map(([position, align]) => (
+              <Tooltip
+                key={position + align}
+                content={position + ' ' + align}
+                relationship="label"
+                positioning={{ position, align, target }}
+                withArrow
+                visible
+              />
+            ))}
+          </div>
+        </div>
+      );
+    },
+    { includeRtl: true, includeHighContrast: true },
+  );

--- a/apps/vr-tests-react-components/src/utilities/TestWrapperDecorator.tsx
+++ b/apps/vr-tests-react-components/src/utilities/TestWrapperDecorator.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { DecoratorFunction } from '@storybook/addons';
+import { ExtendedStoryFnReturnType } from './types';
+
+export const TestWrapperDecorator: DecoratorFunction<ExtendedStoryFnReturnType> = story => (
+  <div style={{ display: 'flex' }}>
+    <div className="testWrapper" style={{ padding: '10px', overflow: 'hidden' }}>
+      {story()}
+    </div>
+  </div>
+);
+
+export const TestWrapperDecoratorTall: DecoratorFunction<ExtendedStoryFnReturnType> = story => (
+  <div style={{ display: 'flex' }}>
+    <div className="testWrapper" style={{ padding: '10px 10px 120px' }}>
+      {story()}
+    </div>
+  </div>
+);
+
+export const TestWrapperDecoratorTallFixedWidth: DecoratorFunction<ExtendedStoryFnReturnType> = story => (
+  <div style={{ display: 'flex' }}>
+    <div className="testWrapper" style={{ padding: '10px 10px 120px', width: '300px' }}>
+      {story()}
+    </div>
+  </div>
+);
+
+export const TestWrapperDecoratorFixedWidth: DecoratorFunction<ExtendedStoryFnReturnType> = story => (
+  <div style={{ display: 'flex' }}>
+    <div className="testWrapper" style={{ padding: '10px', width: '300px' }}>
+      {story()}
+    </div>
+  </div>
+);
+
+export const TestWrapperDecoratorFullWidth: DecoratorFunction<ExtendedStoryFnReturnType> = story => (
+  <div style={{ display: 'flex' }}>
+    <div className="testWrapper" style={{ padding: '10px', width: '100%', overflow: 'hidden' }}>
+      {story()}
+    </div>
+  </div>
+);
+
+const mapper = { default: '', fixed: '300px', full: '100%' };
+
+/**
+ * Temporary helper to modify already decorated stories for screener DOM container
+ * This should be used for all stories that use same story ID multiple times and need different decorator
+ *
+ * > **Why is this needed:**
+ * >
+ * > SB6 duplicates same story ID decorators (until we migrate to CSF format duplication problem this is a workaround)
+ *
+ * @example
+ * ```
+ // this adds first decorator
+ storiesOf('SpinButton', module).addDecorator(TestWrapperDecorator)...
+
+ // this adds another decorator to same DOM tree
+ storiesOf('SpinButton', module).addDecorator(TestWrapperDecoratorFullWidth)...
+
+ // this results having following DOM tree
+ // ↓ ↓ ↓
+   <TestWrapperDecoratorFullWidth>
+     <TestWrapperDecorator>
+       <Story/>
+    </TestWrapperDecorator>
+  </TestWrapperDecoratorFullWidth>
+```
+ */
+export function modifyDeprecatedDecoratorStyles(options: {
+  mode: keyof typeof mapper;
+}): DecoratorFunction<ExtendedStoryFnReturnType> {
+  const { mode } = options;
+  return story => {
+    return (
+      <span
+        ref={el => {
+          if (!el) {
+            return;
+          }
+          const testWrapperNode = el.querySelector('.testWrapper') as HTMLDivElement;
+          testWrapperNode.style.width = mapper[mode];
+        }}
+      >
+        {story()}
+      </span>
+    );
+  };
+}

--- a/apps/vr-tests-react-components/src/utilities/index.ts
+++ b/apps/vr-tests-react-components/src/utilities/index.ts
@@ -1,0 +1,11 @@
+import { ExtendedStoryApi } from './types';
+
+declare module '@storybook/addons' {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  interface StoryApi {
+    /** adds a story, but via VR Tests' addon which auto adds variants like RTL */
+    addStory: ExtendedStoryApi['addStory'];
+  }
+}
+
+export * from './TestWrapperDecorator';

--- a/apps/vr-tests-react-components/src/utilities/index.ts
+++ b/apps/vr-tests-react-components/src/utilities/index.ts
@@ -1,7 +1,6 @@
 import { ExtendedStoryApi } from './types';
 
 declare module '@storybook/addons' {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   interface StoryApi {
     /** adds a story, but via VR Tests' addon which auto adds variants like RTL */
     addStory: ExtendedStoryApi['addStory'];

--- a/apps/vr-tests-react-components/src/utilities/types.ts
+++ b/apps/vr-tests-react-components/src/utilities/types.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { StoryApi, StoryName, LegacyStoryFn } from '@storybook/addons';
 
 /** Extra parameters provided by our addon (see `.storybook/preview.js`) */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export interface AddStoryConfig {
   /** Whether to include an RTL version of the story */
   includeRtl?: boolean;
@@ -16,7 +15,6 @@ export type ExtendedStoryFnReturnType = React.ReactElement<unknown>;
 
 export type ExtendedStoryFn = LegacyStoryFn<ExtendedStoryFnReturnType>;
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export interface ExtendedStoryApi extends StoryApi<ExtendedStoryFnReturnType> {
   addStory: (storyName: StoryName, storyFn: ExtendedStoryFn, config?: AddStoryConfig) => ExtendedStoryApi;
 

--- a/apps/vr-tests-react-components/src/utilities/types.ts
+++ b/apps/vr-tests-react-components/src/utilities/types.ts
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { StoryApi, StoryName, LegacyStoryFn } from '@storybook/addons';
+
+/** Extra parameters provided by our addon (see `.storybook/preview.js`) */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface AddStoryConfig {
+  /** Whether to include an RTL version of the story */
+  includeRtl?: boolean;
+  /** Whether to include a high contrast *theme* version of the story (converged only) */
+  includeHighContrast?: boolean;
+  /** Whether to include a dark theme version of the story (converged only) */
+  includeDarkMode?: boolean;
+}
+
+export type ExtendedStoryFnReturnType = React.ReactElement<unknown>;
+
+export type ExtendedStoryFn = LegacyStoryFn<ExtendedStoryFnReturnType>;
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface ExtendedStoryApi extends StoryApi<ExtendedStoryFnReturnType> {
+  addStory: (storyName: StoryName, storyFn: ExtendedStoryFn, config?: AddStoryConfig) => ExtendedStoryApi;
+
+  add: (storyName: StoryName, storyFn: ExtendedStoryFn) => ExtendedStoryApi;
+}

--- a/apps/vr-tests-react-components/tsconfig.json
+++ b/apps/vr-tests-react-components/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "es5",
+    "outDir": "lib",
+    "module": "commonjs",
+    "jsx": "react",
+    "declaration": true,
+    "sourceMap": true,
+    "noEmit": true,
+    "experimentalDecorators": true,
+    "noUnusedLocals": true,
+    "forceConsistentCasingInFileNames": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "moduleResolution": "node",
+    "preserveConstEnums": true,
+    "skipLibCheck": true,
+    "types": ["webpack-env", "@storybook/react", "screener-storybook"]
+  },
+  "include": ["src"]
+}

--- a/apps/vr-tests/screener.config.js
+++ b/apps/vr-tests/screener.config.js
@@ -33,9 +33,6 @@ const baseBranch = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
 
 // https://github.com/screener-io/screener-storybook#additional-configuration-options
 const config = {
-  fluentInternal: {
-    baseUrl: `${process.env.DEPLOYURL}/react-screener/iframe.html`,
-  },
   projectRepo: 'microsoft/fluentui',
   storybookStaticBuildDir: 'dist/storybook',
   storybookConfigDir: '.storybook',

--- a/apps/vr-tests/screener.config.js
+++ b/apps/vr-tests/screener.config.js
@@ -33,6 +33,9 @@ const baseBranch = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
 
 // https://github.com/screener-io/screener-storybook#additional-configuration-options
 const config = {
+  fluentInternal: {
+    baseUrl: `${process.env.DEPLOYURL}/react-screener/iframe.html`,
+  },
   projectRepo: 'microsoft/fluentui',
   storybookStaticBuildDir: 'dist/storybook',
   storybookConfigDir: '.storybook',

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,6 +111,7 @@ jobs:
       - template: .devops/templates/cleanup.yml
 
   - job: ScreenerNorthstar
+    displayName: Screener @fluentui/react-northstar
     workspace:
       clean: all
     steps:
@@ -147,6 +148,7 @@ jobs:
       - template: .devops/templates/cleanup.yml
 
   - job: Screener
+    displayName: Screener @fluentui/react
     workspace:
       clean: all
     steps:
@@ -179,5 +181,42 @@ jobs:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
           SCREENER_API_KEY: $(screener.key)
+
+      - template: .devops/templates/cleanup.yml
+
+  - job: ScreenerVNext
+    displayName: Screener @fluentui/react-components
+    workspace:
+      clean: all
+    steps:
+      - template: .devops/templates/tools.yml
+
+      - task: Bash@3
+        inputs:
+          filePath: yarn-ci.sh
+        displayName: yarn
+
+      - script: |
+          yarn workspace @fluentui/vr-tests-react-components screener:build
+        displayName: build vr-tests-react-components storybook
+
+      - task: AzureUpload@2
+        displayName: Upload @fluentui/react-components VR test site
+        inputs:
+          azureSubscription: $(azureSubscription)
+          BlobPrefix: $(deployBasePath)/react-components-screener
+          CacheControl: 'public, max-age=600000'
+          ContainerName: '$web'
+          SourcePath: 'apps/vr-tests-react-components/dist/storybook'
+          storage: $(azureStorage)
+
+      # Don't use lage here because it eats long output for reasons that are hard to debug
+      # - script: |
+      #     yarn workspace @fluentui/vr-tests-react-components screener
+      #   displayName: run VR Test
+      #   env:
+      #     SCREENER_ENDPOINT: $(screenerApiUri)
+      #     SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
+      #     SCREENER_API_KEY: $(screener.key)
 
       - template: .devops/templates/cleanup.yml

--- a/scripts/screener/screener.types.ts
+++ b/scripts/screener/screener.types.ts
@@ -19,6 +19,10 @@ export type ScreenerRunnerConfig = {
   baseBranch: string;
   commit: string;
   failureExitCode: number;
+
+  fluentInternal: {
+    baseUrl: string;
+  };
 };
 
 export type ScreenerState = {

--- a/scripts/screener/screener.types.ts
+++ b/scripts/screener/screener.types.ts
@@ -19,10 +19,6 @@ export type ScreenerRunnerConfig = {
   baseBranch: string;
   commit: string;
   failureExitCode: number;
-
-  fluentInternal: {
-    baseUrl: string;
-  };
 };
 
 export type ScreenerState = {

--- a/scripts/tasks/screener.ts
+++ b/scripts/tasks/screener.ts
@@ -15,7 +15,7 @@ import { getStorybook } from '@storybook/react';
 export async function screener() {
   const screenerConfigPath = path.resolve(process.cwd(), './screener.config.js');
   const screenerConfig: ScreenerRunnerConfig = require(screenerConfigPath);
-  const screenerStates = await getScreenerStates(screenerConfig, `${process.env.DEPLOYURL}/react-screener/iframe.html`);
+  const screenerStates = await getScreenerStates(screenerConfig, screenerConfig.fluentInternal.baseUrl);
   screenerConfig.states = screenerStates;
   console.log('screener config for run');
   console.log(JSON.stringify(screenerConfig, null, 2));

--- a/scripts/tasks/screener.ts
+++ b/scripts/tasks/screener.ts
@@ -12,7 +12,7 @@ import { getStorybook } from '@storybook/react';
 export async function screener() {
   const screenerConfigPath = path.resolve(process.cwd(), './screener.config.js');
   const screenerConfig: ScreenerRunnerConfig = require(screenerConfigPath);
-  const screenerStates = await getScreenerStates(screenerConfig, screenerConfig.fluentInternal.baseUrl);
+  const screenerStates = await getScreenerStates(screenerConfig, `${process.env.DEPLOYURL}/react-screener/iframe.html`);
   screenerConfig.states = screenerStates;
   console.log('screener config for run');
   console.log(JSON.stringify(screenerConfig, null, 2));

--- a/workspace.json
+++ b/workspace.json
@@ -705,6 +705,11 @@
       "root": "apps/vr-tests",
       "projectType": "application",
       "implicitDependencies": []
+    },
+    "@fluentui/vr-tests-react-components": {
+      "root": "apps/vr-tests-react-components",
+      "projectType": "application",
+      "implicitDependencies": []
     }
   }
 }


### PR DESCRIPTION
Creates VR test project for react-components that includes all the VR
test stories from the current @fluentui/vr-tests package.

Removes the v8 specific configuration and utils and removes `Converged`
suffix from names.

The tests are copied **(not renamed)** from the current vr-tests package, since we still need existing vr-tests to run for v9 until we setup the full suite of checks for them

## Current Behavior

There is no separate vr-tests site for @fluentui/react-components

## New Behavior

Deploy a vr-tests site for @fluentui/react-components for every PR

[LINK TO CURRENT PR STORYBOOK](https://fluentuipr.z22.web.core.windows.net/pull/21734/react-components-screener/index.html?path=/story/accordion-converged--visibility-focus)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes partially #21070
