### PR TITLE
Update package dependencies in web-components

### DIFF
--- a/change/@fluentui-web-components-94e57592-580c-407b-ab70-e32bd7604171.json
+++ b/change/@fluentui-web-components-94e57592-580c-407b-ab70-e32bd7604171.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update package dependencies in web-components",
+  "packageName": "@fluentui/web-components",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -41,6 +41,7 @@ import { FlipperOptions } from '@microsoft/fast-foundation';
 import { FoundationElement } from '@microsoft/fast-foundation';
 import { FoundationElementDefinition } from '@microsoft/fast-foundation';
 import { FoundationElementRegistry } from '@microsoft/fast-foundation';
+import { FoundationElementTemplate } from '@microsoft/fast-foundation';
 import { HorizontalScroll as HorizontalScroll_2 } from '@microsoft/fast-foundation';
 import { HorizontalScrollOptions } from '@microsoft/fast-foundation';
 import { Listbox as Listbox_2 } from '@microsoft/fast-foundation';
@@ -71,6 +72,7 @@ import { TabPanel } from '@microsoft/fast-foundation';
 import { Tabs } from '@microsoft/fast-foundation';
 import { TextArea as TextArea_2 } from '@microsoft/fast-foundation';
 import { TextField as TextField_2 } from '@microsoft/fast-foundation';
+import { TextFieldOptions } from '@microsoft/fast-foundation';
 import { Toolbar as Toolbar_2 } from '@microsoft/fast-foundation';
 import { Tooltip as Tooltip_2 } from '@microsoft/fast-foundation';
 import { TreeItem } from '@microsoft/fast-foundation';
