### PR TITLE
Removing star exports from @fluentui/react-label

### DIFF
--- a/change/@fluentui-react-label-ef9081a1-1ee4-4ee1-b58b-12a01b3e2dbe.json
+++ b/change/@fluentui-react-label-ef9081a1-1ee4-4ee1-b58b-12a01b3e2dbe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-label",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-label/src/index.ts
+++ b/packages/react-label/src/index.ts
@@ -1,3 +1,10 @@
-// TODO: replace with real exports
-export {};
-export * from './Label';
+export {
+  Label,
+  // eslint-disable-next-line deprecation/deprecation
+  labelClassName,
+  labelClassNames,
+  renderLabel_unstable,
+  useLabelStyles_unstable,
+  useLabel_unstable,
+} from './Label';
+export type { LabelProps, LabelSlots, LabelState } from './Label';


### PR DESCRIPTION
## Current Behavior

`react-label` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-label` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

