### PR TITLE
fix(Progressbar): add ariaLabel prop

### DIFF
--- a/change/@fluentui-react-a3741b7d-6622-4f14-a2a7-c946fad04f38.json
+++ b/change/@fluentui-react-a3741b7d-6622-4f14-a2a7-c946fad04f38.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add ariaLabel to ProgressIndicator",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -7610,6 +7610,7 @@ export { IProcessedStyleSet }
 
 // @public (undocumented)
 export interface IProgressIndicatorProps extends React_2.ClassAttributes<ProgressIndicatorBase> {
+    ariaLabel?: string;
     ariaValueText?: string;
     barHeight?: number;
     className?: string;

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.base.tsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.base.tsx
@@ -85,8 +85,17 @@ export class ProgressIndicatorBase extends React.Component<IProgressIndicatorPro
   }
 
   private _onRenderProgress = (props: IProgressIndicatorProps): JSX.Element => {
-    // eslint-disable-next-line deprecation/deprecation
-    const { ariaValueText, barHeight, className, description, label = this.props.title, styles, theme } = this.props;
+    const {
+      ariaLabel,
+      ariaValueText,
+      barHeight,
+      className,
+      description,
+      // eslint-disable-next-line deprecation/deprecation
+      label = this.props.title,
+      styles,
+      theme,
+    } = this.props;
 
     const percentComplete =
       typeof this.props.percentComplete === 'number'
@@ -117,6 +126,7 @@ export class ProgressIndicatorBase extends React.Component<IProgressIndicatorPro
           style={progressBarStyles}
           role="progressbar"
           aria-describedby={description ? this._descriptionId : undefined}
+          aria-label={ariaLabel}
           aria-labelledby={label ? this._labelId : undefined}
           aria-valuemin={ariaValueMin}
           aria-valuemax={ariaValueMax}

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.test.tsx
@@ -28,6 +28,12 @@ describe('ProgressIndicator', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders with ariaLabel', () => {
+    const component = renderer.create(<ProgressIndicator ariaLabel="Test" />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders React content', () => {
     const component = renderer.create(<ProgressIndicator label={<span>Test</span>} description={<span>Test</span>} />);
     const tree = component.toJSON();

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.types.ts
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.types.ts
@@ -29,6 +29,12 @@ export interface IProgressIndicatorProps extends React.ClassAttributes<ProgressI
   label?: React.ReactNode;
 
   /**
+   * Add screen-reader-only label text to the progressbar.
+   * Prefer `label`, and use this only when other text or visual context provides a visible label
+   */
+  ariaLabel?: string;
+
+  /**
    * Text describing or supplementing the operation. May be a string or React virtual elements.
    */
   description?: React.ReactNode;

--- a/packages/react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`ProgressIndicator renders React content 1`] = `
           text-overflow: ellipsis;
           white-space: nowrap;
         }
-    id="progress-indicator4-label"
+    id="progress-indicator5-label"
   >
     <span>
       Test
@@ -153,8 +153,8 @@ exports[`ProgressIndicator renders React content 1`] = `
           }
     />
     <div
-      aria-describedby="progress-indicator4-description"
-      aria-labelledby="progress-indicator4-label"
+      aria-describedby="progress-indicator5-description"
+      aria-labelledby="progress-indicator5-label"
       className=
           ms-ProgressIndicator-progressBar
           {
@@ -190,7 +190,7 @@ exports[`ProgressIndicator renders React content 1`] = `
           font-size: 12px;
           line-height: 18px;
         }
-    id="progress-indicator4-description"
+    id="progress-indicator5-description"
   >
     <span>
       Test
@@ -293,6 +293,76 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
     id="progress-indicator1-description"
   >
     Test
+  </div>
+</div>
+`;
+
+exports[`ProgressIndicator renders with ariaLabel 1`] = `
+<div
+  className=
+      ms-ProgressIndicator
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+>
+  <div
+    className=
+        ms-ProgressIndicator-itemProgress
+        {
+          height: 2px;
+          overflow: hidden;
+          padding-bottom: 8px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 8px;
+          position: relative;
+        }
+  >
+    <div
+      className=
+          ms-ProgressIndicator-progressTrack
+          {
+            background-color: #edebe9;
+            height: 2px;
+            position: absolute;
+            width: 100%;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            border-bottom: 1px solid WindowText;
+          }
+    />
+    <div
+      aria-label="Test"
+      className=
+          ms-ProgressIndicator-progressBar
+          {
+            animation: keyframes 0%{left:-30%;}100%{left:100%;} 3s infinite;
+            background-color: #0078d4;
+            background: linear-gradient(to right, #edebe9 0%, #0078d4 50%, #edebe9 100%);
+            height: 2px;
+            min-width: 33%;
+            position: absolute;
+            transition: width .3s ease;
+            width: 0px;
+          }
+          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: highlight;
+            background: highlight;
+            forced-color-adjust: none;
+          }
+      role="progressbar"
+      style={
+        Object {
+          "transition": undefined,
+          "width": undefined,
+        }
+      }
+    />
   </div>
 </div>
 `;


### PR DESCRIPTION
Fixes #18351

Adds an `ariaLabel` prop to ProgressIndicator so authors can add an accessible name even if there is no visible text.
