### PR TITLE
create-package sets initial package version to alpha for converged

### DIFF
--- a/scripts/create-package/plop-templates-node/package.json.hbs
+++ b/scripts/create-package/plop-templates-node/package.json.hbs
@@ -1,6 +1,6 @@
 {
   "name": "{{{packageNpmName}}}",
-  "version": "0.1.0",
+  "version": "{{{packageVersion}}}",
   "description": "{{{description}}}",
   "private": true,
   "main": "lib/index.js",

--- a/scripts/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/create-package/plop-templates-react/package.json.hbs
@@ -1,6 +1,6 @@
 {
   "name": "{{{packageNpmName}}}",
-  "version": "0.1.0",
+  "version": "{{{packageVersion}}}",
   "private": true,
   "description": "{{{description}}}",
   "main": "lib-commonjs/index.js",

--- a/scripts/create-package/plopfile.ts
+++ b/scripts/create-package/plopfile.ts
@@ -204,12 +204,10 @@ function replaceVersionsFromReference(
   }
 
   if (answers.isConverged) {
-    // Update the version and beachball config in package.json to match the current v9 ones
-    if (packageJsons[0].version?.[0] === '9') {
-      newPackageJson.version = packageJsons[0].version;
-    } else {
+    if (packageJsons[0].version?.[0] !== '9') {
       throw new Error(`Converged reference package ${packageJsons[0].name} does not appear to have version 9.x`);
     }
+    // Update beachball config in package.json to match the current v9
     if (packageJsons[0].beachball) {
       newPackageJson.beachball = packageJsons[0].beachball;
     }


### PR DESCRIPTION
## Current Behavior

create-package sets new package versions to the same as the first 9.0 packaged reference.  
This sets to the latest version (e.g. 9.0.0-rc.2)

## New Behavior

create-package sets new package version to 9.0.0-alpha.0 for converged.

Note: the package.json.hbs files were not using the packageVersion from the data object set in plopfile.ts, now they are so they pick up the correct v8 or converged initial package version.

## Related Issue(s)

Fixes #21793
