### PR TITLE
Slider: convert tests to use testing-library

### DIFF
--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -307,7 +307,7 @@ describe('Slider', () => {
     expect(container.getElementsByClassName('ms-Slider-value')[0].textContent).toEqual(valueFormat(value));
   });
 
-  it('updates value correctly when down and up are pressed', () => {
+  it('updates value of upperthumb for range slider correctly when down and up are pressed', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
@@ -325,7 +325,7 @@ describe('Slider', () => {
     expect(onChange).toHaveBeenCalledTimes(5);
   });
 
-  it('updates value for range slider correctly when down and up are pressed', () => {
+  it('updates value of upperthumb for range slider correctly when down and up are pressed', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 

--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
-import { resetIds, KeyCodes } from '../../Utilities';
+import { resetIds } from '../../Utilities';
 import { fireEvent, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Slider } from './Slider';
 import { isConformant } from '../../common/isConformant';
 import type { ISlider } from './Slider.types';
 
 const MIN_PREFIX = 'min';
 const MAX_PREFIX = 'max';
+const DOWN = 'arrowdown';
+const UP = 'arrowup';
 
 describe('Slider', () => {
   beforeEach(() => {
@@ -308,16 +311,14 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    const { container } = render(
+    render(
       <Slider label="slider" componentRef={slider} defaultValue={12} min={0} max={100} onChange={onChange} ranged />,
     );
-    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    // move keyboard focus to upperthumb of slider
+    userEvent.tab({ shift: true });
+    //press up and down keys to modify slider value
+    userEvent.keyboard(`{${DOWN}}{${DOWN}}{${DOWN}}{${UP}}{${DOWN}}`);
 
     expect(slider.current?.value).toEqual(9);
 
@@ -328,16 +329,13 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    const { getAllByRole } = render(
+    render(
       <Slider label="slider" componentRef={slider} defaultValue={20} min={12} max={100} onChange={onChange} ranged />,
     );
-    const lowerValueThumb = getAllByRole('slider')[0];
 
-    fireEvent.keyDown(lowerValueThumb, { keyCode: KeyCodes.down });
-    fireEvent.keyDown(lowerValueThumb, { keyCode: KeyCodes.down });
-    fireEvent.keyDown(lowerValueThumb, { keyCode: KeyCodes.down });
-    fireEvent.keyDown(lowerValueThumb, { keyCode: KeyCodes.up });
-    fireEvent.keyDown(lowerValueThumb, { keyCode: KeyCodes.down });
+    // move keyboard focus to upperthumb of slider
+    userEvent.tab({ shift: true });
+    userEvent.keyboard(`{${DOWN}}{${DOWN}}{${DOWN}}{${UP}}{${DOWN}}`);
 
     expect(slider.current?.value).toEqual(17);
 
@@ -351,11 +349,8 @@ describe('Slider', () => {
     const { container } = render(<Slider label="slider" defaultValue={12} min={0} max={100} onChanged={onChanged} />);
     const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    userEvent.tab();
+    userEvent.keyboard(`{${DOWN}}{${DOWN}}{${DOWN}}{${UP}}{${DOWN}}`);
 
     expect(sliderSlideBox.getAttribute('aria-valuenow')).toEqual('9');
 
@@ -369,14 +364,10 @@ describe('Slider', () => {
     jest.useFakeTimers();
     const onChanged = jest.fn();
 
-    const { container } = render(<Slider label="slider" defaultValue={5} min={0} max={100} onChanged={onChanged} />);
-    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
+    render(<Slider label="slider" defaultValue={5} min={0} max={100} onChanged={onChanged} />);
 
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    userEvent.tab();
+    userEvent.keyboard(`{${DOWN}}{${DOWN}}{${DOWN}}{${UP}}{${DOWN}}`);
 
     // onChanged should only be called after a delay
     expect(onChanged).toHaveBeenCalledTimes(0);
@@ -389,12 +380,10 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    const { container } = render(
-      <Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} />,
-    );
-    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
+    render(<Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} />);
 
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    userEvent.tab();
+    userEvent.keyboard(`{${DOWN}}`);
 
     expect(slider.current?.value).toEqual(3);
 
@@ -405,12 +394,10 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    const { container } = render(
-      <Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} />,
-    );
-    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
+    render(<Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} />);
 
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    userEvent.tab();
+    userEvent.keyboard(`{${DOWN}}`);
 
     expect(slider.current?.value).toEqual(3);
 
@@ -422,12 +409,11 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    const { container } = render(
-      <Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} ranged />,
-    );
-    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
+    render(<Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} ranged />);
 
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    // move keyboard focus to upperthumb of slider
+    userEvent.tab({ shift: true });
+    userEvent.keyboard(`{${DOWN}}`);
 
     expect(slider.current?.range).toEqual([0, 3]);
 
@@ -439,14 +425,10 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    const { container } = render(
-      <Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} />,
-    );
-    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
+    render(<Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} />);
 
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
+    userEvent.tab();
+    userEvent.keyboard(`{${UP}}{${UP}}{${UP}}`);
 
     expect(slider.current?.value).toEqual(3);
 
@@ -458,12 +440,13 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    const { container } = render(
+    render(
       <Slider label="slider" defaultValue={10} componentRef={slider} step={-3} min={0} max={100} onChange={onChange} />,
     );
-    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
+    userEvent.tab();
+    userEvent.keyboard(`{${UP}}`);
+
     expect(slider.current?.value).toEqual(7);
   });
 
@@ -473,7 +456,7 @@ describe('Slider', () => {
     const step = 0.0000001;
     const defaultValue = 10;
 
-    const { container } = render(
+    render(
       <Slider
         label="slider"
         defaultValue={defaultValue}
@@ -484,9 +467,10 @@ describe('Slider', () => {
         onChange={onChange}
       />,
     );
-    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
+    userEvent.tab();
+    userEvent.keyboard(`{${UP}}`);
+
     expect(slider.current?.value).toEqual(defaultValue + step);
   });
 });

--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -36,7 +36,6 @@ describe('Slider', () => {
 
   it('can set aria-labelledby attribute', () => {
     render(<Slider aria-labelledby="custom-label" />);
-    // expect(sliderSlideBox.getDOMNode().getAttribute('aria-labelledby')).toEqual('custom-label');
     expect(screen.getByRole('slider').getAttribute('aria-labelledby')).toBe('custom-label');
   });
 

--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { resetIds, KeyCodes } from '../../Utilities';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { Slider } from './Slider';
 import { isConformant } from '../../common/isConformant';
 import type { ISlider } from './Slider.types';
@@ -35,8 +35,8 @@ describe('Slider', () => {
   });
 
   it('can set aria-labelledby attribute', () => {
-    render(<Slider aria-labelledby="custom-label" />);
-    expect(screen.getByRole('slider').getAttribute('aria-labelledby')).toBe('custom-label');
+    const { getByRole } = render(<Slider aria-labelledby="custom-label" />);
+    expect(getByRole('slider').getAttribute('aria-labelledby')).toBe('custom-label');
   });
 
   it('can provide the current value', () => {
@@ -54,9 +54,9 @@ describe('Slider', () => {
   });
 
   it('can set id', () => {
-    const { container } = render(<Slider id="test_id" styles={{ titleLabel: 'test_label' }} />);
+    const { container, getByRole } = render(<Slider id="test_id" styles={{ titleLabel: 'test_label' }} />);
 
-    expect(screen.getByRole('slider').id).toEqual('test_id');
+    expect(getByRole('slider').id).toEqual('test_id');
 
     // properly associates label with custom id
     const label = container.getElementsByClassName('test_label')[0];
@@ -65,9 +65,11 @@ describe('Slider', () => {
 
   it('can set id via buttonProps', () => {
     // Not the recommended way of doing things, but it should work consistently still
-    const { container } = render(<Slider buttonProps={{ id: 'test_id' }} styles={{ titleLabel: 'test_label' }} />);
+    const { container, getByRole } = render(
+      <Slider buttonProps={{ id: 'test_id' }} styles={{ titleLabel: 'test_label' }} />,
+    );
 
-    expect(screen.getByRole('slider').id).toEqual('test_id');
+    expect(getByRole('slider').id).toEqual('test_id');
 
     // properly associates label with custom id
     const label = container.getElementsByClassName('test_label')[0];

--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import * as ReactTestUtils from 'react-dom/test-utils';
-import { mount, ReactWrapper } from 'enzyme';
-import { resetIds, KeyCodes } from '@fluentui/utilities';
-import { create } from '@fluentui/utilities/lib/test';
+import { resetIds, KeyCodes } from '../../Utilities';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { Slider } from './Slider';
 import { isConformant } from '../../common/isConformant';
 import type { ISlider } from './Slider.types';
@@ -12,17 +9,11 @@ const MIN_PREFIX = 'min';
 const MAX_PREFIX = 'max';
 
 describe('Slider', () => {
-  let wrapper: ReactWrapper | undefined;
-
   beforeEach(() => {
     resetIds();
   });
 
   afterEach(() => {
-    if (wrapper) {
-      wrapper.unmount();
-      wrapper = undefined;
-    }
     if ((setTimeout as any).mock) {
       jest.useRealTimers();
     }
@@ -34,71 +25,67 @@ describe('Slider', () => {
   });
 
   it('renders correctly', () => {
-    const component = create(<Slider label="I am a slider" />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Slider label="I am a slider" />);
+    expect(container).toMatchSnapshot();
   });
 
   it('renders range slider correctly', () => {
-    const component = create(<Slider label="I am a ranged slider" ranged defaultValue={5} />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Slider label="I am a ranged slider" ranged defaultValue={5} />);
+    expect(container).toMatchSnapshot();
   });
 
   it('can set aria-labelledby attribute', () => {
-    wrapper = mount(<Slider aria-labelledby="custom-label" />);
-    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
-    expect(sliderSlideBox.getDOMNode().getAttribute('aria-labelledby')).toEqual('custom-label');
+    render(<Slider aria-labelledby="custom-label" />);
+    // expect(sliderSlideBox.getDOMNode().getAttribute('aria-labelledby')).toEqual('custom-label');
+    expect(screen.getByRole('slider').getAttribute('aria-labelledby')).toBe('custom-label');
   });
 
   it('can provide the current value', () => {
     const slider = React.createRef<ISlider>();
 
-    wrapper = mount(<Slider defaultValue={12} min={0} max={100} componentRef={slider} />);
+    render(<Slider defaultValue={12} min={0} max={100} componentRef={slider} />);
     expect(slider.current?.value).toEqual(12);
   });
 
   it('can provide the current range', () => {
     const slider = React.createRef<ISlider>();
 
-    wrapper = mount(<Slider defaultValue={12} min={0} max={100} componentRef={slider} ranged />);
+    render(<Slider defaultValue={12} min={0} max={100} componentRef={slider} ranged />);
     expect(slider.current?.range).toEqual([0, 12]);
   });
 
   it('can set id', () => {
-    wrapper = mount(<Slider id="test_id" styles={{ titleLabel: 'test_label' }} />);
+    const { container } = render(<Slider id="test_id" styles={{ titleLabel: 'test_label' }} />);
 
-    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
-    expect(sliderSlideBox.getDOMNode().id).toEqual('test_id');
+    expect(screen.getByRole('slider').id).toEqual('test_id');
 
     // properly associates label with custom id
-    const label = wrapper.find('label.test_label');
-    expect(label.prop('htmlFor')).toBe('test_id');
+    const label = container.getElementsByClassName('test_label')[0];
+    expect(label.getAttribute('for')).toBe('test_id');
   });
 
   it('can set id via buttonProps', () => {
     // Not the recommended way of doing things, but it should work consistently still
-    wrapper = mount(<Slider buttonProps={{ id: 'test_id' }} styles={{ titleLabel: 'test_label' }} />);
+    const { container } = render(<Slider buttonProps={{ id: 'test_id' }} styles={{ titleLabel: 'test_label' }} />);
 
-    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
-    expect(sliderSlideBox.getDOMNode().id).toEqual('test_id');
+    expect(screen.getByRole('slider').id).toEqual('test_id');
 
     // properly associates label with custom id
-    const label = wrapper.find('label.test_label');
-    expect(label.prop('htmlFor')).toBe('test_id');
+    const label = container.getElementsByClassName('test_label')[0];
+    expect(label.getAttribute('for')).toBe('test_id');
   });
 
   it('handles zero default value', () => {
     const slider = React.createRef<ISlider>();
 
-    wrapper = mount(<Slider defaultValue={0} min={-100} max={100} componentRef={slider} />);
+    render(<Slider defaultValue={0} min={-100} max={100} componentRef={slider} />);
     expect(slider.current!.value).toEqual(0);
   });
 
   it('handles zero value', () => {
     const slider = React.createRef<ISlider>();
 
-    wrapper = mount(<Slider value={0} min={-100} max={100} componentRef={slider} />);
+    render(<Slider value={0} min={-100} max={100} componentRef={slider} />);
     expect(slider.current!.value).toEqual(0);
   });
 
@@ -106,15 +93,17 @@ describe('Slider', () => {
     const onChange = jest.fn();
     const onChanged = jest.fn();
     const slider = React.createRef<ISlider>();
-    wrapper = mount(<Slider onChange={onChange} defaultValue={5} onChanged={onChanged} componentRef={slider} />);
+    const { container, getByRole } = render(
+      <Slider onChange={onChange} defaultValue={5} onChanged={onChanged} componentRef={slider} />,
+    );
 
-    const sliderLine = wrapper.find('.ms-Slider-line');
-    const sliderThumb = wrapper.find('.ms-Slider-slideBox');
+    const sliderLine = container.getElementsByClassName('ms-Slider-line')[0];
+    const sliderThumb = getByRole('slider');
 
-    sliderLine.getDOMNode().getBoundingClientRect = () =>
+    sliderLine.getBoundingClientRect = () =>
       ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 0, clientY: 0 });
+    fireEvent.mouseDown(sliderThumb, { clientX: 0, clientY: 0 });
     // Default min is 0.
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][0]).toEqual(0);
@@ -122,7 +111,7 @@ describe('Slider', () => {
     expect(slider.current!.value).toBe(0);
 
     // have to use a real event to trigger onChanged
-    window.dispatchEvent(new Event('mouseup'));
+    fireEvent.mouseUp(sliderThumb);
     expect(onChange).toHaveBeenCalledTimes(1); // not called again
     expect(onChanged).toHaveBeenCalledTimes(1);
     expect(onChanged.mock.calls[0][1]).toEqual(0);
@@ -132,22 +121,24 @@ describe('Slider', () => {
     const onChange = jest.fn();
     const onChanged = jest.fn();
     const slider = React.createRef<ISlider>();
-    wrapper = mount(<Slider onChange={onChange} onChanged={onChanged} defaultValue={5} ranged componentRef={slider} />);
+    const { container } = render(
+      <Slider onChange={onChange} onChanged={onChanged} defaultValue={5} ranged componentRef={slider} />,
+    );
 
-    const sliderLine = wrapper.find('.ms-Slider-line');
-    const sliderThumb = wrapper.find('.ms-Slider-slideBox');
+    const sliderLine = container.getElementsByClassName('ms-Slider-line')[0];
+    const sliderThumb = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderLine.getDOMNode().getBoundingClientRect = () =>
+    sliderLine.getBoundingClientRect = () =>
       ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 0, clientY: 0 });
+    fireEvent.mouseDown(sliderThumb, { clientX: 0, clientY: 0 });
     // Default min is 0.
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][1]).toEqual([0, 5]);
     expect(onChanged).toHaveBeenCalledTimes(0);
     expect(slider.current!.range).toEqual([0, 5]);
 
-    window.dispatchEvent(new Event('mouseup'));
+    fireEvent.mouseUp(sliderThumb);
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChanged).toHaveBeenCalledTimes(1);
     expect(onChanged.mock.calls[0][2]).toEqual([0, 5]);
@@ -156,40 +147,39 @@ describe('Slider', () => {
   it('does not call onChange or onChanged with range when ranged is false', () => {
     const onChange = jest.fn();
     const onChanged = jest.fn();
-    wrapper = mount(<Slider onChange={onChange} onChanged={onChanged} defaultValue={5} />);
+    const { container } = render(<Slider onChange={onChange} onChanged={onChanged} defaultValue={5} />);
 
-    const sliderLine = wrapper.find('.ms-Slider-line');
-    const sliderThumb = wrapper.find('.ms-Slider-slideBox');
+    const sliderLine = container.getElementsByClassName('ms-Slider-line')[0];
+    const sliderThumb = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderLine.getDOMNode().getBoundingClientRect = () =>
+    sliderLine.getBoundingClientRect = () =>
       ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 0, clientY: 0 });
-
+    fireEvent.mouseDown(sliderThumb, { clientX: 0, clientY: 0 });
     expect(onChange.mock.calls[0][1]).toBeUndefined();
 
-    window.dispatchEvent(new Event('mouseup'));
+    fireEvent.mouseUp(sliderThumb);
     expect(onChanged.mock.calls[0][2]).toBeUndefined();
   });
 
   it('can slide to default min/max and execute onChange', () => {
     const onChange = jest.fn();
 
-    wrapper = mount(<Slider onChange={onChange} />);
+    const { container } = render(<Slider onChange={onChange} />);
 
-    const sliderLine = wrapper.find('.ms-Slider-line');
-    const sliderThumb = wrapper.find('.ms-Slider-slideBox');
+    const sliderLine = container.getElementsByClassName('ms-Slider-line')[0];
+    const sliderThumb = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderLine.getDOMNode().getBoundingClientRect = () =>
+    sliderLine.getBoundingClientRect = () =>
       ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 100, clientY: 0 });
+    fireEvent.mouseDown(sliderThumb, { clientX: 100, clientY: 0 });
 
     // Default max is 10.
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][0]).toEqual(10);
 
-    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 0, clientY: 0 });
+    fireEvent.mouseDown(sliderThumb, { clientX: 0, clientY: 0 });
 
     // Default min is 0.
     expect(onChange).toHaveBeenCalledTimes(2);
@@ -199,15 +189,15 @@ describe('Slider', () => {
   it('updates the upper value thumb when click to the right side of it', () => {
     const onChange = jest.fn();
 
-    wrapper = mount(<Slider onChange={onChange} ranged defaultValue={5} />);
+    const { container } = render(<Slider onChange={onChange} ranged defaultValue={5} />);
 
-    const sliderLine = wrapper.find('.ms-Slider-line');
-    const sliderThumb = wrapper.find('.ms-Slider-slideBox');
+    const sliderLine = container.getElementsByClassName('ms-Slider-line')[0];
+    const sliderThumb = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderLine.getDOMNode().getBoundingClientRect = () =>
+    sliderLine.getBoundingClientRect = () =>
       ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 80, clientY: 0 });
+    fireEvent.mouseDown(sliderThumb, { clientX: 80, clientY: 0 });
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][1]).toEqual([0, 8]);
@@ -216,15 +206,15 @@ describe('Slider', () => {
   it('updates the upper value thumb when click close to it', () => {
     const onChange = jest.fn();
 
-    wrapper = mount(<Slider onChange={onChange} ranged defaultValue={5} />);
+    const { container } = render(<Slider onChange={onChange} ranged defaultValue={5} />);
 
-    const sliderLine = wrapper.find('.ms-Slider-line');
-    const sliderThumb = wrapper.find('.ms-Slider-slideBox');
+    const sliderLine = container.getElementsByClassName('ms-Slider-line')[0];
+    const sliderThumb = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderLine.getDOMNode().getBoundingClientRect = () =>
+    sliderLine.getBoundingClientRect = () =>
       ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 40, clientY: 0 });
+    fireEvent.mouseDown(sliderThumb, { clientX: 40, clientY: 0 });
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][1]).toEqual([0, 4]);
@@ -234,21 +224,21 @@ describe('Slider', () => {
     const onChange = jest.fn();
     const onChanged = jest.fn();
 
-    wrapper = mount(<Slider onChange={onChange} onChanged={onChanged} ranged defaultValue={5} />);
+    const { container } = render(<Slider onChange={onChange} onChanged={onChanged} ranged defaultValue={5} />);
 
-    const sliderLine = wrapper.find('.ms-Slider-line');
-    const sliderThumb = wrapper.find('.ms-Slider-slideBox');
+    const sliderLine = container.getElementsByClassName('ms-Slider-line')[0];
+    const sliderThumb = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderLine.getDOMNode().getBoundingClientRect = () =>
+    sliderLine.getBoundingClientRect = () =>
       ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 10, clientY: 0 });
+    fireEvent.mouseDown(sliderThumb, { clientX: 10, clientY: 0 });
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][1]).toEqual([1, 5]);
 
     // test onChanged here too, since the earlier tests don't cover the lower thumb
-    window.dispatchEvent(new Event('mouseup'));
+    fireEvent.mouseUp(sliderThumb);
     expect(onChanged).toHaveBeenCalledTimes(1);
     expect(onChanged.mock.calls[0][2]).toEqual([1, 5]);
   });
@@ -259,84 +249,74 @@ describe('Slider', () => {
       range = sliderRange;
     };
 
-    wrapper = mount(<Slider onChange={onChange} ranged defaultValue={5} />);
+    const { container } = render(<Slider onChange={onChange} ranged defaultValue={5} />);
 
-    const sliderLine = wrapper.find('.ms-Slider-line');
-    const sliderThumb = wrapper.find('.ms-Slider-slideBox');
+    const sliderLine = container.getElementsByClassName('ms-Slider-line')[0];
+    const sliderThumb = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderLine.getDOMNode().getBoundingClientRect = () =>
+    sliderLine.getBoundingClientRect = () =>
       ({ left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 } as DOMRect);
 
-    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 10, clientY: 0 });
-
-    sliderThumb.simulate('mousedown', { type: 'mousedown', clientX: 20, clientY: 0 });
+    fireEvent.mouseDown(sliderThumb, { clientX: 10, clientY: 0 });
+    fireEvent.mouseDown(sliderThumb, { clientX: 20, clientY: 0 });
 
     expect(range).toEqual([2, 5]);
   });
 
-  it('has type=button on all buttons', () => {
-    wrapper = mount(<Slider />);
-
-    wrapper.find('button').forEach(button => {
-      expect(button.prop('type')).toEqual('button');
-    });
-  });
-
   it('renders correct aria-valuetext', () => {
-    wrapper = mount(<Slider />);
+    const { getByRole, rerender } = render(<Slider value={0} />);
 
-    expect(wrapper.find('.ms-Slider-slideBox').prop('aria-valuetext')).toEqual('0');
+    expect(getByRole('slider').getAttribute('aria-valuetext')).toEqual('0');
 
     const values = ['small', 'medium', 'large'];
     const selected = 1;
     const getTextValue = (value: number) => values[value];
 
-    wrapper.unmount();
-    wrapper = mount(<Slider value={selected} ariaValueText={getTextValue} />);
+    rerender(<Slider value={selected} ariaValueText={getTextValue} />);
 
-    expect(wrapper.find('.ms-Slider-slideBox').prop('aria-valuetext')).toEqual(values[selected]);
+    expect(getByRole('slider').getAttribute('aria-valuetext')).toEqual(values[selected]);
   });
 
   it('renders correct aria properties for range slider', () => {
-    wrapper = mount(<Slider ranged defaultValue={5} aria-label={'range'} />);
+    const { getAllByRole } = render(<Slider ranged defaultValue={5} aria-label={'range'} />);
 
-    const lowerValueThumb = wrapper.find('.ms-Slider-thumb').at(0);
+    const lowerValueThumb = getAllByRole('slider')[0];
 
-    expect(lowerValueThumb.prop('aria-valuemax')).toEqual(5);
-    expect(lowerValueThumb.prop('aria-valuemin')).toEqual(0);
-    expect(lowerValueThumb.prop('aria-valuenow')).toEqual(0);
-    expect(lowerValueThumb.prop('aria-label')).toEqual(`${MIN_PREFIX} range`);
+    expect(lowerValueThumb.getAttribute('aria-valuemax')).toEqual('5');
+    expect(lowerValueThumb.getAttribute('aria-valuemin')).toEqual('0');
+    expect(lowerValueThumb.getAttribute('aria-valuenow')).toEqual('0');
+    expect(lowerValueThumb.getAttribute('aria-label')).toEqual(`${MIN_PREFIX} range`);
 
-    const upperValueThumb = wrapper.find('.ms-Slider-thumb').at(1);
+    const upperValueThumb = getAllByRole('slider')[1];
 
-    expect(upperValueThumb.prop('aria-valuemax')).toEqual(10);
-    expect(upperValueThumb.prop('aria-valuemin')).toEqual(0);
-    expect(upperValueThumb.prop('aria-valuenow')).toEqual(5);
-    expect(upperValueThumb.prop('aria-label')).toEqual(`${MAX_PREFIX} range`);
+    expect(upperValueThumb.getAttribute('aria-valuemax')).toEqual('10');
+    expect(upperValueThumb.getAttribute('aria-valuemin')).toEqual('0');
+    expect(upperValueThumb.getAttribute('aria-valuenow')).toEqual('5');
+    expect(upperValueThumb.getAttribute('aria-label')).toEqual(`${MAX_PREFIX} range`);
   });
 
   it('formats the value when a format function is passed', () => {
     const value = 10;
     const valueFormat = (val: number) => `${val}%`;
-    wrapper = mount(<Slider value={value} min={0} max={100} showValue={true} valueFormat={valueFormat} />);
+    const { container } = render(<Slider value={value} min={0} max={100} showValue={true} valueFormat={valueFormat} />);
 
-    expect(wrapper.find('label.ms-Label.ms-Slider-value').text()).toEqual(valueFormat(value));
+    expect(container.getElementsByClassName('ms-Slider-value')[0].textContent).toEqual(valueFormat(value));
   });
 
   it('updates value correctly when down and up are pressed', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    wrapper = mount(
+    const { container } = render(
       <Slider label="slider" componentRef={slider} defaultValue={12} min={0} max={100} onChange={onChange} ranged />,
     );
-    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
+    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.down });
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.down });
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.down });
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.up });
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
 
     expect(slider.current?.value).toEqual(9);
 
@@ -347,16 +327,16 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    wrapper = mount(
+    const { getAllByRole } = render(
       <Slider label="slider" componentRef={slider} defaultValue={20} min={12} max={100} onChange={onChange} ranged />,
     );
-    const lowerValueThumb = wrapper.find('.ms-Slider-thumb').at(0);
+    const lowerValueThumb = getAllByRole('slider')[0];
 
-    lowerValueThumb.simulate('keydown', { which: KeyCodes.down });
-    lowerValueThumb.simulate('keydown', { which: KeyCodes.down });
-    lowerValueThumb.simulate('keydown', { which: KeyCodes.down });
-    lowerValueThumb.simulate('keydown', { which: KeyCodes.up });
-    lowerValueThumb.simulate('keydown', { which: KeyCodes.down });
+    fireEvent.keyDown(lowerValueThumb, { keyCode: KeyCodes.down });
+    fireEvent.keyDown(lowerValueThumb, { keyCode: KeyCodes.down });
+    fireEvent.keyDown(lowerValueThumb, { keyCode: KeyCodes.down });
+    fireEvent.keyDown(lowerValueThumb, { keyCode: KeyCodes.up });
+    fireEvent.keyDown(lowerValueThumb, { keyCode: KeyCodes.down });
 
     expect(slider.current?.value).toEqual(17);
 
@@ -367,17 +347,14 @@ describe('Slider', () => {
     jest.useFakeTimers();
     const onChanged = jest.fn();
 
-    const container = document.createElement('div');
-    document.body.appendChild(container);
+    const { container } = render(<Slider label="slider" defaultValue={12} min={0} max={100} onChanged={onChanged} />);
+    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    ReactDOM.render(<Slider label="slider" defaultValue={12} min={0} max={100} onChanged={onChanged} />, container);
-    const sliderSlideBox = container.querySelector('.ms-Slider-slideBox') as HTMLElement;
-
-    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
-    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
-    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
-    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.up });
-    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
 
     expect(sliderSlideBox.getAttribute('aria-valuenow')).toEqual('9');
 
@@ -391,17 +368,14 @@ describe('Slider', () => {
     jest.useFakeTimers();
     const onChanged = jest.fn();
 
-    const container = document.createElement('div');
-    document.body.appendChild(container);
+    const { container } = render(<Slider label="slider" defaultValue={5} min={0} max={100} onChanged={onChanged} />);
+    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    ReactDOM.render(<Slider label="slider" defaultValue={5} min={0} max={100} onChanged={onChanged} />, container);
-    const sliderSlideBox = container.querySelector('.ms-Slider-slideBox') as HTMLElement;
-
-    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
-    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
-    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
-    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.up });
-    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
 
     // onChanged should only be called after a delay
     expect(onChanged).toHaveBeenCalledTimes(0);
@@ -414,10 +388,12 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    wrapper = mount(<Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} />);
-    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
+    const { container } = render(
+      <Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} />,
+    );
+    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
 
     expect(slider.current?.value).toEqual(3);
 
@@ -428,10 +404,12 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    wrapper = mount(<Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} />);
-    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
+    const { container } = render(
+      <Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} />,
+    );
+    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
 
     expect(slider.current?.value).toEqual(3);
 
