### PR TITLE
@fluentui/react: Adding style files to export maps

### DIFF
--- a/change/@fluentui-react-60213acf-3761-4496-955f-df9a1876d78a.json
+++ b/change/@fluentui-react-60213acf-3761-4496-955f-df9a1876d78a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding style files to export maps.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -72,10 +72,20 @@
       "import": "./lib/ActivityItem.js",
       "require": "./lib-commonjs/ActivityItem.js"
     },
+    "./lib/components/ActivityItem/ActivityItem.styles": {
+      "types": "./lib/components/ActivityItem/ActivityItem.styles.d.ts",
+      "import": "./lib/components/ActivityItem/ActivityItem.styles.js",
+      "require": "./lib-commonjs/components/ActivityItem/ActivityItem.styles.js"
+    },
     "./lib/Announced": {
       "types": "./lib/Announced.d.ts",
       "import": "./lib/Announced.js",
       "require": "./lib-commonjs/Announced.js"
+    },
+    "./lib/components/Announced/Announced.styles": {
+      "types": "./lib/components/Announced/Announced.styles.d.ts",
+      "import": "./lib/components/Announced/Announced.styles.js",
+      "require": "./lib-commonjs/components/Announced/Announced.styles.js"
     },
     "./lib/Autofill": {
       "types": "./lib/Autofill.d.ts",
@@ -87,50 +97,150 @@
       "import": "./lib/Breadcrumb.js",
       "require": "./lib-commonjs/Breadcrumb.js"
     },
+    "./lib/components/Breadcrumb/Breadcrumb.styles": {
+      "types": "./lib/components/Breadcrumb/Breadcrumb.styles.d.ts",
+      "import": "./lib/components/Breadcrumb/Breadcrumb.styles.js",
+      "require": "./lib-commonjs/components/Breadcrumb/Breadcrumb.styles.js"
+    },
     "./lib/Button": {
       "types": "./lib/Button.d.ts",
       "import": "./lib/Button.js",
       "require": "./lib-commonjs/Button.js"
+    },
+    "./lib/components/Button/BaseButton.styles": {
+      "types": "./lib/components/Button/BaseButton.styles.d.ts",
+      "import": "./lib/components/Button/BaseButton.styles.js",
+      "require": "./lib-commonjs/components/Button/BaseButton.styles.js"
+    },
+    "./lib/components/Button/ActionButton/ActionButton.styles": {
+      "types": "./lib/components/Button/ActionButton/ActionButton.styles.d.ts",
+      "import": "./lib/components/Button/ActionButton/ActionButton.styles.js",
+      "require": "./lib-commonjs/components/Button/ActionButton/ActionButton.styles.js"
+    },
+    "./lib/components/Button/CommandBarButton/CommandBarButton.styles": {
+      "types": "./lib/components/Button/CommandBarButton/CommandBarButton.styles.d.ts",
+      "import": "./lib/components/Button/CommandBarButton/CommandBarButton.styles.js",
+      "require": "./lib-commonjs/components/Button/CommandBarButton/CommandBarButton.styles.js"
+    },
+    "./lib/components/Button/CompoundButton/CompoundButton.styles": {
+      "types": "./lib/components/Button/CompoundButton/CompoundButton.styles.d.ts",
+      "import": "./lib/components/Button/CompoundButton/CompoundButton.styles.js",
+      "require": "./lib-commonjs/components/Button/CompoundButton/CompoundButton.styles.js"
+    },
+    "./lib/components/Button/DefaultButton/DefaultButton.styles": {
+      "types": "./lib/components/Button/DefaultButton/DefaultButton.styles.d.ts",
+      "import": "./lib/components/Button/DefaultButton/DefaultButton.styles.js",
+      "require": "./lib-commonjs/components/Button/DefaultButton/DefaultButton.styles.js"
+    },
+    "./lib/components/Button/IconButton/IconButton.styles": {
+      "types": "./lib/components/Button/IconButton/IconButton.styles.d.ts",
+      "import": "./lib/components/Button/IconButton/IconButton.styles.js",
+      "require": "./lib-commonjs/components/Button/IconButton/IconButton.styles.js"
+    },
+    "./lib/components/Button/MessageBarButton/MessageBarButton.styles": {
+      "types": "./lib/components/Button/MessageBarButton/MessageBarButton.styles.d.ts",
+      "import": "./lib/components/Button/MessageBarButton/MessageBarButton.styles.js",
+      "require": "./lib-commonjs/components/Button/MessageBarButton/MessageBarButton.styles.js"
+    },
+    "./lib/components/Button/SplitButton/SplitButton.styles": {
+      "types": "./lib/components/Button/SplitButton/SplitButton.styles.d.ts",
+      "import": "./lib/components/Button/SplitButton/SplitButton.styles.js",
+      "require": "./lib-commonjs/components/Button/SplitButton/SplitButton.styles.js"
     },
     "./lib/ButtonGrid": {
       "types": "./lib/ButtonGrid.d.ts",
       "import": "./lib/ButtonGrid.js",
       "require": "./lib-commonjs/ButtonGrid.js"
     },
