### PR TITLE
Panel: Only hide siblings when open

### DIFF
--- a/change/@fluentui-react-e2d6e05f-30c2-46fb-862b-4842bbe7a6d3.json
+++ b/change/@fluentui-react-e2d6e05f-30c2-46fb-862b-4842bbe7a6d3.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add conditional to enableAriaHiddenOnChildren prop",
+  "comment": "Panel: Only mark siblings as aria-hidden when open",
   "packageName": "@fluentui/react",
   "email": "ololubek@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-e2d6e05f-30c2-46fb-862b-4842bbe7a6d3.json
+++ b/change/@fluentui-react-e2d6e05f-30c2-46fb-862b-4842bbe7a6d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add conditional to enableAriaHiddenOnChildren prop",
+  "packageName": "@fluentui/react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/common/testUtilities.ts
+++ b/packages/react/src/common/testUtilities.ts
@@ -64,7 +64,7 @@ export function flushPromises() {
 export function expectNoHiddenParents(element: HTMLElement) {
   let el: HTMLElement | null = element;
   while (el) {
-    expect(el.getAttribute('aria-hidden')).toBeNull();
+    expect(el.getAttribute('aria-hidden')).not.toBe('true');
     el = el.parentElement;
   }
 }

--- a/packages/react/src/components/Panel/Panel.base.tsx
+++ b/packages/react/src/components/Panel/Panel.base.tsx
@@ -227,7 +227,7 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
           ariaLabelledBy={this._headerTextId ? this._headerTextId : undefined}
           onDismiss={this.dismiss}
           className={_classNames.hiddenPanel}
-          enableAriaHiddenSiblings={isOpen ? true : false}
+          enableAriaHiddenSiblings={isOpen ? true : undefined}
           {...popupProps}
         >
           <div aria-hidden={!isOpen && isAnimating} {...nativeProps} ref={this._panel} className={_classNames.root}>

--- a/packages/react/src/components/Panel/Panel.base.tsx
+++ b/packages/react/src/components/Panel/Panel.base.tsx
@@ -227,7 +227,7 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
           ariaLabelledBy={this._headerTextId ? this._headerTextId : undefined}
           onDismiss={this.dismiss}
           className={_classNames.hiddenPanel}
-          enableAriaHiddenSiblings={true}
+          enableAriaHiddenSiblings={isOpen ? true : false}
           {...popupProps}
         >
           <div aria-hidden={!isOpen && isAnimating} {...nativeProps} ref={this._panel} className={_classNames.root}>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently, when `isHiddenOnDismiss` is passed in as a prop to `Panel`, `aria-hidden` is set on the root `div` and passed down to the child nodes (due to setting `enableAriaHiddenSiblings` on the `Popup`). This causes screen readers to read a blank screen when the Panel is closed.

## New Behavior

Set `enableAriaHiddenSiblings` to false if the panel is not open. When the panel is closed with `isHiddenOnDismiss` passed in, `aria-hidden` is not set, allowing the screen reader to register the component


Fixes #21843
