### PR TITLE
Ensure RTL example show up in rtl

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -22,6 +22,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add transparent borders to slider @ling1726 ([#22089](https://github.com/microsoft/fluentui/pull/22089))
 - Fix `Popup` opened from right click (on `context`), to not dismiss when scrolling happens in nested Popup @yaunboxue-amber ([#22087](https://github.com/microsoft/fluentui/pull/22087))
 
+### Documentation
+- Ensure RTL examples show up in rtl direction @Hirse ([#22129](https://github.com/microsoft/fluentui/pull/22129))
+
 <!--------------------------------[ v0.61.0 ]------------------------------- -->
 ## [v0.61.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.61.0) (2022-03-10)
 [Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/react-northstar_v0.60.1..@fluentui/react-northstar_v0.61.0)

--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -102,9 +102,9 @@ const childrenStyle: ICSSInJSStyle = {
 class ComponentExample extends React.Component<ComponentExampleProps, ComponentExampleState> {
   kebabExamplePath: string;
 
-  static getClearedActiveState = () => ({
+  static getClearedActiveState = (showRtl: boolean = false) => ({
     showCode: false,
-    showRtl: false,
+    showRtl,
     showVariables: false,
     showTransparent: false,
   });
@@ -149,7 +149,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
     props.history.replace({ ...props.history.location, search: `?${nextQueryString}` });
   };
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps(props: ComponentExampleProps, state) {
     const anchorName = ComponentExample.getAnchorName(props);
     const isActiveHash = ComponentExample.isActiveHash(props);
     const isActive = !!state.showCode || !!state.showVariables;
@@ -164,7 +164,7 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
 
     // deactivate examples when switching from one to the next
     if (!isActiveHash && state.prevHash !== nextHash) {
-      Object.assign(nextState, ComponentExample.getClearedActiveState());
+      Object.assign(nextState, ComponentExample.getClearedActiveState(props.examplePath.endsWith('.rtl')));
     }
 
     return nextState;
@@ -188,11 +188,10 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
       componentVariables: {},
       usedVariables: {},
       showCode: isActiveHash,
-      showRtl: false,
+      showRtl: props.examplePath.endsWith('.rtl'),
       showTransparent: false,
       showVariables: false,
       ...(isActiveHash && ComponentExample.getStateFromURL(props)),
-      ...(/\.rtl$/.test(props.examplePath) && { showRtl: true }),
       // FIXME: this is potentially dangerous operation. Original author should specifi explicit return type of `ComponentExample.getStateFromURL` call to match the state shape
     } as ComponentExampleState;
   }


### PR DESCRIPTION
RTL examples (files suffixed with `.rtl`) should be displayed in RTL direction by default.
The existing check in the constructor of `ComponentExample` is reset by `getDerivedStateFromProps` so we need to repeat the check there.