### PR TITLE
Store the styles property in a local variable so the rest of the props are not bound to the concatenatedStyles function

### DIFF
--- a/change/@fluentui-utilities-291f1e4e-88ca-4c70-903e-5de975c9a5af.json
+++ b/change/@fluentui-utilities-291f1e4e-88ca-4c70-903e-5de975c9a5af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Store the styles property in a local variable so the rest of the props are not bound to the concatednatedStyles function",
+  "packageName": "@fluentui/utilities",
+  "email": "jarmit@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -100,6 +100,8 @@ export function styled<
     const propStyles = props.styles;
     if (!styles.current || customizedStyles !== cache[1] || propStyles !== cache[2]) {
       // Using styled components as the Component arg will result in nested styling arrays.
+      // The function can be cached and in order to prevent the props from being retained within it's closure
+      // we pass in just the styles and not the entire props
       const concatenatedStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet> = (styleProps: TStyleProps) =>
         concatStyleSetsWithProps(styleProps, baseStyles, customizedStyles, propStyles);
 

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -97,21 +97,22 @@ export function styled<
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cache = (styles.current && (styles.current as any).__cachedInputs__) || [];
-    if (!styles.current || customizedStyles !== cache[1] || props.styles !== cache[2]) {
+    const propStyles = props.styles;
+    if (!styles.current || customizedStyles !== cache[1] || propStyles !== cache[2]) {
       // Using styled components as the Component arg will result in nested styling arrays.
       const concatenatedStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet> = (styleProps: TStyleProps) =>
-        concatStyleSetsWithProps(styleProps, baseStyles, customizedStyles, props.styles);
+        concatStyleSetsWithProps(styleProps, baseStyles, customizedStyles, propStyles);
 
       // The __cachedInputs__ array is attached to the function and consumed by the
       // classNamesFunction as a list of keys to include for memoizing classnames.
       (concatenatedStyles as StyleFunction<TStyleProps, TStyleSet>).__cachedInputs__ = [
         baseStyles,
         customizedStyles,
-        props.styles,
+        propStyles,
       ];
 
       (concatenatedStyles as StyleFunction<TStyleProps, TStyleSet>).__noStyleOverride__ =
-        !customizedStyles && !props.styles;
+        !customizedStyles && !propStyles;
 
       styles.current = concatenatedStyles as StyleFunction<TStyleProps, TStyleSet>;
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently, the `concatenatedStyles` function has a reference to the props which can lead to memory leaks as other props can have references to Detached HTMLDivElements especially if the use setState such as onSelectDate in CalendarDayGrid.
## New Behavior

Instead of using the prop argument, the style property is stored in a local variable and used within the `concatenatedStyles` function does not have a reference to the other props.