+    "./lib/utilities/ButtonGrid/ButtonGrid.styles": {
+      "types": "./lib/utilities/ButtonGrid/ButtonGrid.styles.d.ts",
+      "import": "./lib/utilities/ButtonGrid/ButtonGrid.styles.js",
+      "require": "./lib-commonjs/utilities/ButtonGrid/ButtonGrid.styles.js"
+    },
     "./lib/Calendar": {
       "types": "./lib/Calendar.d.ts",
       "import": "./lib/Calendar.js",
       "require": "./lib-commonjs/Calendar.js"
+    },
+    "./lib/components/Calendar/CalendarMonth/CalendarMonth.styles": {
+      "types": "./lib/components/Calendar/CalendarMonth/CalendarMonth.styles.d.ts",
+      "import": "./lib/components/Calendar/CalendarMonth/CalendarMonth.styles.js",
+      "require": "./lib-commonjs/components/Calendar/CalendarMonth/CalendarMonth.styles.js"
+    },
+    "./lib/components/Calendar/CalendarPicker/CalendarPicker.styles": {
+      "types": "./lib/components/Calendar/CalendarPicker/CalendarPicker.styles.d.ts",
+      "import": "./lib/components/Calendar/CalendarPicker/CalendarPicker.styles.js",
+      "require": "./lib-commonjs/components/Calendar/CalendarPicker/CalendarPicker.styles.js"
+    },
+    "./lib/components/Calendar/CalendarYear/CalendarYear.styles": {
+      "types": "./lib/components/Calendar/CalendarYear/CalendarYear.styles.d.ts",
+      "import": "./lib/components/Calendar/CalendarYear/CalendarYear.styles.js",
+      "require": "./lib-commonjs/components/Calendar/CalendarYear/CalendarYear.styles.js"
     },
     "./lib/Callout": {
       "types": "./lib/Callout.d.ts",
       "import": "./lib/Callout.js",
       "require": "./lib-commonjs/Callout.js"
     },
+    "./lib/components/Callout/CalloutContent.styles": {
+      "types": "./lib/components/Callout/CalloutContent.styles.d.ts",
+      "import": "./lib/components/Callout/CalloutContent.styles.js",
+      "require": "./lib-commonjs/components/Callout/CalloutContent.styles.js"
+    },
     "./lib/Check": {
       "types": "./lib/Check.d.ts",
       "import": "./lib/Check.js",
       "require": "./lib-commonjs/Check.js"
+    },
+    "./lib/components/Check/Check.styles": {
+      "types": "./lib/components/Check/Check.styles.d.ts",
+      "import": "./lib/components/Check/Check.styles.js",
+      "require": "./lib-commonjs/components/Check/Check.styles.js"
     },
     "./lib/Checkbox": {
       "types": "./lib/Checkbox.d.ts",
       "import": "./lib/Checkbox.js",
       "require": "./lib-commonjs/Checkbox.js"
     },
+    "./lib/components/Checkbox/Checkbox.styles": {
+      "types": "./lib/components/Checkbox/Checkbox.styles.d.ts",
+      "import": "./lib/components/Checkbox/Checkbox.styles.js",
+      "require": "./lib-commonjs/components/Checkbox/Checkbox.styles.js"
+    },
     "./lib/ChoiceGroup": {
       "types": "./lib/ChoiceGroup.d.ts",
       "import": "./lib/ChoiceGroup.js",
       "require": "./lib-commonjs/ChoiceGroup.js"
+    },
+    "./lib/components/ChoiceGroup/ChoiceGroup.styles": {
+      "types": "./lib/components/ChoiceGroup/ChoiceGroup.styles.d.ts",
+      "import": "./lib/components/ChoiceGroup/ChoiceGroup.styles.js",
+      "require": "./lib-commonjs/components/ChoiceGroup/ChoiceGroup.styles.js"
     },
     "./lib/ChoiceGroupOption": {
       "types": "./lib/ChoiceGroupOption.d.ts",
       "import": "./lib/ChoiceGroupOption.js",
       "require": "./lib-commonjs/ChoiceGroupOption.js"
     },
+    "./lib/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles": {
+      "types": "./lib/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.d.ts",
+      "import": "./lib/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.js",
+      "require": "./lib-commonjs/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.js"
+    },
     "./lib/Coachmark": {
       "types": "./lib/Coachmark.d.ts",
       "import": "./lib/Coachmark.js",
       "require": "./lib-commonjs/Coachmark.js"
+    },
+    "./lib/components/Coachmark/Coachmark.styles": {
+      "types": "./lib/components/Coachmark/Coachmark.styles.d.ts",
+      "import": "./lib/components/Coachmark/Coachmark.styles.js",
+      "require": "./lib-commonjs/components/Coachmark/Coachmark.styles.js"
+    },
+    "./lib/components/Coachmark/Beak/Beak.styles": {
+      "types": "./lib/components/Coachmark/Beak/Beak.styles.d.ts",
+      "import": "./lib/components/Coachmark/Beak/Beak.styles.js",
+      "require": "./lib-commonjs/components/Coachmark/Beak/Beak.styles.js"
     },
     "./lib/Color": {
       "types": "./lib/Color.d.ts",
@@ -142,20 +252,50 @@
       "import": "./lib/ColorPicker.js",
       "require": "./lib-commonjs/ColorPicker.js"
     },
