### PR TITLE
Removing star exports from @fluentui/react-tooltip

### DIFF
--- a/change/@fluentui-react-tooltip-2fe5f0f6-e37a-4bd0-b550-6fcfe8a6ccb1.json
+++ b/change/@fluentui-react-tooltip-2fe5f0f6-e37a-4bd0-b550-6fcfe8a6ccb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tooltip/src/index.ts
+++ b/packages/react-tooltip/src/index.ts
@@ -1,1 +1,10 @@
-export * from './Tooltip';
+export {
+  Tooltip,
+  renderTooltip_unstable,
+  // eslint-disable-next-line deprecation/deprecation
+  tooltipClassName,
+  tooltipClassNames,
+  useTooltipStyles_unstable,
+  useTooltip_unstable,
+} from './Tooltip';
+export type { OnVisibleChangeData, TooltipProps, TooltipSlots, TooltipState, TooltipTriggerProps } from './Tooltip';


### PR DESCRIPTION
## Current Behavior

`react-tooltip` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-tooltip` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

