### PR TITLE
Add a styled demo to tooltip v9

### DIFF
--- a/packages/react-tooltip/src/stories/Tooltip.stories.tsx
+++ b/packages/react-tooltip/src/stories/Tooltip.stories.tsx
@@ -7,6 +7,8 @@ export { RelationshipLabel } from './TooltipRelationshipLabel.stories';
 export { RelationshipDescription } from './TooltipRelationshipDescription.stories';
 export { Inverted } from './TooltipInverted.stories';
 export { WithArrow } from './TooltipWithArrow.stories';
+export { Styled } from './TooltipStyled.stories';
+
 export { Controlled } from './TooltipControlled.stories';
 export { Positioning } from './TooltipPositioning.stories';
 export { Target } from './TooltipTarget.stories';

--- a/packages/react-tooltip/src/stories/TooltipStyled.stories.tsx
+++ b/packages/react-tooltip/src/stories/TooltipStyled.stories.tsx
@@ -4,11 +4,12 @@ import { Tooltip, TooltipProps } from '../Tooltip';
 import { Button } from '@fluentui/react-button';
 import { SlideTextRegular } from '@fluentui/react-icons';
 import { makeStyles } from '@griffel/react';
+import { tokens } from '@fluentui/react-theme';
 
 const getStyles = makeStyles({
   toolTip: {
-    backgroundColor: 'green',
-    color: 'white',
+    backgroundColor: tokens.colorBrandBackground,
+    color: tokens.colorNeutralForegroundInverted,
   },
 });
 

--- a/packages/react-tooltip/src/stories/TooltipStyled.stories.tsx
+++ b/packages/react-tooltip/src/stories/TooltipStyled.stories.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+
+import { Tooltip, TooltipProps } from '../Tooltip';
+import { Button } from '@fluentui/react-button';
+import { SlideTextRegular } from '@fluentui/react-icons';
+import { makeStyles } from '@griffel/react';
+
+const getStyles = makeStyles({
+  toolTip: {
+    backgroundColor: 'green',
+    color: 'white',
+  },
+});
+
+export const Styled = (props: Partial<TooltipProps>) => {
+  const styles = getStyles();
+  return (
+    <Tooltip
+      withArrow
+      content={{ children: 'Example tooltip', className: styles.toolTip }}
+      relationship="label"
+      {...props}
+    >
+      <Button icon={<SlideTextRegular />} size="large" />
+    </Tooltip>
+  );
+};
+
+Styled.parameters = {
+  docs: {
+    description: {
+      story: `To style a tooltip, classNames must be passed through the content slot.`,
+    },
+  },
+};


### PR DESCRIPTION
fixes #21997

Add a simple demo showing how to style a tooltip in v9. This came about after customer was having trouble applying styles to the tooltip itself. 