### PR TITLE
Avatar: Fix style for sizes 20 and 24 to have semibold fontWeight instead of regular

### DIFF
--- a/change/@fluentui-react-avatar-8816dd26-3129-4deb-85b1-e7ec3a402bcd.json
+++ b/change/@fluentui-react-avatar-8816dd26-3129-4deb-85b1-e7ec3a402bcd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Avatar: Fix style for sizes 20 and 24 to have semibold fontWeight instead of regular.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -74,9 +74,9 @@ const useStyles = makeStyles({
     fontWeight: tokens.fontWeightSemibold,
   },
 
-  textCaption2: {
+  textCaption2Strong: {
     fontSize: tokens.fontSizeBase100,
-    fontWeight: tokens.fontWeightRegular,
+    fontWeight: tokens.fontWeightSemibold,
   },
   textCaption1Strong: { fontSize: tokens.fontSizeBase200 },
   textBody1Strong: { fontSize: tokens.fontSizeBase300 },
@@ -372,7 +372,7 @@ export const useAvatarStyles_unstable = (state: AvatarState): AvatarState => {
   const rootClasses = [styles.root, sizeStyles[size], colorStyles[color]];
 
   if (size <= 24) {
-    rootClasses.push(styles.textCaption2);
+    rootClasses.push(styles.textCaption2Strong);
   } else if (size <= 28) {
     rootClasses.push(styles.textCaption1Strong);
   } else if (size <= 40) {


### PR DESCRIPTION
## PR description

The `Avatar` component had a different style for sizes 20 and 24 when compared to the design spec. This PR updates the component so that it matches the design specification of having font weight be `semibold` for sizes 20 and 24 instead of `regular`. 