### PR TITLE
Adding more exports to utilities/merge-styles to unhitch 1js upgrades from fluent upgrades.

### DIFF
--- a/change/@fluentui-merge-styles-0e52ea03-88a2-4689-af55-8cb2b0d97381.json
+++ b/change/@fluentui-merge-styles-0e52ea03-88a2-4689-af55-8cb2b0d97381.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding additional exports to support existing 1js imports (which will be resolved separately.)",
+  "packageName": "@fluentui/merge-styles",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-2f935273-5b27-4eca-9620-19962f00e63a.json
+++ b/change/@fluentui-utilities-2f935273-5b27-4eca-9620-19962f00e63a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding additional exports to support existing 1js imports (which will be resolved separately.)",
+  "packageName": "@fluentui/utilities",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/merge-styles/package.json
+++ b/packages/merge-styles/package.json
@@ -36,6 +36,32 @@
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
+    },
+    "./lib/fontFace": {
+      "types": "./lib/fontFace.d.ts",
+      "import": "./lib/fontFace.js",
+      "require": "./lib-commonjs/fontFace.js"
+    },
+    "./lib/IRawStyleBase": {
+      "types": "./lib/IRawStyleBase.d.ts"
+    },
+    "./lib/IStyle": {
+      "types": "./lib/IStyle.d.ts"
+    },
+    "./lib/keyframes": {
+      "types": "./lib/keyframes.d.ts",
+      "import": "./lib/keyframes.js",
+      "require": "./lib-commonjs/keyframes.js"
+    },
+    "./lib/mergeStyles": {
+      "types": "./lib/mergeStyles.d.ts",
+      "import": "./lib/mergeStyles.js",
+      "require": "./lib-commonjs/mergeStyles.js"
+    },
+    "./lib/mergeStyleSets": {
+      "types": "./lib/mergeStyleSets.d.ts",
+      "import": "./lib/mergeStyleSets.js",
+      "require": "./lib-commonjs/mergeStyleSets.js"
     }
   }
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -45,10 +45,40 @@
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },
+    "./lib/css": {
+      "types": "./lib/css.d.ts",
+      "import": "./lib/css.js",
+      "require": "./lib-commonjs/css.js"
+    },
+    "./lib/getId": {
+      "types": "./lib/getId.d.ts",
+      "import": "./lib/getId.js",
+      "require": "./lib-commonjs/getId.js"
+    },
+    "./lib/initials": {
+      "types": "./lib/initials.d.ts",
+      "import": "./lib/initials.js",
+      "require": "./lib-commonjs/initials.js"
+    },
+    "./lib/memoize": {
+      "types": "./lib/memoize.d.ts",
+      "import": "./lib/memoize.js",
+      "require": "./lib-commonjs/memoize.js"
+    },
+    "./lib/rtl": {
+      "types": "./lib/rtl.d.ts",
+      "import": "./lib/rtl.js",
+      "require": "./lib-commonjs/rtl.js"
+    },
     "./lib/sessionStorage": {
       "types": "./lib/sessionStorage.d.ts",
       "import": "./lib/sessionStorage.js",
       "require": "./lib-commonjs/sessionStorage.js"
+    },
+    "./lib/warn": {
+      "types": "./lib/warn.d.ts",
+      "import": "./lib/warn.js",
+      "require": "./lib-commonjs/warn.js"
     }
   }
 }


### PR DESCRIPTION
In Teams we're trying to update to v8, but a number of 1js packages have deep imports unsupported by the latest v8. To unblock the upgrade, adding a minimum number exports required to unhitch a complex upgrade order.
