### PR TITLE
CompoundButton: Fixing bug where component was iconOnly even when secondaryContent was being provided

### DIFF
--- a/change/@fluentui-react-button-952e8e60-c355-4e57-866d-03d10d70d8d4.json
+++ b/change/@fluentui-react-button-952e8e60-c355-4e57-866d-03d10d70d8d4.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "CompoundButton: Fixing bug where components was iconOnly even when secondaryContent was being provided.",
+  "comment": "CompoundButton: Fixing bug where component was iconOnly even when secondaryContent was being provided.",
   "packageName": "@fluentui/react-button",
   "email": "Humberto.Morimoto@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-button-952e8e60-c355-4e57-866d-03d10d70d8d4.json
+++ b/change/@fluentui-react-button-952e8e60-c355-4e57-866d-03d10d70d8d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "CompoundButton: Fixing bug where components was iconOnly even when secondaryContent was being provided.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/components/CompoundButton/CompoundButton.test.tsx
+++ b/packages/react-button/src/components/CompoundButton/CompoundButton.test.tsx
@@ -19,6 +19,12 @@ describe('CompoundButton', () => {
       expect(button.tagName).toBe('BUTTON');
     });
 
+    it('renders secondaryContent even if no primary content was passed', () => {
+      const secondaryContentText = 'Secondary content';
+      const { queryByText } = render(<CompoundButton icon="Test icon" secondaryContent={secondaryContentText} />);
+      expect(queryByText(secondaryContentText)).toBeTruthy();
+    });
+
     it('can be focused', () => {
       const { getByRole } = render(<CompoundButton>This is a button</CompoundButton>);
       const button = getByRole('button');

--- a/packages/react-button/src/components/CompoundButton/useCompoundButton.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButton.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { resolveShorthand } from '@fluentui/react-utilities';
-import type { CompoundButtonProps, CompoundButtonState } from './CompoundButton.types';
 import { useButton_unstable } from '../Button/index';
+import type { CompoundButtonProps, CompoundButtonState } from './CompoundButton.types';
 
 /**
  * Given user props, defines default props for the CompoundButton, calls useButtonState, and returns processed state.
@@ -12,7 +12,7 @@ export const useCompoundButton_unstable = (
   { contentContainer, secondaryContent, ...props }: CompoundButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): CompoundButtonState => {
-  return {
+  const state: CompoundButtonState = {
     // Button state
     ...useButton_unstable(props, ref),
 
@@ -26,4 +26,9 @@ export const useCompoundButton_unstable = (
     contentContainer: resolveShorthand(contentContainer, { required: true }),
     secondaryContent: resolveShorthand(secondaryContent),
   };
+
+  // Recalculate iconOnly to take into account secondaryContent.
+  state.iconOnly = Boolean(state.icon?.children && !props.children && !state.secondaryContent?.children);
+
+  return state;
 };


### PR DESCRIPTION
## PR description

It was found that `CompoundButton` would render as `iconOnly` even if `secondaryContent` was being provided as long as `children` was not. This happened because the `iconOnly` calculation was only reusing the one in `useButton`.

This PR fixes the issue by doing the correct calculation of `iconOnly` in `useCompoundButton` and adds a test so this doesn't happen again.