### PR TITLE
Fixed ul and ol styles to allow numbering of ol

### DIFF
--- a/.storybook/docs-root.css
+++ b/.storybook/docs-root.css
@@ -90,22 +90,29 @@
   /* Neutrals / Web / Gray 200 #1B1A19 */
   color: #1b1a19;
   margin-top: 8px;
+}
+
+#docs-root .sbdocs-ul {
+  margin: 12px 0;
+}
+
+#docs-root .sbdocs-ul .sbdocs-li {
   list-style: none;
   position: relative;
 }
 
-#docs-root .sbdocs-li::before {
+#docs-root .sbdocs-ul .sbdocs-li::before {
   position: absolute;
   content: '•';
-  color: #bdbdbd;
+  color: #8d8d8d;
   font-size: 16px;
   line-height: 6px;
   top: calc(50% - 3px);
   left: -25px;
 }
 
-#docs-root .sbdocs-ul {
-  margin: 12px 0;
+#docs-root .sbdocs-ol .sbdocs-li {
+  color: #8d8d8d;
 }
 
 #docs-root .sbdocs-preview {


### PR DESCRIPTION
This fixes an issue where ordered lists ol did not have numbering.  The storybook level ul rules were not scoped properly which this fixes.

One small tweak is the the light gray color of the ul bullets was too light when applied to the ol numbers, so darkened it just slightly.  Not a noticable color change from the desired look of storybook content.