+    "./lib/components/ColorPicker/ColorPicker.styles": {
+      "types": "./lib/components/ColorPicker/ColorPicker.styles.d.ts",
+      "import": "./lib/components/ColorPicker/ColorPicker.styles.js",
+      "require": "./lib-commonjs/components/ColorPicker/ColorPicker.styles.js"
+    },
+    "./lib/components/ColorPicker/ColorRectangle/ColorRectangle.styles": {
+      "types": "./lib/components/ColorPicker/ColorRectangle/ColorRectangle.styles.d.ts",
+      "import": "./lib/components/ColorPicker/ColorRectangle/ColorRectangle.styles.js",
+      "require": "./lib-commonjs/components/ColorPicker/ColorRectangle/ColorRectangle.styles.js"
+    },
+    "./lib/components/ColorPicker/ColorSlider/ColorSlider.styles": {
+      "types": "./lib/components/ColorPicker/ColorSlider/ColorSlider.styles.d.ts",
+      "import": "./lib/components/ColorPicker/ColorSlider/ColorSlider.styles.js",
+      "require": "./lib-commonjs/components/ColorPicker/ColorSlider/ColorSlider.styles.js"
+    },
     "./lib/ComboBox": {
       "types": "./lib/ComboBox.d.ts",
       "import": "./lib/ComboBox.js",
       "require": "./lib-commonjs/ComboBox.js"
+    },
+    "./lib/components/ComboBox/ComboBox.styles": {
+      "types": "./lib/components/ComboBox/ComboBox.styles.d.ts",
+      "import": "./lib/components/ComboBox/ComboBox.styles.js",
+      "require": "./lib-commonjs/components/ComboBox/ComboBox.styles.js"
     },
     "./lib/CommandBar": {
       "types": "./lib/CommandBar.d.ts",
       "import": "./lib/CommandBar.js",
       "require": "./lib-commonjs/CommandBar.js"
     },
+    "./lib/components/CommandBar/CommandBar.styles": {
+      "types": "./lib/components/CommandBar/CommandBar.styles.d.ts",
+      "import": "./lib/components/CommandBar/CommandBar.styles.js",
+      "require": "./lib-commonjs/components/CommandBar/CommandBar.styles.js"
+    },
     "./lib/ContextualMenu": {
       "types": "./lib/ContextualMenu.d.ts",
       "import": "./lib/ContextualMenu.js",
       "require": "./lib-commonjs/ContextualMenu.js"
+    },
+    "./lib/components/ContextualMenu/ContextualMenu.styles": {
+      "types": "./lib/components/ContextualMenu/ContextualMenu.styles.d.ts",
+      "import": "./lib/components/ContextualMenu/ContextualMenu.styles.js",
+      "require": "./lib-commonjs/components/ContextualMenu/ContextualMenu.styles.js"
     },
     "./lib/DatePicker": {
       "types": "./lib/DatePicker.d.ts",
@@ -172,20 +312,115 @@
       "import": "./lib/DetailsList.js",
       "require": "./lib-commonjs/DetailsList.js"
     },
+    "./lib/components/DetailsList/DetailsColumn.styles": {
+      "types": "./lib/components/DetailsList/DetailsColumn.styles.d.ts",
+      "import": "./lib/components/DetailsList/DetailsColumn.styles.js",
+      "require": "./lib-commonjs/components/DetailsList/DetailsColumn.styles.js"
+    },
+    "./lib/components/DetailsList/DetailsHeader.styles": {
+      "types": "./lib/components/DetailsList/DetailsHeader.styles.d.ts",
+      "import": "./lib/components/DetailsList/DetailsHeader.styles.js",
+      "require": "./lib-commonjs/components/DetailsList/DetailsHeader.styles.js"
+    },
+    "./lib/components/DetailsList/DetailsList.styles": {
+      "types": "./lib/components/DetailsList/DetailsList.styles.d.ts",
+      "import": "./lib/components/DetailsList/DetailsList.styles.js",
+      "require": "./lib-commonjs/components/DetailsList/DetailsList.styles.js"
+    },
+    "./lib/components/DetailsList/DetailsRowCheck.styles": {
+      "types": "./lib/components/DetailsList/DetailsRowCheck.styles.d.ts",
+      "import": "./lib/components/DetailsList/DetailsRowCheck.styles.js",
+      "require": "./lib-commonjs/components/DetailsList/DetailsRowCheck.styles.js"
+    },
+    "./lib/components/DetailsList/ShimmeredDetailsList.styles": {
+      "types": "./lib/components/DetailsList/ShimmeredDetailsList.styles.d.ts",
+      "import": "./lib/components/DetailsList/ShimmeredDetailsList.styles.js",
+      "require": "./lib-commonjs/components/DetailsList/ShimmeredDetailsList.styles.js"
+    },
     "./lib/Dialog": {
       "types": "./lib/Dialog.d.ts",
       "import": "./lib/Dialog.js",
       "require": "./lib-commonjs/Dialog.js"
+    },
+    "./lib/components/Dialog/Dialog.styles": {
+      "types": "./lib/components/Dialog/Dialog.styles.d.ts",
+      "import": "./lib/components/Dialog/Dialog.styles.js",
+      "require": "./lib-commonjs/components/Dialog/Dialog.styles.js"
+    },
+    "./lib/components/Dialog/DialogContent.styles": {
+      "types": "./lib/components/Dialog/DialogContent.styles.d.ts",
+      "import": "./lib/components/Dialog/DialogContent.styles.js",
+      "require": "./lib-commonjs/components/Dialog/DialogContent.styles.js"
+    },
+    "./lib/components/Dialog/DialogFooter.styles": {
+      "types": "./lib/components/Dialog/DialogFooter.styles.d.ts",
+      "import": "./lib/components/Dialog/DialogFooter.styles.js",
+      "require": "./lib-commonjs/components/Dialog/DialogFooter.styles.js"
     },
     "./lib/Divider": {
       "types": "./lib/Divider.d.ts",
       "import": "./lib/Divider.js",
       "require": "./lib-commonjs/Divider.js"
     },
