### PR TITLE
Ignore prefix in useId() when it is falsey

### DIFF
--- a/change/@fluentui-react-utilities-570f1a73-95a2-4590-a3dc-8991afafbad4.json
+++ b/change/@fluentui-react-utilities-570f1a73-95a2-4590-a3dc-8991afafbad4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ignore prefix in useId() when it is falsey.",
+  "packageName": "@fluentui/react-utilities",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-utilities/src/hooks/useId.test.tsx
+++ b/packages/react-utilities/src/hooks/useId.test.tsx
@@ -13,6 +13,12 @@ describe('useId', () => {
     expect(result.current).toMatch(/^foo/);
   });
 
+  it('does not add "undefined" when prefix is not specified', () => {
+    const { result } = renderHook(() => useId());
+
+    expect(result.current).not.toMatch(/^undefined/);
+  });
+
   it('uses the same ID without prefix', () => {
     const { result, rerender } = renderHook(() => useId());
     const firstResult = result.current;

--- a/packages/react-utilities/src/hooks/useId.test.tsx
+++ b/packages/react-utilities/src/hooks/useId.test.tsx
@@ -13,10 +13,10 @@ describe('useId', () => {
     expect(result.current).toMatch(/^foo/);
   });
 
-  it('does not add "undefined" when prefix is not specified', () => {
+  it('defaults to "fui-" when prefix is not specified', () => {
     const { result } = renderHook(() => useId());
 
-    expect(result.current).not.toMatch(/^undefined/);
+    expect(result.current).toMatch(/^fui-/);
   });
 
   it('uses the same ID without prefix', () => {

--- a/packages/react-utilities/src/hooks/useId.ts
+++ b/packages/react-utilities/src/hooks/useId.ts
@@ -21,5 +21,11 @@ export function resetIdsForTests(): void {
 export function useId(prefix?: string, providedId?: string): string {
   const contextValue = useSSRContext();
 
-  return React.useMemo(() => providedId || `${prefix}${++contextValue.current}`, [prefix, providedId, contextValue]);
+  return React.useMemo(() => {
+    if (providedId) {
+      return providedId;
+    }
+
+    return prefix ? `${prefix}${++contextValue.current}` : `${++contextValue.current}`;
+  }, [prefix, providedId, contextValue]);
 }

--- a/packages/react-utilities/src/hooks/useId.ts
+++ b/packages/react-utilities/src/hooks/useId.ts
@@ -13,12 +13,12 @@ export function resetIdsForTests(): void {
 /**
  * Hook to generate a unique ID.
  *
- * @param prefix - Optional prefix for the ID
+ * @param prefix - Optional prefix for the ID. Defaults to 'fui-'.
  * @param providedId - Optional id provided by a parent component. Defaults to the provided value if present,
  *  without conditioning the hook call
  * @returns The ID
  */
-export function useId(prefix?: string, providedId?: string): string {
+export function useId(prefix: string = 'fui-', providedId?: string): string {
   const contextValue = useSSRContext();
 
   return React.useMemo(() => {
@@ -26,6 +26,6 @@ export function useId(prefix?: string, providedId?: string): string {
       return providedId;
     }
 
-    return `${prefix ?? ''}${++contextValue.current}` ;
+    return `${prefix}${++contextValue.current}`;
   }, [prefix, providedId, contextValue]);
 }

--- a/packages/react-utilities/src/hooks/useId.ts
+++ b/packages/react-utilities/src/hooks/useId.ts
@@ -26,6 +26,6 @@ export function useId(prefix?: string, providedId?: string): string {
       return providedId;
     }
 
-    return prefix ? `${prefix}${++contextValue.current}` : `${++contextValue.current}`;
+    return `${prefix ?? ''}${++contextValue.current}` ;
   }, [prefix, providedId, contextValue]);
 }


### PR DESCRIPTION
## Current Behavior

The `useId()` hook has the following signature:

```ts
function useId(prefix?: string, providedId?: string): string 
```

When calling `useId()` without a prefix the hook returns a value like `"undefined123"`. This is because `prefix` is always concatenated into the returned id string with

```ts
`${prefix}${++contextValue.current}`
```

[Example Codesandbox](https://codesandbox.io/s/useid-undefined-prefix-ftvzlt?file=/src/App.js)

## New Behavior

The signature remains the same (no API changes) but internally the hook now checks `prefix` and only concatenates it into the returned id when it is truthy. Now when calling `useId()` without a prefix the hook returns values like `"123"`.
