### PR TITLE
Allow Label to be as="span" or as="legend"

### DIFF
--- a/change/@fluentui-react-label-82eeb2f9-00f9-4d14-9c97-51062b3a5f58.json
+++ b/change/@fluentui-react-label-82eeb2f9-00f9-4d14-9c97-51062b3a5f58.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow Label to be a span or legend",
+  "packageName": "@fluentui/react-label",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-label/etc/react-label.api.md
+++ b/packages/react-label/etc/react-label.api.md
@@ -6,12 +6,11 @@
 
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
-import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 
 // @public
-export const Label: ForwardRefComponent<LabelProps>;
+export const Label: React_2.ForwardRefExoticComponent<LabelProps & React_2.RefAttributes<HTMLSpanElement>>;
 
 // @public (undocumented)
 export const labelClassName = "fui-Label";
@@ -19,13 +18,13 @@ export const labelClassName = "fui-Label";
 // Warning: (ae-forgotten-export) The symbol "LabelCommons" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> & Partial<LabelCommons> & {
+export type LabelProps = ComponentProps<Omit<LabelSlots, 'required'>> & Partial<LabelCommons> & {
     required?: boolean | Slot<'span'>;
 };
 
 // @public (undocumented)
 export type LabelSlots = {
-    root: Slot<'label'>;
+    root: Slot<'label', 'span' | 'legend'>;
     required?: Slot<'span'>;
 };
 

--- a/packages/react-label/src/components/Label/Label.test.tsx
+++ b/packages/react-label/src/components/Label/Label.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { Label } from './Label';
+import type { LabelProps } from './Label.types';
 import { isConformant } from '../../common/isConformant';
 
 describe('Label', () => {
-  isConformant({
+  isConformant<LabelProps>({
     Component: Label,
     displayName: 'Label',
     requiredProps: { children: "I'm a label." },

--- a/packages/react-label/src/components/Label/Label.tsx
+++ b/packages/react-label/src/components/Label/Label.tsx
@@ -8,11 +8,11 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 /**
  * A label component provides a title or name to a component.
  */
-export const Label: ForwardRefComponent<LabelProps> = React.forwardRef((props, ref) => {
+export const Label = React.forwardRef((props, ref) => {
   const state = useLabel_unstable(props, ref);
 
   useLabelStyles_unstable(state);
   return renderLabel_unstable(state);
-});
+}) as ForwardRefComponent<LabelProps>;
 
 Label.displayName = 'Label';

--- a/packages/react-label/src/components/Label/Label.types.ts
+++ b/packages/react-label/src/components/Label/Label.types.ts
@@ -21,7 +21,7 @@ type LabelCommons = {
 };
 
 export type LabelSlots = {
-  root: Slot<'label'>;
+  root: Slot<'label', 'span' | 'legend'>;
   required?: Slot<'span'>;
 };
 
@@ -33,7 +33,7 @@ export type LabelState = ComponentState<LabelSlots> & LabelCommons;
 /**
  * Label Props
  */
-export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> &
+export type LabelProps = ComponentProps<Omit<LabelSlots, 'required'>> &
   Partial<LabelCommons> & {
     /**
      * Displays and indicator that the label is for a required field. The required prop can be set to true to display

--- a/packages/react-radio/src/components/Radio/useRadio.ts
+++ b/packages/react-radio/src/components/Radio/useRadio.ts
@@ -31,6 +31,7 @@ export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLElement>
   const inputShorthand = resolveShorthand(props.input, {
     required: true,
     defaultProps: {
+      id: useId('radio-item-', id),
       disabled: props.disabled ?? false,
       type: 'radio',
       required: props.required ?? false,
@@ -71,14 +72,14 @@ export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLElement>
     }),
     label: resolveShorthand(props.label, {
       required: true,
+      defaultProps: {
+        htmlFor: inputShorthand.id,
+      },
     }),
     subtext: resolveShorthand(props.subtext, {
       required: false,
     }),
   };
-
-  state.input.id = useId('radio-item-', id);
-  state.label.htmlFor = state.input.id;
 
   return state;
 };


### PR DESCRIPTION
## New Behavior

Allow Label to be as="span" or as="legend" (the latter is for use within a fieldset like RadioGroup).

