### PR TITLE
Button: Deprecating block prop

### DIFF
--- a/change/@fluentui-react-button-83582077-8826-47dd-89e1-58494886e86b.json
+++ b/change/@fluentui-react-button-83582077-8826-47dd-89e1-58494886e86b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Button: Deprecating block prop.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/components/Button/Button.types.ts
+++ b/packages/react-button/src/components/Button/Button.types.ts
@@ -26,6 +26,8 @@ export type ButtonCommons = {
   /**
    * A button can fill the width of its container.
    * @default false
+   *
+   * @deprecated - Use style overrides instead.
    */
   block: boolean;
 

--- a/packages/react-button/src/components/Button/useButton.ts
+++ b/packages/react-button/src/components/Button/useButton.ts
@@ -16,6 +16,7 @@ export const useButton_unstable = (
   const {
     appearance,
     as,
+    // eslint-disable-next-line deprecation/deprecation
     block = false,
     disabled = false,
     disabledFocusable = false,

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -358,7 +358,16 @@ export const useButtonStyles_unstable = (state: ButtonState): ButtonState => {
   const rootIconOnlyStyles = useRootIconOnlyStyles();
   const iconStyles = useIconStyles();
 
-  const { appearance, block, disabled, disabledFocusable, iconOnly, shape, size } = state;
+  const {
+    appearance,
+    // eslint-disable-next-line deprecation/deprecation
+    block,
+    disabled,
+    disabledFocusable,
+    iconOnly,
+    shape,
+    size,
+  } = state;
 
   state.root.className = mergeClasses(
     buttonClassNames.root,

--- a/packages/react-button/src/components/SplitButton/useSplitButton.ts
+++ b/packages/react-button/src/components/SplitButton/useSplitButton.ts
@@ -15,6 +15,7 @@ export const useSplitButton_unstable = (
 ): SplitButtonState => {
   const {
     appearance,
+    // eslint-disable-next-line deprecation/deprecation
     block = false,
     children,
     disabled = false,

--- a/packages/react-button/src/components/SplitButton/useSplitButtonStyles.ts
+++ b/packages/react-button/src/components/SplitButton/useSplitButtonStyles.ts
@@ -144,7 +144,13 @@ export const useSplitButtonStyles_unstable = (state: SplitButtonState): SplitBut
   const rootStyles = useRootStyles();
   const focusStyles = useFocusStyles();
 
-  const { appearance, block, disabled, disabledFocusable } = state;
+  const {
+    appearance,
+    // eslint-disable-next-line deprecation/deprecation
+    block,
+    disabled,
+    disabledFocusable,
+  } = state;
 
   state.root.className = mergeClasses(
     splitButtonClassNames.root,


### PR DESCRIPTION
## PR description

This PR deprecates the `block` prop in the `Button` component to better adhere to our consistent API across form-related components.

## Related Issue(s)

Fixes part of #21926
