### PR TITLE
Ensure Layer uses the specific element for LayerHost, for advanced projection scenarios

### DIFF
--- a/change/@fluentui-react-602dd506-4c38-43b3-97cc-323e2d5da3e4.json
+++ b/change/@fluentui-react-602dd506-4c38-43b3-97cc-323e2d5da3e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose LayerHost element directly to Layer",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6381,6 +6381,7 @@ export interface ILayer {
 // @public
 export interface ILayerHost {
     hostId: string;
+    notifyLayersChanged(): void;
     rootRef: React_2.MutableRefObject<HTMLDivElement | null>;
 }
 

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6378,8 +6378,10 @@ export interface ILabelStyles {
 export interface ILayer {
 }
 
-// @public (undocumented)
+// @public
 export interface ILayerHost {
+    hostId: string;
+    rootRef: React_2.MutableRefObject<HTMLDivElement | null>;
 }
 
 // @public (undocumented)

--- a/packages/react/src/components/Layer/Layer.base.tsx
+++ b/packages/react/src/components/Layer/Layer.base.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Fabric } from '../../Fabric';
 import { classNamesFunction, setPortalAttribute, setVirtualParent } from '../../Utilities';
-import { registerLayer, getDefaultTarget, unregisterLayer } from './Layer.notification';
+import { registerLayer, getDefaultTarget, unregisterLayer, getLayerHost } from './Layer.notification';
 import { useIsomorphicLayoutEffect, useMergedRefs, useWarnings } from '@fluentui/react-hooks';
 import { useDocument } from '../../WindowProvider';
 import type { ILayerProps, ILayerStyleProps, ILayerStyles } from './Layer.types';
@@ -43,16 +43,18 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
 
     // Returns the user provided hostId props element, the default target selector,
     // or undefined if document doesn't exist.
