### PR TITLE
fix: add aria-haspopup for datepicker

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add transparent borders to slider @ling1726 ([#22089](https://github.com/microsoft/fluentui/pull/22089))
 - Fix `Popup` opened from right click (on `context`), to not dismiss when scrolling happens in nested Popup @yaunboxue-amber ([#22087](https://github.com/microsoft/fluentui/pull/22087))
 - Fix `Dropdown` not annoucing placeholder/default value with VoiceOver on macOS @aubreyquinn ([#22173](https://github.com/microsoft/fluentui/pull/22173))
+- Fix `Datepicker` by adding `aria-haspopup="true"` when `allowManualInput` is set to false @chpalac ([#22201](https://github.com/microsoft/fluentui/pull/22201))
 
 <!--------------------------------[ v0.61.0 ]------------------------------- -->
 ## [v0.61.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.61.0) (2022-03-10)

--- a/packages/fluentui/accessibility/src/behaviors/Datepicker/datepickerBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Datepicker/datepickerBehavior.ts
@@ -15,6 +15,7 @@ export const datepickerBehavior: Accessibility<DatepickerBehaviorProps> = props 
     input: {
       'aria-labelledby': props['aria-labelledby'],
       'aria-invalid': props['aria-invalid'],
+      ...(!props.allowManualInput && { 'aria-haspopup': true }),
     },
   },
   keyActions: {
@@ -29,4 +30,5 @@ export const datepickerBehavior: Accessibility<DatepickerBehaviorProps> = props 
 export type DatepickerBehaviorProps = {
   'aria-labelledby'?: AccessibilityAttributes['aria-labelledby'];
   'aria-invalid'?: AccessibilityAttributes['aria-invalid'];
+  allowManualInput?: boolean;
 };

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -390,6 +390,7 @@ export const Datepicker = (React.forwardRef<HTMLDivElement, DatepickerProps>((pr
         createShorthand(Input, input, {
           defaultProps: () =>
             getA11yProps('input', {
+              allowManualInput,
               placeholder: props.inputPlaceholder,
               disabled: props.disabled,
               error: !!error,

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -288,6 +288,7 @@ export const Datepicker = (React.forwardRef<HTMLDivElement, DatepickerProps>((pr
     mapPropsToBehavior: () => ({
       'aria-invalid': ariaInvalid,
       'aria-labelledby': ariaLabelledby,
+      allowManualInput,
     }),
     rtl: context.rtl,
   });
@@ -390,7 +391,6 @@ export const Datepicker = (React.forwardRef<HTMLDivElement, DatepickerProps>((pr
         createShorthand(Input, input, {
           defaultProps: () =>
             getA11yProps('input', {
-              allowManualInput,
               placeholder: props.inputPlaceholder,
               disabled: props.disabled,
               error: !!error,


### PR DESCRIPTION
# Overview 

Fixes: #20979

Add `aria-haspopup="true"` to `DatePicker` input when `allowManualInput` is set to false so screen reader will read it like:

![screenshot](https://user-images.githubusercontent.com/86579954/159829340-2ab3fc69-487c-4d8a-817b-2a68cb9f088a.png)

