### PR TITLE
Calendar: Fix 'year' button color when using dark themes

### DIFF
--- a/change/@fluentui-react-ad3a0e4f-24c0-4734-a881-d47ce24dea8e.json
+++ b/change/@fluentui-react-ad3a0e4f-24c0-4734-a881-d47ce24dea8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add color: inherit to year button so that it gets color from header container",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Calendar/CalendarPicker/CalendarPicker.styles.ts
+++ b/packages/react/src/components/Calendar/CalendarPicker/CalendarPicker.styles.ts
@@ -56,6 +56,7 @@ export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyl
         fontWeight: FontWeights.semibold,
         fontFamily: 'inherit',
         textAlign: 'left',
+        color: 'inherit',
         backgroundColor: 'transparent',
         flexGrow: 1,
         padding: '0 4px 0 10px',


### PR DESCRIPTION
Fixes #21892

![image](https://user-images.githubusercontent.com/1434956/156059553-aa146089-f482-496e-bf6d-dfbd4501a1cb.png)
The month on the left is text (February 2022), but the year on the right is a button (2022). The color for that text is passed down from their parent, so custom themes work on the month text, but don't get inherited by the button.

Adding color: inherited to the button is the simplest change to properly support themes.




Before:

![image](https://user-images.githubusercontent.com/1434956/156060092-c9b5d558-69b2-4339-9709-dbdb4c37fce3.png)




After:

![image](https://user-images.githubusercontent.com/1434956/156060023-cc096a7f-78bf-43a4-9fb8-d0148f7461fa.png)
