### PR TITLE
chore: Scope v8 vr-tests

### DIFF
--- a/scripts/tasks/screener.ts
+++ b/scripts/tasks/screener.ts
@@ -1,8 +1,5 @@
-// import { getAffectedPackages, getAllPackageInfo, findGitRoot } from '../monorepo';
-import {
-  screenerRunner,
-  // cancelScreenerRun
-} from '../screener/screener.runner';
+import { getAffectedPackages, getAllPackageInfo, findGitRoot } from '../monorepo';
+import { screenerRunner, cancelScreenerRun } from '../screener/screener.runner';
 import { ScreenerRunnerConfig, ScreenerRunnerStep, ScreenerState } from '../screener/screener.types';
 import path from 'path';
 // @ts-ignore - screener-storybook has no typings
@@ -19,28 +16,24 @@ export async function screener() {
   screenerConfig.states = screenerStates;
   console.log('screener config for run');
   console.log(JSON.stringify(screenerConfig, null, 2));
-  await screenerRunner(screenerConfig);
-  // screener-storybook internally starts a puppeteer instance that only closes on process exist
-  process.exit(0);
 
-  // Scoping can only be used once the legacy check and new check switch required status
-  // const packageInfos = getAllPackageInfo();
-  // const packagePath = path.relative(findGitRoot(), process.cwd());
-  // const affectedPackageInfo = Object.values(packageInfos).find(x => x.packagePath === packagePath);
-  // const affectedPackages = getAffectedPackages();
-  // try {
-  // if (!affectedPackages.has(affectedPackageInfo.packageJson.name)) {
-  // await cancelScreenerRun(screenerConfig);
-  // } else {
-  // await screenerRunner(screenerConfig);
-  // }
-  // } catch (err) {
-  // console.error('failed to run screener task');
-  // console.error(err);
-  // // screener-storybook internally starts a puppeteer instance that only closes on process exist
-  // process.exit(1);
-  // }
-  // process.exit(0);
+  const packageInfos = getAllPackageInfo();
+  const packagePath = path.relative(findGitRoot(), process.cwd());
+  const affectedPackageInfo = Object.values(packageInfos).find(x => x.packagePath === packagePath);
+  const affectedPackages = getAffectedPackages();
+  try {
+    if (!affectedPackages.has(affectedPackageInfo.packageJson.name)) {
+      await cancelScreenerRun(screenerConfig);
+    } else {
+      await screenerRunner(screenerConfig);
+    }
+  } catch (err) {
+    console.error('failed to run screener task');
+    console.error(err);
+    // screener-storybook internally starts a puppeteer instance that only closes on process exist
+    process.exit(1);
+  }
+  process.exit(0);
 }
 
 /**


### PR DESCRIPTION
Uncomments/adds the code to scope v8 screener tests only when the
affected package graph includes the @fluentui/vr-tests project.

## Current Behavior

V8 VR tests are run for every PR

## New Behavior

V8 VR tests are only run if `@fluentui/vr-tests` is in the affected graph. This is currently the case for v9 too until the vr-tests projects are split in #21734

## Related Issue(s)

Fixes partially #21070
