### PR TITLE
Remove star exports from react-radio

### DIFF
--- a/change/@fluentui-react-radio-a06cb1db-d673-4da6-b4c3-444510433f50.json
+++ b/change/@fluentui-react-radio-a06cb1db-d673-4da6-b4c3-444510433f50.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove star exports from react-radio",
+  "packageName": "@fluentui/react-radio",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-radio/etc/react-radio.api.md
+++ b/packages/react-radio/etc/react-radio.api.md
@@ -100,7 +100,7 @@ export const useRadioStyles_unstable: (state: RadioState) => void;
 
 // Warnings were encountered during analysis:
 //
-// dist/packages/react-radio/src/components/Radio/Radio.types.d.ts:55:5 - (ae-forgotten-export) The symbol "RadioOnChangeData" needs to be exported by the entry point index.d.ts
+// lib/components/components/Radio/Radio.types.d.ts:55:5 - (ae-forgotten-export) The symbol "RadioOnChangeData" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-radio/etc/react-radio.api.md
+++ b/packages/react-radio/etc/react-radio.api.md
@@ -62,6 +62,11 @@ export type RadioGroupState = ComponentState<RadioGroupSlots> & Required<Pick<Ra
 };
 
 // @public
+export type RadioOnChangeData = {
+    value: string;
+};
+
+// @public
 export type RadioProps = Omit<ComponentProps<Partial<RadioSlots>, 'input'>, 'size'> & {
     value?: string;
     labelPosition?: 'after' | 'below';
@@ -97,10 +102,6 @@ export const useRadioGroupStyles_unstable: (state: RadioGroupState) => void;
 
 // @public
 export const useRadioStyles_unstable: (state: RadioState) => void;
-
-// Warnings were encountered during analysis:
-//
-// lib/components/components/Radio/Radio.types.d.ts:55:5 - (ae-forgotten-export) The symbol "RadioOnChangeData" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-radio/etc/react-radio.api.md
+++ b/packages/react-radio/etc/react-radio.api.md
@@ -62,11 +62,6 @@ export type RadioGroupState = ComponentState<RadioGroupSlots> & Required<Pick<Ra
 };
 
 // @public
-export type RadioOnChangeData = {
-    value: string;
-};
-
-// @public
 export type RadioProps = Omit<ComponentProps<Partial<RadioSlots>, 'input'>, 'size'> & {
     value?: string;
     labelPosition?: 'after' | 'below';
@@ -102,6 +97,10 @@ export const useRadioGroupStyles_unstable: (state: RadioGroupState) => void;
 
 // @public
 export const useRadioStyles_unstable: (state: RadioState) => void;
+
+// Warnings were encountered during analysis:
+//
+// dist/packages/react-radio/src/components/Radio/Radio.types.d.ts:55:5 - (ae-forgotten-export) The symbol "RadioOnChangeData" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-radio/src/index.ts
+++ b/packages/react-radio/src/index.ts
@@ -1,3 +1,12 @@
-export * from './RadioGroup';
-export * from './Radio';
-export * from './contexts/RadioGroupContext';
+export {
+  RadioGroup,
+  radioGroupClassName,
+  renderRadioGroup_unstable,
+  useRadioGroupStyles_unstable,
+  useRadioGroup_unstable,
+} from './RadioGroup';
+export type { RadioGroupOnChangeData, RadioGroupProps, RadioGroupSlots, RadioGroupState } from './RadioGroup';
+export { Radio, radioClassName, renderRadio_unstable, useRadioStyles_unstable, useRadio_unstable } from './Radio';
+export type { RadioProps, RadioSlots, RadioState } from './Radio';
+export { RadioGroupContext } from './contexts/RadioGroupContext';
+export type { RadioGroupContextValue } from './contexts/RadioGroupContext';

--- a/packages/react-radio/src/index.ts
+++ b/packages/react-radio/src/index.ts
@@ -1,12 +1,22 @@
 export {
   RadioGroup,
+  /* eslint-disable-next-line deprecation/deprecation */
   radioGroupClassName,
+  radioGroupClassNames,
   renderRadioGroup_unstable,
   useRadioGroupStyles_unstable,
   useRadioGroup_unstable,
 } from './RadioGroup';
 export type { RadioGroupOnChangeData, RadioGroupProps, RadioGroupSlots, RadioGroupState } from './RadioGroup';
-export { Radio, radioClassName, renderRadio_unstable, useRadioStyles_unstable, useRadio_unstable } from './Radio';
-export type { RadioProps, RadioSlots, RadioState } from './Radio';
+export {
+  Radio,
+  /* eslint-disable-next-line deprecation/deprecation */
+  radioClassName,
+  radioClassNames,
+  renderRadio_unstable,
+  useRadioStyles_unstable,
+  useRadio_unstable,
+} from './Radio';
+export type { RadioProps, RadioSlots, RadioState, RadioOnChangeData } from './Radio';
 export { RadioGroupContext } from './contexts/RadioGroupContext';
 export type { RadioGroupContextValue } from './contexts/RadioGroupContext';


### PR DESCRIPTION
## Current Behavior

`react-radio` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-radio` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

