### PR TITLE
Improve Selection with more micro-management capabilities

### DIFF
--- a/change/@fluentui-utilities-cc0c03e5-dd13-492f-aeb8-a4a5db4f7097.json
+++ b/change/@fluentui-utilities-cc0c03e5-dd13-492f-aeb8-a4a5db4f7097.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Enhance selection to support better micro-management",
+  "packageName": "@fluentui/utilities",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -695,6 +695,8 @@ export interface ISelection<TItem = IObjectWithKey> {
     // (undocumented)
     count: number;
     // (undocumented)
+    getItemIndex?(key: string): number;
+    // (undocumented)
     getItems(): TItem[];
     // (undocumented)
     getSelectedCount(): number;
@@ -747,6 +749,8 @@ export interface ISelectionOptions<TItem = IObjectWithKey> {
     getKey?: (item: TItem, index?: number) => string | number;
     // (undocumented)
     items?: TItem[];
+    // (undocumented)
+    onItemsChanged?: () => void;
     // (undocumented)
     onSelectionChanged?: () => void;
     // (undocumented)
@@ -1062,6 +1066,8 @@ class Selection_2<TItem = IObjectWithKey> implements ISelection<TItem> {
     canSelectItem(item: TItem, index?: number): boolean;
     count: number;
     // (undocumented)
+    getItemIndex(key: string): number;
+    // (undocumented)
     getItems(): TItem[];
     // (undocumented)
     getKey(item: TItem, index?: number): string;
@@ -1111,6 +1117,9 @@ export { Selection_2 as Selection }
 
 // @public (undocumented)
 export const SELECTION_CHANGE = "change";
+
+// @public (undocumented)
+export const SELECTION_ITEMS_CHANGE = "items-change";
 
 // @public (undocumented)
 export enum SelectionDirection {

--- a/packages/utilities/src/selection/Selection.ts
+++ b/packages/utilities/src/selection/Selection.ts
@@ -211,6 +211,7 @@ export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
       for (const key of Object.keys(this._keyToIndexMap)) {
         if (!(key in newKeyToIndexMap)) {
           haveItemsChanged = true;
+          break;
         }
       }
     }

--- a/packages/utilities/src/selection/Selection.ts
+++ b/packages/utilities/src/selection/Selection.ts
@@ -80,6 +80,7 @@ export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
     this._onSelectionChanged = onSelectionChanged;
     this._onItemsChanged = onItemsChanged;
     this._canSelectItem = canSelectItem;
+    this._keyToIndexMap = {};
 
     this._isModal = false;
 
@@ -223,7 +224,6 @@ export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
 
     if (hasSelectionChanged) {
       this._updateCount();
-      this._change();
     }
 
     if (haveItemsChanged) {
@@ -232,6 +232,10 @@ export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
       if (this._onItemsChanged) {
         this._onItemsChanged();
       }
+    }
+
+    if (hasSelectionChanged) {
+      this._change();
     }
 
     this.setChangeEvents(true);

--- a/packages/utilities/src/selection/Selection.types.ts
+++ b/packages/utilities/src/selection/Selection.types.ts
@@ -6,6 +6,7 @@ export interface IObjectWithKey {
 }
 
 export const SELECTION_CHANGE = 'change';
+export const SELECTION_ITEMS_CHANGE = 'items-change';
 
 /**
  * {@docCategory Selection}
@@ -32,6 +33,9 @@ export interface ISelection<TItem = IObjectWithKey> {
 
   setItems(items: TItem[], shouldClear: boolean): void;
   getItems(): TItem[];
+
+  // Item utility methods.
+  getItemIndex?(key: string): number;
 
   // Read selection methods.
 


### PR DESCRIPTION
## Current Behavior

The `Selection` model component is critical to the functionality of `DetailsList`, `TilesList`, and other list-rendering components. Most of the time, lists are rendered first, with no items selected, and then a user performs actions to select items (usually facilitated by `SelectionZone`). In code, a host component can create a `Selection` instance, subscribe to it, and then pass it into `DetailsList` or `TilesList`, in order to receive notifications when the selection changes.

One challenge is that `DetailsList` and `TilesList` are responsible for assigning the final `items` array to `Selection`: the host does not provide it upfront. Sometimes, the caller needs to be able to set some items as selected *upfront*; however, `Selection` does not allow items which are not part of the current `items` array to remain selected, so the `setItems()` call made by `DetailsList` or `TilesList` would undo any initial calls to `setKeySelected` or `setItemSelected`. In addition, the `onSelectionChanged` event does not fire if a `setItems` call does not actually cause any changes to set of *selected items*, so it cannot be used as a general callback hook to capture when the `setItems` calls are made.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

This change adds a couple new behaviors to `Selection`. The first is support for an `onItemsChanged` callback, and an `items-change` event to complement the `change` event. The second is a new `getItemIndex` function, which ensures that a handler operation on `Selection` object does not need to iterate every entry in `getItems()` to determine if a `key` is actually in the set.

The `onItemsChanged` callback is carefully invoked so that it is called just after `setItems` is done processing, but before the `onSelectedChanged` callback is fired. In addition, the `onItemsChanged` callback is fired while the `'change'` event of the `Selection` is suppress: this allows the handler to select and unselect items without causing more events to fire. The handler can access the updated selection state (reflecting the changes made by the new `items` array) and interact with an accurate state. The only thing a handler should *not* do is call `setItems()` again!

Added unit tests covering calls to `Selection.setItems()` and the call counts of the handlers and their effects.