+    "./lib/components/Divider/VerticalDivider.styles": {
+      "types": "./lib/components/Divider/VerticalDivider.styles.d.ts",
+      "import": "./lib/components/Divider/VerticalDivider.styles.js",
+      "require": "./lib-commonjs/components/Divider/VerticalDivider.styles.js"
+    },
     "./lib/DocumentCard": {
       "types": "./lib/DocumentCard.d.ts",
       "import": "./lib/DocumentCard.js",
       "require": "./lib-commonjs/DocumentCard.js"
+    },
+    "./lib/components/DocumentCard/DocumentCard.styles": {
+      "types": "./lib/components/DocumentCard/DocumentCard.styles.d.ts",
+      "import": "./lib/components/DocumentCard/DocumentCard.styles.js",
+      "require": "./lib-commonjs/components/DocumentCard/DocumentCard.styles.js"
+    },
+    "./lib/components/DocumentCard/DocumentCardActions.styles": {
+      "types": "./lib/components/DocumentCard/DocumentCardActions.styles.d.ts",
+      "import": "./lib/components/DocumentCard/DocumentCardActions.styles.js",
+      "require": "./lib-commonjs/components/DocumentCard/DocumentCardActions.styles.js"
+    },
+    "./lib/components/DocumentCard/DocumentCardActivity.styles": {
+      "types": "./lib/components/DocumentCard/DocumentCardActivity.styles.d.ts",
+      "import": "./lib/components/DocumentCard/DocumentCardActivity.styles.js",
+      "require": "./lib-commonjs/components/DocumentCard/DocumentCardActivity.styles.js"
+    },
+    "./lib/components/DocumentCard/DocumentCardDetails.styles": {
+      "types": "./lib/components/DocumentCard/DocumentCardDetails.styles.d.ts",
+      "import": "./lib/components/DocumentCard/DocumentCardDetails.styles.js",
+      "require": "./lib-commonjs/components/DocumentCard/DocumentCardDetails.styles.js"
+    },
+    "./lib/components/DocumentCard/DocumentCardImage.styles": {
+      "types": "./lib/components/DocumentCard/DocumentCardImage.styles.d.ts",
+      "import": "./lib/components/DocumentCard/DocumentCardImage.styles.js",
+      "require": "./lib-commonjs/components/DocumentCard/DocumentCardImage.styles.js"
+    },
+    "./lib/components/DocumentCard/DocumentCardLocation.styles": {
+      "types": "./lib/components/DocumentCard/DocumentCardLocation.styles.d.ts",
+      "import": "./lib/components/DocumentCard/DocumentCardLocation.styles.js",
+      "require": "./lib-commonjs/components/DocumentCard/DocumentCardLocation.styles.js"
+    },
+    "./lib/components/DocumentCard/DocumentCardLogo.styles": {
+      "types": "./lib/components/DocumentCard/DocumentCardLogo.styles.d.ts",
+      "import": "./lib/components/DocumentCard/DocumentCardLogo.styles.js",
+      "require": "./lib-commonjs/components/DocumentCard/DocumentCardLogo.styles.js"
+    },
+    "./lib/components/DocumentCard/DocumentCardPreview.styles": {
+      "types": "./lib/components/DocumentCard/DocumentCardPreview.styles.d.ts",
+      "import": "./lib/components/DocumentCard/DocumentCardPreview.styles.js",
+      "require": "./lib-commonjs/components/DocumentCard/DocumentCardPreview.styles.js"
+    },
+    "./lib/components/DocumentCard/DocumentCardStatus.styles": {
+      "types": "./lib/components/DocumentCard/DocumentCardStatus.styles.d.ts",
+      "import": "./lib/components/DocumentCard/DocumentCardStatus.styles.js",
+      "require": "./lib-commonjs/components/DocumentCard/DocumentCardStatus.styles.js"
+    },
+    "./lib/components/DocumentCard/DocumentCardTitle.styles": {
+      "types": "./lib/components/DocumentCard/DocumentCardTitle.styles.d.ts",
+      "import": "./lib/components/DocumentCard/DocumentCardTitle.styles.js",
+      "require": "./lib-commonjs/components/DocumentCard/DocumentCardTitle.styles.js"
     },
     "./lib/DragDrop": {
       "types": "./lib/DragDrop.d.ts",
@@ -197,6 +432,11 @@
       "import": "./lib/Dropdown.js",
       "require": "./lib-commonjs/Dropdown.js"
     },
+    "./lib/components/Dropdown/Dropdown.styles": {
+      "types": "./lib/components/Dropdown/Dropdown.styles.d.ts",
+      "import": "./lib/components/Dropdown/Dropdown.styles.js",
+      "require": "./lib-commonjs/components/Dropdown/Dropdown.styles.js"
+    },
     "./lib/ExtendedPicker": {
       "types": "./lib/ExtendedPicker.d.ts",
       "import": "./lib/ExtendedPicker.js",
@@ -207,10 +447,20 @@
       "import": "./lib/Fabric.js",
       "require": "./lib-commonjs/Fabric.js"
     },
+    "./lib/components/Fabric/Fabric.styles": {
+      "types": "./lib/components/Fabric/Fabric.styles.d.ts",
+      "import": "./lib/components/Fabric/Fabric.styles.js",
+      "require": "./lib-commonjs/components/Fabric/Fabric.styles.js"
+    },
     "./lib/Facepile": {
       "types": "./lib/Facepile.d.ts",
       "import": "./lib/Facepile.js",
       "require": "./lib-commonjs/Facepile.js"
+    },
+    "./lib/components/Facepile/FacepileButton.styles": {
+      "types": "./lib/components/Facepile/FacepileButton.styles.d.ts",
+      "import": "./lib/components/Facepile/FacepileButton.styles.js",
+      "require": "./lib-commonjs/components/Facepile/FacepileButton.styles.js"
     },
     "./lib/FloatingPicker": {
       "types": "./lib/FloatingPicker.d.ts",
@@ -237,15 +487,55 @@
       "import": "./lib/GroupedList.js",
       "require": "./lib-commonjs/GroupedList.js"
     },
