### PR TITLE
TextField (v8): convert tests to use testing-library

### DIFF
--- a/packages/react/src/components/TextField/TextField.test.tsx
+++ b/packages/react/src/components/TextField/TextField.test.tsx
@@ -39,10 +39,6 @@ function sharedAfterEach() {
   }
 }
 
-function getInput(): HTMLInputElement {
-  return screen.getByRole('textbox') as HTMLInputElement;
-}
-
 describe('TextField snapshots', () => {
   beforeEach(sharedBeforeEach);
 
@@ -140,38 +136,47 @@ describe('TextField rendering values from props', () => {
   it('can render a value', () => {
     const testText = 'initial value';
     // use the noOp change handler because onChange is required when value is specified
-    render(<TextField value={testText} onChange={noOp} componentRef={textFieldRef} />);
-    expect(getInput().value).toEqual(testText);
+    const { getByRole } = render(<TextField value={testText} onChange={noOp} componentRef={textFieldRef} />);
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toEqual(testText);
+    expect(textField!.value).toEqual(testText);
   });
 
   it('can render a value as a textarea', () => {
     const testText = 'This\nIs\nMultiline\nText\n';
-    render(<TextField value={testText} onChange={noOp} multiline componentRef={textFieldRef} />);
-    expect(getInput().value).toEqual(testText);
+    const { getByRole } = render(<TextField value={testText} onChange={noOp} multiline componentRef={textFieldRef} />);
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toEqual(testText);
+    expect(textField!.value).toEqual(testText);
   });
 
   it('should render a value of 0 when given the number 0', () => {
-    render(<TextField value={0 as any} onChange={noOp} componentRef={textFieldRef} />);
-    expect(getInput().value).toEqual('0');
+    const { getByRole } = render(<TextField value={0 as any} onChange={noOp} componentRef={textFieldRef} />);
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toEqual('0');
+    expect(textField!.value).toEqual('0');
   });
 
   it('can render a default value', () => {
     const testText = 'initial value';
-    render(<TextField defaultValue={testText} componentRef={textFieldRef} />);
-    expect(getInput().value).toEqual(testText);
+    const { getByRole } = render(<TextField defaultValue={testText} componentRef={textFieldRef} />);
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toEqual(testText);
     expect(textField!.value).toEqual(testText);
   });
 
   it('can render a default value as a textarea', () => {
     const testText = 'This\nIs\nMultiline\nText\n';
-    render(<TextField defaultValue={testText} multiline componentRef={textFieldRef} />);
-    expect(getInput().value).toEqual(testText);
+    const { getByRole } = render(<TextField defaultValue={testText} multiline componentRef={textFieldRef} />);
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toEqual(testText);
     expect(textField!.value).toEqual(testText);
   });
 
   it('should render a default value of 0 when given the number 0', () => {
-    render(<TextField defaultValue={0 as any} componentRef={textFieldRef} />);
-    expect(getInput().value).toEqual('0');
+    const { getByRole } = render(<TextField defaultValue={0 as any} componentRef={textFieldRef} />);
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toEqual('0');
     expect(textField!.value).toEqual('0');
   });
 }); // end rendering values from props
@@ -185,8 +190,8 @@ describe('TextField basic props', () => {
     expect(container.querySelector('label')!.textContent).toEqual(exampleLabel);
   });
   it('should associate the label and input box', () => {
-    const { container } = render(<TextField label="text-field-label" defaultValue="whatever value" />);
-    const inputDOM = getInput();
+    const { container, getByRole } = render(<TextField label="text-field-label" defaultValue="whatever value" />);
+    const inputDOM = getByRole('textbox') as HTMLInputElement;
     const labelDOM = container.querySelector('label')!;
     // Assert the input ID and label FOR attribute are the same.
     expect(inputDOM!.id).toBeTruthy();
@@ -243,21 +248,25 @@ describe('TextField basic props', () => {
     expect(input.type).toEqual('password');
   });
   it('should not give an aria-labelledby if no label is provided', () => {
-    render(<TextField />);
-    expect(getInput().getAttribute('aria-labelledby')).toBeNull();
+    const { getByRole } = render(<TextField />);
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.getAttribute('aria-labelledby')).toBeNull();
   });
   it('should use explicitly defined aria-labelledby prop if one is given', () => {
     const sampleAriaLabelledby = 'sample for aria-labelledby';
-    render(<TextField label="text-field-label" aria-labelledby={sampleAriaLabelledby} />);
-    expect(getInput().getAttribute('aria-labelledby')).toEqual(sampleAriaLabelledby);
+    const { getByRole } = render(<TextField label="text-field-label" aria-labelledby={sampleAriaLabelledby} />);
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.getAttribute('aria-labelledby')).toEqual(sampleAriaLabelledby);
   });
   it('should render a disabled input element', () => {
-    render(<TextField disabled={true} />);
-    expect(getInput().disabled).toEqual(true);
+    const { getByRole } = render(<TextField disabled={true} />);
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.disabled).toEqual(true);
   });
   it('should render a readonly input element', () => {
-    render(<TextField readOnly={true} />);
-    expect(getInput().readOnly).toEqual(true);
+    const { getByRole } = render(<TextField readOnly={true} />);
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.readOnly).toEqual(true);
   });
   it('can render description text', () => {
     const testDescription = 'A custom description';
@@ -325,9 +334,10 @@ describe('TextField with error message', () => {
   it('should render error message when onGetErrorMessage returns a string', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    const { container } = render(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
+    const { container, getByRole } = render(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
+    const input = getByRole('textbox') as HTMLInputElement;
 
-    userEvent.type(getInput(), 'also invalid');
+    userEvent.type(input, 'also invalid');
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(1);
@@ -337,9 +347,10 @@ describe('TextField with error message', () => {
   it('should render error message when onGetErrorMessage returns a JSX.Element', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessageJSX : ''));
 
-    const { container } = render(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
+    const { container, getByRole } = render(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
+    const input = getByRole('textbox') as HTMLInputElement;
 
-    userEvent.type(getInput(), 'also invalid');
+    userEvent.type(input, 'also invalid');
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(1);
@@ -349,9 +360,10 @@ describe('TextField with error message', () => {
   it('should render error message when onGetErrorMessage returns a Promise<string>', () => {
     const validator = jest.fn((value: string) => Promise.resolve(value.length > 3 ? errorMessage : ''));
 
-    const { container } = render(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
+    const { container, getByRole } = render(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
+    const input = getByRole('textbox') as HTMLInputElement;
 
-    userEvent.type(getInput(), 'also invalid');
+    userEvent.type(input, 'also invalid');
 
     // Extra rounds of running everything to account for the debounced validator and the promise...
     jest.runAllTimers();
@@ -366,9 +378,10 @@ describe('TextField with error message', () => {
   it('should render error message when onGetErrorMessage returns a Promise<JSX.Element>', () => {
     const validator = jest.fn((value: string) => Promise.resolve(value.length > 3 ? errorMessageJSX : ''));
 
-    const { container } = render(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
+    const { container, getByRole } = render(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
+    const input = getByRole('textbox') as HTMLInputElement;
 
-    userEvent.type(getInput(), 'also invalid');
+    userEvent.type(input, 'also invalid');
 
     jest.runAllTimers();
     return flushPromises().then(() => {
@@ -440,29 +453,14 @@ describe('TextField with error message', () => {
 
   it('should not validate when receiving props when validating only on focus in', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
+    const baseProps = { validateOnFocusIn: true, onChange: noOp, onGetErrorMessage: validator, validateOnLoad: false };
 
-    const { container, rerender } = render(
-      <TextField
-        validateOnFocusIn
-        value="initial value"
-        onChange={noOp}
-        onGetErrorMessage={validator}
-        validateOnLoad={false}
-      />,
-    );
+    const { container, rerender } = render(<TextField {...baseProps} value="initial value" />);
     jest.runAllTimers();
     expect(validator).toHaveBeenCalledTimes(0);
     assertErrorMessage(container, false);
 
-    rerender(
-      <TextField
-        validateOnFocusIn
-        value="failValidationValue"
-        onChange={noOp}
-        onGetErrorMessage={validator}
-        validateOnLoad={false}
-      />,
-    );
+    rerender(<TextField {...baseProps} value="failValidationValue" />);
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(0);
@@ -471,29 +469,14 @@ describe('TextField with error message', () => {
 
   it('should not validate when receiving props when validating only on focus out', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
+    const baseProps = { validateOnFocusOut: true, onChange: noOp, onGetErrorMessage: validator, validateOnLoad: false };
 
-    const { container, rerender } = render(
-      <TextField
-        validateOnFocusOut
-        value="initial value"
-        onChange={noOp}
-        onGetErrorMessage={validator}
-        validateOnLoad={false}
-      />,
-    );
+    const { container, rerender } = render(<TextField {...baseProps} value="initial value" />);
     jest.runAllTimers();
     expect(validator).toHaveBeenCalledTimes(0);
     assertErrorMessage(container, false);
 
-    rerender(
-      <TextField
-        validateOnFocusOut
-        value="failValidationValue"
-        onChange={noOp}
-        onGetErrorMessage={validator}
-        validateOnLoad={false}
-      />,
-    );
+    rerender(<TextField {...baseProps} value="failValidationValue" />);
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(0);
@@ -503,11 +486,11 @@ describe('TextField with error message', () => {
   it('should trigger validation only on focus', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    const { container } = render(
+    const { container, getByRole } = render(
       <TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusIn />,
     );
 
-    const input = getInput();
+    const input = getByRole('textbox') as HTMLInputElement;
     userEvent.type(input, 'invalid value', { skipClick: true });
     expect(validator).toHaveBeenCalledTimes(1);
 
@@ -523,11 +506,11 @@ describe('TextField with error message', () => {
   it('should trigger validation only on blur', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    const { container } = render(
+    const { container, getByRole } = render(
       <TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusOut />,
     );
 
-    const input = getInput();
+    const input = getByRole('textbox') as HTMLInputElement;
     userEvent.type(input, 'invalid value');
     expect(validator).toHaveBeenCalledTimes(1);
 
@@ -543,15 +526,15 @@ describe('TextField with error message', () => {
   it('should trigger validation on both blur and focus', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    const { container } = render(
+    const { container, getByRole } = render(
       <TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusOut validateOnFocusIn />,
     );
 
-    const input = getInput();
+    const input = getByRole('textbox') as HTMLInputElement;
     userEvent.type(input, 'value before focus', { skipClick: true });
     expect(validator).toHaveBeenCalledTimes(1);
 
-    userEvent.type(input, 'value after foc ');
+    userEvent.type(input, 'value after foc');
     userEvent.type(input, 'value after focus');
     expect(validator).toHaveBeenCalledTimes(2);
     //triggers blur event
@@ -575,7 +558,7 @@ describe('TextField controlled vs uncontrolled usage', () => {
   function verifyWarningsAndValue(warningCount: number, value: string | undefined) {
     expect(warnFn).toHaveBeenCalledTimes(warningCount);
 
-    const inputDOM = getInput();
+    const inputDOM = screen.getByRole('textbox') as HTMLInputElement;
     // check both the DOM and the state to ensure they match
     expect(textField!.value).toEqual(value);
     expect(inputDOM!.value).toEqual(value);
@@ -653,13 +636,13 @@ describe('TextField controlled vs uncontrolled usage', () => {
   });
 
   it('respects update and warns if value goes from provided to undefined', () => {
-    const { rerender } = render(<TextField value={value1} onChange={noOp} componentRef={textFieldRef} />);
+    const { rerender, getByRole } = render(<TextField value={value1} onChange={noOp} componentRef={textFieldRef} />);
     expect(warnFn).toHaveBeenCalledTimes(0);
 
     rerender(<TextField value={undefined} onChange={noOp} componentRef={textFieldRef} />);
 
     expect(warnFn).toHaveBeenCalledTimes(1);
-    const inputDOM = getInput();
+    const inputDOM = getByRole('textbox') as HTMLInputElement;
     expect(textField!.value).toEqual(undefined);
     expect(inputDOM!.value).toEqual('');
   });
@@ -695,7 +678,7 @@ describe('TextField onChange', () => {
   function simulateAndVerifyChange(changeValue: string, calls: number, expectedValue?: string) {
     expectedValue = typeof expectedValue === 'string' ? expectedValue : changeValue;
 
-    const input = getInput();
+    const input = screen.getByRole('textbox') as HTMLInputElement;
     fireEvent.change(input, { target: { value: changeValue } });
 
     expect(onChange).toHaveBeenCalledTimes(calls);
@@ -767,7 +750,7 @@ describe('TextField onChange', () => {
   });
 }); // end on change
 
-// // Other things that don't fit into a category above
+// Other things that don't fit into a category above
 describe('TextField', () => {
   beforeEach(sharedBeforeEach);
   afterEach(sharedAfterEach);
@@ -787,17 +770,17 @@ describe('TextField', () => {
   });
 
   it('sets focus to the input via ITextField focus', () => {
-    render(<TextField componentRef={textFieldRef} />);
+    const { getByRole } = render(<TextField componentRef={textFieldRef} />);
 
-    const input = getInput();
+    const input = getByRole('textbox') as HTMLInputElement;
     textField!.focus();
     expect(document.activeElement).toBe(input);
   });
 
   it('blurs the input via ITextField blur', () => {
-    render(<TextField componentRef={textFieldRef} />);
+    const { getByRole } = render(<TextField componentRef={textFieldRef} />);
 
-    const input = getInput();
+    const input = getByRole('textbox') as HTMLInputElement;
 
     textField!.focus();
     expect(document.activeElement).toBe(input);
@@ -827,20 +810,20 @@ describe('TextField', () => {
   });
 
   it('maintains focus when switching single to multi line and back', () => {
-    const { rerender } = render(<TextField componentRef={textFieldRef} />);
+    const { rerender, getByRole } = render(<TextField componentRef={textFieldRef} />);
 
     // focus input
     textField!.focus();
-    expect(document.activeElement).toBe(getInput());
+    expect(document.activeElement).toBe(getByRole('textbox'));
 
     // switch to multiline
     rerender(<TextField multiline={true} />);
     // verify still focused
-    expect(document.activeElement).toBe(getInput());
+    expect(document.activeElement).toBe(getByRole('textbox'));
     // back to single line
     rerender(<TextField multiline={false} />);
     // verify still focused
-    expect(document.activeElement).toBe(getInput());
+    expect(document.activeElement).toBe(getByRole('textbox'));
   });
 
   it('maintains selection when switching single to multi line and back', () => {

--- a/packages/react/src/components/TextField/TextField.test.tsx
+++ b/packages/react/src/components/TextField/TextField.test.tsx
@@ -491,16 +491,17 @@ describe('TextField with error message', () => {
     );
 
     const input = getByRole('textbox') as HTMLInputElement;
-    userEvent.type(input, 'invalid value', { skipClick: true });
-    expect(validator).toHaveBeenCalledTimes(1);
-
-    userEvent.click(input);
+    userEvent.type(input, 'invalid value');
     expect(validator).toHaveBeenCalledTimes(2);
+
+    userEvent.click(container);
+    userEvent.click(input);
+    expect(validator).toHaveBeenCalledTimes(3);
 
     userEvent.click(container);
     userEvent.type(input, 'also ');
     userEvent.type(input, 'also invalid');
-    expect(validator).toHaveBeenCalledTimes(3);
+    expect(validator).toHaveBeenCalledTimes(4);
   });
 
   it('should trigger validation only on blur', () => {

--- a/packages/react/src/components/TextField/TextField.test.tsx
+++ b/packages/react/src/components/TextField/TextField.test.tsx
@@ -1,20 +1,16 @@
 import * as React from 'react';
-import * as ReactTestUtils from 'react-dom/test-utils';
-import { create } from '@fluentui/utilities/lib/test';
-import { mount, ReactWrapper } from 'enzyme';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import * as path from 'path';
 import { resetIds, setWarningCallback, resetControlledWarnings } from '../../Utilities';
-import { mockEvent, flushPromises } from '../../common/testUtilities';
-import { safeMount } from '@fluentui/test-utilities';
+import { flushPromises } from '../../common/testUtilities';
 
 import { TextField } from './TextField';
-import { TextFieldBase } from './TextField.base';
 import { isConformant } from '../../common/isConformant';
 import type { IRefObject } from '../../Utilities';
-import type { ITextFieldState } from './TextField.base';
-import type { ITextFieldProps, ITextFieldStyles, ITextField } from './TextField.types';
+import type { ITextFieldStyles, ITextField } from './TextField.types';
 
 /**
  * The currently rendered ITextField.
@@ -25,8 +21,7 @@ let textField: ITextField | undefined;
 const textFieldRef: IRefObject<ITextField> = (ref: ITextField | null) => {
   textField = ref!;
 };
-/** Wrapper of the TextField currently being tested */
-let wrapper: ReactWrapper<ITextFieldProps, ITextFieldState, TextFieldBase> | undefined;
+
 const noOp = () => undefined;
 
 function sharedBeforeEach() {
@@ -35,10 +30,6 @@ function sharedBeforeEach() {
 }
 
 function sharedAfterEach() {
-  if (wrapper) {
-    wrapper.unmount();
-    wrapper = undefined;
-  }
   textField = undefined;
 
   // Do this after unmounting the wrapper to make sure any timers cleaned up on unmount are
@@ -48,37 +39,37 @@ function sharedAfterEach() {
   }
 }
 
+function getInput(): HTMLInputElement {
+  return screen.getByRole('textbox') as HTMLInputElement;
+}
+
 describe('TextField snapshots', () => {
   beforeEach(sharedBeforeEach);
 
   it('renders correctly', () => {
     const className = 'testClassName';
     const inputClassName = 'testInputClassName';
-    const component = create(<TextField label="Label" className={className} inputClassName={inputClassName} />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<TextField label="Label" className={className} inputClassName={inputClassName} />);
+    expect(container).toMatchSnapshot();
   });
 
   it('renders multiline non resizable correctly', () => {
-    const component = create(<TextField label="Label" multiline={true} resizable={false} />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<TextField label="Label" multiline={true} resizable={false} />);
+    expect(container).toMatchSnapshot();
   });
 
   it('renders multiline resizable correctly', () => {
-    const component = create(<TextField label="Label" multiline={true} resizable={true} />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<TextField label="Label" multiline={true} resizable={true} />);
+    expect(container).toMatchSnapshot();
   });
 
   it('renders multiline with placeholder correctly', () => {
-    const component = create(<TextField label="Label" multiline={true} placeholder="test placeholder" />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<TextField label="Label" multiline={true} placeholder="test placeholder" />);
+    expect(container).toMatchSnapshot();
   });
 
   it('renders multiline correctly with props affecting styling', () => {
-    const component = create(
+    const { container } = render(
       <TextField
         label="Label"
         errorMessage="test message"
@@ -87,12 +78,11 @@ describe('TextField snapshots', () => {
         suffix="test suffix"
       />,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it('renders multiline correctly with errorMessage', () => {
-    const component = create(
+    const { container } = render(
       <TextField
         label="Label"
         errorMessage="test message"
@@ -101,8 +91,7 @@ describe('TextField snapshots', () => {
         suffix="test suffix"
       />,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it('should respect user component and subcomponent styling', () => {
@@ -114,7 +103,7 @@ describe('TextField snapshots', () => {
         },
       },
     };
-    const component = create(
+    const { container } = render(
       <TextField
         label="Label"
         errorMessage="test message"
@@ -124,14 +113,12 @@ describe('TextField snapshots', () => {
         styles={styles}
       />,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it('renders with reveal password button', () => {
-    const component = create(<TextField type="password" canRevealPassword />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<TextField type="password" canRevealPassword />);
+    expect(container).toMatchSnapshot();
   });
 }); // end snapshots
 
@@ -153,45 +140,38 @@ describe('TextField rendering values from props', () => {
   it('can render a value', () => {
     const testText = 'initial value';
     // use the noOp change handler because onChange is required when value is specified
-    wrapper = mount(<TextField value={testText} onChange={noOp} componentRef={textFieldRef} />);
-    const input = wrapper.getDOMNode().querySelector('input');
-    expect(input!.value).toEqual(testText);
-    expect(textField!.value).toEqual(testText);
+    render(<TextField value={testText} onChange={noOp} componentRef={textFieldRef} />);
+    expect(getInput().value).toEqual(testText);
   });
 
   it('can render a value as a textarea', () => {
     const testText = 'This\nIs\nMultiline\nText\n';
-    wrapper = mount(<TextField value={testText} onChange={noOp} multiline componentRef={textFieldRef} />);
-    const textarea = wrapper.getDOMNode().querySelector('textarea');
-    expect(textarea!.value).toEqual(testText);
-    expect(textField!.value).toEqual(testText);
+    render(<TextField value={testText} onChange={noOp} multiline componentRef={textFieldRef} />);
+    expect(getInput().value).toEqual(testText);
   });
 
   it('should render a value of 0 when given the number 0', () => {
-    wrapper = mount(<TextField value={0 as any} onChange={noOp} componentRef={textFieldRef} />);
-    expect(wrapper.getDOMNode().querySelector('input')!.value).toEqual('0');
-    expect(textField!.value).toEqual('0');
+    render(<TextField value={0 as any} onChange={noOp} componentRef={textFieldRef} />);
+    expect(getInput().value).toEqual('0');
   });
 
   it('can render a default value', () => {
     const testText = 'initial value';
-    wrapper = mount(<TextField defaultValue={testText} componentRef={textFieldRef} />);
-    const input = wrapper.getDOMNode().querySelector('input');
-    expect(input!.value).toEqual(testText);
+    render(<TextField defaultValue={testText} componentRef={textFieldRef} />);
+    expect(getInput().value).toEqual(testText);
     expect(textField!.value).toEqual(testText);
   });
 
   it('can render a default value as a textarea', () => {
     const testText = 'This\nIs\nMultiline\nText\n';
-    wrapper = mount(<TextField defaultValue={testText} multiline componentRef={textFieldRef} />);
-    const textarea = wrapper.getDOMNode().querySelector('textarea');
-    expect(textarea!.value).toEqual(testText);
+    render(<TextField defaultValue={testText} multiline componentRef={textFieldRef} />);
+    expect(getInput().value).toEqual(testText);
     expect(textField!.value).toEqual(testText);
   });
 
   it('should render a default value of 0 when given the number 0', () => {
-    wrapper = mount(<TextField defaultValue={0 as any} componentRef={textFieldRef} />);
-    expect(wrapper.getDOMNode().querySelector('input')!.value).toEqual('0');
+    render(<TextField defaultValue={0 as any} componentRef={textFieldRef} />);
+    expect(getInput().value).toEqual('0');
     expect(textField!.value).toEqual('0');
   });
 }); // end rendering values from props
@@ -199,132 +179,99 @@ describe('TextField rendering values from props', () => {
 describe('TextField basic props', () => {
   beforeEach(sharedBeforeEach);
   afterEach(sharedAfterEach);
-
   it('can render label', () => {
     const exampleLabel = 'this is label';
-
-    wrapper = mount(<TextField label={exampleLabel} />);
-
-    expect(wrapper.getDOMNode().querySelector('label')!.textContent).toEqual(exampleLabel);
+    const { container } = render(<TextField label={exampleLabel} />);
+    expect(container.querySelector('label')!.textContent).toEqual(exampleLabel);
   });
-
   it('should associate the label and input box', () => {
-    wrapper = mount(<TextField label="text-field-label" defaultValue="whatever value" />);
-
-    const inputDOM = wrapper.getDOMNode().querySelector('input');
-    const labelDOM = wrapper.getDOMNode().querySelector('label');
-
+    const { container } = render(<TextField label="text-field-label" defaultValue="whatever value" />);
+    const inputDOM = getInput();
+    const labelDOM = container.querySelector('label')!;
     // Assert the input ID and label FOR attribute are the same.
     expect(inputDOM!.id).toBeTruthy();
     expect(inputDOM!.id).toEqual(labelDOM!.htmlFor);
   });
-
   it('should render prefix', () => {
     const examplePrefix = 'this is a prefix';
-
-    wrapper = mount(<TextField prefix={examplePrefix} />);
-
-    const prefixDOM: Element = wrapper.getDOMNode().getElementsByClassName('ms-TextField-prefix')[0];
+    const { container } = render(<TextField prefix={examplePrefix} />);
+    const prefixDOM: Element = container.getElementsByClassName('ms-TextField-prefix')[0];
     expect(prefixDOM.textContent).toEqual(examplePrefix);
   });
-
   it('should render suffix', () => {
     const exampleSuffix = 'this is a suffix';
-
-    wrapper = mount(<TextField suffix={exampleSuffix} />);
-
-    const suffixDOM: Element = wrapper.getDOMNode().getElementsByClassName('ms-TextField-suffix')[0];
+    const { container } = render(<TextField suffix={exampleSuffix} />);
+    const suffixDOM: Element = container.getElementsByClassName('ms-TextField-suffix')[0];
     expect(suffixDOM.textContent).toEqual(exampleSuffix);
   });
-
   it('should render both prefix and suffix', () => {
     const examplePrefix = 'this is a prefix';
     const exampleSuffix = 'this is a suffix';
-
-    wrapper = mount(<TextField prefix={examplePrefix} suffix={exampleSuffix} />);
-
+    const { container } = render(<TextField prefix={examplePrefix} suffix={exampleSuffix} />);
     // Assert on the prefix and suffix
-    const prefixDOM: Element = wrapper.getDOMNode().getElementsByClassName('ms-TextField-prefix')[0];
-    const suffixDOM: Element = wrapper.getDOMNode().getElementsByClassName('ms-TextField-suffix')[0];
+    const prefixDOM: Element = container.getElementsByClassName('ms-TextField-prefix')[0];
+    const suffixDOM: Element = container.getElementsByClassName('ms-TextField-suffix')[0];
     expect(prefixDOM.textContent).toEqual(examplePrefix);
     expect(suffixDOM.textContent).toEqual(exampleSuffix);
   });
-
   it('should not render reveal password button by default', () => {
-    wrapper = mount(<TextField type="password" />);
-    expect(wrapper.find('.ms-TextField-reveal')).toHaveLength(0);
+    const { container } = render(<TextField type="password" />);
+    expect(container.querySelectorAll('.ms-TextField-reveal')).toHaveLength(0);
   });
-
   it('should render reveal password button if canRevealPassword=true', () => {
-    wrapper = mount(<TextField type="password" canRevealPassword />);
-    expect(wrapper.find('.ms-TextField-reveal')).toHaveLength(1);
+    const { container } = render(<TextField type="password" canRevealPassword />);
+    expect(container.querySelectorAll('.ms-TextField-reveal')).toHaveLength(1);
   });
-
   it('ignores canRevealPassword if type is unspecified', () => {
-    wrapper = mount(<TextField canRevealPassword />);
-    expect(wrapper.find('.ms-TextField-reveal')).toHaveLength(0);
+    const { container } = render(<TextField canRevealPassword />);
+    expect(container.querySelectorAll('.ms-TextField-reveal')).toHaveLength(0);
   });
-
   it('ignores canRevealPassword if type is not password', () => {
-    wrapper = mount(<TextField type="text" canRevealPassword />);
-    expect(wrapper.find('.ms-TextField-reveal')).toHaveLength(0);
+    const { container } = render(<TextField type="text" canRevealPassword />);
+    expect(container.querySelectorAll('.ms-TextField-reveal')).toHaveLength(0);
   });
-
   it('should toggle reveal password on reveal button click', () => {
-    wrapper = mount(<TextField type="password" canRevealPassword={true} />);
-    const input = wrapper.find('input');
-    const reveal = wrapper.find('.ms-TextField-reveal');
+    const { container, getByRole } = render(<TextField type="password" canRevealPassword={true} />);
+    const input = container.querySelector('.ms-TextField-field')! as HTMLInputElement;
+    const reveal = getByRole('button');
 
-    input.simulate('input', mockEvent('Password123$'));
-    expect((input.getDOMNode() as HTMLInputElement).type).toEqual('password');
-    reveal.simulate('click');
-    expect((input.getDOMNode() as HTMLInputElement).type).toEqual('text');
-    reveal.simulate('click');
-    expect((input.getDOMNode() as HTMLInputElement).type).toEqual('password');
+    userEvent.tab();
+    userEvent.type(input, 'Password123$');
+    expect(input.type).toEqual('password');
+    userEvent.click(reveal);
+    expect(input.type).toEqual('text');
+    userEvent.click(reveal);
+    expect(input.type).toEqual('password');
   });
-
   it('should not give an aria-labelledby if no label is provided', () => {
-    wrapper = mount(<TextField />);
-
-    expect(wrapper.getDOMNode().getAttribute('aria-labelledby')).toBeNull();
+    render(<TextField />);
+    expect(getInput().getAttribute('aria-labelledby')).toBeNull();
   });
-
   it('should use explicitly defined aria-labelledby prop if one is given', () => {
     const sampleAriaLabelledby = 'sample for aria-labelledby';
-    wrapper = mount(<TextField label="text-field-label" aria-labelledby={sampleAriaLabelledby} />);
-
-    const inputDOM = wrapper.getDOMNode().querySelector('input');
-    expect(inputDOM!.getAttribute('aria-labelledby')).toEqual(sampleAriaLabelledby);
+    render(<TextField label="text-field-label" aria-labelledby={sampleAriaLabelledby} />);
+    expect(getInput().getAttribute('aria-labelledby')).toEqual(sampleAriaLabelledby);
   });
-
   it('should render a disabled input element', () => {
-    wrapper = mount(<TextField disabled={true} />);
-
-    expect(wrapper.getDOMNode().querySelector('input')!.disabled).toEqual(true);
+    render(<TextField disabled={true} />);
+    expect(getInput().disabled).toEqual(true);
   });
-
   it('should render a readonly input element', () => {
-    wrapper = mount(<TextField readOnly={true} />);
-
-    expect(wrapper.getDOMNode().querySelector('input')!.readOnly).toEqual(true);
+    render(<TextField readOnly={true} />);
+    expect(getInput().readOnly).toEqual(true);
   });
-
   it('can render description text', () => {
     const testDescription = 'A custom description';
-    wrapper = mount(<TextField description={testDescription} />);
-
-    const description = wrapper.getDOMNode().querySelector('.ms-TextField-description');
+    const { container } = render(<TextField description={testDescription} />);
+    const description = container.querySelector('.ms-TextField-description');
     expect(description).toBeTruthy();
     expect(description!.textContent).toEqual(testDescription);
   });
-
   it('can render a static custom description without description text', () => {
     const onRenderDescription = jest.fn(() => {
       return <strong>A custom description</strong>;
     });
-
-    wrapper = mount(<TextField onRenderDescription={onRenderDescription} />);
-
+    render(<TextField onRenderDescription={onRenderDescription} />);
     expect(onRenderDescription).toHaveBeenCalledTimes(1);
   });
 }); // end basic props
@@ -361,17 +308,17 @@ describe('TextField with error message', () => {
     }
   }
 
-  it('should not validate on mount when validateOnLoad is false', () => {
+  it('should not validate on render when validateOnLoad is false', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(<TextField defaultValue="invalid value" onGetErrorMessage={validator} validateOnLoad={false} />);
+    render(<TextField defaultValue="invalid value" onGetErrorMessage={validator} validateOnLoad={false} />);
     expect(validator).toHaveBeenCalledTimes(0);
   });
 
-  it('should validate on mount when validateOnLoad is true', () => {
+  it('should validate on render when validateOnLoad is true', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(<TextField defaultValue="invalid value" onGetErrorMessage={validator} validateOnLoad={true} />);
+    render(<TextField defaultValue="invalid value" onGetErrorMessage={validator} validateOnLoad={true} />);
     jest.runAllTimers();
     expect(validator).toHaveBeenCalledTimes(1);
   });
@@ -379,33 +326,33 @@ describe('TextField with error message', () => {
   it('should render error message when onGetErrorMessage returns a string', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
+    const { container } = render(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
 
-    wrapper.find('input').simulate('input', mockEvent('also invalid'));
+    userEvent.type(getInput(), 'also invalid');
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(1);
-    assertErrorMessage(wrapper.getDOMNode(), errorMessage);
+    assertErrorMessage(container, errorMessage);
   });
 
   it('should render error message when onGetErrorMessage returns a JSX.Element', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessageJSX : ''));
 
-    wrapper = mount(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
+    const { container } = render(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
 
-    wrapper.find('input').simulate('input', mockEvent('also invalid'));
+    userEvent.type(getInput(), 'also invalid');
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(1);
-    assertErrorMessage(wrapper.getDOMNode(), errorMessageJSX);
+    assertErrorMessage(container, errorMessageJSX);
   });
 
   it('should render error message when onGetErrorMessage returns a Promise<string>', () => {
     const validator = jest.fn((value: string) => Promise.resolve(value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
+    const { container } = render(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
 
-    wrapper.find('input').simulate('input', mockEvent('also invalid'));
+    userEvent.type(getInput(), 'also invalid');
 
     // Extra rounds of running everything to account for the debounced validator and the promise...
     jest.runAllTimers();
@@ -413,64 +360,64 @@ describe('TextField with error message', () => {
       jest.runAllTimers();
 
       expect(validator).toHaveBeenCalledTimes(1);
-      assertErrorMessage(wrapper!.getDOMNode(), errorMessage);
+      assertErrorMessage(container, errorMessage);
     });
   });
 
   it('should render error message when onGetErrorMessage returns a Promise<JSX.Element>', () => {
     const validator = jest.fn((value: string) => Promise.resolve(value.length > 3 ? errorMessageJSX : ''));
 
-    wrapper = mount(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
+    const { container } = render(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
 
-    wrapper.find('input').simulate('input', mockEvent('also invalid'));
+    userEvent.type(getInput(), 'also invalid');
 
     jest.runAllTimers();
     return flushPromises().then(() => {
       jest.runAllTimers();
 
       expect(validator).toHaveBeenCalledTimes(1);
-      assertErrorMessage(wrapper!.getDOMNode(), errorMessageJSX);
+      assertErrorMessage(container, errorMessageJSX);
     });
   });
 
   it('should render error message on first render when onGetErrorMessage returns a string', () => {
     const validator = jest.fn(() => errorMessage);
-    wrapper = mount(<TextField defaultValue="invalid value" onGetErrorMessage={validator} />);
+    const { container } = render(<TextField defaultValue="invalid value" onGetErrorMessage={validator} />);
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(1);
-    assertErrorMessage(wrapper.getDOMNode(), errorMessage);
+    assertErrorMessage(container, errorMessage);
   });
 
   it('should render error message on first render when onGetErrorMessage returns a Promise<string>', () => {
     const validator = jest.fn(() => Promise.resolve(errorMessage));
-    wrapper = mount(<TextField defaultValue="invalid value" onGetErrorMessage={validator} />);
+    const { container } = render(<TextField defaultValue="invalid value" onGetErrorMessage={validator} />);
 
     jest.runAllTimers();
     return flushPromises().then(() => {
       jest.runAllTimers();
 
       expect(validator).toHaveBeenCalledTimes(1);
-      assertErrorMessage(wrapper!.getDOMNode(), errorMessage);
+      assertErrorMessage(container, errorMessage);
     });
   });
 
   it('should not render error message when onGetErrorMessage return an empty string', () => {
     const validator = jest.fn(() => '');
-    wrapper = mount(<TextField defaultValue="invalid value" onGetErrorMessage={validator} />);
+    const { container } = render(<TextField defaultValue="invalid value" onGetErrorMessage={validator} />);
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(1);
-    assertErrorMessage(wrapper.getDOMNode(), /* exist */ false);
+    assertErrorMessage(container, /* exist */ false);
   });
 
   it('should not render error message when no value is provided', () => {
     let actualValue: string | undefined = undefined;
 
-    wrapper = mount(<TextField onGetErrorMessage={(value: string) => (actualValue = value)} />);
+    const { container } = render(<TextField onGetErrorMessage={(value: string) => (actualValue = value)} />);
     jest.runAllTimers();
 
-    assertErrorMessage(wrapper.getDOMNode(), /* exist */ false);
+    assertErrorMessage(container, /* exist */ false);
     expect(actualValue).toEqual('');
   });
 
@@ -479,21 +426,23 @@ describe('TextField with error message', () => {
       return value.length > 3 ? errorMessage : '';
     }
 
-    wrapper = mount(<TextField value="initial value" onChange={noOp} onGetErrorMessage={validator} />);
+    const { container, rerender } = render(
+      <TextField value="initial value" onChange={noOp} onGetErrorMessage={validator} />,
+    );
     jest.runAllTimers();
 
-    assertErrorMessage(wrapper.getDOMNode(), errorMessage);
+    assertErrorMessage(container, errorMessage);
 
-    wrapper.setProps({ value: '' });
+    rerender(<TextField value="" onChange={noOp} onGetErrorMessage={validator} />);
     jest.runAllTimers();
 
-    assertErrorMessage(wrapper.getDOMNode(), /* exist */ false);
+    assertErrorMessage(container, /* exist */ false);
   });
 
   it('should not validate when receiving props when validating only on focus in', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(
+    const { container, rerender } = render(
       <TextField
         validateOnFocusIn
         value="initial value"
@@ -504,19 +453,27 @@ describe('TextField with error message', () => {
     );
     jest.runAllTimers();
     expect(validator).toHaveBeenCalledTimes(0);
-    assertErrorMessage(wrapper.getDOMNode(), false);
+    assertErrorMessage(container, false);
 
-    wrapper.setProps({ value: 'failValidationValue' });
+    rerender(
+      <TextField
+        validateOnFocusIn
+        value="failValidationValue"
+        onChange={noOp}
+        onGetErrorMessage={validator}
+        validateOnLoad={false}
+      />,
+    );
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(0);
-    assertErrorMessage(wrapper.getDOMNode(), false);
+    assertErrorMessage(container, false);
   });
 
   it('should not validate when receiving props when validating only on focus out', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(
+    const { container, rerender } = render(
       <TextField
         validateOnFocusOut
         value="initial value"
@@ -527,78 +484,84 @@ describe('TextField with error message', () => {
     );
     jest.runAllTimers();
     expect(validator).toHaveBeenCalledTimes(0);
-    assertErrorMessage(wrapper.getDOMNode(), false);
+    assertErrorMessage(container, false);
 
-    wrapper.setProps({ value: 'failValidationValue' });
+    rerender(
+      <TextField
+        validateOnFocusOut
+        value="failValidationValue"
+        onChange={noOp}
+        onGetErrorMessage={validator}
+        validateOnLoad={false}
+      />,
+    );
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(0);
-    assertErrorMessage(wrapper.getDOMNode(), false);
+    assertErrorMessage(container, false);
   });
 
   it('should trigger validation only on focus', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(<TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusIn />);
+    const { container } = render(
+      <TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusIn />,
+    );
 
-    const input = wrapper.find('input');
-    input.simulate('input', mockEvent('invalid value'));
+    const input = getInput();
+    userEvent.type(input, 'invalid value', { skipClick: true });
     expect(validator).toHaveBeenCalledTimes(1);
 
-    input.simulate('focus');
+    userEvent.click(input);
     expect(validator).toHaveBeenCalledTimes(2);
 
-    input.simulate('input', mockEvent('also '));
-    input.simulate('input', mockEvent('also invalid'));
-    input.simulate('focus');
+    userEvent.click(container);
+    userEvent.type(input, 'also ');
+    userEvent.type(input, 'also invalid');
     expect(validator).toHaveBeenCalledTimes(3);
   });
 
   it('should trigger validation only on blur', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(<TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusOut />);
+    render(<TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusOut />);
 
-    const input = wrapper.find('input');
-    input.simulate('input', mockEvent('invalid value'));
+    const input = getInput();
+    userEvent.type(input, 'invalid value');
     expect(validator).toHaveBeenCalledTimes(1);
 
-    input.simulate('blur');
+    userEvent.tab();
     expect(validator).toHaveBeenCalledTimes(2);
 
-    input.simulate('input', mockEvent('also '));
-    input.simulate('input', mockEvent('also invalid'));
-
-    input.simulate('blur');
+    userEvent.type(input, 'also ');
+    userEvent.type(input, 'also invalid');
+    userEvent.tab();
     expect(validator).toHaveBeenCalledTimes(3);
   });
 
   it('should trigger validation on both blur and focus', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(
+    const { container } = render(
       <TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusOut validateOnFocusIn />,
     );
 
-    const input = wrapper.find('input');
-    input.simulate('input', mockEvent('value before focus'));
+    const input = getInput();
+    userEvent.type(input, 'value before focus', { skipClick: true });
     expect(validator).toHaveBeenCalledTimes(1);
 
-    input.simulate('focus');
+    userEvent.type(input, 'value after foc ');
+    userEvent.type(input, 'value after focus');
     expect(validator).toHaveBeenCalledTimes(2);
-
-    input.simulate('input', mockEvent('value before foc'));
-    input.simulate('input', mockEvent('value before focus'));
-    input.simulate('focus');
+    //triggers blur event
+    userEvent.click(container);
     expect(validator).toHaveBeenCalledTimes(3);
 
-    input.simulate('input', mockEvent('value before blur'));
-    input.simulate('blur');
+    userEvent.type(input, 'value before bl');
+    userEvent.type(input, 'value before blur');
     expect(validator).toHaveBeenCalledTimes(4);
-
-    input.simulate('input', mockEvent('value before bl'));
-    input.simulate('input', mockEvent('value before blur'));
-    input.simulate('blur');
+    //triggers blur event
+    userEvent.click(container);
     expect(validator).toHaveBeenCalledTimes(5);
   });
 }); // end error message
@@ -611,7 +574,7 @@ describe('TextField controlled vs uncontrolled usage', () => {
   function verifyWarningsAndValue(warningCount: number, value: string | undefined) {
     expect(warnFn).toHaveBeenCalledTimes(warningCount);
 
-    const inputDOM = wrapper!.getDOMNode().querySelector('input');
+    const inputDOM = getInput();
     // check both the DOM and the state to ensure they match
     expect(textField!.value).toEqual(value);
     expect(inputDOM!.value).toEqual(value);
@@ -628,89 +591,89 @@ describe('TextField controlled vs uncontrolled usage', () => {
   });
 
   it('warns if value is provided without onChange', () => {
-    mount(<TextField value="some value" />);
+    render(<TextField value="some value" />);
     expect(warnFn).toHaveBeenCalledTimes(1);
   });
 
   it('does not warn if defaultValue is provided without onChange', () => {
-    mount(<TextField defaultValue="some value" />);
+    render(<TextField defaultValue="some value" />);
     expect(warnFn).toHaveBeenCalledTimes(0);
   });
 
   it('does not warn if value and onChange are provided', () => {
-    mount(<TextField value="some value" onChange={noOp} />);
+    render(<TextField value="some value" onChange={noOp} />);
     expect(warnFn).toHaveBeenCalledTimes(0);
   });
 
   it('does not warn if value and readOnly are provided', () => {
-    mount(<TextField value="some value" readOnly />);
+    render(<TextField value="some value" readOnly />);
     expect(warnFn).toHaveBeenCalledTimes(0);
   });
 
   it('warns if value is null', () => {
-    mount(<TextField value={null as any} onChange={noOp} />);
+    render(<TextField value={null as any} onChange={noOp} />);
     expect(warnFn).toHaveBeenCalledTimes(1);
   });
 
   it('does not warn if value is empty string', () => {
-    mount(<TextField value="" onChange={noOp} />);
+    render(<TextField value="" onChange={noOp} />);
     expect(warnFn).toHaveBeenCalledTimes(0);
   });
 
   it('does not warn if defaultValue is null', () => {
-    mount(<TextField defaultValue={null as any} />);
+    render(<TextField defaultValue={null as any} />);
     expect(warnFn).toHaveBeenCalledTimes(0);
   });
 
   it('warns if both value and defaultValue are provided, uses value', () => {
-    wrapper = mount(<TextField value={value1} defaultValue={value2} onChange={noOp} componentRef={textFieldRef} />);
+    render(<TextField value={value1} defaultValue={value2} onChange={noOp} componentRef={textFieldRef} />);
     verifyWarningsAndValue(1, value1);
   });
 
   it('respects updates to value', () => {
-    wrapper = mount(<TextField value={value1} onChange={noOp} componentRef={textFieldRef} />);
+    const { rerender } = render(<TextField value={value1} onChange={noOp} componentRef={textFieldRef} />);
 
     // should respect updating to non-empty string
-    wrapper.setProps({ value: value2, onChange: noOp });
+    rerender(<TextField value={value2} onChange={noOp} componentRef={textFieldRef} />);
     verifyWarningsAndValue(0, value2);
 
     // should respect updating to empty string
-    wrapper.setProps({ value: '', onChange: noOp });
+    rerender(<TextField value={''} onChange={noOp} componentRef={textFieldRef} />);
     verifyWarningsAndValue(0, '');
   });
 
   it('respects update and warns if value goes from undefined to provided', () => {
     // React's <input> warns in this case, but we don't
-    wrapper = mount(<TextField onChange={noOp} componentRef={textFieldRef} />);
+    const { rerender } = render(<TextField onChange={noOp} componentRef={textFieldRef} />);
     expect(warnFn).toHaveBeenCalledTimes(0);
 
-    wrapper.setProps({ value: value1, onChange: noOp });
+    rerender(<TextField value={value1} onChange={noOp} componentRef={textFieldRef} />);
     verifyWarningsAndValue(1, value1);
   });
 
   it('respects update and warns if value goes from provided to undefined', () => {
-    wrapper = mount(<TextField value={value1} onChange={noOp} componentRef={textFieldRef} />);
+    const { rerender } = render(<TextField value={value1} onChange={noOp} componentRef={textFieldRef} />);
     expect(warnFn).toHaveBeenCalledTimes(0);
 
-    wrapper.setProps({ value: undefined, onChange: noOp });
+    rerender(<TextField value={undefined} onChange={noOp} componentRef={textFieldRef} />);
 
     expect(warnFn).toHaveBeenCalledTimes(1);
-    const inputDOM = wrapper.getDOMNode().querySelector('input');
+    const inputDOM = getInput();
     expect(textField!.value).toEqual(undefined);
     expect(inputDOM!.value).toEqual('');
   });
 
   it('ignores updates to defaultValue', () => {
-    wrapper = mount(<TextField defaultValue={value1} componentRef={textFieldRef} />);
+    const { rerender } = render(<TextField defaultValue={value1} componentRef={textFieldRef} />);
 
-    wrapper.setProps({ defaultValue: value2 });
+    rerender(<TextField defaultValue={value2} componentRef={textFieldRef} />);
     verifyWarningsAndValue(0, value1);
   });
 
   it('ignores if defaultValue goes from undefined to provided', () => {
-    wrapper = mount(<TextField componentRef={textFieldRef} />);
+    const { rerender } = render(<TextField componentRef={textFieldRef} />);
 
-    wrapper.setProps({ defaultValue: value1 });
+    rerender(<TextField componentRef={textFieldRef} defaultValue={value1} />);
     verifyWarningsAndValue(0, '');
   });
 }); // end controlled vs uncontrolled usage
@@ -731,14 +694,12 @@ describe('TextField onChange', () => {
   function simulateAndVerifyChange(changeValue: string, calls: number, expectedValue?: string) {
     expectedValue = typeof expectedValue === 'string' ? expectedValue : changeValue;
 
-    const input = wrapper!.find('input');
-    // Fire input AND change events to more realistically test
-    input.simulate('input', mockEvent(changeValue));
-    input.simulate('change', mockEvent(changeValue));
+    const input = getInput();
+    fireEvent.change(input, { target: { value: changeValue } });
 
     expect(onChange).toHaveBeenCalledTimes(calls);
     expect(textField!.value).toEqual(expectedValue);
-    expect((input.getDOMNode() as HTMLInputElement).value).toEqual(expectedValue);
+    expect(input.value).toEqual(expectedValue);
   }
 
   beforeEach(() => {
@@ -746,66 +707,66 @@ describe('TextField onChange', () => {
   });
 
   it('should be called for input change and apply edits if uncontrolled', () => {
-    wrapper = mount(<TextField componentRef={textFieldRef} defaultValue={initialValue} onChange={onChange} />);
+    render(<TextField componentRef={textFieldRef} defaultValue={initialValue} onChange={onChange} />);
 
     expect(onChange).toHaveBeenCalledTimes(0);
-    simulateAndVerifyChange('value change', 1);
+    simulateAndVerifyChange('a', 1);
     simulateAndVerifyChange('', 2);
   });
 
   it('should not be called when initial value is undefined and input change is an empty string', () => {
-    wrapper = mount(<TextField componentRef={textFieldRef} onChange={onChange} />);
+    render(<TextField componentRef={textFieldRef} onChange={onChange} />);
 
     expect(onChange).toHaveBeenCalledTimes(0);
     simulateAndVerifyChange('', 0);
   });
 
   it('should apply edits if implicitly uncontrolled', () => {
-    wrapper = mount(<TextField componentRef={textFieldRef} onChange={onChange} />);
+    render(<TextField componentRef={textFieldRef} onChange={onChange} />);
 
-    simulateAndVerifyChange('value change', 1);
+    simulateAndVerifyChange('a', 1);
   });
 
   it('should not apply edits if controlled', () => {
-    wrapper = mount(<TextField componentRef={textFieldRef} value={initialValue} onChange={onChange} />);
+    render(<TextField componentRef={textFieldRef} value={initialValue} onChange={onChange} />);
 
     expect(onChange).toHaveBeenCalledTimes(0);
-    simulateAndVerifyChange('value change', 1, initialValue);
+    simulateAndVerifyChange('a', 1, initialValue);
   });
 
   it('should not apply edits if controlled (empty initial value)', () => {
-    wrapper = mount(<TextField componentRef={textFieldRef} value="" onChange={onChange} />);
+    render(<TextField componentRef={textFieldRef} value="" onChange={onChange} />);
 
     expect(onChange).toHaveBeenCalledTimes(0);
-    simulateAndVerifyChange('value change', 1, '');
+    simulateAndVerifyChange('a', 1, '');
   });
 
   it('respects prop updates in response to onChange', () => {
     onChange = jest.fn((ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value?: string) =>
-      wrapper!.setProps({ value }),
+      rerender(<TextField componentRef={textFieldRef} value={value} onChange={onChange} />),
     );
-    wrapper = mount(<TextField componentRef={textFieldRef} value="" onChange={onChange} />);
+    const { rerender } = render(<TextField componentRef={textFieldRef} value="" onChange={onChange} />);
 
     simulateAndVerifyChange('a', 1);
   });
 
   it('should apply edits after clearing field', () => {
     onChange = jest.fn((ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value?: string) =>
-      wrapper!.setProps({ value }),
+      rerender(<TextField componentRef={textFieldRef} value={value} onChange={onChange} />),
     );
-    wrapper = mount(<TextField componentRef={textFieldRef} value="" onChange={onChange} />);
+    const { rerender } = render(<TextField componentRef={textFieldRef} value="" onChange={onChange} />);
 
     simulateAndVerifyChange('a', 1);
 
     // clear the value manually (not via a change event)
-    wrapper.setProps({ value: '' });
+    rerender(<TextField componentRef={textFieldRef} value="" onChange={onChange} />);
 
     // updating to the same value as before should be respected
     simulateAndVerifyChange('a', 2);
   });
 }); // end on change
 
-// Other things that don't fit into a category above
+// // Other things that don't fit into a category above
 describe('TextField', () => {
   beforeEach(sharedBeforeEach);
   afterEach(sharedAfterEach);
@@ -819,113 +780,89 @@ describe('TextField', () => {
       expect(selectedText!.toString()).toEqual(initialValue);
     };
 
-    ReactTestUtils.renderIntoDocument(
-      <TextField componentRef={textFieldRef} defaultValue={initialValue} onSelect={onSelect} />,
-    );
+    render(<TextField componentRef={textFieldRef} defaultValue={initialValue} onSelect={onSelect} />);
 
     textField!.setSelectionRange(0, initialValue.length);
   });
 
   it('sets focus to the input via ITextField focus', () => {
-    safeMount(
-      <TextField componentRef={textFieldRef} />,
-      wrapper2 => {
-        const inputEl = wrapper2.find('input').getDOMNode();
+    render(<TextField componentRef={textFieldRef} />);
 
-        textField!.focus();
-
-        expect(document.activeElement).toBe(inputEl);
-      },
-      true /* attach */,
-    );
+    const input = getInput();
+    textField!.focus();
+    expect(document.activeElement).toBe(input);
   });
 
   it('blurs the input via ITextField blur', () => {
-    safeMount(
-      <TextField componentRef={textFieldRef} />,
-      wrapper2 => {
-        const inputEl = wrapper2.find('input').getDOMNode();
+    render(<TextField componentRef={textFieldRef} />);
 
-        textField!.focus();
-        expect(document.activeElement).toBe(inputEl);
+    const input = getInput();
 
-        textField!.blur();
-        expect(document.activeElement).toBe(document.body);
-      },
-      true /* attach */,
-    );
+    textField!.focus();
+    expect(document.activeElement).toBe(input);
+
+    textField!.blur();
+    expect(document.activeElement).toBe(document.body);
   });
 
   it('can switch from single to multi line and back', () => {
-    const getInput = () => wrapper!.getDOMNode().querySelector('input');
-    const getTextarea = () => wrapper!.getDOMNode().querySelector('textarea');
+    const getInputField = () => container.querySelector('input');
+    const getTextarea = () => container.querySelector('textarea');
 
     // start as single line
-    wrapper = mount(<TextField />);
-    expect(getInput()).toBeTruthy();
+    const { container, rerender } = render(<TextField />);
+    expect(getInputField()).toBeTruthy();
     expect(getTextarea()).toBeNull();
 
     // switch to multiline
-    wrapper.setProps({ multiline: true });
+    rerender(<TextField multiline={true} />);
     expect(getTextarea()).toBeTruthy();
-    expect(getInput()).toBeNull();
+    expect(getInputField()).toBeNull();
 
     // switch back
-    wrapper.setProps({ multiline: false });
-    expect(getInput()).toBeTruthy();
+    rerender(<TextField multiline={false} />);
+    expect(getInputField()).toBeTruthy();
     expect(getTextarea()).toBeNull();
   });
 
   it('maintains focus when switching single to multi line and back', () => {
-    safeMount(
-      <TextField componentRef={textFieldRef} />,
-      wrapper2 => {
-        // focus input
-        textField!.focus();
-        let input = wrapper2.find('input').getDOMNode();
-        expect(document.activeElement).toBe(input);
+    const { rerender } = render(<TextField componentRef={textFieldRef} />);
 
-        // switch to multiline
-        wrapper2.setProps({ multiline: true });
-        // verify still focused
-        const textarea = wrapper2.find('textarea').getDOMNode();
-        expect(document.activeElement).toBe(textarea);
+    // focus input
+    textField!.focus();
+    expect(document.activeElement).toBe(getInput());
 
-        // back to single line
-        wrapper2.setProps({ multiline: false });
-        // verify still focused
-        input = wrapper2.find('input').getDOMNode();
-        expect(document.activeElement).toBe(input);
-      },
-      true /* attach */,
-    );
+    // switch to multiline
+    rerender(<TextField multiline={true} />);
+    // verify still focused
+    expect(document.activeElement).toBe(getInput());
+    // back to single line
+    rerender(<TextField multiline={false} />);
+    // verify still focused
+    expect(document.activeElement).toBe(getInput());
   });
 
   it('maintains selection when switching single to multi line and back', () => {
     const start = 1;
     const end = 3;
-    safeMount(
-      <TextField componentRef={textFieldRef} defaultValue="some text" />,
-      wrapper2 => {
-        // select
-        textField!.focus();
-        textField!.setSelectionRange(start, end);
-        expect(textField!.selectionStart).toBe(start);
-        expect(textField!.selectionEnd).toBe(end);
+    const { rerender } = render(<TextField componentRef={textFieldRef} defaultValue="some text" />);
 
-        // switch to multiline
-        wrapper2.setProps({ multiline: true });
-        // verify still selected
-        expect(textField!.selectionStart).toBe(start);
-        expect(textField!.selectionEnd).toBe(end);
+    // select
+    textField!.focus();
+    textField!.setSelectionRange(start, end);
+    expect(textField!.selectionStart).toBe(start);
+    expect(textField!.selectionEnd).toBe(end);
 
-        // back to single line
-        wrapper2.setProps({ multiline: false });
-        // verify still selected
-        expect(textField!.selectionStart).toBe(start);
-        expect(textField!.selectionEnd).toBe(end);
-      },
-      true /* attach */,
-    );
+    // switch to multiline
+    rerender(<TextField componentRef={textFieldRef} defaultValue="some text" multiline={true} />);
+    // verify still selected
+    expect(textField!.selectionStart).toBe(start);
+    expect(textField!.selectionEnd).toBe(end);
+
+    // back to single line
+    rerender(<TextField componentRef={textFieldRef} defaultValue="some text" multiline={false} />);
+    // verify still selected
+    expect(textField!.selectionStart).toBe(start);
+    expect(textField!.selectionEnd).toBe(end);
   });
 });

--- a/packages/react/src/components/TextField/TextField.test.tsx
+++ b/packages/react/src/components/TextField/TextField.test.tsx
@@ -235,7 +235,6 @@ describe('TextField basic props', () => {
     const input = container.querySelector('.ms-TextField-field')! as HTMLInputElement;
     const reveal = getByRole('button');
 
-    userEvent.tab();
     userEvent.type(input, 'Password123$');
     expect(input.type).toEqual('password');
     userEvent.click(reveal);
@@ -524,18 +523,20 @@ describe('TextField with error message', () => {
   it('should trigger validation only on blur', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    render(<TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusOut />);
+    const { container } = render(
+      <TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusOut />,
+    );
 
     const input = getInput();
     userEvent.type(input, 'invalid value');
     expect(validator).toHaveBeenCalledTimes(1);
 
-    userEvent.tab();
+    userEvent.click(container);
     expect(validator).toHaveBeenCalledTimes(2);
 
     userEvent.type(input, 'also ');
     userEvent.type(input, 'also invalid');
-    userEvent.tab();
+    userEvent.click(container);
     expect(validator).toHaveBeenCalledTimes(3);
   });
 

--- a/packages/react/src/components/TextField/TextField.test.tsx
+++ b/packages/react/src/components/TextField/TextField.test.tsx
@@ -711,7 +711,7 @@ describe('TextField onChange', () => {
     render(<TextField componentRef={textFieldRef} defaultValue={initialValue} onChange={onChange} />);
 
     expect(onChange).toHaveBeenCalledTimes(0);
-    simulateAndVerifyChange('a', 1);
+    simulateAndVerifyChange('value change', 1);
     simulateAndVerifyChange('', 2);
   });
 
@@ -725,21 +725,21 @@ describe('TextField onChange', () => {
   it('should apply edits if implicitly uncontrolled', () => {
     render(<TextField componentRef={textFieldRef} onChange={onChange} />);
 
-    simulateAndVerifyChange('a', 1);
+    simulateAndVerifyChange('value change', 1);
   });
 
   it('should not apply edits if controlled', () => {
     render(<TextField componentRef={textFieldRef} value={initialValue} onChange={onChange} />);
 
     expect(onChange).toHaveBeenCalledTimes(0);
-    simulateAndVerifyChange('a', 1, initialValue);
+    simulateAndVerifyChange('value change', 1, initialValue);
   });
 
   it('should not apply edits if controlled (empty initial value)', () => {
     render(<TextField componentRef={textFieldRef} value="" onChange={onChange} />);
 
     expect(onChange).toHaveBeenCalledTimes(0);
-    simulateAndVerifyChange('a', 1, '');
+    simulateAndVerifyChange('value change', 1, '');
   });
 
   it('respects prop updates in response to onChange', () => {

--- a/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1,1707 +1,1663 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextField snapshots renders correctly 1`] = `
-<div
-  className=
-      ms-TextField
-      testClassName
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        box-shadow: none;
-        box-sizing: border-box;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        margin-bottom: 0px;
-        margin-left: 0px;
-        margin-right: 0px;
-        margin-top: 0px;
-        padding-bottom: 0px;
-        padding-left: 0px;
-        padding-right: 0px;
-        padding-top: 0px;
-        position: relative;
-      }
->
+<div>
   <div
-    className="ms-TextField-wrapper"
+    class=
+        ms-TextField
+        testClassName
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
   >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #323130;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 600;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-      htmlFor="TextField0"
-      id="TextFieldLabel2"
-    >
-      Label
-    </label>
     <div
-      className=
-          ms-TextField-fieldGroup
-          {
-            align-items: stretch;
-            background: #ffffff;
-            border-radius: 2px;
-            border: 1px solid #605e5c;
-            box-shadow: none;
-            box-sizing: border-box;
-            cursor: text;
-            display: flex;
-            flex-direction: row;
-            height: 32px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-          }
-          &:hover {
-            border-color: #323130;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-            -ms-high-contrast-adjust: none;
-            border-color: Highlight;
-            forced-color-adjust: none;
-          }
+      class="ms-TextField-wrapper"
     >
-      <input
-        aria-invalid={false}
-        aria-labelledby="TextFieldLabel2"
-        className=
-            ms-TextField-field
-            testInputClassName
+      <label
+        class=
+            ms-Label
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              background: none;
-              border-radius: 0px;
-              border: none;
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
+              display: block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
-              font-weight: 400;
+              font-weight: 600;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 0px;
-              outline: 0px;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              text-overflow: ellipsis;
-              width: 100%;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
             }
-            &:active {
-              outline: 0px;
-            }
-            &:focus {
-              outline: 0px;
+        for="TextField0"
+        id="TextFieldLabel2"
+      >
+        Label
+      </label>
+      <div
+        class=
+            ms-TextField-fieldGroup
+            {
+              align-items: stretch;
+              background: #ffffff;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-shadow: none;
+              box-sizing: border-box;
+              cursor: text;
+              display: flex;
+              flex-direction: row;
+              height: 32px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
             }
             &:hover {
-              outline: 0px;
+              border-color: #323130;
             }
-            &::-ms-clear {
-              display: none;
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
+              border-color: Highlight;
+              forced-color-adjust: none;
             }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-            &::placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-              color: GrayText;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-              color: GrayText;
-            }
-        id="TextField0"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        type="text"
-        value=""
-      />
+      >
+        <input
+          aria-invalid="false"
+          aria-labelledby="TextFieldLabel2"
+          class=
+              ms-TextField-field
+              testInputClassName
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                background: none;
+                border-radius: 0px;
+                border: none;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 0px;
+                outline: 0px;
+                padding-bottom: 0;
+                padding-left: 8px;
+                padding-right: 8px;
+                padding-top: 0;
+                text-overflow: ellipsis;
+                width: 100%;
+              }
+              &:active {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                color: GrayText;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                color: GrayText;
+              }
+          id="TextField0"
+          type="text"
+          value=""
+        />
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`TextField snapshots renders multiline correctly with errorMessage 1`] = `
-<div
-  className=
-      ms-TextField
-      ms-TextField--underlined
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        box-shadow: none;
-        box-sizing: border-box;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        margin-bottom: 0px;
-        margin-left: 0px;
-        margin-right: 0px;
-        margin-top: 0px;
-        padding-bottom: 0px;
-        padding-left: 0px;
-        padding-right: 0px;
-        padding-top: 0px;
-        position: relative;
-      }
->
+<div>
   <div
-    className=
-        ms-TextField-wrapper
+    class=
+        ms-TextField
+        ms-TextField--underlined
         {
-          border-bottom: 1px solid #a4262c;
-          display: flex;
-          width: 100%;
-        }
-        &:hover {
-          border-bottom-color: #a4262c;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-          -ms-high-contrast-adjust: none;
-          border-bottom-color: Highlight;
-          forced-color-adjust: none;
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
         }
   >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #323130;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 600;
-            height: 32px;
-            line-height: 22px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 8px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 12px;
-            padding-right: 0px;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-      htmlFor="TextField0"
-      id="TextFieldLabel2"
-    >
-      Label
-    </label>
     <div
-      className=
-          ms-TextField-fieldGroup
+      class=
+          ms-TextField-wrapper
           {
-            align-items: stretch;
-            background: #ffffff;
-            border-radius: 2px;
-            border: none;
-            box-shadow: none;
-            box-sizing: border-box;
-            cursor: text;
+            border-bottom: 1px solid #a4262c;
             display: flex;
-            flex-direction: row;
-            flex: 1 1 0px;
-            height: 32px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            text-align: left;
+            width: 100%;
           }
           &:hover {
-            border-color: #323130;
+            border-bottom-color: #a4262c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
-            border-color: Highlight;
+            border-bottom-color: Highlight;
             forced-color-adjust: none;
           }
     >
-      <div
-        className=
-            ms-TextField-prefix
-            {
-              align-items: center;
-              background: #f3f2f1;
-              color: #605e5c;
-              display: flex;
-              flex-shrink: 0;
-              line-height: 1px;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              white-space: nowrap;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-        id="TextFieldPrefix3"
-      >
-        <span
-          style={
-            Object {
-              "paddingBottom": "1px",
-            }
-          }
-        >
-          test prefix
-        </span>
-      </div>
-      <input
-        aria-describedby="TextFieldDescription1"
-        aria-invalid={true}
-        aria-labelledby="TextFieldLabel2 TextFieldPrefix3 TextFieldSuffix4"
-        className=
-            ms-TextField-field
+      <label
+        class=
+            ms-Label
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              background: none;
-              border-radius: 0px;
-              border: none;
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
+              display: block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
-              font-weight: 400;
+              font-weight: 600;
+              height: 32px;
+              line-height: 22px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 8px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 12px;
+              padding-right: 0px;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+        for="TextField0"
+        id="TextFieldLabel2"
+      >
+        Label
+      </label>
+      <div
+        class=
+            ms-TextField-fieldGroup
+            {
+              align-items: stretch;
+              background: #ffffff;
+              border-radius: 2px;
+              border: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              cursor: text;
+              display: flex;
+              flex-direction: row;
+              flex: 1 1 0px;
+              height: 32px;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 0px;
-              outline: 0px;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
               text-align: left;
-              text-overflow: ellipsis;
-              width: 100%;
-            }
-            &:active {
-              outline: 0px;
-            }
-            &:focus {
-              outline: 0px;
             }
             &:hover {
-              outline: 0px;
+              border-color: #323130;
             }
-            &::-ms-clear {
-              display: none;
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
+              border-color: Highlight;
+              forced-color-adjust: none;
             }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-            &::placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-              color: GrayText;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-              color: GrayText;
-            }
-        id="TextField0"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        type="text"
-        value=""
-      />
-      <div
-        className=
-            ms-TextField-suffix
-            {
-              align-items: center;
-              background: #f3f2f1;
-              color: #605e5c;
-              display: flex;
-              flex-shrink: 0;
-              line-height: 1px;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              white-space: nowrap;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-        id="TextFieldSuffix4"
       >
-        <span
-          style={
-            Object {
-              "paddingBottom": "1px",
-            }
-          }
+        <div
+          class=
+              ms-TextField-prefix
+              {
+                align-items: center;
+                background: #f3f2f1;
+                color: #605e5c;
+                display: flex;
+                flex-shrink: 0;
+                line-height: 1px;
+                padding-bottom: 0;
+                padding-left: 10px;
+                padding-right: 10px;
+                padding-top: 0;
+                white-space: nowrap;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+          id="TextFieldPrefix3"
         >
-          test suffix
-        </span>
+          <span
+            style="padding-bottom: 1px;"
+          >
+            test prefix
+          </span>
+        </div>
+        <input
+          aria-describedby="TextFieldDescription1"
+          aria-invalid="true"
+          aria-labelledby="TextFieldLabel2 TextFieldPrefix3 TextFieldSuffix4"
+          class=
+              ms-TextField-field
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                background: none;
+                border-radius: 0px;
+                border: none;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 0px;
+                outline: 0px;
+                padding-bottom: 0;
+                padding-left: 8px;
+                padding-right: 8px;
+                padding-top: 0;
+                text-align: left;
+                text-overflow: ellipsis;
+                width: 100%;
+              }
+              &:active {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                color: GrayText;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                color: GrayText;
+              }
+          id="TextField0"
+          type="text"
+          value=""
+        />
+        <div
+          class=
+              ms-TextField-suffix
+              {
+                align-items: center;
+                background: #f3f2f1;
+                color: #605e5c;
+                display: flex;
+                flex-shrink: 0;
+                line-height: 1px;
+                padding-bottom: 0;
+                padding-left: 10px;
+                padding-right: 10px;
+                padding-top: 0;
+                white-space: nowrap;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+          id="TextFieldSuffix4"
+        >
+          <span
+            style="padding-bottom: 1px;"
+          >
+            test suffix
+          </span>
+        </div>
       </div>
     </div>
+    <span
+      id="TextFieldDescription1"
+    >
+      <div
+        role="alert"
+      />
+    </span>
   </div>
-  <span
-    id="TextFieldDescription1"
-  >
-    <div
-      role="alert"
-    />
-  </span>
 </div>
 `;
 
 exports[`TextField snapshots renders multiline correctly with props affecting styling 1`] = `
-<div
-  className=
-      ms-TextField
-      ms-TextField--underlined
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        box-shadow: none;
-        box-sizing: border-box;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        margin-bottom: 0px;
-        margin-left: 0px;
-        margin-right: 0px;
-        margin-top: 0px;
-        padding-bottom: 0px;
-        padding-left: 0px;
-        padding-right: 0px;
-        padding-top: 0px;
-        position: relative;
-      }
->
+<div>
   <div
-    className=
-        ms-TextField-wrapper
+    class=
+        ms-TextField
+        ms-TextField--underlined
         {
-          border-bottom: 1px solid #a4262c;
-          display: flex;
-          width: 100%;
-        }
-        &:hover {
-          border-bottom-color: #a4262c;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-          -ms-high-contrast-adjust: none;
-          border-bottom-color: Highlight;
-          forced-color-adjust: none;
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
         }
   >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #323130;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 600;
-            height: 32px;
-            line-height: 22px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 8px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 12px;
-            padding-right: 0px;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-      htmlFor="TextField0"
-      id="TextFieldLabel2"
-    >
-      Label
-    </label>
     <div
-      className=
-          ms-TextField-fieldGroup
+      class=
+          ms-TextField-wrapper
           {
-            align-items: stretch;
-            background: #ffffff;
-            border-radius: 2px;
-            border: none;
-            box-shadow: none;
-            box-sizing: border-box;
-            cursor: text;
+            border-bottom: 1px solid #a4262c;
             display: flex;
-            flex-direction: row;
-            flex: 1 1 0px;
-            height: 32px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            text-align: left;
+            width: 100%;
           }
           &:hover {
-            border-color: #323130;
+            border-bottom-color: #a4262c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
-            border-color: Highlight;
+            border-bottom-color: Highlight;
             forced-color-adjust: none;
           }
     >
-      <div
-        className=
-            ms-TextField-prefix
-            {
-              align-items: center;
-              background: #f3f2f1;
-              color: #605e5c;
-              display: flex;
-              flex-shrink: 0;
-              line-height: 1px;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              white-space: nowrap;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-        id="TextFieldPrefix3"
-      >
-        <span
-          style={
-            Object {
-              "paddingBottom": "1px",
-            }
-          }
-        >
-          test prefix
-        </span>
-      </div>
-      <input
-        aria-describedby="TextFieldDescription1"
-        aria-invalid={true}
-        aria-labelledby="TextFieldLabel2 TextFieldPrefix3 TextFieldSuffix4"
-        className=
-            ms-TextField-field
+      <label
+        class=
+            ms-Label
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              background: none;
-              border-radius: 0px;
-              border: none;
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
+              display: block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
-              font-weight: 400;
+              font-weight: 600;
+              height: 32px;
+              line-height: 22px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 8px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 12px;
+              padding-right: 0px;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+        for="TextField0"
+        id="TextFieldLabel2"
+      >
+        Label
+      </label>
+      <div
+        class=
+            ms-TextField-fieldGroup
+            {
+              align-items: stretch;
+              background: #ffffff;
+              border-radius: 2px;
+              border: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              cursor: text;
+              display: flex;
+              flex-direction: row;
+              flex: 1 1 0px;
+              height: 32px;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 0px;
-              outline: 0px;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
               text-align: left;
-              text-overflow: ellipsis;
-              width: 100%;
-            }
-            &:active {
-              outline: 0px;
-            }
-            &:focus {
-              outline: 0px;
             }
             &:hover {
-              outline: 0px;
+              border-color: #323130;
             }
-            &::-ms-clear {
-              display: none;
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
+              border-color: Highlight;
+              forced-color-adjust: none;
             }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-            &::placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-              color: GrayText;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-              color: GrayText;
-            }
-        id="TextField0"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        type="text"
-        value=""
-      />
-      <div
-        className=
-            ms-TextField-suffix
-            {
-              align-items: center;
-              background: #f3f2f1;
-              color: #605e5c;
-              display: flex;
-              flex-shrink: 0;
-              line-height: 1px;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              white-space: nowrap;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-        id="TextFieldSuffix4"
       >
-        <span
-          style={
-            Object {
-              "paddingBottom": "1px",
-            }
-          }
+        <div
+          class=
+              ms-TextField-prefix
+              {
+                align-items: center;
+                background: #f3f2f1;
+                color: #605e5c;
+                display: flex;
+                flex-shrink: 0;
+                line-height: 1px;
+                padding-bottom: 0;
+                padding-left: 10px;
+                padding-right: 10px;
+                padding-top: 0;
+                white-space: nowrap;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+          id="TextFieldPrefix3"
         >
-          test suffix
-        </span>
+          <span
+            style="padding-bottom: 1px;"
+          >
+            test prefix
+          </span>
+        </div>
+        <input
+          aria-describedby="TextFieldDescription1"
+          aria-invalid="true"
+          aria-labelledby="TextFieldLabel2 TextFieldPrefix3 TextFieldSuffix4"
+          class=
+              ms-TextField-field
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                background: none;
+                border-radius: 0px;
+                border: none;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 0px;
+                outline: 0px;
+                padding-bottom: 0;
+                padding-left: 8px;
+                padding-right: 8px;
+                padding-top: 0;
+                text-align: left;
+                text-overflow: ellipsis;
+                width: 100%;
+              }
+              &:active {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                color: GrayText;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                color: GrayText;
+              }
+          id="TextField0"
+          type="text"
+          value=""
+        />
+        <div
+          class=
+              ms-TextField-suffix
+              {
+                align-items: center;
+                background: #f3f2f1;
+                color: #605e5c;
+                display: flex;
+                flex-shrink: 0;
+                line-height: 1px;
+                padding-bottom: 0;
+                padding-left: 10px;
+                padding-right: 10px;
+                padding-top: 0;
+                white-space: nowrap;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+          id="TextFieldSuffix4"
+        >
+          <span
+            style="padding-bottom: 1px;"
+          >
+            test suffix
+          </span>
+        </div>
       </div>
     </div>
+    <span
+      id="TextFieldDescription1"
+    >
+      <div
+        role="alert"
+      />
+    </span>
   </div>
-  <span
-    id="TextFieldDescription1"
-  >
-    <div
-      role="alert"
-    />
-  </span>
 </div>
 `;
 
 exports[`TextField snapshots renders multiline non resizable correctly 1`] = `
-<div
-  className=
-      ms-TextField
-      ms-TextField--multiline
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        box-shadow: none;
-        box-sizing: border-box;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        margin-bottom: 0px;
-        margin-left: 0px;
-        margin-right: 0px;
-        margin-top: 0px;
-        padding-bottom: 0px;
-        padding-left: 0px;
-        padding-right: 0px;
-        padding-top: 0px;
-        position: relative;
-      }
->
+<div>
   <div
-    className="ms-TextField-wrapper"
+    class=
+        ms-TextField
+        ms-TextField--multiline
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
   >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #323130;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 600;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-      htmlFor="TextField0"
-      id="TextFieldLabel2"
-    >
-      Label
-    </label>
     <div
-      className=
-          ms-TextField-fieldGroup
-          {
-            align-items: stretch;
-            background: #ffffff;
-            border-radius: 2px;
-            border: 1px solid #605e5c;
-            box-shadow: none;
-            box-sizing: border-box;
-            cursor: text;
-            display: flex;
-            flex-direction: row;
-            height: auto;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            min-height: 60px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-          }
-          &:hover {
-            border-color: #323130;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-            -ms-high-contrast-adjust: none;
-            border-color: Highlight;
-            forced-color-adjust: none;
-          }
+      class="ms-TextField-wrapper"
     >
-      <textarea
-        aria-invalid={false}
-        aria-labelledby="TextFieldLabel2"
-        className=
-            ms-TextField-field
-            ms-TextField--unresizable
+      <label
+        class=
+            ms-Label
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              background: none;
-              border-radius: 0px;
-              border: none;
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              flex-grow: 1;
+              display: block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
-              font-weight: 400;
-              line-height: 17px;
+              font-weight: 600;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-height: inherit;
-              min-width: 0px;
-              outline: 0px;
-              overflow: auto;
-              padding-bottom: 6px;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 6px;
-              resize: none;
-              text-overflow: ellipsis;
-              width: 100%;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
             }
-            &:active {
-              outline: 0px;
-            }
-            &:focus {
-              outline: 0px;
+        for="TextField0"
+        id="TextFieldLabel2"
+      >
+        Label
+      </label>
+      <div
+        class=
+            ms-TextField-fieldGroup
+            {
+              align-items: stretch;
+              background: #ffffff;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-shadow: none;
+              box-sizing: border-box;
+              cursor: text;
+              display: flex;
+              flex-direction: row;
+              height: auto;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-height: 60px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
             }
             &:hover {
-              outline: 0px;
+              border-color: #323130;
             }
-            &::-ms-clear {
-              display: none;
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
+              border-color: Highlight;
+              forced-color-adjust: none;
             }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-            &::placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-              color: GrayText;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-              color: GrayText;
-            }
-        id="TextField0"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        value=""
-      />
+      >
+        <textarea
+          aria-invalid="false"
+          aria-labelledby="TextFieldLabel2"
+          class=
+              ms-TextField-field
+              ms-TextField--unresizable
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                background: none;
+                border-radius: 0px;
+                border: none;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                flex-grow: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                line-height: 17px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-height: inherit;
+                min-width: 0px;
+                outline: 0px;
+                overflow: auto;
+                padding-bottom: 6px;
+                padding-left: 8px;
+                padding-right: 8px;
+                padding-top: 6px;
+                resize: none;
+                text-overflow: ellipsis;
+                width: 100%;
+              }
+              &:active {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                color: GrayText;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                color: GrayText;
+              }
+          id="TextField0"
+        />
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`TextField snapshots renders multiline resizable correctly 1`] = `
-<div
-  className=
-      ms-TextField
-      ms-TextField--multiline
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        box-shadow: none;
-        box-sizing: border-box;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        margin-bottom: 0px;
-        margin-left: 0px;
-        margin-right: 0px;
-        margin-top: 0px;
-        padding-bottom: 0px;
-        padding-left: 0px;
-        padding-right: 0px;
-        padding-top: 0px;
-        position: relative;
-      }
->
+<div>
   <div
-    className="ms-TextField-wrapper"
+    class=
+        ms-TextField
+        ms-TextField--multiline
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
   >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #323130;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 600;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-      htmlFor="TextField0"
-      id="TextFieldLabel2"
-    >
-      Label
-    </label>
     <div
-      className=
-          ms-TextField-fieldGroup
-          {
-            align-items: stretch;
-            background: #ffffff;
-            border-radius: 2px;
-            border: 1px solid #605e5c;
-            box-shadow: none;
-            box-sizing: border-box;
-            cursor: text;
-            display: flex;
-            flex-direction: row;
-            height: auto;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            min-height: 60px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-          }
-          &:hover {
-            border-color: #323130;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-            -ms-high-contrast-adjust: none;
-            border-color: Highlight;
-            forced-color-adjust: none;
-          }
+      class="ms-TextField-wrapper"
     >
-      <textarea
-        aria-invalid={false}
-        aria-labelledby="TextFieldLabel2"
-        className=
-            ms-TextField-field
+      <label
+        class=
+            ms-Label
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              background: none;
-              border-radius: 0px;
-              border: none;
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              flex-grow: 1;
+              display: block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
-              font-weight: 400;
-              line-height: 17px;
+              font-weight: 600;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-height: inherit;
-              min-width: 0px;
-              outline: 0px;
-              overflow: auto;
-              padding-bottom: 6px;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 6px;
-              text-overflow: ellipsis;
-              width: 100%;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
             }
-            &:active {
-              outline: 0px;
-            }
-            &:focus {
-              outline: 0px;
+        for="TextField0"
+        id="TextFieldLabel2"
+      >
+        Label
+      </label>
+      <div
+        class=
+            ms-TextField-fieldGroup
+            {
+              align-items: stretch;
+              background: #ffffff;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-shadow: none;
+              box-sizing: border-box;
+              cursor: text;
+              display: flex;
+              flex-direction: row;
+              height: auto;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-height: 60px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
             }
             &:hover {
-              outline: 0px;
+              border-color: #323130;
             }
-            &::-ms-clear {
-              display: none;
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
+              border-color: Highlight;
+              forced-color-adjust: none;
             }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-            &::placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-              color: GrayText;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-              color: GrayText;
-            }
-        id="TextField0"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        value=""
-      />
+      >
+        <textarea
+          aria-invalid="false"
+          aria-labelledby="TextFieldLabel2"
+          class=
+              ms-TextField-field
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                background: none;
+                border-radius: 0px;
+                border: none;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                flex-grow: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                line-height: 17px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-height: inherit;
+                min-width: 0px;
+                outline: 0px;
+                overflow: auto;
+                padding-bottom: 6px;
+                padding-left: 8px;
+                padding-right: 8px;
+                padding-top: 6px;
+                text-overflow: ellipsis;
+                width: 100%;
+              }
+              &:active {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                color: GrayText;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                color: GrayText;
+              }
+          id="TextField0"
+        />
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`TextField snapshots renders multiline with placeholder correctly 1`] = `
-<div
-  className=
-      ms-TextField
-      ms-TextField--multiline
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        box-shadow: none;
-        box-sizing: border-box;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        margin-bottom: 0px;
-        margin-left: 0px;
-        margin-right: 0px;
-        margin-top: 0px;
-        padding-bottom: 0px;
-        padding-left: 0px;
-        padding-right: 0px;
-        padding-top: 0px;
-        position: relative;
-      }
->
+<div>
   <div
-    className="ms-TextField-wrapper"
+    class=
+        ms-TextField
+        ms-TextField--multiline
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
   >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #323130;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 600;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-      htmlFor="TextField0"
-      id="TextFieldLabel2"
-    >
-      Label
-    </label>
     <div
-      className=
-          ms-TextField-fieldGroup
-          {
-            align-items: stretch;
-            background: #ffffff;
-            border-radius: 2px;
-            border: 1px solid #605e5c;
-            box-shadow: none;
-            box-sizing: border-box;
-            cursor: text;
-            display: flex;
-            flex-direction: row;
-            height: auto;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            min-height: 60px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-          }
-          &:hover {
-            border-color: #323130;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-            -ms-high-contrast-adjust: none;
-            border-color: Highlight;
-            forced-color-adjust: none;
-          }
+      class="ms-TextField-wrapper"
     >
-      <textarea
-        aria-invalid={false}
-        aria-labelledby="TextFieldLabel2"
-        className=
-            ms-TextField-field
+      <label
+        class=
+            ms-Label
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              background: none;
-              border-radius: 0px;
-              border: none;
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
-              flex-grow: 1;
+              display: block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
-              font-weight: 400;
-              line-height: 17px;
+              font-weight: 600;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-height: inherit;
-              min-width: 0px;
-              outline: 0px;
-              overflow: auto;
-              padding-bottom: 6px;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 6px;
-              text-overflow: ellipsis;
-              width: 100%;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
             }
-            &:active {
-              outline: 0px;
-            }
-            &:focus {
-              outline: 0px;
+        for="TextField0"
+        id="TextFieldLabel2"
+      >
+        Label
+      </label>
+      <div
+        class=
+            ms-TextField-fieldGroup
+            {
+              align-items: stretch;
+              background: #ffffff;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
+              box-shadow: none;
+              box-sizing: border-box;
+              cursor: text;
+              display: flex;
+              flex-direction: row;
+              height: auto;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-height: 60px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
             }
             &:hover {
-              outline: 0px;
+              border-color: #323130;
             }
-            &::-ms-clear {
-              display: none;
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
+              border-color: Highlight;
+              forced-color-adjust: none;
             }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-            &::placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-              color: GrayText;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-              color: GrayText;
-            }
-        id="TextField0"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        placeholder="test placeholder"
-        value=""
-      />
+      >
+        <textarea
+          aria-invalid="false"
+          aria-labelledby="TextFieldLabel2"
+          class=
+              ms-TextField-field
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                background: none;
+                border-radius: 0px;
+                border: none;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                flex-grow: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                line-height: 17px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-height: inherit;
+                min-width: 0px;
+                outline: 0px;
+                overflow: auto;
+                padding-bottom: 6px;
+                padding-left: 8px;
+                padding-right: 8px;
+                padding-top: 6px;
+                text-overflow: ellipsis;
+                width: 100%;
+              }
+              &:active {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                color: GrayText;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                color: GrayText;
+              }
+          id="TextField0"
+          placeholder="test placeholder"
+        />
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`TextField snapshots renders with reveal password button 1`] = `
-<div
-  className=
-      ms-TextField
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        box-shadow: none;
-        box-sizing: border-box;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        margin-bottom: 0px;
-        margin-left: 0px;
-        margin-right: 0px;
-        margin-top: 0px;
-        padding-bottom: 0px;
-        padding-left: 0px;
-        padding-right: 0px;
-        padding-top: 0px;
-        position: relative;
-      }
->
+<div>
   <div
-    className="ms-TextField-wrapper"
+    class=
+        ms-TextField
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
   >
     <div
-      className=
-          ms-TextField-fieldGroup
-          {
-            align-items: stretch;
-            background: #ffffff;
-            border-radius: 2px;
-            border: 1px solid #605e5c;
-            box-shadow: none;
-            box-sizing: border-box;
-            cursor: text;
-            display: flex;
-            flex-direction: row;
-            height: 32px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-          }
-          &:hover {
-            border-color: #323130;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-            -ms-high-contrast-adjust: none;
-            border-color: Highlight;
-            forced-color-adjust: none;
-          }
+      class="ms-TextField-wrapper"
     >
-      <input
-        aria-invalid={false}
-        className=
-            ms-TextField-field
+      <div
+        class=
+            ms-TextField-fieldGroup
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              background: none;
-              border-radius: 0px;
-              border: none;
+              align-items: stretch;
+              background: #ffffff;
+              border-radius: 2px;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
-              color: #323130;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
+              cursor: text;
+              display: flex;
+              flex-direction: row;
+              height: 32px;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 0px;
-              outline: 0px;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              text-overflow: ellipsis;
-              width: 100%;
-            }
-            &:active {
-              outline: 0px;
-            }
-            &:focus {
-              outline: 0px;
-            }
-            &:hover {
-              outline: 0px;
-            }
-            &::-ms-clear {
-              display: none;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-            &::placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-              color: GrayText;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-              color: GrayText;
-            }
-        id="TextField0"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        type="password"
-        value=""
-      />
-      <button
-        aria-pressed={false}
-        className=
-            ms-TextField-reveal
-            ms-Button
-            ms-Button--icon
-            {
-              background-color: transparent;
-              border: none;
-              color: #0078d4;
-              height: 30px;
-              outline: transparent;
               padding-bottom: 0px;
-              padding-left: 4px;
-              padding-right: 4px;
+              padding-left: 0px;
+              padding-right: 0px;
               padding-top: 0px;
               position: relative;
-              width: 32px;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
-              bottom: 2px;
-              content: "";
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: absolute;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
             }
             &:hover {
-              background-color: #f3f2f1;
-              color: #106ebe;
-              outline: 0px;
+              border-color: #323130;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
               border-color: Highlight;
-              color: Highlight;
+              forced-color-adjust: none;
             }
-            &:focus {
-              outline: 0px;
-            }
-        onClick={[Function]}
-        type="button"
       >
-        <span
-          className=
-
+        <input
+          aria-invalid="false"
+          class=
+              ms-TextField-field
               {
-                align-items: center;
-                display: flex;
-                height: 100%;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                background: none;
+                border-radius: 0px;
+                border: none;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 0px;
+                outline: 0px;
+                padding-bottom: 0;
+                padding-left: 8px;
+                padding-right: 8px;
+                padding-top: 0;
+                text-overflow: ellipsis;
+                width: 100%;
               }
+              &:active {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                color: GrayText;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                color: GrayText;
+              }
+          id="TextField0"
+          type="password"
+          value=""
+        />
+        <button
+          aria-pressed="false"
+          class=
+              ms-TextField-reveal
+              ms-Button
+              ms-Button--icon
+              {
+                background-color: transparent;
+                border: none;
+                color: #0078d4;
+                height: 30px;
+                outline: transparent;
+                padding-bottom: 0px;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0px;
+                position: relative;
+                width: 32px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 2px;
+                content: "";
+                left: 2px;
+                outline: 1px solid #605e5c;
+                position: absolute;
+                right: 2px;
+                top: 2px;
+                z-index: 1;
+              }
+              &:hover {
+                background-color: #f3f2f1;
+                color: #106ebe;
+                outline: 0px;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:focus {
+                outline: 0px;
+              }
+          type="button"
         >
-          <i
-            aria-hidden={true}
-            className=
+          <span
+            class=
 
                 {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  bottom: 6px;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons-1";
-                  font-size: 16px;
-                  font-style: normal;
-                  font-weight: normal;
-                  line-height: 18px;
-                  margin-bottom: 0px;
-                  margin-left: 4px;
-                  margin-right: 4px;
-                  margin-top: 0px;
-                  pointer-events: none;
-                  right: 8px;
-                  speak: none;
-                  top: auto;
+                  align-items: center;
+                  display: flex;
+                  height: 100%;
                 }
-            data-icon-name="RedEye"
           >
-            
-          </i>
-        </span>
-      </button>
+            <i
+              aria-hidden="true"
+              class=
+
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    bottom: 6px;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons-1";
+                    font-size: 16px;
+                    font-style: normal;
+                    font-weight: normal;
+                    line-height: 18px;
+                    margin-bottom: 0px;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0px;
+                    pointer-events: none;
+                    right: 8px;
+                    speak: none;
+                    top: auto;
+                  }
+              data-icon-name="RedEye"
+            >
+              
+            </i>
+          </span>
+        </button>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`TextField snapshots should respect user component and subcomponent styling 1`] = `
-<div
-  className=
-      ms-TextField
-      ms-TextField--underlined
-      root-testClassName
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        box-shadow: none;
-        box-sizing: border-box;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        margin-bottom: 0px;
-        margin-left: 0px;
-        margin-right: 0px;
-        margin-top: 0px;
-        padding-bottom: 0px;
-        padding-left: 0px;
-        padding-right: 0px;
-        padding-top: 0px;
-        position: relative;
-      }
->
+<div>
   <div
-    className=
-        ms-TextField-wrapper
+    class=
+        ms-TextField
+        ms-TextField--underlined
+        root-testClassName
         {
-          border-bottom: 1px solid #a4262c;
-          display: flex;
-          width: 100%;
-        }
-        &:hover {
-          border-bottom-color: #a4262c;
-        }
-        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-          -ms-high-contrast-adjust: none;
-          border-bottom-color: Highlight;
-          forced-color-adjust: none;
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
         }
   >
-    <label
-      className=
-          ms-Label
-          label-testClassName
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #323130;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 600;
-            height: 32px;
-            line-height: 22px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 8px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 12px;
-            padding-right: 0px;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-      htmlFor="TextField0"
-      id="TextFieldLabel2"
-    >
-      Label
-    </label>
     <div
-      className=
-          ms-TextField-fieldGroup
+      class=
+          ms-TextField-wrapper
           {
-            align-items: stretch;
-            background: #ffffff;
-            border-radius: 2px;
-            border: none;
-            box-shadow: none;
-            box-sizing: border-box;
-            cursor: text;
+            border-bottom: 1px solid #a4262c;
             display: flex;
-            flex-direction: row;
-            flex: 1 1 0px;
-            height: 32px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            text-align: left;
+            width: 100%;
           }
           &:hover {
-            border-color: #323130;
+            border-bottom-color: #a4262c;
           }
           @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
-            border-color: Highlight;
+            border-bottom-color: Highlight;
             forced-color-adjust: none;
           }
     >
-      <div
-        className=
-            ms-TextField-prefix
-            {
-              align-items: center;
-              background: #f3f2f1;
-              color: #605e5c;
-              display: flex;
-              flex-shrink: 0;
-              line-height: 1px;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              white-space: nowrap;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-        id="TextFieldPrefix3"
-      >
-        <span
-          style={
-            Object {
-              "paddingBottom": "1px",
-            }
-          }
-        >
-          test prefix
-        </span>
-      </div>
-      <input
-        aria-describedby="TextFieldDescription1"
-        aria-invalid={true}
-        aria-labelledby="TextFieldLabel2 TextFieldPrefix3 TextFieldSuffix4"
-        className=
-            ms-TextField-field
+      <label
+        class=
+            ms-Label
+            label-testClassName
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              background: none;
-              border-radius: 0px;
-              border: none;
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
+              display: block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
-              font-weight: 400;
+              font-weight: 600;
+              height: 32px;
+              line-height: 22px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 8px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 12px;
+              padding-right: 0px;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+        for="TextField0"
+        id="TextFieldLabel2"
+      >
+        Label
+      </label>
+      <div
+        class=
+            ms-TextField-fieldGroup
+            {
+              align-items: stretch;
+              background: #ffffff;
+              border-radius: 2px;
+              border: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              cursor: text;
+              display: flex;
+              flex-direction: row;
+              flex: 1 1 0px;
+              height: 32px;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 0px;
-              outline: 0px;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
               text-align: left;
-              text-overflow: ellipsis;
-              width: 100%;
-            }
-            &:active {
-              outline: 0px;
-            }
-            &:focus {
-              outline: 0px;
             }
             &:hover {
-              outline: 0px;
+              border-color: #323130;
             }
-            &::-ms-clear {
-              display: none;
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+              -ms-high-contrast-adjust: none;
+              border-color: Highlight;
+              forced-color-adjust: none;
             }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-            &::placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-              color: GrayText;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-              color: GrayText;
-            }
-        id="TextField0"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        type="text"
-        value=""
-      />
-      <div
-        className=
-            ms-TextField-suffix
-            {
-              align-items: center;
-              background: #f3f2f1;
-              color: #605e5c;
-              display: flex;
-              flex-shrink: 0;
-              line-height: 1px;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              white-space: nowrap;
-            }
-            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-              background: Window;
-              color: WindowText;
-            }
-        id="TextFieldSuffix4"
       >
-        <span
-          style={
-            Object {
-              "paddingBottom": "1px",
-            }
-          }
+        <div
+          class=
+              ms-TextField-prefix
+              {
+                align-items: center;
+                background: #f3f2f1;
+                color: #605e5c;
+                display: flex;
+                flex-shrink: 0;
+                line-height: 1px;
+                padding-bottom: 0;
+                padding-left: 10px;
+                padding-right: 10px;
+                padding-top: 0;
+                white-space: nowrap;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+          id="TextFieldPrefix3"
         >
-          test suffix
-        </span>
+          <span
+            style="padding-bottom: 1px;"
+          >
+            test prefix
+          </span>
+        </div>
+        <input
+          aria-describedby="TextFieldDescription1"
+          aria-invalid="true"
+          aria-labelledby="TextFieldLabel2 TextFieldPrefix3 TextFieldSuffix4"
+          class=
+              ms-TextField-field
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                background: none;
+                border-radius: 0px;
+                border: none;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 0px;
+                outline: 0px;
+                padding-bottom: 0;
+                padding-left: 8px;
+                padding-right: 8px;
+                padding-top: 0;
+                text-align: left;
+                text-overflow: ellipsis;
+                width: 100%;
+              }
+              &:active {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                color: GrayText;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                color: GrayText;
+              }
+          id="TextField0"
+          type="text"
+          value=""
+        />
+        <div
+          class=
+              ms-TextField-suffix
+              {
+                align-items: center;
+                background: #f3f2f1;
+                color: #605e5c;
+                display: flex;
+                flex-shrink: 0;
+                line-height: 1px;
+                padding-bottom: 0;
+                padding-left: 10px;
+                padding-right: 10px;
+                padding-top: 0;
+                white-space: nowrap;
+              }
+              @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                background: Window;
+                color: WindowText;
+              }
+          id="TextFieldSuffix4"
+        >
+          <span
+            style="padding-bottom: 1px;"
+          >
+            test suffix
+          </span>
+        </div>
       </div>
     </div>
+    <span
+      id="TextFieldDescription1"
+    >
+      <div
+        role="alert"
+      />
+    </span>
   </div>
-  <span
-    id="TextFieldDescription1"
-  >
-    <div
-      role="alert"
-    />
-  </span>
 </div>
 `;


### PR DESCRIPTION
## Current Behavior

- v8 `TextField` tests don't use testing-library

## New Behavior

- Convert `TextField` to fully use testing-library

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

part of #21663 