### PR TITLE
Removing star exports from @fluentui/react-button

### DIFF
--- a/change/@fluentui-react-button-a9f35e7a-9acc-43aa-8ffe-ce04b66a9b55.json
+++ b/change/@fluentui-react-button-a9f35e7a-9acc-43aa-8ffe-ce04b66a9b55.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/index.ts
+++ b/packages/react-button/src/index.ts
@@ -1,5 +1,45 @@
-export * from './Button';
-export * from './CompoundButton';
-export * from './MenuButton';
-export * from './SplitButton';
-export * from './ToggleButton';
+export {
+  Button,
+  buttonClassName,
+  buttonClassNames,
+  renderButton_unstable,
+  useButtonStyles_unstable,
+  useButton_unstable,
+} from './Button';
+export type { ButtonProps, ButtonSlots, ButtonState } from './Button';
+export {
+  CompoundButton,
+  compoundButtonClassName,
+  compoundButtonClassNames,
+  renderCompoundButton_unstable,
+  useCompoundButtonStyles_unstable,
+  useCompoundButton_unstable,
+} from './CompoundButton';
+export type { CompoundButtonProps, CompoundButtonSlots, CompoundButtonState } from './CompoundButton';
+export {
+  MenuButton,
+  menuButtonClassName,
+  menuButtonClassNames,
+  renderMenuButton_unstable,
+  useMenuButtonStyles_unstable,
+  useMenuButton_unstable,
+} from './MenuButton';
+export type { MenuButtonProps, MenuButtonSlots, MenuButtonState } from './MenuButton';
+export {
+  SplitButton,
+  renderSplitButton_unstable,
+  splitButtonClassName,
+  splitButtonClassNames,
+  useSplitButtonStyles_unstable,
+  useSplitButton_unstable,
+} from './SplitButton';
+export type { SplitButtonProps, SplitButtonSlots, SplitButtonState } from './SplitButton';
+export {
+  ToggleButton,
+  renderToggleButton_unstable,
+  toggleButtonClassName,
+  toggleButtonClassNames,
+  useToggleButtonStyles_unstable,
+  useToggleButton_unstable,
+} from './ToggleButton';
+export type { ToggleButtonProps, ToggleButtonState } from './ToggleButton';


### PR DESCRIPTION
## Current Behavior

`react-button` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-button` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