+    "./lib/components/GroupedList/GroupedList.styles": {
+      "types": "./lib/components/GroupedList/GroupedList.styles.d.ts",
+      "import": "./lib/components/GroupedList/GroupedList.styles.js",
+      "require": "./lib-commonjs/components/GroupedList/GroupedList.styles.js"
+    },
+    "./lib/components/GroupedList/GroupFooter.styles": {
+      "types": "./lib/components/GroupedList/GroupFooter.styles.d.ts",
+      "import": "./lib/components/GroupedList/GroupFooter.styles.js",
+      "require": "./lib-commonjs/components/GroupedList/GroupFooter.styles.js"
+    },
+    "./lib/components/GroupedList/GroupHeader.styles": {
+      "types": "./lib/components/GroupedList/GroupHeader.styles.d.ts",
+      "import": "./lib/components/GroupedList/GroupHeader.styles.js",
+      "require": "./lib-commonjs/components/GroupedList/GroupHeader.styles.js"
+    },
+    "./lib/components/GroupedList/GroupShowAll.styles": {
+      "types": "./lib/components/GroupedList/GroupShowAll.styles.d.ts",
+      "import": "./lib/components/GroupedList/GroupShowAll.styles.js",
+      "require": "./lib-commonjs/components/GroupedList/GroupShowAll.styles.js"
+    },
     "./lib/HoverCard": {
       "types": "./lib/HoverCard.d.ts",
       "import": "./lib/HoverCard.js",
       "require": "./lib-commonjs/HoverCard.js"
     },
+    "./lib/components/HoverCard/ExpandingCard.styles": {
+      "types": "./lib/components/HoverCard/ExpandingCard.styles.d.ts",
+      "import": "./lib/components/HoverCard/ExpandingCard.styles.js",
+      "require": "./lib-commonjs/components/HoverCard/ExpandingCard.styles.js"
+    },
+    "./lib/components/HoverCard/HoverCard.styles": {
+      "types": "./lib/components/HoverCard/HoverCard.styles.d.ts",
+      "import": "./lib/components/HoverCard/HoverCard.styles.js",
+      "require": "./lib-commonjs/components/HoverCard/HoverCard.styles.js"
+    },
+    "./lib/components/HoverCard/PlainCard.styles": {
+      "types": "./lib/components/HoverCard/PlainCard.styles.d.ts",
+      "import": "./lib/components/HoverCard/PlainCard.styles.js",
+      "require": "./lib-commonjs/components/HoverCard/PlainCard.styles.js"
+    },
     "./lib/Icon": {
       "types": "./lib/Icon.d.ts",
       "import": "./lib/Icon.js",
       "require": "./lib-commonjs/Icon.js"
+    },
+    "./lib/components/Icon/Icon.styles": {
+      "types": "./lib/components/Icon/Icon.styles.d.ts",
+      "import": "./lib/components/Icon/Icon.styles.js",
+      "require": "./lib-commonjs/components/Icon/Icon.styles.js"
     },
     "./lib/Icons": {
       "types": "./lib/Icons.d.ts",
@@ -256,6 +546,11 @@
       "types": "./lib/Image.d.ts",
       "import": "./lib/Image.js",
       "require": "./lib-commonjs/Image.js"
+    },
+    "./lib/components/Image/Image.styles": {
+      "types": "./lib/components/Image/Image.styles.d.ts",
+      "import": "./lib/components/Image/Image.styles.js",
+      "require": "./lib-commonjs/components/Image/Image.styles.js"
     },
     "./lib/index.bundle": {
       "types": "./lib/index.bundle.d.ts",
@@ -272,6 +567,11 @@
       "import": "./lib/Keytip.js",
       "require": "./lib-commonjs/Keytip.js"
     },
+    "./lib/components/Keytip/Keytip.styles": {
+      "types": "./lib/components/Keytip/Keytip.styles.d.ts",
+      "import": "./lib/components/Keytip/Keytip.styles.js",
+      "require": "./lib-commonjs/components/Keytip/Keytip.styles.js"
+    },
     "./lib/KeytipData": {
       "types": "./lib/KeytipData.d.ts",
       "import": "./lib/KeytipData.js",
@@ -281,6 +581,11 @@
       "types": "./lib/KeytipLayer.d.ts",
       "import": "./lib/KeytipLayer.js",
       "require": "./lib-commonjs/KeytipLayer.js"
+    },
+    "./lib/components/KeytipLayer/KeytipLayer.styles": {
+      "types": "./lib/components/KeytipLayer/KeytipLayer.styles.d.ts",
+      "import": "./lib/components/KeytipLayer/KeytipLayer.styles.js",
+      "require": "./lib-commonjs/components/KeytipLayer/KeytipLayer.styles.js"
     },
     "./lib/Keytips": {
       "types": "./lib/Keytips.d.ts",
@@ -292,15 +597,30 @@
       "import": "./lib/Label.js",
       "require": "./lib-commonjs/Label.js"
     },
+    "./lib/components/Label/Label.styles": {
+      "types": "./lib/components/Label/Label.styles.d.ts",
+      "import": "./lib/components/Label/Label.styles.js",
+      "require": "./lib-commonjs/components/Label/Label.styles.js"
+    },
     "./lib/Layer": {
       "types": "./lib/Layer.d.ts",
       "import": "./lib/Layer.js",
       "require": "./lib-commonjs/Layer.js"
     },
