### PR TITLE
Remove aria-live prop to prevent Narrator from reading twice

### DIFF
--- a/packages/react-examples/src/react/Callout/Callout.Status.Example.tsx
+++ b/packages/react-examples/src/react/Callout/Callout.Status.Example.tsx
@@ -16,13 +16,7 @@ export const StatusCalloutExample: React.FunctionComponent = () => {
         className={styles.button}
       />
       {isCalloutVisible && (
-        <Callout
-          className={styles.callout}
-          target={`#${buttonId}`}
-          onDismiss={toggleIsCalloutVisible}
-          role="alert"
-          aria-live="assertive"
-        >
+        <Callout className={styles.callout} target={`#${buttonId}`} onDismiss={toggleIsCalloutVisible} role="alert">
           <DelayedRender>
             <Text variant="small">
               This message is treated as an aria-live assertive status message, and will be read by a screen reader


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Narrator announces elements in a live region twice, because `aria-live="assertive"` is set

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Removes the `aria-live="assertive"` prop and Narrator only announces once
## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
