### PR TITLE
Disabling lint rule for deprecated [component]ClassName exports

### DIFF
--- a/change/@fluentui-react-button-633a115e-13c7-4d93-b2f1-a76ce33e883f.json
+++ b/change/@fluentui-react-button-633a115e-13c7-4d93-b2f1-a76ce33e883f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Disabling lint rule for deprecated [component]ClassName exports.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/index.ts
+++ b/packages/react-button/src/index.ts
@@ -1,5 +1,6 @@
 export {
   Button,
+  // eslint-disable-next-line deprecation/deprecation
   buttonClassName,
   buttonClassNames,
   renderButton_unstable,
@@ -9,6 +10,7 @@ export {
 export type { ButtonProps, ButtonSlots, ButtonState } from './Button';
 export {
   CompoundButton,
+  // eslint-disable-next-line deprecation/deprecation
   compoundButtonClassName,
   compoundButtonClassNames,
   renderCompoundButton_unstable,
@@ -18,6 +20,7 @@ export {
 export type { CompoundButtonProps, CompoundButtonSlots, CompoundButtonState } from './CompoundButton';
 export {
   MenuButton,
+  // eslint-disable-next-line deprecation/deprecation
   menuButtonClassName,
   menuButtonClassNames,
   renderMenuButton_unstable,
@@ -28,6 +31,7 @@ export type { MenuButtonProps, MenuButtonSlots, MenuButtonState } from './MenuBu
 export {
   SplitButton,
   renderSplitButton_unstable,
+  // eslint-disable-next-line deprecation/deprecation
   splitButtonClassName,
   splitButtonClassNames,
   useSplitButtonStyles_unstable,
@@ -37,6 +41,7 @@ export type { SplitButtonProps, SplitButtonSlots, SplitButtonState } from './Spl
 export {
   ToggleButton,
   renderToggleButton_unstable,
+  // eslint-disable-next-line deprecation/deprecation
   toggleButtonClassName,
   toggleButtonClassNames,
   useToggleButtonStyles_unstable,


### PR DESCRIPTION
## PR description

A previous PR merged with an old build that is causing master to fail because the `lint` step is erroring on deprecated `[component]ClassName` objects being exported from `@fluentui/react-button`. This PR fixes the issue by disabling the rule for those exports since they are still needed.