### PR TITLE
fix: Add react-theme as dependency to react-image

### DIFF
--- a/change/@fluentui-react-image-c3a7ec7f-295b-4a5a-afe5-e1e353944e9e.json
+++ b/change/@fluentui-react-image-c3a7ec7f-295b-4a5a-afe5-e1e353944e9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Add react-theme as dependency to react-image",
+  "packageName": "@fluentui/react-image",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@griffel/react": "1.0.0",
+    "@fluentui/react-theme": "9.0.0-rc.1",
     "@fluentui/react-utilities": "9.0.0-rc.1",
     "tslib": "^2.1.0"
   },


### PR DESCRIPTION
## Current Behavior

@fluentui/react-theme is not  a dependency of @fluentui/react-image

## New Behavior

@fluentui/react-theme is a dependency of @fluentui/react-image

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
