### PR TITLE
fix(Menu): fix icon and submenuIndicator alignment for non-v9 icons

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Menu.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Menu.stories.tsx
@@ -329,3 +329,91 @@ storiesOf('Menu nested within a MenuTrigger', module)
       </MenuPopover>
     </Menu>
   ));
+
+// this places text in the icon slot to verify alignment when not using v9 icons
+storiesOf('Menu Converged - icon slotted content', module)
+  .addDecorator(story => (
+    <Screener steps={new Screener.Steps().hover('[role="menuitem"]').snapshot('hover menuitem').end()}>
+      {story()}
+    </Screener>
+  ))
+  .addStory(
+    'default',
+    () => (
+      <Menu open>
+        <MenuTrigger>
+          <button>Toggle menu</button>
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <MenuItem icon={<span>X</span>} secondaryContent="Ctrl+X">
+              Cut
+            </MenuItem>
+            <MenuItem icon={<span>C</span>} secondaryContent="Ctrl+C">
+              Copy
+            </MenuItem>
+            <MenuItem icon={<span>V</span>} secondaryContent="Ctrl+V">
+              Paste
+            </MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    ),
+    { includeRtl: true },
+  );
+
+// this places text in the submenuIndicator slot to verify alignment when not using v9 icons
+storiesOf('Menu Converged - submenuIndicator slotted content', module)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps().click('#nestedTrigger1').click('#nestedTrigger2').snapshot('submenus open').end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory(
+    'default',
+    () => (
+      <Menu open>
+        <MenuTrigger>
+          <button>Toggle menu</button>
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <Menu>
+              <MenuTrigger>
+                <MenuItem id="nestedTrigger1" submenuIndicator={<span>N</span>}>
+                  New
+                </MenuItem>
+              </MenuTrigger>
+
+              <MenuPopover>
+                <MenuList>
+                  <MenuItem>File </MenuItem>
+                  <MenuItem>Folder</MenuItem>
+                  <Menu>
+                    <MenuTrigger>
+                      <MenuItem id="nestedTrigger2" submenuIndicator={<span>P</span>}>
+                        Project
+                      </MenuItem>
+                    </MenuTrigger>
+
+                    <MenuPopover>
+                      <MenuList>
+                        <MenuItem>Financial</MenuItem>
+                        <MenuItem>Planning</MenuItem>
+                        <MenuItem>Status</MenuItem>
+                      </MenuList>
+                    </MenuPopover>
+                  </Menu>
+                </MenuList>
+              </MenuPopover>
+            </Menu>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    ),
+    { includeRtl: true },
+  );

--- a/change/@fluentui-react-menu-1918e3b8-f0c6-43a7-982c-f778eef4ecf1.json
+++ b/change/@fluentui-react-menu-1918e3b8-f0c6-43a7-982c-f778eef4ecf1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updated icon and submenuIndicator styles to align with menu item text",
+  "packageName": "@fluentui/react-menu",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-1918e3b8-f0c6-43a7-982c-f778eef4ecf1.json
+++ b/change/@fluentui-react-menu-1918e3b8-f0c6-43a7-982c-f778eef4ecf1.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Updated icon and submenuIndicator styles to align with menu item text",
+  "comment": "fix(MenuItem): Alignment for non v9 icons",
   "packageName": "@fluentui/react-menu",
   "email": "gcox@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
+++ b/packages/react-menu/src/components/MenuItem/useMenuItemStyles.ts
@@ -52,12 +52,18 @@ const useStyles = makeStyles({
     height: '20px',
     fontSize: '20px',
     lineHeight: 0,
+    alignItems: 'center',
+    display: 'inline-flex',
+    justifyContent: 'center',
   },
   submenuIndicator: {
     width: '20px',
     height: '20px',
     fontSize: '20px',
     lineHeight: 0,
+    alignItems: 'center',
+    display: 'inline-flex',
+    justifyContent: 'center',
   },
   disabled: {
     color: tokens.colorNeutralForegroundDisabled,


### PR DESCRIPTION
## Current Behavior

The menu item does not align the icon slot and submenuIndicator slot content with the menu item text.

<img width="243" alt="menu-before-alignment" src="https://user-images.githubusercontent.com/28762486/156680668-95ccf825-7be9-4c13-bbfd-f72bd2131ffe.png">

<img width="625" alt="submenu-before-alignment" src="https://user-images.githubusercontent.com/28762486/156680723-63a94f59-e233-4366-a51f-b8005d892778.png">

> These were created by modifying the associated stories to use the v8 icons and spans with plain text as the icon or submenuIndicator.

## New Behavior

Menu item aligns icon and submenuIndicator slot content using flex just like button does.

<img width="243" alt="menu-after-alignment" src="https://user-images.githubusercontent.com/28762486/156680867-ba813726-944d-4ca0-835a-04cf4be8bf4e.png">

<img width="625" alt="submenu-after-alignment" src="https://user-images.githubusercontent.com/28762486/156680887-b6ce86e6-262a-4493-9e8c-9f8ab7673eb4.png">


## Related Issue(s)

This was discovered as part of writing the ContextualMenuButton shim for the v8 -> v9 upgrade.
