### PR TITLE
chore: move react-conformance to peerDeps to resolve dep issues when RC is bumped

### DIFF
--- a/change/@fluentui-react-conformance-griffel-ff56e60b-7eed-4630-b33e-a69f6feaae95.json
+++ b/change/@fluentui-react-conformance-griffel-ff56e60b-7eed-4630-b33e-a69f6feaae95.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: move react-conformance to peerDeps to resolve dep issues when RC is bumped",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-conformance-griffel/package.json
+++ b/packages/react-conformance-griffel/package.json
@@ -27,10 +27,10 @@
   "peerDependencies": {
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
-    "typescript": "^4.3.0"
+    "typescript": "^4.3.0",
+    "@fluentui/react-conformance": "^0.13.0"
   },
   "dependencies": {
-    "@fluentui/react-conformance": "^0.12.0",
     "@griffel/react": "1.0.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-conformance-griffel/package.json
+++ b/packages/react-conformance-griffel/package.json
@@ -22,7 +22,8 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/react-conformance": "*"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <18.0.0",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

Every time someone bumps `react-conformance` it causes yarn.lock changes as that bump won't bump other packages that use it as dependency (react-conformance-griffel).

> **Additional Notes:**
> even if there was a depedent change type I think it won't be bumped... since we have different scopes with beachball for  v9/8 releases

## New Behavior

Moving RC to `peerDependencies` to avoid this CI failure for good.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
