### PR TITLE
Ensure useEventCallback always returns a stable callback reference

### DIFF
--- a/change/@fluentui-react-utilities-64945e33-8335-4a62-b5c1-00419ff30ae7.json
+++ b/change/@fluentui-react-utilities-64945e33-8335-4a62-b5c1-00419ff30ae7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "useEventCallback: ensure callback reference is always stable, and update docs",
+  "packageName": "@fluentui/react-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Current Behavior

`useEventCallback` in v9 uses `React.useCallback` to return the callback reference, which is supposed to be guaranteed to be stable. However, [`useCallback` internally uses `useMemo`](https://github.com/facebook/react/blob/75f3ddebfa0d9885ce8df42571cf0c09ad6c0a3b/packages/react-dom/src/server/ReactPartialRendererHooks.js#L470), and the [React docs](https://reactjs.org/docs/hooks-reference.html#usememo) state the following:

> You may rely on useMemo as a performance optimization, not as a semantic guarantee. In the future, React may choose to “forget” some previously memoized values and recalculate them on next render, e.g. to free memory for offscreen components.

(I noticed this issue when looking at adding a `useEventCallback` hook to v8.)

## New Behavior

Update `useEventCallback` to use `useConst` when defining the callback. `useConst` internally uses `useRef` to guarantee stability.