### PR TITLE
Button components: Making root a non-nullable slot

### DIFF
--- a/change/@fluentui-react-button-94a03308-210e-4d14-a9bd-a33e4aca69ae.json
+++ b/change/@fluentui-react-button-94a03308-210e-4d14-a9bd-a33e4aca69ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Button components: Making root a non-nullable slot.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -28,7 +28,7 @@ export type ButtonProps = ComponentProps<ButtonSlots> & Partial<ButtonCommons>;
 
 // @public (undocumented)
 export type ButtonSlots = {
-    root: Slot<ARIAButtonSlotProps>;
+    root: NonNullable<Slot<ARIAButtonSlotProps>>;
     icon?: Slot<'span'>;
 };
 
@@ -106,7 +106,7 @@ export type SplitButtonProps = ComponentProps<SplitButtonSlots> & Omit<ButtonPro
 
 // @public (undocumented)
 export type SplitButtonSlots = {
-    root: Slot<'div'>;
+    root: NonNullable<Slot<'div'>>;
     menuButton?: Slot<typeof MenuButton>;
     primaryActionButton?: Slot<typeof Button>;
 };

--- a/packages/react-button/src/components/Button/Button.types.ts
+++ b/packages/react-button/src/components/Button/Button.types.ts
@@ -5,7 +5,7 @@ export type ButtonSlots = {
   /**
    * Root of the component that renders as either a `<button>` tag or an `<a>` tag.
    */
-  root: Slot<ARIAButtonSlotProps>;
+  root: NonNullable<Slot<ARIAButtonSlotProps>>;
 
   /**
    * Icon that renders either before or after the `children` as specified by the `iconPosition` prop.

--- a/packages/react-button/src/components/SplitButton/SplitButton.types.ts
+++ b/packages/react-button/src/components/SplitButton/SplitButton.types.ts
@@ -8,7 +8,7 @@ export type SplitButtonSlots = {
   /**
    * Root of the component that wraps the primary action button and menu button.
    */
-  root: Slot<'div'>;
+  root: NonNullable<Slot<'div'>>;
 
   /**
    * Button that opens menu with secondary actions in SplitButton.


### PR DESCRIPTION
## Current Behavior

The `root` slot of `Button` components is nullable, which should not be the case for any `root` slots.

## New Behavior

This PR fixes the issue by making the `root` slot of all `Button` components non-nullable.

## Related Issue(s)

Fixes part of #21926
