### PR TITLE
feat: decouple react-conformance-griffel from react-conformance

### DIFF
--- a/change/@fluentui-react-conformance-37b92a30-6487-4e1d-bd83-00dbc0292509.json
+++ b/change/@fluentui-react-conformance-37b92a30-6487-4e1d-bd83-00dbc0292509.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "refactor: unify types with react-conformance-griffel",
+  "packageName": "@fluentui/react-conformance",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-griffel-b1f8580e-46d6-4116-8036-e63263d705fa.json
+++ b/change/@fluentui-react-conformance-griffel-b1f8580e-46d6-4116-8036-e63263d705fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: decouple react-conformance-griffel from react-conformance",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -383,7 +383,6 @@
           "@fluentui/dom-utilities",
           "@fluentui/eslint-plugin",
           "@fluentui/react",
-          "@fluentui/react-conformance",
           "stylis"
         ]
       },

--- a/packages/react-conformance-griffel/package.json
+++ b/packages/react-conformance-griffel/package.json
@@ -27,11 +27,13 @@
   "peerDependencies": {
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
+    "@types/enzyme": "^3.10.3",
+    "jest": "^26.0.0",
     "typescript": "^4.3.0"
   },
   "dependencies": {
-    "@fluentui/react-conformance": "*",
     "@griffel/react": "1.0.0",
+    "react-docgen-typescript": "^2.1.0",
     "tslib": "^2.1.0"
   },
   "beachball": {

--- a/packages/react-conformance-griffel/src/index.ts
+++ b/packages/react-conformance-griffel/src/index.ts
@@ -1,5 +1,5 @@
-import { TestObject } from '@fluentui/react-conformance';
 import { OVERRIDES_WIN_TEST_NAME, overridesWin } from './overridesWin';
+import type { TestObject } from './types';
 
 const makeStylesTests: TestObject = {
   [OVERRIDES_WIN_TEST_NAME]: overridesWin,

--- a/packages/react-conformance-griffel/src/overridesWin.ts
+++ b/packages/react-conformance-griffel/src/overridesWin.ts
@@ -1,4 +1,4 @@
-import type { IsConformantOptions, ConformanceTest, TestOptions } from '@fluentui/react-conformance';
+import type { IsConformantOptions, ConformanceTest, TestOptions } from './types';
 import './matchers/index';
 
 export const OVERRIDES_WIN_TEST_NAME = 'make-styles-overrides-win';

--- a/packages/react-conformance-griffel/src/types.ts
+++ b/packages/react-conformance-griffel/src/types.ts
@@ -1,0 +1,109 @@
+import type { ElementType, ComponentType } from 'react';
+import type { ComponentDoc } from 'react-docgen-typescript';
+import type { Program } from 'typescript';
+
+import type { mount, ComponentType as EnzymeComponentType } from 'enzyme';
+
+/**
+ * Individual test options
+ */
+export interface TestOptions {
+  'consistent-callback-names'?: {
+    ignoreProps?: string[];
+  };
+  'consistent-callback-args'?: {
+    ignoreProps?: string[];
+  };
+  'has-static-classnames'?: {
+    props: {
+      [key: string]: string | {};
+    };
+    expectedClassNames?: {
+      [key: string]: string;
+    };
+  }[];
+}
+
+export interface IsConformantOptions<TProps = {}> {
+  /**
+   * Path to component file.
+   */
+  componentPath: string;
+  /**
+   * Component object to test.
+   */
+  Component: ComponentType<TProps>;
+  /**
+   * Display name that will be considered as the correct displayName.
+   */
+  displayName: string;
+  /**
+   * In case that the mount from enzyme does not work for the component, a custom mount function can be provided.
+   */
+  customMount?: typeof mount;
+  /**
+   * If there are tests that aren't supposed to run on a component, this allows to opt out of any test.
+   */
+  disabledTests?: string[];
+  /**
+   * Optional flag that means the component is not exported at top level.
+   * @defaultvalue false
+   */
+  isInternal?: boolean;
+  /**
+   * Additional tests to run.
+   */
+  extraTests?: TestObject<TProps>;
+  /**
+   * If the component has required props, they can be added in this object and will be applied when mounting/rendering.
+   */
+  requiredProps?: Partial<TProps>;
+  /**
+   * Optional flag to use the default export.
+   * @defaultvalue false
+   */
+  useDefaultExport?: boolean;
+  /**
+   * Allows specific test options.
+   */
+  testOptions?: TestOptions;
+  /**
+   * This component uses wrapper slot to wrap the 'meaningful' element.
+   */
+  wrapperComponent?: ElementType;
+  /**
+   * Helpers such as FocusZone and Ref which should be ignored when finding nontrivial children.
+   */
+  helperComponents?: ElementType[];
+  /**
+   * An alternative name for the ref prop which resolves to
+   * the root element (e.g. `elementRef`).
+   * @defaultvalue 'ref'
+   */
+  elementRefName?: string;
+  /**
+   * Child component that will receive unhandledProps.
+   */
+  targetComponent?: EnzymeComponentType<TProps>;
+  /**
+   * The name of the slot designated as "primary", which receives native props passed to the component.
+   * This is 'root' by default, and only needs to be specified if it's a slot other than 'root'.
+   */
+  primarySlot?: keyof TProps | 'root';
+
+  /**
+   * Test will load the first tsconfig.json file working upwards from `tsconfigDir`.
+   * @defaultvalue the directory of the component being tested
+   */
+  tsconfigDir?: string;
+}
+
+export type ConformanceTest<TProps = {}> = (
+  componentInfo: ComponentDoc,
+  testInfo: IsConformantOptions<TProps>,
+  tsProgram: Program,
+) => void;
+
+export interface TestObject<TProps = {}> {
+  [key: string]: ConformanceTest<TProps>;
+}

--- a/packages/react-conformance/src/types.ts
+++ b/packages/react-conformance/src/types.ts
@@ -1,8 +1,8 @@
-import * as React from 'react';
-import { ComponentDoc } from 'react-docgen-typescript';
-import * as ts from 'typescript';
+import type { ElementType, ComponentType } from 'react';
+import type { ComponentDoc } from 'react-docgen-typescript';
+import type { Program } from 'typescript';
 
-import { mount, ComponentType } from 'enzyme';
+import type { mount, ComponentType as EnzymeComponentType } from 'enzyme';
 
 /**
  * Individual test options
@@ -32,7 +32,7 @@ export interface IsConformantOptions<TProps = {}> {
   /**
    * Component object to test.
    */
-  Component: React.ComponentType<TProps>;
+  Component: ComponentType<TProps>;
   /**
    * Display name that will be considered as the correct displayName.
    */
@@ -70,11 +70,11 @@ export interface IsConformantOptions<TProps = {}> {
   /**
    * This component uses wrapper slot to wrap the 'meaningful' element.
    */
-  wrapperComponent?: React.ElementType;
+  wrapperComponent?: ElementType;
   /**
    * Helpers such as FocusZone and Ref which should be ignored when finding nontrivial children.
    */
-  helperComponents?: React.ElementType[];
+  helperComponents?: ElementType[];
   /**
    * An alternative name for the ref prop which resolves to
    * the root element (e.g. `elementRef`).
@@ -84,7 +84,7 @@ export interface IsConformantOptions<TProps = {}> {
   /**
    * Child component that will receive unhandledProps.
    */
-  targetComponent?: ComponentType<TProps>;
+  targetComponent?: EnzymeComponentType<TProps>;
   /**
    * The name of the slot designated as "primary", which receives native props passed to the component.
    * This is 'root' by default, and only needs to be specified if it's a slot other than 'root'.
@@ -101,7 +101,7 @@ export interface IsConformantOptions<TProps = {}> {
 export type ConformanceTest<TProps = {}> = (
   componentInfo: ComponentDoc,
   testInfo: IsConformantOptions<TProps>,
-  tsProgram: ts.Program,
+  tsProgram: Program,
 ) => void;
 
 export interface TestObject<TProps = {}> {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

- v7,8 packages are used in v9

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- v9 uses only v9 as direct dependencies

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/microsoft/fluentui/issues/21980

## Remarks

Future goal should be to create conformance-core which would be extended by specialized pluggable packages
