### PR TITLE
Azure Theme: Choice Group size fix 

### DIFF
--- a/change/@uifabric-azure-themes-7fe70699-a313-4a60-aff0-537c302a5170.json
+++ b/change/@uifabric-azure-themes-7fe70699-a313-4a60-aff0-537c302a5170.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ChoiceGroup update from 20x to 18px",
+  "packageName": "@uifabric/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-experiments-bf027ce7-9e34-402a-a1e3-4e9ff62576ca.json
+++ b/change/@uifabric-experiments-bf027ce7-9e34-402a-a1e3-4e9ff62576ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ChoiceGroup update from 20x to 18px",
+  "packageName": "@uifabric/experiments",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-file-type-icons-9180bd66-bb22-4b1d-a062-9d0d84af155f.json
+++ b/change/@uifabric-file-type-icons-9180bd66-bb22-4b1d-a062-9d0d84af155f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ChoiceGroup update from 20x to 18px",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-react-cards-9081cfcc-33f5-499b-9943-23b2181fed03.json
+++ b/change/@uifabric-react-cards-9081cfcc-33f5-499b-9943-23b2181fed03.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ChoiceGroup update from 20x to 18px",
+  "packageName": "@uifabric/react-cards",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/Constants.ts
+++ b/packages/azure-themes/src/azure/Constants.ts
@@ -18,6 +18,7 @@ export const fontFamily =
   'Segoe UI, "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue",sans-serif';
 export const fontWeightRegular = '400';
 export const fontWeightBold = '700';
+export const choiceGroupDimensions = '18px';
 export const inputControlHeight = '24px';
 export const inputControlPadding = '12px';
 export const inputControlHeightInner = '20px';

--- a/packages/azure-themes/src/azure/styles/ChoiceGroupOptions.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ChoiceGroupOptions.styles.ts
@@ -58,6 +58,7 @@ export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Pa
           // The dot
           ':after': [
             {
+              borderColor: extendedSemanticColors.checkboxBorderChecked,
               top: 4,
               left: 4,
             },
@@ -80,6 +81,7 @@ export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Pa
                 },
                 ':after': {
                   borderColor: extendedSemanticColors.checkboxBorderChecked,
+                  backgroundColor: extendedSemanticColors.choiceGroupUncheckedDotHover,
                   top: 4,
                   left: 4,
                 },

--- a/packages/azure-themes/src/azure/styles/ChoiceGroupOptions.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ChoiceGroupOptions.styles.ts
@@ -37,6 +37,8 @@ export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Pa
           // The circle
           ':before': [
             {
+              width: StyleConstants.choiceGroupDimensions,
+              height: StyleConstants.choiceGroupDimensions,
               borderColor: semanticColors.bodyText,
             },
             checked && {
@@ -56,7 +58,8 @@ export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Pa
           // The dot
           ':after': [
             {
-              borderColor: extendedSemanticColors.checkboxBorderChecked,
+              top: 4,
+              left: 4,
             },
             checked &&
               disabled && {
@@ -77,7 +80,8 @@ export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Pa
                 },
                 ':after': {
                   borderColor: extendedSemanticColors.checkboxBorderChecked,
-                  backgroundColor: extendedSemanticColors.choiceGroupUncheckedDotHover,
+                  top: 4,
+                  left: 4,
                 },
               },
             },


### PR DESCRIPTION
## Current Behavior
Control was 20x20px
![image](https://user-images.githubusercontent.com/30805892/160480228-2ac3e47a-9a57-43da-a3f8-2fa9970f74f9.png)

## New Behavior
Control now 18x18, the dot inside is same as before. No color changes, so all 4 subthemes (light, dark, and 2 high contrasts) look good. 
![image](https://user-images.githubusercontent.com/30805892/160480023-8ea0e728-3f2f-42da-b659-588ccf0a87c1.png)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes devops # 13782375
