### PR TITLE
chore: enable pretty logs from typescript to make it work in child-pa…

### DIFF
--- a/scripts/tasks/ts.ts
+++ b/scripts/tasks/ts.ts
@@ -12,6 +12,7 @@ const useTsBuildInfo =
 function prepareTsTaskConfig(options: TscTaskOptions) {
   // docs say pretty is on by default, but it's actually disabled when tsc is run in a
   // non-TTY context (which is what just-scripts tscTask does)
+  // https://github.com/nrwl/nx/issues/9069#issuecomment-1048028504
   options.pretty = true;
 
   if (getJustArgv().production) {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,6 +9,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
+    "pretty": true,
     "typeRoots": ["node_modules/@types", "./typings"],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
…rent process communication

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

If `tsc` is invoked via `fork` or wrapper task runner `pretty` is turned off

![image](https://user-images.githubusercontent.com/1223799/155557791-4f8180af-4f5c-4e20-b566-6f13facbfc71.png)


<!-- This is the behavior we have today -->

## New Behavior

no matter how `tsc` is invoked `pretty` is output is preserved

![image](https://user-images.githubusercontent.com/1223799/155557884-7ffc95ca-4be8-4d23-b1a1-0b51e6eb483c.png)


## Related Issue(s)

https://github.com/nrwl/nx/issues/9069#issuecomment-1048028504
