### PR TITLE
Dropdown: Fixing issue where tabbing once focused on the Dropdown options would restore focus to the current Dropdown instead of going to the next/previous focusable elements

### DIFF
--- a/change/@fluentui-react-44987c53-5d43-4040-92b0-856b0b97a34f.json
+++ b/change/@fluentui-react-44987c53-5d43-4040-92b0-856b0b97a34f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: Fixing issue where tabbing once focused on the Dropdown options would restore focus to the current Dropdown instead of going to the next/previous focusable elements.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -31,7 +31,7 @@ import { ResponsiveMode, useResponsiveMode } from '../../ResponsiveMode';
 import { SelectableOptionMenuItemType, getAllSelectedOptions } from '../../SelectableOption';
 // import and use V7 Checkbox to ensure no breaking changes.
 import { Checkbox } from '../../Checkbox';
-import { getPropsWithDefaults } from '@fluentui/utilities';
+import { getNextElement, getPreviousElement, getPropsWithDefaults } from '@fluentui/utilities';
 import { useMergedRefs, usePrevious } from '@fluentui/react-hooks';
 import type { IStyleFunctionOrObject } from '../../Utilities';
 import type {
@@ -56,7 +56,7 @@ const getClassNames = classNamesFunction<IDropdownStyleProps, IDropdownStyles>()
 // eslint-disable-next-line deprecation/deprecation
 interface IDropdownInternalProps extends Omit<IDropdownProps, 'ref'>, IWithResponsiveModeState {
   hoisted: {
-    rootRef: React.Ref<HTMLDivElement>;
+    rootRef: React.RefObject<HTMLDivElement>;
     selectedIndices: number[];
     setSelectedIndices: React.Dispatch<React.SetStateAction<number[]>>;
   };
@@ -1180,7 +1180,17 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
       case KeyCodes.tab:
         this.setState({ isOpen: false });
-        return;
+
+        const document = getDocument();
+
+        if (document) {
+          if (ev.shiftKey) {
+            getPreviousElement(document.body, this._dropDown.current)?.focus();
+          } else {
+            getNextElement(document.body, this._dropDown.current)?.focus();
+          }
+        }
+        break;
 
       default:
         return;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## PR description

When opening a `Dropdown` component, the focus automatically goes to the first selected option, or the first option in the `Dropdown` if no option has been selected. Tabbing while focus is on one of the options should go to the next/previous focusable element, however, tabbing currently restores focus to the current `Dropdown`.

This is a regression from v7 that is occurring because of the change introduced in #17405 that fixed this focus restoring functionality for components such as `DatePicker` that were not getting focused back when the `Popup` was being dismissed. However, this fix also meant that this logic is now applied to the `Dropdown` component, with focus coming back to the current `Dropdown` always instead of going to the correct next/previous element, as it had been working before by virtue of the focus restoring logic being broken.

This PR restores this tabbing functionality in the `Dropdown` component without removing the focus restoring functionality that's needed for components like `DatePicker`. It does this by making use of our `getNextElement` and `getPreviousElement` utilities when tabbing away from the `Dropdown` options.

## Related Issue(s)

Fixes [ADO issue 13797](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/13797)
