### PR TITLE
Combobox: Adding fixes for onChange and onPendingValueChanged callbacks

### DIFF
--- a/change/@fluentui-react-b72ecaba-1b37-4eda-a00c-9501cc53b693.json
+++ b/change/@fluentui-react-b72ecaba-1b37-4eda-a00c-9501cc53b693.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Combobox: Adding fixes for onChange and onPendingValueChanged callbacks.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1055,7 +1055,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
       // Call onChange after state is updated
       if (onChange) {
-        onChange(submitPendingValueEvent, option, index, undefined);
+        onChange(submitPendingValueEvent, option, index, option.text);
       }
     }
     if (this.props.multiSelect && this.state.isOpen) {
@@ -1882,7 +1882,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const { currentPendingValue, currentPendingValueValidIndex, currentPendingValueValidIndexOnHover } = this.state;
 
     let newPendingIndex: number | undefined = undefined;
-    let newPendingValue: string | undefined = undefined;
+    let newPendingValue: string | undefined = prevState.currentPendingValue;
 
     if (
       currentPendingValueValidIndexOnHover !== prevState.currentPendingValueValidIndexOnHover &&

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1055,7 +1055,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
       // Call onChange after state is updated
       if (onChange) {
-        onChange(submitPendingValueEvent, option, index, option.text);
+        onChange(submitPendingValueEvent, option, index, getPreviewText(option));
       }
     }
     if (this.props.multiSelect && this.state.isOpen) {

--- a/packages/react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/react/src/components/ComboBox/ComboBox.types.ts
@@ -74,8 +74,8 @@ export interface IComboBoxProps
    * 2) A manually edited value is submitted. In this case there may not be a matched option if `allowFreeform`
    *    is also true (and hence only `value` would be provided; the other parameters would be unspecified).
    *
-   * The value passed to the callback reflects the changed option's text, or the user-typed input when freeform is
-   * allowed.
+   * The value passed to the callback (4th paramenter) reflects the changed option's text, or the user-typed input when
+   * freeform is allowed.
    */
   onChange?: (event: React.FormEvent<IComboBox>, option?: IComboBoxOption, index?: number, value?: string) => void;
 

--- a/packages/react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/react/src/components/ComboBox/ComboBox.types.ts
@@ -73,6 +73,9 @@ export interface IComboBoxProps
    * 1) The selected option changes.
    * 2) A manually edited value is submitted. In this case there may not be a matched option if `allowFreeform`
    *    is also true (and hence only `value` would be provided; the other parameters would be unspecified).
+   *
+   * The value passed to the callback reflects the changed option's text, or the user-typed input when freeform is
+   * allowed.
    */
   onChange?: (event: React.FormEvent<IComboBox>, option?: IComboBoxOption, index?: number, value?: string) => void;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Right now, selecting an option in a `Combobox` or writing down an option if freeform is allowed will send `undefined` as the value of the `onChange` callback. Furthermore, in the case that state is changed while typing on a freeform `Combobox`, `onPendingValueChanged` is being called twice, first with the correct value and then with `undefined`.

## New Behavior

This PR fixes some of these issues by always sending the correct value to the `onChange` and `onPendingValueChanged` callbacks. This PR does not fix the issue of `onPendingValueChanged` being called twice.

## Notes

See [this codepen](https://codepen.io/khmakoto/pen/ZEvYqBL?editors=0010) for how the previous behavior looks like.