### PR TITLE
Refactor Checkbox styles to use CSS pseudo-classes

### DIFF
--- a/change/@fluentui-react-checkbox-ec315fd3-3852-463a-b6ea-62a3884cb750.json
+++ b/change/@fluentui-react-checkbox-ec315fd3-3852-463a-b6ea-62a3884cb750.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Refactor Checkbox styles to use CSS pseudo-classes",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-checkbox/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react-checkbox/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -5,21 +5,21 @@ exports[`Checkbox renders a custom indicator 1`] = `
   <span
     class="fui-Checkbox"
   >
-    <div
-      aria-hidden="true"
-      class="fui-Checkbox-indicator"
-    >
-      <span
-        id="indicator"
-      />
-    </div>
     <input
       class=""
       id="checkbox-1"
       type="checkbox"
     />
+    <div
+      aria-hidden="true"
+      class="fui-Checkbox__indicator"
+    >
+      <span
+        id="indicator"
+      />
+    </div>
     <label
-      class="fui-Label"
+      class="fui-Label fui-Checkbox__label"
       for="checkbox-1"
     >
       Custom indicator
@@ -33,9 +33,14 @@ exports[`Checkbox renders a default state 1`] = `
   <span
     class="fui-Checkbox"
   >
+    <input
+      class=""
+      id="checkbox-1"
+      type="checkbox"
+    />
     <div
       aria-hidden="true"
-      class="fui-Checkbox-indicator"
+      class="fui-Checkbox__indicator"
     >
       <svg
         aria-hidden="true"
@@ -51,11 +56,6 @@ exports[`Checkbox renders a default state 1`] = `
         />
       </svg>
     </div>
-    <input
-      class=""
-      id="checkbox-1"
-      type="checkbox"
-    />
   </span>
 </div>
 `;
@@ -65,9 +65,15 @@ exports[`Checkbox renders checked 1`] = `
   <span
     class="fui-Checkbox"
   >
+    <input
+      checked=""
+      class=""
+      id="checkbox-1"
+      type="checkbox"
+    />
     <div
       aria-hidden="true"
-      class="fui-Checkbox-indicator"
+      class="fui-Checkbox__indicator"
     >
       <svg
         aria-hidden="true"
@@ -83,14 +89,8 @@ exports[`Checkbox renders checked 1`] = `
         />
       </svg>
     </div>
-    <input
-      checked=""
-      class=""
-      id="checkbox-1"
-      type="checkbox"
-    />
     <label
-      class="fui-Label"
+      class="fui-Label fui-Checkbox__label"
       for="checkbox-1"
     >
       Checked Checkbox
@@ -104,9 +104,14 @@ exports[`Checkbox renders mixed 1`] = `
   <span
     class="fui-Checkbox"
   >
+    <input
+      class=""
+      id="checkbox-1"
+      type="checkbox"
+    />
     <div
       aria-hidden="true"
-      class="fui-Checkbox-indicator"
+      class="fui-Checkbox__indicator"
     >
       <svg
         aria-hidden="true"
@@ -122,13 +127,8 @@ exports[`Checkbox renders mixed 1`] = `
         />
       </svg>
     </div>
-    <input
-      class=""
-      id="checkbox-1"
-      type="checkbox"
-    />
     <label
-      class="fui-Label"
+      class="fui-Label fui-Checkbox__label"
       for="checkbox-1"
     >
       Mixed Checkbox
@@ -142,9 +142,14 @@ exports[`Checkbox renders with a label 1`] = `
   <span
     class="fui-Checkbox"
   >
+    <input
+      class=""
+      id="checkbox-1"
+      type="checkbox"
+    />
     <div
       aria-hidden="true"
-      class="fui-Checkbox-indicator"
+      class="fui-Checkbox__indicator"
     >
       <svg
         aria-hidden="true"
