### PR TITLE
Add choiceGroup subtext as optional prop

### DIFF
--- a/apps/vr-tests/src/stories/ChoiceGroup.stories.tsx
+++ b/apps/vr-tests/src/stories/ChoiceGroup.stories.tsx
@@ -44,6 +44,17 @@ storiesOf('ChoiceGroup', module)
       required
     />,
   )
+  .addStory('With subtext', () =>
+    // prettier-ignore
+    <ChoiceGroup
+      options={[
+        ...options,
+        { key: 'C', text: 'Subtext', subtext: 'Subtext'},
+        { key: 'C', text: 'Disabled Subtext', subtext: 'Subtext', disabled: true}
+      ]}
+      label="Pick one"
+    />,
+  )
   .addStory(
     'With icons',
     () => (

--- a/change/@fluentui-react-94b7daab-ca31-4598-810f-479dcbc4cb1b.json
+++ b/change/@fluentui-react-94b7daab-ca31-4598-810f-479dcbc4cb1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add optional field subtext to ChoiceGroupOption",
+  "packageName": "@fluentui/react",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Label.Example.tsx
+++ b/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Label.Example.tsx
@@ -10,7 +10,8 @@ const options: IChoiceGroupOption[] = [
   { key: 'B', text: 'Option B' },
   { key: 'C', text: 'Option C', disabled: true },
   { key: 'D', text: 'Option D' },
-  { key: 'E', text: 'Option E', subtext: 'Option E with subtext' },
+  { key: 'E', text: 'Option E', subtext: 'Option with subtext' },
+  { key: 'F', text: 'Option F', subtext: 'Disabled with subtext', disabled: true },
 ];
 
 export const ChoiceGroupLabelExample: React.FunctionComponent = () => {

--- a/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Label.Example.tsx
+++ b/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Label.Example.tsx
@@ -10,6 +10,7 @@ const options: IChoiceGroupOption[] = [
   { key: 'B', text: 'Option B' },
   { key: 'C', text: 'Option C', disabled: true },
   { key: 'D', text: 'Option D' },
+  { key: 'E', text: 'Option E', subtext: 'Option E with subtext' },
 ];
 
 export const ChoiceGroupLabelExample: React.FunctionComponent = () => {

--- a/packages/react-radio/Spec.md
+++ b/packages/react-radio/Spec.md
@@ -257,7 +257,6 @@ _⚠️ Props not included in this section are marked as deprecated and will not
 | Used to customize option rendering.                                             | onRenderField      | -                | -        |
 | Used to customize label rendering.                                              | onRenderLabel      | -                | -        |
 | The src of image for choice field which is selected.                            | selectedImageSrc   | -                | -        |
-| The subtext string for the option.                                              | subtext            | -                | -        |
 | Accessibility behavior if overridden by the user.                               | -                  | accessibility    | -        |
 | Whether or not radio item is checked.                                           | -                  | checked          | -        |
 | The checked radio item indicator can be customized.                             | -                  | checkedIndicator | -        |

--- a/packages/react-radio/Spec.md
+++ b/packages/react-radio/Spec.md
@@ -257,6 +257,7 @@ _⚠️ Props not included in this section are marked as deprecated and will not
 | Used to customize option rendering.                                             | onRenderField      | -                | -        |
 | Used to customize label rendering.                                              | onRenderLabel      | -                | -        |
 | The src of image for choice field which is selected.                            | selectedImageSrc   | -                | -        |
+| The subtext string for the option.                                              | subtext            | -                | -        |
 | Accessibility behavior if overridden by the user.                               | -                  | accessibility    | -        |
 | Whether or not radio item is checked.                                           | -                  | checked          | -        |
 | The checked radio item indicator can be customized.                             | -                  | checkedIndicator | -        |

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3197,6 +3197,7 @@ export interface IChoiceGroupOption extends Omit<React_2.InputHTMLAttributes<HTM
     onRenderLabel?: IRenderFunction<IChoiceGroupOptionProps>;
     selectedImageSrc?: string;
     styles?: IStyleFunctionOrObject<IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles>;
+    subtext?: string;
     text: string;
 }
 
@@ -3251,6 +3252,8 @@ export interface IChoiceGroupOptionStyles {
     root?: IStyle;
     // (undocumented)
     selectedImageWrapper?: IStyle;
+    // (undocumented)
+    subtext?: IStyle;
 }
 
 // @public (undocumented)

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -96,7 +96,7 @@ export interface IChoiceGroupOption extends Omit<React.InputHTMLAttributes<HTMLE
   /**
    * The subtext string, displayed below the option.
    */
-  subtext: string;
+  subtext?: string;
 
   /**
    * Used to customize option rendering.

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -94,6 +94,11 @@ export interface IChoiceGroupOption extends Omit<React.InputHTMLAttributes<HTMLE
   text: string;
 
   /**
+   * The subtext string, displayed below the option.
+   */
+  subtext: string;
+
+  /**
    * Used to customize option rendering.
    */
   onRenderField?: IRenderFunction<IChoiceGroupOptionProps>;

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -42,6 +42,7 @@ export const ChoiceGroupOptionBase: React.FunctionComponent<IChoiceGroupOptionPr
     id,
     styles,
     name,
+    subtext,
     ...rest
   } = props;
 
@@ -95,6 +96,7 @@ export const ChoiceGroupOptionBase: React.FunctionComponent<IChoiceGroupOptionPr
           </div>
         )}
         {imageSrc || iconProps ? <div className={classNames.labelWrapper}>{label}</div> : label}
