### PR TITLE
Add warning text to ChoiceGroup image/icon layout

### DIFF
--- a/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Icon.Example.tsx
+++ b/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Icon.Example.tsx
@@ -8,5 +8,15 @@ const options: IChoiceGroupOption[] = [
 ];
 
 export const ChoiceGroupIconExample: React.FunctionComponent = () => {
-  return <ChoiceGroup label="Pick one icon" defaultSelectedKey="day" options={options} />;
+  return (
+    <>
+      <ChoiceGroup label="Pick one icon" defaultSelectedKey="day" options={options} />;
+      <p>
+        Warning: this ChoiceGroup option layout restricts the space that label text has to expand and wrap. This can
+        cause issues for accessibility, when zoom and text spacing increase the length of words and lines, and also
+        internationalization, since translated text length will vary.
+      </p>
+      <p>We recommend using the standard layout with an inline icon for labels longer than a single short word.</p>
+    </>
+  );
 };

--- a/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Image.Example.tsx
+++ b/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Image.Example.tsx
@@ -22,5 +22,15 @@ const options: IChoiceGroupOption[] = [
 ];
 
 export const ChoiceGroupImageExample: React.FunctionComponent = () => {
-  return <ChoiceGroup label="Pick one image" defaultSelectedKey="bar" options={options} />;
+  return (
+    <>
+      <ChoiceGroup label="Pick one image" defaultSelectedKey="bar" options={options} />
+      <p>
+        Warning: this ChoiceGroup option layout restricts the space that label text has to expand and wrap. This can
+        cause issues for accessibility, when zoom and text spacing increase the length of words and lines, and also
+        internationalization, since translated text length will vary.
+      </p>
+      <p>We recommend using the standard layout with an inline image for labels longer than a single short word.</p>
+    </>
+  );
 };


### PR DESCRIPTION
Fixes [13334](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/13334)

Adds more easily visible text wrapping/spacing warning to ChoiceGroup's image and icon variations