### PR TITLE
fix: Tooltip content color for HC theme

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Tooltip` close tooltip with ESC key only when is opened @kolaps33 ([#21936](https://github.com/microsoft/fluentui/pull/21936))
 - Replace ReactNodeArray with ReactNode[] @jurokapsiar ([#21957](https://github.com/microsoft/fluentui/pull/21957))
 - Fix `Dropdown` focus indicator appearance when `highlightFirstItemOnOpen` is true while accessing from keyboard @annabratseiko ([#21991](https://github.com/microsoft/fluentui/pull/21991))
+- Fix `Tooltip` color for HC theme @chpalac ([#21994](https://github.com/microsoft/fluentui/pull/21994))
 
 ### Features
 - Add new Popup prop `closeOnScroll` to close popup when scroll happens outside of the popover element @yuanboxue-amber ([#21453](https://github.com/microsoft/fluentui/pull/21453))

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Tooltip/tooltipContentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Tooltip/tooltipContentVariables.ts
@@ -2,8 +2,8 @@ import { TooltipContentVariables } from '../../../teams/components/Tooltip/toolt
 
 export const tooltipContentVariables = (siteVars): Partial<TooltipContentVariables> => ({
   boxShadow: undefined,
-  color: siteVars.colors.black,
-  backgroundColor: siteVars.colors.white,
-  subtleBackgroundColor: siteVars.colors.white,
-  subtleForegroundColor: siteVars.colors.black,
+  color: siteVars.colors.white,
+  backgroundColor: siteVars.colors.black,
+  subtleBackgroundColor: siteVars.colors.black,
+  subtleForegroundColor: siteVars.colors.white,
 });


### PR DESCRIPTION
# Overview

Fix `TooltipContent` colors for HC theme

Before:

![Screenshot (61)](https://user-images.githubusercontent.com/86579954/157444675-63379de7-39b0-4ceb-bbca-fbf2e0108ed4.png)

After:

![Screenshot (62)](https://user-images.githubusercontent.com/86579954/157444709-0c3b1578-0a00-4656-bf78-ffe0c92c59bb.png)