@@ -443,12 +421,12 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    wrapper = mount(
+    const { container } = render(
       <Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} ranged />,
     );
-    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
+    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.down });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.down });
 
     expect(slider.current?.range).toEqual([0, 3]);
 
@@ -460,12 +438,14 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    wrapper = mount(<Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} />);
-    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
+    const { container } = render(
+      <Slider label="slider" componentRef={slider} value={3} min={0} max={100} onChange={onChange} />,
+    );
+    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.up });
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.up });
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.up });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
 
     expect(slider.current?.value).toEqual(3);
 
@@ -477,23 +457,22 @@ describe('Slider', () => {
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
 
-    wrapper = mount(
+    const { container } = render(
       <Slider label="slider" defaultValue={10} componentRef={slider} step={-3} min={0} max={100} onChange={onChange} />,
     );
-    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
+    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.up });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
     expect(slider.current?.value).toEqual(7);
   });
 
   it('correctly changes value with decimal steps', () => {
-    const container = document.createElement('div');
     const slider = React.createRef<ISlider>();
     const onChange = jest.fn();
     const step = 0.0000001;
     const defaultValue = 10;
 
-    wrapper = mount(
+    const { container } = render(
       <Slider
         label="slider"
         defaultValue={defaultValue}
@@ -504,10 +483,9 @@ describe('Slider', () => {
         onChange={onChange}
       />,
     );
-    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
+    const sliderSlideBox = container.getElementsByClassName('ms-Slider-slideBox')[0];
 
-    sliderSlideBox.simulate('keydown', { which: KeyCodes.up });
+    fireEvent.keyDown(sliderSlideBox, { keyCode: KeyCodes.up });
     expect(slider.current?.value).toEqual(defaultValue + step);
-    ReactDOM.unmountComponentAtNode(container);
   });
 });

--- a/packages/react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -1,262 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Slider renders correctly 1`] = `
-<div
-  className=
-      ms-Slider
-      ms-Slider-enabled
-      ms-Slider-row
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        user-select: none;
-      }
->
-  <label
-    className=
-        ms-Label
+<div>
+  <div
+    class=
+        ms-Slider
+        ms-Slider-enabled
+        ms-Slider-row
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 0px;
-          padding-left: 0px;
-          padding-right: 0px;
-          padding-top: 0px;
-          word-wrap: break-word;
-        }
-    htmlFor="Slider0"
-  >
-    I am a slider
-  </label>
-  <div
-    className=
-        ms-Slider-container
-        {
-          align-items: center;
-          display: flex;
-          flex-wrap: nowrap;
+          font-weight: 400;
+          user-select: none;
         }
   >
