### PR TITLE
Radio/RadioGroup API alignment.

### DIFF
--- a/change/@fluentui-react-radio-f7aff2b9-7b7d-47fa-812f-6facc942259f.json
+++ b/change/@fluentui-react-radio-f7aff2b9-7b7d-47fa-812f-6facc942259f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Radio/RadioGroup API alignment.",
+  "packageName": "@fluentui/react-radio",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-radio/etc/react-radio.api.md
+++ b/packages/react-radio/etc/react-radio.api.md
@@ -46,7 +46,7 @@ export type RadioGroupProps = Omit<ComponentProps<Partial<RadioGroupSlots>>, 'on
 
 // @public (undocumented)
 export type RadioGroupSlots = {
-    root: Slot<'div'>;
+    root: NonNullable<Slot<'div'>>;
 };
 
 // @public

--- a/packages/react-radio/src/components/RadioGroup/RadioGroup.types.ts
+++ b/packages/react-radio/src/components/RadioGroup/RadioGroup.types.ts
@@ -6,7 +6,7 @@ export type RadioGroupSlots = {
   /**
    * The radio group root.
    */
-  root: Slot<'div'>;
+  root: NonNullable<Slot<'div'>>;
 };
 
 export type RadioGroupProps = Omit<ComponentProps<Partial<RadioGroupSlots>>, 'onChange'> & {


### PR DESCRIPTION
Updates to `Radio` and `RadioGroup` to align their APIs with other input
components.

Note that the event type for `RadioGroup.onChange` was not changed to `React.ChangeEvent` as this handler is on a div so `React.FormEvent` is the correct type.

Fixes #21928
