### PR TITLE
Adding Switch to @fluentui/react-components/unstable

### DIFF
--- a/change/@fluentui-react-components-fd2612fd-ab61-44c8-89bf-0b66795fa1df.json
+++ b/change/@fluentui-react-components-fd2612fd-ab61-44c8-89bf-0b66795fa1df.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding Switch to @fluentui/react-components/unstable.",
+  "packageName": "@fluentui/react-components",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -51,6 +51,7 @@
     "@fluentui/react-provider": "9.0.0-rc.5",
     "@fluentui/react-radio": "9.0.0-beta.2",
     "@fluentui/react-slider": "9.0.0-beta.10",
+    "@fluentui/react-switch": "9.0.0-rc.5",
     "@fluentui/react-tabs": "9.0.0-beta.8",
     "@fluentui/react-theme": "9.0.0-rc.4",
     "@fluentui/react-tooltip": "9.0.0-rc.5",

--- a/packages/react-components/src/unstable/index.ts
+++ b/packages/react-components/src/unstable/index.ts
@@ -94,8 +94,16 @@ export {
   useSlider_unstable,
   renderSlider_unstable,
 } from '@fluentui/react-slider';
-
 export type { SliderProps, SliderSlots, SliderOnChangeData, SliderState } from '@fluentui/react-slider';
+
+export {
+  Switch,
+  switchClassNames,
+  renderSwitch_unstable,
+  useSwitch_unstable,
+  useSwitchStyles_unstable,
+} from '@fluentui/react-switch';
+export type { SwitchOnChangeData, SwitchProps, SwitchSlots, SwitchState } from '@fluentui/react-switch';
 
 export {
   Tab,
@@ -109,7 +117,6 @@ export {
   useTabListStyles_unstable,
   renderTabList_unstable,
 } from '@fluentui/react-tabs';
-
 export type {
   TabValue,
   TabProps,

--- a/packages/react-switch/src/stories/Switch.stories.tsx
+++ b/packages/react-switch/src/stories/Switch.stories.tsx
@@ -12,7 +12,7 @@ export * from './SwitchRequired.stories';
 export * from './SwitchThemed.stories';
 
 export default {
-  title: 'Components/Switch',
+  title: 'Preview Components/Switch',
   component: Switch,
   parameters: {
     docs: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## PR Description

This PR adds the `Switch` component to the `unstable` folder of the `@fluentui/react-components` package.

Fixes part of #21739
