### PR TITLE
Fix markdown-to-jsx import

### DIFF
--- a/change/@fluentui-react-docsite-components-c92fcf60-45e3-46e8-8999-a621bc42b86b.json
+++ b/change/@fluentui-react-docsite-components-c92fcf60-45e3-46e8-8999-a621bc42b86b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix import of markdown-to-jsx",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-docsite-components/src/components/Markdown/Markdown.tsx
+++ b/packages/react-docsite-components/src/components/Markdown/Markdown.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import MarkdownComponent, { MarkdownToJSX } from 'markdown-to-jsx';
+import type MarkdownComponentType from 'markdown-to-jsx';
+import type { MarkdownToJSX } from 'markdown-to-jsx';
+import * as MarkdownModule from 'markdown-to-jsx';
 import { Image, IImageStyles, classNamesFunction, IStyleFunction, styled } from '@fluentui/react';
 import { DefaultButton } from '@fluentui/react/lib/Button';
 import { DisplayToggle } from '../DisplayToggle/index';
@@ -11,7 +13,14 @@ import { IMarkdownProps, IMarkdownSubComponentStyles, IMarkdownStyleProps, IMark
 import { MarkdownLink } from './MarkdownLink';
 import { MarkdownPre } from './MarkdownPre';
 
-const getStyles: IStyleFunction<IMarkdownStyleProps, IMarkdownStyles> = props => {
+// This is to work around inconsistency between the way markdown-to-jsx declares its types
+// (as having a default export) and the way it actually builds its files (for its cjs `main` file,
+// assigning to module.exports and not setting a default export)
+const MarkdownComponent: typeof MarkdownComponentType =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (MarkdownModule as any).default || (MarkdownModule as any);
+
+const getStyles: IStyleFunction<IMarkdownStyleProps, IMarkdownStyles> = () => {
   const imageStyles: Partial<IImageStyles> = {
     root: {
       maxWidth: '100%',

--- a/packages/react-docsite-components/src/components/Markdown/Markdown.types.ts
+++ b/packages/react-docsite-components/src/components/Markdown/Markdown.types.ts
@@ -1,9 +1,9 @@
-import { ITheme, IStyleFunctionOrObject, IStyle, ILinkStyleProps, IImageStyleProps } from '@fluentui/react';
-import { IMarkdownHeaderStyleProps } from './MarkdownHeader';
-import { IMarkdownParagraphStyleProps } from './MarkdownParagraph';
-import { IMarkdownCodeStyleProps } from './MarkdownCode';
-import { IMarkdownTableStyleProps } from '../MarkdownTable/index';
-import { MarkdownToJSX } from 'markdown-to-jsx';
+import type { ITheme, IStyleFunctionOrObject, IStyle, ILinkStyleProps, IImageStyleProps } from '@fluentui/react';
+import type { IMarkdownHeaderStyleProps } from './MarkdownHeader';
+import type { IMarkdownParagraphStyleProps } from './MarkdownParagraph';
+import type { IMarkdownCodeStyleProps } from './MarkdownCode';
+import type { IMarkdownTableStyleProps } from '../MarkdownTable/index';
+import type { MarkdownToJSX } from 'markdown-to-jsx';
 
 export interface IMarkdownProps {
   /** CSS class to apply to the component root */


### PR DESCRIPTION
## Current Behavior

Markdown components on legacy doc sites fail to render after updating the `markdown-to-jsx` version in #21780.

Turns out this is because `markdown-to-jsx` declares in its types that it uses a default export, but its cjs `main` file actually assigns to `module.exports`. This would work fine with `esModuleInterop`, but we don't use that.

## New Behavior

Import the module with `import *`. The markdown component is the default export if it exists, or the whole module if not (and cast to set the appropriate type).

I'll also make a PR with `markdown-to-jsx` to fix the root cause, but this will work around the issue for now.