### PR TITLE
Use spawn for prettier runner for windows compat

### DIFF
--- a/scripts/prettier/prettier-helpers.js
+++ b/scripts/prettier/prettier-helpers.js
@@ -1,8 +1,7 @@
 // @ts-check
 const path = require('path');
 const fs = require('fs');
-const execSync = require('../exec-sync');
-const exec = require('../exec');
+const { spawn, spawnSync } = require('child_process');
 const findGitRoot = require('../monorepo/findGitRoot');
 
 const repoRoot = findGitRoot();
@@ -74,10 +73,10 @@ function runPrettier(files, config = {}) {
   ].join(' ');
 
   if (runAsync) {
-    return exec(cmd, undefined, undefined, process);
+    return spawn(cmd, { shell: true });
   }
 
-  return execSync(cmd);
+  return spawnSync(cmd, { shell: true });
 }
 
 /**


### PR DESCRIPTION
## Current Behavior

Prettier is executed by a custom `exec-sync` wrapper that we have in the repo. `exec` seems to cause issues that `node` does not exist in path on windows.

```
Command failed: node E:\projects\fluentui\node_modules\prettier\bin-prettier.js --config E:\projects\fluentui\prettier.config.js --ignore-path "E:\projects\fluentui\.prettierignore" --write E:\projects\fluentui\packages\fluentui\add-a-feature.md
```

## New Behavior

Now uses native `spawn` and `spawnSync` which is similar to another windows fix in #21509.

