### PR TITLE
Removing star exports from @fluentui/react-divider

### DIFF
--- a/change/@fluentui-react-divider-a296016c-a48d-4eee-a35f-e3f92dc129de.json
+++ b/change/@fluentui-react-divider-a296016c-a48d-4eee-a35f-e3f92dc129de.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-divider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-divider/src/index.ts
+++ b/packages/react-divider/src/index.ts
@@ -1,1 +1,10 @@
-export * from './Divider';
+export {
+  Divider,
+  // eslint-disable-next-line deprecation/deprecation
+  dividerClassName,
+  dividerClassNames,
+  renderDivider_unstable,
+  useDividerStyles_unstable,
+  useDivider_unstable,
+} from './Divider';
+export type { DividerProps, DividerSlots, DividerState } from './Divider';


### PR DESCRIPTION
## Current Behavior

`react-divider` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-divider` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

