### PR TITLE
Switch useLayoutEffect in v8 components to useIsomorphicLayoutEffect

### DIFF
--- a/change/@fluentui-react-842cfe69-2477-474b-a9cd-88e0930dc6ea.json
+++ b/change/@fluentui-react-842cfe69-2477-474b-a9cd-88e0930dc6ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu, Image, Keytips, Layer, MaskedTextField: Use useIsomorphicLayoutEffect instead of useLayoutEffect to avoid warnings in SSR",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-hooks-7b9d0375-f811-4b85-9b1d-0762b9aadd12.json
+++ b/change/@fluentui-react-hooks-7b9d0375-f811-4b85-9b1d-0762b9aadd12.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add useIsomorphicLayoutEffect",
+  "packageName": "@fluentui/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-75f44cef-664f-42ec-bbe0-a6cc7ce5bf75.json
+++ b/change/@fluentui-utilities-75f44cef-664f-42ec-bbe0-a6cc7ce5bf75.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add useIsomorphicLayoutEffect",
+  "packageName": "@fluentui/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -9,6 +9,7 @@ Helpful hooks not provided by React itself. These hooks were built for use in Fl
 - [useControllableValue](#usecontrollablevalue) - Manage the current value for a component that could be either controlled or uncontrolled
 - [useForceUpdate](#useforceupdate) - Force a function component to update
 - [useId](#useid) - Get a globally unique ID
+- [useIsomorphicLayoutEffect](#useisomorphiclayouteffect) - Calls `useLayoutEffect` in browser and `useEffect` in SSR, to avoid warnings
 - [useMergedRefs](#usemergedrefs) - Merge multiple refs into a single ref callback
 - [useOnEvent](#useonevent) - Attach an event handler on mount and handle cleanup
 - [usePrevious](#useprevious) - Get a value from the previous execution of the component
@@ -166,6 +167,17 @@ const TextField = ({ labelText, defaultValue }) => {
 };
 ```
 
+## useIsomorphicLayoutEffect
+
+```ts
+// Type is the same as React.useEffect (not fully specifying here)
+function useIsomorphicLayoutEffect(effect, deps?): void;
+```
+
+To avoid warnings about `useLayoutEffect` when server-side rendering, this calls `useEffect` on the server (no-op) and `useLayoutEffect` on the client. SSR is determined based on `setSSR` from `@fluentui/utilities`.
+
+Prefer `useEffect` unless you have a specific need to do something after mount and before paint.
+
 ## useMergedRefs
 
 ```ts
@@ -206,26 +218,6 @@ const MyComponent = () => {
   return <div />;
 };
 });
-```
-
-## useMountSync (deprecated)
-
-```ts
-const useMountSync: (callback: () => void) => void;
-```
-
-Hook which synchronously execute a callback when the component has been mounted using [useLayoutEffect](https://reactjs.org/docs/hooks-reference.html#uselayouteffect). Use `useMount` for most scenarios. You should only use the synchronous version in the rare case you need to perform an action after the component has been mounted and before the browser paints, such as measuring content and adjusting the result. Using this will trigger debug warnings in server-rendered scenarios.
-
-```tsx
-import { useMountSync } from '@fluentui/react-hooks';
-
-const MyComponent = () => {
-  useMountSync(() => {
-    console.log('Example');
-  });
-
-  return <div />;
-};
 ```
 
 ## useOnEvent
@@ -394,11 +386,3 @@ The following types of warnings are supported (see typings for details on how to
   - The component is attempting to switch between controlled and uncontrolled
 
 Note that all warnings except `controlledUsage` will only be shown on first render. New `controlledUsage` warnings may be shown later based on prop changes. All warnings are shown synchronously during render (not wrapped in `useEffect`) for easier tracing/debugging.
-
-## Deprecated hooks
-
-### useConstCallback
-
-This hook was intended for creating callbacks which have no dependencies, and therefore never need to change. It works fine if everyone using it is extremely mindful of how closures work, but that's not a safe assumption--so in practice, usage of this hook tends to result in bugs like unintentionally capturing the first value of a prop and not respecting updates (when updates should be respected).
-
-If absolutely necessary, you can imitate `useConstCallback`'s behavior with `useConst`: `const myCallback = useConst(() => () => { /* callback body */ })`. (The extra function wrapper is necessary to prevent the callback itself from being interpreted as an initializer.)

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -10,6 +10,7 @@ import type { IWarnControlledUsageParams } from '@fluentui/utilities/lib/warn';
 import type { Point } from '@fluentui/utilities';
 import * as React_2 from 'react';
 import { Rectangle } from '@fluentui/utilities';
+import { useIsomorphicLayoutEffect } from '@fluentui/utilities';
 
 // @public (undocumented)
 export type ChangeCallback<TElement extends HTMLElement, TValue, TEvent extends React_2.SyntheticEvent<TElement> | undefined> = (ev: TEvent, newValue: TValue | undefined) => void;
@@ -71,6 +72,8 @@ export function useForceUpdate(): () => void;
 
 // @public
 export function useId(prefix?: string, providedId?: string): string;
+
+export { useIsomorphicLayoutEffect }
 
 // @public
 export function useMergedRefs<T>(...refs: (React_2.Ref<T> | undefined)[]): RefObjectFunction<T>;

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -17,3 +17,5 @@ export * from './useSetTimeout';
 export * from './useTarget';
 export * from './useUnmount';
 export * from './useWarnings';
+// re-export since this is a hook, which people would reasonably expect to import from react-hooks
+export { useIsomorphicLayoutEffect } from '@fluentui/utilities';

--- a/packages/react-hooks/src/useConstCallback.ts
+++ b/packages/react-hooks/src/useConstCallback.ts
@@ -1,8 +1,13 @@
 import * as React from 'react';
 
 /**
- * @deprecated Deprecated due to potential for misuse (see package readme).
- * Use `React.useCallback` instead.
+ * @deprecated Deprecated due to potential for misuse. Generally, use `React.useCallback` instead.
+ *
+ * This hook was intended for creating callbacks which have no dependencies, and therefore never
+ * need to change. It works fine if everyone using it is extremely mindful of how closures work,
+ * but that's not a safe assumption--so in practice, usage of this hook tends to result in bugs
+ * like unintentionally capturing the first value of a prop and not respecting updates (when
+ * updates should be respected).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function useConstCallback<T extends (...args: any[]) => any>(callback: T): T {

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -31,7 +31,15 @@ import {
 } from './ContextualMenuItemWrapper/index';
 import { concatStyleSetsWithProps } from '../../Styling';
 import { getItemStyles } from './ContextualMenu.classNames';
-import { useTarget, usePrevious, useAsync, useWarnings, useId, Target } from '@fluentui/react-hooks';
+import {
+  useTarget,
+  usePrevious,
+  useAsync,
+  useWarnings,
+  useId,
+  Target,
+  useIsomorphicLayoutEffect,
+} from '@fluentui/react-hooks';
 import { useResponsiveMode, ResponsiveMode } from '../../ResponsiveMode';
 import { MenuContext } from '../../utilities/MenuContext/index';
 import type {
@@ -255,8 +263,7 @@ function usePreviousActiveElement({ hidden, onRestoreFocus }: IContextualMenuPro
     [onRestoreFocus],
   );
 
-  // eslint-disable-next-line no-restricted-properties
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!hidden) {
       previousActiveElement.current = targetWindow?.document.activeElement as HTMLElement;
     } else if (previousActiveElement.current) {

--- a/packages/react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -10,7 +10,7 @@ import {
   modalize,
   on,
 } from '../../Utilities';
-import { useId, useConst, useMergedRefs } from '@fluentui/react-hooks';
+import { useId, useConst, useMergedRefs, useUnmount } from '@fluentui/react-hooks';
 import { useDocument } from '../../WindowProvider';
 import type { IRefObject } from '../../Utilities';
 import type { IFocusTrapZoneProps, IFocusTrapZone } from './FocusTrapZone.types';
@@ -375,19 +375,6 @@ export const FocusTrapZone: React.FunctionComponent<IFocusTrapZoneProps> & {
     </div>
   );
 }) as any;
-
-const useUnmount = (unmountFunction: () => void) => {
-  const unmountRef = React.useRef(unmountFunction);
-  unmountRef.current = unmountFunction;
-  React.useEffect(
-    () => () => {
-      if (unmountRef.current) {
-        unmountRef.current();
-      }
-    },
-    [unmountFunction],
-  );
-};
 
 FocusTrapZone.displayName = COMPONENT_NAME;
 FocusTrapZone.focusStack = [];

--- a/packages/react/src/components/Image/Image.base.tsx
+++ b/packages/react/src/components/Image/Image.base.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { classNamesFunction, getNativeProps, imgProperties } from '../../Utilities';
 import { ImageCoverStyle, ImageFit, ImageLoadState } from './Image.types';
-import { useMergedRefs } from '@fluentui/react-hooks';
+import { useIsomorphicLayoutEffect, useMergedRefs } from '@fluentui/react-hooks';
 import type { IImageProps, IImageStyleProps, IImageStyles } from './Image.types';
 
 const getClassNames = classNamesFunction<IImageStyleProps, IImageStyles>();
@@ -25,8 +25,7 @@ function useLoadState(
 
   const [loadState, setLoadState] = React.useState<ImageLoadState>(ImageLoadState.notLoaded);
 
-  // eslint-disable-next-line no-restricted-properties
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     // If the src property changes, reset the load state
     // (does nothing if the load state is already notLoaded)
     setLoadState(ImageLoadState.notLoaded);

--- a/packages/react/src/components/KeytipData/useKeytipData.ts
+++ b/packages/react/src/components/KeytipData/useKeytipData.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useConst, usePrevious } from '@fluentui/react-hooks';
+import { useConst, useIsomorphicLayoutEffect, usePrevious } from '@fluentui/react-hooks';
 import { mergeAriaAttributeValues } from '../../Utilities';
 import { KeytipManager, mergeOverflows, sequencesToID, getAriaDescribedBy } from '../../utilities/keytips/index';
 import type { KeytipDataOptions } from './KeytipData.types';
@@ -26,8 +26,7 @@ export function useKeytipData(options: KeytipDataOptions): IKeytipData {
   const prevOptions = usePrevious(options);
 
   // useLayoutEffect used to strictly emulate didUpdate/didMount behavior
-  // eslint-disable-next-line no-restricted-properties
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (
       uniqueId.current &&
       keytipProps &&
@@ -37,8 +36,7 @@ export function useKeytipData(options: KeytipDataOptions): IKeytipData {
     }
   });
 
-  // eslint-disable-next-line no-restricted-properties
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     // Register Keytip in KeytipManager
     if (keytipProps) {
       uniqueId.current = keytipManager.register(keytipProps);

--- a/packages/react/src/components/Layer/Layer.base.tsx
+++ b/packages/react/src/components/Layer/Layer.base.tsx
@@ -3,7 +3,7 @@ import * as ReactDOM from 'react-dom';
 import { Fabric } from '../../Fabric';
 import { classNamesFunction, setPortalAttribute, setVirtualParent } from '../../Utilities';
 import { registerLayer, getDefaultTarget, unregisterLayer } from './Layer.notification';
-import { useMergedRefs, useWarnings } from '@fluentui/react-hooks';
+import { useIsomorphicLayoutEffect, useMergedRefs, useWarnings } from '@fluentui/react-hooks';
 import { useDocument } from '../../WindowProvider';
 import type { ILayerProps, ILayerStyleProps, ILayerStyles } from './Layer.types';
 
@@ -92,8 +92,7 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
       setNeedRaiseLayerMount(true);
     };
 
-    // eslint-disable-next-line no-restricted-properties
-    React.useLayoutEffect(() => {
+    useIsomorphicLayoutEffect(() => {
       createLayerElement();
       // Check if the user provided a hostId prop and register the layer with the ID.
       if (hostId) {

--- a/packages/react/src/components/Layer/LayerHost.tsx
+++ b/packages/react/src/components/Layer/LayerHost.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useUnmount } from '@fluentui/react-hooks';
 import { css } from '../../Utilities';
 import { notifyHostChanged } from './Layer.notification';
 import type { ILayerHostProps } from './LayerHost.types';
@@ -16,17 +17,4 @@ export const LayerHost: React.FunctionComponent<ILayerHostProps> = props => {
   });
 
   return <div {...props} className={css('ms-LayerHost', className)} />;
-};
-
-const useUnmount = (unmountFunction: () => void) => {
-  const unmountRef = React.useRef(unmountFunction);
-  unmountRef.current = unmountFunction;
-  React.useEffect(
-    () => () => {
-      if (unmountRef.current) {
-        unmountRef.current();
-      }
-    },
-    [],
-  );
 };

--- a/packages/react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
+++ b/packages/react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
@@ -12,7 +12,7 @@ import {
   insertString,
   parseMask,
 } from './inputMask';
-import { useConst } from '@fluentui/react-hooks';
+import { useConst, useIsomorphicLayoutEffect } from '@fluentui/react-hooks';
 import type { IMaskedTextFieldProps, IMaskedTextField } from '../TextField.types';
 import type { IRefObject } from '../../../Utilities';
 import type { IMaskValue } from './inputMask';
@@ -345,8 +345,7 @@ export const MaskedTextField: React.FunctionComponent<IMaskedTextFieldProps> = R
   }, [mask, value]);
 
   // Run before browser paint to avoid flickering from selection reset.
-  // eslint-disable-next-line no-restricted-properties
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     // Move the cursor to position before paint.
     if (maskCursorPosition !== undefined && textField.current) {
       textField.current.setSelectionRange(maskCursorPosition, maskCursorPosition);

--- a/packages/react/src/utilities/useOverflow.ts
+++ b/packages/react/src/utilities/useOverflow.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useRefEffect } from '@fluentui/react-hooks';
+import { useIsomorphicLayoutEffect, useRefEffect } from '@fluentui/react-hooks';
 import { getWindow } from '@fluentui/utilities';
 import { observeResize } from './observeResize';
 import type { RefCallback } from '@fluentui/react-hooks';
@@ -76,8 +76,7 @@ export const useOverflow = ({ onOverflowItemsChanged, rtl, pinnedIndex }: Overfl
     return () => containerRef(null);
   });
 
-  // eslint-disable-next-line no-restricted-properties
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const container = containerRef.current;
     const menuButton = menuButtonRef.current;
     if (!container || !menuButton) {

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -1216,6 +1216,9 @@ export function useCustomizationSettings(properties: string[], scopeName?: strin
 export function useFocusRects(rootRef?: React_2.RefObject<HTMLElement>): void;
 
 // @public
+export const useIsomorphicLayoutEffect: typeof React_2.useEffect;
+
+// @public
 export function values<T>(obj: any): T[];
 
 // @public

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -72,6 +72,7 @@ export * from './getPropsWithDefaults';
 export { setFocusVisibility, IsFocusVisibleClassName } from './setFocusVisibility';
 export { setSSR } from './dom/setSSR';
 export { createMergedRef } from './createMergedRef';
+export * from './useIsomorphicLayoutEffect';
 
 import './version';
 

--- a/packages/utilities/src/useIsomorphicLayoutEffect.ts
+++ b/packages/utilities/src/useIsomorphicLayoutEffect.ts
@@ -16,4 +16,4 @@ import { _isSSR } from './dom/setSSR';
  * https://github.com/reduxjs/react-redux/blob/master/src/utils/useIsomorphicLayoutEffect.js
  */
 // eslint-disable-next-line no-restricted-properties
-export const useIsomorphicLayoutEffect: typeof React.useEffect = _isSSR ? React.useLayoutEffect : React.useEffect;
+export const useIsomorphicLayoutEffect: typeof React.useEffect = _isSSR ? React.useEffect : React.useLayoutEffect;

--- a/packages/utilities/src/useIsomorphicLayoutEffect.ts
+++ b/packages/utilities/src/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { _isSSR } from './dom/setSSR';
+
+// This hook must live in @fluentui/utilities because _isSSR is not exported
+
+/**
+ * React currently throws a warning when using `useLayoutEffect` on the server. To get around it,
+ * this hook calls `useEffect` on the server (no-op) and `useLayoutEffect` in the browser.
+ *
+ * Prefer `useEffect` unless you have a specific need to do something after mount and before paint,
+ * such as to avoid a render flash for certain operations.
+ *
+ * Server-side rendering is detected based on `setSSR` from `@fluentui/utilities`.
+ *
+ * https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85
+ * https://github.com/reduxjs/react-redux/blob/master/src/utils/useIsomorphicLayoutEffect.js
+ */
+// eslint-disable-next-line no-restricted-properties
+export const useIsomorphicLayoutEffect: typeof React.useEffect = _isSSR ? React.useLayoutEffect : React.useEffect;


### PR DESCRIPTION
## Current Behavior

Some v8 components use `useLayoutEffect`, causing warnings in SSR.

## New Behavior

Introduce `useIsomorphicLayoutEffect` similar to v9, and replace all `useLayoutEffect` usage. `useIsomorphicLayoutEffect` calls `useEffect` (no-op) on the server and `useLayoutEffect` on the client. The implementation had to go in `@fluentui/utilities` instead of `@fluentui/react-hooks` because it relies on `_isSSR` which is intentionally not exported from utilities.

Also update some docs for the react-hooks package, and remove old `useUnmount` implementations in a couple components in favor of the react-hooks implementation.

## Related Issue(s)

Fixes #18916