### PR TITLE
Removing star exports from @fluentui/react-input

### DIFF
--- a/change/@fluentui-react-input-0394afa3-93d8-4114-8186-351ee5141788.json
+++ b/change/@fluentui-react-input-0394afa3-93d8-4114-8186-351ee5141788.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-input",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-input/src/index.ts
+++ b/packages/react-input/src/index.ts
@@ -1,1 +1,10 @@
-export * from './Input';
+export {
+  Input,
+  // eslint-disable-next-line deprecation/deprecation
+  inputClassName,
+  inputClassNames,
+  renderInput_unstable,
+  useInputStyles_unstable,
+  useInput_unstable,
+} from './Input';
+export type { InputOnChangeData, InputProps, InputSlots, InputState } from './Input';


### PR DESCRIPTION
## Current Behavior

`react-input` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-input` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