-    <div
-      aria-disabled={false}
-      aria-label="I am a slider"
-      aria-valuemax={10}
-      aria-valuemin={0}
-      aria-valuenow={0}
-      aria-valuetext="0"
-      className=
-          ms-Slider-slideBox
-          ms-Slider-showValue
-          ms-Slider-showTransitions
-          {
-            align-items: center;
-            background: transparent;
-            border: none;
-            display: flex;
-            flex-grow: 1;
-            height: 28px;
-            line-height: 28px;
-            outline: transparent;
-            padding-bottom: 0;
-            padding-left: 8px;
-            padding-right: 8px;
-            padding-top: 0;
-            position: relative;
-            width: auto;
-          }
-          &::-moz-focus-inner {
-            border: 0;
-          }
-          .ms-Fabric--isFocusVisible &:focus:after {
-            border: 1px solid #ffffff;
-            bottom: 1px;
-            content: "";
-            left: 1px;
-            outline: 1px solid #605e5c;
-            position: absolute;
-            right: 1px;
-            top: 1px;
-            z-index: 1;
-          }
-          &:active .ms-Slider-active {
-            background-color: #005a9e;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-active {
-            background-color: Highlight;
-          }
-          &:hover .ms-Slider-active {
-            background-color: #0078d4;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-active {
-            background-color: Highlight;
-          }
-          &:active .ms-Slider-inactive {
-            background-color: #deecf9;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-inactive {
-            border-color: Highlight;
-          }
-          &:hover .ms-Slider-inactive {
-            background-color: #deecf9;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-inactive {
-            border-color: Highlight;
-          }
-          &:active .ms-Slider-thumb {
-            border: 2px solid #005a9e;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-thumb {
-            border-color: Highlight;
-          }
-          &:hover .ms-Slider-thumb {
-            border: 2px solid #005a9e;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-thumb {
-            border-color: Highlight;
-          }
-          &:active .ms-Slider-zeroTick {
-            background-color: #deecf9;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-zeroTick {
-            background-color: Highlight;
-          }
-          &:hover .ms-Slider-zeroTick {
-            background-color: #deecf9;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
-            background-color: Highlight;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-            forced-color-adjust: none;
-          }
-      data-is-focusable={true}
-      id="Slider0"
-      onKeyDown={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
-      role="slider"
-      tabIndex={0}
-    >
-      <div
-        className=
-            ms-Slider-line
-            {
-              display: flex;
-              position: relative;
-              width: 100%;
-            }
-      >
-        <span
-          className=
-              ms-Slider-thumb
-              {
-                background: #ffffff;
-                border-color: #605e5c;
-                border-radius: 10px;
-                border-style: solid;
-                border-width: 2px;
-                box-sizing: border-box;
-                display: block;
-                height: 16px;
-                position: absolute;
-                top: -6px;
-                transform: translateX(-50%);
-                transition: left 0.367s cubic-bezier(.1,.9,.2,1);
-                width: 16px;
-              }
-          style={
-            Object {
-              "left": "0%",
-            }
-          }
-        />
-        <span
-          className=
-              ms-Slider-inactive
-              {
-                border-radius: 4px;
-                box-sizing: border-box;
-                height: 4px;
-                width: 100%;
-              }
-              {
-                background: #c8c6c4;
-                transition: width 0.367s cubic-bezier(.1,.9,.2,1);
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                border: 1px solid WindowText;
-              }
-          style={
-            Object {
-              "width": "0%",
-            }
-          }
-        />
-        <span
-          className=
-              ms-Slider-active
-              {
-                border-radius: 4px;
-                box-sizing: border-box;
-                height: 4px;
-                width: 100%;
-              }
-              {
-                background: #605e5c;
-                transition: width 0.367s cubic-bezier(.1,.9,.2,1);
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                background-color: WindowText;
-              }
-          style={
-            Object {
-              "width": "0%",
-            }
-          }
-        />
-        <span
-          className=
-              ms-Slider-inactive
-              {
-                border-radius: 4px;
-                box-sizing: border-box;
-                height: 4px;
-                width: 100%;
-              }
-              {
-                background: #c8c6c4;
-                transition: width 0.367s cubic-bezier(.1,.9,.2,1);
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                border: 1px solid WindowText;
-              }
-          style={
-            Object {
-              "width": "100%",
-            }
-          }
-        />
-      </div>
-    </div>
     <label
-      className=
+      class=
           ms-Label
-          ms-Slider-value
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
@@ -264,87 +26,271 @@ exports[`Slider renders correctly 1`] = `
             box-sizing: border-box;
             color: #323130;
             display: block;
-            flex-shrink: 1;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
-            line-height: 1;
-            margin-bottom: 0;
-            margin-left: 8px;
-            margin-right: 8px;
-            margin-top: 0;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
             overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            white-space: nowrap;
-            width: 40px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
             word-wrap: break-word;
           }
+      for="Slider0"
     >
-      0
+      I am a slider
     </label>
+    <div
+      class=
+          ms-Slider-container
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+          }
+    >
+      <div
+        aria-disabled="false"
+        aria-label="I am a slider"
+        aria-valuemax="10"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        aria-valuetext="0"
+        class=
+            ms-Slider-slideBox
+            ms-Slider-showValue
+            ms-Slider-showTransitions
+            {
+              align-items: center;
+              background: transparent;
+              border: none;
+              display: flex;
+              flex-grow: 1;
+              height: 28px;
+              line-height: 28px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              width: auto;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:active .ms-Slider-active {
+              background-color: #005a9e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-active {
+              background-color: Highlight;
+            }
+            &:hover .ms-Slider-active {
+              background-color: #0078d4;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-active {
+              background-color: Highlight;
+            }
+            &:active .ms-Slider-inactive {
+              background-color: #deecf9;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-inactive {
+              border-color: Highlight;
+            }
+            &:hover .ms-Slider-inactive {
+              background-color: #deecf9;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-inactive {
+              border-color: Highlight;
+            }
+            &:active .ms-Slider-thumb {
+              border: 2px solid #005a9e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-thumb {
+              border-color: Highlight;
+            }
+            &:hover .ms-Slider-thumb {
+              border: 2px solid #005a9e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-thumb {
+              border-color: Highlight;
+            }
+            &:active .ms-Slider-zeroTick {
+              background-color: #deecf9;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-zeroTick {
+              background-color: Highlight;
+            }
+            &:hover .ms-Slider-zeroTick {
+              background-color: #deecf9;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
+              background-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
+        data-is-focusable="true"
+        id="Slider0"
+        role="slider"
+        tabindex="0"
+      >
+        <div
+          class=
+              ms-Slider-line
+              {
+                display: flex;
+                position: relative;
+                width: 100%;
+              }
+        >
+          <span
+            class=
+                ms-Slider-thumb
+                {
+                  background: #ffffff;
+                  border-color: #605e5c;
+                  border-radius: 10px;
+                  border-style: solid;
+                  border-width: 2px;
+                  box-sizing: border-box;
+                  display: block;
+                  height: 16px;
+                  position: absolute;
+                  top: -6px;
+                  transform: translateX(-50%);
+                  transition: left 0.367s cubic-bezier(.1,.9,.2,1);
+                  width: 16px;
+                }
+            style="left: 0%;"
+          />
+          <span
+            class=
+                ms-Slider-inactive
+                {
+                  border-radius: 4px;
+                  box-sizing: border-box;
+                  height: 4px;
+                  width: 100%;
+                }
+                {
+                  background: #c8c6c4;
+                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border: 1px solid WindowText;
+                }
+            style="width: 0%;"
+          />
+          <span
+            class=
+                ms-Slider-active
+                {
+                  border-radius: 4px;
+                  box-sizing: border-box;
+                  height: 4px;
+                  width: 100%;
+                }
+                {
+                  background: #605e5c;
+                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  background-color: WindowText;
+                }
+            style="width: 0%;"
+          />
+          <span
+            class=
+                ms-Slider-inactive
+                {
+                  border-radius: 4px;
+                  box-sizing: border-box;
+                  height: 4px;
+                  width: 100%;
+                }
+                {
+                  background: #c8c6c4;
+                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border: 1px solid WindowText;
+                }
+            style="width: 100%;"
+          />
+        </div>
+      </div>
+      <label
+        class=
+            ms-Label
+            ms-Slider-value
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              flex-shrink: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              line-height: 1;
+              margin-bottom: 0;
+              margin-left: 8px;
+              margin-right: 8px;
+              margin-top: 0;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              white-space: nowrap;
+              width: 40px;
+              word-wrap: break-word;
+            }
+      >
+        0
+      </label>
+    </div>
   </div>
 </div>
 `;
 
 exports[`Slider renders range slider correctly 1`] = `
-<div
-  className=
-      ms-Slider
-      ms-Slider-enabled
-      ms-Slider-row
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        user-select: none;
-      }
->
-  <label
-    className=
-        ms-Label
+<div>
+  <div
+    class=
+        ms-Slider
+        ms-Slider-enabled
+        ms-Slider-row
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 0px;
-          padding-left: 0px;
-          padding-right: 0px;
-          padding-top: 0px;
-          word-wrap: break-word;
-        }
-    htmlFor="Slider0"
-  >
-    I am a ranged slider
-  </label>
-  <div
-    className=
-        ms-Slider-container
-        {
-          align-items: center;
-          display: flex;
-          flex-wrap: nowrap;
+          font-weight: 400;
+          user-select: none;
         }
   >
     <label
-      className=
+      class=
           ms-Label
-          ms-Slider-value
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
@@ -352,311 +298,325 @@ exports[`Slider renders range slider correctly 1`] = `
             box-sizing: border-box;
             color: #323130;
             display: block;
-            flex-shrink: 1;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 600;
-            line-height: 1;
-            margin-bottom: 0;
-            margin-left: 8px;
-            margin-right: 8px;
-            margin-top: 0;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
             overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            white-space: nowrap;
-            width: 40px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
             word-wrap: break-word;
           }
