### PR TITLE
fix focus indicator appearance when highlightFirstItemOnOpen is true

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Dropdown` repositioning when always open and have multilines @chpalac ([#21754](https://github.com/microsoft/fluentui/pull/21754))
 - Fix `Tooltip` close tooltip with ESC key only when is opened @kolaps33 ([#21936](https://github.com/microsoft/fluentui/pull/21936))
 - Replace ReactNodeArray with ReactNode[] @jurokapsiar ([#21957](https://github.com/microsoft/fluentui/pull/21957))
+- Fix `Dropdown` focus indicator appearance when `highlightFirstItemOnOpen` is true while accessing from keyboard @annabratseiko ([#21991](https://github.com/microsoft/fluentui/pull/21991))
 
 ### Features
 - Add new Popup prop `closeOnScroll` to close popup when scroll happens outside of the popover element @yuanboxue-amber ([#21453](https://github.com/microsoft/fluentui/pull/21453))

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -941,6 +941,7 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
       case Downshift.stateChangeTypes.clickButton:
       case Downshift.stateChangeTypes.keyDownSpaceButton:
         newState.open = changes.isOpen;
+        newState.itemIsFromKeyboard = isFromKeyboard;
 
         if (changes.isOpen) {
           const highlightedIndexOnArrowKeyOpen = getHighlightedIndexOnArrowKeyOpen(changes);


### PR DESCRIPTION
Fix focus indicator appearance when highlightFirstItemOnOpen is true while accessing from keyboard.

## Current Behavior

When you open dropdown for the first time with 'highlightFirstItemOnOpen', the first item is highlighted but missing focus indicator. 

From keyboard:
<img width="360" alt="image" src="https://user-images.githubusercontent.com/20684334/157207337-0980d998-c0c4-4366-b70c-65529a54ec87.png">

## New Behavior

From keyboard:
<img width="360" alt="image" src="https://user-images.githubusercontent.com/20684334/157207788-54785672-4b1b-4844-accb-cb1e1b988d50.png">


