### PR TITLE
Port #14945 (Port #8842 to add tooltip for cancel button in Panel) from office-ui-fabric-react_v5.79.1 to hotfix/5.135.6

### DIFF
--- a/common/changes/office-ui-fabric-react/hotfix_03-hotfix-5.135.6_2022-03-19-06-33.json
+++ b/common/changes/office-ui-fabric-react/hotfix_03-hotfix-5.135.6_2022-03-19-06-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added the title attribute for the cancel icon in the Panel which is same as aira-label",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "xianwang@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -267,6 +267,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
             className={ css('ms-Panel-closeButton ms-PanelAction-close') }
             onClick={ this._onPanelClick }
             ariaLabel={ closeButtonAriaLabel }
+            title={ closeButtonAriaLabel }
             data-is-visible={ true }
             iconProps={ { iconName: 'Cancel' } }
           />


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Port #14945 from office-ui-fabric-react_v5.79.1 to hotfix/5.135.6
For #14945: Port #8842 to add tooltip for cancel button in Panel of office-ui-fabric-react/5.79.1
