### PR TITLE
Update Jest config types

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -10,7 +10,7 @@ const tsPathAliases = pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
 });
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 const baseConfig = {
   transform: {

--- a/packages/bundle-size/jest.config.js
+++ b/packages/bundle-size/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'bundle-size',

--- a/packages/keyboard-keys/jest.config.js
+++ b/packages/keyboard-keys/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'keyboard-keys',

--- a/packages/priority-overflow/jest.config.js
+++ b/packages/priority-overflow/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'priority-overflow',

--- a/packages/react-accordion/jest.config.js
+++ b/packages/react-accordion/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-accordion',

--- a/packages/react-aria/jest.config.js
+++ b/packages/react-aria/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-aria',

--- a/packages/react-avatar/jest.config.js
+++ b/packages/react-avatar/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-avatar',

--- a/packages/react-badge/jest.config.js
+++ b/packages/react-badge/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-badge',

--- a/packages/react-button/jest.config.js
+++ b/packages/react-button/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-button',

--- a/packages/react-card/jest.config.js
+++ b/packages/react-card/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-card',

--- a/packages/react-checkbox/jest.config.js
+++ b/packages/react-checkbox/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-checkbox',

--- a/packages/react-combobox/jest.config.js
+++ b/packages/react-combobox/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-combobox',

--- a/packages/react-components/jest.config.js
+++ b/packages/react-components/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-components',

--- a/packages/react-conformance-griffel/jest.config.js
+++ b/packages/react-conformance-griffel/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-conformance-griffel',

--- a/packages/react-context-selector/jest.config.js
+++ b/packages/react-context-selector/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-context-selector',

--- a/packages/react-dialog/jest.config.js
+++ b/packages/react-dialog/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-dialog',

--- a/packages/react-divider/jest.config.js
+++ b/packages/react-divider/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-divider',

--- a/packages/react-image/jest.config.js
+++ b/packages/react-image/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-image',

--- a/packages/react-input/jest.config.js
+++ b/packages/react-input/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-input',

--- a/packages/react-label/jest.config.js
+++ b/packages/react-label/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-label',

--- a/packages/react-link/jest.config.js
+++ b/packages/react-link/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-link',

--- a/packages/react-menu/jest.config.js
+++ b/packages/react-menu/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-menu',

--- a/packages/react-popover/jest.config.js
+++ b/packages/react-popover/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-popover',

--- a/packages/react-portal/jest.config.js
+++ b/packages/react-portal/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-portal',

--- a/packages/react-positioning/jest.config.js
+++ b/packages/react-positioning/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-positioning',

--- a/packages/react-priority-overflow/jest.config.js
+++ b/packages/react-priority-overflow/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-priority-overflow',

--- a/packages/react-provider/jest.config.js
+++ b/packages/react-provider/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-provider',

--- a/packages/react-radio/jest.config.js
+++ b/packages/react-radio/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-radio',

--- a/packages/react-select/jest.config.js
+++ b/packages/react-select/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-select',

--- a/packages/react-shared-contexts/jest.config.js
+++ b/packages/react-shared-contexts/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-shared-contexts',

--- a/packages/react-slider/jest.config.js
+++ b/packages/react-slider/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-slider',

--- a/packages/react-spinbutton/jest.config.js
+++ b/packages/react-spinbutton/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-spinbutton',

--- a/packages/react-spinner/jest.config.js
+++ b/packages/react-spinner/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-spinner',

--- a/packages/react-storybook-addon/jest.config.js
+++ b/packages/react-storybook-addon/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-storybook-addon',

--- a/packages/react-storybook/jest.config.js
+++ b/packages/react-storybook/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-storybook',

--- a/packages/react-switch/jest.config.js
+++ b/packages/react-switch/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-switch',

--- a/packages/react-tabs/jest.config.js
+++ b/packages/react-tabs/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-tabs',

--- a/packages/react-tabster/jest.config.js
+++ b/packages/react-tabster/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-tabster',

--- a/packages/react-text/jest.config.js
+++ b/packages/react-text/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-text',

--- a/packages/react-textarea/jest.config.js
+++ b/packages/react-textarea/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-textarea',

--- a/packages/react-theme/jest.config.js
+++ b/packages/react-theme/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-theme',

--- a/packages/react-toolbar/jest.config.js
+++ b/packages/react-toolbar/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-toolbar',

--- a/packages/react-tooltip/jest.config.js
+++ b/packages/react-tooltip/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-tooltip',

--- a/packages/react-utilities/jest.config.js
+++ b/packages/react-utilities/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'react-utilities',

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -392,7 +392,7 @@ describe('migrate-converged-pkg generator', () => {
         "// @ts-check
 
         /**
-        * @type {jest.InitialOptions}
+        * @type {import('@jest/types').Config.InitialOptions}
         */
         module.exports = {
         displayName: 'react-dummy',

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -214,7 +214,7 @@ const templates = {
       // @ts-check
 
       /**
-      * @type {jest.InitialOptions}
+      * @type {import('@jest/types').Config.InitialOptions}
       */
       module.exports = {
         displayName: '${options.pkgName}',

--- a/tools/jest.config.js
+++ b/tools/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'tools',


### PR DESCRIPTION
## Current Behavior

Jest configs were typed as `jest.InitialOptions` which no longer resolves properly.

## New Behavior

Change the types to `import('@jest/types').Config.InitialOptions`