### PR TITLE
fix: Skip screener check

### DIFF
--- a/scripts/tasks/screener.ts
+++ b/scripts/tasks/screener.ts
@@ -23,7 +23,7 @@ export async function screener() {
   const affectedPackages = getAffectedPackages();
   try {
     if (!affectedPackages.has(affectedPackageInfo.packageJson.name)) {
-      await cancelScreenerRun(screenerConfig);
+      await cancelScreenerRun(screenerConfig, 'skipped');
     } else {
       await screenerRunner(screenerConfig);
     }


### PR DESCRIPTION
By default the `cancelScreenerRun` API sets the `cancelled` conclusion
to PRs, which doesn't actually pass CI.

This was done so that skipping (i.e. passing) was done explicitly. I
have fallen into my own trap here.

## Current Behavior

Non-necessary v8 screener runs are cancelled, which don't pass CI check

## New Behavior

Non-necessary v8 screener runs are skipped, which pass CI check

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #