### PR TITLE
More friendly behavior when GroupedList header is too long

### DIFF
--- a/change/@fluentui-react-5855132c-df7c-48fb-a439-ba589755f330.json
+++ b/change/@fluentui-react-5855132c-df7c-48fb-a439-ba589755f330.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "icon of group header is not shrink",
+  "packageName": "@fluentui/react",
+  "email": "15898297@qq.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -7930,6 +7930,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     color: #605e5c;
                                     cursor: default;
                                     display: flex;
+                                    flex-shrink: 0;
                                     font-size: 12px;
                                     height: 48px;
                                     justify-content: center;
@@ -7996,6 +7997,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   font-size: 16px;
                                   font-weight: 600;
                                   outline: 0px;
+                                  overflow: hidden;
                                   padding-left: 12px;
                                   text-overflow: ellipsis;
                                   white-space: nowrap;
@@ -8795,6 +8797,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     color: #605e5c;
                                     cursor: default;
                                     display: flex;
+                                    flex-shrink: 0;
                                     font-size: 12px;
                                     height: 48px;
                                     justify-content: center;
@@ -8861,6 +8864,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   font-size: 16px;
                                   font-weight: 600;
                                   outline: 0px;
+                                  overflow: hidden;
                                   padding-left: 12px;
                                   text-overflow: ellipsis;
                                   white-space: nowrap;

--- a/packages/react/src/components/GroupedList/GroupHeader.styles.ts
+++ b/packages/react/src/components/GroupedList/GroupHeader.styles.ts
@@ -147,7 +147,7 @@ export const getStyles = (props: IGroupHeaderStyleProps): IGroupHeaderStyles => 
       checkExpandResetStyles,
       {
         display: 'flex',
-        flexShrink:0,
+        flexShrink: 0,
         alignItems: 'center',
         justifyContent: 'center',
         fontSize: fonts.small.fontSize,
@@ -190,6 +190,7 @@ export const getStyles = (props: IGroupHeaderStyleProps): IGroupHeaderStyles => 
         outline: 0,
         whiteSpace: 'nowrap',
         textOverflow: 'ellipsis',
+        overflow: 'hidden',
       },
     ],
     dropIcon: [

--- a/packages/react/src/components/GroupedList/GroupHeader.styles.ts
+++ b/packages/react/src/components/GroupedList/GroupHeader.styles.ts
@@ -147,6 +147,7 @@ export const getStyles = (props: IGroupHeaderStyleProps): IGroupHeaderStyles => 
       checkExpandResetStyles,
       {
         display: 'flex',
+        flexShrink:0,
         alignItems: 'center',
         justifyContent: 'center',
         fontSize: fonts.small.fontSize,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
![image](https://user-images.githubusercontent.com/28779355/157430826-db2659f4-8f8c-4af1-8509-71b26309c405.png)

## New Behavior
![image](https://user-images.githubusercontent.com/28779355/157431482-fb96bed1-0891-4766-bc00-232e9a327e35.png)

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21275 
