### PR TITLE
feat(eslint-plugin): add autofixable import rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,9 @@
   // When opening a file, `editor.tabSize` and `editor.insertSpaces` will NOT be detected based on the file contents.
   "editor.detectIndentation": false,
   "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   // When enabled, will trim trailing whitespace when you save a file.
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
@@ -45,6 +48,7 @@
   },
   "editor.rulers": [120],
   "eslint.workingDirectories": [{ "mode": "auto" }], // infer working directory based on .eslintrc/package.json location
+  "eslint.codeActionsOnSave.mode": "problems",
   "files.associations": {
     "**/package.json.hbs": "json",
     "**/*.json.hbs": "jsonc"

--- a/change/@fluentui-eslint-plugin-e6e0684b-1ee7-4695-a151-9f716d78ab67.json
+++ b/change/@fluentui-eslint-plugin-e6e0684b-1ee7-4695-a151-9f716d78ab67.json
@@ -3,5 +3,5 @@
   "comment": "enable autofixable import rules",
   "packageName": "@fluentui/eslint-plugin",
   "email": "martinhochel@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@fluentui-eslint-plugin-e6e0684b-1ee7-4695-a151-9f716d78ab67.json
+++ b/change/@fluentui-eslint-plugin-e6e0684b-1ee7-4695-a151-9f716d78ab67.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "enable autofixable import rules",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -68,31 +68,11 @@ const config = {
     '**/*.scss.ts',
   ],
   rules: {
-    '@rnx-kit/no-export-all': ['error', { expand: 'external-only' }],
-    '@fluentui/no-global-react': 'error',
-    '@fluentui/max-len': [
-      'error',
-      {
-        ignorePatterns: [
-          'require(<.*?>)?\\(',
-          'https?:\\/\\/',
-          '^(import|export) ',
-          '^\\s+(<path )?d=',
-          '!raw-loader',
-          '\\bdata:image/',
-        ],
-        max: 120,
-      },
-    ],
-    '@fluentui/no-tslint-comments': 'error',
-
-    // tslint: function-name, variable-name
-    ...configHelpers.getNamingConventionRule(false /* prefixWithI */),
-
-    '@typescript-eslint/no-empty-function': 'error',
-    '@typescript-eslint/no-explicit-any': 'error', // tslint: no-any
-    '@typescript-eslint/prefer-namespace-keyword': 'error',
-
+    /**
+     *
+     * core eslint rules
+     * @see https://eslint.org/docs/rules
+     */
     curly: ['error', 'all'],
     'dot-notation': 'error',
     eqeqeq: ['error', 'always'],
@@ -108,20 +88,14 @@ const config = {
     'no-empty': 'error',
     'no-eval': 'error',
     'no-new-wrappers': 'error',
+    // handles only member sort, rest is handled via import/order
+    'sort-imports': ['warn', { ignoreDeclarationSort: true }],
     'no-restricted-globals': [
       'error',
       ...['blur', 'close', 'focus', 'length', 'name', 'parent', 'self', 'stop'].map(name => ({
         name,
         message: `"${name}" refers to a DOM global. Did you mean to reference a local value instead?`,
       })),
-    ],
-    '@fluentui/ban-imports': [
-      'error',
-      {
-        path: 'react',
-        names: ['useLayoutEffect'],
-        message: '`useLayoutEffect` causes a warning in SSR. Use `useIsomorphicLayoutEffect`',
-      },
     ],
     'no-restricted-properties': [
       'error',
@@ -138,53 +112,6 @@ const config = {
     'prefer-const': 'error',
     'prefer-arrow-callback': 'error', // tslint: no-function-expression
     radix: ['error', 'always'],
-    'react/jsx-key': 'error',
-    'react/jsx-no-bind': [
-      'error',
-      {
-        allowArrowFunctions: false, // tslint: jsx-no-lambda
-        allowFunctions: false,
-        allowBind: false,
-        ignoreDOMComponents: true,
-        ignoreRefs: true,
-      },
-    ],
-    'react/no-string-refs': 'error',
-    'react/self-closing-comp': 'error',
-    'react-hooks/exhaustive-deps': [
-      'error',
-      {
-        additionalHooks: 'useIsomorphicLayoutEffect',
-      },
-    ],
-    'react-hooks/rules-of-hooks': 'error',
-
-    // airbnb or other config overrides (some temporary)
-    // TODO: determine which rules we want to enable, and make needed changes (separate PR)
-    'arrow-body-style': 'off',
-    'class-methods-use-this': 'off',
-    'consistent-return': 'off',
-    'default-case': 'off',
-    'func-names': 'off',
-    'global-require': 'off',
-
-    'jsx-a11y/alt-text': 'off',
-    'jsx-a11y/anchor-is-valid': 'off',
-    'jsx-a11y/aria-activedescendant-has-tabindex': 'off',
-    'jsx-a11y/aria-role': 'off',
-    'jsx-a11y/click-events-have-key-events': 'off',
-    'jsx-a11y/control-has-associated-label': 'off',
-    'jsx-a11y/role-has-required-aria-props': 'off',
-    'jsx-a11y/interactive-supports-focus': 'off',
-    'jsx-a11y/label-has-associated-control': 'off',
-    'jsx-a11y/media-has-caption': 'off',
-    'jsx-a11y/mouse-events-have-key-events': 'off',
-    'jsx-a11y/no-interactive-element-to-noninteractive-role': 'off',
-    'jsx-a11y/no-noninteractive-element-interactions': 'off',
-    'jsx-a11y/no-noninteractive-tabindex': 'off',
-    'jsx-a11y/no-redundant-roles': 'off',
-    'jsx-a11y/no-static-element-interactions': 'off',
-    'jsx-a11y/role-supports-aria-props': 'off',
     'lines-between-class-members': 'off',
     'max-classes-per-file': 'off',
     'no-case-declarations': 'off',
@@ -216,6 +143,93 @@ const config = {
     'operator-assignment': 'off',
     'prefer-destructuring': 'off',
     'prefer-template': 'off',
+    // airbnb or other config overrides (some temporary)
+    // TODO: determine which rules we want to enable, and make needed changes (separate PR)
+    'arrow-body-style': 'off',
+    'class-methods-use-this': 'off',
+    'consistent-return': 'off',
+    'default-case': 'off',
+    'func-names': 'off',
+    'global-require': 'off',
+    'spaced-comment': 'off',
+    // airbnb options ban for-of which is unnecessary for TS and modern node (https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js#L334)
+    // but this is a very powerful rule we may want to use in other ways
+    'no-restricted-syntax': 'off',
+    // permanently disable because we disagree with these rules
+    'no-await-in-loop': 'off', // contrary to rule docs, awaited things often are NOT parallelizable
+    // permanently disable due to performance issues (using custom rule `@fluentui/max-len` instead)
+    'max-len': 'off',
+    // permanently disable due to perf problems and limited benefit
+    // see here for perf testing (note that you must run eslint directly)
+    // https://eslint.org/docs/developer-guide/working-with-rules#per-rule-performance
+    'no-empty-character-class': 'off',
+
+    /**
+     *
+     * `@typescript-eslint`plugin eslint rules
+     * @see https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/eslint-plugin
+     */
+    // tslint: function-name, variable-name
+    ...configHelpers.getNamingConventionRule(false),
+    '@typescript-eslint/no-empty-function': 'error',
+    '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/prefer-namespace-keyword': 'error',
+
+    /**
+     *
+     * `@rnx-kit` eslint rules
+     * @see https://github.com/microsoft/rnx-kit/tree/main/packages/eslint-plugin
+     */
+    '@rnx-kit/no-export-all': ['error', { expand: 'external-only' }],
+
+    /**
+     *
+     * `@fluentui` eslint rules / This package
+     * @see https://www.npmjs.com/package/@fluentui/eslint-plugin
+     */
+    '@fluentui/ban-imports': [
+      'error',
+      {
+        path: 'react',
+        names: ['useLayoutEffect'],
+        message: '`useLayoutEffect` causes a warning in SSR. Use `useIsomorphicLayoutEffect`',
+      },
+    ],
+    '@fluentui/no-global-react': 'error',
+    '@fluentui/max-len': [
+      'error',
+      {
+        ignorePatterns: [
+          'require(<.*?>)?\\(',
+          'https?:\\/\\/',
+          '^(import|export) ',
+          '^\\s+(<path )?d=',
+          '!raw-loader',
+          '\\bdata:image/',
+        ],
+        max: 120,
+      },
+    ],
+    '@fluentui/no-tslint-comments': 'error',
+
+    /**
+     *
+     * react eslint rules
+     * @see https://github.com/yannickcr/eslint-plugin-react
+     */
+    'react/jsx-key': 'error',
+    'react/jsx-no-bind': [
+      'error',
+      {
+        allowArrowFunctions: false, // tslint: jsx-no-lambda
+        allowFunctions: false,
+        allowBind: false,
+        ignoreDOMComponents: true,
+        ignoreRefs: true,
+      },
+    ],
+    'react/no-string-refs': 'error',
+    'react/self-closing-comp': 'error',
     'react/button-has-type': 'off',
     'react/destructuring-assignment': 'off',
     'react/forbid-prop-types': 'off',
@@ -235,30 +249,56 @@ const config = {
     'react/state-in-constructor': 'off',
     'react/static-property-placement': 'off',
     'react/require-default-props': 'off',
-    'spaced-comment': 'off',
-
-    // airbnb options ban for-of which is unnecessary for TS and modern node (https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js#L334)
-    // but this is a very powerful rule we may want to use in other ways
-    'no-restricted-syntax': 'off',
-
-    // permanently disable because we disagree with these rules
-    'no-await-in-loop': 'off', // contrary to rule docs, awaited things often are NOT parallelizable
-    'react/jsx-props-no-spreading': 'off',
-    'react/prop-types': 'off',
-
-    // permanently disable due to performance issues (using custom rule `@fluentui/max-len` instead)
-    'max-len': 'off',
-
-    // permanently disable due to perf problems and limited benefit
-    // see here for perf testing (note that you must run eslint directly)
-    // https://eslint.org/docs/developer-guide/working-with-rules#per-rule-performance
-    'no-empty-character-class': 'off',
     'react/no-unknown-property': 'off', // expensive, limited benefit with TS
     // these ones have minor negative perf impact and are unnecessary
     'react/default-props-match-prop-types': 'off',
     'react/no-unused-prop-types': 'off',
     'react/prefer-es6-class': 'off',
+    // permanently disable because we disagree with these rules
+    'react/jsx-props-no-spreading': 'off',
+    'react/prop-types': 'off',
 
+    /**
+     *
+     * react-hooks rules
+     * @see https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks
+     */
+    'react-hooks/exhaustive-deps': [
+      'error',
+      {
+        additionalHooks: 'useIsomorphicLayoutEffect',
+      },
+    ],
+    'react-hooks/rules-of-hooks': 'error',
+
+    /**
+     *
+     * jsx-a11y rules
+     * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y
+     */
+    'jsx-a11y/alt-text': 'off',
+    'jsx-a11y/anchor-is-valid': 'off',
+    'jsx-a11y/aria-activedescendant-has-tabindex': 'off',
+    'jsx-a11y/aria-role': 'off',
+    'jsx-a11y/click-events-have-key-events': 'off',
+    'jsx-a11y/control-has-associated-label': 'off',
+    'jsx-a11y/role-has-required-aria-props': 'off',
+    'jsx-a11y/interactive-supports-focus': 'off',
+    'jsx-a11y/label-has-associated-control': 'off',
+    'jsx-a11y/media-has-caption': 'off',
+    'jsx-a11y/mouse-events-have-key-events': 'off',
+    'jsx-a11y/no-interactive-element-to-noninteractive-role': 'off',
+    'jsx-a11y/no-noninteractive-element-interactions': 'off',
+    'jsx-a11y/no-noninteractive-tabindex': 'off',
+    'jsx-a11y/no-redundant-roles': 'off',
+    'jsx-a11y/no-static-element-interactions': 'off',
+    'jsx-a11y/role-supports-aria-props': 'off',
+
+    /**
+     *
+     * jsdoc plugin rules
+     * @see https://github.com/gajus/eslint-plugin-jsdoc
+     */
     'jsdoc/check-tag-names': [
       'error',
       {
@@ -273,15 +313,24 @@ const config = {
      * @see https://github.com/import-js/eslint-plugin-import
      */
     'import/no-extraneous-dependencies': ['error', { devDependencies: false }],
+    'import/no-duplicates': 'warn',
+    'import/first': 'warn',
+    'import/order': [
+      'warn',
+      {
+        'newlines-between': 'always',
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: false,
+        },
+      },
+    ],
     'import/extensions': 'off',
-    'import/first': 'off',
     'import/newline-after-import': 'off',
-    'import/no-duplicates': 'off', // mostly redundant with no-duplicate-imports
     'import/no-dynamic-require': 'off',
     'import/no-mutable-exports': 'off',
     'import/no-unresolved': 'off',
     'import/no-useless-path-segments': 'off',
-    'import/order': 'off',
     'import/prefer-default-export': 'off',
     // may cause perf problems per https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#eslint-plugin-import
     'import/no-cycle': 'off',


### PR DESCRIPTION
## Current Behavior

1. lint rules from various plugins are not collocated - hard to read
2. no module import consistency across whole monorepo

## New Behavior

1. lint rules from various plugins are collocated
2. autofixable lint rules for consistent module imports

**Fixable lint problems:**
- will be resolved automatically during `pre-commit` hook
- can be triggered manually by user

https://user-images.githubusercontent.com/1223799/157691286-14933494-8f74-4fea-886d-6406059e8e40.mov

- every problem will be autofixed, one at time, when hitting `onSave` in VSCode  

https://user-images.githubusercontent.com/1223799/157691330-bf2341da-a5a6-4be8-8887-a02db0c32336.mov


## Remarks

Note that this will trigger probably a lot of lint warnings on CI. we should create task so people can follow up and apply autofixes by themselves gradually.

###  Follow up/replacement of this PR 
https://github.com/microsoft/fluentui/pull/22128

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/microsoft/fluentui/issues/22049
Fixes https://github.com/microsoft/fluentui/issues/18594