+        {!imageSrc && subtext && <div className={classNames.subtext}>{subtext}</div>}
       </label>
     );
   };

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -18,6 +18,7 @@ const GlobalClassNames = {
 const labelWrapperLineHeight = 15;
 const labelWrapperHeight = labelWrapperLineHeight * 2 + 2; // adding 2px height to ensure text doesn't get cutoff
 const iconSize = 32;
+const labelIndent = '26px';
 const choiceFieldSize = 20;
 const choiceFieldTransitionDuration = '200ms';
 const choiceFieldTransitionTiming = 'cubic-bezier(.4, 0, .23, 1)';
@@ -265,7 +266,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
         !hasImage && {
           selectors: {
             '.ms-ChoiceFieldLabel': {
-              paddingLeft: '26px',
+              paddingLeft: labelIndent,
             },
           },
         },
@@ -418,6 +419,14 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
         maxWidth: imageSize!.width * 2,
         overflow: 'hidden',
         whiteSpace: 'pre-wrap',
+      },
+    ],
+    subtext: [
+      classNames.labelWrapper,
+      fonts.medium,
+      {
+        paddingTop: '6px',
+        paddingLeft: labelIndent,
       },
     ],
   };

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -124,9 +124,6 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
       '.ms-ChoiceFieldLabel': {
         color: labelHoverFocusColor,
       },
-      subtext: {
-        color: labelHoverFocusColor,
-      },
       ':before': {
         borderColor: checked ? circleCheckedHoveredBorderColor : circleHoveredBorderColor,
       },
@@ -147,6 +144,9 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
           background: dotCheckedHoveredColor,
         },
       ],
+      subtext: {
+        color: labelHoverFocusColor,
+      },
     },
   };
 
@@ -425,7 +425,6 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
       },
     ],
     subtext: [
-      classNames.labelWrapper,
       fonts.medium,
       {
         paddingTop: '4px',

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -124,6 +124,9 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
       '.ms-ChoiceFieldLabel': {
         color: labelHoverFocusColor,
       },
+      subtext: {
+        color: labelHoverFocusColor,
+      },
       ':before': {
         borderColor: checked ? circleCheckedHoveredBorderColor : circleHoveredBorderColor,
       },
@@ -427,6 +430,16 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
       {
         paddingTop: '4px',
         paddingLeft: labelIndent,
+      },
+      disabled && {
+        cursor: 'default',
+        color: semanticColors.disabledBodyText,
+        selectors: {
+          [HighContrastSelector]: {
+            color: 'GrayText',
+            ...getHighContrastNoAdjustStyle(),
+          },
+        },
       },
     ],
   };

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -425,7 +425,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
       classNames.labelWrapper,
       fonts.medium,
       {
-        paddingTop: '6px',
+        paddingTop: '4px',
         paddingLeft: labelIndent,
       },
     ],

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
@@ -114,4 +114,5 @@ export interface IChoiceGroupOptionStyles {
   selectedImageWrapper?: IStyle;
   iconWrapper?: IStyle;
   labelWrapper?: IStyle;
+  subtext?: IStyle;
 }

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -75,6 +75,9 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
               transition-property: background-color;
               width: 10px;
             }
