### PR TITLE
fix(Dropdown examples): selected option custom style example, best practices wording

### DIFF
--- a/packages/react-examples/src/react/Dropdown/Dropdown.SelectStyle.Example.tsx
+++ b/packages/react-examples/src/react/Dropdown/Dropdown.SelectStyle.Example.tsx
@@ -37,12 +37,7 @@ const stackTokens: IStackTokens = { childrenGap: 20 };
 export const DropdownSelectStyleExample: React.FunctionComponent = () => {
   return (
     <Stack tokens={stackTokens}>
-      <Dropdown
-        placeholder="Select an option"
-        label="Basic uncontrolled example"
-        options={options}
-        styles={dropdownStyles}
-      />
+      <Dropdown placeholder="Select an option" label="Favorite Fruit" options={options} styles={dropdownStyles} />
     </Stack>
   );
 };

--- a/packages/react-examples/src/react/Dropdown/Dropdown.SelectStyle.Example.tsx
+++ b/packages/react-examples/src/react/Dropdown/Dropdown.SelectStyle.Example.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { IStackTokens, Stack } from '@fluentui/react/lib/Stack';
+import { Dropdown, DropdownMenuItemType, IDropdownStyles, IDropdownOption } from '@fluentui/react/lib/Dropdown';
+
+const dropdownStyles: Partial<IDropdownStyles> = {
+  dropdown: { width: 300 },
+  dropdownItemSelected: {
+    selectors: {
+      '&:before': {
+        content: '""',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        bottom: 0,
+        width: '4px',
+        background: 'rgb(0, 120, 212)',
+      },
+    },
+  },
+};
+
+const options: IDropdownOption[] = [
+  { key: 'fruitsHeader', text: 'Fruits', itemType: DropdownMenuItemType.Header },
+  { key: 'apple', text: 'Apple' },
+  { key: 'banana', text: 'Banana' },
+  { key: 'orange', text: 'Orange', disabled: true },
+  { key: 'grape', text: 'Grape' },
+  { key: 'divider_1', text: '-', itemType: DropdownMenuItemType.Divider },
+  { key: 'vegetablesHeader', text: 'Vegetables', itemType: DropdownMenuItemType.Header },
+  { key: 'broccoli', text: 'Broccoli' },
+  { key: 'carrot', text: 'Carrot' },
+  { key: 'lettuce', text: 'Lettuce' },
+];
+
+const stackTokens: IStackTokens = { childrenGap: 20 };
+
+export const DropdownSelectStyleExample: React.FunctionComponent = () => {
+  return (
+    <Stack tokens={stackTokens}>
+      <Dropdown
+        placeholder="Select an option"
+        label="Basic uncontrolled example"
+        options={options}
+        styles={dropdownStyles}
+      />
+    </Stack>
+  );
+};

--- a/packages/react-examples/src/react/Dropdown/Dropdown.doc.tsx
+++ b/packages/react-examples/src/react/Dropdown/Dropdown.doc.tsx
@@ -8,6 +8,7 @@ import { DropdownCustomExample } from './Dropdown.Custom.Example';
 import { DropdownWrappingExample } from './Dropdown.Wrapping.Example';
 import { DropdownErrorExample } from './Dropdown.Error.Example';
 import { DropdownRequiredExample } from './Dropdown.Required.Example';
+import { DropdownSelectStyleExample } from './Dropdown.SelectStyle.Example';
 
 const DropdownBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Dropdown/Dropdown.Basic.Example.tsx') as string;
 const DropdownControlledExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Dropdown/Dropdown.Controlled.Example.tsx') as string;
@@ -16,6 +17,7 @@ const DropdownCustomExampleCode = require('!raw-loader?esModule=false!@fluentui/
 const DropdownWrappingExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Dropdown/Dropdown.Wrapping.Example.tsx') as string;
 const DropdownErrorExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Dropdown/Dropdown.Error.Example.tsx') as string;
 const DropdownRequiredExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Dropdown/Dropdown.Required.Example.tsx') as string;
+const DropdownSelectStyleExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Dropdown/Dropdown.SelectStyle.Example.tsx') as string;
 
 export const DropdownPageProps: IDocPageProps = {
   title: 'Dropdown',
@@ -59,6 +61,16 @@ export const DropdownPageProps: IDocPageProps = {
         <>
           <p>This example also demonstrates how to programmatically set focus on and open a Dropdown.</p>
           <DropdownRequiredExample />
+        </>
+      ),
+    },
+    {
+      title: 'Dropdown with custom selected option styles',
+      code: DropdownSelectStyleExampleCode,
+      view: (
+        <>
+          <p>This example demonstrates how to add custom selection styles for better contrast and accessibility.</p>
+          <DropdownSelectStyleExample />
         </>
       ),
     },

--- a/packages/react-examples/src/react/Dropdown/docs/DropdownBestPractices.md
+++ b/packages/react-examples/src/react/Dropdown/docs/DropdownBestPractices.md
@@ -26,3 +26,9 @@ By default, the Dropdown truncates option text instead of wrapping to a new line
 Because this can lose meaningful information, it is recommended to adjust styles to wrap the option text.
 
 The `Dropdown with wrapping option text` example demonstrates how to override truncation styles to support wrapping. The default style will continue to truncate to support existing implementations.
+
+#### Selected Option Styles
+
+The default styles for the selected option in single-select Dropdowns is a light grey background. This doesn't have strong contrast against the default white background, so adding custom selection styles is recommended and demonstrated in the "Dropdown with custom selected option styles" example.
+
+Although the selected item text is displayed in the Dropdown itself, adding additional contrast to the selected option within the list of options adds better accessibility for users with low vision.

--- a/packages/react-examples/src/react/Dropdown/docs/DropdownBestPractices.md
+++ b/packages/react-examples/src/react/Dropdown/docs/DropdownBestPractices.md
@@ -27,7 +27,7 @@ Because this can lose meaningful information, it is recommended to adjust styles
 
 The `Dropdown with wrapping option text` example demonstrates how to override truncation styles to support wrapping. The default style will continue to truncate to support existing implementations.
 
-#### Selected Option Styles
+#### Selected option styles
 
 The default styles for the selected option in single-select Dropdowns is a light grey background. This doesn't have strong contrast against the default white background, so adding custom selection styles is recommended and demonstrated in the "Dropdown with custom selected option styles" example.
 


### PR DESCRIPTION
Fixes [12917](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/12917)

Our current selected option style in Dropdown is very low contrast, but changing the visuals in v7/v8 has a high risk of breaking custom styles for partner teams.

This PR adds wording to the best practices docs about contrast-y selection styles, and adds an example with custom selected option styles.

Current selection styling:
![screenshot of dropdown, showing Apple selected with a very light grey background vs. white unselected items](https://user-images.githubusercontent.com/3819570/160721066-0251d725-a7d7-42da-b5b6-cf3678224bc1.png)

New example:
![screenshot of dropdown, showing Apple selected with a thick blue border to the left of the option text](https://user-images.githubusercontent.com/3819570/160721194-8e754ea6-c557-4328-8d59-eed1e98c4293.png)

