### PR TITLE
Adding "/unstable" export to @fluentui/react-components

### DIFF
--- a/change/@fluentui-react-components-9e580541-4783-4fe8-9998-75fc823712e5.json
+++ b/change/@fluentui-react-components-9e580541-4783-4fe8-9998-75fc823712e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding /unstable export to exports map.",
+  "packageName": "@fluentui/react-components",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -82,6 +82,11 @@
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },
+    "./unstable": {
+      "types": "./lib/unstable/index.d.ts",
+      "import": "./lib/unstable/index.js",
+      "require": "./lib-commonjs/unstable/index.js"
+    },
     "./package.json": "./package.json"
   }
 }


### PR DESCRIPTION
The `/unstable` import for `react-components` package was missing in the exports map.

Adding it for Webpack 5 to be happier and for supported imports to be explicit. :)

Fixes #21953