### PR TITLE
@fluentui/theme missing a ./lib/createTheme export

### DIFF
--- a/change/@fluentui-theme-abd89837-a058-4b70-9f37-7ee3d73aca2b.json
+++ b/change/@fluentui-theme-abd89837-a058-4b70-9f37-7ee3d73aca2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding ./lib/createTheme export to @fluentui/theme package.",
+  "packageName": "@fluentui/theme",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -42,6 +42,11 @@
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
+    },
+    "./lib/createTheme": {
+      "types": "./lib/createTheme.d.ts",
+      "import": "./lib/createTheme.js",
+      "require": "./lib-commonjs/createTheme.js"
     }
   }
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -43,10 +43,64 @@
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },
+    "./lib/colors/DefaultPalette": {
+      "types": "./lib/colors/DefaultPalette.d.ts",
+      "import": "./lib/colors/DefaultPalette.js",
+      "require": "./lib-commonjs/DefaultPalette.js"
+    },
     "./lib/createTheme": {
       "types": "./lib/createTheme.d.ts",
       "import": "./lib/createTheme.js",
       "require": "./lib-commonjs/createTheme.js"
+    },
+    "./lib/effects/DefaultEffects": {
+      "types": "./lib/effects/DefaultEffects.d.ts",
+      "import": "./lib/effects/DefaultEffects.js",
+      "require": "./lib-commonjs/DefaultEffects.js"
+    },
+    "./lib/fonts/DefaultFontStyles": {
+      "types": "./lib/fonts/DefaultFontStyles.d.ts",
+      "import": "./lib/fonts/DefaultFontStyles.js",
+      "require": "./lib-commonjs/DefaultFontStyles.js"
+    },
+    "./lib/fonts/index": {
+      "types": "./lib/fonts/index.d.ts",
+      "import": "./lib/fonts/index.js",
+      "require": "./lib-commonjs/index.js"
+    },
+    "./lib/motion/AnimationStyles": {
+      "types": "./lib/motion/AnimationStyles.d.ts",
+      "import": "./lib/motion/AnimationStyles.js",
+      "require": "./lib-commonjs/AnimationStyles.js"
+    },
+    "./lib/spacing/DefaultSpacing": {
+      "types": "./lib/spacing/DefaultSpacing.d.ts",
+      "import": "./lib/spacing/DefaultSpacing.js",
+      "require": "./lib-commonjs/DefaultSpacing.js"
+    },
+    "./lib/types/IAnimationStyles": {
+      "types": "./lib/types/IAnimationStyles.d.ts"
+    },
+    "./lib/types/IEffects": {
+      "types": "./lib/types/IEffects.d.ts"
+    },
+    "./lib/types/IFontStyles": {
+      "types": "./lib/types/IFontStyles.d.ts"
+    },
+    "./lib/types/IPalette": {
+      "types": "./lib/types/IPalette.d.ts"
+    },
+    "./lib/types/ISemanticColors": {
+      "types": "./lib/types/ISemanticColors.d.ts"
+    },
+    "./lib/types/ISemanticTextColors": {
+      "types": "./lib/types/ISemanticTextColors.d.ts"
+    },
+    "./lib/types/ISpacing": {
+      "types": "./lib/types/ISpacing.d.ts"
+    },
+    "./lib/types/ITheme": {
+      "types": "./lib/types/ITheme.d.ts"
     }
   }
 }


### PR DESCRIPTION
It turns out some repos are consuming the v8 `@fluentui/theme` through v7 `@uifabric/styling package` references via pinning to disregard semver.

This is a problem in itself, but was working until exports maps were introduced. When @uifabric/styling imports createTheme, it gets it from `@fluentui/theme/lib/createTheme` which now breaks in a webpack 5 environment. v8 packages do not use this theme, so separately we need to remove v7, but to unblock the partial upgrade in 1JS, we need to add this entry.

