### PR TITLE
adjust slider styles to match contrast ratios

### DIFF
--- a/change/@fluentui-react-676587fb-05b6-4230-92fc-290587f81d9d.json
+++ b/change/@fluentui-react-676587fb-05b6-4230-92fc-290587f81d9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adjust slider styles to match contrast ratios",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Slider/Slider.styles.ts
+++ b/packages/react/src/components/Slider/Slider.styles.ts
@@ -27,7 +27,7 @@ const GlobalClassNames = {
 
 export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
   const { className, titleLabelClassName, theme, vertical, disabled, showTransitions, showValue, ranged } = props;
-  const { semanticColors } = theme;
+  const { semanticColors, palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   /** Tokens:
@@ -35,9 +35,9 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
    *   The word "inactive" in the token refers to the unselected section of the slider */
   const pressedActiveSectionColor = semanticColors.inputBackgroundCheckedHovered;
   const hoveredActiveSectionColor = semanticColors.inputBackgroundChecked;
-  const hoveredPressedinactiveSectionColor = semanticColors.inputPlaceholderBackgroundChecked;
-  const restActiveSectionColor = semanticColors.smallInputBorder;
-  const restInactiveSectionColor = semanticColors.disabledBorder;
+  const hoveredPressedinactiveSectionColor = palette.neutralSecondaryAlt;
+  const restActiveSectionColor = palette.neutralPrimary;
+  const restInactiveSectionColor = palette.neutralSecondaryAlt;
 
   const disabledActiveSectionColor = semanticColors.disabledText;
   const disabledInactiveSectionColor = semanticColors.disabledBackground;

--- a/packages/react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -107,13 +107,13 @@ exports[`Slider renders correctly 1`] = `
               background-color: Highlight;
             }
             &:active .ms-Slider-inactive {
-              background-color: #deecf9;
+              background-color: #8a8886;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-inactive {
               border-color: Highlight;
             }
             &:hover .ms-Slider-inactive {
-              background-color: #deecf9;
+              background-color: #8a8886;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-inactive {
               border-color: Highlight;
@@ -189,7 +189,7 @@ exports[`Slider renders correctly 1`] = `
                   width: 100%;
                 }
                 {
-                  background: #c8c6c4;
+                  background: #8a8886;
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -207,7 +207,7 @@ exports[`Slider renders correctly 1`] = `
                   width: 100%;
                 }
                 {
-                  background: #605e5c;
+                  background: #323130;
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -225,7 +225,7 @@ exports[`Slider renders correctly 1`] = `
                   width: 100%;
                 }
                 {
-                  background: #c8c6c4;
+                  background: #8a8886;
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -389,13 +389,13 @@ exports[`Slider renders range slider correctly 1`] = `
               background-color: Highlight;
             }
             &:active .ms-Slider-inactive {
-              background-color: #deecf9;
+              background-color: #8a8886;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active .ms-Slider-inactive {
               border-color: Highlight;
             }
             &:hover .ms-Slider-inactive {
-              background-color: #deecf9;
+              background-color: #8a8886;
             }
             @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover .ms-Slider-inactive {
               border-color: Highlight;
@@ -538,7 +538,7 @@ exports[`Slider renders range slider correctly 1`] = `
                   width: 100%;
                 }
                 {
-                  background: #c8c6c4;
+                  background: #8a8886;
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -556,7 +556,7 @@ exports[`Slider renders range slider correctly 1`] = `
                   width: 100%;
                 }
                 {
-                  background: #605e5c;
+                  background: #323130;
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
@@ -574,7 +574,7 @@ exports[`Slider renders range slider correctly 1`] = `
                   width: 100%;
                 }
                 {
-                  background: #c8c6c4;
+                  background: #8a8886;
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
                 @media screen and (-ms-high-contrast: active), (forced-colors: active){& {


### PR DESCRIPTION
new WCAG 2.1 rules specify that UI which indicate state and boundaries, needs to meet a 3:1 contrast radio. The current v8 slider styles does not match that. 
(both right side of the rail colors are below 3:1)
![image](https://user-images.githubusercontent.com/1434956/160916411-5c59ef50-44e4-45db-83b1-779bb4994afe.png)
![image](https://user-images.githubusercontent.com/1434956/160916457-96998976-63a9-449d-bd0c-57fcad1e8d32.png)

Proposed solution is to bump up the default grays used for the default state, and then only change the 'progress' color on hover. This was chosen to fix the problem with the least change from the original styles (rather than moving over to the v9 approach). We also are not changing the right side on hover due to no palette lighter palette colors that meet the 3:1 ratio. This split blue/gray approach matches our v9 style, so we're at least moving towards v9 styles there.

I also used palette over semantic in that the original semantic names were meaningless, and picking another random semantic name with that color seemed just as meaningless.

```
  const hoveredPressedinactiveSectionColor = palette.neutralSecondaryAlt;
  const restActiveSectionColor = palette.neutralPrimary;
  const restInactiveSectionColor = palette.neutralSecondaryAlt;
```

![image](https://user-images.githubusercontent.com/1434956/160916994-15a66b11-3192-4e8b-827b-044e1dd62f34.png)
![image](https://user-images.githubusercontent.com/1434956/160917014-28211873-1b21-47e7-80b0-c75c1fd2a44f.png)
