### PR TITLE
refactor: PopoverSurface should be rendered from the Popover component

### DIFF
--- a/change/@fluentui-react-popover-449d9645-0e53-43c9-9a91-0ce5bc4e5fd1.json
+++ b/change/@fluentui-react-popover-449d9645-0e53-43c9-9a91-0ce5bc4e5fd1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "refactor: PopoverSurface should be rendered from the Popover component",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-popover/etc/react-popover.api.md
+++ b/packages/react-popover/etc/react-popover.api.md
@@ -37,7 +37,7 @@ export const Popover: React_2.FC<PopoverProps>;
 export const PopoverContext: Context<PopoverContextValue>;
 
 // @public
-export type PopoverContextValue = Pick<PopoverState, 'open' | 'setOpen' | 'triggerRef' | 'contentRef' | 'openOnHover' | 'openOnContext' | 'mountNode' | 'noArrow' | 'arrowRef' | 'size' | 'appearance' | 'trapFocus'>;
+export type PopoverContextValue = Pick<PopoverState, 'setOpen' | 'triggerRef' | 'contentRef' | 'openOnHover' | 'openOnContext' | 'mountNode' | 'noArrow' | 'arrowRef' | 'size' | 'appearance' | 'trapFocus'>;
 
 // Warning: (ae-forgotten-export) The symbol "PopoverCommons" needs to be exported by the entry point index.d.ts
 //
@@ -58,6 +58,8 @@ export type PopoverState = PopoverCommons & Pick<PopoverProps, 'children'> & {
     contextTarget: PopperVirtualElement | undefined;
     setContextTarget: ReturnType<typeof usePopperMouseTarget>[1];
     size: NonNullable<PopoverProps['size']>;
+    popoverTrigger: React_2.ReactElement | undefined;
+    popoverSurface: React_2.ReactElement | undefined;
 };
 
 // @public
@@ -75,7 +77,7 @@ export type PopoverSurfaceSlots = {
 };
 
 // @public
