### PR TITLE
Removing star exports from @fluentui/react-tabs

### DIFF
--- a/change/@fluentui-react-tabs-798b8aec-7f35-4265-9215-435d7b834d9a.json
+++ b/change/@fluentui-react-tabs-798b8aec-7f35-4265-9215-435d7b834d9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-tabs",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tabs/src/index.ts
+++ b/packages/react-tabs/src/index.ts
@@ -1,2 +1,35 @@
-export * from './Tab';
-export * from './TabList';
+export {
+  Tab,
+  renderTab_unstable,
+  // eslint-disable-next-line deprecation/deprecation
+  tabClassName,
+  tabClassNames,
+  useTabStyles_unstable,
+  useTab_unstable,
+} from './Tab';
+export type { TabProps, TabSlots, TabState, TabValue } from './Tab';
+export {
+  TabList,
+  indicatorLengthVar,
+  indicatorOffsetVar,
+  renderTabList_unstable,
+  // eslint-disable-next-line deprecation/deprecation
+  tabListClassName,
+  tabListClassNames,
+  tabListSelectionIndicatorName,
+  useTabListStyles_unstable,
+  useTabList_unstable,
+} from './TabList';
+export type {
+  RegisterTabData,
+  RegisterTabEventHandler,
+  SelectTabData,
+  SelectTabEvent,
+  SelectTabEventHandler,
+  TabContentRect,
+  TabListContextValue,
+  TabListContextValues,
+  TabListProps,
+  TabListSlots,
+  TabListState,
+} from './TabList';


### PR DESCRIPTION
## Current Behavior

`react-tabs` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-tabs` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