-    const getHost = (): Node | undefined => {
-      if (!doc) {
-        return undefined;
-      }
-
+    const getHost = (): Node | null => {
       if (hostId) {
-        return doc.getElementById(hostId) as Node;
+        const layerHost = getLayerHost(hostId);
+
+        if (layerHost) {
+          return layerHost.rootRef.current ?? null;
+        }
+
+        return doc?.getElementById(hostId) ?? null;
       } else {
         const defaultHostSelector = getDefaultTarget();
-        return defaultHostSelector ? (doc.querySelector(defaultHostSelector) as Node) : doc.body;
+        return (defaultHostSelector ? doc?.querySelector(defaultHostSelector) : doc?.body) ?? null;
       }
     };
 
@@ -74,22 +76,24 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
     const createLayerElement = () => {
       const host = getHost();
 
-      if (!doc || !host) {
+      if (!host) {
         return;
       }
 
       // Remove and re-create any previous existing layer elements.
       removeLayerElement();
 
-      const el: HTMLDivElement = doc.createElement('div');
+      const el = (host.ownerDocument ?? doc)?.createElement('div');
 
-      el.className = classNames.root!;
-      setPortalAttribute(el);
-      setVirtualParent(el, rootRef.current!);
+      if (el) {
+        el.className = classNames.root!;
+        setPortalAttribute(el);
+        setVirtualParent(el, rootRef.current!);
 
-      insertFirst ? host.insertBefore(el, host.firstChild) : host.appendChild(el);
-      layerRef.current = el;
-      setNeedRaiseLayerMount(true);
+        insertFirst ? host.insertBefore(el, host.firstChild) : host.appendChild(el);
+        layerRef.current = el;
+        setNeedRaiseLayerMount(true);
+      }
     };
 
     useIsomorphicLayoutEffect(() => {

--- a/packages/react/src/components/Layer/Layer.notification.ts
+++ b/packages/react/src/components/Layer/Layer.notification.ts
@@ -16,6 +16,14 @@ export function registerLayer(hostId: string, callback: () => void) {
   }
 
   _layersByHostId[hostId].push(callback);
+
+  const layerHosts = _layerHostsById[hostId];
+
+  if (layerHosts) {
+    for (const layerHost of layerHosts) {
+      layerHost.notifyLayersChanged();
+    }
+  }
 }
 
 /**
@@ -24,15 +32,37 @@ export function registerLayer(hostId: string, callback: () => void) {
  * @param layer Layer instance
  */
 export function unregisterLayer(hostId: string, callback: () => void) {
-  if (_layersByHostId[hostId]) {
-    const idx = _layersByHostId[hostId].indexOf(callback);
+  const layers = _layersByHostId[hostId];
+
+  if (layers) {
+    const idx = layers.indexOf(callback);
     if (idx >= 0) {
-      _layersByHostId[hostId].splice(idx, 1);
-      if (_layersByHostId[hostId].length === 0) {
+      layers.splice(idx, 1);
+
+      if (layers.length === 0) {
         delete _layersByHostId[hostId];
       }
     }
   }
+
+  const layerHosts = _layerHostsById[hostId];
+
+  if (layerHosts) {
+    for (const layerHost of layerHosts) {
+      layerHost.notifyLayersChanged();
+    }
+  }
+}
+
+/**
+ * Gets the number of layers currently registered with a host id.
+ * @param hostId Id of the layer host.
+ * @returns The number of layers currently registered with the host.
+ */
+export function getLayerCount(hostId: string): number {
+  const layers = _layerHostsById[hostId];
+
+  return layers ? layers.length : 0;
 }
 
 /**

--- a/packages/react/src/components/Layer/Layer.notification.ts
+++ b/packages/react/src/components/Layer/Layer.notification.ts
@@ -84,7 +84,7 @@ export function getLayerHost(hostId: string): ILayerHost | undefined {
 export function registerLayerHost(hostId: string, layerHost: ILayerHost): void {
   const layerHosts = _layerHostsById[hostId] || (_layerHostsById[hostId] = []);
 
-  // Insert this at the stary of an array to avoid race conditions between mount and unmount.
+  // Insert this at the start of an array to avoid race conditions between mount and unmount.
   // If a LayerHost is re-mounted, and mount of the new instance may occur before the unmount of the old one.
   // Putting the new instance at the start of this array ensures that calls to `getLayerHost` will immediately
   // get the new one even if the old one is around briefly.

--- a/packages/react/src/components/Layer/LayerHost.tsx
+++ b/packages/react/src/components/Layer/LayerHost.tsx
@@ -14,6 +14,9 @@ export const LayerHost: React.FunctionComponent<ILayerHostProps> = props => {
   const layerHostRef = React.useRef<ILayerHost>({
     hostId,
     rootRef: React.useRef<HTMLDivElement | null>(null),
+    notifyLayersChanged: () => {
+      // Nothing, since the default implementation of Layer Host does not need to react to layer changes.
+    },
   });
 
   React.useImperativeHandle(props.componentRef, () => layerHostRef.current);

--- a/packages/react/src/components/Layer/LayerHost.tsx
+++ b/packages/react/src/components/Layer/LayerHost.tsx
@@ -1,20 +1,33 @@
 import * as React from 'react';
 import { useUnmount } from '@fluentui/react-hooks';
-import { css } from '../../Utilities';
-import { notifyHostChanged } from './Layer.notification';
-import type { ILayerHostProps } from './LayerHost.types';
+import { css, getId } from '../../Utilities';
+import { notifyHostChanged, registerLayerHost, unregisterLayerHost } from './Layer.notification';
+import type { ILayerHost, ILayerHostProps } from './LayerHost.types';
 
 export const LayerHost: React.FunctionComponent<ILayerHostProps> = props => {
-  const { id, className } = props;
+  const { className } = props;
+
+  const [layerHostId] = React.useState(() => getId());
+
+  const { id: hostId = layerHostId } = props;
+
+  const layerHostRef = React.useRef<ILayerHost>({
+    hostId,
+    rootRef: React.useRef<HTMLDivElement | null>(null),
+  });
+
+  React.useImperativeHandle(props.componentRef, () => layerHostRef.current);
 
   React.useEffect(() => {
-    notifyHostChanged(id!);
+    registerLayerHost(hostId, layerHostRef.current);
+    notifyHostChanged(hostId);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on first render
   }, []);
 
   useUnmount(() => {
-    notifyHostChanged(id!);
+    unregisterLayerHost(hostId, layerHostRef.current);
+    notifyHostChanged(hostId);
   });
 
-  return <div {...props} className={css('ms-LayerHost', className)} />;
+  return <div {...props} className={css('ms-LayerHost', className)} ref={layerHostRef.current.rootRef} />;
 };

--- a/packages/react/src/components/Layer/LayerHost.types.ts
+++ b/packages/react/src/components/Layer/LayerHost.types.ts
@@ -1,7 +1,20 @@
 import * as React from 'react';
 import type { IRefObject } from '../../Utilities';
 
-export interface ILayerHost {}
+/**
+ * Represents a mounted layer host, and provides access to its `hostId` and root element.
+ */
+export interface ILayerHost {
+  /**
+   * The hostId for this host, to be propagatd to layers using Customizer.
+   */
+  hostId: string;
+  /**
+   * An element ref to the layer host's content root.
+   * This is the element to which layers will be added.
+   */
+  rootRef: React.MutableRefObject<HTMLDivElement | null>;
+}
 
 export interface ILayerHostProps extends React.HTMLAttributes<HTMLElement> {
   /**

--- a/packages/react/src/components/Layer/LayerHost.types.ts
+++ b/packages/react/src/components/Layer/LayerHost.types.ts
@@ -14,6 +14,10 @@ export interface ILayerHost {
    * This is the element to which layers will be added.
    */
   rootRef: React.MutableRefObject<HTMLDivElement | null>;
+  /**
+   * Notifies the layer host that layers may have been added or removed within its root element.
+   */
+  notifyLayersChanged(): void;
 }
 
 export interface ILayerHostProps extends React.HTMLAttributes<HTMLElement> {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The `Layer` component defaults to creating an element at the end of the current document.
If ` hostId` is provided, `Layer` simply uses a query selector to find an element in the current document matching the `hostId`.
Even if the host app provides a `LayerHost` React component, it's just a glorified way to render a `<div>` with an `id`. The intent of `LayerHost` was to allow 'projection' of `Layer` into other areas, but the simple query selector is limiting.

## New Behavior

This PR augments `LayerHost` and `Layer` so that `Layer` first tries to resolve an `ILayerHost` with a matching `hostId`, and use the provided `elementRef`. This allows `LayerHost` to be rendered into another `window`, and have the correct element passed to `Layer`. The logic falls back to the old query selector if `hostId` cannot be resolved to an `ILayerHost`.
The existing behaviors of `Layer` are all otherwise preserved, including the ability of `Layer` to re-mount if the given host changes.
