### PR TITLE
Cherry picked from 7.0 branch: reducing ChoiceGroup radio button to 18px

### DIFF
--- a/change/@fluentui-azure-themes-e723c0d2-b2be-4910-97f8-61da88c187ef.json
+++ b/change/@fluentui-azure-themes-e723c0d2-b2be-4910-97f8-61da88c187ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Cherry picked from 7.0 branch: reducing choicegroup radio button to 18px from 20px",
+  "packageName": "@fluentui/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/Constants.ts
+++ b/packages/azure-themes/src/azure/Constants.ts
@@ -18,6 +18,7 @@ export const fontFamily =
 export const fontWeightRegular = '400';
 export const fontWeightBold = '700';
 export const inputControlHeight = '24px';
+export const choiceGroupDimensions = '18px';
 export const inputControlPadding = '12px';
 export const inputControlHeightInner = '20px';
 export const textAlignCenter = 'center';

--- a/packages/azure-themes/src/azure/styles/ChoiceGroupOptions.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ChoiceGroupOptions.styles.ts
@@ -37,6 +37,8 @@ export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Pa
           // The circle
           ':before': [
             {
+              width: StyleConstants.choiceGroupDimensions,
+              height: StyleConstants.choiceGroupDimensions,
               borderColor: semanticColors.bodyText,
             },
             checked && {
@@ -57,6 +59,8 @@ export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Pa
           ':after': [
             {
               borderColor: extendedSemanticColors.checkboxBorderChecked,
+              top: 4,
+              left: 4,
             },
             checked &&
               disabled && {
@@ -78,6 +82,8 @@ export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Pa
                 ':after': {
                   borderColor: extendedSemanticColors.checkboxBorderChecked,
                   backgroundColor: extendedSemanticColors.choiceGroupUncheckedDotHover,
+                  top: 4,
+                  left: 4,
                 },
               },
             },


### PR DESCRIPTION
Cherry picked from 7.0 branch #22227

## Current Behavior
Control was 20x20px
![image](https://user-images.githubusercontent.com/30805892/160480228-2ac3e47a-9a57-43da-a3f8-2fa9970f74f9.png)

## New Behavior
Control now 18x18, the dot inside is same as before. No color changes, so all 4 subthemes (light, dark, and 2 high contrasts) look good. 
![image](https://user-images.githubusercontent.com/30805892/160480023-8ea0e728-3f2f-42da-b659-588ccf0a87c1.png)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes devops # 13782375
