### PR TITLE
Port #19707 (Port #9163 to update expand button's aria label to include link name in Nav) from office-ui-fabric-react_v5.79.1 to hotfix/5.135.6

### DIFF
--- a/common/changes/office-ui-fabric-react/hotfix_09-hotfix-5.135.6_2022-03-19-14-26.json
+++ b/common/changes/office-ui-fabric-react/hotfix_09-hotfix-5.135.6_2022-03-19-14-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Nav: Prepend link name to aria label for expand button and set it as default if no label is provided",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "xianwang@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -176,7 +176,7 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
 
   private _renderCompositeLink(link: INavLink, linkIndex: number, nestingLevel: number): React.ReactElement<{}> {
     const divProps: React.HTMLProps<HTMLDivElement> = { ...getNativeProps(link, divProperties, ['onClick']) };
-    const { getStyles, groups, theme } = this.props;
+    const { expandButtonAriaLabel, getStyles, groups, theme } = this.props;
     const classNames = getClassNames(getStyles!, {
       theme: theme!,
       isExpanded: !!link.isExpanded,
@@ -185,6 +185,8 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
       position: _indentationSize * nestingLevel + 1,
       groups
     });
+
+    const finalExpandBtnAriaLabel = expandButtonAriaLabel ? `${link.name} ${expandButtonAriaLabel}` : link.name;
 
     return (
       <div
@@ -196,7 +198,7 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
           <button
             className={ classNames.chevronButton }
             onClick={ this._onLinkExpandClicked.bind(this, link) }
-            aria-label={ this.props.expandButtonAriaLabel }
+            aria-label={ finalExpandBtnAriaLabel }
             aria-expanded={ link.isExpanded ? 'true' : 'false' }
           >
             <Icon

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -86,7 +86,8 @@ export interface INavProps {
   ariaLabel?: string;
 
   /**
-   * (Optional) The nav container aria label.
+   * (Optional) The nav container aria label. The link name is prepended to this label.
+   * If not provided, the aria label will default to the link name.
    */
   expandButtonAriaLabel?: string;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Port #19707 from office-ui-fabric-react_v5.79.1 to hotfix/5.135.6
For #19707, Port #9163 to update expand button's aria label to include link name in Nav
