### PR TITLE
perf: simplify merge functions for themes

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,6 +18,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- `mergeThemes()` and other `merge*` functions used for styling accept only two parameters @layershifter ([#22123](https://github.com/microsoft/fluentui/pull/22123))
+
 ### Fixes
 - Add transparent borders to slider @ling1726 ([#22089](https://github.com/microsoft/fluentui/pull/22089))
 - Fix `Popup` opened from right click (on `context`), to not dismiss when scrolling happens in nested Popup @yaunboxue-amber ([#22087](https://github.com/microsoft/fluentui/pull/22087))

--- a/packages/fluentui/docs/src/examples/components/Provider/Performance/ProviderMergeThemes.perf.tsx
+++ b/packages/fluentui/docs/src/examples/components/Provider/Performance/ProviderMergeThemes.perf.tsx
@@ -6,7 +6,9 @@ import * as _ from 'lodash';
  * Not a real performance test, just a temporary POC
  */
 const providerMergeThemesPerf = () => {
-  const merged = mergeThemes(..._.times(100, n => teamsTheme));
+  const merged = _.times(100).reduce(acc => {
+    return mergeThemes(acc, teamsTheme);
+  }, teamsTheme);
   const resolvedStyles = _.mapValues(merged.componentStyles, (componentStyle, componentName) => {
     const compVariables = _.get(merged.componentVariables, componentName, callable({}))(merged.siteVariables);
     const styleParam: ComponentStyleFunctionParam = {

--- a/packages/fluentui/react-bindings/src/styles/resolveVariables.ts
+++ b/packages/fluentui/react-bindings/src/styles/resolveVariables.ts
@@ -2,6 +2,7 @@ import {
   callable,
   ComponentVariablesInput,
   ComponentVariablesObject,
+  ComponentVariablesPrepared,
   mergeComponentVariables,
   ThemePrepared,
   withDebugId,
@@ -43,9 +44,12 @@ export const resolveVariables = (
           theme.siteVariables,
         );
       } else {
-        variablesThemeCache[handlingDisplayName] = mergeComponentVariables(
-          ...effectiveDisplayNames.map(displayName => theme.componentVariables[displayName]),
-        )(theme.siteVariables);
+        variablesThemeCache[handlingDisplayName] = effectiveDisplayNames.reduce<ComponentVariablesPrepared | undefined>(
+          (acc, displayName) => {
+            return mergeComponentVariables(acc, theme.componentVariables[displayName]);
+          },
+          undefined,
+        );
       }
 
       variablesCache.set(theme, variablesThemeCache);
@@ -55,9 +59,12 @@ export const resolveVariables = (
   } else if (effectiveDisplayNames.length === 1) {
     componentThemeVariables = callable(theme.componentVariables[effectiveDisplayNames[0]])(theme.siteVariables) || {};
   } else {
-    componentThemeVariables = mergeComponentVariables(
-      ...effectiveDisplayNames.map(displayName => theme.componentVariables[displayName]),
-    )(theme.siteVariables);
+    componentThemeVariables = effectiveDisplayNames.reduce<ComponentVariablesPrepared | undefined>(
+      (acc, displayName) => {
+        return mergeComponentVariables(acc, theme.componentVariables[displayName]);
+      },
+      undefined,
+    );
   }
 
   if (variables === undefined) {

--- a/packages/fluentui/react-bindings/src/styles/resolveVariables.ts
+++ b/packages/fluentui/react-bindings/src/styles/resolveVariables.ts
@@ -44,12 +44,12 @@ export const resolveVariables = (
           theme.siteVariables,
         );
       } else {
-        variablesThemeCache[handlingDisplayName] = effectiveDisplayNames.reduce<ComponentVariablesPrepared | undefined>(
+        variablesThemeCache[handlingDisplayName] = effectiveDisplayNames.reduce<ComponentVariablesPrepared>(
           (acc, displayName) => {
             return mergeComponentVariables(acc, theme.componentVariables[displayName]);
           },
-          undefined,
-        );
+          () => ({}),
+        )(theme.siteVariables);
       }
 
       variablesCache.set(theme, variablesThemeCache);
@@ -59,12 +59,12 @@ export const resolveVariables = (
   } else if (effectiveDisplayNames.length === 1) {
     componentThemeVariables = callable(theme.componentVariables[effectiveDisplayNames[0]])(theme.siteVariables) || {};
   } else {
-    componentThemeVariables = effectiveDisplayNames.reduce<ComponentVariablesPrepared | undefined>(
+    componentThemeVariables = effectiveDisplayNames.reduce<ComponentVariablesPrepared>(
       (acc, displayName) => {
         return mergeComponentVariables(acc, theme.componentVariables[displayName]);
       },
-      undefined,
-    );
+      () => ({}),
+    )(theme.siteVariables);
   }
 
   if (variables === undefined) {

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/customToolbar/index.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/customToolbar/index.tsx
@@ -57,7 +57,7 @@ const CustomToolbarPrototype: React.FunctionComponent = () => {
   if (themeName === 'teamsDark') {
     theme = mergeThemes(teamsDarkTheme, darkThemeOverrides);
   } else if (themeName === 'teamsHighContrast') {
-    theme = mergeThemes(teamsHighContrastTheme, darkThemeOverrides, highContrastThemeOverrides);
+    theme = mergeThemes(mergeThemes(teamsHighContrastTheme, darkThemeOverrides), highContrastThemeOverrides);
   }
 
   React.useEffect(() => {

--- a/packages/fluentui/react-northstar/src/components/Provider/Provider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Provider/Provider.tsx
@@ -78,7 +78,7 @@ const renderStaticStyles = (renderer: Renderer, theme: ThemeInput, siteVariables
     } else if (_.isPlainObject(staticStyle)) {
       renderObject(staticStyle as StaticStyleObject);
     } else if (_.isFunction(staticStyle)) {
-      const preparedSiteVariables = mergeSiteVariables(siteVariables);
+      const preparedSiteVariables = mergeSiteVariables(undefined, siteVariables);
       renderObject((staticStyle as StaticStyleFunction)(preparedSiteVariables));
     } else {
       throw new Error(

--- a/packages/fluentui/styles/src/mergeThemes.ts
+++ b/packages/fluentui/styles/src/mergeThemes.ts
@@ -23,7 +23,6 @@ import {
 import { isEnabled as isDebugEnabled } from './debugEnabled';
 import { deepmerge } from './deepmerge';
 import { objectKeyToValues } from './objectKeysToValues';
-import { toCompactArray } from './toCompactArray';
 import { withDebugId } from './withDebugId';
 
 export const emptyTheme: ThemePrepared = {
@@ -120,7 +119,7 @@ export const mergeComponentStyles__DEV: typeof mergeComponentStyles = (stylesA, 
       // new object required to prevent circular JSON structure error in <Debug />
       return {
         ...styles,
-        _debug: _debug || [{ styles: { ...styles }, debugId: stylesA._debugId }],
+        _debug: _debug || [{ styles: { ...styles }, debugId: stylesA?._debugId }],
       };
     };
 
@@ -130,7 +129,7 @@ export const mergeComponentStyles__DEV: typeof mergeComponentStyles = (stylesA, 
       // new object required to prevent circular JSON structure error in <Debug />
       return {
         ...styles,
-        _debug: _debug || [{ styles: { ...styles }, debugId: stylesB._debugId }],
+        _debug: _debug || [{ styles: { ...styles }, debugId: stylesB?._debugId }],
       };
     };
 
@@ -166,35 +165,40 @@ export const mergeComponentStyles: (
 /**
  * Merges a single component's variables with another component's variables.
  */
-export const mergeComponentVariables__PROD = (...sources: ComponentVariablesInput[]): ComponentVariablesPrepared => {
-  const initial = () => ({});
+export const mergeComponentVariables__PROD = (
+  variablesA: ComponentVariablesInput | undefined,
+  variablesB: ComponentVariablesInput | undefined,
+): ComponentVariablesPrepared => {
+  if (variablesA && variablesB) {
+    return function mergedComponentVariables(...args) {
+      const resolvedVariablesA = typeof variablesA === 'function' ? variablesA(...args) : variablesA || {};
+      const resolvedVariablesB = typeof variablesB === 'function' ? variablesB(...args) : variablesB || {};
 
-  // filtering is required as some arguments can be undefined
-  const filteredSources = sources.filter(Boolean);
-
-  // a short circle to avoid calls of deepmerge()
-  if (filteredSources.length === 1) {
-    return typeof filteredSources[0] === 'function' ? filteredSources[0] : callable(filteredSources[0]);
+      return deepmerge(resolvedVariablesA, resolvedVariablesB);
+    };
   }
 
-  return filteredSources.reduce<ComponentVariablesPrepared>((acc, next) => {
-    return function mergeComponentVariables(...args) {
-      const accumulatedVariables = acc(...args);
-      const fn = typeof next === 'function' ? next : callable(next);
-      const computedComponentVariables = fn(...args);
+  if (variablesA) {
+    return typeof variablesA === 'function' ? variablesA : () => variablesA || {};
+  }
 
-      return deepmerge(accumulatedVariables, computedComponentVariables);
-    };
-  }, initial);
+  if (variablesB) {
+    return typeof variablesB === 'function' ? variablesB : () => variablesB || {};
+  }
+
+  return () => ({});
 };
 
-export const mergeComponentVariables__DEV = (...sources: ComponentVariablesInput[]): ComponentVariablesPrepared => {
+export const mergeComponentVariables__DEV: typeof mergeComponentVariables__PROD = (
+  variablesA,
+  variablesB,
+): ComponentVariablesPrepared => {
   if (!isDebugEnabled) {
-    return mergeComponentVariables__PROD(...sources);
+    return mergeComponentVariables__PROD(variablesA, variablesB);
   }
   const initial = () => ({});
 
-  return sources.reduce<ComponentVariablesPrepared>((acc, next) => {
+  return [variablesA, variablesB].reduce<ComponentVariablesPrepared>((acc, next) => {
     return siteVariables => {
       const { _debug = [], ...accumulatedVariables } = acc(siteVariables);
       const { _debug: computedDebug = undefined, _debugId = undefined, ...computedComponentVariables } =
@@ -228,26 +232,37 @@ export const mergeComponentVariables =
  * They are flat objects and do not depend on render-time values, such as props.
  */
 export const mergeSiteVariables__PROD = (
-  ...sources: (SiteVariablesInput | null | undefined)[]
+  siteVariablesA: SiteVariablesInput | undefined,
+  siteVariablesB: SiteVariablesInput | undefined,
 ): SiteVariablesPrepared => {
   const initial: SiteVariablesPrepared = {
     fontSizes: {},
   };
-  return deepmerge(initial, ...sources);
+
+  if (siteVariablesA && siteVariablesB) {
+    return deepmerge(initial, siteVariablesA, siteVariablesB);
+  }
+
+  if (siteVariablesA) {
+    return { ...initial, ...siteVariablesA };
+  }
+
+  return { ...initial, ...siteVariablesB };
 };
 
-export const mergeSiteVariables__DEV = (
-  ...sources: (SiteVariablesInput | null | undefined)[]
+export const mergeSiteVariables__DEV: typeof mergeSiteVariables__PROD = (
+  siteVariablesA,
+  siteVariablesB,
 ): SiteVariablesPrepared => {
   if (!isDebugEnabled) {
-    return mergeSiteVariables__PROD(...sources);
+    return mergeSiteVariables__PROD(siteVariablesA, siteVariablesB);
   }
 
   const initial: SiteVariablesPrepared = {
     fontSizes: {},
   };
 
-  return sources.reduce<SiteVariablesPrepared>((acc, next) => {
+  return [siteVariablesA, siteVariablesB].reduce<SiteVariablesPrepared>((acc, next) => {
     const { _debug = [], ...accumulatedSiteVariables } = acc;
     const { _debug: computedDebug = undefined, _invertedKeys = undefined, _debugId = undefined, ...nextSiteVariables } =
       next || {};
@@ -271,26 +286,55 @@ export const mergeSiteVariables =
  */
 
 export const mergeThemeVariables__PROD = (
-  ...sources: (ThemeComponentVariablesInput | null | undefined)[]
+  themeComponentVariablesA: ThemeComponentVariablesInput | undefined,
+  themeComponentVariablesB: ThemeComponentVariablesInput | undefined,
 ): ThemeComponentVariablesPrepared => {
-  const displayNames = _.union(..._.map(sources, _.keys));
-  return displayNames.reduce((componentVariables, displayName) => {
-    componentVariables[displayName] = mergeComponentVariables(..._.map(sources, displayName));
-    return componentVariables;
-  }, {});
-};
+  if (themeComponentVariablesA && themeComponentVariablesB) {
+    const displayNames = _.union(..._.map([themeComponentVariablesA, themeComponentVariablesB], _.keys));
 
-export const mergeThemeVariables__DEV = (
-  ...sources: (ThemeComponentVariablesInput | null | undefined)[]
-): ThemeComponentVariablesPrepared => {
-  if (!isDebugEnabled) {
-    return mergeThemeVariables__PROD(...sources);
+    return displayNames.reduce((componentVariables, displayName) => {
+      componentVariables[displayName] = mergeComponentVariables(
+        themeComponentVariablesA[displayName],
+        themeComponentVariablesB[displayName],
+      );
+
+      return componentVariables;
+    }, {});
   }
 
-  const displayNames = _.union(..._.map(sources, _.keys));
+  if (themeComponentVariablesA) {
+    return Object.fromEntries(
+      Object.entries(themeComponentVariablesA).map(([displayName, variables]) => {
+        return [displayName, mergeComponentVariables(undefined, variables)];
+      }),
+    );
+  }
+
+  if (themeComponentVariablesB) {
+    return Object.fromEntries(
+      Object.entries(themeComponentVariablesB).map(([displayName, variables]) => {
+        return [displayName, mergeComponentVariables(undefined, variables)];
+      }),
+    );
+  }
+
+  return {};
+};
+
+export const mergeThemeVariables__DEV: typeof mergeThemeVariables__PROD = (
+  themeComponentVariablesA,
+  themeComponentVariablesB,
+) => {
+  if (!isDebugEnabled) {
+    return mergeThemeVariables__PROD(themeComponentVariablesA, themeComponentVariablesB);
+  }
+
+  const displayNames = _.union(..._.map([themeComponentVariablesA, themeComponentVariablesB], _.keys));
+
   return displayNames.reduce((componentVariables, displayName) => {
     componentVariables[displayName] = mergeComponentVariables(
-      ..._.map(sources, source => source && withDebugId(source[displayName], source._debugId)),
+      themeComponentVariablesA && withDebugId(themeComponentVariablesA[displayName], themeComponentVariablesA._debugId),
+      themeComponentVariablesB && withDebugId(themeComponentVariablesB[displayName], themeComponentVariablesB._debugId),
     );
     return componentVariables;
   }, {});
@@ -304,12 +348,46 @@ export const mergeThemeVariables =
  * Component styles adhere to the same pattern as component variables, except
  *   that they return style objects.
  */
-export const mergeThemeStyles = (
-  ...sources: (ThemeComponentStylesInput | null | undefined)[]
+const mergeThemeStyles__PROD = (
+  themeComponentStylesA: ThemeComponentStylesInput | undefined,
+  themeComponentStylesB: ThemeComponentStylesInput | undefined,
 ): ThemeComponentStylesPrepared => {
+  if (themeComponentStylesA && themeComponentStylesB) {
+    const displayNames = _.union(..._.map([themeComponentStylesA, themeComponentStylesB], _.keys));
+
+    return displayNames.reduce((themeComponentStyles, displayName) => {
+      themeComponentStyles[displayName] = mergeComponentStyles(
+        themeComponentStylesA[displayName],
+        themeComponentStylesB[displayName],
+      );
+
+      return themeComponentStyles;
+    }, {});
+  }
+
+  if (themeComponentStylesA) {
+    return Object.fromEntries(
+      Object.entries(themeComponentStylesA).map(([displayName, styles]) => {
+        return [displayName, mergeComponentStyles(undefined, styles)];
+      }),
+    );
+  }
+
+  if (themeComponentStylesB) {
+    return Object.fromEntries(
+      Object.entries(themeComponentStylesB).map(([displayName, styles]) => {
+        return [displayName, mergeComponentStyles(undefined, styles)];
+      }),
+    );
+  }
+
+  return {};
+};
+
+const mergeThemeStyles__DEV: typeof mergeThemeStyles__PROD = (componentStylesA, componentStylesB) => {
   const initial: ThemeComponentStylesPrepared = {};
 
-  return sources.reduce<ThemeComponentStylesPrepared>((themeComponentStyles, next) => {
+  return [componentStylesA, componentStylesB].reduce<ThemeComponentStylesPrepared>((themeComponentStyles, next) => {
     _.forEach(next, (stylesByPart, displayName) => {
       themeComponentStyles[displayName] = mergeComponentStyles(
         themeComponentStyles[displayName],
@@ -321,16 +399,24 @@ export const mergeThemeStyles = (
   }, initial);
 };
 
-export const mergeFontFaces = (...sources: FontFace[]) => {
-  return toCompactArray<FontFace>(...sources);
+export const mergeThemeStyles = process.env.NODE_ENV === 'production' ? mergeThemeStyles__PROD : mergeThemeStyles__DEV;
+
+export const mergeFontFaces = (fontFacesA: FontFace[] | undefined, fontFacesB: FontFace[] | undefined): FontFace[] => {
+  return [...(fontFacesA || []), ...(fontFacesB || [])];
 };
 
-export const mergeStaticStyles = (...sources: StaticStyle[]) => {
-  return toCompactArray<StaticStyle>(...sources);
+export const mergeStaticStyles = (
+  staticStylesA: StaticStyle[] | undefined,
+  staticStylesB: StaticStyle[] | undefined,
+): StaticStyle[] => {
+  return [...(staticStylesA || []), ...(staticStylesB || [])];
 };
 
-export const mergeAnimations = (...sources: { [key: string]: ThemeAnimation }[]): { [key: string]: ThemeAnimation } => {
-  return Object.assign({}, ...sources);
+export const mergeAnimations = (
+  animationsA: { [key: string]: ThemeAnimation } | undefined,
+  animationsB: { [key: string]: ThemeAnimation } | undefined,
+): { [key: string]: ThemeAnimation } => {
+  return { ...animationsA, ...animationsB };
 };
 
 export const mergeStyles = (...sources: ComponentSlotStyle[]) => {
@@ -341,30 +427,54 @@ export const mergeStyles = (...sources: ComponentSlotStyle[]) => {
   };
 };
 
-export const mergeThemes = (...themes: ThemeInput[]): ThemePrepared => {
-  return themes.reduce<ThemePrepared>(
-    (acc: ThemePrepared, next: ThemeInput) => {
-      if (!next) return acc;
-      const nextDebugId = next['_debugId'];
+export const mergeThemes = (
+  themeA: ThemeInput | ThemePrepared | undefined,
+  themeB: ThemeInput | ThemePrepared | undefined,
+): ThemePrepared => {
+  const debugIdA = themeA?.['_debugId'];
+  const debugIdB = themeB?.['_debugId'];
 
-      acc.siteVariables = mergeSiteVariables(acc.siteVariables, withDebugId(next.siteVariables, nextDebugId));
+  if (themeA && themeB) {
+    return {
+      animations: mergeAnimations(themeA.animations, themeB.animations),
+      componentVariables: mergeThemeVariables(
+        withDebugId(themeA.componentVariables, debugIdA),
+        withDebugId(themeB.componentVariables, debugIdB),
+      ),
+      componentStyles: mergeThemeStyles(
+        withDebugId(themeA.componentStyles, debugIdA),
+        withDebugId(themeB.componentStyles, debugIdB),
+      ),
+      fontFaces: mergeFontFaces(themeA.fontFaces, themeB.fontFaces),
+      siteVariables: mergeSiteVariables(
+        withDebugId(themeA.siteVariables, debugIdA),
+        withDebugId(themeB.siteVariables, debugIdB),
+      ),
+      staticStyles: mergeStaticStyles(themeA.staticStyles, themeB.staticStyles),
+    };
+  }
 
-      acc.componentVariables = mergeThemeVariables(
-        acc.componentVariables,
-        withDebugId(next.componentVariables, nextDebugId),
-      );
+  if (themeA) {
+    return {
+      animations: mergeAnimations(undefined, themeA.animations),
+      componentVariables: mergeThemeVariables(undefined, withDebugId(themeA.componentVariables, debugIdA)),
+      componentStyles: mergeThemeStyles(undefined, withDebugId(themeA.componentStyles, debugIdA)),
+      fontFaces: mergeFontFaces(undefined, themeA.fontFaces),
+      siteVariables: mergeSiteVariables(undefined, withDebugId(themeA.siteVariables, debugIdA)),
+      staticStyles: mergeStaticStyles(undefined, themeA.staticStyles),
+    };
+  }
 
-      acc.componentStyles = mergeThemeStyles(acc.componentStyles, withDebugId(next.componentStyles, nextDebugId));
+  if (themeB) {
+    return {
+      animations: mergeAnimations(undefined, themeB.animations),
+      componentVariables: mergeThemeVariables(undefined, withDebugId(themeB.componentVariables, debugIdB)),
+      componentStyles: mergeThemeStyles(undefined, withDebugId(themeB.componentStyles, debugIdB)),
+      fontFaces: mergeFontFaces(undefined, themeB.fontFaces),
+      siteVariables: mergeSiteVariables(undefined, withDebugId(themeB.siteVariables, debugIdB)),
+      staticStyles: mergeStaticStyles(undefined, themeB.staticStyles),
+    };
+  }
 
-      acc.fontFaces = mergeFontFaces(...acc.fontFaces, ...(next.fontFaces || []));
-
-      acc.staticStyles = mergeStaticStyles(...acc.staticStyles, ...(next.staticStyles || []));
-
-      acc.animations = mergeAnimations(acc.animations, next.animations);
-
-      return acc;
-    },
-    // .reduce() will modify "emptyTheme" object, so we should clone it before actual usage
-    { ...emptyTheme },
-  );
+  return { ...emptyTheme };
 };

--- a/packages/fluentui/styles/src/mergeThemes.ts
+++ b/packages/fluentui/styles/src/mergeThemes.ts
@@ -6,6 +6,7 @@ import {
   ComponentSlotStylesInput,
   ComponentSlotStylesPrepared,
   ComponentVariablesInput,
+  ComponentVariablesObject,
   ComponentVariablesPrepared,
   FontFace,
   SiteVariablesInput,
@@ -170,9 +171,11 @@ export const mergeComponentVariables__PROD = (
   variablesB: ComponentVariablesInput | undefined,
 ): ComponentVariablesPrepared => {
   if (variablesA && variablesB) {
-    return function mergedComponentVariables(...args) {
-      const resolvedVariablesA = typeof variablesA === 'function' ? variablesA(...args) : variablesA || {};
-      const resolvedVariablesB = typeof variablesB === 'function' ? variablesB(...args) : variablesB || {};
+    return function mergedComponentVariables(
+      siteVariables: SiteVariablesPrepared | undefined,
+    ): ComponentVariablesObject {
+      const resolvedVariablesA = typeof variablesA === 'function' ? variablesA(siteVariables) : variablesA || {};
+      const resolvedVariablesB = typeof variablesB === 'function' ? variablesB(siteVariables) : variablesB || {};
 
       return deepmerge(resolvedVariablesA, resolvedVariablesB);
     };
@@ -385,6 +388,10 @@ const mergeThemeStyles__PROD = (
 };
 
 const mergeThemeStyles__DEV: typeof mergeThemeStyles__PROD = (componentStylesA, componentStylesB) => {
+  if (!isDebugEnabled) {
+    return mergeThemeStyles__PROD(componentStylesA, componentStylesB);
+  }
+
   const initial: ThemeComponentStylesPrepared = {};
 
   return [componentStylesA, componentStylesB].reduce<ThemeComponentStylesPrepared>((themeComponentStyles, next) => {

--- a/packages/fluentui/styles/src/toCompactArray.ts
+++ b/packages/fluentui/styles/src/toCompactArray.ts
@@ -1,3 +1,0 @@
-export const toCompactArray = <T>(...values: T[]): T[] => {
-  return ([] as T[]).concat(...values).filter(Boolean);
-};

--- a/packages/fluentui/styles/src/types.ts
+++ b/packages/fluentui/styles/src/types.ts
@@ -216,12 +216,8 @@ export interface ThemeInput<ThemeStylesProps extends Record<string, any> = any> 
 // context, the resulting theme takes this shape.
 export interface ThemePrepared<ThemeStylesProps extends Record<string, any> = any> {
   siteVariables: SiteVariablesPrepared;
-  componentVariables: {
-    [key in keyof ThemeComponentVariablesPrepared<ThemeStylesProps>]: ComponentVariablesPrepared;
-  };
-  componentStyles: {
-    [key in keyof ThemeComponentStylesPrepared<ThemeStylesProps>]: ComponentSlotStylesPrepared;
-  };
+  componentVariables: ThemeComponentVariablesPrepared<ThemeStylesProps>;
+  componentStyles: ThemeComponentStylesPrepared<ThemeStylesProps>;
   fontFaces: FontFaces;
   staticStyles: StaticStyles;
   animations: Record<string, ThemeAnimation>;

--- a/packages/fluentui/styles/test/mergeThemes/mergeComponentStyles-test.ts
+++ b/packages/fluentui/styles/test/mergeThemes/mergeComponentStyles-test.ts
@@ -30,7 +30,7 @@ describe('mergeComponentStyles', () => {
     });
   }
 
-  function testMergeComponentStyles(mergeComponentStyles) {
+  function testMergeComponentStyles(mergeComponentStyles: typeof mergeComponentStyles__PROD) {
     test(`always returns an object`, () => {
       expect(mergeComponentStyles({}, {})).toMatchObject({});
       expect(mergeComponentStyles(null, null)).toMatchObject({});
@@ -46,21 +46,19 @@ describe('mergeComponentStyles', () => {
       expect(mergeComponentStyles(null, {})).toMatchObject({});
     });
 
-    test('gracefully handles null and undefined', () => {
+    test('gracefully handles undefined', () => {
       const styles = { root: { color: 'black' } };
-      const stylesWithNull = { root: { color: null }, icon: null };
       const stylesWithUndefined = { root: { color: undefined }, icon: undefined };
 
       expect(() => mergeComponentStyles(styles, null)).not.toThrow();
-      expect(() => mergeComponentStyles(styles, stylesWithNull)).not.toThrow();
-
       expect(() => mergeComponentStyles(null, styles)).not.toThrow();
-      expect(() => mergeComponentStyles(stylesWithNull, styles)).not.toThrow();
 
       expect(() => mergeComponentStyles(styles, undefined)).not.toThrow();
+      // @ts-expect-error
       expect(() => mergeComponentStyles(styles, stylesWithUndefined)).not.toThrow();
 
       expect(() => mergeComponentStyles(undefined, styles)).not.toThrow();
+      // @ts-expect-error
       expect(() => mergeComponentStyles(stylesWithUndefined, styles)).not.toThrow();
     });
 
@@ -85,8 +83,7 @@ describe('mergeComponentStyles', () => {
 
     test('converts target only component parts to functions', () => {
       const target = { root: { color: 'red' } };
-
-      const merged = mergeComponentStyles(target);
+      const merged = mergeComponentStyles(undefined, target);
 
       expect(merged.root).toBeInstanceOf(Function);
     });
@@ -110,7 +107,16 @@ describe('mergeComponentStyles', () => {
         },
       };
       const merged = mergeComponentStyles(target, source);
-      expect(merged.root()).toMatchObject({
+
+      const styleFunctionParams = {
+        props: {},
+        variables: {},
+        theme: emptyTheme,
+        disableAnimations: false,
+        rtl: false,
+      };
+
+      expect(merged.root(styleFunctionParams)).toMatchObject({
         display: 'inline-block',
         color: 'blue',
         '::before': {

--- a/packages/fluentui/styles/test/mergeThemes/mergeFontFaces-test.ts
+++ b/packages/fluentui/styles/test/mergeThemes/mergeFontFaces-test.ts
@@ -3,9 +3,7 @@ import { mergeFontFaces } from '@fluentui/styles';
 describe('mergeFontFaces', () => {
   test('returns a compact array', () => {
     expect(
-      mergeFontFaces(
-        undefined,
-        null,
+      mergeFontFaces(undefined, [
         {
           name: 'Segoe UI',
           paths: ['public/fonts/segoe-ui-regular.woff2'],
@@ -21,7 +19,7 @@ describe('mergeFontFaces', () => {
           paths: ['public/fonts/segoe-ui-bold.woff2'],
           props: { fontWeight: 700 },
         },
-      ),
+      ]),
     ).toEqual([
       {
         name: 'Segoe UI',

--- a/packages/fluentui/styles/test/mergeThemes/mergeSiteVariables-test.ts
+++ b/packages/fluentui/styles/test/mergeThemes/mergeSiteVariables-test.ts
@@ -22,20 +22,13 @@ describe('mergeSiteVariables', () => {
     });
   }
 
-  function testMergeSiteVariables(mergeSiteVariables) {
+  function testMergeSiteVariables(mergeSiteVariables: typeof mergeSiteVariables__PROD) {
     test(`always returns an object`, () => {
       expect(mergeSiteVariables({}, {})).toMatchObject({});
-      expect(mergeSiteVariables(null, null)).toMatchObject({});
+
       expect(mergeSiteVariables(undefined, undefined)).toMatchObject({});
-
-      expect(mergeSiteVariables(null, undefined)).toMatchObject({});
-      expect(mergeSiteVariables(undefined, null)).toMatchObject({});
-
       expect(mergeSiteVariables({}, undefined)).toMatchObject({});
       expect(mergeSiteVariables(undefined, {})).toMatchObject({});
-
-      expect(mergeSiteVariables({}, null)).toMatchObject({});
-      expect(mergeSiteVariables(null, {})).toMatchObject({});
     });
 
     test('always adds fontSizes', () => {
@@ -46,12 +39,6 @@ describe('mergeSiteVariables', () => {
     });
 
     test('gracefully handles null and undefined', () => {
-      expect(() => mergeSiteVariables({ color: 'black' }, null)).not.toThrow();
-      expect(() => mergeSiteVariables({ color: 'black' }, { color: null })).not.toThrow();
-
-      expect(() => mergeSiteVariables(null, { color: 'black' })).not.toThrow();
-      expect(() => mergeSiteVariables({ color: null }, { color: 'black' })).not.toThrow();
-
       expect(() => mergeSiteVariables({ color: 'black' }, undefined)).not.toThrow();
       expect(() => mergeSiteVariables({ color: 'black' }, { color: undefined })).not.toThrow();
 

--- a/packages/fluentui/styles/test/mergeThemes/mergeStaticStyles-test.ts
+++ b/packages/fluentui/styles/test/mergeThemes/mergeStaticStyles-test.ts
@@ -2,7 +2,7 @@ import { mergeStaticStyles } from '@fluentui/styles';
 
 describe('mergeStaticStyles', () => {
   test('returns a compact array', () => {
-    expect(mergeStaticStyles(undefined, null, '', { body: { color: 'red' } }, '*{box-sizing:border-box;}')).toEqual([
+    expect(mergeStaticStyles(undefined, [{ body: { color: 'red' } }, '*{box-sizing:border-box;}'])).toEqual([
       { body: { color: 'red' } },
       '*{box-sizing:border-box;}',
     ]);

--- a/packages/fluentui/styles/test/mergeThemes/mergeThemeVariables-test.ts
+++ b/packages/fluentui/styles/test/mergeThemes/mergeThemeVariables-test.ts
@@ -23,7 +23,7 @@ describe('mergeThemeVariables', () => {
     });
   }
 
-  function testMergeThemeVariables(mergeThemeVariables) {
+  function testMergeThemeVariables(mergeThemeVariables: typeof mergeThemeVariables__PROD) {
     test('component variables are merged', () => {
       const target = { Button: {} };
       const source = { Icon: {} };
@@ -53,7 +53,6 @@ describe('mergeThemeVariables', () => {
         's1',
       );
       const source2 = { Button: { c: 'cS2' } };
-      const source3 = { Button: { d: 'dS3' } };
 
       const siteVariables = {
         fontSizes: {},
@@ -62,10 +61,10 @@ describe('mergeThemeVariables', () => {
           colorForC: 'c_color',
         },
       };
-      const merged = mergeThemeVariables(target, mergeThemeVariables(source1, source2), source3);
+      const merged = mergeThemeVariables(target, mergeThemeVariables(source1, source2));
       const resolved = _.mapValues(merged, cv => cv(siteVariables));
       expect(resolved).toMatchObject({
-        Button: { a: 'a', b: 'b_color', c: 'cS2', d: 'dS3', e: 'e' },
+        Button: { a: 'a', b: 'b_color', c: 'cS2', e: 'e' },
       });
     });
   }

--- a/packages/fluentui/styles/test/mergeThemes/mergeThemes-test.ts
+++ b/packages/fluentui/styles/test/mergeThemes/mergeThemes-test.ts
@@ -21,17 +21,10 @@ const styleParam: ComponentStyleFunctionParam = {
 describe('mergeThemes', () => {
   test(`always returns an object`, () => {
     expect(mergeThemes({}, {})).toMatchObject({});
-    expect(mergeThemes(null, null)).toMatchObject({});
     expect(mergeThemes(undefined, undefined)).toMatchObject({});
-
-    expect(mergeThemes(null, undefined)).toMatchObject({});
-    expect(mergeThemes(undefined, null)).toMatchObject({});
 
     expect(mergeThemes({}, undefined)).toMatchObject({});
     expect(mergeThemes(undefined, {})).toMatchObject({});
-
-    expect(mergeThemes({}, null)).toMatchObject({});
-    expect(mergeThemes(null, {})).toMatchObject({});
   });
 
   test('gracefully handles merging a theme in with undefined values', () => {
@@ -201,16 +194,15 @@ describe('mergeThemes', () => {
 
       const merged = mergeThemes(target, source);
 
-      expect(merged.componentStyles.Button.root).toBeInstanceOf(Function);
-      expect(merged.componentStyles.Icon.root).toBeInstanceOf(Function);
+      expect(merged.componentStyles.Button?.root).toBeInstanceOf(Function);
+      expect(merged.componentStyles.Icon?.root).toBeInstanceOf(Function);
     });
 
     test('converts target only component parts to functions', () => {
       const target = { componentStyles: { Button: { root: { color: 'red' } } } };
+      const merged = mergeThemes(undefined, target);
 
-      const merged = mergeThemes(target);
-
-      expect(merged.componentStyles.Button.root).toBeInstanceOf(Function);
+      expect(merged.componentStyles.Button?.root).toBeInstanceOf(Function);
     });
 
     test('component part styles are deeply merged', () => {
@@ -243,7 +235,7 @@ describe('mergeThemes', () => {
 
       const merged = mergeThemes(target, source);
 
-      expect(merged.componentStyles.Button.root(styleParam)).toMatchObject({
+      expect(merged.componentStyles.Button?.root(styleParam)).toMatchObject({
         display: 'inline-block',
         color: 'blue',
         '::before': {
@@ -277,7 +269,7 @@ describe('mergeThemes', () => {
         props: { primary: true },
       } as any;
 
-      expect(merged.componentStyles.Button.root(styleParam)).toMatchObject({
+      expect(merged.componentStyles.Button?.root(styleParam)).toMatchObject({
         source: true,
         target: true,
         ...styleParam,
@@ -289,7 +281,6 @@ describe('mergeThemes', () => {
     test('returns a compact array', () => {
       expect(
         mergeThemes(
-          { fontFaces: null },
           { fontFaces: undefined },
           {
             fontFaces: [
@@ -298,23 +289,10 @@ describe('mergeThemes', () => {
                 paths: ['public/fonts/segoe-ui-regular.woff2'],
                 props: { fontWeight: 400 },
               },
-            ],
-          },
-          {
-            fontFaces: [
               {
                 name: 'Segoe UI',
                 paths: ['public/fonts/segoe-ui-semibold.woff2'],
                 props: { fontWeight: 600 },
-              },
-            ],
-          },
-          {
-            fontFaces: [
-              {
-                name: 'Segoe UI',
-                paths: ['public/fonts/segoe-ui-bold.woff2'],
-                props: { fontWeight: 700 },
               },
             ],
           },
@@ -331,11 +309,6 @@ describe('mergeThemes', () => {
             paths: ['public/fonts/segoe-ui-semibold.woff2'],
             props: { fontWeight: 600 },
           },
-          {
-            name: 'Segoe UI',
-            paths: ['public/fonts/segoe-ui-bold.woff2'],
-            props: { fontWeight: 700 },
-          },
         ],
       });
     });
@@ -345,11 +318,8 @@ describe('mergeThemes', () => {
     test('returns a compact array', () => {
       expect(
         mergeThemes(
-          { staticStyles: null },
           { staticStyles: undefined },
-          { staticStyles: [''] },
-          { staticStyles: [{ body: { color: 'red' } }] },
-          { staticStyles: ['*{box-sizing:border-box;}'] },
+          { staticStyles: [{ body: { color: 'red' } }, '*{box-sizing:border-box;}'] },
         ),
       ).toMatchObject({
         staticStyles: [{ body: { color: 'red' } }, '*{box-sizing:border-box;}'],
@@ -439,7 +409,7 @@ describe('mergeThemes', () => {
         componentVariables: { Button: { btnVar: 'tBtnVar' } },
         componentStyles: { Button: { root: { style: 'tStyleA' } } },
       };
-      const source = {
+      const source: ThemeInput = {
         siteVariables: { varA: 'sVarA' },
         componentVariables: { Button: sv => ({ btnVar: sv.varA }) },
         componentStyles: { Button: { root: ({ variables }) => ({ style: variables.btnVar }) } },
@@ -448,27 +418,15 @@ describe('mergeThemes', () => {
       const merged = mergeThemes(target, source);
 
       expect(merged.siteVariables).toMatchObject({
-        _debug: [
-          {
-            /* FIXME: unnecessary empty object */
-          },
-          { resolved: { varA: 'tVarA' } },
-          { resolved: { varA: 'sVarA' } },
-        ],
+        _debug: [{ resolved: { varA: 'tVarA' } }, { resolved: { varA: 'sVarA' } }],
       });
 
       const buttonVariables = merged.componentVariables.Button(merged.siteVariables);
       expect(buttonVariables).toMatchObject({
-        _debug: [
-          {
-            /* FIXME: unnecessary empty object */
-          },
-          { resolved: { btnVar: 'tBtnVar' } },
-          { resolved: { btnVar: 'sVarA' } },
-        ],
+        _debug: [{ resolved: { btnVar: 'tBtnVar' } }, { resolved: { btnVar: 'sVarA' } }],
       });
 
-      const buttonRootStyles = merged.componentStyles.Button.root({
+      const buttonRootStyles = merged.componentStyles.Button?.root({
         variables: buttonVariables,
       } as any);
       expect(buttonRootStyles).toMatchObject({
@@ -493,7 +451,7 @@ describe('mergeThemes', () => {
       expect(merged.siteVariables._debug).toBe(undefined);
       const buttonVariables = merged.componentVariables.Button(merged.siteVariables);
       expect(buttonVariables._debug).toBe(undefined);
-      const buttonRootStyles = merged.componentStyles.Button.root({
+      const buttonRootStyles = merged.componentStyles.Button?.root({
         variables: buttonVariables,
       } as any);
       expect((buttonRootStyles as any)._debug).toBe(undefined);
@@ -521,27 +479,15 @@ describe('mergeThemes', () => {
       const merged = mergeThemes(target, source);
 
       expect(merged.siteVariables).toMatchObject({
-        _debug: [
-          {
-            /* FIXME: unnecessary empty object */
-          },
-          { debugId: 'target' },
-          { debugId: 'source' },
-        ],
+        _debug: [{ debugId: 'target' }, { debugId: 'source' }],
       });
 
       const buttonVariables = merged.componentVariables.Button(merged.siteVariables);
       expect(buttonVariables).toMatchObject({
-        _debug: [
-          {
-            /* FIXME: unnecessary empty object */
-          },
-          { debugId: 'target' },
-          { debugId: 'source' },
-        ],
+        _debug: [{ debugId: 'target' }, { debugId: 'source' }],
       });
 
-      const buttonRootStyles = merged.componentStyles.Button.root({
+      const buttonRootStyles = merged.componentStyles.Button?.root({
         variables: buttonVariables,
       } as any);
       expect(buttonRootStyles).toMatchObject({

--- a/packages/fluentui/styles/tsconfig.json
+++ b/packages/fluentui/styles/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../../scripts/typescript/tsconfig.fluentui",
   "compilerOptions": {
     "composite": true,
+    "strict": true,
+    "strictNullChecks": true,
     "outDir": "dist/dts"
   },
   "include": ["src", "test"],

--- a/scripts/typescript/tsconfig.fluentui.json
+++ b/scripts/typescript/tsconfig.fluentui.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
-    "lib": ["es2015", "dom"],
+    "lib": ["es2019", "dom"],
     "baseUrl": "../../",
     "paths": {
       "@fluentui/scripts": ["scripts"],


### PR DESCRIPTION
# BREAKING CHANGES

`merge*` functions from `@fluentui/styles` do not accept variable amount of arguments, now it's fixed to two arguments.

### Before

```tsx
mergeThemes(themeA, themeB);
mergeThemes(themeA, themeB, themeC);
```

### After

```tsx
// ✅ still works
mergeThemes(themeA, themeB);
// ⚠️ multiple theme merging should be done in a chain
mergeThemes(themeA, mergeThemes(themeB, themeC));
```

## Changes description

This changes are done to simplify theme merging, avoid merges that are not needed and improve performance. The main goal is to avoid theme merging on top level `Provider`:

```tsx
function App() {
  return <Provider theme={teamsTheme} />;
}
```

Before even in this example we were merging `teamsTheme` with `emptyTheme` that comes from default context value. After `teamsTheme` will be still processed to ensure that it's prepared, but heavy merging operations will not happen.

Functions used in dev for debugging remained without refactor.

## Perf results

![image](https://user-images.githubusercontent.com/14183168/158994416-0984ccca-7481-4c93-bd4f-326ff07a4265.png)

| Example                          | min  | avg   | median | max   |
| -------------------------------- | ---- | ----- | ------ | ----- |
| ProviderMinimal.perf.tsx         | 6.32 | 12.43 | 14.31  | 18.92 |
| ProviderMinimalRefactor.perf.tsx | 2.96 | 7.8   | 5.16   | 15.66 |

- Test renders a single `Provider` with `teamsTheme` applied