@@ -222,8 +224,40 @@ export const allComponents: {
     fluentTabs: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, Tabs>;
     fluentTab: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, Tab>;
     fluentTabPanel: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, TabPanel>;
-    fluentTextArea: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, TextArea>;
-    fluentTextField: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, TextField>;
+    fluentTextArea: (overrideDefinition?: OverrideFoundationElementDefinition<    {
+    baseName: string;
+    baseClass: TextArea_2;
+    template: FoundationElementTemplate<ViewTemplate<TextArea_2, any>, FoundationElementDefinition>;
+    styles: (context: any, definition: any) => ElementStyles;
+    shadowOptions: {
+    delegatesFocus: true;
+    };
+    }> | undefined) => FoundationElementRegistry<    {
+    baseName: string;
+    baseClass: TextArea_2;
+    template: FoundationElementTemplate<ViewTemplate<TextArea_2, any>, FoundationElementDefinition>;
+    styles: (context: any, definition: any) => ElementStyles;
+    shadowOptions: {
+    delegatesFocus: true;
+    };
+    }, TextArea>;
+    fluentTextField: (overrideDefinition?: OverrideFoundationElementDefinition<    {
+    baseName: string;
+    baseClass: TextField_2;
+    template: FoundationElementTemplate<ViewTemplate<TextField_2, any>, TextFieldOptions>;
+    styles: (context: any, definition: any) => ElementStyles;
+    shadowOptions: {
+    delegatesFocus: true;
+    };
+    }> | undefined) => FoundationElementRegistry<    {
+    baseName: string;
+    baseClass: TextField_2;
+    template: FoundationElementTemplate<ViewTemplate<TextField_2, any>, TextFieldOptions>;
+    styles: (context: any, definition: any) => ElementStyles;
+    shadowOptions: {
+    delegatesFocus: true;
+    };
+    }, TextField>;
     fluentToolbar: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, Toolbar>;
     fluentTooltip: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, Tooltip>;
     fluentTreeView: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, TreeView>;
@@ -682,12 +716,44 @@ export const fluentTabs: (overrideDefinition?: OverrideFoundationElementDefiniti
 // Warning: (ae-incompatible-release-tags) The symbol "fluentTextArea" is marked as @public, but its signature references "TextArea" which is marked as @internal
 //
 // @public
-export const fluentTextArea: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof TextArea>;
+export const fluentTextArea: (overrideDefinition?: OverrideFoundationElementDefinition<    {
+baseName: string;
+baseClass: typeof TextArea_2;
+template: FoundationElementTemplate<ViewTemplate<TextArea_2, any>, FoundationElementDefinition>;
+styles: (context: any, definition: any) => ElementStyles;
+shadowOptions: {
+delegatesFocus: true;
+};
+}> | undefined) => FoundationElementRegistry<    {
+baseName: string;
+baseClass: typeof TextArea_2;
+template: FoundationElementTemplate<ViewTemplate<TextArea_2, any>, FoundationElementDefinition>;
+styles: (context: any, definition: any) => ElementStyles;
+shadowOptions: {
+delegatesFocus: true;
+};
+}, typeof TextArea>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "fluentTextField" is marked as @public, but its signature references "TextField" which is marked as @internal
 //
 // @public
-export const fluentTextField: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof TextField>;
+export const fluentTextField: (overrideDefinition?: OverrideFoundationElementDefinition<    {
+baseName: string;
+baseClass: typeof TextField_2;
+template: FoundationElementTemplate<ViewTemplate<TextField_2, any>, TextFieldOptions>;
+styles: (context: any, definition: any) => ElementStyles;
+shadowOptions: {
+delegatesFocus: true;
+};
+}> | undefined) => FoundationElementRegistry<    {
+baseName: string;
+baseClass: typeof TextField_2;
+template: FoundationElementTemplate<ViewTemplate<TextField_2, any>, TextFieldOptions>;
+styles: (context: any, definition: any) => ElementStyles;
+shadowOptions: {
+delegatesFocus: true;
+};
+}, typeof TextField>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "fluentToolbar" is marked as @public, but its signature references "Toolbar" which is marked as @internal
 //
@@ -1657,9 +1723,9 @@ export const typeRampPlus6LineHeight: CSSDesignToken<string>;
 // dist/dts/custom-elements.d.ts:53:5 - (ae-incompatible-release-tags) The symbol "fluentBadge" is marked as @public, but its signature references "Badge" which is marked as @internal
 // dist/dts/custom-elements.d.ts:56:5 - (ae-incompatible-release-tags) The symbol "fluentButton" is marked as @public, but its signature references "Button" which is marked as @internal
 // dist/dts/custom-elements.d.ts:95:5 - (ae-incompatible-release-tags) The symbol "fluentTextArea" is marked as @public, but its signature references "TextArea" which is marked as @internal
-// dist/dts/custom-elements.d.ts:96:5 - (ae-incompatible-release-tags) The symbol "fluentTextField" is marked as @public, but its signature references "TextField" which is marked as @internal
-// dist/dts/custom-elements.d.ts:97:5 - (ae-incompatible-release-tags) The symbol "fluentToolbar" is marked as @public, but its signature references "Toolbar" which is marked as @internal
-// dist/dts/custom-elements.d.ts:98:5 - (ae-incompatible-release-tags) The symbol "fluentTooltip" is marked as @public, but its signature references "Tooltip" which is marked as @internal
+// dist/dts/custom-elements.d.ts:112:5 - (ae-incompatible-release-tags) The symbol "fluentTextField" is marked as @public, but its signature references "TextField" which is marked as @internal
+// dist/dts/custom-elements.d.ts:129:5 - (ae-incompatible-release-tags) The symbol "fluentToolbar" is marked as @public, but its signature references "Toolbar" which is marked as @internal
+// dist/dts/custom-elements.d.ts:130:5 - (ae-incompatible-release-tags) The symbol "fluentTooltip" is marked as @public, but its signature references "Tooltip" which is marked as @internal
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -86,10 +86,10 @@
     "webpack": "^4.43.0"
   },
   "dependencies": {
-    "@microsoft/fast-colors": "^5.1.0",
-    "@microsoft/fast-element": "^1.6.0",
-    "@microsoft/fast-foundation": "^2.32.0",
-    "@microsoft/fast-web-utilities": "^5.0.0",
+    "@microsoft/fast-colors": "^5.1.5",
+    "@microsoft/fast-element": "^1.7.2",
+    "@microsoft/fast-foundation": "^2.33.6",
+    "@microsoft/fast-web-utilities": "^5.1.0",
     "tslib": "^1.13.0"
   }
 }

