### PR TITLE
feat(eslint-plugin): enable no-export-all:all for all packages public…

### DIFF
--- a/change/@fluentui-eslint-plugin-4067e75c-636a-4ca2-a360-3d1e3e43a9bb.json
+++ b/change/@fluentui-eslint-plugin-4067e75c-636a-4ca2-a360-3d1e3e43a9bb.json
@@ -3,5 +3,5 @@
   "comment": "feat(eslint-plugin): enable no-export-all:all for all packages public API",
   "packageName": "@fluentui/eslint-plugin",
   "email": "martinhochel@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@fluentui-eslint-plugin-4067e75c-636a-4ca2-a360-3d1e3e43a9bb.json
+++ b/change/@fluentui-eslint-plugin-4067e75c-636a-4ca2-a360-3d1e3e43a9bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(eslint-plugin): enable no-export-all:all for all packages public API",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -312,6 +312,13 @@ const getOverrides = () => [
   // Enable rules requiring type info only for appropriate files/circumstances
   ...configHelpers.getTypeInfoRuleOverrides(typeAwareRules),
   {
+    files: '**/src/index.{ts,tsx,js}',
+    rules: {
+      // TODO: propagate to `error` once all packages barrel files have been fixed
+      '@rnx-kit/no-export-all': ['warn', { expand: 'all' }],
+    },
+  },
+  {
     files: '**/*.{ts,tsx}',
     // This turns off a few rules that don't work or are unnecessary for TS, and enables a few
     // that make sense for TS: no-var, prefer-const, prefer-rest-params, prefer-spread

--- a/packages/react-components/.eslintrc.json
+++ b/packages/react-components/.eslintrc.json
@@ -5,6 +5,7 @@
     {
       "files": "**/index.ts",
       "rules": {
+        "@rnx-kit/no-export-all": ["error", { "expand": "all" }],
         "@fluentui/ban-imports": [
           "error",
           {


### PR DESCRIPTION
… API

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- we allow `export * from` for internal modules
- `export * from` is dissallowed for external packages only for dedups/tree shake-ability reasons

```js
// @filename src/index.ts
// OK  ✅
export * from './Foo'
// Error 🚨
export * from 'lib-a'

// @filename src/Foo/index.ts
// OK ✅
export * from './Foo'
// Error 🚨
export * from 'lib-a'
```

## New Behavior

- to improve tree-shaking capabilities even further we should dissallow `export *` for all public API's
  - this already happens for `react-components` although  only for "external" dependencies - THIS PR adds check for internal ones ✅ 


```js
// @filename src/index.ts
// Error 🚨 - export * is bad idea for tree shake-ability on public API surface
export * from './Foo'
// Error 🚨
export * from 'lib-a'

// @filename src/Foo/index.ts
// OK ✅ - this is fine, no need to be explicit in every module
export * from './Foo'
// Error 🚨
export * from 'lib-a'
```

**To recap new functionality:** 
- `export *` for external packages is dissallowed in every module
- public apis of packages (index.ts,index.tsx,index.js) are dissalowed to use `export *`


https://user-images.githubusercontent.com/1223799/157895243-b3dea0c3-0713-42e8-ab5d-5e63ed916781.mov

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Follows https://github.com/microsoft/fluentui/pull/22046

## Remarks

- for easy gradual migration the lint is set to `warn`, after we fix all v9 packages gradually it will be propagated to `error`
