### PR TITLE
chore: Update react-components nightly release name format

### DIFF
--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -36,9 +36,9 @@ steps:
 
     # Bumps all v9 packages to a x.x.x-nightly.commitSha version and checks in change files
   - script: |
-      date=$(date +"%Y%m%d.%H%M")
-      #release version name will follow a 0.0.0-nightly.{year}{month}{day}.{hour}{minute} format.
-      yarn nx workspace-generator version-bump --all --bumpType nightly --prereleaseTag "nightly.${date}"
+      date=$(date +"%Y%m%d-%H%M")
+      #release version name will follow a 0.0.0-nightly-{year}{month}{day}-{hour}{minute} format.
+      yarn nx workspace-generator version-bump --all --bumpType nightly --prereleaseTag "nightly-${date}"
       git add .
       git commit -m "bump nightly versions"
       yarn change --type prerelease --message "Release nightly v9"

--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -36,9 +36,8 @@ steps:
 
     # Bumps all v9 packages to a x.x.x-nightly.commitSha version and checks in change files
   - script: |
-      commitSha=$(git log -n 1 --pretty=format:"%h")
-      date=$(date +"%Y%m%d")
-      yarn nx workspace-generator version-bump --all --bumpType nightly --prereleaseTag "nightly${commitSha}${date}"
+      date=$(date +"%Y%m%d.%H%M")
+      yarn nx workspace-generator version-bump --all --bumpType nightly --prereleaseTag "nightly.${date}"
       git add .
       git commit -m "bump nightly versions"
       yarn change --type prerelease --message "Release nightly v9"

--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -37,6 +37,7 @@ steps:
     # Bumps all v9 packages to a x.x.x-nightly.commitSha version and checks in change files
   - script: |
       date=$(date +"%Y%m%d.%H%M")
+      #release version name will follow a 0.0.0-nightly.{year}{month}{day}.{hour}{minute} format.
       yarn nx workspace-generator version-bump --all --bumpType nightly --prereleaseTag "nightly.${date}"
       git add .
       git commit -m "bump nightly versions"


### PR DESCRIPTION

## Current Behavior
- Nightly releases currently uses the name format of `0.0.0-nightly{commitSha}{date}` which leads to disjointed looking version history names like: `0.0.0-nightlya0aef7969220220228.1`


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- As discussed in the v-build sync, version history names will now follow a more readable format of `0.0.0-nightly-{year}{month}{day}-{hour}{minute}` which should lead to outputs like `0.0.0-nightly-20220228-1008.1`