+    "./lib/components/Layer/Layer.styles": {
+      "types": "./lib/components/Layer/Layer.styles.d.ts",
+      "import": "./lib/components/Layer/Layer.styles.js",
+      "require": "./lib-commonjs/components/Layer/Layer.styles.js"
+    },
     "./lib/Link": {
       "types": "./lib/Link.d.ts",
       "import": "./lib/Link.js",
       "require": "./lib-commonjs/Link.js"
+    },
+    "./lib/components/Link/Link.styles": {
+      "types": "./lib/components/Link/Link.styles.d.ts",
+      "import": "./lib/components/Link/Link.styles.js",
+      "require": "./lib-commonjs/components/Link/Link.styles.js"
     },
     "./lib/List": {
       "types": "./lib/List.d.ts",
@@ -317,55 +637,140 @@
       "import": "./lib/MessageBar.js",
       "require": "./lib-commonjs/MessageBar.js"
     },
+    "./lib/components/MessageBar/MessageBar.styles": {
+      "types": "./lib/components/MessageBar/MessageBar.styles.d.ts",
+      "import": "./lib/components/MessageBar/MessageBar.styles.js",
+      "require": "./lib-commonjs/components/MessageBar/MessageBar.styles.js"
+    },
     "./lib/Modal": {
       "types": "./lib/Modal.d.ts",
       "import": "./lib/Modal.js",
       "require": "./lib-commonjs/Modal.js"
+    },
+    "./lib/components/Modal/Modal.styles": {
+      "types": "./lib/components/Modal/Modal.styles.d.ts",
+      "import": "./lib/components/Modal/Modal.styles.js",
+      "require": "./lib-commonjs/components/Modal/Modal.styles.js"
     },
     "./lib/Nav": {
       "types": "./lib/Nav.d.ts",
       "import": "./lib/Nav.js",
       "require": "./lib-commonjs/Nav.js"
     },
+    "./lib/components/Nav/Nav.styles": {
+      "types": "./lib/components/Nav/Nav.styles.d.ts",
+      "import": "./lib/components/Nav/Nav.styles.js",
+      "require": "./lib-commonjs/components/Nav/Nav.styles.js"
+    },
     "./lib/OverflowSet": {
       "types": "./lib/OverflowSet.d.ts",
       "import": "./lib/OverflowSet.js",
       "require": "./lib-commonjs/OverflowSet.js"
+    },
+    "./lib/components/OverflowSet/OverflowSet.styles": {
+      "types": "./lib/components/OverflowSet/OverflowSet.styles.d.ts",
+      "import": "./lib/components/OverflowSet/OverflowSet.styles.js",
+      "require": "./lib-commonjs/components/OverflowSet/OverflowSet.styles.js"
     },
     "./lib/Overlay": {
       "types": "./lib/Overlay.d.ts",
       "import": "./lib/Overlay.js",
       "require": "./lib-commonjs/Overlay.js"
     },
+    "./lib/components/Overlay/Overlay.styles": {
+      "types": "./lib/components/Overlay/Overlay.styles.d.ts",
+      "import": "./lib/components/Overlay/Overlay.styles.js",
+      "require": "./lib-commonjs/components/Overlay/Overlay.styles.js"
+    },
     "./lib/Panel": {
       "types": "./lib/Panel.d.ts",
       "import": "./lib/Panel.js",
       "require": "./lib-commonjs/Panel.js"
+    },
+    "./lib/components/Panel/Panel.styles": {
+      "types": "./lib/components/Panel/Panel.styles.d.ts",
+      "import": "./lib/components/Panel/Panel.styles.js",
+      "require": "./lib-commonjs/components/Panel/Panel.styles.js"
     },
     "./lib/Persona": {
       "types": "./lib/Persona.d.ts",
       "import": "./lib/Persona.js",
       "require": "./lib-commonjs/Persona.js"
     },
+    "./lib/components/Persona/Persona.styles": {
+      "types": "./lib/components/Persona/Persona.styles.d.ts",
+      "import": "./lib/components/Persona/Persona.styles.js",
+      "require": "./lib-commonjs/components/Persona/Persona.styles.js"
+    },
     "./lib/PersonaCoin": {
       "types": "./lib/PersonaCoin.d.ts",
       "import": "./lib/PersonaCoin.js",
       "require": "./lib-commonjs/PersonaCoin.js"
+    },
+    "./lib/components/Persona/PersonaCoin/PersonaCoin.styles": {
+      "types": "./lib/components/Persona/PersonaCoin/PersonaCoin.styles.d.ts",
+      "import": "./lib/components/Persona/PersonaCoin/PersonaCoin.styles.js",
+      "require": "./lib-commonjs/components/Persona/PersonaCoin/PersonaCoin.styles.js"
     },
     "./lib/PersonaPresence": {
       "types": "./lib/PersonaPresence.d.ts",
       "import": "./lib/PersonaPresence.js",
       "require": "./lib-commonjs/PersonaPresence.js"
     },
+    "./lib/components/Persona/PersonaPresence/PersonaPresence.styles": {
+      "types": "./lib/components/Persona/PersonaPresence/PersonaPresence.styles.d.ts",
+      "import": "./lib/components/Persona/PersonaPresence/PersonaPresence.styles.js",
+      "require": "./lib-commonjs/components/Persona/PersonaPresence/PersonaPresence.styles.js"
+    },
     "./lib/Pickers": {
       "types": "./lib/Pickers.d.ts",
       "import": "./lib/Pickers.js",
       "require": "./lib-commonjs/Pickers.js"
     },
