### PR TITLE
Button (v8): convert tests to use testing-library

### DIFF
--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -76,24 +76,23 @@ describe('Button', () => {
 
   describe('DefaultButton', () => {
     it('can render without an onClick.', () => {
-      const { getByRole } = render(<DefaultButton>Hello</DefaultButton>);
-
-      expect(getByRole('button').tagName).toEqual('BUTTON');
+      const { container } = render(<DefaultButton>Hello</DefaultButton>);
+      expect(container.firstElementChild!.tagName).toEqual('BUTTON');
     });
 
     it('can render with an onClick.', () => {
       const onClick: () => null = () => null;
-      const { getByRole } = render(<DefaultButton onClick={onClick}>Hello</DefaultButton>);
-      expect(getByRole('button').tagName).toEqual('BUTTON');
+      const { container } = render(<DefaultButton onClick={onClick}>Hello</DefaultButton>);
+      expect(container.firstElementChild!.tagName).toEqual('BUTTON');
     });
 
     it('can render with an href', () => {
-      const { getByRole } = render(
+      const { container } = render(
         <DefaultButton href="http://www.microsoft.com" target="_blank">
           Hello
         </DefaultButton>,
       );
-      expect(getByRole('link').tagName).toEqual('A');
+      expect(container.firstElementChild!.tagName).toEqual('A');
     });
 
     it('can handle elementRef', () => {

--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-
-import * as ReactTestUtils from 'react-dom/test-utils';
-import { create } from '@fluentui/utilities/lib/test';
-import { safeMount } from '@fluentui/test-utilities';
+import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { DefaultButton } from './DefaultButton/DefaultButton';
 import { IconButton } from './IconButton/IconButton';
@@ -11,7 +8,6 @@ import { ActionButton } from './ActionButton/ActionButton';
 import { CommandBarButton } from './CommandBarButton/CommandBarButton';
 import { CompoundButton } from './CompoundButton/CompoundButton';
 import { KeyCodes, resetIds } from '../../Utilities';
-import { renderIntoDocument } from '../../common/testUtilities';
 import type { IContextualMenuProps } from '../../ContextualMenu';
 
 const alertClicked = (): void => {
@@ -19,37 +15,18 @@ const alertClicked = (): void => {
 };
 
 describe('Button', () => {
-  let container: HTMLElement;
-
   beforeEach(() => {
     resetIds();
-    container = document.createElement('div');
-    document.body.appendChild(container);
   });
-
-  afterEach(() => {
-    if (container) {
-      ReactDOM.unmountComponentAtNode(container);
-    }
-    document.body.innerHTML = '';
-  });
-
-  function render(content: JSX.Element): Element {
-    ReactDOM.render(content, container);
-
-    return container.firstChild as Element;
-  }
 
   it('renders DefaultButton correctly', () => {
-    const component = create(<DefaultButton text="Button" />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<DefaultButton text="Button" />);
+    expect(container).toMatchSnapshot();
   });
 
   it('renders ActionButton correctly', () => {
-    const component = create(<ActionButton>Button</ActionButton>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<ActionButton>Button</ActionButton>);
+    expect(container).toMatchSnapshot();
   });
 
   it('renders a DefaultButton with a keytip correctly', () => {
@@ -57,13 +34,12 @@ describe('Button', () => {
       content: 'A',
       keySequences: ['a'],
     };
-    const component = create(<DefaultButton text="Button" keytipProps={keytipProps} />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<DefaultButton text="Button" keytipProps={keytipProps} />);
+    expect(container).toMatchSnapshot();
   });
 
   it('renders CommandBarButton correctly', () => {
-    const component = create(
+    const { container } = render(
       <CommandBarButton
         iconProps={{ iconName: 'Add' }}
         text="Create account"
@@ -83,60 +59,57 @@ describe('Button', () => {
         }}
       />,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it('renders CompoundButton correctly', () => {
-    const component = create(
+    const { container } = render(
       <CompoundButton secondaryText="You can create a new account here.">Create account</CompoundButton>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it('renders IconButton correctly', () => {
-    const component = create(<IconButton iconProps={{ iconName: 'Emoji2' }} title="Emoji" ariaLabel="Emoji" />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<IconButton iconProps={{ iconName: 'Emoji2' }} title="Emoji" ariaLabel="Emoji" />);
+    expect(container).toMatchSnapshot();
   });
 
   describe('DefaultButton', () => {
     it('can render without an onClick.', () => {
-      const button = render(<DefaultButton>Hello</DefaultButton>);
+      const { getByRole } = render(<DefaultButton>Hello</DefaultButton>);
 
-      expect(button.tagName).toEqual('BUTTON');
+      expect(getByRole('button').tagName).toEqual('BUTTON');
     });
 
     it('can render with an onClick.', () => {
       const onClick: () => null = () => null;
-      const button = render(<DefaultButton onClick={onClick}>Hello</DefaultButton>);
-      expect(button.tagName).toEqual('BUTTON');
+      const { getByRole } = render(<DefaultButton onClick={onClick}>Hello</DefaultButton>);
+      expect(getByRole('button').tagName).toEqual('BUTTON');
     });
 
     it('can render with an href', () => {
-      const button = render(
+      const { getByRole } = render(
         <DefaultButton href="http://www.microsoft.com" target="_blank">
           Hello
         </DefaultButton>,
       );
-      expect(button.tagName).toEqual('A');
+      expect(getByRole('link').tagName).toEqual('A');
     });
 
     it('can handle elementRef', () => {
       const ref = React.createRef<HTMLElement>();
-      safeMount(<DefaultButton elementRef={ref}>Content</DefaultButton>, button => {
-        expect(ref.current).toBeTruthy();
-      });
+      render(<DefaultButton elementRef={ref}>Content</DefaultButton>);
+      expect(ref.current).toBeTruthy();
     });
 
     describe('aria attributes', () => {
       it('does not apply aria attributes that are not passed in', () => {
-        const button: any = render(
+        const { getByRole } = render(
           <DefaultButton href="http://www.microsoft.com" target="_blank">
             Hello
           </DefaultButton>,
         );
+        const button = getByRole('link');
 
         expect(button.getAttribute('aria-label')).toBeNull();
         expect(button.getAttribute('aria-labelledby')).toBeNull();
@@ -145,7 +118,7 @@ describe('Button', () => {
       });
 
       it('overrides native aria-label with Button ariaLabel', () => {
-        const button = render(
+        const { getByRole } = render(
           <DefaultButton
             href="http://www.microsoft.com"
             target="_blank"
@@ -155,6 +128,7 @@ describe('Button', () => {
             Hello
           </DefaultButton>,
         );
+        const button = getByRole('link');
 
         expect(button.getAttribute('aria-label')).toEqual('ButtonLabel');
         expect(button.getAttribute('aria-labelledby')).toBeNull();
@@ -162,11 +136,12 @@ describe('Button', () => {
       });
 
       it('applies aria-label', () => {
-        const button = render(
+        const { getByRole } = render(
           <DefaultButton href="http://www.microsoft.com" target="_blank" aria-label="MyLabel">
             Hello
           </DefaultButton>,
         );
+        const button = getByRole('link');
 
         expect(button.getAttribute('aria-label')).toEqual('MyLabel');
         expect(button.getAttribute('aria-labelledby')).toBeNull();
@@ -174,27 +149,29 @@ describe('Button', () => {
       });
 
       it('applies aria-labelledby', () => {
-        const button = render(
+        const { getByRole } = render(
           <DefaultButton href="http://www.microsoft.com" target="_blank" aria-labelledby="someid">
             Hello
           </DefaultButton>,
         );
+        const button = getByRole('link');
 
         expect(button.getAttribute('aria-labelledby')).toEqual('someid');
         expect(button.getAttribute('aria-describedby')).toBeNull();
       });
 
       it('does not apply aria-labelledby to a button with no text', () => {
-        const button = render(
+        const { getByRole } = render(
           <DefaultButton href="http://www.microsoft.com" target="_blank" aria-describedby="someid" />,
         );
+        const button = getByRole('link');
 
         expect(button.getAttribute('aria-labelledby')).toBeNull();
         expect(button.getAttribute('aria-describedby')).toEqual('someid');
       });
 
       it('applies aria-labelledby and aria-describedby', () => {
-        const button = render(
+        const { getByRole } = render(
           <DefaultButton
             href="http://www.microsoft.com"
             target="_blank"
@@ -204,6 +181,7 @@ describe('Button', () => {
             Hello
           </DefaultButton>,
         );
+        const button = getByRole('link');
 
         expect(button.getAttribute('aria-label')).toBeNull();
 
@@ -213,13 +191,14 @@ describe('Button', () => {
       });
 
       it('applies aria-describedby to an IconButton', () => {
-        const button = render(
+        const { getByRole } = render(
           <IconButton
             iconProps={{ iconName: 'Emoji2' }}
             ariaDescription="Description on icon button"
             styles={{ screenReaderText: 'some-screenreader-class' }}
           />,
         );
+        const button = getByRole('button');
 
         expect(button.getAttribute('aria-label')).toBeNull();
 
@@ -229,7 +208,7 @@ describe('Button', () => {
       });
 
       it('applies aria-labelledby and aria-describedby to a CompoundButton with ariaDescription', () => {
-        const button = render(
+        const { getByRole } = render(
           <CompoundButton
             secondaryText="Some awesome description"
             ariaDescription="Description on icon button"
@@ -238,6 +217,7 @@ describe('Button', () => {
             And this is the label
           </CompoundButton>,
         );
+        const button = getByRole('button');
 
         expect(button.getAttribute('aria-label')).toBeNull();
 
@@ -250,9 +230,10 @@ describe('Button', () => {
         'applies aria-labelledby and aria-describedby to a CompoundButton with secondaryText ' +
           'and no ariaDescription',
         () => {
-          const button = render(
+          const { getByRole } = render(
             <CompoundButton secondaryText="Some awesome description">And this is the label</CompoundButton>,
           );
+          const button = getByRole('button');
 
           expect(button.getAttribute('aria-label')).toBeNull();
 
@@ -263,23 +244,23 @@ describe('Button', () => {
       );
 
       it('does not apply aria-pressed to an unchecked button', () => {
-        const button: any = render(<DefaultButton toggle={true}>Hello</DefaultButton>);
+        const { getByRole } = render(<DefaultButton toggle={true}>Hello</DefaultButton>);
 
-        expect(button.getAttribute('aria-pressed')).toEqual('false');
+        expect(getByRole('button').getAttribute('aria-pressed')).toEqual('false');
       });
 
       it('applies aria-pressed to a checked button', () => {
-        const button: any = render(
+        const { getByRole } = render(
           <DefaultButton toggle={true} checked={true}>
             Hello
           </DefaultButton>,
         );
 
-        expect(button.getAttribute('aria-pressed')).toEqual('true');
+        expect(getByRole('button').getAttribute('aria-pressed')).toEqual('true');
       });
 
       it('does not apply aria-pressed to an unchecked split button', () => {
-        const button: any = render(
+        const { getAllByRole } = render(
           <DefaultButton
             toggle={true}
             split={true}
@@ -298,33 +279,33 @@ describe('Button', () => {
           </DefaultButton>,
         );
 
-        expect(button.getAttribute('aria-pressed')).toEqual('false');
+        expect(getAllByRole('button')[0].getAttribute('aria-pressed')).toEqual('false');
       });
 
       it('applies aria-checked to a role=menuitemcheckbox checked button', () => {
-        const button: any = render(
+        const { getByRole } = render(
           <DefaultButton role="menuitemcheckbox" toggle={true} checked={true}>
             Hello
           </DefaultButton>,
         );
 
-        expect(button.getAttribute('aria-checked')).toEqual('true');
+        expect(getByRole('menuitemcheckbox').getAttribute('aria-checked')).toEqual('true');
       });
 
       it('applies aria-checked to a role=checkbox checked button', () => {
-        const button: any = render(
+        const { getByRole } = render(
           <DefaultButton role="checkbox" toggle={true} checked={true}>
             Hello
           </DefaultButton>,
         );
 
-        expect(button.getAttribute('aria-checked')).toEqual('true');
+        expect(getByRole('checkbox').getAttribute('aria-checked')).toEqual('true');
       });
 
       it('applies aria-checked=false to a role=checkbox button even if toggle is not passed', () => {
-        const button: any = render(<DefaultButton role="checkbox">Hello</DefaultButton>);
+        const { getByRole } = render(<DefaultButton role="checkbox">Hello</DefaultButton>);
 
-        expect(button.getAttribute('aria-checked')).toEqual('false');
+        expect(getByRole('checkbox').getAttribute('aria-checked')).toEqual('false');
       });
 
       it('does not mutate menuprops hidden property', () => {
@@ -338,13 +319,13 @@ describe('Button', () => {
             },
           ],
         };
-        const button: any = render(
+        const { getAllByRole } = render(
           <DefaultButton toggle={true} split={true} onClick={alertClicked} persistMenu={true} menuProps={menuProps}>
             Hello
           </DefaultButton>,
         );
 
-        expect(button).toBeTruthy();
+        expect(getAllByRole('button')[0]).toBeTruthy();
         expect(menuProps.hidden).toEqual(false);
       });
 
@@ -359,14 +340,16 @@ describe('Button', () => {
           ],
         };
 
-        const button = renderIntoDocument(<DefaultButton menuProps={menuProps}>Hello</DefaultButton>);
-        ReactTestUtils.Simulate.click(button);
+        const { getByRole } = render(<DefaultButton menuProps={menuProps}>Hello</DefaultButton>);
+        const button = getByRole('button');
+
+        userEvent.click(button);
 
         expect(button.getAttribute('aria-controls')).toBe('custom-id');
       });
 
       it('applies aria-pressed to a checked split button', () => {
-        const button: any = render(
+        const { getAllByRole } = render(
           <DefaultButton
             toggle={true}
             checked={true}
@@ -386,48 +369,36 @@ describe('Button', () => {
           </DefaultButton>,
         );
 
-        expect(button.getAttribute('aria-pressed')).toEqual('true');
+        expect(getAllByRole('button')[0].getAttribute('aria-pressed')).toEqual('true');
       });
     });
 
     describe('with menuProps', () => {
-      let button: Element;
-
-      beforeAll(() => {
-        button = render(<DefaultButton menuProps={{ items: [{ key: 'item', text: 'Item' }] }}>Hello</DefaultButton>);
-      });
-
       it('contains aria-haspopup=true', () => {
-        expect(button.getAttribute('aria-haspopup')).toEqual('true');
+        const { getAllByRole } = render(
+          <DefaultButton menuProps={{ items: [{ key: 'item', text: 'Item' }] }}>Hello</DefaultButton>,
+        );
+
+        expect(getAllByRole('button')[0].getAttribute('aria-haspopup')).toEqual('true');
       });
     });
 
     describe('without menuProps', () => {
-      let button: Element;
-
-      beforeAll(() => {
-        button = render(<DefaultButton>Hello</DefaultButton>);
-      });
-
       it('does not contain aria-haspopup', () => {
-        expect(button.getAttribute('aria-haspopup')).toEqual(null);
+        const { getByRole } = render(<DefaultButton>Hello</DefaultButton>);
+        expect(getByRole('button').getAttribute('aria-haspopup')).toEqual(null);
       });
     });
 
     describe('with menuIconProps', () => {
-      let button: Element;
-
-      beforeAll(() => {
-        button = render(<DefaultButton menuIconProps={{ iconName: 'fontColor' }}>Hello</DefaultButton>);
-      });
-
       it('Contains the expected icon via menuIconProps', () => {
-        expect(button.querySelectorAll('[data-icon-name="fontColor"]').length).toEqual(1);
+        const { getAllByRole } = render(<DefaultButton menuIconProps={{ iconName: 'fontColor' }}>Hello</DefaultButton>);
+        expect(getAllByRole('button')[0].querySelectorAll('[data-icon-name="fontColor"]').length).toEqual(1);
       });
     });
 
     it('Providing onClick and menuProps does not render a SplitButton', () => {
-      const button = render(
+      const { getAllByRole } = render(
         <DefaultButton
           text="Create account"
           onClick={alertClicked}
@@ -447,13 +418,12 @@ describe('Button', () => {
           }}
         />,
       );
-      expect(button.tagName).not.toEqual('DIV');
+      expect(getAllByRole('button')[0].tagName).not.toEqual('DIV');
     });
 
     it('Providing onKeyDown and menuProps still fires provided onKeyDown', () => {
       const keyDownSpy = jest.fn();
-
-      const button = render(
+      render(
         <DefaultButton
           text="Create account"
           onKeyDown={keyDownSpy}
@@ -473,16 +443,14 @@ describe('Button', () => {
           }}
         />,
       );
-
-      ReactTestUtils.Simulate.keyDown(button, { which: KeyCodes.enter });
-
+      userEvent.tab();
+      userEvent.keyboard('{enter}');
       expect(keyDownSpy).toHaveBeenCalled();
     });
 
     it('Providing onKeyDown, menuProps and splitButton=true fires provided onKeyDown on both buttons', () => {
       const keyDownSpy = jest.fn();
-
-      const button = render(
+      render(
         <DefaultButton
           text="Create account"
           onKeyDown={keyDownSpy}
@@ -504,19 +472,15 @@ describe('Button', () => {
           }}
         />,
       );
-      const primaryButtonDOM: HTMLElement = button.querySelector(
-        "[data-automationid='splitbuttonprimary']",
-      ) as HTMLElement;
-
-      ReactTestUtils.Simulate.keyDown(primaryButtonDOM, { which: KeyCodes.enter });
-
+      userEvent.tab();
+      userEvent.keyboard('{arrowdown}');
       expect(keyDownSpy).toHaveBeenCalled();
     });
 
     it('Space keydown in a splitButton will fire onClick', () => {
       const onClickSpy = jest.fn();
 
-      const button = render(
+      render(
         <DefaultButton
           data-automation-id="test"
           text="Create account"
@@ -538,15 +502,13 @@ describe('Button', () => {
           }}
         />,
       );
-      const buttonContainer: HTMLDivElement = button.getElementsByTagName('span')[0] as HTMLDivElement;
-
-      ReactTestUtils.Simulate.keyDown(buttonContainer, { which: KeyCodes.space });
-
+      userEvent.tab();
+      userEvent.keyboard('{space}');
       expect(onClickSpy).toHaveBeenCalled();
     });
 
     it('Providing onClick, menuProps and setting splitButton to true renders a SplitButton', () => {
-      const button = render(
+      const { getAllByRole } = render(
         <DefaultButton
           text="Create account"
           split={true}
@@ -567,11 +529,11 @@ describe('Button', () => {
           }}
         />,
       );
-      expect(button.tagName).toEqual('DIV');
+      expect(getAllByRole('button')[0].tagName).toEqual('DIV');
     });
 
     it('Tapping menu button of SplitButton expands menu', () => {
-      const button = render(
+      const { getAllByRole } = render(
         <DefaultButton
           text="Create account"
           split={true}
@@ -592,13 +554,13 @@ describe('Button', () => {
           }}
         />,
       );
-      const menuButtonDOM: HTMLButtonElement = button.getElementsByTagName('button')[1] as HTMLButtonElement;
-      ReactTestUtils.Simulate.click(menuButtonDOM);
-      expect(button.getAttribute('aria-expanded')).toEqual('true');
+      const menuButton = getAllByRole('button')[2];
+      userEvent.click(menuButton);
+      expect(getAllByRole('button')[0].getAttribute('aria-expanded')).toEqual('true');
     });
 
     it('Touch Start on primary button of SplitButton expands menu', () => {
-      const button = render(
+      const { getAllByRole } = render(
         <DefaultButton
           text="Create account"
           split={true}
@@ -619,18 +581,18 @@ describe('Button', () => {
           }}
         />,
       );
-      const primaryButtonDOM: HTMLButtonElement = button.getElementsByTagName('button')[0] as HTMLButtonElement;
+      const primaryButton = getAllByRole('button')[1];
 
       // in a normal scenario, when we do a touchstart we would also cause a
       // click event to fire. This doesn't happen in the simulator so we're
       // manually adding this in.
-      ReactTestUtils.Simulate.touchStart(primaryButtonDOM);
-      ReactTestUtils.Simulate.click(primaryButtonDOM);
-      expect(button.getAttribute('aria-expanded')).toEqual('true');
+      fireEvent.touchStart(primaryButton);
+      fireEvent.click(primaryButton);
+      expect(getAllByRole('button')[0].getAttribute('aria-expanded')).toEqual('true');
     });
 
     it('If menu trigger is disabled, pressing down does not trigger menu', () => {
-      const button = render(
+      const { getAllByRole } = render(
         <DefaultButton
           text="Create account"
           menuTriggerKeyCode={null}
@@ -650,15 +612,13 @@ describe('Button', () => {
           }}
         />,
       );
-
-      ReactTestUtils.Simulate.keyDown(button, {
-        which: KeyCodes.down,
-      });
-      expect(button.getAttribute('aria-expanded')).toEqual('false');
+      userEvent.tab();
+      userEvent.keyboard('{arrowdown}');
+      expect(getAllByRole('button')[0].getAttribute('aria-expanded')).toEqual('false');
     });
 
     it('If menu trigger is specified, default key is overridden', () => {
-      const button = render(
+      const { getAllByRole } = render(
         <DefaultButton
           text="Create account"
           menuTriggerKeyCode={KeyCodes.right}
@@ -679,14 +639,13 @@ describe('Button', () => {
         />,
       );
 
-      ReactTestUtils.Simulate.keyDown(button, {
-        which: KeyCodes.down,
-      });
+      const button = getAllByRole('button')[0];
+      userEvent.tab();
+
+      userEvent.keyboard('{arrowdown}');
       expect(button.getAttribute('aria-expanded')).toEqual('false');
 
-      ReactTestUtils.Simulate.keyDown(button, {
-        which: KeyCodes.right,
-      });
+      userEvent.keyboard('{arrowright}');
       expect(button.getAttribute('aria-expanded')).toEqual('true');
     });
 
@@ -701,7 +660,7 @@ describe('Button', () => {
       });
 
       function buildRenderButtonWithMenu(callbackMock?: jest.Mock<unknown>, persistMenu?: boolean): HTMLElement {
-        const button: HTMLElement = renderIntoDocument(
+        const { getAllByRole } = render(
           <DefaultButton
             text="Create account"
             split={true}
@@ -724,25 +683,20 @@ describe('Button', () => {
             }}
           />,
         );
-        return button;
+        return getAllByRole('button')[0];
       }
 
       it('Clicking SplitButton button triggers action', () => {
         const button: HTMLElement = buildRenderButtonWithMenu();
         const menuButtonDOM: HTMLButtonElement = button.querySelectorAll('button')[0];
-
-        ReactTestUtils.Simulate.click(menuButtonDOM);
+        userEvent.click(menuButtonDOM);
         expect(didClick).toEqual(true);
       });
 
       it('Pressing alt + down on SplitButton triggers menu', () => {
         const button: HTMLElement = buildRenderButtonWithMenu();
-        const menuButtonElement = button.querySelectorAll('button')[1];
-
-        ReactTestUtils.Simulate.keyDown(menuButtonElement, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
+        userEvent.tab();
+        userEvent.keyboard('{alt}{arrowdown}');
         expect(button.getAttribute('aria-expanded')).toEqual('true');
       });
 
@@ -751,11 +705,10 @@ describe('Button', () => {
 
         const button: HTMLElement = buildRenderButtonWithMenu(callbackMock);
         const menuButtonElement = button.querySelectorAll('button')[1];
+        userEvent.click(menuButtonElement);
 
-        ReactTestUtils.Simulate.click(menuButtonElement);
         expect(button.getAttribute('aria-expanded')).toEqual('true');
-
-        ReactTestUtils.Simulate.click(menuButtonElement);
+        userEvent.click(menuButtonElement);
         expect(button.getAttribute('aria-expanded')).toEqual('false');
         expect(callbackMock.mock.calls.length).toBe(1);
       });
@@ -765,17 +718,16 @@ describe('Button', () => {
 
         const button: HTMLElement = buildRenderButtonWithMenu(callbackMock, true);
         const menuButtonElement = button.querySelectorAll('button')[1];
+        userEvent.click(menuButtonElement);
 
-        ReactTestUtils.Simulate.click(menuButtonElement);
         expect(button.getAttribute('aria-expanded')).toEqual('true');
-
-        ReactTestUtils.Simulate.click(menuButtonElement);
+        userEvent.click(menuButtonElement);
         expect(button.getAttribute('aria-expanded')).toEqual('false');
         expect(callbackMock.mock.calls.length).toBe(1);
       });
 
       it('A disabled SplitButton does not respond to input events', () => {
-        const button: HTMLElement = renderIntoDocument(
+        const { getAllByRole } = render(
           <DefaultButton
             disabled={true}
             text="Create account"
@@ -803,35 +755,14 @@ describe('Button', () => {
           />,
         );
 
-        ReactTestUtils.Simulate.click(button);
-        ReactTestUtils.Simulate.keyDown(button, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
-        ReactTestUtils.Simulate.keyUp(button, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
-        ReactTestUtils.Simulate.keyPress(button, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
-        ReactTestUtils.Simulate.mouseDown(button, {
-          type: 'mousedown',
-          clientX: 0,
-          clientY: 0,
-        });
-
-        ReactTestUtils.Simulate.mouseUp(button, {
-          type: 'mouseup',
-          clientX: 0,
-          clientY: 0,
-        });
+        const button = getAllByRole('button')[0];
+        userEvent.click(button);
+        userEvent.keyboard('{alt}{arrowdown}');
         expect(didClick).toEqual(false);
       });
 
       it('A disabled Button does not respond to input events', () => {
-        const button: HTMLElement = renderIntoDocument(
+        const { getAllByRole } = render(
           <DefaultButton
             disabled={true}
             text="Create account"
@@ -845,34 +776,13 @@ describe('Button', () => {
           />,
         );
 
-        ReactTestUtils.Simulate.click(button);
-        ReactTestUtils.Simulate.keyDown(button, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
-        ReactTestUtils.Simulate.keyUp(button, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
-        ReactTestUtils.Simulate.keyPress(button, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
-        ReactTestUtils.Simulate.mouseDown(button, {
-          type: 'mousedown',
-          clientX: 0,
-          clientY: 0,
-        });
-
-        ReactTestUtils.Simulate.mouseUp(button, {
-          type: 'mouseup',
-          clientX: 0,
-          clientY: 0,
-        });
+        const button = getAllByRole('button')[0];
+        userEvent.click(button);
+        userEvent.keyboard('{alt}{arrowdown}');
         expect(didClick).toEqual(false);
       });
       it('A focusable disabled button does not respond to input events', () => {
-        const button: HTMLElement = renderIntoDocument(
+        const { getAllByRole } = render(
           <DefaultButton
             disabled={true}
             allowDisabledFocus={true}
@@ -887,34 +797,13 @@ describe('Button', () => {
           />,
         );
 
-        ReactTestUtils.Simulate.click(button);
-        ReactTestUtils.Simulate.keyDown(button, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
-        ReactTestUtils.Simulate.keyUp(button, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
-        ReactTestUtils.Simulate.keyPress(button, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
-        ReactTestUtils.Simulate.mouseDown(button, {
-          type: 'mousedown',
-          clientX: 0,
-          clientY: 0,
-        });
-
-        ReactTestUtils.Simulate.mouseUp(button, {
-          type: 'mouseup',
-          clientX: 0,
-          clientY: 0,
-        });
+        const button = getAllByRole('button')[0];
+        userEvent.click(button);
+        userEvent.keyboard('{alt}{arrowdown}');
         expect(didClick).toEqual(false);
       });
       it('A focusable disabled menu button does not respond to input events', () => {
-        const button: HTMLElement = renderIntoDocument(
+        const { getAllByRole } = render(
           <DefaultButton
             disabled={true}
             allowDisabledFocus={true}
@@ -943,30 +832,9 @@ describe('Button', () => {
           />,
         );
 
-        ReactTestUtils.Simulate.click(button);
-        ReactTestUtils.Simulate.keyDown(button, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
-        ReactTestUtils.Simulate.keyUp(button, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
-        ReactTestUtils.Simulate.keyPress(button, {
-          which: KeyCodes.down,
-          altKey: true,
-        });
-        ReactTestUtils.Simulate.mouseDown(button, {
-          type: 'mousedown',
-          clientX: 0,
-          clientY: 0,
-        });
-
-        ReactTestUtils.Simulate.mouseUp(button, {
-          type: 'mouseup',
-          clientX: 0,
-          clientY: 0,
-        });
+        const button = getAllByRole('button')[0];
+        userEvent.click(button);
+        userEvent.keyboard('{alt}{arrowdown}');
         expect(didClick).toEqual(false);
       });
     });
@@ -988,12 +856,9 @@ describe('Button', () => {
           </DefaultButton>
         );
 
-        render(element);
-
-        const button = render(element);
-
-        ReactTestUtils.Simulate.click(button);
-
+        const { getAllByRole } = render(element);
+        const button = getAllByRole('button')[0];
+        userEvent.click(button);
         // get the menu id from the button's aria attribute
         const menuId = button.getAttribute('aria-controls');
         expect(menuId).toBeTruthy();
@@ -1046,26 +911,22 @@ describe('Button', () => {
       it('Click on button opens the menu, escape press dismisses menu', () => {
         const callbackMock = jest.fn();
         const menuProps = { items: [{ key: 'item', name: 'Item' }], onDismiss: callbackMock };
-        const element: React.ReactElement<any> = (
+        const { getAllByRole } = render(
           <DefaultButton iconProps={{ iconName: 'Add' }} menuProps={menuProps}>
             {'Button Text'}
-          </DefaultButton>
+          </DefaultButton>,
         );
 
-        render(element);
-
-        const button = render(element);
-
-        ReactTestUtils.Simulate.click(button);
+        const button = getAllByRole('button')[0];
+        userEvent.click(button);
 
         // get the menu id from the button's aria attribute
         const menuId = button.getAttribute('aria-controls');
         expect(menuId).toBeTruthy();
-
         const contextualMenuElement = button.ownerDocument!.getElementById(menuId as string);
         expect(contextualMenuElement).not.toBeNull();
-
-        ReactTestUtils.Simulate.keyDown(contextualMenuElement!, { which: KeyCodes.escape });
+        userEvent.tab();
+        userEvent.keyboard('{esc}');
         expect(callbackMock.mock.calls.length).toBe(1);
 
         // Expect that the menu doesn't exist any more since it's been dismissed
@@ -1074,7 +935,7 @@ describe('Button', () => {
       });
 
       it(`If button has text but labelElementId provided in menuProps, contextual menu has
-      aria-labelledBy reflecting labelElementId`, () => {
+          aria-labelledBy reflecting labelElementId`, () => {
         const explicitLabelElementId = 'id_ExplicitLabel';
         const contextualMenuElement = buildRenderAndClickButtonAndReturnContextualMenuDOMElement(
           { labelElementId: explicitLabelElementId },

--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -587,7 +587,7 @@ describe('Button', () => {
       // click event to fire. This doesn't happen in the simulator so we're
       // manually adding this in.
       fireEvent.touchStart(primaryButton);
-      fireEvent.click(primaryButton);
+      userEvent.click(primaryButton);
       expect(getAllByRole('button')[0].getAttribute('aria-expanded')).toEqual('true');
     });
 

--- a/packages/react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -1,858 +1,821 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button renders ActionButton correctly 1`] = `
-<button
-  className=
-      ms-Button
-      ms-Button--action
-      ms-Button--command
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        background-color: transparent;
-        border-radius: 2px;
-        border: 1px solid transparent;
-        box-sizing: border-box;
-        color: #323130;
-        cursor: pointer;
-        display: inline-block;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        height: 40px;
-        outline: transparent;
-        padding-bottom: 0;
-        padding-left: 4px;
-        padding-right: 4px;
-        padding-top: 0;
-        position: relative;
-        text-align: center;
-        text-decoration: none;
-        user-select: none;
-      }
-      &::-moz-focus-inner {
-        border: 0;
-      }
-      .ms-Fabric--isFocusVisible &:focus:after {
-        border: 1px solid transparent;
-        bottom: 2px;
-        content: "";
-        left: 2px;
-        outline: 1px solid #605e5c;
-        position: absolute;
-        right: 2px;
-        top: 2px;
-        z-index: 1;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-        bottom: -2px;
-        left: -2px;
-        outline-color: ButtonText;
-        right: -2px;
-        top: -2px;
-      }
-      &:active > * {
-        left: 0px;
-        position: relative;
-        top: 0px;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-        border-color: Window;
-      }
-      &:hover {
-        color: #0078d4;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-        color: Highlight;
-      }
-      &:hover .ms-Button-icon {
-        color: #0078d4;
-      }
-      &:active {
-        color: #000000;
-      }
-      &:active .ms-Button-icon {
-        color: #004578;
-      }
-  data-is-focusable={true}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyPress={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseUp={[Function]}
-  type="button"
->
-  <span
-    className=
-        ms-Button-flexContainer
+<div>
+  <button
+    class=
+        ms-Button
+        ms-Button--action
+        ms-Button--command
         {
-          align-items: center;
-          display: flex;
-          flex-wrap: nowrap;
-          height: 100%;
-          justify-content: flex-start;
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: transparent;
+          border-radius: 2px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #323130;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 40px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 4px;
+          padding-right: 4px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
         }
-    data-automationid="splitbuttonprimary"
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid transparent;
+          bottom: 2px;
+          content: "";
+          left: 2px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 2px;
+          top: 2px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+          border-color: Window;
+        }
+        &:hover {
+          color: #0078d4;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+          color: Highlight;
+        }
+        &:hover .ms-Button-icon {
+          color: #0078d4;
+        }
+        &:active {
+          color: #000000;
+        }
+        &:active .ms-Button-icon {
+          color: #004578;
+        }
+    data-is-focusable="true"
+    type="button"
   >
     <span
-      className=
-          ms-Button-textContainer
+      class=
+          ms-Button-flexContainer
           {
-            display: block;
-            flex-grow: 0;
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: flex-start;
           }
+      data-automationid="splitbuttonprimary"
     >
       <span
-        className=
-            ms-Button-label
+        class=
+            ms-Button-textContainer
             {
               display: block;
-              line-height: 100%;
-              margin-bottom: 0;
-              margin-left: 4px;
-              margin-right: 4px;
-              margin-top: 0;
+              flex-grow: 0;
             }
-        id="id__0"
       >
-        Button
+        <span
+          class=
+              ms-Button-label
+              {
+                display: block;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
+          id="id__0"
+        >
+          Button
+        </span>
       </span>
     </span>
-  </span>
-</button>
+  </button>
+</div>
 `;
 
 exports[`Button renders CommandBarButton correctly 1`] = `
-<button
-  aria-controls={null}
-  aria-expanded={false}
-  aria-haspopup={true}
-  className=
-      ms-Button
-      ms-Button--commandBar
-      ms-Button--hasMenu
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        background-color: #ffffff;
-        border-radius: 0px;
-        border: none;
-        box-sizing: border-box;
-        color: #323130;
-        cursor: pointer;
-        display: inline-block;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        min-width: 40px;
-        outline: transparent;
-        padding-bottom: 0;
-        padding-left: 4px;
-        padding-right: 4px;
-        padding-top: 0;
-        position: relative;
-        text-align: center;
-        text-decoration: none;
-        user-select: none;
-      }
-      &::-moz-focus-inner {
-        border: 0;
-      }
-      .ms-Fabric--isFocusVisible &:focus:after {
-        border: 1px solid transparent;
-        bottom: 3px;
-        content: "";
-        left: 3px;
-        outline: 1px solid #605e5c;
-        position: absolute;
-        right: 3px;
-        top: 3px;
-        z-index: 1;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-        border: none;
-        bottom: 4px;
-        left: 4px;
-        outline-color: ButtonText;
-        right: 4px;
-        top: 4px;
-      }
-      &:active > * {
-        left: 0px;
-        position: relative;
-        top: 0px;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-        border: none;
-      }
-      &:hover {
-        background-color: #f3f2f1;
-        color: #201f1e;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-        color: Highlight;
-      }
-      &:hover .ms-Button-icon {
-        color: #106ebe;
-      }
-      &:hover .ms-Button-menuIcon {
-        color: #323130;
-      }
-      &:active {
-        background-color: #edebe9;
-        color: #201f1e;
-      }
-      &:active .ms-Button-icon {
-        color: #005a9e;
-      }
-      &:active .ms-Button-menuIcon {
-        color: #323130;
-      }
-  data-is-focusable={true}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyPress={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseUp={[Function]}
-  type="button"
->
-  <span
-    className=
-        ms-Button-flexContainer
+<div>
+  <button
+    aria-expanded="false"
+    aria-haspopup="true"
+    class=
+        ms-Button
+        ms-Button--commandBar
+        ms-Button--hasMenu
         {
-          align-items: center;
-          display: flex;
-          flex-wrap: nowrap;
-          height: 100%;
-          justify-content: center;
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #ffffff;
+          border-radius: 0px;
+          border: none;
+          box-sizing: border-box;
+          color: #323130;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          min-width: 40px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 4px;
+          padding-right: 4px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
         }
-    data-automationid="splitbuttonprimary"
-  >
-    <i
-      aria-hidden={true}
-      className=
-          ms-Icon
-          ms-Button-icon
-          {
-            display: inline-block;
-          }
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            font-family: "FabricMDL2Icons";
-            font-style: normal;
-            font-weight: normal;
-            speak: none;
-          }
-          {
-            color: #0078d4;
-            flex-shrink: 0;
-            font-size: 16px;
-            height: 16px;
-            line-height: 16px;
-            margin-bottom: 0;
-            margin-left: 4px;
-            margin-right: 4px;
-            margin-top: 0;
-            text-align: center;
-          }
-      data-icon-name="Add"
-      style={
-        Object {
-          "fontFamily": "\\"FabricMDL2Icons\\"",
+        &::-moz-focus-inner {
+          border: 0;
         }
-      }
-    >
-      
-    </i>
-    <span
-      className=
-          ms-Button-textContainer
-          {
-            display: block;
-            flex-grow: 1;
-          }
-    >
-      <span
-        className=
-            ms-Button-label
-            {
-              display: block;
-              font-weight: normal;
-              line-height: 100%;
-              margin-bottom: 0;
-              margin-left: 4px;
-              margin-right: 4px;
-              margin-top: 0;
-            }
-        id="id__0"
-      >
-        Create account
-      </span>
-    </span>
-    <i
-      aria-hidden={true}
-      className=
-          ms-Icon
-          ms-Button-menuIcon
-          {
-            display: inline-block;
-          }
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            font-family: "FabricMDL2Icons";
-            font-style: normal;
-            font-weight: normal;
-            speak: none;
-          }
-          {
-            color: #605e5c;
-            flex-shrink: 0;
-            font-size: 12px;
-            height: 16px;
-            line-height: 16px;
-            margin-bottom: 0;
-            margin-left: 4px;
-            margin-right: 4px;
-            margin-top: 0;
-            text-align: center;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-            color: GrayText;
-          }
-      data-icon-name="ChevronDown"
-      style={
-        Object {
-          "fontFamily": "\\"FabricMDL2Icons\\"",
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid transparent;
+          bottom: 3px;
+          content: "";
+          left: 3px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 3px;
+          top: 3px;
+          z-index: 1;
         }
-      }
-    >
-      
-    </i>
-  </span>
-</button>
-`;
-
-exports[`Button renders CompoundButton correctly 1`] = `
-<button
-  aria-describedby="id__1"
-  aria-labelledby="id__0"
-  className=
-      ms-Button
-      ms-Button--compound
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        background-color: #ffffff;
-        border-radius: 2px;
-        border: 1px solid #8a8886;
-        box-sizing: border-box;
-        color: #323130;
-        cursor: pointer;
-        display: inline-block;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        height: auto;
-        max-width: 280px;
-        min-height: 72px;
-        outline: transparent;
-        padding-bottom: 16px;
-        padding-left: 12px;
-        padding-right: 12px;
-        padding-top: 16px;
-        position: relative;
-        text-align: center;
-        text-decoration: none;
-        user-select: none;
-      }
-      &::-moz-focus-inner {
-        border: 0;
-      }
-      .ms-Fabric--isFocusVisible &:focus:after {
-        border: 1px solid transparent;
-        bottom: 2px;
-        content: "";
-        left: 2px;
-        outline: 1px solid #605e5c;
-        position: absolute;
-        right: 2px;
-        top: 2px;
-        z-index: 1;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-        bottom: -2px;
-        left: -2px;
-        outline-color: ButtonText;
-        right: -2px;
-        top: -2px;
-      }
-      &:active > * {
-        left: 0px;
-        position: relative;
-        top: 0px;
-      }
-      &:hover {
-        background-color: #f3f2f1;
-        color: #201f1e;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-        border-color: Highlight;
-        color: Highlight;
-      }
-      &:hover .ms-Button-description {
-        color: #201f1e;
-      }
-      &:active {
-        background-color: #edebe9;
-        color: #201f1e;
-      }
-      &:active .ms-Button-description {
-        color: inherit;
-      }
-  data-is-focusable={true}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyPress={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseUp={[Function]}
-  type="button"
->
-  <span
-    className=
-        ms-Button-flexContainer
-        {
-          align-items: flex-start;
-          display: flex;
-          flex-direction: row;
-          flex-wrap: nowrap;
-          height: 100%;
-          justify-content: center;
-          margin-bottom: ;
-          margin-left: ;
-          margin-right: ;
-          margin-top: ;
-          min-width: 100%;
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: 4px;
+          left: 4px;
+          outline-color: ButtonText;
+          right: 4px;
+          top: 4px;
         }
-    data-automationid="splitbuttonprimary"
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+          border: none;
+        }
+        &:hover {
+          background-color: #f3f2f1;
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+          color: Highlight;
+        }
+        &:hover .ms-Button-icon {
+          color: #106ebe;
+        }
+        &:hover .ms-Button-menuIcon {
+          color: #323130;
+        }
+        &:active {
+          background-color: #edebe9;
+          color: #201f1e;
+        }
+        &:active .ms-Button-icon {
+          color: #005a9e;
+        }
+        &:active .ms-Button-menuIcon {
+          color: #323130;
+        }
+    data-is-focusable="true"
+    type="button"
   >
     <span
-      className=
-          ms-Button-textContainer
+      class=
+          ms-Button-flexContainer
           {
-            display: block;
-            flex-grow: 1;
-            text-align: left;
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
           }
+      data-automationid="splitbuttonprimary"
     >
-      <span
-        className=
-            ms-Button-label
+      <i
+        aria-hidden="true"
+        class=
+            ms-Icon
+            ms-Button-icon
             {
-              display: block;
-              font-weight: 600;
-              line-height: 100%;
-              margin-bottom: 5px;
-              margin-left: 0;
-              margin-right: 0;
-              margin-top: 0;
+              display: inline-block;
             }
-        id="id__0"
-      >
-        Create account
-      </span>
-      <span
-        className=
-            ms-Button-description
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              display: block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              line-height: 100%;
+              font-family: "FabricMDL2Icons";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
             }
-        id="id__1"
+            {
+              color: #0078d4;
+              flex-shrink: 0;
+              font-size: 16px;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              text-align: center;
+            }
+        data-icon-name="Add"
+        style="font-family: \\"FabricMDL2Icons\\";"
       >
-        You can create a new account here.
+        
+      </i>
+      <span
+        class=
+            ms-Button-textContainer
+            {
+              display: block;
+              flex-grow: 1;
+            }
+      >
+        <span
+          class=
+              ms-Button-label
+              {
+                display: block;
+                font-weight: normal;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
+          id="id__0"
+        >
+          Create account
+        </span>
+      </span>
+      <i
+        aria-hidden="true"
+        class=
+            ms-Icon
+            ms-Button-menuIcon
+            {
+              display: inline-block;
+            }
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: "FabricMDL2Icons";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
+            {
+              color: #605e5c;
+              flex-shrink: 0;
+              font-size: 12px;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              text-align: center;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              color: GrayText;
+            }
+        data-icon-name="ChevronDown"
+        style="font-family: \\"FabricMDL2Icons\\";"
+      >
+        
+      </i>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`Button renders CompoundButton correctly 1`] = `
+<div>
+  <button
+    aria-describedby="id__1"
+    aria-labelledby="id__0"
+    class=
+        ms-Button
+        ms-Button--compound
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #ffffff;
+          border-radius: 2px;
+          border: 1px solid #8a8886;
+          box-sizing: border-box;
+          color: #323130;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: auto;
+          max-width: 280px;
+          min-height: 72px;
+          outline: transparent;
+          padding-bottom: 16px;
+          padding-left: 12px;
+          padding-right: 12px;
+          padding-top: 16px;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid transparent;
+          bottom: 2px;
+          content: "";
+          left: 2px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 2px;
+          top: 2px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #f3f2f1;
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:hover .ms-Button-description {
+          color: #201f1e;
+        }
+        &:active {
+          background-color: #edebe9;
+          color: #201f1e;
+        }
+        &:active .ms-Button-description {
+          color: inherit;
+        }
+    data-is-focusable="true"
+    type="button"
+  >
+    <span
+      class=
+          ms-Button-flexContainer
+          {
+            align-items: flex-start;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+            margin-bottom: ;
+            margin-left: ;
+            margin-right: ;
+            margin-top: ;
+            min-width: 100%;
+          }
+      data-automationid="splitbuttonprimary"
+    >
+      <span
+        class=
+            ms-Button-textContainer
+            {
+              display: block;
+              flex-grow: 1;
+              text-align: left;
+            }
+      >
+        <span
+          class=
+              ms-Button-label
+              {
+                display: block;
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 5px;
+                margin-left: 0;
+                margin-right: 0;
+                margin-top: 0;
+              }
+          id="id__0"
+        >
+          Create account
+        </span>
+        <span
+          class=
+              ms-Button-description
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                line-height: 100%;
+              }
+          id="id__1"
+        >
+          You can create a new account here.
+        </span>
       </span>
     </span>
-  </span>
-</button>
+  </button>
+</div>
 `;
 
 exports[`Button renders DefaultButton correctly 1`] = `
-<button
-  className=
-      ms-Button
-      ms-Button--default
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        background-color: #ffffff;
-        border-radius: 2px;
-        border: 1px solid #8a8886;
-        box-sizing: border-box;
-        color: #323130;
-        cursor: pointer;
-        display: inline-block;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        height: 32px;
-        min-width: 80px;
-        outline: transparent;
-        padding-bottom: 0;
-        padding-left: 16px;
-        padding-right: 16px;
-        padding-top: 0;
-        position: relative;
-        text-align: center;
-        text-decoration: none;
-        user-select: none;
-      }
-      &::-moz-focus-inner {
-        border: 0;
-      }
-      .ms-Fabric--isFocusVisible &:focus:after {
-        border: 1px solid transparent;
-        bottom: 2px;
-        content: "";
-        left: 2px;
-        outline: 1px solid #605e5c;
-        position: absolute;
-        right: 2px;
-        top: 2px;
-        z-index: 1;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-        bottom: -2px;
-        left: -2px;
-        outline-color: ButtonText;
-        right: -2px;
-        top: -2px;
-      }
-      &:active > * {
-        left: 0px;
-        position: relative;
-        top: 0px;
-      }
-      &:hover {
-        background-color: #f3f2f1;
-        color: #201f1e;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-        border-color: Highlight;
-        color: Highlight;
-      }
-      &:active {
-        background-color: #edebe9;
-        color: #201f1e;
-      }
-  data-is-focusable={true}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyPress={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseUp={[Function]}
-  type="button"
->
-  <span
-    className=
-        ms-Button-flexContainer
+<div>
+  <button
+    class=
+        ms-Button
+        ms-Button--default
         {
-          align-items: center;
-          display: flex;
-          flex-wrap: nowrap;
-          height: 100%;
-          justify-content: center;
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #ffffff;
+          border-radius: 2px;
+          border: 1px solid #8a8886;
+          box-sizing: border-box;
+          color: #323130;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
         }
-    data-automationid="splitbuttonprimary"
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid transparent;
+          bottom: 2px;
+          content: "";
+          left: 2px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 2px;
+          top: 2px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #f3f2f1;
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #edebe9;
+          color: #201f1e;
+        }
+    data-is-focusable="true"
+    type="button"
   >
     <span
-      className=
-          ms-Button-textContainer
+      class=
+          ms-Button-flexContainer
           {
-            display: block;
-            flex-grow: 1;
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
           }
+      data-automationid="splitbuttonprimary"
     >
       <span
-        className=
-            ms-Button-label
+        class=
+            ms-Button-textContainer
             {
               display: block;
-              font-weight: 600;
-              line-height: 100%;
-              margin-bottom: 0;
-              margin-left: 4px;
-              margin-right: 4px;
-              margin-top: 0;
+              flex-grow: 1;
             }
-        id="id__0"
       >
-        Button
+        <span
+          class=
+              ms-Button-label
+              {
+                display: block;
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
+          id="id__0"
+        >
+          Button
+        </span>
       </span>
     </span>
-  </span>
-</button>
+  </button>
+</div>
 `;
 
 exports[`Button renders IconButton correctly 1`] = `
-<button
-  aria-label="Emoji"
-  className=
-      ms-Button
-      ms-Button--icon
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        background-color: transparent;
-        border-radius: 2px;
-        border: none;
-        box-sizing: border-box;
-        color: #0078d4;
-        cursor: pointer;
-        display: inline-block;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        height: 32px;
-        outline: transparent;
-        padding-bottom: 0;
-        padding-left: 4px;
-        padding-right: 4px;
-        padding-top: 0;
-        position: relative;
-        text-align: center;
-        text-decoration: none;
-        user-select: none;
-        width: 32px;
-      }
-      &::-moz-focus-inner {
-        border: 0;
-      }
-      .ms-Fabric--isFocusVisible &:focus:after {
-        border: 1px solid transparent;
-        bottom: 2px;
-        content: "";
-        left: 2px;
-        outline: 1px solid #605e5c;
-        position: absolute;
-        right: 2px;
-        top: 2px;
-        z-index: 1;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-        bottom: -2px;
-        left: -2px;
-        outline-color: ButtonText;
-        right: -2px;
-        top: -2px;
-      }
-      &:active > * {
-        left: 0px;
-        position: relative;
-        top: 0px;
-      }
-      &:hover {
-        background-color: #f3f2f1;
-        color: #106ebe;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-        border-color: Highlight;
-        color: Highlight;
-      }
-      &:active {
-        background-color: #edebe9;
-        color: #005a9e;
-      }
-  data-is-focusable={true}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyPress={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseUp={[Function]}
-  title="Emoji"
-  type="button"
->
-  <span
-    className=
-        ms-Button-flexContainer
+<div>
+  <button
+    aria-label="Emoji"
+    class=
+        ms-Button
+        ms-Button--icon
         {
-          align-items: center;
-          display: flex;
-          flex-wrap: nowrap;
-          height: 100%;
-          justify-content: center;
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: transparent;
+          border-radius: 2px;
+          border: none;
+          box-sizing: border-box;
+          color: #0078d4;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 4px;
+          padding-right: 4px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          width: 32px;
         }
-    data-automationid="splitbuttonprimary"
-  >
-    <i
-      aria-hidden={true}
-      className=
-          ms-Icon
-          ms-Button-icon
-          {
-            display: inline-block;
-          }
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            font-family: "FabricMDL2Icons-0";
-            font-style: normal;
-            font-weight: normal;
-            speak: none;
-          }
-          {
-            flex-shrink: 0;
-            font-size: 16px;
-            height: 16px;
-            line-height: 16px;
-            margin-bottom: 0;
-            margin-left: 4px;
-            margin-right: 4px;
-            margin-top: 0;
-            text-align: center;
-          }
-      data-icon-name="Emoji2"
-      style={
-        Object {
-          "fontFamily": "\\"FabricMDL2Icons-0\\"",
+        &::-moz-focus-inner {
+          border: 0;
         }
-      }
-    >
-      
-    </i>
-  </span>
-</button>
-`;
-
-exports[`Button renders a DefaultButton with a keytip correctly 1`] = `
-<button
-  aria-describedby="ktp-layer-id ktp-a"
-  className=
-      ms-Button
-      ms-Button--default
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        background-color: #ffffff;
-        border-radius: 2px;
-        border: 1px solid #8a8886;
-        box-sizing: border-box;
-        color: #323130;
-        cursor: pointer;
-        display: inline-block;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        height: 32px;
-        min-width: 80px;
-        outline: transparent;
-        padding-bottom: 0;
-        padding-left: 16px;
-        padding-right: 16px;
-        padding-top: 0;
-        position: relative;
-        text-align: center;
-        text-decoration: none;
-        user-select: none;
-      }
-      &::-moz-focus-inner {
-        border: 0;
-      }
-      .ms-Fabric--isFocusVisible &:focus:after {
-        border: 1px solid transparent;
-        bottom: 2px;
-        content: "";
-        left: 2px;
-        outline: 1px solid #605e5c;
-        position: absolute;
-        right: 2px;
-        top: 2px;
-        z-index: 1;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-        bottom: -2px;
-        left: -2px;
-        outline-color: ButtonText;
-        right: -2px;
-        top: -2px;
-      }
-      &:active > * {
-        left: 0px;
-        position: relative;
-        top: 0px;
-      }
-      &:hover {
-        background-color: #f3f2f1;
-        color: #201f1e;
-      }
-      @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-        border-color: Highlight;
-        color: Highlight;
-      }
-      &:active {
-        background-color: #edebe9;
-        color: #201f1e;
-      }
-  data-is-focusable={true}
-  data-ktp-execute-target="ktp-a"
-  data-ktp-target="ktp-a"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyPress={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseUp={[Function]}
-  type="button"
->
-  <span
-    className=
-        ms-Button-flexContainer
-        {
-          align-items: center;
-          display: flex;
-          flex-wrap: nowrap;
-          height: 100%;
-          justify-content: center;
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid transparent;
+          bottom: 2px;
+          content: "";
+          left: 2px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 2px;
+          top: 2px;
+          z-index: 1;
         }
-    data-automationid="splitbuttonprimary"
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #f3f2f1;
+          color: #106ebe;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #edebe9;
+          color: #005a9e;
+        }
+    data-is-focusable="true"
+    title="Emoji"
+    type="button"
   >
     <span
-      className=
-          ms-Button-textContainer
+      class=
+          ms-Button-flexContainer
           {
-            display: block;
-            flex-grow: 1;
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
           }
+      data-automationid="splitbuttonprimary"
     >
-      <span
-        className=
-            ms-Button-label
+      <i
+        aria-hidden="true"
+        class=
+            ms-Icon
+            ms-Button-icon
             {
-              display: block;
-              font-weight: 600;
-              line-height: 100%;
+              display: inline-block;
+            }
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: "FabricMDL2Icons-0";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
+            {
+              flex-shrink: 0;
+              font-size: 16px;
+              height: 16px;
+              line-height: 16px;
               margin-bottom: 0;
               margin-left: 4px;
               margin-right: 4px;
               margin-top: 0;
+              text-align: center;
             }
-        id="id__0"
+        data-icon-name="Emoji2"
+        style="font-family: \\"FabricMDL2Icons-0\\";"
       >
-        Button
+        
+      </i>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`Button renders a DefaultButton with a keytip correctly 1`] = `
+<div>
+  <button
+    aria-describedby="ktp-layer-id ktp-a"
+    class=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #ffffff;
+          border-radius: 2px;
+          border: 1px solid #8a8886;
+          box-sizing: border-box;
+          color: #323130;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid transparent;
+          bottom: 2px;
+          content: "";
+          left: 2px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 2px;
+          top: 2px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #f3f2f1;
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #edebe9;
+          color: #201f1e;
+        }
+    data-is-focusable="true"
+    data-ktp-execute-target="ktp-a"
+    data-ktp-target="ktp-a"
+    type="button"
+  >
+    <span
+      class=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+      data-automationid="splitbuttonprimary"
+    >
+      <span
+        class=
+            ms-Button-textContainer
+            {
+              display: block;
+              flex-grow: 1;
+            }
+      >
+        <span
+          class=
+              ms-Button-label
+              {
+                display: block;
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
+          id="id__0"
+        >
+          Button
+        </span>
       </span>
     </span>
-  </span>
-</button>
+  </button>
+</div>
 `;


### PR DESCRIPTION
## Current Behavior

- v8 `Button` tests don't use testing-library

## New Behavior

- Convert `Button` to fully use testing-library

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

part of #21663 