### PR TITLE
Convert a11y-testing package to testing-library

### DIFF
--- a/packages/a11y-testing/package.json
+++ b/packages/a11y-testing/package.json
@@ -25,8 +25,9 @@
     "tslib": "^2.1.0"
   },
   "peerDependencies": {
-    "enzyme": "^3.0.0",
     "jest": "^26.0.0",
+    "@testing-library/react": "^12.0.0",
+    "@testing-library/user-event": "^13.0.0",
     "react": ">=16.8.0 <18.0.0"
   }
 }


### PR DESCRIPTION
## Current Behavior

While working on #22245 I discovered that `@fluentui/a11y-testing` (used by northstar, react-button, and react-link) still uses Enzyme.

## New Behavior

Switch the package to use testing-library. I also simplified some of the logic in the one base file that was modified.

## Related Issue(s)

Part of #21663