### PR TITLE
Disable SBOM in v6 because tool hangs on recursive pnpm projects

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -114,14 +114,15 @@ steps:
       publishLocation: 'Container'
     displayName: 'Publish Artifact: Fabric Website Resources'
 
-  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    displayName: 📒 Generate Manifest
-    inputs:
-      BuildDropPath: $(System.DefaultWorkingDirectory)
-      Verbosity: Verbose
+  # SBOM generation disabled until SBOM tool can properly handle complex pnpm projects
+  # - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  #   displayName: 📒 Generate Manifest
+  #   inputs:
+  #     BuildDropPath: $(System.DefaultWorkingDirectory)
+  #     Verbosity: Verbose
 
-  - task: PublishPipelineArtifact@1
-    displayName: 📒 Publish Manifest
-    inputs:
-      artifactName: SBom-$(System.JobAttempt)
-      targetPath: $(System.DefaultWorkingDirectory)/_manifest
+  # - task: PublishPipelineArtifact@1
+  #   displayName: 📒 Publish Manifest
+  #   inputs:
+  #     artifactName: SBom-$(System.JobAttempt)
+  #     targetPath: $(System.DefaultWorkingDirectory)/_manifest


### PR DESCRIPTION
Temporarily disabling SBOM in v6 until the SBOM tool can properly handle PNPM projects. 