+            &:hover subtext {
+              color: #201f1e;
+            }
             &:focus .ms-ChoiceFieldLabel {
               color: #201f1e;
             }
@@ -89,6 +92,9 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
               top: 5px;
               transition-property: background-color;
               width: 10px;
+            }
+            &:focus subtext {
+              color: #201f1e;
             }
             &:before {
               background-color: #ffffff;
@@ -202,6 +208,9 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
               transition-property: background-color;
               width: 10px;
             }
+            &:hover subtext {
+              color: #201f1e;
+            }
             &:focus .ms-ChoiceFieldLabel {
               color: #201f1e;
             }
@@ -216,6 +225,9 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
               top: 5px;
               transition-property: background-color;
               width: 10px;
+            }
+            &:focus subtext {
+              color: #201f1e;
             }
             &:before {
               background-color: #ffffff;
@@ -331,6 +343,9 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
               transition-property: background-color;
               width: 10px;
             }
+            &:hover subtext {
+              color: #201f1e;
+            }
             &:focus .ms-ChoiceFieldLabel {
               color: #201f1e;
             }
@@ -345,6 +360,9 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
               top: 5px;
               transition-property: background-color;
               width: 10px;
+            }
+            &:focus subtext {
+              color: #201f1e;
             }
             &:before {
               background-color: #ffffff;
@@ -469,6 +487,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               transition-property: background-color;
               width: 10px;
             }
+            &:hover subtext {
+              color: #201f1e;
+            }
             &:focus .ms-ChoiceFieldLabel {
               color: #201f1e;
             }
@@ -483,6 +504,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               top: 5px;
               transition-property: background-color;
               width: 10px;
+            }
+            &:focus subtext {
+              color: #201f1e;
             }
             &:before {
               background-color: #ffffff;
@@ -621,6 +645,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               transition-property: background-color;
               width: 10px;
             }
+            &:hover subtext {
+              color: #201f1e;
+            }
             &:focus .ms-ChoiceFieldLabel {
               color: #201f1e;
             }
@@ -635,6 +662,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               top: 5px;
               transition-property: background-color;
               width: 10px;
+            }
+            &:focus subtext {
+              color: #201f1e;
             }
             &:before {
               background-color: #ffffff;
@@ -771,6 +801,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               background: #005a9e;
               border-color: #005a9e;
             }
+            &:hover subtext {
+              color: #201f1e;
+            }
             &:focus .ms-ChoiceFieldLabel {
               color: #201f1e;
             }
@@ -780,6 +813,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             &:focus:after {
               background: #005a9e;
               border-color: #005a9e;
+            }
+            &:focus subtext {
+              color: #201f1e;
             }
             &:before {
               background-color: #ffffff;
@@ -1166,6 +1202,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               border-color: #323130;
               opacity: 1;
             }
+            &:hover subtext {
+              color: #201f1e;
+            }
             &:focus {
               border-color: #323130;
             }
@@ -1175,6 +1214,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             &:focus:before {
               border-color: #323130;
               opacity: 1;
+            }
+            &:focus subtext {
+              color: #201f1e;
             }
             &:before {
               background-color: #ffffff;
@@ -1391,6 +1433,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               border-color: #323130;
               opacity: 1;
             }
+            &:hover subtext {
+              color: #201f1e;
+            }
             &:focus {
               border-color: #323130;
             }
@@ -1400,6 +1445,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             &:focus:before {
               border-color: #323130;
               opacity: 1;
+            }
+            &:focus subtext {
+              color: #201f1e;
             }
             &:before {
               background-color: #ffffff;
@@ -1600,6 +1648,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               background: #005a9e;
               border-color: #005a9e;
             }
