### PR TITLE
Removing star exports from @fluentui/react-switch

### DIFF
--- a/change/@fluentui-react-switch-79de723f-654c-4eba-adc9-b31e8ba303ef.json
+++ b/change/@fluentui-react-switch-79de723f-654c-4eba-adc9-b31e8ba303ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-switch",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-switch/src/index.ts
+++ b/packages/react-switch/src/index.ts
@@ -1,2 +1,10 @@
-export {};
-export * from './Switch';
+export {
+  Switch,
+  renderSwitch_unstable,
+  // eslint-disable-next-line deprecation/deprecation
+  switchClassName,
+  switchClassNames,
+  useSwitchStyles_unstable,
+  useSwitch_unstable,
+} from './Switch';
+export type { SwitchOnChangeData, SwitchProps, SwitchSlots, SwitchState } from './Switch';


### PR DESCRIPTION
## Current Behavior

`react-switch` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-switch` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

