### PR TITLE
Update react-label README

### DIFF
--- a/change/@fluentui-react-label-f0755fa2-4c9c-4ca5-b65c-763611f23e66.json
+++ b/change/@fluentui-react-label-f0755fa2-4c9c-4ca5-b65c-763611f23e66.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update react-label README example",
+  "packageName": "@fluentui/react-label",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-label/README.md
+++ b/packages/react-label/README.md
@@ -11,9 +11,10 @@ To use the `Label` component import it from `@fluentui/react-label` and use it a
 ```tsx
 import * as React from 'react';
 import { Label } from '@fluentui/react-label';
+import { useId } from '@fluentui/react-utilities';
 
 export const labelExample = () => {
-  const inputId = React.useId('firstNameLabel');
+  const inputId = useId('firstNameLabel-');
 
   return (
     <>


### PR DESCRIPTION
## Current Behavior

README showed usage of React 18's `useId()` hook and used the hook incorrectly (it does not accept any arguments).

## New Behavior

README shows usage of `@fluentui/react-utilities`' `useId()` hook. This is consistent with how IDs are generated internally in `@fluentui/react-components` and aligns with the minimum supported React version for this library which is currently `16.8.6`

