### PR TITLE
Respect shouldFocusOnContainer prop when opening a menu via mouse click

### DIFF
--- a/change/@fluentui-react-c425b099-b5fd-43fa-a973-4c7474177a34.json
+++ b/change/@fluentui-react-c425b099-b5fd-43fa-a973-4c7474177a34.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Respect shouldFocusOnContainer prop if it is set when opening menu via click",
+  "packageName": "@fluentui/react",
+  "email": "makopch@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -931,13 +931,13 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
   private _onMenuClick = (
     ev: React.MouseEvent<HTMLDivElement | HTMLButtonElement | HTMLAnchorElement | HTMLSpanElement>,
   ) => {
-    const { onMenuClick } = this.props;
+    const { onMenuClick, menuProps } = this.props;
     if (onMenuClick) {
       onMenuClick(ev, this.props);
     }
 
     if (!ev.defaultPrevented) {
-      this._onToggleMenu(false);
+      this._onToggleMenu(menuProps?.shouldFocusOnContainer || false);
       ev.preventDefault();
       ev.stopPropagation();
     }


### PR DESCRIPTION
## Current Behavior

When opening a menu, focus always goes to the first element.  The prop `shouldFocusOnContainer` should be the method for overriding this.  However, the calls to _onToggleMenu hardcode `false` instead of respecting the props.

## New Behavior

The props are respected when doing _onToggleMenu allowing a consumer to override the default focus behavior.


This shouldn't have any impact on the previous issue that was fixed since the prop is false by default.
https://github.com/microsoft/fluentui/pull/20601