### PR TITLE
Pickers: Spinner has aria label properly applied

### DIFF
--- a/change/@fluentui-react-1e10d5c9-bb3c-4095-b830-fc297028d7e6.json
+++ b/change/@fluentui-react-1e10d5c9-bb3c-4095-b830-fc297028d7e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "picker spinners have aria label properly applied",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -196,7 +196,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
             {forceResolveText}
           </CommandButton>
         )}
-        {isLoading && <Spinner {...spinnerClassNameOrStyles} label={loadingText} />}
+        {isLoading && <Spinner {...spinnerClassNameOrStyles} ariaLabel={loadingText} label={loadingText} />}
         {hasNoSuggestions ? noResults() : this._renderSuggestions()}
         {searchForMoreText && moreSuggestionsAvailable && (
           <CommandButton
@@ -211,7 +211,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
             {searchForMoreText}
           </CommandButton>
         )}
-        {isSearching ? <Spinner {...spinnerClassNameOrStyles} label={searchingText} /> : null}
+        {isSearching ? <Spinner {...spinnerClassNameOrStyles} ariaLabel={searchingText} label={searchingText} /> : null}
         {footerTitle && !moreSuggestionsAvailable && !isMostRecentlyUsedVisible && !isSearching ? (
           <div className={this._classNames.title}>{footerTitle(this.props)}</div>
         ) : null}


### PR DESCRIPTION
fixes #21912

`loadText` was being passed into a "label" span, but since there is no focusable element, the label was not being announced. Spinner takes in an `ariaLabel` prop which, if provided, renders an `aria-live`, visually hidden message.

This PR passes the `loadText` into the `ariaLabel` as well as the `label`. 

One other option would be to extend the `pickerSuggestionsProps` to allow for explicit `loadTextAriaLabel` or something, but this should probably be the default behavior, and would mean adding `searchTextAriaLabel` as well.  