### PR TITLE
fix(@fluentui/react) DocumentCardPreview add alt prop

### DIFF
--- a/change/@fluentui-react-57229a06-8a53-4e00-a522-00fdd1654299.json
+++ b/change/@fluentui-react-57229a06-8a53-4e00-a522-00fdd1654299.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix(@fluentui/react) DocumentCardPreview alt prop missing",
+  "packageName": "@fluentui/react",
+  "email": "zaidalbaker@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DocumentCard/DocumentCardPreview.base.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCardPreview.base.tsx
@@ -65,7 +65,7 @@ export class DocumentCardPreviewBase extends React.Component<IDocumentCardPrevie
   private _renderPreviewImage(
     previewImage: IDocumentCardPreviewImage,
   ): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> {
-    const { width, height, imageFit, previewIconProps, previewIconContainerClass } = previewImage;
+    const { alt = '', width, height, imageFit, previewIconProps, previewIconContainerClass } = previewImage;
 
     if (previewIconProps) {
       return (
@@ -85,13 +85,13 @@ export class DocumentCardPreviewBase extends React.Component<IDocumentCardPrevie
         imageFit={imageFit}
         src={previewImage.previewImageSrc}
         role="presentation"
-        alt=""
+        alt={alt}
       />
     );
 
     let icon;
     if (previewImage.iconSrc) {
-      icon = <Image className={this._classNames.icon} src={previewImage.iconSrc} role="presentation" alt="" />;
+      icon = <Image className={this._classNames.icon} src={previewImage.iconSrc} role="presentation" alt={alt} />;
     }
 
     return (
@@ -124,7 +124,7 @@ export class DocumentCardPreviewBase extends React.Component<IDocumentCardPrevie
           className={this._classNames.fileListIcon}
           src={file.iconSrc}
           role="presentation"
-          alt=""
+          alt={file.alt || ''}
           width="16px"
           height="16px"
         />

--- a/packages/react/src/components/DocumentCard/DocumentCardPreview.test.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCardPreview.test.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+
+import { DocumentCardPreview } from './DocumentCardPreview';
+import { TestImages } from '@fluentui/example-data';
+
+describe('DocumentCardPreview', () => {
+  it('renders DocumentCardPreview with an Image (no icon) and "alt" prop', () => {
+    const component = renderer.create(
+      <DocumentCardPreview
+        previewImages={[
+          {
+            name: 'Contoso Marketing Presentation',
+            linkProps: {
+              href: 'http://bing.com',
+            },
+            previewImageSrc: TestImages.documentPreview,
+            width: 144,
+            alt: 'Some fancy Contoso Image',
+          },
+        ]}
+      />,
+    );
+    const root = component.root;
+
+    const imgWrapper = root.findAll(n => {
+      if (!n.props.className) {
+        return false;
+      }
+      return n.type === 'div' && n.props.className.indexOf('ms-DocumentCardPreview-icon') > -1;
+    });
+    expect(imgWrapper).toHaveLength(0);
+
+    const img = root.find(n => n.type === 'img');
+    expect(img.props.alt).toEqual('Some fancy Contoso Image');
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+  it('renders DocumentCardPreview with an Image (w/ icon) and "alt" prop', () => {
+    const component = renderer.create(
+      <DocumentCardPreview
+        previewImages={[
+          {
+            name: 'Contoso Marketing Presentation',
+            linkProps: {
+              href: 'http://bing.com',
+            },
+            iconSrc: TestImages.iconPpt,
+            width: 144,
+            alt: 'Some fancy Contoso Image',
+          },
+        ]}
+      />,
+    );
+    const root = component.root;
+
+    const imgWrapper = root.findAll(n => {
+      if (!n.props.className) {
+        return false;
+      }
+      return n.type === 'div' && n.props.className.indexOf('ms-DocumentCardPreview-icon') > -1;
+    });
+    expect(imgWrapper).toHaveLength(1);
+
+    const img = root.findAll(n => {
+      return n.type === 'img';
+    });
+    expect(img[0].props.alt).toEqual('Some fancy Contoso Image');
+    expect(img[1].props.alt).toEqual('Some fancy Contoso Image');
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+});

--- a/packages/react/src/components/DocumentCard/DocumentCardPreview.types.ts
+++ b/packages/react/src/components/DocumentCard/DocumentCardPreview.types.ts
@@ -126,6 +126,11 @@ export interface IDocumentCardPreviewImage {
    * If provided, icon container classname will be used..
    */
   previewIconContainerClass?: string;
+
+  /**
+   * If provided, sets the alt attribute
+   */
+  alt?: string;
 }
 
 /**

--- a/packages/react/src/components/DocumentCard/__snapshots__/DocumentCardPreview.test.tsx.snap
+++ b/packages/react/src/components/DocumentCard/__snapshots__/DocumentCardPreview.test.tsx.snap
@@ -1,0 +1,155 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DocumentCardPreview renders DocumentCardPreview with an Image (no icon) and "alt" prop 1`] = `
+<div
+  className=
+      ms-DocumentCardPreview
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background-color: #faf9f8;
+        border-bottom: 1px solid #edebe9;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 12px;
+        font-weight: 400;
+        overflow: hidden;
+        position: relative;
+      }
+>
+  <div>
+    <div
+      className=
+          ms-Image
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+          }
+      style={
+        Object {
+          "height": undefined,
+          "width": 144,
+        }
+      }
+    >
+      <img
+        alt="Some fancy Contoso Image"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: auto;
+              opacity: 0;
+              width: 100%;
+            }
+        onError={[Function]}
+        onLoad={[Function]}
+        role="presentation"
+        src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/document-preview.png"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DocumentCardPreview renders DocumentCardPreview with an Image (w/ icon) and "alt" prop 1`] = `
+<div
+  className=
+      ms-DocumentCardPreview
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background-color: #faf9f8;
+        border-bottom: 1px solid #edebe9;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 12px;
+        font-weight: 400;
+        overflow: hidden;
+        position: relative;
+      }
+>
+  <div>
+    <div
+      className=
+          ms-Image
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+          }
+      style={
+        Object {
+          "height": undefined,
+          "width": 144,
+        }
+      }
+    >
+      <img
+        alt="Some fancy Contoso Image"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: auto;
+              opacity: 0;
+              width: 100%;
+            }
+        onError={[Function]}
+        onLoad={[Function]}
+        role="presentation"
+      />
+    </div>
+    <div
+      className=
+          ms-Image
+          ms-DocumentCardPreview-icon
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            bottom: 10px;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            left: 10px;
+            overflow: hidden;
+            position: absolute;
+          }
+      style={
+        Object {
+          "height": undefined,
+          "width": undefined,
+        }
+      }
+    >
+      <img
+        alt="Some fancy Contoso Image"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              opacity: 0;
+            }
+        onError={[Function]}
+        onLoad={[Function]}
+        role="presentation"
+        src="https://static2.sharepointonline.com/files/fabric/assets/item-types/32/pptx.png"
+      />
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Fixes #21109

## Current Behavior
**DocumentCardPreview** does not allow for an `alt` attribute to be passed down as a prop and hardcodes it to an empty string `alt=""`
<!-- This is the behavior we have today -->

## New Behavior
Now you can pass an alt prop to the component making it a bit more accessible (grade C requirement)
<!-- This is the behavior we should expect with the changes in this PR -->
```jsx
<DocumentCardPreview
  previewImages={[
    {
        name: 'Contoso Marketing Presentation',
        linkProps: {
          href: 'http://bing.com',
        },
        previewImageSrc: TestImages.documentPreview,
        width: 144,
        alt: 'Some fancy Contoso Image',
    },
  ]}
/>
```
