### PR TITLE
Port #18078 (Port #7048 to remove role 'list' from the base picker text element in BasePicker) from office-ui-fabric-react_v5.79.1 to hotfix/5.135.6

### DIFF
--- a/common/changes/office-ui-fabric-react/hotfix_07-hotfix-5.135.6_2022-03-19-12-06.json
+++ b/common/changes/office-ui-fabric-react/hotfix_07-hotfix-5.135.6_2022-03-19-12-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "BasePicker: Remove role 'list' from the base picker text element",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "xianwang@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -214,7 +214,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
           <SelectionZone selection={ this.selection } selectionMode={ SelectionMode.multiple }>
             <div
               className={ css('ms-BasePicker-text', styles.pickerText, this.state.isFocused && styles.inputFocused) }
-              role={ 'list' }
             >
               <span id={ this._ariaMap.selectedItems }>{ this.renderItems() }</span>
               { this.canAddItems() && (

--- a/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -29,7 +29,6 @@ exports[`Pickers BasePicker renders BasePicker correctly 1`] = `
     >
       <div
         className="ms-BasePicker-text"
-        role="list"
       >
         <span
           id="selected-items-id__0"
@@ -93,7 +92,6 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
     >
       <div
         className="ms-BasePicker-text"
-        role="list"
       >
         <span
           id="selected-items-id__69"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Port #18078 from office-ui-fabric-react_v5.79.1 to hotfix/5.135.6
For #18078, Port #7048 to remove role 'list' from the base picker text element in BasePicker