-export type PopoverSurfaceState = ComponentState<PopoverSurfaceSlots> & Pick<PopoverContextValue, 'open' | 'mountNode' | 'noArrow' | 'size' | 'appearance' | 'arrowRef'> & {
+export type PopoverSurfaceState = ComponentState<PopoverSurfaceSlots> & Pick<PopoverContextValue, 'mountNode' | 'noArrow' | 'size' | 'appearance' | 'arrowRef'> & {
     arrowClassName?: string;
 };
 
@@ -103,7 +105,7 @@ export type PopoverTriggerState = {
 export const renderPopover_unstable: (state: PopoverState) => JSX.Element;
 
 // @public
-export const renderPopoverSurface_unstable: (state: PopoverSurfaceState) => JSX.Element | null;
+export const renderPopoverSurface_unstable: (state: PopoverSurfaceState) => JSX.Element;
 
 // @public
 export const renderPopoverTrigger_unstable: (state: PopoverTriggerState) => ReactElement<any, string | JSXElementConstructor<any>> | null;

--- a/packages/react-popover/etc/react-popover.api.md
+++ b/packages/react-popover/etc/react-popover.api.md
@@ -37,7 +37,7 @@ export const Popover: React_2.FC<PopoverProps>;
 export const PopoverContext: Context<PopoverContextValue>;
 
 // @public
-export type PopoverContextValue = Pick<PopoverState, 'setOpen' | 'triggerRef' | 'contentRef' | 'openOnHover' | 'openOnContext' | 'mountNode' | 'noArrow' | 'arrowRef' | 'size' | 'appearance' | 'trapFocus'>;
+export type PopoverContextValue = Pick<PopoverState, 'toggleOpen' | 'setOpen' | 'triggerRef' | 'contentRef' | 'openOnHover' | 'openOnContext' | 'mountNode' | 'noArrow' | 'arrowRef' | 'size' | 'appearance' | 'trapFocus'>;
 
 // Warning: (ae-forgotten-export) The symbol "PopoverCommons" needs to be exported by the entry point index.d.ts
 //
@@ -52,6 +52,7 @@ export type PopoverSize = 'small' | 'medium' | 'large';
 // @public
 export type PopoverState = PopoverCommons & Pick<PopoverProps, 'children'> & {
     setOpen: (e: OpenPopoverEvents, open: boolean) => void;
+    toggleOpen: (e: OpenPopoverEvents) => void;
     triggerRef: React_2.MutableRefObject<HTMLElement | null>;
     contentRef: React_2.MutableRefObject<HTMLElement | null>;
     arrowRef: React_2.MutableRefObject<HTMLDivElement | null>;

--- a/packages/react-popover/src/common/mockUsePopoverContext.ts
+++ b/packages/react-popover/src/common/mockUsePopoverContext.ts
@@ -8,7 +8,6 @@ import type { PopoverContextValue } from '../popoverContext';
  */
 export const mockPopoverContext = (options: Partial<PopoverContextValue> = {}) => {
   const mockContext: PopoverContextValue = {
-    open: false,
     setOpen: () => null,
     triggerRef: { current: null },
     contentRef: { current: null },

--- a/packages/react-popover/src/common/mockUsePopoverContext.ts
+++ b/packages/react-popover/src/common/mockUsePopoverContext.ts
@@ -9,6 +9,7 @@ import type { PopoverContextValue } from '../popoverContext';
 export const mockPopoverContext = (options: Partial<PopoverContextValue> = {}) => {
   const mockContext: PopoverContextValue = {
     setOpen: () => null,
+    toggleOpen: () => null,
     triggerRef: { current: null },
     contentRef: { current: null },
     arrowRef: { current: null },

--- a/packages/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-popover/src/components/Popover/Popover.types.ts
@@ -77,6 +77,10 @@ export type PopoverState = PopoverCommons &
      */
     setOpen: (e: OpenPopoverEvents, open: boolean) => void;
     /**
+     * Callback to toggle the open state of the Popover
+     */
+    toggleOpen: (e: OpenPopoverEvents) => void;
+    /**
      * Ref of the PopoverTrigger
      */
     triggerRef: React.MutableRefObject<HTMLElement | null>;

--- a/packages/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-popover/src/components/Popover/Popover.types.ts
@@ -98,6 +98,10 @@ export type PopoverState = PopoverCommons &
     setContextTarget: ReturnType<typeof usePopperMouseTarget>[1];
 
     size: NonNullable<PopoverProps['size']>;
+
+    popoverTrigger: React.ReactElement | undefined;
+
+    popoverSurface: React.ReactElement | undefined;
   };
 
 /**

--- a/packages/react-popover/src/components/Popover/renderPopover.tsx
+++ b/packages/react-popover/src/components/Popover/renderPopover.tsx
@@ -7,7 +7,6 @@ import type { PopoverState } from './Popover.types';
  */
 export const renderPopover_unstable = (state: PopoverState) => {
   const {
-    open,
     setOpen,
     triggerRef,
     contentRef,
@@ -24,7 +23,6 @@ export const renderPopover_unstable = (state: PopoverState) => {
   return (
     <PopoverContext.Provider
       value={{
-        open,
         setOpen,
         triggerRef,
         contentRef,
@@ -38,7 +36,8 @@ export const renderPopover_unstable = (state: PopoverState) => {
         trapFocus,
       }}
     >
-      {state.children}
+      {state.popoverTrigger}
+      {state.open && state.popoverSurface}
     </PopoverContext.Provider>
   );
 };

--- a/packages/react-popover/src/components/Popover/renderPopover.tsx
+++ b/packages/react-popover/src/components/Popover/renderPopover.tsx
@@ -8,6 +8,7 @@ import type { PopoverState } from './Popover.types';
 export const renderPopover_unstable = (state: PopoverState) => {
   const {
     setOpen,
+    toggleOpen,
     triggerRef,
     contentRef,
     openOnContext,
@@ -24,6 +25,7 @@ export const renderPopover_unstable = (state: PopoverState) => {
     <PopoverContext.Provider
       value={{
         setOpen,
+        toggleOpen,
         triggerRef,
         contentRef,
         openOnHover,

--- a/packages/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-popover/src/components/Popover/usePopover.ts
@@ -58,6 +58,13 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
   }
 
   const [open, setOpen] = useOpenState(initialState);
+  const toggleOpen = React.useCallback<PopoverState['toggleOpen']>(
+    e => {
+      setOpen(e, !open);
+    },
+    [setOpen, open],
+  );
+
   const popperRefs = usePopoverRefs(initialState);
 
   const { targetDocument } = useFluent();
@@ -92,6 +99,7 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
     popoverSurface,
     open,
     setOpen,
+    toggleOpen,
     setContextTarget,
     contextTarget,
   };

--- a/packages/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-popover/src/components/Popover/usePopover.ts
@@ -39,12 +39,12 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
   if (process.env.NODE_ENV !== 'production') {
     if (children.length === 0) {
       // eslint-disable-next-line no-console
-      console.warn('Menu must contain at least one child');
+      console.warn('Popover must contain at least one child');
     }
 
     if (children.length > 2) {
       // eslint-disable-next-line no-console
-      console.warn('Menu must contain at most two children');
+      console.warn('Popover must contain at most two children');
     }
   }
 

--- a/packages/react-popover/src/components/PopoverSurface/PopoverSurface.test.tsx
+++ b/packages/react-popover/src/components/PopoverSurface/PopoverSurface.test.tsx
@@ -19,7 +19,7 @@ describe('PopoverSurface', () => {
 
   beforeEach(() => {
     resetIdsForTests();
-    mockPopoverContext({ open: true });
+    mockPopoverContext({});
   });
 
   // PopoverSurface is rendered by a Portal so won't be available in the rendered container
@@ -53,18 +53,9 @@ describe('PopoverSurface', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  it('should not render when open is false', () => {
-    // Arrange
-    mockPopoverContext({ open: false });
-    const { queryByTestId } = render(<PopoverSurface data-testid={testid}>Content</PopoverSurface>);
-
-    // Assert
-    expect(queryByTestId(testid)).toBeNull();
-  });
-
   it('should set aria-modal true if focus trap is active', () => {
     // Arrange
-    mockPopoverContext({ open: true, trapFocus: true });
+    mockPopoverContext({ trapFocus: true });
     const { getByTestId } = render(<PopoverSurface data-testid={testid}>Content</PopoverSurface>);
 
     // Assert
@@ -73,7 +64,7 @@ describe('PopoverSurface', () => {
 
   it('should set role dialog if focus trap is active', () => {
     // Arrange
-    mockPopoverContext({ open: true, trapFocus: true });
+    mockPopoverContext({ trapFocus: true });
     const { queryByRole } = render(<PopoverSurface data-testid={testid}>Content</PopoverSurface>);
 
     // Assert
@@ -82,7 +73,7 @@ describe('PopoverSurface', () => {
 
   it('should set role complementary if focus trap is not active', () => {
     // Arrange
-    mockPopoverContext({ open: true, trapFocus: false });
+    mockPopoverContext({ trapFocus: false });
     const { getByTestId } = render(<PopoverSurface data-testid={testid}>Content</PopoverSurface>);
 
     // Assert

--- a/packages/react-popover/src/components/PopoverSurface/PopoverSurface.types.ts
+++ b/packages/react-popover/src/components/PopoverSurface/PopoverSurface.types.ts
@@ -17,7 +17,7 @@ export type PopoverSurfaceSlots = {
  * PopoverSurface State
  */
 export type PopoverSurfaceState = ComponentState<PopoverSurfaceSlots> &
-  Pick<PopoverContextValue, 'open' | 'mountNode' | 'noArrow' | 'size' | 'appearance' | 'arrowRef'> & {
+  Pick<PopoverContextValue, 'mountNode' | 'noArrow' | 'size' | 'appearance' | 'arrowRef'> & {
     /**
      * CSS class for the arrow element
      */

--- a/packages/react-popover/src/components/PopoverSurface/renderPopoverSurface.tsx
+++ b/packages/react-popover/src/components/PopoverSurface/renderPopoverSurface.tsx
@@ -9,11 +9,6 @@ import type { PopoverSurfaceSlots, PopoverSurfaceState } from './PopoverSurface.
 export const renderPopoverSurface_unstable = (state: PopoverSurfaceState) => {
   const { slots, slotProps } = getSlots<PopoverSurfaceSlots>(state);
 
-  // TODO should hidden Popovers be supported ?
-  if (!state.open) {
-    return null;
-  }
-
   return (
     <Portal mountNode={state.mountNode}>
       <slots.root {...slotProps.root}>

--- a/packages/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { getNativeElementProps, useMergedRefs } from '@fluentui/react-utilities';
-import { useFocusFinders, useModalAttributes } from '@fluentui/react-tabster';
+import { useModalAttributes } from '@fluentui/react-tabster';
 import { usePopoverContext_unstable } from '../../popoverContext';
 import type { PopoverSurfaceProps, PopoverSurfaceState } from './PopoverSurface.types';
 
@@ -18,7 +18,6 @@ export const usePopoverSurface_unstable = (
   ref: React.Ref<HTMLDivElement>,
 ): PopoverSurfaceState => {
   const contentRef = usePopoverContext_unstable(context => context.contentRef);
-  const open = usePopoverContext_unstable(context => context.open);
   const openOnHover = usePopoverContext_unstable(context => context.openOnHover);
   const setOpen = usePopoverContext_unstable(context => context.setOpen);
   const mountNode = usePopoverContext_unstable(context => context.mountNode);
@@ -34,7 +33,6 @@ export const usePopoverSurface_unstable = (
     noArrow,
     size,
     arrowRef,
-    open,
     mountNode,
     components: {
       root: 'div',
@@ -79,13 +77,5 @@ export const usePopoverSurface_unstable = (
     onKeyDownOriginal?.(e);
   };
 
-  const { findFirstFocusable } = useFocusFinders();
-
-  React.useEffect(() => {
-    if (state.open && contentRef.current) {
-      const firstFocusable = findFirstFocusable(contentRef.current);
-      firstFocusable?.focus();
-    }
-  }, [contentRef, findFirstFocusable, state.open]);
   return state;
 };

--- a/packages/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
+++ b/packages/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
@@ -24,6 +24,7 @@ export const usePopoverTrigger_unstable = (props: PopoverTriggerProps): PopoverT
   const child = React.isValidElement(children) ? getTriggerChild(children) : undefined;
 
   const setOpen = usePopoverContext_unstable(context => context.setOpen);
+  const toggleOpen = usePopoverContext_unstable(context => context.toggleOpen);
   const triggerRef = usePopoverContext_unstable(context => context.triggerRef);
   const openOnHover = usePopoverContext_unstable(context => context.openOnHover);
   const openOnContext = usePopoverContext_unstable(context => context.openOnContext);
@@ -39,7 +40,7 @@ export const usePopoverTrigger_unstable = (props: PopoverTriggerProps): PopoverT
 
   const onClick = (e: React.MouseEvent<HTMLElement>) => {
     if (!openOnContext) {
-      setOpen(e, !open);
+      toggleOpen(e);
     }
   };
 

--- a/packages/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
+++ b/packages/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
@@ -24,7 +24,6 @@ export const usePopoverTrigger_unstable = (props: PopoverTriggerProps): PopoverT
   const child = React.isValidElement(children) ? getTriggerChild(children) : undefined;
 
   const setOpen = usePopoverContext_unstable(context => context.setOpen);
-  const open = usePopoverContext_unstable(context => context.open);
   const triggerRef = usePopoverContext_unstable(context => context.triggerRef);
   const openOnHover = usePopoverContext_unstable(context => context.openOnHover);
   const openOnContext = usePopoverContext_unstable(context => context.openOnContext);

--- a/packages/react-popover/src/popoverContext.ts
+++ b/packages/react-popover/src/popoverContext.ts
@@ -3,7 +3,6 @@ import type { ContextSelector, Context } from '@fluentui/react-context-selector'
 import type { PopoverState } from './components/Popover/index';
 
 export const PopoverContext: Context<PopoverContextValue> = createContext<PopoverContextValue>({
-  open: false,
   setOpen: () => null,
   triggerRef: { current: null },
   contentRef: { current: null },
@@ -19,7 +18,6 @@ export const PopoverContext: Context<PopoverContextValue> = createContext<Popove
  */
 export type PopoverContextValue = Pick<
   PopoverState,
-  | 'open'
   | 'setOpen'
   | 'triggerRef'
   | 'contentRef'

--- a/packages/react-popover/src/popoverContext.ts
+++ b/packages/react-popover/src/popoverContext.ts
@@ -4,6 +4,7 @@ import type { PopoverState } from './components/Popover/index';
 
 export const PopoverContext: Context<PopoverContextValue> = createContext<PopoverContextValue>({
   setOpen: () => null,
+  toggleOpen: () => null,
   triggerRef: { current: null },
   contentRef: { current: null },
   arrowRef: { current: null },
@@ -18,6 +19,7 @@ export const PopoverContext: Context<PopoverContextValue> = createContext<Popove
  */
 export type PopoverContextValue = Pick<
   PopoverState,
+  | 'toggleOpen'
   | 'setOpen'
   | 'triggerRef'
   | 'contentRef'


### PR DESCRIPTION
Refactor `Popover` to render  `PopoverSurface` based on the `open` value similar to `Menu`. This is due to a limitation with context-selectors: dai-shi/use-context-selector#69

## Current Behavior

It's not possible to get a ref for `PopoverSurface` or any content within `PopoverSurface` in an effect.

## New Behavior

It's possible to get a ref for `PopoverSurface` or any content within `PopoverSurface` in an effect.

Adds a new `toggleOpen` callback to context to avoid drilling down `open` value.
