### PR TITLE
refactor: autofix no export star at index file for cxe-prg packages

### DIFF
--- a/change/@fluentui-react-card-b5427f10-a658-4cde-b635-404c560a4bed.json
+++ b/change/@fluentui-react-card-b5427f10-a658-4cde-b635-404c560a4bed.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "refactor: autofix no export star at index file for cxe-prg packages",
+  "packageName": "@fluentui/react-card",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-ddbe4c9f-a8fe-41a8-92f2-c99744d85d5e.json
+++ b/change/@fluentui-react-image-ddbe4c9f-a8fe-41a8-92f2-c99744d85d5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "refactor: autofix no export star at index file for cxe-prg packages",
+  "packageName": "@fluentui/react-image",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-e6ab4ed2-0b42-48c8-8a28-3947b6d76b5b.json
+++ b/change/@fluentui-react-text-e6ab4ed2-0b42-48c8-8a28-3947b6d76b5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "refactor: autofix no export star at index file for cxe-prg packages",
+  "packageName": "@fluentui/react-text",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-card/src/index.ts
+++ b/packages/react-card/src/index.ts
@@ -1,4 +1,38 @@
-export * from './Card';
-export * from './CardFooter';
-export * from './CardHeader';
-export * from './CardPreview';
+/* eslint-disable deprecation/deprecation -- https://github.com/microsoft/fluentui/pull/21960#issuecomment-1068991851*/
+
+export {
+  Card,
+  cardClassName,
+  cardClassNames,
+  renderCard_unstable,
+  useCardStyles_unstable,
+  useCard_unstable,
+} from './Card';
+export type { CardCommons, CardProps, CardSlots, CardState } from './Card';
+export {
+  CardFooter,
+  cardFooterClassName,
+  cardFooterClassNames,
+  renderCardFooter_unstable,
+  useCardFooterStyles_unstable,
+  useCardFooter_unstable,
+} from './CardFooter';
+export type { CardFooterProps, CardFooterSlots, CardFooterState } from './CardFooter';
+export {
+  CardHeader,
+  cardHeaderClassName,
+  cardHeaderClassNames,
+  renderCardHeader_unstable,
+  useCardHeaderStyles_unstable,
+  useCardHeader_unstable,
+} from './CardHeader';
+export type { CardHeaderProps, CardHeaderSlots, CardHeaderState } from './CardHeader';
+export {
+  CardPreview,
+  cardPreviewClassName,
+  cardPreviewClassNames,
+  renderCardPreview_unstable,
+  useCardPreviewStyles_unstable,
+  useCardPreview_unstable,
+} from './CardPreview';
+export type { CardPreviewProps, CardPreviewSlots, CardPreviewState } from './CardPreview';

--- a/packages/react-dialog/src/index.ts
+++ b/packages/react-dialog/src/index.ts
@@ -1,3 +1,11 @@
 // TODO: replace with real exports
 export {};
-export * from './Dialog';
+export {
+  Dialog,
+  dialogClassName,
+  dialogClassNames,
+  renderDialog_unstable,
+  useDialogStyles_unstable,
+  useDialog_unstable,
+} from './Dialog';
+export type { DialogProps, DialogSlots, DialogState } from './Dialog';

--- a/packages/react-dialog/src/index.ts
+++ b/packages/react-dialog/src/index.ts
@@ -1,7 +1,6 @@
-// TODO: replace with real exports
-export {};
 export {
   Dialog,
+  // eslint-disable-next-line deprecation/deprecation -- https://github.com/microsoft/fluentui/pull/21960#issuecomment-1068991851
   dialogClassName,
   dialogClassNames,
   renderDialog_unstable,

--- a/packages/react-image/src/index.ts
+++ b/packages/react-image/src/index.ts
@@ -1,1 +1,10 @@
-export * from './Image';
+export {
+  Image,
+  // eslint-disable-next-line deprecation/deprecation -- https://github.com/microsoft/fluentui/pull/21960#issuecomment-1068991851
+  imageClassName,
+  imageClassNames,
+  renderImage_unstable,
+  useImageStyles_unstable,
+  useImage_unstable,
+} from './Image';
+export type { ImageProps, ImageSlots, ImageState } from './Image';

--- a/packages/react-storybook/src/index.ts
+++ b/packages/react-storybook/src/index.ts
@@ -1,1 +1,1 @@
-export * from './decorators/index';
+export { withFluentProvider, withStrictMode } from './decorators/index';

--- a/packages/react-text/src/index.ts
+++ b/packages/react-text/src/index.ts
@@ -1,10 +1,19 @@
-export * from './Text';
-export * from './Display';
-export * from './LargeTitle';
-export * from './Title1';
-export * from './Title2';
-export * from './Title3';
-export * from './Headline';
-export * from './Subheadline';
-export * from './Body';
-export * from './Caption';
+/* eslint-disable deprecation/deprecation -- https://github.com/microsoft/fluentui/pull/21960#issuecomment-1068991851 */
+export {
+  Text,
+  renderText_unstable,
+  textClassName,
+  textClassNames,
+  useTextStyles_unstable,
+  useText_unstable,
+} from './Text';
+export type { TextProps, TextSlots, TextState } from './Text';
+export { Display, displayClassName, displayClassNames } from './Display';
+export { LargeTitle, largeTitleClassName, largeTitleClassNames } from './LargeTitle';
+export { Title1, title1ClassName, title1ClassNames } from './Title1';
+export { Title2, title2ClassName, title2ClassNames } from './Title2';
+export { Title3, title3ClassName, title3ClassNames } from './Title3';
+export { Headline, headlineClassName, headlineClassNames } from './Headline';
+export { Subheadline, subheadlineClassName, subheadlineClassNames } from './Subheadline';
+export { Body, bodyClassName, bodyClassNames } from './Body';
+export { Caption, captionClassName, captionClassNames } from './Caption';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes Partially https://github.com/microsoft/fluentui/issues/22099


## Remarks

note that because following PR, there was lot of deprecated API introduced https://github.com/microsoft/fluentui/pull/21960#issuecomment-1068991851.

This is the reason why our barrel files have `deprecation` rule being turned off  in this PR.

**Q:** why didn't you turn that rule off in our local eslint configs?
**A:** because that would trigger this rule during pre-commit phase which is expensive. we have magic in our eslint-config plugin that turns type-aware checks off when run via lint-staged. I cannot easily reproduce the same behaviour per package - needs better API design