### PR TITLE
feat(tools): bootstrap migrate-v8-pkg generator

### DIFF
--- a/tools/generators/migrate-v8-pkg/README.md
+++ b/tools/generators/migrate-v8-pkg/README.md
@@ -1,0 +1,38 @@
+# migrate-v8-pkg
+
+Workspace Generator ...TODO...
+
+<!-- toc -->
+
+- [Usage](#usage)
+  - [Examples](#examples)
+- [Options](#options)
+  - [`name`](#name)
+
+<!-- tocstop -->
+
+## Usage
+
+```sh
+yarn nx workspace-generator migrate-v8-pkg ...
+```
+
+Show what will be generated without writing to disk:
+
+```sh
+yarn nx workspace-generator migrate-v8-pkg --dry-run
+```
+
+### Examples
+
+```sh
+yarn nx workspace-generator migrate-v8-pkg
+```
+
+## Options
+
+#### `name`
+
+Type: `string`
+
+TODO...

--- a/tools/generators/migrate-v8-pkg/files/constants.ts__tmpl__
+++ b/tools/generators/migrate-v8-pkg/files/constants.ts__tmpl__
@@ -1,0 +1,1 @@
+export const variable = "<%= name %>";

--- a/tools/generators/migrate-v8-pkg/index.spec.ts
+++ b/tools/generators/migrate-v8-pkg/index.spec.ts
@@ -1,0 +1,20 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { Tree, readProjectConfiguration } from '@nrwl/devkit';
+
+import generator from './index';
+import { MigrateV8PkgGeneratorSchema } from './schema';
+
+describe('migrate-v8-pkg generator', () => {
+  let appTree: Tree;
+  const options: MigrateV8PkgGeneratorSchema = { name: 'test' };
+
+  beforeEach(() => {
+    appTree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should run successfully', async () => {
+    await generator(appTree, options);
+    const config = readProjectConfiguration(appTree, 'test');
+    expect(config).toBeDefined();
+  });
+});

--- a/tools/generators/migrate-v8-pkg/index.ts
+++ b/tools/generators/migrate-v8-pkg/index.ts
@@ -1,0 +1,50 @@
+import * as path from 'path';
+import { Tree, formatFiles, installPackagesTask, names, generateFiles } from '@nrwl/devkit';
+import { libraryGenerator } from '@nrwl/workspace/generators';
+
+import { getProjectConfig } from '../../utils';
+
+import { MigrateV8PkgGeneratorSchema } from './schema';
+
+interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}
+
+export default async function (tree: Tree, schema: MigrateV8PkgGeneratorSchema) {
+  await libraryGenerator(tree, { name: schema.name });
+
+  const normalizedOptions = normalizeOptions(tree, schema);
+
+  addFiles(tree, normalizedOptions);
+
+  await formatFiles(tree);
+
+  return () => {
+    installPackagesTask(tree);
+  };
+}
+
+function normalizeOptions(tree: Tree, options: MigrateV8PkgGeneratorSchema) {
+  const project = getProjectConfig(tree, { packageName: options.name });
+
+  return {
+    ...options,
+    ...project,
+    ...names(options.name),
+  };
+}
+
+/**
+ * NOTE: remove this if your generator doesn't process any static/dynamic templates
+ */
+function addFiles(tree: Tree, options: NormalizedSchema) {
+  const templateOptions = {
+    ...options,
+    tmpl: '',
+  };
+
+  generateFiles(
+    tree,
+    path.join(__dirname, 'files'),
+    path.join(options.projectConfig.root, options.name),
+    templateOptions,
+  );
+}

--- a/tools/generators/migrate-v8-pkg/lib/utils.spec.ts
+++ b/tools/generators/migrate-v8-pkg/lib/utils.spec.ts
@@ -1,0 +1,7 @@
+import { dummyHelper } from './utils';
+
+describe(`utils`, () => {
+  it(`should behave...`, () => {
+    expect(dummyHelper()).toBe(undefined);
+  });
+});

--- a/tools/generators/migrate-v8-pkg/lib/utils.ts
+++ b/tools/generators/migrate-v8-pkg/lib/utils.ts
@@ -1,0 +1,5 @@
+// use this module to define any kind of generic utilities that are used in more than 1 place within the generator implementation
+
+export function dummyHelper() {
+  return;
+}

--- a/tools/generators/migrate-v8-pkg/schema.json
+++ b/tools/generators/migrate-v8-pkg/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "id": "migrate-v8-pkg",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Library name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    }
+  },
+  "required": []
+}

--- a/tools/generators/migrate-v8-pkg/schema.ts
+++ b/tools/generators/migrate-v8-pkg/schema.ts
@@ -1,0 +1,6 @@
+export interface MigrateV8PkgGeneratorSchema {
+  /**
+   * Library name
+   */
+  name: string;
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

As we agreed within v-build, we will not branch out vNext. Thus we need to come up with approach how to migrate vNext DX/tooling to v8. All the progress will be handled via automation. This is the 1st step.

## Current Behavior

<!-- This is the behavior we have today -->

## New Behavior

- executed `yarn nx workspace-generator workspace-generator`
- new generator scaffold

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->


