### PR TITLE
Remove star exports from react-spinbutton

### DIFF
--- a/packages/react-spinbutton/src/index.ts
+++ b/packages/react-spinbutton/src/index.ts
@@ -1,3 +1,18 @@
 // TODO: replace with real exports
 export {};
-export * from './SpinButton';
+export {
+  SpinButton,
+  renderSpinButton_unstable,
+  spinButtonClassName,
+  useSpinButtonStyles_unstable,
+  useSpinButton_unstable,
+} from './SpinButton';
+export type {
+  SpinButtonChangeData,
+  SpinButtonCommons,
+  SpinButtonFormatter,
+  SpinButtonParser,
+  SpinButtonProps,
+  SpinButtonSlots,
+  SpinButtonState,
+} from './SpinButton';

--- a/packages/react-spinbutton/src/index.ts
+++ b/packages/react-spinbutton/src/index.ts
@@ -1,9 +1,9 @@
-// TODO: replace with real exports
-export {};
 export {
   SpinButton,
   renderSpinButton_unstable,
+  /* eslint-disable-next-line deprecation/deprecation */
   spinButtonClassName,
+  spinButtonClassNames,
   useSpinButtonStyles_unstable,
   useSpinButton_unstable,
 } from './SpinButton';


### PR DESCRIPTION
## Current Behavior

`react-spinbutton` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-spinbutton` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

