### PR TITLE
chore: Enable v9 screener run

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -9,6 +9,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
+    "screener": "just-scripts screener",
     "screener:build": "cross-env NODE_OPTIONS=--max-old-space-size=3072 just-scripts storybook:build",
     "start": "just-scripts dev:storybook"
   },

--- a/apps/vr-tests-react-components/screener.config.js
+++ b/apps/vr-tests-react-components/screener.config.js
@@ -44,6 +44,7 @@ const config = {
   ...(process.env.BUILD_SOURCEBRANCH && process.env.BUILD_SOURCEBRANCH.indexOf('refs/pull') > -1
     ? { commit: getCurrentHash() }
     : null),
+  baseUrl: `${process.env.DEPLOYURL}/react-components-screener/iframe.html`,
 };
 console.log('Screener config: ' + JSON.stringify({ ...config, apiKey: '...' }, null, 2));
 

--- a/apps/vr-tests/screener.config.js
+++ b/apps/vr-tests/screener.config.js
@@ -44,6 +44,7 @@ const config = {
   ...(process.env.BUILD_SOURCEBRANCH && process.env.BUILD_SOURCEBRANCH.indexOf('refs/pull') > -1
     ? { commit: getCurrentHash() }
     : null),
+  baseUrl: `${process.env.DEPLOYURL}/react-screener/iframe.html`,
 };
 console.log('Screener config: ' + JSON.stringify({ ...config, apiKey: '...' }, null, 2));
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,7 +135,7 @@ jobs:
           storage: $(azureStorage)
 
       - script: yarn workspace @fluentui/docs vr:test
-        displayName: start FUI N* VR Test
+        displayName: Start FUI N* VR Test
         env:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
@@ -172,7 +172,7 @@ jobs:
       # Don't use lage here because it eats long output for reasons that are hard to debug
       - script: |
           yarn workspace @fluentui/vr-tests screener
-        displayName: run VR Test
+        displayName: Start VR Test
         env:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
@@ -209,7 +209,7 @@ jobs:
       # Don't use lage here because it eats long output for reasons that are hard to debug
       - script: |
           yarn workspace @fluentui/vr-tests-react-components screener
-        displayName: run VR Test
+        displayName: Start VR Test
         env:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,12 +207,12 @@ jobs:
           storage: $(azureStorage)
 
       # Don't use lage here because it eats long output for reasons that are hard to debug
-      # - script: |
-      #     yarn workspace @fluentui/vr-tests-react-components screener
-      #   displayName: run VR Test
-      #   env:
-      #     SCREENER_ENDPOINT: $(screenerApiUri)
-      #     SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
-      #     SCREENER_API_KEY: $(screener.key)
+      - script: |
+          yarn workspace @fluentui/vr-tests-react-components screener
+        displayName: run VR Test
+        env:
+          SCREENER_ENDPOINT: $(screenerApiUri)
+          SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
+          SCREENER_API_KEY: $(screener.key)
 
       - template: .devops/templates/cleanup.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,7 +135,7 @@ jobs:
           storage: $(azureStorage)
 
       - script: yarn workspace @fluentui/docs vr:test
-        displayName: Start FUI N* VR Test
+        displayName: Start @fluentui/react-northstar VR Test
         env:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
@@ -172,7 +172,7 @@ jobs:
       # Don't use lage here because it eats long output for reasons that are hard to debug
       - script: |
           yarn workspace @fluentui/vr-tests screener
-        displayName: Start VR Test
+        displayName: Start @fluentui/react VR Test
         env:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
@@ -209,7 +209,7 @@ jobs:
       # Don't use lage here because it eats long output for reasons that are hard to debug
       - script: |
           yarn workspace @fluentui/vr-tests-react-components screener
-        displayName: Start VR Test
+        displayName: Start @fluentui/react-components VR Test
         env:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)

--- a/scripts/gulp/tasks/screener.ts
+++ b/scripts/gulp/tasks/screener.ts
@@ -40,10 +40,10 @@ task('screener:runner', cb => {
   const screenerConfig = require(screenerConfigPath);
   const isPrBuild = process.env.BUILD_SOURCEBRANCH && process.env.BUILD_SOURCEBRANCH.includes('refs/pull');
 
-  if (changedPackages.has(docsPackageName) && isPrBuild) {
-    handlePromiseExit(screenerRunner(screenerConfig));
-  } else {
+  if (!changedPackages.has(docsPackageName) && isPrBuild) {
     handlePromiseExit(cancelScreenerRun(screenerConfig, 'skipped'));
+  } else {
+    handlePromiseExit(screenerRunner(screenerConfig));
   }
 });
 

--- a/scripts/screener/screener.types.ts
+++ b/scripts/screener/screener.types.ts
@@ -19,6 +19,9 @@ export type ScreenerRunnerConfig = {
   baseBranch: string;
   commit: string;
   failureExitCode: number;
+
+  /** Base url of deployed storybook screener should test */
+  baseUrl: string;
 };
 
 export type ScreenerState = {

--- a/scripts/tasks/screener.ts
+++ b/scripts/tasks/screener.ts
@@ -12,7 +12,7 @@ import { getStorybook } from '@storybook/react';
 export async function screener() {
   const screenerConfigPath = path.resolve(process.cwd(), './screener.config.js');
   const screenerConfig: ScreenerRunnerConfig = require(screenerConfigPath);
-  const screenerStates = await getScreenerStates(screenerConfig, `${process.env.DEPLOYURL}/react-screener/iframe.html`);
+  const screenerStates = await getScreenerStates(screenerConfig);
   screenerConfig.states = screenerStates;
   console.log('screener config for run');
   console.log(JSON.stringify(screenerConfig, null, 2));
@@ -64,10 +64,10 @@ function transformToStates(storybook: ScreenerStorybookSection, baseUrl: string)
   }, []);
 }
 
-async function getScreenerStates(screenerConfig, baseUrl): Promise<ScreenerState[]> {
+async function getScreenerStates(screenerConfig: ScreenerRunnerConfig): Promise<ScreenerState[]> {
   await startStorybook(screenerConfig, {});
 
-  return transformToStates(screenerGetStorybook() as ScreenerStorybookSection, baseUrl);
+  return transformToStates(screenerGetStorybook() as ScreenerStorybookSection, screenerConfig.baseUrl);
 }
 
 type ScreenerStory = { steps?: ScreenerRunnerStep[] };

--- a/scripts/tasks/screener.ts
+++ b/scripts/tasks/screener.ts
@@ -12,10 +12,10 @@ import { getStorybook } from '@storybook/react';
 export async function screener() {
   const screenerConfigPath = path.resolve(process.cwd(), './screener.config.js');
   const screenerConfig: ScreenerRunnerConfig = require(screenerConfigPath);
-  const screenerStates = await getScreenerStates(screenerConfig);
-  screenerConfig.states = screenerStates;
   console.log('screener config for run');
   console.log(JSON.stringify(screenerConfig, null, 2));
+  const screenerStates = await getScreenerStates(screenerConfig);
+  screenerConfig.states = screenerStates;
 
   const packageInfos = getAllPackageInfo();
   const packagePath = path.relative(findGitRoot(), process.cwd());


### PR DESCRIPTION
## Current Behavior

Screener tests don't run for only v9

## New Behavior

New `microsoft/fluentui/react-components` screener project that stores screenshots just for v9.

The associated check is `Screener @fluentui/react-components`. The end result should be a rename of all our screener checks to follow `Screener <package name>` pattern.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes partially #21070
