### PR TITLE
ContextualMenu: add empty iconProps to onRenderIcon example 

### DIFF
--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Icon.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Icon.Example.tsx
@@ -19,6 +19,7 @@ export const ContextualMenuIconExample: React.FunctionComponent = () => {
       {
         key: 'openInWord',
         text: 'Open in Word',
+        iconProps: {},
         onRenderIcon: (props: IContextualMenuItemProps) => {
           return (
             <span className={classNames.iconContainer}>


### PR DESCRIPTION
As noted in #21804, if no contextual menu items have `iconProps`, the control will not think there are any icons. This can easily be solved by passing in an empty `iconProps` object. The alternative would be to assume that any contexual menu with an item containing an `onRenderIcon`, actually did have icons (and made space for them). This feels like it'd have a high change of regression for an edge case that can easily be avoided. 

I've updated the example here to point users in the right direction, that even if there's an `onRenderIcon`, you should also include `iconProps`.

I would add a comment there, but `iconProps` isn't REQUIRED in this case, and I wouldn't want people they think they always needed to add them. 