### PR TITLE
Update onRenderIcon docs to warn of render condition

### DIFF
--- a/change/@fluentui-react-7a038fb1-c2d9-46cf-a15c-ccff8f64d11d.json
+++ b/change/@fluentui-react-7a038fb1-c2d9-46cf-a15c-ccff8f64d11d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update onRenderIcon docs to warn of render condition",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -357,6 +357,7 @@ export interface IContextualMenuItem {
 
   /**
    * Custom render function for the menu item icon
+   * iconProps must be present on at least one item for onRenderIcon to be called
    */
   onRenderIcon?: IRenderFunction<IContextualMenuItemProps>;
 


### PR DESCRIPTION
fixes #21804

Adding a note to the onRenderIcon function that at least one of the items needs iconProps in order for onRenderIcon to be called. 