### PR TITLE
Resizegroup support CSS scaled content

### DIFF
--- a/change/@fluentui-react-33dc3612-9a0f-4e5a-9ba5-d14a21df9855.json
+++ b/change/@fluentui-react-33dc3612-9a0f-4e5a-9ba5-d14a21df9855.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "move from scrollWidth to bounding rect to support scaled content",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -414,9 +414,10 @@ function useResizingBehavior(props: IResizeGroupProps, rootRef: React.RefObject<
           if (!refToMeasure.current) {
             return 0;
           }
+          const measuredBoundingRect = refToMeasure.current.getBoundingClientRect();
           return props.direction === ResizeGroupDirection.vertical
-            ? refToMeasure.current.scrollHeight
-            : refToMeasure.current.scrollWidth;
+            ? measuredBoundingRect.height
+            : measuredBoundingRect.width;
         },
         containerDimension,
       );


### PR DESCRIPTION
Fixes #21888

scrollWidth and getBoundingClientRect have different behaviors when measuring scaled content. 
https://codepen.io/micahgodbolt/pen/dyZgLeK?editors=1111

scrollWidth does not account for css scale, while bounding rect does.

getNextState was being called with content measured by getBoundingClientRect  and hidden content measured by scrollWidth, causing it to break.

This PR changes the 'hidden' content to be measured by getBoundingClientRect so that both measurements capture the calculated value of the content.

