### PR TITLE
Add compat exports to date-time-utilities

### DIFF
--- a/change/@fluentui-date-time-utilities-2308a8ce-79bb-4197-b0c0-6a29a8889460.json
+++ b/change/@fluentui-date-time-utilities-2308a8ce-79bb-4197-b0c0-6a29a8889460.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add compat exports to date-time-utilities",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/date-time-utilities/package.json
+++ b/packages/date-time-utilities/package.json
@@ -35,6 +35,21 @@
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
+    },
+    "./lib/dateMath/dateMath": {
+      "types": "./lib/dateMath/dateMath.d.ts",
+      "import": "./lib/dateMath/dateMath.js",
+      "require": "./lib-commonjs/dateMath.js"
+    },
+    "./lib/dateValues/dateValues": {
+      "types": "./lib/dateValues/dateValues.d.ts",
+      "import": "./lib/dateValues/dateValues.js",
+      "require": "./lib-commonjs/dateValues.js"
+    },
+    "./lib/dateValues/timeConstants": {
+      "types": "./lib/dateValues/timeConstants.d.ts",
+      "import": "./lib/dateValues/timeConstants.js",
+      "require": "./lib-commonjs/dateValues/timeConstants.js"
     }
   }
 }


### PR DESCRIPTION
Fixes exports to support older version of fluent before [this commit](https://github.com/microsoft/fluentui/commit/f2f1c0ea948cc3517eeb442c05433eb0918def29) that had their date-time-utilities upgraded while the version of fluent using deep imports remained the same.

This is in association with other compat export add backs in [PR 22062](https://github.com/microsoft/fluentui/pull/22062)

This adds back the exports necessary to allow the scenario to work.
