### PR TITLE
keyboard-keys: Adding missing tslib dependency

### DIFF
--- a/change/@fluentui-keyboard-keys-e85295cb-376c-4067-8d3b-79dfd84ac1e6.json
+++ b/change/@fluentui-keyboard-keys-e85295cb-376c-4067-8d3b-79dfd84ac1e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "keyboard-keys: Adding missing tslib dependency.",
+  "packageName": "@fluentui/keyboard-keys",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/keyboard-keys/package.json
+++ b/packages/keyboard-keys/package.json
@@ -26,7 +26,9 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.1.0"
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",


### PR DESCRIPTION
A recent partner build error led to the conclusion that we are missing a `tslib` dependency in the `@fluentui/keyboard-keys` package. This PR aims to fix that by adding the missing dependency.