### PR TITLE
Removing star exports from @fluentui/react-slider

### DIFF
--- a/change/@fluentui-react-slider-74f2e75b-fa8d-4b9d-8c1a-2e6f983e72f7.json
+++ b/change/@fluentui-react-slider-74f2e75b-fa8d-4b9d-8c1a-2e6f983e72f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-slider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-slider/src/index.ts
+++ b/packages/react-slider/src/index.ts
@@ -1,1 +1,9 @@
-export * from './Slider';
+export {
+  Slider,
+  renderSlider_unstable,
+  sliderClassNames,
+  useSliderState_unstable,
+  useSliderStyles_unstable,
+  useSlider_unstable,
+} from './Slider';
+export type { SliderOnChangeData, SliderProps, SliderSlots, SliderState } from './Slider';


### PR DESCRIPTION
## Current Behavior

`react-slider` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-slider` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