+            &:hover subtext {
+              color: #201f1e;
+            }
             &:focus {
               border-color: #005a9e;
             }
@@ -1613,6 +1664,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             &:focus:after {
               background: #005a9e;
               border-color: #005a9e;
+            }
+            &:focus subtext {
+              color: #201f1e;
             }
             &:before {
               background-color: #ffffff;

--- a/packages/react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -100,6 +100,9 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
                   transition-property: background-color;
                   width: 10px;
                 }
+                &:hover subtext {
+                  color: #201f1e;
+                }
                 &:focus .ms-ChoiceFieldLabel {
                   color: #201f1e;
                 }
@@ -114,6 +117,9 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
                   top: 5px;
                   transition-property: background-color;
                   width: 10px;
+                }
+                &:focus subtext {
+                  color: #201f1e;
                 }
                 &:before {
                   background-color: #ffffff;
@@ -235,6 +241,9 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
                   transition-property: background-color;
                   width: 10px;
                 }
+                &:hover subtext {
+                  color: #201f1e;
+                }
                 &:focus .ms-ChoiceFieldLabel {
                   color: #201f1e;
                 }
@@ -249,6 +258,9 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
                   top: 5px;
                   transition-property: background-color;
                   width: 10px;
+                }
+                &:focus subtext {
+                  color: #201f1e;
                 }
                 &:before {
                   background-color: #ffffff;
@@ -370,6 +382,9 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
                   transition-property: background-color;
                   width: 10px;
                 }
+                &:hover subtext {
+                  color: #201f1e;
+                }
                 &:focus .ms-ChoiceFieldLabel {
                   color: #201f1e;
                 }
@@ -384,6 +399,9 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
                   top: 5px;
                   transition-property: background-color;
                   width: 10px;
+                }
+                &:focus subtext {
+                  color: #201f1e;
                 }
                 &:before {
                   background-color: #ffffff;
@@ -567,6 +585,9 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
                   transition-property: background-color;
                   width: 10px;
                 }
+                &:hover subtext {
+                  color: #201f1e;
+                }
                 &:focus .ms-ChoiceFieldLabel {
                   color: #201f1e;
                 }
@@ -581,6 +602,9 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
                   top: 5px;
                   transition-property: background-color;
                   width: 10px;
+                }
+                &:focus subtext {
+                  color: #201f1e;
                 }
                 &:before {
                   background-color: #ffffff;
@@ -702,6 +726,9 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
                   transition-property: background-color;
                   width: 10px;
                 }
+                &:hover subtext {
+                  color: #201f1e;
+                }
                 &:focus .ms-ChoiceFieldLabel {
                   color: #201f1e;
                 }
@@ -716,6 +743,9 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
                   top: 5px;
                   transition-property: background-color;
                   width: 10px;
+                }
+                &:focus subtext {
+                  color: #201f1e;
                 }
                 &:before {
                   background-color: #ffffff;
@@ -837,6 +867,9 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
                   transition-property: background-color;
                   width: 10px;
                 }
+                &:hover subtext {
+                  color: #201f1e;
+                }
                 &:focus .ms-ChoiceFieldLabel {
                   color: #201f1e;
                 }
@@ -851,6 +884,9 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
                   top: 5px;
                   transition-property: background-color;
                   width: 10px;
+                }
+                &:focus subtext {
+                  color: #201f1e;
                 }
                 &:before {
                   background-color: #ffffff;


### PR DESCRIPTION
<!--
* [*] Code is up-to-date with the `master` branch
* [*] Added changes to snapshots
* [*] You've run `yarn change` locally


PR flow tips:
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently we do not have a standardized method of adding subtext below choice groups, this was a request from our MADS team to add and use in admin 365 components via fluent.

## New Behavior
![image](https://user-images.githubusercontent.com/99835933/155810287-3544a107-a35f-4467-9fde-259e4821c568.png)

## Spec'd Behavior (MADS)
![image](https://user-images.githubusercontent.com/99835933/155810550-50ad0c14-e5f0-4ce1-802e-4d0beafc9717.png)

## Related Issue(s)

Internal m365 admin ticket 4102: