### PR TITLE
feat: automate codeowner addition for new packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,7 +120,7 @@ common/_semanticSlots.scss @microsoft/cxe-red @phkuo
 common/_themeOverrides.scss @microsoft/cxe-red @phkuo
 common/_common.scss @microsoft/cxe-red @phkuo
 
-## Component packages
+## vNext packages
 packages/react-accordion/ @microsoft/teams-prg @microsoft/cxe-coastal
 packages/react-avatar/ @microsoft/cxe-red @behowell @khmakoto
 packages/react-badge/ @microsoft/teams-prg @microsoft/cxe-red @behowell
@@ -148,6 +148,7 @@ packages/react-tabs/ @microsoft/cxe-coastal @geoffcoxmsft
 packages/react-text/ @microsoft/cxe-prg
 packages/react-textarea/ @microsoft/cxe-red @sopranopillow
 packages/react-tooltip/ @microsoft/cxe-red @behowell @khmakoto
+# <%= NX-CODEOWNER-PLACEHOLDER %>
 
 ## Components
 packages/react @microsoft/cxe-red

--- a/scripts/create-package/plopfile.ts
+++ b/scripts/create-package/plopfile.ts
@@ -25,6 +25,7 @@ interface Answers {
   packageName: string;
   target: 'react' | 'node';
   description: string;
+  codeowner: string;
   hasTests?: boolean;
   isConverged?: boolean;
 }
