### PR TITLE
Update legacy demo apps to use bundled React

### DIFF
--- a/apps/public-docsite-resources/config/pre-copy.json
+++ b/apps/public-docsite-resources/config/pre-copy.json
@@ -1,10 +1,6 @@
 {
   "copyTo": {
-    "dist/demo": [
-      "@fluentui/react-docsite-components/index.html",
-      "react/umd/react.development.js",
-      "react-dom/umd/react-dom.development.js"
-    ],
+    "dist/demo": ["@fluentui/react-docsite-components/index.html"],
     "dist/sass": [
       "office-ui-fabric-core/dist/sass/**/*",
       "./src/common/_highContrast.scss",

--- a/apps/public-docsite-resources/webpack.serve.config.js
+++ b/apps/public-docsite-resources/webpack.serve.config.js
@@ -10,11 +10,6 @@ module.exports = resources.createServeConfig(
       [BUNDLE_NAME]: ['react-app-polyfill/ie11', './src/index.tsx'],
     },
 
-    externals: {
-      react: 'React',
-      'react-dom': 'ReactDOM',
-    },
-
     resolve: {
       alias: getResolveAlias(),
     },

--- a/apps/theming-designer/index.html
+++ b/apps/theming-designer/index.html
@@ -6,14 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <title>Fluent UI Theme Designer</title>
-    <script
-      type="text/javascript"
-      src="//cdnjs.cloudflare.com/ajax/libs/react/16.8.6/umd/react.production.min.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="//cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.6/umd/react-dom.production.min.js"
-    ></script>
   </head>
 
   <body>

--- a/apps/theming-designer/webpack.config.js
+++ b/apps/theming-designer/webpack.config.js
@@ -1,4 +1,3 @@
-let path = require('path');
 const resources = require('../../scripts/webpack/webpack-resources');
 
 const BUNDLE_NAME = 'theming-designer';
@@ -13,13 +12,4 @@ module.exports = resources.createConfig(BUNDLE_NAME, IS_PRODUCTION, {
     libraryTarget: 'var',
     library: 'Fabric',
   },
-
-  externals: [
-    {
-      react: 'React',
-    },
-    {
-      'react-dom': 'ReactDOM',
-    },
-  ],
 });

--- a/apps/theming-designer/webpack.serve.config.js
+++ b/apps/theming-designer/webpack.serve.config.js
@@ -8,11 +8,6 @@ module.exports = resources.createServeConfig(
       filename: 'theming-designer.js',
     },
 
-    externals: {
-      react: 'React',
-      'react-dom': 'ReactDOM',
-    },
-
     resolve: {
       alias: getResolveAlias(),
     },

--- a/change/@fluentui-react-button-c43ab8d5-656a-4430-844b-fae8a2a58c0c.json
+++ b/change/@fluentui-react-button-c43ab8d5-656a-4430-844b-fae8a2a58c0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove config file that's no longer needed",
+  "packageName": "@fluentui/react-button",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-e51a553b-83bf-43dc-8e75-a347735e28cb.json
+++ b/change/@fluentui-react-charting-e51a553b-83bf-43dc-8e75-a347735e28cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update legacy demo apps to use bundled React",
+  "packageName": "@fluentui/react-charting",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-docsite-components-7d1e02be-24ff-4e39-a7a0-887fa75942d5.json
+++ b/change/@fluentui-react-docsite-components-7d1e02be-24ff-4e39-a7a0-887fa75942d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update index.html to not load `react` and `react-dom` from CDN (they must be bundled with the demo)",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-experiments-fc9020db-737d-4f3a-9094-00c0db8e292a.json
+++ b/change/@fluentui-react-experiments-fc9020db-737d-4f3a-9094-00c0db8e292a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update legacy demo apps to use bundled React",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-488835a4-0a19-4632-81cc-6ea2640a549f.json
+++ b/change/@fluentui-react-monaco-editor-488835a4-0a19-4632-81cc-6ea2640a549f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update legacy demo apps to use bundled React",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-button/config/pre-copy.json
+++ b/packages/react-button/config/pre-copy.json
@@ -1,9 +1,0 @@
-{
-  "copyTo": {
-    "dist/demo": [
-      "@fluentui/react-docsite-components/index.html",
-      "react/umd/react.development.js",
-      "react-dom/umd/react-dom.development.js"
-    ]
-  }
-}

--- a/packages/react-charting/config/pre-copy.json
+++ b/packages/react-charting/config/pre-copy.json
@@ -1,9 +1,5 @@
 {
   "copyTo": {
-    "dist/demo": [
-      "@fluentui/react-docsite-components/index.html",
-      "react/umd/react.development.js",
-      "react-dom/umd/react-dom.development.js"
-    ]
+    "dist/demo": ["@fluentui/react-docsite-components/index.html"]
   }
 }

--- a/packages/react-docsite-components/config/pre-copy.json
+++ b/packages/react-docsite-components/config/pre-copy.json
@@ -1,5 +1,5 @@
 {
   "copyTo": {
-    "dist/demo": ["./index.html", "react/umd/react.development.js", "react-dom/umd/react-dom.development.js"]
+    "dist/demo": ["./index.html"]
   }
 }

--- a/packages/react-docsite-components/index.html
+++ b/packages/react-docsite-components/index.html
@@ -27,33 +27,14 @@
       var useMinified =
         !isDev && minParam !== '0' && (minParam === '1' || location.pathname === '/fabric-react/master/');
 
-      function loadScript(n) {
-        for (var i = 0; i < n.length; i++) {
-          var s = document.createElement('script');
-          s.src = n[i];
-          s.async = false;
-          document.body.appendChild(s);
-        }
+      function loadScript(src) {
+        var s = document.createElement('script');
+        s.src = src;
+        s.async = false;
+        document.body.appendChild(s);
       }
 
-      const scripts = [];
-
-      if (isLocal) {
-        scripts.push('./react.development.js');
-        scripts.push('./react-dom.development.js');
-      } else {
-        const reactVersion = isDev ? 'development.js' : 'production.min.js';
-        scripts.push('//cdnjs.cloudflare.com/ajax/libs/react/16.8.6/umd/react.' + reactVersion);
-        scripts.push('//cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.6/umd/react-dom.' + reactVersion);
-      }
-
-      if (useMinified) {
-        scripts.push('demo-app.min.js');
-      } else {
-        scripts.push('demo-app.js');
-      }
-
-      loadScript(scripts);
+      loadScript(useMinified ? 'demo-app.min.js' : 'demo-app.js');
 
       function getParameterByName(name, url) {
         if (!url) {

--- a/packages/react-docsite-components/src/components/CodepenComponent/CodepenComponent.tsx
+++ b/packages/react-docsite-components/src/components/CodepenComponent/CodepenComponent.tsx
@@ -53,8 +53,8 @@ const CodepenComponentBase: React.FunctionComponent<ICodepenProps> = props => {
       .filter(line => !!line)
       .join('\n');
 
-    const headContent = `${script('react@16.8.6/umd/react.development.js')}\n${script(
-      'react-dom@16.8.6/umd/react-dom.development.js',
+    const headContent = `${script('react@16/umd/react.development.js')}\n${script(
+      'react-dom@16/umd/react-dom.development.js',
     )}`;
 
     const valueData: ICodepenPrefill = {

--- a/packages/react-docsite-components/webpack.serve.config.js
+++ b/packages/react-docsite-components/webpack.serve.config.js
@@ -6,9 +6,4 @@ module.exports = resources.createServeConfig({
   output: {
     filename: 'demo-app.js',
   },
-
-  externals: {
-    react: 'React',
-    'react-dom': 'ReactDOM',
-  },
 });

--- a/packages/react-experiments/config/pre-copy.json
+++ b/packages/react-experiments/config/pre-copy.json
@@ -1,9 +1,5 @@
 {
   "copyTo": {
-    "dist/demo": [
-      "@fluentui/react-docsite-components/index.html",
-      "react/umd/react.development.js",
-      "react-dom/umd/react-dom.development.js"
-    ]
+    "dist/demo": ["@fluentui/react-docsite-components/index.html"]
   }
 }

--- a/packages/react-monaco-editor/config/pre-copy.json
+++ b/packages/react-monaco-editor/config/pre-copy.json
@@ -1,5 +1,5 @@
 {
   "copyTo": {
-    "dist/demo": ["./index.html", "react/umd/react.development.js", "react-dom/umd/react-dom.development.js"]
+    "dist/demo": ["./index.html"]
   }
 }

--- a/packages/react-monaco-editor/index.html
+++ b/packages/react-monaco-editor/index.html
@@ -47,8 +47,8 @@
         scripts.push('./react.development.js');
         scripts.push('./react-dom.development.js');
       } else {
-        scripts.push('//cdnjs.cloudflare.com/ajax/libs/react/16.8.6/umd/react.production.min.js');
-        scripts.push('//cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.6/umd/react-dom.production.min.js');
+        scripts.push('//cdnjs.cloudflare.com/ajax/libs/react/16.14.0/umd/react.production.min.js');
+        scripts.push('//cdnjs.cloudflare.com/ajax/libs/react-dom/16.14.0/umd/react-dom.production.min.js');
       }
 
       scripts.push('demo-app' + jsSuffix);

--- a/packages/react-monaco-editor/index.html
+++ b/packages/react-monaco-editor/index.html
@@ -32,28 +32,14 @@
         useMinified: useMinified,
       };
 
-      function loadScript(n) {
-        for (var i = 0; i < n.length; i++) {
-          var s = document.createElement('script');
-          s.src = n[i];
-          s.async = false;
-          document.body.appendChild(s);
-        }
+      function loadScript(src) {
+        var s = document.createElement('script');
+        s.src = src;
+        s.async = false;
+        document.body.appendChild(s);
       }
 
-      const scripts = [];
-
-      if (isLocal) {
-        scripts.push('./react.development.js');
-        scripts.push('./react-dom.development.js');
-      } else {
-        scripts.push('//cdnjs.cloudflare.com/ajax/libs/react/16.14.0/umd/react.production.min.js');
-        scripts.push('//cdnjs.cloudflare.com/ajax/libs/react-dom/16.14.0/umd/react-dom.production.min.js');
-      }
-
-      scripts.push('demo-app' + jsSuffix);
-
-      loadScript(scripts);
+      loadScript('demo-app' + jsSuffix);
     </script>
   </body>
 </html>

--- a/packages/react-monaco-editor/webpack.serve.config.js
+++ b/packages/react-monaco-editor/webpack.serve.config.js
@@ -21,11 +21,6 @@ module.exports = resources.createServeConfig(
       writeToDisk: true, // for debugging
     },
 
-    externals: {
-      react: 'React',
-      'react-dom': 'ReactDOM',
-    },
-
     plugins: [/** @type {any} */ (new BundleAnalyzerPlugin())],
 
     resolve: {

--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -306,11 +306,6 @@ module.exports = {
         filename: 'demo-app.js',
       },
 
-      externals: {
-        react: 'React',
-        'react-dom': 'ReactDOM',
-      },
-
       resolve: {
         // Use the aliases for react-examples since the examples and demo may depend on some things
         // that the package itself doesn't (and it will include the aliases for all the package's deps)


### PR DESCRIPTION
## Current Behavior

In #21769 I updated our React version to 16.14, but I forgot to update the version in some CDN URLs in legacy demo apps. ~~This made them fail to load.~~ EDIT: this was wrong, the actual reason the demo apps were failing to load was the update of markdown-to-jsx in an earlier PR (and fixed in #22076)--but we should still update the demo apps' react version.

## New Behavior

Switch to including React in the legacy demo app bundles (instead of having it as an external loaded from a CDN, or from `dist` in local versions) to ensure that the version is always the same as the local version in the repo. This may not be a realistic setup for consumers and is a bit worse for build perf, but that's less of a concern since the legacy demo apps are more or less in maintenance mode now, and it's one less thing to forget wile doing dep upgrades.

A lot of the demos also copied the local versions of `react` and `react-dom` into `dist` and loaded them from there on local runs. That's no longer needed either, which is the reason for all the `pre-copy.json` updates.