### PR TITLE
react-utilities: Adding helper type to define slot class names

### DIFF
--- a/change/@fluentui-react-switch-582d3a8b-9cf7-42f4-b32c-0b5fb3e8f14b.json
+++ b/change/@fluentui-react-switch-582d3a8b-9cf7-42f4-b32c-0b5fb3e8f14b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating class names to use slot class names helper type.",
+  "packageName": "@fluentui/react-switch",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-d4dc0a30-cae7-4596-9a5c-e72b444fe765.json
+++ b/change/@fluentui-react-utilities-d4dc0a30-cae7-4596-9a5c-e72b444fe765.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding helper type to define slot class names.",
+  "packageName": "@fluentui/react-utilities",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-switch/etc/react-switch.api.md
+++ b/packages/react-switch/etc/react-switch.api.md
@@ -10,6 +10,7 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { Label } from '@fluentui/react-label';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
+import type { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public
 export const renderSwitch_unstable: (state: SwitchState) => JSX.Element;
@@ -21,9 +22,7 @@ export const Switch: ForwardRefComponent<SwitchProps>;
 export const switchClassName: string;
 
 // @public (undocumented)
-export const switchClassNames: {
-    [SlotName in keyof SwitchSlots]-?: string;
-};
+export const switchClassNames: SlotClassNames<SwitchSlots>;
 
 // @public (undocumented)
 export type SwitchOnChangeData = {

--- a/packages/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -1,11 +1,10 @@
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import { tokens } from '@fluentui/react-theme';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { SwitchSlots, SwitchState } from './Switch.types';
 
-export const switchClassNames: {
-  [SlotName in keyof SwitchSlots]-?: string;
-} = {
+export const switchClassNames: SlotClassNames<SwitchSlots> = {
   root: 'fui-Switch',
   indicator: 'fui-Switch__indicator',
   input: 'fui-Switch__input',

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -199,6 +199,11 @@ export type Slot<Type extends keyof JSX.IntrinsicElements | React_2.ComponentTyp
 }[AlternateAs] | null : 'Error: First parameter to Slot must not be not a union of types. See documentation of Slot type.';
 
 // @public
+export type SlotClassNames<Slots> = {
+    [SlotName in keyof Slots]-?: string;
+};
+
+// @public
 export type SlotPropsRecord = Record<string, UnknownSlotProps | SlotShorthandValue | null | undefined>;
 
 // @public (undocumented)

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -216,3 +216,10 @@ export type ForwardRefComponent<Props> = ObscureEventName extends keyof Props
 // export type ForwardRefComponent<Props> = Props extends React.DOMAttributes<infer Element>
 //   ? React.ForwardRefExoticComponent<Props> & React.RefAttributes<Element>
 //   : never;
+
+/**
+ * Helper type to correctly define the slot class names object.
+ */
+export type SlotClassNames<Slots> = {
+  [SlotName in keyof Slots]-?: string;
+};


### PR DESCRIPTION
## PR description

This PR adds a `SlotClassNames` helper type, as specified in RFC #21206, under `@fluentui/react-utilities` to help correctly define the slot class names object for our components, ensuring that all slots have a corresponding class name. This PR also updates the `switchClassNames` object under `@fluentui/react-switch` to use this new helper type.

## Related Issue(s)

Fixes part of #21847.