+    "./lib/components/pickers/BasePicker.styles": {
+      "types": "./lib/components/pickers/BasePicker.styles.d.ts",
+      "import": "./lib/components/pickers/BasePicker.styles.js",
+      "require": "./lib-commonjs/components/pickers/BasePicker.styles.js"
+    },
+    "./lib/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles": {
+      "types": "./lib/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.d.ts",
+      "import": "./lib/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.js",
+      "require": "./lib-commonjs/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.js"
+    },
+    "./lib/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.styles": {
+      "types": "./lib/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.styles.d.ts",
+      "import": "./lib/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.styles.js",
+      "require": "./lib-commonjs/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.styles.js"
+    },
+    "./lib/components/pickers/Suggestions/Suggestions.styles": {
+      "types": "./lib/components/pickers/Suggestions/Suggestions.styles.d.ts",
+      "import": "./lib/components/pickers/Suggestions/Suggestions.styles.js",
+      "require": "./lib-commonjs/components/pickers/Suggestions/Suggestions.styles.js"
+    },
+    "./lib/components/pickers/Suggestions/SuggestionsItem.styles": {
+      "types": "./lib/components/pickers/Suggestions/SuggestionsItem.styles.d.ts",
+      "import": "./lib/components/pickers/Suggestions/SuggestionsItem.styles.js",
+      "require": "./lib-commonjs/components/pickers/Suggestions/SuggestionsItem.styles.js"
+    },
+    "./lib/components/pickers/TagPicker/TagItem.styles": {
+      "types": "./lib/components/pickers/TagPicker/TagItem.styles.d.ts",
+      "import": "./lib/components/pickers/TagPicker/TagItem.styles.js",
+      "require": "./lib-commonjs/components/pickers/TagPicker/TagItem.styles.js"
+    },
+    "./lib/components/pickers/TagPicker/TagItemSuggestion.styles": {
+      "types": "./lib/components/pickers/TagPicker/TagItemSuggestion.styles.d.ts",
+      "import": "./lib/components/pickers/TagPicker/TagItemSuggestion.styles.js",
+      "require": "./lib-commonjs/components/pickers/TagPicker/TagItemSuggestion.styles.js"
+    },
     "./lib/Pivot": {
       "types": "./lib/Pivot.d.ts",
       "import": "./lib/Pivot.js",
       "require": "./lib-commonjs/Pivot.js"
+    },
+    "./lib/components/Pivot/Pivot.styles": {
+      "types": "./lib/components/Pivot/Pivot.styles.d.ts",
+      "import": "./lib/components/Pivot/Pivot.styles.js",
+      "require": "./lib-commonjs/components/Pivot/Pivot.styles.js"
     },
     "./lib/Popup": {
       "types": "./lib/Popup.d.ts",
@@ -387,10 +792,20 @@
       "import": "./lib/ProgressIndicator.js",
       "require": "./lib-commonjs/ProgressIndicator.js"
     },
+    "./lib/components/ProgressIndicator/ProgressIndicator.styles": {
+      "types": "./lib/components/ProgressIndicator/ProgressIndicator.styles.d.ts",
+      "import": "./lib/components/ProgressIndicator/ProgressIndicator.styles.js",
+      "require": "./lib-commonjs/components/ProgressIndicator/ProgressIndicator.styles.js"
+    },
     "./lib/Rating": {
       "types": "./lib/Rating.d.ts",
       "import": "./lib/Rating.js",
       "require": "./lib-commonjs/Rating.js"
+    },
+    "./lib/components/Rating/Rating.styles": {
+      "types": "./lib/components/Rating/Rating.styles.d.ts",
+      "import": "./lib/components/Rating/Rating.styles.js",
+      "require": "./lib-commonjs/components/Rating/Rating.styles.js"
     },
     "./lib/ResizeGroup": {
       "types": "./lib/ResizeGroup.d.ts",
@@ -407,6 +822,11 @@
       "import": "./lib/ScrollablePane.js",
       "require": "./lib-commonjs/ScrollablePane.js"
     },
+    "./lib/components/ScrollablePane/ScrollablePane.styles": {
+      "types": "./lib/components/ScrollablePane/ScrollablePane.styles.d.ts",
+      "import": "./lib/components/ScrollablePane/ScrollablePane.styles.js",
+      "require": "./lib-commonjs/components/ScrollablePane/ScrollablePane.styles.js"
+    },
     "./lib/SearchBox": {
       "types": "./lib/SearchBox.d.ts",
       "import": "./lib/SearchBox.js",
@@ -422,6 +842,11 @@
       "import": "./lib/SelectedItemsList.js",
       "require": "./lib-commonjs/SelectedItemsList.js"
     },
+    "./lib/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.styles": {
+      "types": "./lib/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.styles.d.ts",
+      "import": "./lib/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.styles.js",
+      "require": "./lib-commonjs/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.styles.js"
+    },
     "./lib/Selection": {
       "types": "./lib/Selection.d.ts",
       "import": "./lib/Selection.js",
@@ -432,10 +857,40 @@
       "import": "./lib/Separator.js",
       "require": "./lib-commonjs/Separator.js"
     },