+      for="Slider0"
     >
-      0
+      I am a ranged slider
     </label>
     <div
-      className=
-          ms-Slider-slideBox
-          ms-Slider-showValue
-          ms-Slider-showTransitions
+      class=
+          ms-Slider-container
           {
             align-items: center;
-            background: transparent;
-            border: none;
             display: flex;
-            flex-grow: 1;
-            height: 28px;
-            line-height: 28px;
-            padding-bottom: 0;
-            padding-left: 8px;
-            padding-right: 8px;
-            padding-top: 0;
-            width: auto;
+            flex-wrap: nowrap;
           }
-          &:active .ms-Slider-active {
-            background-color: #005a9e;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-active {
-            background-color: Highlight;
-          }
-          &:hover .ms-Slider-active {
-            background-color: #0078d4;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-active {
-            background-color: Highlight;
-          }
-          &:active .ms-Slider-inactive {
-            background-color: #deecf9;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-inactive {
-            border-color: Highlight;
-          }
-          &:hover .ms-Slider-inactive {
-            background-color: #deecf9;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-inactive {
-            border-color: Highlight;
-          }
-          &:active .ms-Slider-thumb {
-            border: 2px solid #005a9e;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-thumb {
-            border-color: Highlight;
-          }
-          &:hover .ms-Slider-thumb {
-            border: 2px solid #005a9e;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-thumb {
-            border-color: Highlight;
-          }
-          &:active .ms-Slider-zeroTick {
-            background-color: #deecf9;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-zeroTick {
-            background-color: Highlight;
-          }
-          &:hover .ms-Slider-zeroTick {
-            background-color: #deecf9;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
-            background-color: Highlight;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-            forced-color-adjust: none;
-          }
-      id="Slider0"
-      onKeyDown={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
     >
-      <div
-        className=
-            ms-Slider-line
+      <label
+        class=
+            ms-Label
+            ms-Slider-value
             {
-              display: flex;
-              position: relative;
-              width: 100%;
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              flex-shrink: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              line-height: 1;
+              margin-bottom: 0;
+              margin-left: 8px;
+              margin-right: 8px;
+              margin-top: 0;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              white-space: nowrap;
+              width: 40px;
+              word-wrap: break-word;
             }
       >
-        <span
-          aria-disabled={false}
-          aria-label="min I am a ranged slider"
-          aria-valuemax={5}
-          aria-valuemin={0}
-          aria-valuenow={0}
-          aria-valuetext="0"
-          className=
-              ms-Slider-thumb
-              {
-                background: #ffffff;
-                border-color: #605e5c;
-                border-radius: 10px;
-                border-style: solid;
-                border-width: 2px;
-                box-sizing: border-box;
-                display: block;
-                height: 16px;
-                outline: transparent;
-                position: absolute;
-                top: -6px;
-                transform: translateX(-50%);
-                transition: left 0.367s cubic-bezier(.1,.9,.2,1);
-                width: 16px;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: -3px;
-                content: "";
-                left: -3px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: -3px;
-                top: -3px;
-                z-index: 1;
-              }
-          data-is-focusable={true}
-          id="min-Slider0"
-          onFocus={[Function]}
-          role="slider"
-          style={
-            Object {
-              "left": "0%",
+        0
+      </label>
+      <div
+        class=
+            ms-Slider-slideBox
+            ms-Slider-showValue
+            ms-Slider-showTransitions
+            {
+              align-items: center;
+              background: transparent;
+              border: none;
+              display: flex;
+              flex-grow: 1;
+              height: 28px;
+              line-height: 28px;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              width: auto;
             }
-          }
-          tabIndex={0}
-        />
-        <span
-          aria-disabled={false}
-          aria-label="max I am a ranged slider"
-          aria-valuemax={10}
-          aria-valuemin={0}
-          aria-valuenow={5}
-          aria-valuetext="5"
-          className=
-              ms-Slider-thumb
-              {
-                background: #ffffff;
-                border-color: #605e5c;
-                border-radius: 10px;
-                border-style: solid;
-                border-width: 2px;
-                box-sizing: border-box;
-                display: block;
-                height: 16px;
-                outline: transparent;
-                position: absolute;
-                top: -6px;
-                transform: translateX(-50%);
-                transition: left 0.367s cubic-bezier(.1,.9,.2,1);
-                width: 16px;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: -3px;
-                content: "";
-                left: -3px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: -3px;
-                top: -3px;
-                z-index: 1;
-              }
-          data-is-focusable={true}
-          id="max-Slider0"
-          onFocus={[Function]}
-          role="slider"
-          style={
-            Object {
-              "left": "50%",
+            &:active .ms-Slider-active {
+              background-color: #005a9e;
             }
-          }
-          tabIndex={0}
-        />
-        <span
-          className=
-              ms-Slider-inactive
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-active {
+              background-color: Highlight;
+            }
+            &:hover .ms-Slider-active {
+              background-color: #0078d4;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-active {
+              background-color: Highlight;
+            }
+            &:active .ms-Slider-inactive {
+              background-color: #deecf9;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-inactive {
+              border-color: Highlight;
+            }
+            &:hover .ms-Slider-inactive {
+              background-color: #deecf9;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-inactive {
+              border-color: Highlight;
+            }
+            &:active .ms-Slider-thumb {
+              border: 2px solid #005a9e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-thumb {
+              border-color: Highlight;
+            }
+            &:hover .ms-Slider-thumb {
+              border: 2px solid #005a9e;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-thumb {
+              border-color: Highlight;
+            }
+            &:active .ms-Slider-zeroTick {
+              background-color: #deecf9;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-zeroTick {
+              background-color: Highlight;
+            }
+            &:hover .ms-Slider-zeroTick {
+              background-color: #deecf9;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-zeroTick {
+              background-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
+        id="Slider0"
+      >
+        <div
+          class=
+              ms-Slider-line
               {
-                border-radius: 4px;
-                box-sizing: border-box;
-                height: 4px;
+                display: flex;
+                position: relative;
                 width: 100%;
               }
-              {
-                background: #c8c6c4;
-                transition: width 0.367s cubic-bezier(.1,.9,.2,1);
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                border: 1px solid WindowText;
-              }
-          style={
-            Object {
-              "width": "0%",
-            }
-          }
-        />
-        <span
-          className=
-              ms-Slider-active
-              {
-                border-radius: 4px;
-                box-sizing: border-box;
-                height: 4px;
-                width: 100%;
-              }
-              {
-                background: #605e5c;
-                transition: width 0.367s cubic-bezier(.1,.9,.2,1);
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                background-color: WindowText;
-              }
-          style={
-            Object {
-              "width": "50%",
-            }
-          }
-        />
-        <span
-          className=
-              ms-Slider-inactive
-              {
-                border-radius: 4px;
-                box-sizing: border-box;
-                height: 4px;
-                width: 100%;
-              }
-              {
-                background: #c8c6c4;
-                transition: width 0.367s cubic-bezier(.1,.9,.2,1);
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                border: 1px solid WindowText;
-              }
-          style={
-            Object {
-              "width": "50%",
-            }
-          }
-        />
+        >
+          <span
+            aria-disabled="false"
+            aria-label="min I am a ranged slider"
+            aria-valuemax="5"
+            aria-valuemin="0"
+            aria-valuenow="0"
+            aria-valuetext="0"
+            class=
+                ms-Slider-thumb
+                {
+                  background: #ffffff;
+                  border-color: #605e5c;
+                  border-radius: 10px;
+                  border-style: solid;
+                  border-width: 2px;
+                  box-sizing: border-box;
+                  display: block;
+                  height: 16px;
+                  outline: transparent;
+                  position: absolute;
+                  top: -6px;
+                  transform: translateX(-50%);
+                  transition: left 0.367s cubic-bezier(.1,.9,.2,1);
+                  width: 16px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: -3px;
+                  content: "";
+                  left: -3px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: -3px;
+                  top: -3px;
+                  z-index: 1;
+                }
+            data-is-focusable="true"
+            id="min-Slider0"
+            role="slider"
+            style="left: 0%;"
+            tabindex="0"
+          />
+          <span
+            aria-disabled="false"
+            aria-label="max I am a ranged slider"
+            aria-valuemax="10"
+            aria-valuemin="0"
+            aria-valuenow="5"
+            aria-valuetext="5"
+            class=
+                ms-Slider-thumb
+                {
+                  background: #ffffff;
+                  border-color: #605e5c;
+                  border-radius: 10px;
+                  border-style: solid;
+                  border-width: 2px;
+                  box-sizing: border-box;
+                  display: block;
+                  height: 16px;
+                  outline: transparent;
+                  position: absolute;
+                  top: -6px;
+                  transform: translateX(-50%);
+                  transition: left 0.367s cubic-bezier(.1,.9,.2,1);
+                  width: 16px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: -3px;
+                  content: "";
+                  left: -3px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: -3px;
+                  top: -3px;
+                  z-index: 1;
+                }
+            data-is-focusable="true"
+            id="max-Slider0"
+            role="slider"
+            style="left: 50%;"
+            tabindex="0"
+          />
+          <span
+            class=
+                ms-Slider-inactive
+                {
+                  border-radius: 4px;
+                  box-sizing: border-box;
+                  height: 4px;
+                  width: 100%;
+                }
+                {
+                  background: #c8c6c4;
+                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border: 1px solid WindowText;
+                }
+            style="width: 0%;"
+          />
+          <span
+            class=
+                ms-Slider-active
+                {
+                  border-radius: 4px;
+                  box-sizing: border-box;
+                  height: 4px;
+                  width: 100%;
+                }
+                {
+                  background: #605e5c;
+                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  background-color: WindowText;
+                }
+            style="width: 50%;"
+          />
+          <span
+            class=
+                ms-Slider-inactive
+                {
+                  border-radius: 4px;
+                  box-sizing: border-box;
+                  height: 4px;
+                  width: 100%;
+                }
+                {
+                  background: #c8c6c4;
+                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                  border: 1px solid WindowText;
+                }
+            style="width: 50%;"
+          />
+        </div>
       </div>
+      <label
+        class=
+            ms-Label
+            ms-Slider-value
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: block;
+              flex-shrink: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              line-height: 1;
+              margin-bottom: 0;
+              margin-left: 8px;
+              margin-right: 8px;
+              margin-top: 0;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              white-space: nowrap;
+              width: 40px;
+              word-wrap: break-word;
+            }
+      >
+        5
+      </label>
     </div>
-    <label
-      className=
-          ms-Label
-          ms-Slider-value
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #323130;
-            display: block;
-            flex-shrink: 1;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 600;
-            line-height: 1;
-            margin-bottom: 0;
-            margin-left: 8px;
-            margin-right: 8px;
-            margin-top: 0;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            white-space: nowrap;
-            width: 40px;
-            word-wrap: break-word;
-          }
-    >
-      5
-    </label>
   </div>
 </div>
 `;


### PR DESCRIPTION

## Current Behavior

- v8 `Slider` tests don't use testing-library

## New Behavior

- Convert Slider to fully use testing-library
## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

part of #21663 