### PR TITLE
Added secondary text styling

### DIFF
--- a/change/@fluentui-react-6bcee362-8474-433d-9c1f-4a4005e02a77.json
+++ b/change/@fluentui-react-6bcee362-8474-433d-9c1f-4a4005e02a77.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed secondary text styling in PeoplePicker Personas when displayed in the input.",
+  "packageName": "@fluentui/react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.Normal.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.Normal.Example.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { Checkbox } from '@fluentui/react/lib/Checkbox';
 import { IPersonaProps } from '@fluentui/react/lib/Persona';
-import { IBasePickerSuggestionsProps, NormalPeoplePicker, ValidationState } from '@fluentui/react/lib/Pickers';
+import {
+  IBasePickerSuggestionsProps,
+  IPeoplePickerItemSelectedProps,
+  NormalPeoplePicker,
+  PeoplePickerItem,
+  ValidationState,
+} from '@fluentui/react/lib/Pickers';
 import { people, mru } from '@fluentui/example-data';
 
 const suggestionProps: IBasePickerSuggestionsProps = {
@@ -23,6 +29,7 @@ const checkboxStyles = {
 export const PeoplePickerNormalExample: React.FunctionComponent = () => {
   const [delayResults, setDelayResults] = React.useState(false);
   const [isPickerDisabled, setIsPickerDisabled] = React.useState(false);
+  const [showSecondaryText, setShowSecondaryText] = React.useState(false);
   const [mostRecentlyUsed, setMostRecentlyUsed] = React.useState<IPersonaProps[]>(mru);
   const [peopleList, setPeopleList] = React.useState<IPersonaProps[]>(people);
 
@@ -79,12 +86,29 @@ export const PeoplePickerNormalExample: React.FunctionComponent = () => {
     }
   };
 
+  const renderItemWithSecondaryText = (props: IPeoplePickerItemSelectedProps) => {
+    const newProps = {
+      ...props,
+      item: {
+        ...props.item,
+        ValidationState: ValidationState.valid,
+        showSecondaryText: true,
+      },
+    };
+
+    return <PeoplePickerItem {...newProps} />;
+  };
+
   const onDisabledButtonClick = (): void => {
     setIsPickerDisabled(!isPickerDisabled);
   };
 
   const onToggleDelayResultsChange = (): void => {
     setDelayResults(!delayResults);
+  };
+
+  const onToggleShowSecondaryText = (): void => {
+    setShowSecondaryText(!showSecondaryText);
   };
 
   return (
@@ -100,6 +124,7 @@ export const PeoplePickerNormalExample: React.FunctionComponent = () => {
         key={'normal'}
         // eslint-disable-next-line react/jsx-no-bind
         onRemoveSuggestion={onRemoveSuggestion}
+        onRenderItem={showSecondaryText ? renderItemWithSecondaryText : undefined}
         onValidateInput={validateInput}
         selectionAriaLabel={'Selected contacts'}
         removeButtonAriaLabel={'Remove'}
@@ -125,6 +150,13 @@ export const PeoplePickerNormalExample: React.FunctionComponent = () => {
         defaultChecked={delayResults}
         // eslint-disable-next-line react/jsx-no-bind
         onChange={onToggleDelayResultsChange}
+        styles={checkboxStyles}
+      />
+      <Checkbox
+        label="Show Secondary Text"
+        defaultChecked={showSecondaryText}
+        // eslint-disable-next-line react/jsx-no-bind
+        onChange={onToggleShowSecondaryText}
         styles={checkboxStyles}
       />
     </div>

--- a/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
+++ b/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
@@ -64,6 +64,22 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
     },
   ];
 
+  const personaSecondaryTextStyles: IStyle = [
+    selected &&
+      !invalid &&
+      !disabled && {
+        color: palette.white,
+        selectors: {
+          ':hover': {
+            color: palette.white,
+          },
+          [HighContrastSelector]: {
+            color: 'HighlightText',
+          },
+        },
+      },
+  ];
+
   const personaCoinInitialsStyles: IStyle = [
     invalid && {
       fontSize: fonts.xLarge.fontSize,
@@ -179,6 +195,7 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
     subComponentStyles: {
       persona: {
         primaryText: personaPrimaryTextStyles,
+        secondaryText: personaSecondaryTextStyles,
       },
       personaCoin: {
         initials: personaCoinInitialsStyles,


### PR DESCRIPTION
## Current Behavior

Secondary text not colored correctly in people picker items when shown and selected. (see issue)

## New Behavior

Secondary text styled correctly.
Added option to NormalPeoplePicker example.

## Related Issue(s)

Fixes #22199
