### PR TITLE
Fix: trigger button id should no longer be used as aria label

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Add transparent borders to slider @ling1726 ([#22089](https://github.com/microsoft/fluentui/pull/22089))
 - Fix `Popup` opened from right click (on `context`), to not dismiss when scrolling happens in nested Popup @yaunboxue-amber ([#22087](https://github.com/microsoft/fluentui/pull/22087))
+- Fix `Dropdown` not annoucing placeholder/default value with VoiceOver on macOS @aubreyquinn ([#22173](https://github.com/microsoft/fluentui/pull/22173))
 
 <!--------------------------------[ v0.61.0 ]------------------------------- -->
 ## [v0.61.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.61.0) (2022-03-10)

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -552,8 +552,10 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
       },
       'aria-invalid': ariaInvalid,
       'aria-label': undefined,
-      'aria-labelledby': [ariaLabelledby, triggerButtonId].filter(l => !!l).join(' '),
-      ...(open && { 'aria-expanded': true }),
+      ...(ariaLabelledby && {
+        'aria-labelledby': [ariaLabelledby].filter(l => !!l).join(' '),
+        ...(open && { 'aria-expanded': true }),
+      }),
     });
 
     const { onClick, onFocus, onBlur, onKeyDown, ...restTriggerButtonProps } = triggerButtonProps;

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -552,9 +552,7 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
       },
       'aria-invalid': ariaInvalid,
       'aria-label': undefined,
-      ...(ariaLabelledby && {
-        'aria-labelledby': [ariaLabelledby].filter(l => !!l).join(' '),
-      }),
+      ...(ariaLabelledby && { 'aria-labelledby': ariaLabelledby }),
       ...(open && { 'aria-expanded': true }),
     });
 

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -554,8 +554,8 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
       'aria-label': undefined,
       ...(ariaLabelledby && {
         'aria-labelledby': [ariaLabelledby].filter(l => !!l).join(' '),
-        ...(open && { 'aria-expanded': true }),
       }),
+      ...(open && { 'aria-expanded': true }),
     });
 
     const { onClick, onFocus, onBlur, onKeyDown, ...restTriggerButtonProps } = triggerButtonProps;

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -1999,4 +1999,27 @@ describe('Dropdown', () => {
       expect(getItemNodeAtIndex(0)).toHaveTextContent(items[0]);
     });
   });
+
+  describe('accessibility trigger button aria labels', () => {
+    it('trigger button should not have aria-label', () => {
+      const { triggerButtonNode } = renderDropdown({ items });
+      expect(triggerButtonNode).not.toHaveAttribute('aria-label');
+    });
+
+    it('trigger button should not have aria-labelledby', () => {
+      const { triggerButtonNode } = renderDropdown({ items });
+      expect(triggerButtonNode).not.toHaveAttribute('aria-labelledby');
+    });
+
+    it('trigger button should have aria-labelledby', () => {
+      const { triggerButtonNode } = renderDropdown({ items, 'aria-labelledby': 'form-label' });
+      expect(triggerButtonNode).toHaveAttribute('aria-labelledby', 'form-label');
+    });
+
+    it('trigger button should not have aria-describedby', () => {
+      const { triggerButtonNode } = renderDropdown({ items });
+      expect(triggerButtonNode).not.toHaveAttribute('aria-describedby');
+    });
+  });
+
 });

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -2011,7 +2011,7 @@ describe('Dropdown', () => {
       expect(triggerButtonNode).not.toHaveAttribute('aria-labelledby');
     });
 
-    it('trigger button should have aria-labelledby', () => {
+    it('trigger button should have aria-labelledby from user prop', () => {
       const { triggerButtonNode } = renderDropdown({ items, 'aria-labelledby': 'form-label' });
       expect(triggerButtonNode).toHaveAttribute('aria-labelledby', 'form-label');
     });
@@ -2021,5 +2021,4 @@ describe('Dropdown', () => {
       expect(triggerButtonNode).not.toHaveAttribute('aria-describedby');
     });
   });
-
 });


### PR DESCRIPTION
Fix for Bug #21887 aria-labelledby on Dropdown is set to Dropdown itself if no id provided

The solution has been tested with the keyboard, JAWS, and NVDA.

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally

## Current Behaviour

Currently, the aria-labelledby is being passed down to the trigger button along with the id label of the trigger button. It's causing issues for some screen readers including Mac's VoiceOver.
https://codesandbox.io/s/tv5h0?module=/example.js

e.g.

`<button role="button" data-aa-class="Button" class="ui-button ui-dropdown__trigger-button" id="dropdown-trigger-button-1" type="button" aria-haspopup="true" data-toggle="true" aria-labelledby="dropdown-trigger-button-1"><span dir="auto" class="ui-button__content jg ji jj bq jk jl">Select your hero</span></button>`
 
## New Behavior

If no aria-labelledby prop is provided, then it will not be present in the DOM.

`<button role="button" data-aa-class="Button" class="ui-button ui-dropdown__trigger-button" id="dropdown-trigger-button-1" type="button" aria-haspopup="true" data-toggle="true"><span dir="auto" class="ui-button__content jg ji jj bq jk jl">Select your hero</span></button>`

## Related Issue(s)

Fixes #21887 
