### PR TITLE
Port #14932 (Port #6836 to fix typo in role attribute in DocumentCardActivity) from office-ui-fabric-react_v5.79.1 to hotfix/5.135.6

### DIFF
--- a/common/changes/office-ui-fabric-react/hotfix_04-hotfix-5.135.6_2022-03-19-06-51.json
+++ b/common/changes/office-ui-fabric-react/hotfix_04-hotfix-5.135.6_2022-03-19-06-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix typo in role attribute in DocumentCardActivity",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "xianwang@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActivity.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActivity.tsx
@@ -48,7 +48,7 @@ export class DocumentCardActivity extends BaseComponent<IDocumentCardActivityPro
           imageUrl={ person.profileImageSrc }
           initialsColor={ person.initialsColor }
           allowPhoneInitials={ person.allowPhoneInitials }
-          role='persentation'
+          role='presentation'
           size={ PersonaSize.size32 }
         />
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
               ms-Persona-coin
               ms-Persona--size32
 
-          role="persentation"
+          role="presentation"
           size={11}
         >
           <div


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Port #14932 from office-ui-fabric-react_v5.79.1 to hotfix/5.135.6
For #14932, Port #6836 to fix typo in role attribute in DocumentCardActivity of office-ui-fabric-react/5.79.1
