### PR TITLE
perf-test v9: update URL to point to newly dedicated deploy site page specifically for package

### DIFF
--- a/apps/perf-test-react-components/tasks/perf-test.ts
+++ b/apps/perf-test-react-components/tasks/perf-test.ts
@@ -114,9 +114,9 @@ const urlForDeployPath = process.env.DEPLOYURL
 const urlForDeploy = 'file://' + path.resolve(__dirname, '../dist/') + '/index.html';
 
 const targetPath = `heads/${process.env.SYSTEM_PULLREQUEST_TARGETBRANCH || 'master'}`;
-// TODO: Once merged to master, replace /perf-test/index.html with /perf-test-react-components/index.html.
-// This is because we need /perf-test-react-components to be deployed to master first before being usable.
-const urlForMaster = `https://${process.env.DEPLOYHOST || DEPLOY_URL}/${targetPath}/perf-test/index.html`;
+const urlForMaster = `https://${
+  process.env.DEPLOYHOST || DEPLOY_URL
+}/${targetPath}/perf-test-react-components/index.html`;
 
 const outDir = path.join(__dirname, '../dist');
 const tempDir = path.join(__dirname, '../logfiles');


### PR DESCRIPTION
Followup to https://github.com/microsoft/fluentui/pull/21873#discussion_r818065918.

Now that `perf-test-react-components` is uploaded to the Deployed [site ](https://fluentuipr.z22.web.core.windows.net/heads/master/) for master, this PR updates the new v9 perf test package to point to that url.