@@ -56,6 +57,18 @@ module.exports = (plop: NodePlopAPI) => {
         validate: (input: string) => !!input || 'Must enter a description',
       },
       {
+        type: 'list',
+        name: 'codeowner',
+        message: 'Provide team that owns this package',
+        choices: [
+          '@microsoft/fluentui-react-build',
+          '@microsoft/teams-prg',
+          '@microsoft/cxe-coastal',
+          '@microsoft/cxe-red',
+          '@microsoft/cxe-prg',
+        ],
+      },
+      {
         type: 'confirm',
         name: 'hasTests',
         message: 'Will this package have tests?',
@@ -84,6 +97,7 @@ module.exports = (plop: NodePlopAPI) => {
           /^.|-./g, // first char or char after -
           (substr, index) => (index > 0 ? ' ' : '') + substr.replace('-', '').toUpperCase(),
         ),
+        owner: answers.codeowner,
       };
 
       return [
@@ -131,7 +145,13 @@ module.exports = (plop: NodePlopAPI) => {
           console.log(`\nRunning migrate-converged-pkg...`);
           const migrateResult = spawnSync(
             'yarn',
-            ['nx', 'workspace-generator', 'migrate-converged-pkg', `--name='${data.packageNpmName}'`],
+            [
+              'nx',
+              'workspace-generator',
+              'migrate-converged-pkg',
+              `--name='${data.packageNpmName}'`,
+              `--owner='${data.owner}'`,
+            ],
             { cwd: root, stdio: 'inherit', shell: true },
           );
           if (migrateResult.status !== 0) {

--- a/tools/generators/add-codeowners.spec.ts
+++ b/tools/generators/add-codeowners.spec.ts
@@ -1,9 +1,10 @@
-import { Tree, stripIndents, addProjectConfiguration } from '@nrwl/devkit';
+import { Tree, addProjectConfiguration, stripIndents } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { addCodeowner } from './add-codeowners';
+import { setupCodeowners } from '../utils-testing';
+import { workspacePaths } from '../utils';
 
 describe(`#addCodeowner`, () => {
-  const codeownersPath = '/.github/CODEOWNERS';
   let tree: Tree;
 
   beforeEach(() => {
@@ -36,16 +37,16 @@ describe(`#addCodeowner`, () => {
   });
 
   it(`should throw if NX placeholder is missing`, () => {
-    setupCodeowners(tree, { withPlaceholder: false });
+    createCodeowners(tree, { withPlaceholder: false });
     expect(() => {
       addCodeowner(tree, { packageName: '@proj/react-three', owner: '@org/team-three' });
     }).toThrowErrorMatchingInlineSnapshot(`"CODEOWNERS is missing '# <%= NX-CODEOWNER-PLACEHOLDER %>' placeholder"`);
   });
 
   it(`should add codeowner`, () => {
-    setupCodeowners(tree);
+    createCodeowners(tree);
 
-    expect(tree.read(codeownersPath, 'utf8')).toMatchInlineSnapshot(`
+    expect(tree.read(workspacePaths.github.codeowners, 'utf8')).toMatchInlineSnapshot(`
       "/packages/react-one @org/team-one
       /packages/react-one @org/team-two
       # <%= NX-CODEOWNER-PLACEHOLDER %>"
@@ -53,7 +54,7 @@ describe(`#addCodeowner`, () => {
 
     addCodeowner(tree, { packageName: '@proj/react-three', owner: '@org/team-three' });
 
-    expect(tree.read(codeownersPath, 'utf8')).toMatchInlineSnapshot(`
+    expect(tree.read(workspacePaths.github.codeowners, 'utf8')).toMatchInlineSnapshot(`
       "/packages/react-one @org/team-one
       /packages/react-one @org/team-two
       /packages/react-three @org/team-three
@@ -62,16 +63,13 @@ describe(`#addCodeowner`, () => {
     `);
   });
 
-  function setupCodeowners(tree: Tree, options: { withPlaceholder?: boolean } = {}) {
-    const { withPlaceholder } = { withPlaceholder: true, ...options };
-
-    tree.write(
-      codeownersPath,
-      stripIndents`
-      /packages/react-one @org/team-one
+  function createCodeowners(tree: Tree, options: { withPlaceholder?: boolean } = {}) {
+    setupCodeowners(tree, {
+      content: stripIndents`
+     /packages/react-one @org/team-one
       /packages/react-one @org/team-two
-      ${withPlaceholder ? '# <%= NX-CODEOWNER-PLACEHOLDER %>' : ''}
-    `,
-    );
+     `,
+      ...options,
+    });
   }
 });

--- a/tools/generators/add-codeowners.spec.ts
+++ b/tools/generators/add-codeowners.spec.ts
@@ -62,14 +62,14 @@ describe(`#addCodeowner`, () => {
       "
     `);
   });
+});
 
-  function createCodeowners(tree: Tree, options: { withPlaceholder?: boolean } = {}) {
-    setupCodeowners(tree, {
-      content: stripIndents`
+function createCodeowners(tree: Tree, options: { withPlaceholder?: boolean } = {}) {
+  setupCodeowners(tree, {
+    content: stripIndents`
      /packages/react-one @org/team-one
       /packages/react-one @org/team-two
      `,
-      ...options,
-    });
-  }
-});
+    ...options,
+  });
+}

--- a/tools/generators/add-codeowners.spec.ts
+++ b/tools/generators/add-codeowners.spec.ts
@@ -1,0 +1,77 @@
+import { Tree, stripIndents, addProjectConfiguration } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { addCodeowner } from './add-codeowners';
+
+describe(`#addCodeowner`, () => {
+  const codeownersPath = '/.github/CODEOWNERS';
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    addProjectConfiguration(tree, '@proj/react-one', {
+      root: '/packages/react-one',
+      projectType: 'library',
+      sourceRoot: '/packages/react-one/src',
+      targets: {},
+    });
+    addProjectConfiguration(tree, '@proj/react-two', {
+      root: '/packages/react-two',
+      projectType: 'library',
+      sourceRoot: '/packages/react-two/src',
+      targets: {},
+    });
+    addProjectConfiguration(tree, '@proj/react-three', {
+      root: '/packages/react-three',
+      projectType: 'library',
+      sourceRoot: '/packages/react-three/src',
+      targets: {},
+    });
+  });
+
+  it(`should throw if no CODEOWNER exists`, () => {
+    expect(() => {
+      addCodeowner(tree, { packageName: '@proj/react-three', owner: '@org/team-three' });
+    }).toThrowErrorMatchingInlineSnapshot(`"CODEOWNERS doesn't exists"`);
+  });
+
+  it(`should throw if NX placeholder is missing`, () => {
+    setupCodeowners(tree, { withPlaceholder: false });
+    expect(() => {
+      addCodeowner(tree, { packageName: '@proj/react-three', owner: '@org/team-three' });
+    }).toThrowErrorMatchingInlineSnapshot(`"CODEOWNERS is missing '# <%= NX-CODEOWNER-PLACEHOLDER %>' placeholder"`);
+  });
+
+  it(`should add codeowner`, () => {
+    setupCodeowners(tree);
+
+    expect(tree.read(codeownersPath, 'utf8')).toMatchInlineSnapshot(`
+      "/packages/react-one @org/team-one
+      /packages/react-one @org/team-two
+      # <%= NX-CODEOWNER-PLACEHOLDER %>"
+    `);
+
+    addCodeowner(tree, { packageName: '@proj/react-three', owner: '@org/team-three' });
+
+    expect(tree.read(codeownersPath, 'utf8')).toMatchInlineSnapshot(`
+      "/packages/react-one @org/team-one
+      /packages/react-one @org/team-two
+      /packages/react-three @org/team-three
+      ## <%= NX-CODEOWNER-PLACEHOLDER %>
+      "
+    `);
+  });
+
+  function setupCodeowners(tree: Tree, options: { withPlaceholder?: boolean } = {}) {
+    const { withPlaceholder } = { withPlaceholder: true, ...options };
+
+    tree.write(
+      codeownersPath,
+      stripIndents`
+      /packages/react-one @org/team-one
+      /packages/react-one @org/team-two
+      ${withPlaceholder ? '# <%= NX-CODEOWNER-PLACEHOLDER %>' : ''}
+    `,
+    );
+  }
+});

--- a/tools/generators/add-codeowners.ts
+++ b/tools/generators/add-codeowners.ts
@@ -1,0 +1,51 @@
+import { applyChangesToString, Tree } from '@nrwl/devkit';
+import { joinPathFragments, StringChange, ChangeType } from '@nrwl/devkit';
+
+import { getProjectConfig } from '../utils';
+
+interface Options {
+  packageName: string;
+  owner: string;
+}
+export function addCodeowner(tree: Tree, options: Options) {
+  const project = getProjectConfig(tree, options);
+  processCodeowners(tree, { ...project, owner: options.owner });
+}
+
+function processCodeowners(tree: Tree, options: ReturnType<typeof getProjectConfig> & Pick<Options, 'owner'>) {
+  const placeholder = '# <%= NX-CODEOWNER-PLACEHOLDER %>';
+  const codeownersPath = joinPathFragments('/.github', 'CODEOWNERS');
+
+  if (!tree.exists(codeownersPath)) {
+    throw new Error(`CODEOWNERS doesn't exists`);
+  }
+
+  const codeownersContent = tree.read(codeownersPath, 'utf8') as string;
+  const placeholderPosition = codeownersContent.indexOf(placeholder);
+
+  if (placeholderPosition === -1) {
+    throw new Error(`CODEOWNERS is missing '${placeholder}' placeholder`);
+  }
+
+  const changes: StringChange[] = [
+    {
+      type: ChangeType.Delete,
+      start: placeholderPosition + 1,
+      length: placeholder.length,
+    },
+    {
+      index: placeholderPosition,
+      type: ChangeType.Insert,
+      text: `${options.projectConfig.root} ${options.owner}\n`,
+    },
+    {
+      type: ChangeType.Insert,
+      index: placeholderPosition + 1,
+      text: placeholder + '\n',
+    },
+  ];
+
+  const newContents = applyChangesToString(codeownersContent, changes);
+
+  tree.write(codeownersPath, newContents);
+}

--- a/tools/generators/migrate-converged-pkg/README.md
+++ b/tools/generators/migrate-converged-pkg/README.md
@@ -70,6 +70,12 @@ To run migration on multiple packages you can specify a comma separated list of 
 yarn nx workspace-generator migrate-converged-pkg --name='@fluentui/lib-zero,@fluentui/lib-one,@fluentui/lib-two'
 ```
 
+#### `owner`
+
+Type: `string`
+
+Add particular team to CODEOWNERS file
+
 #### `all`
 
 Type: `boolean`

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -21,6 +21,7 @@ import { PackageJson, TsConfig } from '../../types';
 import { arePromptsEnabled, getProjectConfig, getProjects, printUserLogs, prompt, UserLog } from '../../utils';
 
 import { MigrateConvergedPkgGeneratorSchema } from './schema';
+import { addCodeowner } from '../add-codeowners';
 
 interface ProjectConfiguration extends ReturnType<typeof readProjectConfiguration> {}
 
@@ -77,6 +78,10 @@ function runBatchMigration(tree: Tree, userLog: UserLog, projectNames?: string[]
 
 function runMigrationOnProject(tree: Tree, schema: AssertedSchema, userLog: UserLog) {
   const options = normalizeOptions(tree, schema);
+
+  if (options.owner) {
+    addCodeowner(tree, { owner: options.owner, packageName: options.name });
+  }
 
   // 1. update TsConfigs
   updatedLocalTsConfig(tree, options);

--- a/tools/generators/migrate-converged-pkg/schema.json
+++ b/tools/generators/migrate-converged-pkg/schema.json
@@ -20,6 +20,10 @@
     "all": {
       "type": "boolean",
       "description": "Run generator on all vNext packages"
+    },
+    "owner": {
+      "type": "string",
+      "description": "Add particular team to CODEOWNERS file"
     }
   },
   "required": []

--- a/tools/generators/migrate-converged-pkg/schema.json
+++ b/tools/generators/migrate-converged-pkg/schema.json
@@ -23,7 +23,8 @@
     },
     "owner": {
       "type": "string",
-      "description": "Add particular team to CODEOWNERS file"
+      "description": "Add particular team to CODEOWNERS file",
+      "pattern": "^@[/-\\w]+$"
     }
   },
   "required": []

--- a/tools/generators/migrate-converged-pkg/schema.ts
+++ b/tools/generators/migrate-converged-pkg/schema.ts
@@ -11,4 +11,8 @@ export interface MigrateConvergedPkgGeneratorSchema {
    * Run generator on all vNext packages
    */
   all?: boolean;
+  /**
+   * Add particular team to CODEOWNERS file
+   */
+  owner?: string;
 }

--- a/tools/utils-testing.ts
+++ b/tools/utils-testing.ts
@@ -1,0 +1,17 @@
+import { stripIndents, Tree } from '@nrwl/devkit';
+
+import { workspacePaths } from './utils';
+
+export function setupCodeowners(tree: Tree, options: { withPlaceholder?: boolean; content: string }) {
+  const { withPlaceholder, content } = { withPlaceholder: true, ...options };
+
+  tree.write(
+    workspacePaths.github.codeowners,
+    stripIndents`
+      ${content}
+      ${withPlaceholder ? '# <%= NX-CODEOWNER-PLACEHOLDER %>' : ''}
+    `,
+  );
+
+  return tree;
+}

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -123,6 +123,21 @@ export function getProjectConfig(tree: Tree, options: { packageName: string }) {
   };
 }
 
+export const workspacePaths = {
+  workspace: '/workspace.json',
+  nx: '/nx.json',
+  tsconfig: '/tsconfig.base.json',
+  packageJson: '/package.json',
+  jest: { preset: '/jest.preset.js', config: '/jest.config.js' },
+  github: {
+    root: '/.github',
+    codeowners: joinPathFragments('/.github', 'CODEOWNERS'),
+  },
+  storybook: {
+    root: '/.storyboook',
+  },
+};
+
 export type UserLog = Array<{ type: keyof typeof logger; message: string }>;
 export function printUserLogs(logs: UserLog) {
   logger.log(`${'='.repeat(80)}\n`);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior


When user bootstraps new package via `create-package` codeowner is not being enforced to be setup, which goes against our reviews/ownership process. 

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- `create-package` asks user to select which team will be owning this new package


**DEMO:**

https://user-images.githubusercontent.com/1223799/159723793-d447e55c-9ccd-47cc-b287-c18c700f5dbd.mov


**How it works flow:**

```mermaid
graph TD
    A[create-package] --> |select team that will own the package| B(nx migrate-converged-pkg)
    B -->  |adds package root path + team to CODEOWNERS| C[DONE]
```

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/microsoft/fluentui/issues/21844


## Remarks

with this implemented, vNext packages missing owner can add codeowners by running

`yarn nx workspace-generator migrate-converged-pkg --name=@fluentui/react-<name> --owner=@microsoft/<team>`