### PR TITLE
CommandBar (v8): convert tests to use testing-library

### DIFF
--- a/packages/react/src/components/CommandBar/CommandBar.test.tsx
+++ b/packages/react/src/components/CommandBar/CommandBar.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, within } from '@testing-library/react';
+import { act, render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CommandBar } from './CommandBar';
 import { isConformant } from '../../common/isConformant';
@@ -9,6 +9,12 @@ import type { IContextualMenuItem } from '../../ContextualMenu';
 describe('CommandBar', () => {
   beforeEach(() => {
     resetIds();
+  });
+
+  afterEach(() => {
+    if ((setTimeout as any).mock) {
+      jest.useRealTimers();
+    }
   });
 
   it('renders commands correctly', () => {
@@ -46,6 +52,8 @@ describe('CommandBar', () => {
   });
 
   it('opens a menu with IContextualMenuItem.subMenuProps.items property', () => {
+    jest.useFakeTimers();
+
     const { getByRole } = render(
       <CommandBar
         items={[
@@ -66,13 +74,20 @@ describe('CommandBar', () => {
         ]}
       />,
     );
+    //Initial rendering of component is "hidden" while measurements are made
+    // therefore we need to wait a bit before getting roles.
+    act(() => {
+      jest.runAllTimers();
+    });
 
-    const menuItem = getByRole('menuitem', { hidden: true });
+    const menuItem = getByRole('menuitem');
     userEvent.click(menuItem);
     expect(getByRole('menu')).toBeTruthy();
   });
 
   it('passes event and item to button onClick callbacks', () => {
+    jest.useFakeTimers();
+
     let testValue: IContextualMenuItem | undefined;
 
     const itemData: IContextualMenuItem = {
@@ -89,12 +104,20 @@ describe('CommandBar', () => {
 
     const { getByRole } = render(<CommandBar items={[itemData]} />);
 
-    const menuItem = getByRole('menuitem', { hidden: true });
+    //Initial rendering of component is "hidden" while measurements are made
+    // therefore we need to wait a bit before getting roles.
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const menuItem = getByRole('menuitem');
     userEvent.click(menuItem);
     expect(testValue).toEqual(itemData);
   });
 
   it('keeps menu open after update if item is still present', () => {
+    jest.useFakeTimers();
+
     const items = [
       {
         text: 'TestText 1',
@@ -112,7 +135,13 @@ describe('CommandBar', () => {
     ];
     const { getByRole, rerender } = render(<CommandBar items={items} />);
 
-    const menuItem = getByRole('menuitem', { hidden: true });
+    //Initial rendering of component is "hidden" while measurements are made
+    // therefore we need to wait a bit before getting roles.
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const menuItem = getByRole('menuitem');
     userEvent.click(menuItem);
 
     // Make sure the menu is open before the re-render
@@ -126,32 +155,42 @@ describe('CommandBar', () => {
     });
     rerender(<CommandBar items={items} />);
 
+    act(() => {
+      jest.runAllTimers();
+    });
+
     // Make sure the menu is still open after the re-render
     expect(getByRole('menu')).toBeTruthy();
   });
 
-  it('closes menu after update if item is not longer present', () => {
-    const { getByRole, queryByRole, rerender } = render(
-      <CommandBar
-        items={[
-          {
-            text: 'TestText 1',
-            key: 'TestKey1',
-            subMenuProps: {
-              items: [
-                {
-                  text: 'SubmenuText 1',
-                  key: 'SubmenuKey1',
-                  className: 'SubMenuClass',
-                },
-              ],
-            },
-          },
-        ]}
-      />,
-    );
+  it('closes menu after update if item is no longer present', () => {
+    jest.useFakeTimers();
 
-    const menuItem = getByRole('menuitem', { hidden: true });
+    const items = [
+      {
+        text: 'TestText 1',
+        key: 'TestKey1',
+        subMenuProps: {
+          items: [
+            {
+              text: 'SubmenuText 1',
+              key: 'SubmenuKey1',
+              className: 'SubMenuClass',
+            },
+          ],
+        },
+      },
+    ];
+
+    const { getByRole, queryByRole, rerender } = render(<CommandBar items={items} />);
+
+    //Initial rendering of component is "hidden" while measurements are made
+    // therefore we need to wait a bit before getting roles.
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const menuItem = getByRole('menuitem');
     userEvent.click(menuItem);
 
     // Make sure the menu is open before the re-render
@@ -160,11 +199,17 @@ describe('CommandBar', () => {
     // Update the props, and re-render
     rerender(<CommandBar items={[]} />);
 
+    act(() => {
+      jest.runAllTimers();
+    });
+
     // Make sure the menu is still open after the re-render
     expect(queryByRole('menu')).toBeNull();
   });
 
   it('passes overflowButton menuProps to the menu, and prepend menuProps.items to top of overflow', () => {
+    jest.useFakeTimers();
+
     const items = [
       {
         name: 'Text1',
@@ -192,7 +237,13 @@ describe('CommandBar', () => {
       />,
     );
 
-    const overflowMenuButton = getAllByRole('menuitem', { hidden: true })[1];
+    //Initial rendering of component is "hidden" while measurements are made
+    // therefore we need to wait a bit before getting roles.
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const overflowMenuButton = getAllByRole('menuitem')[1];
     userEvent.click(overflowMenuButton);
 
     const overfowItems = within(getByRole('menu')).getAllByRole('menuitem');
@@ -204,6 +255,8 @@ describe('CommandBar', () => {
   });
 
   it('updates menu after update if item is still present', () => {
+    jest.useFakeTimers();
+
     const items = (subMenuItemClassName: string) => [
       {
         name: 'TestText 1',
@@ -222,7 +275,13 @@ describe('CommandBar', () => {
 
     const { getByRole, rerender } = render(<CommandBar items={items('SubMenuClass')} />);
 
-    const menuItem = getByRole('menuitem', { hidden: true });
+    //Initial rendering of component is "hidden" while measurements are made
+    // therefore we need to wait a bit before getting roles.
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const menuItem = getByRole('menuitem');
 
     userEvent.click(menuItem);
 
@@ -231,6 +290,10 @@ describe('CommandBar', () => {
 
     // Update the props, and re-render
     rerender(<CommandBar items={items('SubMenuClassUpdate')} />);
+
+    act(() => {
+      jest.runAllTimers();
+    });
 
     // Make sure the menu is still open after the re-render
     expect(getByRole('menu').querySelector('.SubMenuClassUpdate')).toBeTruthy();

--- a/packages/react/src/components/CommandBar/CommandBar.test.tsx
+++ b/packages/react/src/components/CommandBar/CommandBar.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import * as renderer from 'react-test-renderer';
-
+import { render, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { CommandBar } from './CommandBar';
-import { mount } from 'enzyme';
 import { isConformant } from '../../common/isConformant';
 import { resetIds } from '../../Utilities';
 import type { IContextualMenuItem } from '../../ContextualMenu';
@@ -12,45 +11,30 @@ describe('CommandBar', () => {
     resetIds();
   });
 
-  afterEach(() => {
-    for (let i = 0; i < document.body.children.length; i++) {
-      if (document.body.children[i].tagName === 'DIV') {
-        document.body.removeChild(document.body.children[i]);
-        i--;
-      }
-    }
-  });
-
   it('renders commands correctly', () => {
-    expect(
-      renderer
-        .create(
-          <CommandBar
-            items={[
-              { key: '1', text: 'asdf' },
-              { key: '2', text: 'asdf' },
-            ]}
-            className={'TestClassName'}
-          />,
-        )
-        .toJSON(),
-    ).toMatchSnapshot();
+    const { container } = render(
+      <CommandBar
+        items={[
+          { key: '1', text: 'asdf' },
+          { key: '2', text: 'asdf' },
+        ]}
+        className={'TestClassName'}
+      />,
+    );
+    expect(container).toMatchSnapshot();
   });
 
   it('renders empty farItems correctly', () => {
-    expect(
-      renderer
-        .create(
-          <CommandBar
-            items={[
-              { key: '1', text: 'asdf' },
-              { key: '2', text: 'asdf' },
-            ]}
-            farItems={[]}
-          />,
-        )
-        .toJSON(),
-    ).toMatchSnapshot();
+    const { container } = render(
+      <CommandBar
+        items={[
+          { key: '1', text: 'asdf' },
+          { key: '2', text: 'asdf' },
+        ]}
+        farItems={[]}
+      />,
+    );
+    expect(container).toMatchSnapshot();
   });
 
   isConformant({
@@ -62,7 +46,7 @@ describe('CommandBar', () => {
   });
 
   it('opens a menu with IContextualMenuItem.subMenuProps.items property', () => {
-    const commandBar = mount(
+    const { getByRole } = render(
       <CommandBar
         items={[
           {
@@ -83,13 +67,9 @@ describe('CommandBar', () => {
       />,
     );
 
-    const menuItem = commandBar.find('.MenuItem button');
-
-    expect(menuItem.length).toEqual(1);
-
-    menuItem.simulate('click');
-
-    expect(document.querySelector('.SubMenuClass')).toBeTruthy();
+    const menuItem = getByRole('menuitem', { hidden: true });
+    userEvent.click(menuItem);
+    expect(getByRole('menu')).toBeTruthy();
   });
 
   it('passes event and item to button onClick callbacks', () => {
@@ -107,59 +87,51 @@ describe('CommandBar', () => {
       },
     };
 
-    const commandBar = mount(<CommandBar items={[itemData]} />);
+    const { getByRole } = render(<CommandBar items={[itemData]} />);
 
-    const menuItem = commandBar.find('.MenuItem button');
-
-    menuItem.simulate('click');
-
+    const menuItem = getByRole('menuitem', { hidden: true });
+    userEvent.click(menuItem);
     expect(testValue).toEqual(itemData);
   });
 
   it('keeps menu open after update if item is still present', () => {
-    const commandBar = mount(
-      <CommandBar
-        items={[
-          {
-            text: 'TestText 1',
-            key: 'TestKey1',
-            subMenuProps: {
-              items: [
-                {
-                  text: 'SubmenuText 1',
-                  key: 'SubmenuKey1',
-                  className: 'SubMenuClass',
-                },
-              ],
+    const items = [
+      {
+        text: 'TestText 1',
+        key: 'TestKey1',
+        subMenuProps: {
+          items: [
+            {
+              text: 'SubmenuText 1',
+              key: 'SubmenuKey1',
+              className: 'SubMenuClass',
             },
-          },
-        ]}
-      />,
-    );
+          ],
+        },
+      },
+    ];
+    const { getByRole, rerender } = render(<CommandBar items={items} />);
 
-    const menuItem = commandBar.find('button');
-
-    menuItem.simulate('click');
+    const menuItem = getByRole('menuitem', { hidden: true });
+    userEvent.click(menuItem);
 
     // Make sure the menu is open before the re-render
-    expect(document.querySelector('.SubMenuClass')).toBeTruthy();
+    expect(getByRole('menu')).toBeTruthy();
 
     // Update the props, and re-render
-    commandBar.setProps({
-      items: commandBar.props().items.concat([
-        {
-          name: 'Test Key 2',
-          key: 'TestKey2',
-        },
-      ]),
+    items.push({
+      text: 'Test Key 2',
+      key: 'TestKey2',
+      subMenuProps: { items: [{ text: 'SubmenuText 2', key: 'SubmenuKey2', className: 'SubmenuClass' }] },
     });
+    rerender(<CommandBar items={items} />);
 
     // Make sure the menu is still open after the re-render
-    expect(document.querySelector('.SubMenuClass')).toBeTruthy();
+    expect(getByRole('menu')).toBeTruthy();
   });
 
   it('closes menu after update if item is not longer present', () => {
-    const commandBar = mount(
+    const { getByRole, queryByRole, rerender } = render(
       <CommandBar
         items={[
           {
@@ -179,20 +151,17 @@ describe('CommandBar', () => {
       />,
     );
 
-    const menuItem = commandBar.find('button');
-
-    menuItem.simulate('click');
+    const menuItem = getByRole('menuitem', { hidden: true });
+    userEvent.click(menuItem);
 
     // Make sure the menu is open before the re-render
-    expect(document.querySelector('.SubMenuClass')).toBeTruthy();
+    expect(getByRole('menu')).toBeTruthy();
 
     // Update the props, and re-render
-    commandBar.setProps({
-      items: [],
-    });
+    rerender(<CommandBar items={[]} />);
 
     // Make sure the menu is still open after the re-render
-    expect(document.querySelector('.SubMenuClass')).toBeFalsy();
+    expect(queryByRole('menu')).toBeNull();
   });
 
   it('passes overflowButton menuProps to the menu, and prepend menuProps.items to top of overflow', () => {
@@ -210,7 +179,7 @@ describe('CommandBar', () => {
       },
     ];
 
-    const commandBar = mount(
+    const { getByRole, getAllByRole } = render(
       <CommandBar
         overflowButtonProps={{
           menuProps: {
@@ -223,16 +192,15 @@ describe('CommandBar', () => {
       />,
     );
 
-    const overflowMenuButton = commandBar.find('.ms-CommandBar-overflowButton');
+    const overflowMenuButton = getAllByRole('menuitem', { hidden: true })[1];
+    userEvent.click(overflowMenuButton);
 
-    overflowMenuButton.hostNodes().simulate('click');
-
-    const overfowItems = document.querySelectorAll('.ms-ContextualMenu-item');
+    const overfowItems = within(getByRole('menu')).getAllByRole('menuitem');
 
     expect(overfowItems).toHaveLength(2);
     expect(overfowItems[0].textContent).toEqual('Text3');
     expect(overfowItems[1].textContent).toEqual('Text2');
-    expect(document.querySelectorAll('.customMenuClass')).toHaveLength(1);
+    expect(getByRole('menu').querySelectorAll('.customMenuClass')!.length).toEqual(1);
   });
 
   it('updates menu after update if item is still present', () => {
@@ -252,21 +220,19 @@ describe('CommandBar', () => {
       },
     ];
 
-    const commandBar = mount(<CommandBar items={items('SubMenuClass')} />);
+    const { getByRole, rerender } = render(<CommandBar items={items('SubMenuClass')} />);
 
-    const menuItem = commandBar.find('button');
+    const menuItem = getByRole('menuitem', { hidden: true });
 
-    menuItem.simulate('click');
+    userEvent.click(menuItem);
 
     // Make sure the menu is open before the re-render
-    expect(document.querySelector('.SubMenuClass')).toBeTruthy();
+    expect(getByRole('menu')).toBeTruthy();
 
-    // Re-render
-    commandBar.setProps({
-      items: items('SubMenuClassUpdate'),
-    });
+    // Update the props, and re-render
+    rerender(<CommandBar items={items('SubMenuClassUpdate')} />);
 
     // Make sure the menu is still open after the re-render
-    expect(document.querySelector('.SubMenuClassUpdate')).toBeTruthy();
+    expect(getByRole('menu').querySelector('.SubMenuClassUpdate')).toBeTruthy();
   });
 });

--- a/packages/react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -1,350 +1,330 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CommandBar renders commands correctly 1`] = `
-<div
-  className="TestClassName"
->
+<div>
   <div
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
+    class="TestClassName"
   >
     <div
-      data-automation-id="visibleContent"
-      style={
-        Object {
-          "position": "fixed",
-          "visibility": "hidden",
-        }
-      }
+      style="position: relative;"
     >
       <div
-        className=
-            ms-FocusZone
-            ms-CommandBar
-            &:focus {
-              outline: none;
-            }
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: #ffffff;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              padding-bottom: 0;
-              padding-left: 24px;
-              padding-right: 14px;
-              padding-top: 0;
-            }
-        data-focuszone-id="FocusZone0"
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="menubar"
+        data-automation-id="visibleContent"
+        style="position: fixed; visibility: hidden;"
       >
         <div
-          className=
-              ms-OverflowSet
-              ms-CommandBar-primaryCommand
-              {
-                align-items: stretch;
-                display: flex;
-                flex-grow: 1;
-                flex-wrap: nowrap;
-                position: relative;
+          class=
+              ms-FocusZone
+              ms-CommandBar
+              &:focus {
+                outline: none;
               }
-          role="none"
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #ffffff;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 44px;
+                padding-bottom: 0;
+                padding-left: 24px;
+                padding-right: 14px;
+                padding-top: 0;
+              }
+          data-focuszone-id="FocusZone0"
+          role="menubar"
         >
           <div
-            className=
-                ms-OverflowSet-item
+            class=
+                ms-OverflowSet
+                ms-CommandBar-primaryCommand
                 {
-                  display: inherit;
-                  flex-shrink: 0;
+                  align-items: stretch;
+                  display: flex;
+                  flex-grow: 1;
+                  flex-wrap: nowrap;
+                  position: relative;
                 }
             role="none"
           >
-            <button
-              className=
-                  ms-Button
-                  ms-Button--commandBar
-                  ms-CommandBarItem-link
+            <div
+              class=
+                  ms-OverflowSet-item
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    background-color: #ffffff;
-                    border-radius: 0px;
-                    border: none;
-                    box-sizing: border-box;
-                    color: #323130;
-                    cursor: pointer;
-                    display: inline-block;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 100%;
-                    min-width: 40px;
-                    outline: transparent;
-                    padding-bottom: 0;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 0;
-                    position: relative;
-                    text-align: center;
-                    text-decoration: none;
-                    user-select: none;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
-                  &::-moz-focus-inner {
-                    border: 0;
-                  }
-                  .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid transparent;
-                    bottom: 3px;
-                    content: "";
-                    left: 3px;
-                    outline: 1px solid #605e5c;
-                    position: absolute;
-                    right: 3px;
-                    top: 3px;
-                    z-index: 1;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                    border: none;
-                    bottom: 4px;
-                    left: 4px;
-                    outline-color: ButtonText;
-                    right: 4px;
-                    top: 4px;
-                  }
-                  &:active > * {
-                    left: 0px;
-                    position: relative;
-                    top: 0px;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                    border: none;
-                  }
-                  &:hover {
-                    background-color: #f3f2f1;
-                    color: #201f1e;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                    color: Highlight;
-                  }
-                  &:hover .ms-Button-icon {
-                    color: #106ebe;
-                  }
-                  &:hover .ms-Button-menuIcon {
-                    color: #323130;
-                  }
-                  &:active {
-                    background-color: #edebe9;
-                    color: #201f1e;
-                  }
-                  &:active .ms-Button-icon {
-                    color: #005a9e;
-                  }
-                  &:active .ms-Button-menuIcon {
-                    color: #323130;
-                  }
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              role="menuitem"
-              type="button"
+              role="none"
             >
-              <span
-                className=
-                    ms-Button-flexContainer
+              <button
+                class=
+                    ms-Button
+                    ms-Button--commandBar
+                    ms-CommandBarItem-link
                     {
-                      align-items: center;
-                      display: flex;
-                      flex-wrap: nowrap;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
                       height: 100%;
-                      justify-content: center;
+                      min-width: 40px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                     }
-                data-automationid="splitbuttonprimary"
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid transparent;
+                      bottom: 3px;
+                      content: "";
+                      left: 3px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 3px;
+                      top: 3px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: 4px;
+                      left: 4px;
+                      outline-color: ButtonText;
+                      right: 4px;
+                      top: 4px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      border: none;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #106ebe;
+                    }
+                    &:hover .ms-Button-menuIcon {
+                      color: #323130;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #005a9e;
+                    }
+                    &:active .ms-Button-menuIcon {
+                      color: #323130;
+                    }
+                data-is-focusable="true"
+                role="menuitem"
+                tabindex="0"
+                type="button"
               >
                 <span
-                  className=
-                      ms-Button-textContainer
+                  class=
+                      ms-Button-flexContainer
                       {
-                        display: block;
-                        flex-grow: 1;
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
                       }
+                  data-automationid="splitbuttonprimary"
                 >
                   <span
-                    className=
-                        ms-Button-label
+                    class=
+                        ms-Button-textContainer
                         {
                           display: block;
-                          font-weight: normal;
-                          line-height: 100%;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                          white-space: nowrap;
+                          flex-grow: 1;
                         }
-                    id="id__1"
                   >
-                    asdf
+                    <span
+                      class=
+                          ms-Button-label
+                          {
+                            display: block;
+                            font-weight: normal;
+                            line-height: 100%;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            white-space: nowrap;
+                          }
+                      id="id__1"
+                    >
+                      asdf
+                    </span>
                   </span>
                 </span>
-              </span>
-            </button>
-          </div>
-          <div
-            className=
-                ms-OverflowSet-item
-                {
-                  display: inherit;
-                  flex-shrink: 0;
-                }
-            role="none"
-          >
-            <button
-              className=
-                  ms-Button
-                  ms-Button--commandBar
-                  ms-CommandBarItem-link
+              </button>
+            </div>
+            <div
+              class=
+                  ms-OverflowSet-item
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    background-color: #ffffff;
-                    border-radius: 0px;
-                    border: none;
-                    box-sizing: border-box;
-                    color: #323130;
-                    cursor: pointer;
-                    display: inline-block;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 100%;
-                    min-width: 40px;
-                    outline: transparent;
-                    padding-bottom: 0;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 0;
-                    position: relative;
-                    text-align: center;
-                    text-decoration: none;
-                    user-select: none;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
-                  &::-moz-focus-inner {
-                    border: 0;
-                  }
-                  .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid transparent;
-                    bottom: 3px;
-                    content: "";
-                    left: 3px;
-                    outline: 1px solid #605e5c;
-                    position: absolute;
-                    right: 3px;
-                    top: 3px;
-                    z-index: 1;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                    border: none;
-                    bottom: 4px;
-                    left: 4px;
-                    outline-color: ButtonText;
-                    right: 4px;
-                    top: 4px;
-                  }
-                  &:active > * {
-                    left: 0px;
-                    position: relative;
-                    top: 0px;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                    border: none;
-                  }
-                  &:hover {
-                    background-color: #f3f2f1;
-                    color: #201f1e;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                    color: Highlight;
-                  }
-                  &:hover .ms-Button-icon {
-                    color: #106ebe;
-                  }
-                  &:hover .ms-Button-menuIcon {
-                    color: #323130;
-                  }
-                  &:active {
-                    background-color: #edebe9;
-                    color: #201f1e;
-                  }
-                  &:active .ms-Button-icon {
-                    color: #005a9e;
-                  }
-                  &:active .ms-Button-menuIcon {
-                    color: #323130;
-                  }
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              role="menuitem"
-              type="button"
+              role="none"
             >
-              <span
-                className=
-                    ms-Button-flexContainer
+              <button
+                class=
+                    ms-Button
+                    ms-Button--commandBar
+                    ms-CommandBarItem-link
                     {
-                      align-items: center;
-                      display: flex;
-                      flex-wrap: nowrap;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
                       height: 100%;
-                      justify-content: center;
+                      min-width: 40px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                     }
-                data-automationid="splitbuttonprimary"
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid transparent;
+                      bottom: 3px;
+                      content: "";
+                      left: 3px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 3px;
+                      top: 3px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: 4px;
+                      left: 4px;
+                      outline-color: ButtonText;
+                      right: 4px;
+                      top: 4px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      border: none;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #106ebe;
+                    }
+                    &:hover .ms-Button-menuIcon {
+                      color: #323130;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #005a9e;
+                    }
+                    &:active .ms-Button-menuIcon {
+                      color: #323130;
+                    }
+                data-is-focusable="true"
+                role="menuitem"
+                tabindex="-1"
+                type="button"
               >
                 <span
-                  className=
-                      ms-Button-textContainer
+                  class=
+                      ms-Button-flexContainer
                       {
-                        display: block;
-                        flex-grow: 1;
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
                       }
+                  data-automationid="splitbuttonprimary"
                 >
                   <span
-                    className=
-                        ms-Button-label
+                    class=
+                        ms-Button-textContainer
                         {
                           display: block;
-                          font-weight: normal;
-                          line-height: 100%;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                          white-space: nowrap;
+                          flex-grow: 1;
                         }
-                    id="id__4"
                   >
-                    asdf
+                    <span
+                      class=
+                          ms-Button-label
+                          {
+                            display: block;
+                            font-weight: normal;
+                            line-height: 100%;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            white-space: nowrap;
+                          }
+                      id="id__4"
+                    >
+                      asdf
+                    </span>
                   </span>
                 </span>
-              </span>
-            </button>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -355,347 +335,327 @@ exports[`CommandBar renders commands correctly 1`] = `
 
 exports[`CommandBar renders empty farItems correctly 1`] = `
 <div>
-  <div
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-  >
+  <div>
     <div
-      data-automation-id="visibleContent"
-      style={
-        Object {
-          "position": "fixed",
-          "visibility": "hidden",
-        }
-      }
+      style="position: relative;"
     >
       <div
-        className=
-            ms-FocusZone
-            ms-CommandBar
-            &:focus {
-              outline: none;
-            }
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: #ffffff;
-              display: flex;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              padding-bottom: 0;
-              padding-left: 24px;
-              padding-right: 14px;
-              padding-top: 0;
-            }
-        data-focuszone-id="FocusZone0"
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="menubar"
+        data-automation-id="visibleContent"
+        style="position: fixed; visibility: hidden;"
       >
         <div
-          className=
-              ms-OverflowSet
-              ms-CommandBar-primaryCommand
-              {
-                align-items: stretch;
-                display: flex;
-                flex-grow: 1;
-                flex-wrap: nowrap;
-                position: relative;
+          class=
+              ms-FocusZone
+              ms-CommandBar
+              &:focus {
+                outline: none;
               }
-          role="none"
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #ffffff;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 44px;
+                padding-bottom: 0;
+                padding-left: 24px;
+                padding-right: 14px;
+                padding-top: 0;
+              }
+          data-focuszone-id="FocusZone0"
+          role="menubar"
         >
           <div
-            className=
-                ms-OverflowSet-item
+            class=
+                ms-OverflowSet
+                ms-CommandBar-primaryCommand
                 {
-                  display: inherit;
-                  flex-shrink: 0;
+                  align-items: stretch;
+                  display: flex;
+                  flex-grow: 1;
+                  flex-wrap: nowrap;
+                  position: relative;
                 }
             role="none"
           >
-            <button
-              className=
-                  ms-Button
-                  ms-Button--commandBar
-                  ms-CommandBarItem-link
+            <div
+              class=
+                  ms-OverflowSet-item
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    background-color: #ffffff;
-                    border-radius: 0px;
-                    border: none;
-                    box-sizing: border-box;
-                    color: #323130;
-                    cursor: pointer;
-                    display: inline-block;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 100%;
-                    min-width: 40px;
-                    outline: transparent;
-                    padding-bottom: 0;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 0;
-                    position: relative;
-                    text-align: center;
-                    text-decoration: none;
-                    user-select: none;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
-                  &::-moz-focus-inner {
-                    border: 0;
-                  }
-                  .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid transparent;
-                    bottom: 3px;
-                    content: "";
-                    left: 3px;
-                    outline: 1px solid #605e5c;
-                    position: absolute;
-                    right: 3px;
-                    top: 3px;
-                    z-index: 1;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                    border: none;
-                    bottom: 4px;
-                    left: 4px;
-                    outline-color: ButtonText;
-                    right: 4px;
-                    top: 4px;
-                  }
-                  &:active > * {
-                    left: 0px;
-                    position: relative;
-                    top: 0px;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                    border: none;
-                  }
-                  &:hover {
-                    background-color: #f3f2f1;
-                    color: #201f1e;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                    color: Highlight;
-                  }
-                  &:hover .ms-Button-icon {
-                    color: #106ebe;
-                  }
-                  &:hover .ms-Button-menuIcon {
-                    color: #323130;
-                  }
-                  &:active {
-                    background-color: #edebe9;
-                    color: #201f1e;
-                  }
-                  &:active .ms-Button-icon {
-                    color: #005a9e;
-                  }
-                  &:active .ms-Button-menuIcon {
-                    color: #323130;
-                  }
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              role="menuitem"
-              type="button"
+              role="none"
             >
-              <span
-                className=
-                    ms-Button-flexContainer
+              <button
+                class=
+                    ms-Button
+                    ms-Button--commandBar
+                    ms-CommandBarItem-link
                     {
-                      align-items: center;
-                      display: flex;
-                      flex-wrap: nowrap;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
                       height: 100%;
-                      justify-content: center;
+                      min-width: 40px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                     }
-                data-automationid="splitbuttonprimary"
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid transparent;
+                      bottom: 3px;
+                      content: "";
+                      left: 3px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 3px;
+                      top: 3px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: 4px;
+                      left: 4px;
+                      outline-color: ButtonText;
+                      right: 4px;
+                      top: 4px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      border: none;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #106ebe;
+                    }
+                    &:hover .ms-Button-menuIcon {
+                      color: #323130;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #005a9e;
+                    }
+                    &:active .ms-Button-menuIcon {
+                      color: #323130;
+                    }
+                data-is-focusable="true"
+                role="menuitem"
+                tabindex="0"
+                type="button"
               >
                 <span
-                  className=
-                      ms-Button-textContainer
+                  class=
+                      ms-Button-flexContainer
                       {
-                        display: block;
-                        flex-grow: 1;
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
                       }
+                  data-automationid="splitbuttonprimary"
                 >
                   <span
-                    className=
-                        ms-Button-label
+                    class=
+                        ms-Button-textContainer
                         {
                           display: block;
-                          font-weight: normal;
-                          line-height: 100%;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                          white-space: nowrap;
+                          flex-grow: 1;
                         }
-                    id="id__1"
                   >
-                    asdf
+                    <span
+                      class=
+                          ms-Button-label
+                          {
+                            display: block;
+                            font-weight: normal;
+                            line-height: 100%;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            white-space: nowrap;
+                          }
+                      id="id__1"
+                    >
+                      asdf
+                    </span>
                   </span>
                 </span>
-              </span>
-            </button>
-          </div>
-          <div
-            className=
-                ms-OverflowSet-item
-                {
-                  display: inherit;
-                  flex-shrink: 0;
-                }
-            role="none"
-          >
-            <button
-              className=
-                  ms-Button
-                  ms-Button--commandBar
-                  ms-CommandBarItem-link
+              </button>
+            </div>
+            <div
+              class=
+                  ms-OverflowSet-item
                   {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    background-color: #ffffff;
-                    border-radius: 0px;
-                    border: none;
-                    box-sizing: border-box;
-                    color: #323130;
-                    cursor: pointer;
-                    display: inline-block;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 100%;
-                    min-width: 40px;
-                    outline: transparent;
-                    padding-bottom: 0;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 0;
-                    position: relative;
-                    text-align: center;
-                    text-decoration: none;
-                    user-select: none;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
-                  &::-moz-focus-inner {
-                    border: 0;
-                  }
-                  .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid transparent;
-                    bottom: 3px;
-                    content: "";
-                    left: 3px;
-                    outline: 1px solid #605e5c;
-                    position: absolute;
-                    right: 3px;
-                    top: 3px;
-                    z-index: 1;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                    border: none;
-                    bottom: 4px;
-                    left: 4px;
-                    outline-color: ButtonText;
-                    right: 4px;
-                    top: 4px;
-                  }
-                  &:active > * {
-                    left: 0px;
-                    position: relative;
-                    top: 0px;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                    border: none;
-                  }
-                  &:hover {
-                    background-color: #f3f2f1;
-                    color: #201f1e;
-                  }
-                  @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                    color: Highlight;
-                  }
-                  &:hover .ms-Button-icon {
-                    color: #106ebe;
-                  }
-                  &:hover .ms-Button-menuIcon {
-                    color: #323130;
-                  }
-                  &:active {
-                    background-color: #edebe9;
-                    color: #201f1e;
-                  }
-                  &:active .ms-Button-icon {
-                    color: #005a9e;
-                  }
-                  &:active .ms-Button-menuIcon {
-                    color: #323130;
-                  }
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              role="menuitem"
-              type="button"
+              role="none"
             >
-              <span
-                className=
-                    ms-Button-flexContainer
+              <button
+                class=
+                    ms-Button
+                    ms-Button--commandBar
+                    ms-CommandBarItem-link
                     {
-                      align-items: center;
-                      display: flex;
-                      flex-wrap: nowrap;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
                       height: 100%;
-                      justify-content: center;
+                      min-width: 40px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                     }
-                data-automationid="splitbuttonprimary"
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid transparent;
+                      bottom: 3px;
+                      content: "";
+                      left: 3px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 3px;
+                      top: 3px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: 4px;
+                      left: 4px;
+                      outline-color: ButtonText;
+                      right: 4px;
+                      top: 4px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                      border: none;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                    }
+                    @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #106ebe;
+                    }
+                    &:hover .ms-Button-menuIcon {
+                      color: #323130;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #005a9e;
+                    }
+                    &:active .ms-Button-menuIcon {
+                      color: #323130;
+                    }
+                data-is-focusable="true"
+                role="menuitem"
+                tabindex="-1"
+                type="button"
               >
                 <span
-                  className=
-                      ms-Button-textContainer
+                  class=
+                      ms-Button-flexContainer
                       {
-                        display: block;
-                        flex-grow: 1;
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
                       }
+                  data-automationid="splitbuttonprimary"
                 >
                   <span
-                    className=
-                        ms-Button-label
+                    class=
+                        ms-Button-textContainer
                         {
                           display: block;
-                          font-weight: normal;
-                          line-height: 100%;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                          white-space: nowrap;
+                          flex-grow: 1;
                         }
-                    id="id__4"
                   >
-                    asdf
+                    <span
+                      class=
+                          ms-Button-label
+                          {
+                            display: block;
+                            font-weight: normal;
+                            line-height: 100%;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            white-space: nowrap;
+                          }
+                      id="id__4"
+                    >
+                      asdf
+                    </span>
                   </span>
                 </span>
-              </span>
-            </button>
+              </button>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Current Behavior

- v8 `CommandBar` tests don't use testing-library

## New Behavior

- Convert `CommandBar` to fully use testing-library

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

part of #21663 