### PR TITLE
fix(react): respect isDayPickerVisible on mobile

### DIFF
--- a/change/@fluentui-react-1ad12aef-a8f5-4fc2-89d4-af3ffddd59ed.json
+++ b/change/@fluentui-react-1ad12aef-a8f5-4fc2-89d4-af3ffddd59ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Respect isDayPickerVisible prop in Calendar on mobile",
+  "packageName": "@fluentui/react",
+  "email": "livoratom@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Calendar/Calendar.base.tsx
+++ b/packages/react/src/components/Calendar/Calendar.base.tsx
@@ -397,7 +397,7 @@ export const CalendarBase: React.FunctionComponent<ICalendarProps> = React.forwa
 );
 CalendarBase.displayName = 'CalendarBase';
 
-function getShowMonthPickerAsOverlay(props: ICalendarProps) {
+function getShowMonthPickerAsOverlay({ showMonthPickerAsOverlay, isDayPickerVisible }: ICalendarProps) {
   const win = getWindow();
-  return props.showMonthPickerAsOverlay || (win && win.innerWidth <= MIN_SIZE_FORCE_OVERLAY);
+  return showMonthPickerAsOverlay || (isDayPickerVisible && win && win.innerWidth <= MIN_SIZE_FORCE_OVERLAY);
 }


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Calendar component does not respect `isDayPickerVisible={false}` on very small screens. You can see [here](https://github.com/microsoft/fluentui/blob/3dbb57b1e6940df2d4039f61a35d961bcb8560c3/packages/react/src/components/Calendar/Calendar.base.tsx#L107) that `isDayPickerVisible` prop value is completely ignored when `getShowMonthPickerAsOverlay` function returns `true`. This wouldn't be a problem if [getShowMonthPickerAsOverlay](https://github.com/microsoft/fluentui/blob/3dbb57b1e6940df2d4039f61a35d961bcb8560c3/packages/react/src/components/Calendar/Calendar.base.tsx#L400-L403) took `isDayPickerVisible` into account.

## New Behavior

Unless `showMonthPickerAsOverlay={true}`, the month picker is not shown as overlay in month-only mode (when `isDayPickerVisible={true}`). This can be easily verified in **Calendar / Inline Month Only** story in Storybook.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21255
