### PR TITLE
Remove star exports from react-checkbox

### DIFF
--- a/change/@fluentui-react-checkbox-0ec4c118-8da5-4273-8d77-d53fee032706.json
+++ b/change/@fluentui-react-checkbox-0ec4c118-8da5-4273-8d77-d53fee032706.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove star exports from react-checkbox",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-checkbox/src/index.ts
+++ b/packages/react-checkbox/src/index.ts
@@ -1,1 +1,8 @@
-export * from './Checkbox';
+export {
+  Checkbox,
+  checkboxClassName,
+  renderCheckbox_unstable,
+  useCheckboxStyles_unstable,
+  useCheckbox_unstable,
+} from './Checkbox';
+export type { CheckboxOnChangeData, CheckboxProps, CheckboxSlots, CheckboxState } from './Checkbox';


### PR DESCRIPTION
## Current Behavior

`react-checkbox` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-checkbox` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

