### PR TITLE
fix(react): Apply component style overrides to root slot by default

### DIFF
--- a/change/@fluentui-foundation-legacy-d8f593e7-c408-4bcf-a45e-4fe7de874252.json
+++ b/change/@fluentui-foundation-legacy-d8f593e7-c408-4bcf-a45e-4fe7de874252.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Component style overrides on the ThemeProvider now applied to root slot by default",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "39736248+andrefcdias@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/foundation-legacy/src/createComponent.tsx
+++ b/packages/foundation-legacy/src/createComponent.tsx
@@ -82,7 +82,9 @@ export function createComponent<
       ...componentProps,
       styles,
       tokens,
-      _defaultStyles: styles,
+      _defaultStyles: {
+        root: styles,
+      },
       theme,
     } as unknown) as TViewProps & IDefaultSlotProps<any>;
 


### PR DESCRIPTION
## Current Behavior

The `createComponent` function used for `Text` does not properly apply styles defined on the theme.
This is because the `getSlots` function expects the `styles` prop to have keys with the styles and not the styles directly, so essentially, all styles get ignored.

Looking at the example below:

```
<ThemeProvider
  theme={{
    components: {
      Text: {
        styles: {
          color: 'steelblue',
        },
      },
    },
  }}
>
  <Text>Is not blue</Text>
</ThemeProvider>
```

`getSlots` will try and get styles from `_defaultStyles` with the `root` name:

```
 return _renderSlot<any, any, any>(
  mixedProps.slots && mixedProps.slots[name],
  // _defaultStyles should always be present, but a check for existence is added to make view tests
  // easier to use.
  mixedProps._defaultStyles && mixedProps._defaultStyles[name],
  (mixedProps as any).theme,
);
```

But this is the content:

```
{
  color: 'steelblue',
  root: { //props applied by Text }
}
```

## New Behavior

`createComponent` will now inject the styles into `_defaultStyles` but into the `root` key.
Implementation stays the same, but the text will now have the style applied to it.

## Related Issue(s)

Fixes #21967
