### PR TITLE
Remove enzyme test setup code from converged packages

### DIFF
--- a/packages/priority-overflow/config/tests.js
+++ b/packages/priority-overflow/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-accordion/config/tests.js
+++ b/packages/react-accordion/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-aria/config/tests.js
+++ b/packages/react-aria/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-avatar/config/tests.js
+++ b/packages/react-avatar/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-badge/config/tests.js
+++ b/packages/react-badge/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-button/config/tests.js
+++ b/packages/react-button/config/tests.js
@@ -1,6 +1,1 @@
 /** Jest test setup file. */
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-card/config/tests.js
+++ b/packages/react-card/config/tests.js
@@ -1,6 +1,1 @@
 /** Jest test setup file. */
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-checkbox/config/tests.js
+++ b/packages/react-checkbox/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-combobox/config/tests.js
+++ b/packages/react-combobox/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-dialog/config/tests.js
+++ b/packages/react-dialog/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-divider/config/tests.js
+++ b/packages/react-divider/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-image/config/tests.js
+++ b/packages/react-image/config/tests.js
@@ -1,6 +1,1 @@
 /** Jest test setup file. */
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-input/config/tests.js
+++ b/packages/react-input/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-label/config/tests.js
+++ b/packages/react-label/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-link/config/tests.js
+++ b/packages/react-link/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-menu/config/tests.js
+++ b/packages/react-menu/config/tests.js
@@ -1,9 +1,3 @@
 /** Jest test setup file. */
 
 require('@testing-library/jest-dom');
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-popover/config/tests.js
+++ b/packages/react-popover/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-portal/config/tests.js
+++ b/packages/react-portal/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-provider/config/tests.js
+++ b/packages/react-provider/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-radio/config/tests.js
+++ b/packages/react-radio/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-select/config/tests.js
+++ b/packages/react-select/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-shared-contexts/config/tests.js
+++ b/packages/react-shared-contexts/config/tests.js
@@ -1,6 +1,1 @@
 /** Jest test setup file. */
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-slider/config/tests.js
+++ b/packages/react-slider/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-spinbutton/config/tests.js
+++ b/packages/react-spinbutton/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-spinner/config/tests.js
+++ b/packages/react-spinner/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-switch/config/tests.js
+++ b/packages/react-switch/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-tabs/config/tests.js
+++ b/packages/react-tabs/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-text/config/tests.js
+++ b/packages/react-text/config/tests.js
@@ -1,9 +1,3 @@
 /** Jest test setup file. */
 
 require('@testing-library/jest-dom');
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-textarea/config/tests.js
+++ b/packages/react-textarea/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-theme/config/tests.js
+++ b/packages/react-theme/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-toolbar/config/tests.js
+++ b/packages/react-toolbar/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-tooltip/config/tests.js
+++ b/packages/react-tooltip/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-utilities/config/tests.js
+++ b/packages/react-utilities/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/scripts/beachball/.beachballrc.base.json
+++ b/scripts/beachball/.beachballrc.base.json
@@ -10,6 +10,7 @@
     "**/__fixtures__/**",
     "**/__mocks__/**",
     "**/common/isConformant.ts",
+    "**/config/tests.js",
     "**/jest.config.js",
     "**/SPEC*.md",
     "**/tests/**"

