### PR TITLE
chore: Add syncpack check to v9 release pipeline

### DIFF
--- a/azure-pipelines.release-vnext.yml
+++ b/azure-pipelines.release-vnext.yml
@@ -80,6 +80,11 @@ steps:
       artifactName: SBom-$(System.JobAttempt)
       targetPath: $(System.DefaultWorkingDirectory)/_manifest
 
+  # Since releases are scoped, this should warn for any packages that were mistakenly not included in scoping
+  - script: |
+      yarn syncpack:list
+    displayName: Check for dependency mismatches
+
   # TODO update release notes script for v9
   # - script: |
   #     node -r ./scripts/ts-node-register ./scripts/updateReleaseNotes/index.ts --token=$(githubPAT) --apply --debug


### PR DESCRIPTION
Somewhat of a mitigation for #21805

@fluentui/vr-tests-react-components had the version at 0.1.0 which mean it was never scoped for bump by publish step. There's no way to enforce this apart from failing in the release pipeline. So the syncpack check should provide some early warning in the future if there are packages that weren't bumped.
