### PR TITLE
fix(Portal): update `mountNode` types to accept HTMLElement

### DIFF
--- a/change/@fluentui-react-portal-0160db08-c837-47b2-bcc0-2016365a121c.json
+++ b/change/@fluentui-react-portal-0160db08-c837-47b2-bcc0-2016365a121c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update `mountNode` types to accept HTMLElement",
+  "packageName": "@fluentui/react-portal",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-portal/src/components/Portal/Portal.types.ts
+++ b/packages/react-portal/src/components/Portal/Portal.types.ts
@@ -9,7 +9,7 @@ type PortalCommons = {
    * Where the portal children are mounted on DOM
    * @defaultValue a new element on document.body without any styling
    */
-  mountNode: HTMLDivElement | undefined;
+  mountNode: HTMLElement | undefined;
 };
 
 export type PortalProps = Partial<PortalCommons>;

--- a/packages/react-portal/src/components/Portal/Portal.types.ts
+++ b/packages/react-portal/src/components/Portal/Portal.types.ts
@@ -9,7 +9,7 @@ type PortalCommons = {
    * Where the portal children are mounted on DOM
    * @defaultValue a new element on document.body without any styling
    */
-  mountNode: HTMLElement | undefined;
+  mountNode: HTMLElement | null;
 };
 
 export type PortalProps = Partial<PortalCommons>;

--- a/packages/react-portal/src/components/Portal/usePortalMountNode.ts
+++ b/packages/react-portal/src/components/Portal/usePortalMountNode.ts
@@ -13,13 +13,13 @@ export type UsePortalMountNodeOptions = {
 /**
  * Creates a new element on a document.body to mount portals
  */
-export const usePortalMountNode = (options: UsePortalMountNodeOptions) => {
+export const usePortalMountNode = (options: UsePortalMountNodeOptions): HTMLElement | null => {
   const themeClassName = useThemeClassName();
   const { targetDocument, dir } = useFluent();
 
   const element = React.useMemo(() => {
     if (targetDocument === undefined || options.disabled) {
-      return undefined;
+      return null;
     }
 
     const newElement = targetDocument.createElement('div');


### PR DESCRIPTION
## Current Behavior

`mountNode` accepts only `HTMLDivElement`

## New Behavior

`mountNode` accepts only `HTMLElement`