@@ -160,13 +165,8 @@ exports[`Checkbox renders with a label 1`] = `
         />
       </svg>
     </div>
-    <input
-      class=""
-      id="checkbox-1"
-      type="checkbox"
-    />
     <label
-      class="fui-Label"
+      class="fui-Label fui-Checkbox__label"
       for="checkbox-1"
     >
       Unchecked Checkbox

--- a/packages/react-checkbox/src/components/Checkbox/renderCheckbox.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/renderCheckbox.tsx
@@ -7,9 +7,9 @@ export const renderCheckbox_unstable = (state: CheckboxState) => {
 
   return (
     <slots.root {...slotProps.root}>
+      <slots.input {...slotProps.input} />
       {state.labelPosition === 'before' && slots.label && <slots.label {...slotProps.label} />}
       <slots.indicator {...slotProps.indicator} />
-      <slots.input {...slotProps.input} />
       {state.labelPosition === 'after' && slots.label && <slots.label {...slotProps.label} />}
     </slots.root>
   );

--- a/packages/react-checkbox/src/components/Checkbox/useCheckbox.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/useCheckbox.tsx
@@ -14,8 +14,7 @@ import {
   Checkmark16Filled,
   Square12Filled,
   Square16Filled,
-  Circle12Filled,
-  Circle16Filled,
+  CircleFilled,
 } from '@fluentui/react-icons';
 import { Label } from '@fluentui/react-label';
 
@@ -49,7 +48,7 @@ export const useCheckbox_unstable = (props: CheckboxProps, ref: React.Ref<HTMLIn
   let checkmarkIcon;
   if (mixed) {
     if (shape === 'circular') {
-      checkmarkIcon = size === 'large' ? <Circle16Filled /> : <Circle12Filled />;
+      checkmarkIcon = <CircleFilled />;
     } else {
       checkmarkIcon = size === 'large' ? <Square16Filled /> : <Square12Filled />;
     }

--- a/packages/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -15,18 +15,14 @@ const spacingHorizontalM = '12px';
 const indicatorSizeMedium = '16px';
 const indicatorSizeLarge = '20px';
 
-/**
- * Styles for the root slot
- */
 const useRootStyles = makeStyles({
   base: {
     position: 'relative',
     display: 'inline-flex',
     columnGap: spacingHorizontalM,
     ...shorthands.padding(spacingHorizontalS),
+    ...createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
   },
-
-  focusIndicator: createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
 });
 
 const useInputStyles = makeStyles({
@@ -41,9 +37,9 @@ const useInputStyles = makeStyles({
     opacity: 0,
     cursor: 'pointer',
 
-    // Hide the child of the indicator (the checkmark icon) when not checked
+    // When unchecked, hide the the checkmark icon (child of the indicator slot)
     [`:not(:checked):not(:indeterminate) ~ .${indicatorClassName} > *`]: {
-      opacity: '0',
+      opacity: 0,
     },
 
     // Colors for the unchecked state
@@ -196,12 +192,7 @@ const useLabelStyles = makeStyles({
  */
 export const useCheckboxStyles_unstable = (state: CheckboxState): CheckboxState => {
   const rootStyles = useRootStyles();
-  state.root.className = mergeClasses(
-    checkboxClassName,
-    rootStyles.base,
-    rootStyles.focusIndicator,
-    state.root.className,
-  );
+  state.root.className = mergeClasses(checkboxClassName, rootStyles.base, state.root.className);
 
   const inputStyles = useInputStyles();
   state.input.className = mergeClasses(inputStyles.base, state.input.className);

--- a/packages/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -4,7 +4,8 @@ import { tokens } from '@fluentui/react-theme';
 import { CheckboxState } from './Checkbox.types';
 
 export const checkboxClassName = 'fui-Checkbox';
-const indicatorClassName = 'fui-Checkbox-indicator';
+const indicatorClassName = 'fui-Checkbox__indicator';
+const labelClassName = 'fui-Checkbox__label';
 
 // TODO replace these spacing constants with theme values once they're on the theme
 const spacingHorizontalS = '8px';
@@ -21,92 +22,11 @@ const useRootStyles = makeStyles({
   base: {
     position: 'relative',
     display: 'inline-flex',
-    flexDirection: 'row',
-    cursor: 'pointer',
     columnGap: spacingHorizontalM,
     ...shorthands.padding(spacingHorizontalS),
   },
 
-  disabled: {
-    cursor: 'default',
-  },
-
   focusIndicator: createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
-
-  // These `__Colors` styles are mutually exclusive: exactly one should be applied at any time
-  uncheckedColors: {
-    color: tokens.colorNeutralForeground3,
-    [`& .${indicatorClassName}`]: {
-      ...shorthands.borderColor(tokens.colorNeutralStrokeAccessible),
-    },
-
-    ':hover': {
-      color: tokens.colorNeutralForeground2,
-      [`& .${indicatorClassName}`]: {
-        ...shorthands.borderColor(tokens.colorNeutralStrokeAccessibleHover),
-      },
-    },
-
-    ':active:hover': {
-      color: tokens.colorNeutralForeground1,
-      [`& .${indicatorClassName}`]: {
-        ...shorthands.borderColor(tokens.colorNeutralStrokeAccessiblePressed),
-      },
-    },
-  },
-
-  checkedColors: {
-    color: tokens.colorNeutralForeground1,
-    [`& .${indicatorClassName}`]: {
-      backgroundColor: tokens.colorCompoundBrandBackground,
-      color: tokens.colorNeutralForegroundOnBrand,
-      ...shorthands.borderColor(tokens.colorCompoundBrandBackground),
-    },
-
-    ':hover': {
-      [`& .${indicatorClassName}`]: {
-        backgroundColor: tokens.colorCompoundBrandBackgroundHover,
-        ...shorthands.borderColor(tokens.colorCompoundBrandBackgroundHover),
-      },
-    },
-
-    ':active:hover': {
-      [`& .${indicatorClassName}`]: {
-        backgroundColor: tokens.colorCompoundBrandBackgroundPressed,
-        ...shorthands.borderColor(tokens.colorCompoundBrandBackgroundPressed),
-      },
-    },
-  },
-
-  mixedColors: {
-    color: tokens.colorNeutralForeground1,
-    [`& .${indicatorClassName}`]: {
-      ...shorthands.borderColor(tokens.colorCompoundBrandStroke),
-      color: tokens.colorCompoundBrandForeground1,
-    },
-
-    ':hover': {
-      [`& .${indicatorClassName}`]: {
-        ...shorthands.borderColor(tokens.colorCompoundBrandStrokeHover),
-        color: tokens.colorCompoundBrandForeground1Hover,
-      },
-    },
-
-    ':active:hover': {
-      [`& .${indicatorClassName}`]: {
-        ...shorthands.borderColor(tokens.colorCompoundBrandStrokePressed),
-        color: tokens.colorCompoundBrandForeground1Pressed,
-      },
-    },
-  },
-
-  disabledColors: {
-    color: tokens.colorNeutralForegroundDisabled,
-    [`& .${indicatorClassName}`]: {
-      ...shorthands.borderColor(tokens.colorNeutralStrokeDisabled),
-      color: tokens.colorNeutralForegroundDisabled,
-    },
-  },
 });
 
 const useInputStyles = makeStyles({
@@ -119,7 +39,103 @@ const useInputStyles = makeStyles({
     boxSizing: 'border-box',
     ...shorthands.margin(0),
     opacity: 0,
-    cursor: 'inherit',
+    cursor: 'pointer',
+
+    // Hide the child of the indicator (the checkmark icon) when not checked
+    [`:not(:checked):not(:indeterminate) ~ .${indicatorClassName} > *`]: {
+      opacity: '0',
+    },
+
+    // Colors for the unchecked state
+    ':enabled:not(:checked):not(:indeterminate)': {
+      [`& ~ .${labelClassName}`]: {
+        color: tokens.colorNeutralForeground3,
+      },
+      [`& ~ .${indicatorClassName}`]: {
+        ...shorthands.borderColor(tokens.colorNeutralStrokeAccessible),
+      },
+
+      ':hover': {
+        [`& ~ .${labelClassName}`]: {
+          color: tokens.colorNeutralForeground2,
+        },
+        [`& ~ .${indicatorClassName}`]: {
+          ...shorthands.borderColor(tokens.colorNeutralStrokeAccessibleHover),
+        },
+      },
+
+      ':active:hover': {
+        [`& ~ .${labelClassName}`]: {
+          color: tokens.colorNeutralForeground1,
+        },
+        [`& ~ .${indicatorClassName}`]: {
+          ...shorthands.borderColor(tokens.colorNeutralStrokeAccessiblePressed),
+        },
+      },
+    },
+
+    // Colors for the checked state
+    ':enabled:checked:not(:indeterminate)': {
+      [`& ~ .${labelClassName}`]: {
+        color: tokens.colorNeutralForeground1,
+      },
+      [`& ~ .${indicatorClassName}`]: {
+        backgroundColor: tokens.colorCompoundBrandBackground,
+        color: tokens.colorNeutralForegroundOnBrand,
+        ...shorthands.borderColor(tokens.colorCompoundBrandBackground),
+      },
+
+      ':hover': {
+        [`& ~ .${indicatorClassName}`]: {
+          backgroundColor: tokens.colorCompoundBrandBackgroundHover,
+          ...shorthands.borderColor(tokens.colorCompoundBrandBackgroundHover),
+        },
+      },
+
+      ':active:hover': {
+        [`& ~ .${indicatorClassName}`]: {
+          backgroundColor: tokens.colorCompoundBrandBackgroundPressed,
+          ...shorthands.borderColor(tokens.colorCompoundBrandBackgroundPressed),
+        },
+      },
+    },
+
+    // Colors for the mixed state
+    ':enabled:indeterminate': {
+      [`& ~ .${labelClassName}`]: {
+        color: tokens.colorNeutralForeground1,
+      },
+      [`& ~ .${indicatorClassName}`]: {
+        ...shorthands.borderColor(tokens.colorCompoundBrandStroke),
+        color: tokens.colorCompoundBrandForeground1,
+      },
+
+      ':hover': {
+        [`& ~ .${indicatorClassName}`]: {
+          ...shorthands.borderColor(tokens.colorCompoundBrandStrokeHover),
+          color: tokens.colorCompoundBrandForeground1Hover,
+        },
+      },
+
+      ':active:hover': {
+        [`& ~ .${indicatorClassName}`]: {
+          ...shorthands.borderColor(tokens.colorCompoundBrandStrokePressed),
+          color: tokens.colorCompoundBrandForeground1Pressed,
+        },
+      },
+    },
+
+    ':disabled': {
+      cursor: 'default',
+
+      [`& ~ .${labelClassName}`]: {
+        color: tokens.colorNeutralForegroundDisabled,
+      },
+      [`& ~ .${indicatorClassName}`]: {
+        ...shorthands.borderColor(tokens.colorNeutralStrokeDisabled),
+        color: tokens.colorNeutralForegroundDisabled,
+      },
+    },
   },
 });
 
@@ -137,27 +153,23 @@ const useIndicatorStyles = makeStyles({
     ...shorthands.border(tokens.strokeWidthThin, 'solid'),
     ...shorthands.borderRadius(tokens.borderRadiusSmall),
     fill: 'currentColor',
-    cursor: 'inherit',
+    pointerEvents: 'none',
   },
 
   medium: {
     width: indicatorSizeMedium,
     height: indicatorSizeMedium,
+    fontSize: '12px',
   },
 
   large: {
     width: indicatorSizeLarge,
     height: indicatorSizeLarge,
+    fontSize: '16px',
   },
 
   circular: {
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
-  },
-
-  unchecked: {
-    '& > *': {
-      opacity: '0',
-    },
   },
 });
 
@@ -188,15 +200,6 @@ export const useCheckboxStyles_unstable = (state: CheckboxState): CheckboxState 
     checkboxClassName,
     rootStyles.base,
     rootStyles.focusIndicator,
-    state.input.disabled && rootStyles.disabled,
-    // Pick exactly one of the color classes, based on `disabled` and `checked`
-    state.input.disabled
-      ? rootStyles.disabledColors
-      : state.checked === 'mixed'
-      ? rootStyles.mixedColors
-      : state.checked
-      ? rootStyles.checkedColors
-      : rootStyles.uncheckedColors,
     state.root.className,
   );
 
@@ -210,14 +213,18 @@ export const useCheckboxStyles_unstable = (state: CheckboxState): CheckboxState 
       indicatorStyles.base,
       indicatorStyles[state.size],
       state.shape === 'circular' && indicatorStyles.circular,
-      !state.checked && indicatorStyles.unchecked,
       state.indicator.className,
     );
   }
 
   const labelStyles = useLabelStyles();
   if (state.label) {
-    state.label.className = mergeClasses(labelStyles.base, labelStyles[state.size], state.label.className);
+    state.label.className = mergeClasses(
+      labelClassName,
+      labelStyles.base,
+      labelStyles[state.size],
+      state.label.className,
+    );
   }
 
   return state;


### PR DESCRIPTION
## Current Behavior

Checkbox's styles depend on the checked, mixed, and disabled state values. This can result in the checkbox using enabled colors if it is disabled by being inside a disabled group.

## New Behavior

Use CSS pseudo-classes on the input slot, to change the colors of the indicator and label.
