### PR TITLE
Adding 2 more exports to @fluentui/theme for v7 backwards compatibility purposes.

### DIFF
--- a/change/@fluentui-theme-12e3f5b4-2c39-4451-9e47-b81fc7cacb6b.json
+++ b/change/@fluentui-theme-12e3f5b4-2c39-4451-9e47-b81fc7cacb6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding exports entries for 2 more entry points to keep @uifabric/fluent-theme package compatible with the latest theme package.",
+  "packageName": "@fluentui/theme",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -48,6 +48,11 @@
       "import": "./lib/colors/DefaultPalette.js",
       "require": "./lib-commonjs/DefaultPalette.js"
     },
+    "./lib/colors/FluentColors": {
+      "types": "./lib/colors/FluentColors.d.ts",
+      "import": "./lib/colors/FluentColors.js",
+      "require": "./lib-commonjs/FluentColors.js"
+    },
     "./lib/createTheme": {
       "types": "./lib/createTheme.d.ts",
       "import": "./lib/createTheme.js",
@@ -62,6 +67,11 @@
       "types": "./lib/fonts/DefaultFontStyles.d.ts",
       "import": "./lib/fonts/DefaultFontStyles.js",
       "require": "./lib-commonjs/DefaultFontStyles.js"
+    },
+    "./lib/fonts/FluentFonts": {
+      "types": "./lib/fonts/FluentFonts.d.ts",
+      "import": "./lib/fonts/FluentFonts.js",
+      "require": "./lib-commonjs/FluentFonts.js"
     },
     "./lib/fonts/index": {
       "types": "./lib/fonts/index.d.ts",


### PR DESCRIPTION
Found 2 more imports from @uifabric/fluent-theme which won't work with the latest @fluentui/theme due to missing exports.

