### PR TITLE
fix: Run v9 production build before publish

### DIFF
--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -44,19 +44,19 @@ steps:
       yarn change --type prerelease --message "Release nightly v9"
     displayName: 'Bump and commit nightly versions'
 
-  - script: |
-      yarn run:published build --production
-    displayName: yarn build
-
   # --only makes it only run tests (otherwise due to the missing --production arg, lage would re-run the build)
   # https://github.com/microsoft/fluentui/issues/21686
   - script: |
-      yarn run:published test --only
+      yarn run:published test
     displayName: yarn test
 
   - script: |
-      yarn run:published lint --only
+      yarn run:published lint
     displayName: yarn lint
+
+  - script: |
+      yarn run:published build --production
+    displayName: yarn build
 
   - script: |
       yarn publish:beachball -n $(npmToken) --no-push --tag nightly

--- a/azure-pipelines.release-vnext.yml
+++ b/azure-pipelines.release-vnext.yml
@@ -43,19 +43,19 @@ steps:
       filePath: yarn-ci.sh
     displayName: yarn
 
-  - script: |
-      yarn run:published build --production
-    displayName: yarn build
-
   # --only makes it only run tests (otherwise due to the missing --production arg, lage would re-run the build)
   # https://github.com/microsoft/fluentui/issues/21686
   - script: |
-      yarn run:published test --only
+      yarn run:published test
     displayName: yarn test
 
   - script: |
-      yarn run:published lint --only
+      yarn run:published lint
     displayName: yarn lint
+
+  - script: |
+      yarn run:published build --production
+    displayName: yarn build
 
   - script: |
       yarn publish:beachball -n $(npmToken)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

`yarn lage run --only` does not work it still triggers build -> triggered an issue with Lage microsoft/lage#220

## New Behavior

Run production build before publish step so source maps are correctly generated.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21686
