### PR TITLE
revert: ESlint - support tsconfig excluded files

### DIFF
--- a/change/@fluentui-eslint-plugin-c78892bf-1aff-4715-aa5c-a43a942b4184.json
+++ b/change/@fluentui-eslint-plugin-c78892bf-1aff-4715-aa5c-a43a942b4184.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "revert: ESlint - support tsconfig excluded files",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -296,15 +296,21 @@ const config = {
   },
 };
 
+/** @type {import("eslint").Linter.RulesRecord} */
+const typeAwareRules = {
+  /**
+   * plugin: https://github.com/gund/eslint-plugin-deprecation
+   */
+  'deprecation/deprecation': 'error',
+};
+
 /**
  * Override definitions for `config`. See explanation at bottom of file for why/how this function is used.
  * @returns {import("eslint").Linter.ConfigOverride[]}
  */
 const getOverrides = () => [
   // Enable rules requiring type info only for appropriate files/circumstances
-  ...configHelpers.getTypeInfoRuleOverrides({
-    'deprecation/deprecation': 'error',
-  }),
+  ...configHelpers.getTypeInfoRuleOverrides(typeAwareRules),
   {
     files: '**/*.{ts,tsx}',
     // This turns off a few rules that don't work or are unnecessary for TS, and enables a few

--- a/packages/eslint-plugin/src/utils/configHelpers.js
+++ b/packages/eslint-plugin/src/utils/configHelpers.js
@@ -132,7 +132,7 @@ module.exports = {
    * @returns {import("eslint").Linter.ConfigOverride[]} A single-entry array with a config for TS files if
    * *not* running lint-staged (or empty array for lint-staged)
    */
-  getTypeInfoRuleOverrides: (rules, tsconfigPath) => {
+  getTypeInfoRuleOverrides: (rules, tsconfigPath = path.join(process.cwd(), 'tsconfig.json')) => {
     if (isLintStaged) {
       return [];
     }
@@ -140,16 +140,14 @@ module.exports = {
     // Type info-dependent rules must only apply to TS files included in a project.
     // Usually this is files under src, but check the tsconfig to verify.
     const tsGlob = '**/*.{ts,tsx}';
-    let tsFiles = [`src/${tsGlob}`];
-    tsconfigPath = tsconfigPath || path.join(process.cwd(), 'tsconfig.json');
 
     if (!fs.existsSync(tsconfigPath)) {
       return [];
     }
 
     /**
-       * Note that this approach only accounts for a single level of extends. JJU is used for parsing
-       * the tsconfig because Typescript functions are more complex than necessary.
+       * Note that this approach only accounts for a single level of extends.
+       * - JJU is used for tsconfig parsing because Typescript configs support JS comments (JSON5 "standard")
        *
        * @type {{
           extends: string;
@@ -159,29 +157,9 @@ module.exports = {
           references?: Array<{path:string}>
           }}
        */
-    let tsconfig = jju.parse(fs.readFileSync(tsconfigPath).toString());
+    const tsconfig = jju.parse(fs.readFileSync(tsconfigPath).toString());
 
-    /**
-     * Handle any necessary extends merging here, make sure to treat just like native tsconfigs would
-     */
-    if (tsconfig.extends) {
-      const parentTsConfigPath = path.join(path.dirname(tsconfigPath), tsconfig.extends);
-      /** @type { typeof tsconfig } */
-      const parentTsConfig = jju.parse(fs.readFileSync(parentTsConfigPath).toString());
-
-      // Extending config overrides parent files, include and exclude
-      // https://www.typescriptlang.org/tsconfig#extends
-      tsconfig = {
-        ...parentTsConfig,
-        ...tsconfig,
-        compilerOptions: {
-          ...parentTsConfig.compilerOptions,
-          ...tsconfig.compilerOptions,
-        },
-      };
-    }
-
-    // if project is using solution TS style config (process references)
+    // vNext setup - if project is using solution TS style config (process references)
     if (tsconfig.references) {
       return [
         {
@@ -194,10 +172,11 @@ module.exports = {
       ];
     }
 
+    // v8.v0 setup
+
+    let tsFiles = [`src/${tsGlob}`];
     if (tsconfig.include) {
-      tsFiles = /** @type {string[]} */ (tsconfig.include).map(
-        includePath => `${includePath.replace(/\*.*/, '')}/${tsGlob}`,
-      );
+      tsFiles = tsconfig.include.map(includePath => `${includePath.replace(/\*.*/, '')}/${tsGlob}`);
     } else if (tsconfig.compilerOptions && tsconfig.compilerOptions.rootDir) {
       tsFiles = [`${tsconfig.compilerOptions.rootDir}/${tsGlob}`];
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- eslint contains unused logic

## New Behavior

- reverts https://github.com/microsoft/fluentui/pull/20466 as that functionality is not needed/used after vNext migrated to solution ts config
- simplified args handling in `getTypeInfoRuleOverrides`