--- a/scripts/create-package/plop-templates-react/config/tests.js
+++ b/scripts/create-package/plop-templates-react/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -443,21 +443,13 @@ describe('migrate-converged-pkg generator', () => {
         return tree.read(jestSetupFilePath)?.toString('utf-8');
       }
 
-      let content = getJestSetupFile();
-      expect(content).toMatchInlineSnapshot(`"/** Jest test setup file. */"`);
-
-      await generator(tree, options);
-
-      content = getJestSetupFile();
-      expect(content).toMatchInlineSnapshot(`"/** Jest test setup file. */"`);
-
       tree.delete(jestSetupFilePath);
       expect(tree.exists(jestSetupFilePath)).toBeFalsy();
 
       await generator(tree, options);
 
-      content = getJestSetupFile();
-      expect(content).toMatchInlineSnapshot(`"/** Jest test setup file. */"`);
+      expect(tree.exists(jestSetupFilePath)).toBeTruthy();
+      expect(getJestSetupFile()).toMatchInlineSnapshot(`"/** Jest test setup file. */"`);
     });
   });
 

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -444,28 +444,12 @@ describe('migrate-converged-pkg generator', () => {
       }
 
       let content = getJestSetupFile();
-      expect(content).toMatchInlineSnapshot(`
-        "/** Jest test setup file. */
-
-        const { configure } = require('enzyme');
-        const Adapter = require('enzyme-adapter-react-16');
-
-        // Configure enzyme.
-        configure({ adapter: new Adapter() });"
-      `);
+      expect(content).toMatchInlineSnapshot(`"/** Jest test setup file. */"`);
 
       await generator(tree, options);
 
       content = getJestSetupFile();
-      expect(content).toMatchInlineSnapshot(`
-        "/** Jest test setup file. */
-
-        const { configure } = require('enzyme');
-        const Adapter = require('enzyme-adapter-react-16');
-
-        // Configure enzyme.
-        configure({ adapter: new Adapter() });"
-      `);
+      expect(content).toMatchInlineSnapshot(`"/** Jest test setup file. */"`);
 
       tree.delete(jestSetupFilePath);
       expect(tree.exists(jestSetupFilePath)).toBeFalsy();
@@ -1242,12 +1226,6 @@ function setupDummyPackage(
     `,
     jestSetupFile: stripIndents`
      /** Jest test setup file. */
-
-    const { configure } = require('enzyme');
-    const Adapter = require('enzyme-adapter-react-16');
-
-    // Configure enzyme.
-    configure({ adapter: new Adapter() });
     `,
     npmConfig: stripIndents`
       *.api.json

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -753,7 +753,19 @@ function updateLocalJestConfig(tree: Tree, options: NormalizedSchema) {
 
   tree.write(options.paths.jestConfig, templates.jest(config));
 
-  if (!tree.exists(jestSetupFilePath)) {
+  if (tree.exists(jestSetupFilePath)) {
+    const content = tree.read(jestSetupFilePath)!.toString('utf-8');
+    const newContent = content.replace(
+      stripIndents`const { configure } = require('enzyme');
+        const Adapter = require('enzyme-adapter-react-16');
+
+        // Configure enzyme.
+        configure({ adapter: new Adapter() });"
+      `,
+      '',
+    );
+    tree.write(jestSetupFilePath, newContent);
+  } else {
     tree.write(jestSetupFilePath, templates.jestSetup);
   }
 

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -753,19 +753,7 @@ function updateLocalJestConfig(tree: Tree, options: NormalizedSchema) {
 
   tree.write(options.paths.jestConfig, templates.jest(config));
 
-  if (tree.exists(jestSetupFilePath)) {
-    const content = tree.read(jestSetupFilePath)!.toString('utf-8');
-    const newContent = content.replace(
-      stripIndents`const { configure } = require('enzyme');
-        const Adapter = require('enzyme-adapter-react-16');
-
-        // Configure enzyme.
-        configure({ adapter: new Adapter() });"
-      `,
-      '',
-    );
-    tree.write(jestSetupFilePath, newContent);
-  } else {
+  if (!tree.exists(jestSetupFilePath)) {
     tree.write(jestSetupFilePath, templates.jestSetup);
   }
 


### PR DESCRIPTION
## Current Behavior

After #22009, react-conformance no longer uses enzyme, which means converged packages no longer use enzyme at all. But they still have setup for it in their test setup files.

## New Behavior

Remove Enzyme test setup from converged packages.

~Through a build failure, I discovered that `@fluentui/a11y-testing` still uses Enzyme, so `@fluentui/react-button` and `@fluentui/react-link` must keep their Enzyme setup for now.~ 
- Fixed https://github.com/microsoft/fluentui/pull/22262

This is tracked by an item in #21663 or I can make a separate issue.

Also add `**/config/tests.js` to the list of files ignored by beachball, since those will never affect the published packages (that path should have already been ignored but it was an unintentional omission).

## Related Issue(s)

Fixes #22118