--- a/packages/web-components/src/combobox/index.ts
+++ b/packages/web-components/src/combobox/index.ts
@@ -66,6 +66,9 @@ export class Combobox extends FoundationCombobox {
 export const fluentCombobox = Combobox.compose<ComboboxOptions>({
   baseName: 'combobox',
   baseClass: FoundationCombobox,
+  shadowOptions: {
+    delegatesFocus: true,
+  },
   template,
   styles,
   indicator: `

--- a/yarn.lock
+++ b/yarn.lock
@@ -2902,27 +2902,27 @@
     source-map "~0.6.1"
     typescript "~4.3.2"
 
-"@microsoft/fast-colors@^5.1.0":
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-colors/-/fast-colors-5.1.3.tgz#5c46147401a823835a3833e3e18dae7f06016966"
-  integrity sha512-XDEnRYxPO5P3Jsizm4TCxLu1osS/uV3Lym6SfRhq2PxfXPTgEcdvOYDUXyV2drqebs3U5VQnOcYcJiSp73xhng==
+"@microsoft/fast-colors@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-colors/-/fast-colors-5.1.5.tgz#3d7dacae85c263030c793ba457991d4cdcec7538"
+  integrity sha512-g8FByhbmRxibSpHkDE90CLCsh61HzH4ujPBG5N1zWXgM8LtzaF6OYBzfd8uGJ/md+SGeHf3aH9fcT8HTCbarXw==
 
-"@microsoft/fast-element@^1.6.0", "@microsoft/fast-element@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.7.0.tgz#7e4b164c77c07d93b28f057231b37e7e2e8fed04"
-  integrity sha512-2qpAWuiOSdQfH/XdO8ZtVhlvQVCjHlojWUPoGbvHJDizBccZib+4uGReG87RIBp2Fi0s7ngYPRUioS1Lr+Xe0A==
+"@microsoft/fast-element@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.7.2.tgz#b381c95b1c0f04faa5819785e1cd92b4d9f9ae8a"
+  integrity sha512-bV+wFQUoMtyd1ccwE6k8CVjWSWQv9wgMj6nA2j2l5EtcN8+/XT23Ljce98GaMdIBARYpb35RQwCQq7stVWZUTg==
 
-"@microsoft/fast-foundation@^2.32.0":
-  version "2.32.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-2.32.1.tgz#371462f7569266a5d86f5813f3047144f7e8a52b"
-  integrity sha512-X+rXtPezZJAbHFx/3LxvpjrVKjw9RGa8UhM8Q6CJbhD6Kgi0zNpCRb1h+fUkMIra5DmhXAaGBKrGEtHDSRsYAw==
+"@microsoft/fast-foundation@^2.33.6":
+  version "2.33.6"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-2.33.6.tgz#8f6964b1a41a26e25195041212a86ab1f363d47e"
+  integrity sha512-geROGEc760qBXqeYfCDn6Vlq0fXegpqUdVyUD/Fo1BvzI/MbxFqMy37wAEzzqB7B9XcPAoav34cBriWtEWE+gw==
   dependencies:
-    "@microsoft/fast-element" "^1.7.0"
+    "@microsoft/fast-element" "^1.7.2"
     "@microsoft/fast-web-utilities" "^5.1.0"
     tabbable "^5.2.0"
     tslib "^1.13.0"
 
-"@microsoft/fast-web-utilities@^5.0.0", "@microsoft/fast-web-utilities@^5.1.0":
+"@microsoft/fast-web-utilities@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@microsoft/fast-web-utilities/-/fast-web-utilities-5.1.0.tgz#e060fea2b47c2dcfb4a9ba90a55559f0844d1cdb"
   integrity sha512-S2PCxI4XqtIxLM1N7i/NuIAgx+mJM01+mDzyB3vZlYibAkOT0bzp5YZCp+coXowokSin/nK5T2kqShMXEzI6Jg==


### PR DESCRIPTION
## Current Behavior

The package dependencies in `@fluentui/web-components` are out of date. Additionally, the `<fluent-combobox>` component is missing the `delegatesFocus` configuration.

## New Behavior

* Updates `@microsoft/fast-element` to `^1.7.0`
* Updates `@microsoft/fast-foundation` to `^2.33.6`
* Updates `@microsoft/fast-colors` to `^5.1.5`
* Updates `@microsoft/fast-web-utilities` to `^5.1.0`
* Restores missing `delegatesFocus` property configuration for `<fluent-combobox>`

