### PR TITLE
Add text direction knob to Storybook

### DIFF
--- a/packages/react-storybook/src/decorators/withFluentProvider.tsx
+++ b/packages/react-storybook/src/decorators/withFluentProvider.tsx
@@ -3,11 +3,17 @@ import { FluentProvider } from '@fluentui/react-provider';
 import * as React from 'react';
 
 import { useFluentTheme } from '../knobs/useFluentTheme';
+import { useTextDirection } from '../knobs/useTextDirection';
 
 const ProviderWrapper: React.FunctionComponent = props => {
   const { theme } = useFluentTheme();
+  const { direction } = useTextDirection();
 
-  return <FluentProvider theme={theme}>{props.children}</FluentProvider>;
+  return (
+    <FluentProvider theme={theme} dir={direction}>
+      {props.children}
+    </FluentProvider>
+  );
 };
 
 export const withFluentProvider = makeDecorator({

--- a/packages/react-storybook/src/knobs/useTextDirection.ts
+++ b/packages/react-storybook/src/knobs/useTextDirection.ts
@@ -1,0 +1,20 @@
+import { select } from '@storybook/addon-knobs';
+
+const directionSelectorLabel = 'Text Direction';
+
+type TextDirection = 'ltr' | 'rtl';
+
+const directionOptions: { label: string; direction: TextDirection }[] = [
+  { label: 'LTR', direction: 'ltr' },
+  { label: 'RTL', direction: 'rtl' },
+];
+
+export const useTextDirection = (): { label: string; direction: TextDirection } => {
+  // Casting any here due to issue: https://github.com/storybookjs/storybook/issues/9751
+  const directionLabels = directionOptions.map(option => ({ label: option.label }));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { label } = select(directionSelectorLabel, directionLabels, directionLabels[0] as any);
+
+  const { direction } = directionOptions.find(pair => pair.label === label) || { direction: 'ltr' };
+  return { label, direction };
+};


### PR DESCRIPTION
## Current Behavior

There is no easy way to change text direction to RTL in Storybook.

# New Behavior

Adds a text direction know to Storybook that allows the `dir` prop on FluentProvider to be set via the Storybook UI making it easier to view components in right-to-left layout. Support values are LTR (the default, left-to-right) and RTL (right-to-left).

![screen recording demonstrating the new knob](https://user-images.githubusercontent.com/93940821/157566535-5e02b24b-a645-4314-9ba1-9bf3c1db9062.gif)