+    "./lib/components/Separator/Separator.styles": {
+      "types": "./lib/components/Separator/Separator.styles.d.ts",
+      "import": "./lib/components/Separator/Separator.styles.js",
+      "require": "./lib-commonjs/components/Separator/Separator.styles.js"
+    },
     "./lib/Shimmer": {
       "types": "./lib/Shimmer.d.ts",
       "import": "./lib/Shimmer.js",
       "require": "./lib-commonjs/Shimmer.js"
+    },
+    "./lib/components/Shimmer/Shimmer.styles": {
+      "types": "./lib/components/Shimmer/Shimmer.styles.d.ts",
+      "import": "./lib/components/Shimmer/Shimmer.styles.js",
+      "require": "./lib-commonjs/components/Shimmer/Shimmer.styles.js"
+    },
+    "./lib/components/Shimmer/ShimmerCircle/ShimmerCircle.styles": {
+      "types": "./lib/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.d.ts",
+      "import": "./lib/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.js",
+      "require": "./lib-commonjs/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.js"
+    },
+    "./lib/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.styles": {
+      "types": "./lib/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.styles.d.ts",
+      "import": "./lib/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.styles.js",
+      "require": "./lib-commonjs/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.styles.js"
+    },
+    "./lib/components/Shimmer/ShimmerGap/ShimmerGap.styles": {
+      "types": "./lib/components/Shimmer/ShimmerGap/ShimmerGap.styles.d.ts",
+      "import": "./lib/components/Shimmer/ShimmerGap/ShimmerGap.styles.js",
+      "require": "./lib-commonjs/components/Shimmer/ShimmerGap/ShimmerGap.styles.js"
+    },
+    "./lib/components/Shimmer/ShimmerLine/ShimmerLine.styles": {
+      "types": "./lib/components/Shimmer/ShimmerLine/ShimmerLine.styles.d.ts",
+      "import": "./lib/components/Shimmer/ShimmerLine/ShimmerLine.styles.js",
+      "require": "./lib-commonjs/components/Shimmer/ShimmerLine/ShimmerLine.styles.js"
     },
     "./lib/ShimmeredDetailsList": {
       "types": "./lib/ShimmeredDetailsList.d.ts",
@@ -447,10 +902,20 @@
       "import": "./lib/Slider.js",
       "require": "./lib-commonjs/Slider.js"
     },
+    "./lib/components/Slider/Slider.styles": {
+      "types": "./lib/components/Slider/Slider.styles.d.ts",
+      "import": "./lib/components/Slider/Slider.styles.js",
+      "require": "./lib-commonjs/components/Slider/Slider.styles.js"
+    },
     "./lib/SpinButton": {
       "types": "./lib/SpinButton.d.ts",
       "import": "./lib/SpinButton.js",
       "require": "./lib-commonjs/SpinButton.js"
+    },
+    "./lib/components/SpinButton/SpinButton.styles": {
+      "types": "./lib/components/SpinButton/SpinButton.styles.d.ts",
+      "import": "./lib/components/SpinButton/SpinButton.styles.js",
+      "require": "./lib-commonjs/components/SpinButton/SpinButton.styles.js"
     },
     "./lib/Spinner": {
       "types": "./lib/Spinner.d.ts",
@@ -477,10 +942,25 @@
       "import": "./lib/SwatchColorPicker.js",
       "require": "./lib-commonjs/SwatchColorPicker.js"
     },
+    "./lib/components/SwatchColorPicker/ColorPickerGridCell.styles": {
+      "types": "./lib/components/SwatchColorPicker/ColorPickerGridCell.styles.d.ts",
+      "import": "./lib/components/SwatchColorPicker/ColorPickerGridCell.styles.js",
+      "require": "./lib-commonjs/components/SwatchColorPicker/ColorPickerGridCell.styles.js"
+    },
+    "./lib/components/SwatchColorPicker/SwatchColorPicker.styles": {
+      "types": "./lib/components/SwatchColorPicker/SwatchColorPicker.styles.d.ts",
+      "import": "./lib/components/SwatchColorPicker/SwatchColorPicker.styles.js",
+      "require": "./lib-commonjs/components/SwatchColorPicker/SwatchColorPicker.styles.js"
+    },
     "./lib/TeachingBubble": {
       "types": "./lib/TeachingBubble.d.ts",
       "import": "./lib/TeachingBubble.js",
       "require": "./lib-commonjs/TeachingBubble.js"
+    },
+    "./lib/components/TeachingBubble/TeachingBubble.styles": {
+      "types": "./lib/components/TeachingBubble/TeachingBubble.styles.d.ts",
+      "import": "./lib/components/TeachingBubble/TeachingBubble.styles.js",
+      "require": "./lib-commonjs/components/TeachingBubble/TeachingBubble.styles.js"
     },
     "./lib/Text": {
       "types": "./lib/Text.d.ts",
@@ -512,10 +992,25 @@
       "import": "./lib/Toggle.js",
       "require": "./lib-commonjs/Toggle.js"
     },
+    "./lib/components/Toggle/Toggle.styles": {
+      "types": "./lib/components/Toggle/Toggle.styles.d.ts",
+      "import": "./lib/components/Toggle/Toggle.styles.js",
+      "require": "./lib-commonjs/components/Toggle/Toggle.styles.js"
+    },
     "./lib/Tooltip": {
       "types": "./lib/Tooltip.d.ts",
       "import": "./lib/Tooltip.js",
       "require": "./lib-commonjs/Tooltip.js"
+    },
+    "./lib/components/Tooltip/Tooltip.styles": {
+      "types": "./lib/components/Tooltip/Tooltip.styles.d.ts",
+      "import": "./lib/components/Tooltip/Tooltip.styles.js",
+      "require": "./lib-commonjs/components/Tooltip/Tooltip.styles.js"
+    },
+    "./lib/components/Tooltip/TooltipHost.styles": {
+      "types": "./lib/components/Tooltip/TooltipHost.styles.d.ts",
+      "import": "./lib/components/Tooltip/TooltipHost.styles.js",
+      "require": "./lib-commonjs/components/Tooltip/TooltipHost.styles.js"
     },
     "./lib/Utilities": {
       "types": "./lib/Utilities.d.ts",


### PR DESCRIPTION
## PR description

This PR fixes an issue that resulted from the inclusion of export maps in the `@fluentui/react` package that made it impossible to import the `getStyles` functions from those components. After internal discussion we agreed to include the deep import style files in the export maps for the `@fluentui/react` package to solve the issue, which is what is being done in this PR.

## Related Issue(s)

Fixes #22126
