### PR TITLE
Align Checkbox API with other input controls

### DIFF
--- a/change/@fluentui-react-checkbox-5f3195e1-e873-494f-b453-bf74eb55dea8.json
+++ b/change/@fluentui-react-checkbox-5f3195e1-e873-494f-b453-bf74eb55dea8.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Update Checkbox types.",
+  "comment": "Update Checkbox onChange event parameter to be of type ChangeEvent instead of type FormEvent.",
   "packageName": "@fluentui/react-checkbox",
   "email": "seanmonahan@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-checkbox-5f3195e1-e873-494f-b453-bf74eb55dea8.json
+++ b/change/@fluentui-react-checkbox-5f3195e1-e873-494f-b453-bf74eb55dea8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update Checkbox types.",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-checkbox/etc/react-checkbox.api.md
+++ b/packages/react-checkbox/etc/react-checkbox.api.md
@@ -28,7 +28,7 @@ export interface CheckboxOnChangeData {
 // @public
 export type CheckboxProps = Omit<ComponentProps<Partial<CheckboxSlots>, 'input'>, 'size' | 'checked' | 'defaultChecked' | 'onChange'> & Partial<CheckboxCommons> & {
     children?: never;
-    onChange?: (ev: React_2.FormEvent<HTMLInputElement>, data: CheckboxOnChangeData) => void;
+    onChange?: (ev: React_2.ChangeEvent<HTMLInputElement>, data: CheckboxOnChangeData) => void;
     defaultChecked?: 'mixed' | boolean;
 };
 

--- a/packages/react-checkbox/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react-checkbox/src/components/Checkbox/Checkbox.types.ts
@@ -86,7 +86,7 @@ export type CheckboxProps = Omit<
     /**
      * Callback to be called when the checked state value changes.
      */
-    onChange?: (ev: React.FormEvent<HTMLInputElement>, data: CheckboxOnChangeData) => void;
+    onChange?: (ev: React.ChangeEvent<HTMLInputElement>, data: CheckboxOnChangeData) => void;
 
     /**
      * Whether the checkbox should be rendered as checked by default.


### PR DESCRIPTION
## Current Behavior

`Checkbox`'s `onChange` event type is `React.FormEvent`.

## New Behavior

`Checkbox`'s `onChange` event type is `React.ChangeEvent`.

## Related Issue(s)

#21931
#21809



