### PR TITLE
fix(react): Apply `menuitem` role to overflow items in Pivot

### DIFF
--- a/change/@fluentui-react-fcdb408e-5bd1-48a1-b5c6-3a9e372543bc.json
+++ b/change/@fluentui-react-fcdb408e-5bd1-48a1-b5c6-3a9e372543bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add proper ARIA role to overflow Pivot items",
+  "packageName": "@fluentui/react",
+  "email": "39736248+andrefcdias@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -247,6 +247,8 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
           .slice(overflowIndex)
           .filter(link => link.itemKey !== renderedSelectedKey)
           .map((link, index) => {
+            link.role = 'menuitem';
+
             return {
               key: link.itemKey || `${overflowIndex + index}`,
               onRender: () => renderPivotLink(linkCollection, link, renderedSelectedKey, classNames.linkInMenu),


### PR DESCRIPTION
## Current Behavior

Pivot is not applying any role to the items on overflow, which means they're inside of a `menu` but have a role of `tab` as this is applied by default.

## New Behavior

Items sent to the overflow are applied the role of `menuitem`.

## Related Issue(s)

Fixes #20661