### PR TITLE
ColorPicker (v8): convert tests to use testing-library

### DIFF
--- a/packages/react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -1,18 +1,12 @@
 import * as React from 'react';
-import * as renderer from 'react-test-renderer';
-import { mount, ReactWrapper } from 'enzyme';
-import * as ReactTestUtils from 'react-dom/test-utils';
+import { render, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { ColorPicker } from './ColorPicker';
 import { ColorPickerBase } from './ColorPicker.base';
 import { resetIds } from '../../Utilities';
 import { getColorFromString } from '../../utilities/color/getColorFromString';
-import { mockEvent } from '../../common/testUtilities';
-import { ColorRectangleBase } from './ColorRectangle/ColorRectangle.base';
-import { ColorSliderBase } from './ColorSlider/ColorSlider.base';
-import { TooltipHost } from '../../Tooltip';
 import { isConformant } from '../../common/isConformant';
-import type { IColorPickerState } from './ColorPicker.base';
 import type { IColorPickerProps, IColorPickerStrings } from './ColorPicker.types';
 import type { IColor } from '../../utilities/color/interfaces';
 
@@ -28,7 +22,6 @@ describe('ColorPicker', () => {
     resetIds();
   });
 
-  let wrapper: ReactWrapper<IColorPickerProps, IColorPickerState, ColorPickerBase> | undefined;
   let colorPicker: ColorPickerBase | null = null;
   const colorPickerRef = (ref: ColorPickerBase | null) => {
     colorPicker = ref;
@@ -48,9 +41,12 @@ describe('ColorPicker', () => {
   }
 
   /** Verify that the text inputs have the correct values */
-  function verifyInputs(color: IColor, alphaType: IColorPickerProps['alphaType'] = 'alpha') {
+  function verifyInputs(
+    inputs: HTMLInputElement[],
+    color: IColor,
+    alphaType: IColorPickerProps['alphaType'] = 'alpha',
+  ) {
     const hasAlpha = alphaType !== 'none';
-    const inputs = wrapper!.getDOMNode().querySelectorAll('input') as NodeListOf<HTMLInputElement>;
     expect(inputs).toHaveLength(hasAlpha ? 5 : 4);
     expect(inputs[0].value).toBe(color.hex);
     expect(inputs[1].value).toBe(String(color.r));
@@ -74,31 +70,24 @@ describe('ColorPicker', () => {
   }
 
   afterEach(() => {
-    if (wrapper) {
-      wrapper.unmount();
-      wrapper = undefined;
-    }
     updatedColor = undefined;
     // clear onChange calls
     onChange.mockClear();
   });
 
   it('renders correctly', () => {
-    const component = renderer.create(<ColorPicker color="#abcdef" />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<ColorPicker color="#abcdef" />);
+    expect(container).toMatchSnapshot();
   });
 
   it('renders correctly with preview', () => {
-    const component = renderer.create(<ColorPicker color="#abcdef" showPreview />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<ColorPicker color="#abcdef" showPreview />);
+    expect(container).toMatchSnapshot();
   });
 
   it('renders correctly with transparency', () => {
-    const component = renderer.create(<ColorPicker color="#abcdef" alphaType="transparency" />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<ColorPicker color="#abcdef" alphaType="transparency" />);
+    expect(container).toMatchSnapshot();
   });
 
   isConformant({
@@ -110,89 +99,99 @@ describe('ColorPicker', () => {
   });
 
   it('uses provided color string', () => {
-    wrapper = mount(<ColorPicker color={abcdef.str} onChange={noOp} componentRef={colorPickerRef} />);
+    const { getAllByRole } = render(<ColorPicker color={abcdef.str} onChange={noOp} componentRef={colorPickerRef} />);
 
     expect(colorPicker!.color.hex).toEqual(abcdef.hex);
-    verifyInputs(abcdef);
+    const inputs = getAllByRole('textbox') as HTMLInputElement[];
+    verifyInputs(inputs, abcdef);
   });
 
   it('uses provided color object', () => {
-    wrapper = mount(<ColorPicker color={abcdef} onChange={noOp} componentRef={colorPickerRef} />);
+    const { getAllByRole } = render(<ColorPicker color={abcdef} onChange={noOp} componentRef={colorPickerRef} />);
 
     expect(colorPicker!.color).toEqual(abcdef);
-    verifyInputs(abcdef);
+    const inputs = getAllByRole('textbox') as HTMLInputElement[];
+    verifyInputs(inputs, abcdef);
   });
 
   it('handles color object with 0 values correctly', () => {
-    wrapper = mount(<ColorPicker color={black} onChange={noOp} componentRef={colorPickerRef} />);
+    const { getAllByRole } = render(<ColorPicker color={black} onChange={noOp} componentRef={colorPickerRef} />);
+    const inputs = getAllByRole('textbox') as HTMLInputElement[];
     // Inputs should not have empty strings
-    verifyInputs(black);
+    verifyInputs(inputs, black);
   });
 
   it('respects color prop change', () => {
-    wrapper = mount(<ColorPicker color="#abcdef" onChange={onChange} componentRef={colorPickerRef} />);
+    const { getAllByRole, rerender } = render(
+      <ColorPicker color="#abcdef" onChange={onChange} componentRef={colorPickerRef} />,
+    );
 
-    wrapper.setProps({ color: AEAEAE.str });
+    rerender(<ColorPicker color={AEAEAE.str} onChange={onChange} componentRef={colorPickerRef} />);
     expect(colorPicker!.color.hex).toEqual(AEAEAE.hex);
-    verifyInputs(AEAEAE);
+    const inputs = getAllByRole('textbox') as HTMLInputElement[];
+    verifyInputs(inputs, AEAEAE);
     // shouldn't call onChange when the consumer updates the color prop
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 
   it('ignores invalid updates to color prop', () => {
-    wrapper = mount(<ColorPicker color={abcdef} onChange={onChange} componentRef={colorPickerRef} />);
+    const { getAllByRole, rerender } = render(
+      <ColorPicker color={abcdef} onChange={onChange} componentRef={colorPickerRef} />,
+    );
 
-    wrapper.setProps({ color: 'foo' });
+    rerender(<ColorPicker color={'foo'} onChange={onChange} componentRef={colorPickerRef} />);
     expect(colorPicker!.color.hex).toEqual(abcdef.hex);
-    verifyInputs(abcdef);
+    const inputs = getAllByRole('textbox') as HTMLInputElement[];
+    verifyInputs(inputs, abcdef);
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 
   it('hides alpha control slider', () => {
-    wrapper = mount(<ColorPicker color={white} alphaType="none" />);
+    const { getAllByRole, queryByRole } = render(<ColorPicker color={white} alphaType="none" />);
 
-    const alphaSlider = wrapper.find('.is-alpha');
-    const tableHeaders = wrapper.find('thead td');
+    const alphaSlider = queryByRole('slider', { name: 'Alpha' });
+    const tableHeaders = getAllByRole('group')[1].firstElementChild!.firstElementChild!.children;
 
     // There should only be table headers and inputs for hex, red, green, and blue (no alpha)
-    expect(alphaSlider.exists()).toBe(false);
+    expect(alphaSlider).toBeFalsy();
     expect(tableHeaders).toHaveLength(4);
-    verifyInputs(white, 'none');
+    const inputs = getAllByRole('textbox') as HTMLInputElement[];
+    verifyInputs(inputs, white, 'none');
   });
 
   it('shows preview box', () => {
-    wrapper = mount(<ColorPicker color="#FFFFFF" showPreview={true} />);
+    const { getAllByRole } = render(<ColorPicker color="#FFFFFF" showPreview={true} />);
 
-    const previewBox = wrapper.find('.is-preview');
+    const previewBox = getAllByRole('group')[0].querySelector('.is-preview');
 
     // There should be one preview box
-    expect(previewBox.exists()).toBe(true);
+    expect(previewBox).toBeTruthy();
   });
 
   it('hides preview box', () => {
-    wrapper = mount(<ColorPicker color="#FFFFFF" showPreview={false} />);
+    const { getAllByRole } = render(<ColorPicker color="#FFFFFF" showPreview={false} />);
 
-    const previewBox = wrapper.find('.is-preview');
+    const previewBox = getAllByRole('group')[0].querySelector('.is-preview');
 
     // There should be one preview box
-    expect(previewBox.exists()).toBe(false);
+    expect(previewBox).toBeFalsy();
   });
 
   it('renders default RGBA/Hex strings', () => {
-    wrapper = mount(<ColorPicker color="#FFFFFF" />);
+    const { getAllByRole } = render(<ColorPicker color="#FFFFFF" />);
 
-    const tableHeaders = wrapper.find('thead td');
+    const tableHeaders = Array.from(getAllByRole('group')[1].firstElementChild!.firstElementChild!.children);
     const strings = ColorPickerBase.defaultProps.strings!;
     const textHeaders = [strings.hex, strings.red, strings.green, strings.blue, strings.alpha];
 
     tableHeaders.forEach((node, index) => {
-      expect(node.text()).toEqual(textHeaders[index]);
+      expect(node.textContent).toEqual(textHeaders[index]);
     });
 
     // also check the corresponding aria labels
-    const inputs = wrapper.find('input');
+    const inputs = getAllByRole('textbox') as HTMLInputElement[];
     inputs.forEach((node, index) => {
-      expect(node.prop('aria-label')).toEqual(textHeaders[index]);
+      expect(node.getAttribute('aria-label')).toEqual(textHeaders[index]);
     });
   });
 
@@ -210,62 +209,67 @@ describe('ColorPicker', () => {
       hueAriaLabel: 'custom hue',
     };
 
-    wrapper = mount(<ColorPicker color="#FFFFFF" strings={customStrings} />);
+    const { getAllByRole } = render(<ColorPicker color="#FFFFFF" strings={customStrings} />);
 
-    const tableHeaders = wrapper.find('thead td');
+    const tableHeaders = Array.from(getAllByRole('group')[1].firstElementChild!.firstElementChild!.children);
     tableHeaders.forEach((node, index) => {
-      expect(node.text()).toEqual(fields[index]);
+      expect(node.textContent).toEqual(fields[index]);
     });
 
     // Check for the aria strings in the HTML of the corresponding components (simplest way
     // to verify ColorPicker is passing custom values through correctly)
-    const rectangleHtml = wrapper.find(ColorRectangleBase).html();
-    expect(rectangleHtml).toContain(customStrings.svAriaLabel);
-    expect(rectangleHtml).toContain(customStrings.svAriaDescription);
-    expect(rectangleHtml).toContain(customStrings.svAriaValueFormat);
+    const rectangleHtml = getAllByRole('slider')[0];
+    expect(rectangleHtml.getAttribute('aria-label')).toEqual(customStrings.svAriaLabel);
+    expect(rectangleHtml.firstElementChild!.textContent).toEqual(customStrings.svAriaDescription);
+    expect(rectangleHtml.getAttribute('aria-valuetext')).toEqual(customStrings.svAriaValueFormat);
 
-    const sliders = wrapper.find(ColorSliderBase);
-    expect(sliders.at(0).html()).toContain(customStrings.hueAriaLabel);
-    expect(sliders.at(1).html()).toContain('Custom Alpha');
+    const sliders = getAllByRole('slider');
+    expect(sliders[1].getAttribute('aria-label')).toEqual(customStrings.hueAriaLabel);
+    expect(sliders[2].getAttribute('aria-label')).toEqual('Custom Alpha');
   });
 
   it('uses default aria label', () => {
-    wrapper = mount(<ColorPicker color="#abcdef" />);
-    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe(
+    const { getAllByRole, rerender } = render(<ColorPicker color="#abcdef" />);
+    expect(getAllByRole('group')[0].getAttribute('aria-label')).toBe(
       'Color picker, Red 171 Green 205 Blue 239 Alpha 100% selected.',
     );
 
-    wrapper.setProps({ color: 'rgba(255, 0, 0, 0.5)' });
-    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe(
+    rerender(<ColorPicker color="rgba(255, 0, 0, 0.5)" />);
+
+    expect(getAllByRole('group')[0].getAttribute('aria-label')).toBe(
       'Color picker, Red 255 Green 0 Blue 0 Alpha 50% selected.',
     );
   });
 
   it('can use custom aria label', () => {
-    wrapper = mount(<ColorPicker color="#abcdef" strings={{ rootAriaLabelFormat: 'custom color picker {0}' }} />);
-    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe(
+    const { getAllByRole } = render(
+      <ColorPicker color="#abcdef" strings={{ rootAriaLabelFormat: 'custom color picker {0}' }} />,
+    );
+    expect(getAllByRole('group')[0].getAttribute('aria-label')).toBe(
       'custom color picker Red 171 Green 205 Blue 239 Alpha 100%',
     );
   });
 
   it('handles transparency', () => {
     const color = getColorFromString('rgba(20, 30, 40, 0.3)')!;
-    wrapper = mount(
+    const { getAllByRole } = render(
       <ColorPicker color={color} alphaType="transparency" onChange={noOp} componentRef={colorPickerRef} />,
     );
 
     expect(colorPicker!.color).toEqual(color);
-    verifyInputs(color, 'transparency');
+    const inputs = getAllByRole('textbox') as HTMLInputElement[];
+    verifyInputs(inputs, color, 'transparency');
 
-    const tableHeaders = wrapper.find('thead td');
-    expect(tableHeaders.at(4).text()).toBe('Transparency');
+    const tableHeaders = Array.from(getAllByRole('group')[1].firstElementChild!.firstElementChild!.children);
+
+    expect(tableHeaders[4].textContent).toBe('Transparency');
   });
 
   it('keeps color value when tabbing between Hex and RGBA text inputs', () => {
     const colorStringValue = 'abcdef';
     const colorChangeSpy = jest.fn();
     const inputClassName = 'input-tab-test';
-    wrapper = mount(
+    const { getAllByRole } = render(
       <ColorPicker
         color={`#${colorStringValue}`}
         onChange={colorChangeSpy}
@@ -278,12 +282,12 @@ describe('ColorPicker', () => {
     expect(colorChangeSpy).toHaveBeenCalledTimes(0);
 
     // Tab between text inputs checking state after each time.
-    const allInputs = wrapper.find(`.${inputClassName} input`);
-    expect(allInputs.length).toBe(5);
+    const inputs = getAllByRole('textbox') as HTMLInputElement[];
+    expect(inputs.length).toBe(5);
 
-    allInputs.forEach(input => {
-      input.simulate('focus');
-      input.simulate('blur');
+    inputs.forEach(input => {
+      userEvent.tab();
+      userEvent.tab({ shift: true });
 
       expect(colorPicker!.color.hex).toEqual(colorStringValue);
       expect(colorChangeSpy).toHaveBeenCalledTimes(0);
@@ -291,40 +295,46 @@ describe('ColorPicker', () => {
   });
 
   it('allows updating text fields', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+    const { container, getAllByRole } = render(
+      <ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />,
+    );
 
-    const inputs = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input') as NodeListOf<HTMLInputElement>;
+    const inputs = getAllByRole('textbox') as HTMLInputElement[];
 
     const redInput = inputs[1];
-    ReactTestUtils.Simulate.input(redInput, mockEvent('255'));
+    userEvent.clear(redInput);
+    userEvent.paste(redInput, '255');
     validateChange({ calls: 1, prop: 'str', value: '#ff0000' });
     validateChange({ calls: 1, prop: 'r', value: 255, input: redInput });
     // blur and make sure nothing changes
-    ReactTestUtils.Simulate.blur(redInput);
+    userEvent.click(container);
     validateChange({ calls: 1, prop: 'str', value: '#ff0000' });
 
     const hexInput = inputs[0];
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('00ff00'));
+    userEvent.clear(hexInput);
+    userEvent.paste(hexInput, '00ff00');
     validateChange({ calls: 2, prop: 'str', value: '#00ff00' });
     validateChange({ calls: 2, prop: 'hex', value: '00ff00', input: hexInput });
-    ReactTestUtils.Simulate.blur(hexInput);
+    userEvent.click(container);
     validateChange({ calls: 2, prop: 'str', value: '#00ff00' });
 
     const alphaInput = inputs[4];
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('50'));
-    ReactTestUtils.Simulate.blur(alphaInput);
+    userEvent.clear(alphaInput);
+    userEvent.paste(alphaInput, '50');
+    userEvent.click(container);
     validateChange({ calls: 3, prop: 'str', value: 'rgba(0, 255, 0, 0.5)' });
     validateChange({ calls: 3, prop: 'a', value: 50 });
   });
 
   it('handles updating transparency text field', () => {
-    wrapper = mount(
+    const { getAllByRole } = render(
       <ColorPicker alphaType="transparency" onChange={onChange} color="#000000" componentRef={colorPickerRef} />,
     );
 
-    const transparencyInput = wrapper.getDOMNode().querySelectorAll('input')[4];
+    const transparencyInput = getAllByRole('textbox')[4] as HTMLInputElement;
 
-    ReactTestUtils.Simulate.input(transparencyInput, mockEvent('30'));
+    userEvent.clear(transparencyInput);
+    userEvent.paste(transparencyInput, '30');
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(updatedColor!.t).toBe(30);
     expect(colorPicker!.color.t).toBe(30);
@@ -335,23 +345,27 @@ describe('ColorPicker', () => {
 
   // This has repeatedly broken in the past (really)
   it('allows updating text fields when alpha slider is hidden', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" alphaType="none" componentRef={colorPickerRef} />);
+    const { container, getAllByRole } = render(
+      <ColorPicker onChange={onChange} color="#000000" alphaType="none" componentRef={colorPickerRef} />,
+    );
 
-    const inputs = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input') as NodeListOf<HTMLInputElement>;
+    const inputs = getAllByRole('textbox') as HTMLInputElement[];
 
     const redInput = inputs[1];
-    ReactTestUtils.Simulate.input(redInput, mockEvent('255'));
+    userEvent.clear(redInput);
+    userEvent.paste(redInput, '255');
     validateChange({ calls: 1, prop: 'str', value: '#ff0000' });
     validateChange({ calls: 1, prop: 'r', value: 255, input: redInput });
     // blur and make sure nothing changes
-    ReactTestUtils.Simulate.blur(redInput);
+    userEvent.click(container);
     validateChange({ calls: 1, prop: 'str', value: '#ff0000' });
 
     const hexInput = inputs[0];
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('00ff00'));
+    userEvent.clear(hexInput);
+    userEvent.paste(hexInput, '00ff00');
     validateChange({ calls: 2, prop: 'str', value: '#00ff00' });
     validateChange({ calls: 2, prop: 'hex', value: '00ff00', input: hexInput });
-    ReactTestUtils.Simulate.blur(hexInput);
+    userEvent.click(container);
     validateChange({ calls: 2, prop: 'str', value: '#00ff00' });
   });
 
@@ -361,108 +375,120 @@ describe('ColorPicker', () => {
       newColor = color;
       ev.preventDefault();
     });
-    wrapper = mount(<ColorPicker onChange={onChange1} color="#000000" componentRef={colorPickerRef} />);
+    const { getAllByRole } = render(<ColorPicker onChange={onChange1} color="#000000" componentRef={colorPickerRef} />);
 
-    const redInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[1] as HTMLInputElement;
-    ReactTestUtils.Simulate.input(redInput, mockEvent('255'));
+    const redInput = getAllByRole('textbox')[1] as HTMLInputElement;
+    userEvent.clear(redInput);
+    userEvent.paste(redInput, '255');
     expect(onChange1).toHaveBeenCalledTimes(1);
     expect(newColor!.r).toBe(255);
     expect(colorPicker!.color.r).toBe(0);
   });
 
   it('ignores non-numeric RGBA input', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+    const { getAllByRole } = render(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
 
-    const redInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[1] as HTMLInputElement;
+    const redInput = getAllByRole('textbox')[1] as HTMLInputElement;
 
     // valid value => accepted
-    ReactTestUtils.Simulate.input(redInput, mockEvent('12'));
+    userEvent.clear(redInput);
+    userEvent.paste(redInput, '12');
     validateChange({ calls: 1, prop: 'r', value: 12, input: redInput });
 
     // decimal added to valid value => totally ignored
-    ReactTestUtils.Simulate.input(redInput, mockEvent('12.'));
+    userEvent.type(redInput, '.');
     validateChange({ calls: 1, prop: 'r', value: 12 });
 
     // non-number added to valid value => totally ignored
-    ReactTestUtils.Simulate.input(redInput, mockEvent('12x'));
+    userEvent.type(redInput, 'x');
     validateChange({ calls: 1, prop: 'r', value: 12 });
 
     // empty value => color not updated, value preserved
-    ReactTestUtils.Simulate.input(redInput, mockEvent(''));
+    userEvent.clear(redInput);
     validateChange({ calls: 1, prop: 'r', value: 12, input: redInput, inputValue: '' });
 
     // non-number in empty field => totally ignored
-    ReactTestUtils.Simulate.input(redInput, mockEvent('x'));
+    userEvent.type(redInput, 'x');
     validateChange({ calls: 1, prop: 'r', value: 12, input: redInput, inputValue: '' });
   });
 
   it('reverts to previous valid RGBA value on blur if field is empty', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+    const { container, getAllByRole } = render(
+      <ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />,
+    );
 
-    const redInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[1] as HTMLInputElement;
+    const redInput = getAllByRole('textbox')[1] as HTMLInputElement;
 
     // valid value => accepted
-    ReactTestUtils.Simulate.input(redInput, mockEvent('123'));
+    userEvent.clear(redInput);
+    userEvent.paste(redInput, '123');
     validateChange({ calls: 1, prop: 'r', value: 123, input: redInput });
 
     // empty value => color not updated, value preserved
-    ReactTestUtils.Simulate.input(redInput, mockEvent(''));
+    userEvent.clear(redInput);
     validateChange({ calls: 1, prop: 'r', value: 123, input: redInput, inputValue: '' });
 
     // reverts to previous valid value on blur
-    ReactTestUtils.Simulate.blur(redInput);
+    userEvent.click(container);
     validateChange({ calls: 1, prop: 'r', value: 123 });
   });
 
   it('clamps RGB input too large', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+    const { container, getAllByRole } = render(
+      <ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />,
+    );
 
-    const redInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[1] as HTMLInputElement;
-
-    ReactTestUtils.Simulate.input(redInput, mockEvent('123'));
+    const redInput = getAllByRole('textbox')[1] as HTMLInputElement;
+    userEvent.clear(redInput);
+    userEvent.paste(redInput, '123');
     validateChange({ calls: 1, prop: 'r', value: 123, input: redInput });
 
     // value too large => allowed in field but onChange not called
-    ReactTestUtils.Simulate.input(redInput, mockEvent('456'));
+    userEvent.clear(redInput);
+    userEvent.paste(redInput, '456');
     validateChange({ calls: 1, prop: 'r', value: 123, input: redInput, inputValue: '456' });
 
     // blur => value clamped
-    ReactTestUtils.Simulate.blur(redInput);
+    userEvent.click(container);
     validateChange({ calls: 2, prop: 'r', value: 255, input: redInput });
   });
 
   it('clamps alpha input too large', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+    const { container, getAllByRole } = render(
+      <ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />,
+    );
 
-    const alphaInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[4] as HTMLInputElement;
+    const alphaInput = getAllByRole('textbox')[4] as HTMLInputElement;
 
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('50'));
+    userEvent.clear(alphaInput);
+    userEvent.paste(alphaInput, '50');
     validateChange({ calls: 1, prop: 'a', value: 50, input: alphaInput });
 
     // value too large => allowed in field but onChange not called
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('123'));
+    userEvent.clear(alphaInput);
+    userEvent.paste(alphaInput, '123');
     validateChange({ calls: 1, prop: 'a', value: 50, input: alphaInput, inputValue: '123' });
 
     // blur => value clamped
-    ReactTestUtils.Simulate.blur(alphaInput);
+    userEvent.click(container);
     validateChange({ calls: 2, prop: 'a', value: 100, input: alphaInput });
   });
 
   it('shows error state and tooltip for invalid red value', () => {
     jest.useFakeTimers();
-    wrapper = mount(<ColorPicker color="#000000" componentRef={colorPickerRef} tooltipProps={{ delay: 2 }} />);
+    const { getAllByRole } = render(
+      <ColorPicker color="#000000" componentRef={colorPickerRef} tooltipProps={{ delay: 2 }} />,
+    );
 
-    const redInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[1] as HTMLInputElement;
-    const redTooltipWrapper = wrapper.find(TooltipHost).at(1);
+    const redInput = getAllByRole('textbox')[1] as HTMLInputElement;
 
     // input should be valid before entering an invalid number
     expect(redInput.getAttribute('aria-invalid')).toEqual('false');
 
     // choose a number that can be typed, but is not allowed
-    ReactTestUtils.Simulate.input(redInput, mockEvent('456'));
-    ReactTestUtils.Simulate.mouseEnter(redTooltipWrapper.getDOMNode());
+    userEvent.type(redInput, '456');
 
-    ReactTestUtils.act(() => {
+    act(() => {
       jest.runAllTimers();
     });
 
@@ -477,7 +503,7 @@ describe('ColorPicker', () => {
   it('shows error state and tooltip for invalid hex value', () => {
     jest.useFakeTimers();
     const customHexError = 'test hex error';
-    wrapper = mount(
+    const { getAllByRole } = render(
       <ColorPicker
         color="#000000"
         componentRef={colorPickerRef}
@@ -486,17 +512,16 @@ describe('ColorPicker', () => {
       />,
     );
 
-    const hexInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[0] as HTMLInputElement;
-    const hexTooltipWrapper = wrapper.find(TooltipHost).at(0);
+    const hexInput = getAllByRole('textbox')[0] as HTMLInputElement;
 
     // input should be valid before entering an invalid hex
     expect(hexInput.getAttribute('aria-invalid')).toEqual('false');
 
+    userEvent.clear(hexInput);
     // enter a 2-digit hex
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('ff'));
-    ReactTestUtils.Simulate.mouseEnter(hexTooltipWrapper.getDOMNode());
+    userEvent.type(hexInput, 'ff');
 
-    ReactTestUtils.act(() => {
+    act(() => {
       jest.runAllTimers();
     });
 
@@ -509,165 +534,191 @@ describe('ColorPicker', () => {
   });
 
   it('handles RGBA input too long', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+    const { getAllByRole } = render(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
 
-    const redInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[1] as HTMLInputElement;
+    const redInput = getAllByRole('textbox')[1] as HTMLInputElement;
 
     // valid value => accepted
-    ReactTestUtils.Simulate.input(redInput, mockEvent('123'));
+    userEvent.clear(redInput);
+    userEvent.paste(redInput, '123');
     validateChange({ calls: 1, prop: 'r', value: 123, input: redInput });
 
     // extra char added => use existing substring
-    ReactTestUtils.Simulate.input(redInput, mockEvent('1234'));
+    userEvent.type(redInput, '4');
     validateChange({ calls: 1, prop: 'r', value: 123, input: redInput });
 
     // new value too long "pasted" => use substring
-    ReactTestUtils.Simulate.input(redInput, mockEvent('1000'));
+    userEvent.clear(redInput);
+    userEvent.paste(redInput, '1000');
     validateChange({ calls: 2, prop: 'r', value: 100, input: redInput });
 
     // invalid new value too long "pasted" => use substring but don't call onChange
-    ReactTestUtils.Simulate.input(redInput, mockEvent('4567'));
+    userEvent.clear(redInput);
+    userEvent.paste(redInput, '4567');
+
     validateChange({ calls: 2, prop: 'r', value: 100, input: redInput, inputValue: '456' });
   });
 
   it('handles 3-char hex value', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+    const { container, getAllByRole } = render(
+      <ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />,
+    );
 
-    const hexInput = wrapper.getDOMNode().querySelector('.ms-ColorPicker-input input') as HTMLInputElement;
+    const hexInput = getAllByRole('textbox')[0] as HTMLInputElement;
 
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('faf'));
+    userEvent.clear(hexInput);
+    userEvent.paste(hexInput, 'faf');
     expect(onChange).toHaveBeenCalledTimes(0);
     expect(hexInput.value).toBe('faf');
 
-    ReactTestUtils.Simulate.blur(hexInput);
+    userEvent.click(container);
     validateChange({ calls: 1, prop: 'hex', value: 'ffaaff', input: hexInput });
     expect(colorPicker!.color.str).toBe('#faf');
   });
 
   it('handles incrementally typing a 6-char hex value', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+    const { getAllByRole } = render(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
 
-    const hexInput = wrapper.getDOMNode().querySelector('.ms-ColorPicker-input input') as HTMLInputElement;
+    const hexInput = getAllByRole('textbox')[0] as HTMLInputElement;
     const testHexValue = 'f1f2f3';
 
     // The intermediate value should be preserved, not automatically converted to length 6
     for (let i = 2; i <= 5; i++) {
-      const hexSubstr = testHexValue.substr(0, i);
-      ReactTestUtils.Simulate.input(hexInput, mockEvent(hexSubstr));
+      const hexSubstr = testHexValue.substring(0, i);
+      userEvent.clear(hexInput);
+      userEvent.paste(hexInput, hexSubstr);
       validateChange({ calls: 0, prop: 'hex', value: '000000', input: hexInput, inputValue: hexSubstr });
     }
 
     // Only the full-length value should trigger onChange
-    ReactTestUtils.Simulate.input(hexInput, mockEvent(testHexValue));
+    userEvent.clear(hexInput);
+    userEvent.paste(hexInput, testHexValue);
     validateChange({ calls: 1, prop: 'hex', value: testHexValue, input: hexInput });
   });
 
   it('handles uppercase hex', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+    const { getAllByRole } = render(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
 
-    const hexInput = wrapper.getDOMNode().querySelector('.ms-ColorPicker-input input') as HTMLInputElement;
+    const hexInput = getAllByRole('textbox')[0] as HTMLInputElement;
+
     const testHexValue = 'F1F2F3';
 
-    ReactTestUtils.Simulate.input(hexInput, mockEvent(testHexValue));
+    userEvent.clear(hexInput);
+    userEvent.paste(hexInput, testHexValue);
+
     validateChange({ calls: 1, prop: 'hex', value: testHexValue.toLowerCase(), input: hexInput });
     validateChange({ calls: 1, prop: 'str', value: '#' + testHexValue });
   });
 
   it('ignores non-hexadecimal hex input', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+    const { container, getAllByRole } = render(
+      <ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />,
+    );
 
-    const hexInput = wrapper.getDOMNode().querySelector('.ms-ColorPicker-input input') as HTMLInputElement;
+    const hexInput = getAllByRole('textbox')[0] as HTMLInputElement;
 
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('hello'));
+    userEvent.paste(hexInput, 'hello');
     validateChange({ calls: 0, prop: 'hex', value: '000000', input: hexInput });
-
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('abc'));
+    userEvent.clear(hexInput);
+    userEvent.paste(hexInput, 'abc');
     validateChange({ calls: 0, prop: 'hex', value: '000000', input: hexInput, inputValue: 'abc' });
 
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('abch'));
+    userEvent.type(hexInput, 'h');
     validateChange({ calls: 0, prop: 'hex', value: '000000', input: hexInput, inputValue: 'abc' });
 
-    ReactTestUtils.Simulate.blur(hexInput);
+    userEvent.click(container);
     validateChange({ calls: 1, prop: 'hex', value: 'aabbcc', input: hexInput });
   });
 
   it('handles hex value too long', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+    const { getAllByRole } = render(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
 
-    const hexInput = wrapper.getDOMNode().querySelector('.ms-ColorPicker-input input') as HTMLInputElement;
+    const hexInput = getAllByRole('textbox')[0] as HTMLInputElement;
 
     // input too long "pasted" => use substring
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('1234567'));
+    userEvent.clear(hexInput);
+    userEvent.paste(hexInput, '1234567');
     validateChange({ calls: 1, prop: 'hex', value: '123456', input: hexInput });
 
     // invalid new value too long "pasted" => ignore
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('hello world'));
+    userEvent.paste(hexInput, 'hello world');
     validateChange({ calls: 1, prop: 'hex', value: '123456', input: hexInput });
   });
 
   it('reverts to previous valid hex value on blur if input is too short', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#abcdef" componentRef={colorPickerRef} />);
+    const { container, getAllByRole } = render(
+      <ColorPicker onChange={onChange} color="#abcdef" componentRef={colorPickerRef} />,
+    );
 
-    const hexInput = wrapper.getDOMNode().querySelector('.ms-ColorPicker-input input') as HTMLInputElement;
+    const hexInput = getAllByRole('textbox')[0] as HTMLInputElement;
 
-    ReactTestUtils.Simulate.input(hexInput, mockEvent(''));
+    userEvent.clear(hexInput);
     validateChange({ calls: 0, prop: 'hex', value: 'abcdef', input: hexInput, inputValue: '' });
-    ReactTestUtils.Simulate.blur(hexInput);
+    userEvent.click(container);
     validateChange({ calls: 0, prop: 'hex', value: 'abcdef' });
 
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('12'));
+    userEvent.clear(hexInput);
+    userEvent.type(hexInput, '12');
     validateChange({ calls: 0, prop: 'hex', value: 'abcdef', input: hexInput, inputValue: '12' });
-    ReactTestUtils.Simulate.blur(hexInput);
+    userEvent.click(container);
     validateChange({ calls: 0, prop: 'hex', value: 'abcdef' });
   });
 
   it('handles hex value of length 4 or 5 on blur', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+    const { container, getAllByRole } = render(
+      <ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />,
+    );
 
-    const hexInput = wrapper.getDOMNode().querySelector('.ms-ColorPicker-input input') as HTMLInputElement;
+    const hexInput = getAllByRole('textbox')[0] as HTMLInputElement;
 
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('abcd'));
+    userEvent.clear(hexInput);
+    userEvent.type(hexInput, 'abcd');
+
     validateChange({ calls: 0, prop: 'hex', value: '000000', input: hexInput, inputValue: 'abcd' });
     // interpret as 3-char hex on blur
-    ReactTestUtils.Simulate.blur(hexInput);
+    userEvent.click(container);
     validateChange({ calls: 1, prop: 'hex', value: 'aabbcc' });
 
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('12345'));
+    userEvent.clear(hexInput);
+    userEvent.type(hexInput, '12345');
     validateChange({ calls: 1, prop: 'hex', value: 'aabbcc', input: hexInput, inputValue: '12345' });
-    ReactTestUtils.Simulate.blur(hexInput);
+    userEvent.click(container);
     validateChange({ calls: 2, prop: 'hex', value: '112233' });
   });
 
   it('handles typing invalid value then going back to previous valid value', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#abcdef" componentRef={colorPickerRef} />);
+    const { container, getAllByRole } = render(
+      <ColorPicker onChange={onChange} color="#abcdef" componentRef={colorPickerRef} />,
+    );
 
-    const hexInput = wrapper.getDOMNode().querySelector('.ms-ColorPicker-input input') as HTMLInputElement;
+    const hexInput = getAllByRole('textbox')[0] as HTMLInputElement;
 
     // suppose they delete a character
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('abcde'));
+    userEvent.type(hexInput, '{backspace}');
     validateChange({ calls: 0, prop: 'hex', value: 'abcdef', input: hexInput, inputValue: 'abcde' });
     // then add it back
-    ReactTestUtils.Simulate.input(hexInput, mockEvent('abcdef'));
+    userEvent.type(hexInput, 'f');
     validateChange({ calls: 0, prop: 'hex', value: 'abcdef', input: hexInput });
     // verify the internal intermediate value is cleared
     expect(colorPicker!.state.editingColor).toBeUndefined();
 
     // original value is preserved on blur
-    ReactTestUtils.Simulate.blur(hexInput);
+    userEvent.click(container);
     validateChange({ calls: 0, prop: 'hex', value: 'abcdef', input: hexInput });
   });
 
   it('handles intermediate invalid transparency values', () => {
     const color = getColorFromString('rgba(20, 30, 40, 0.3)')!;
 
-    wrapper = mount(
+    const { container, getAllByRole } = render(
       <ColorPicker alphaType="transparency" onChange={onChange} color={color} componentRef={colorPickerRef} />,
     );
 
-    const transparencyInput = wrapper.getDOMNode().querySelectorAll('input')[4];
+    const transparencyInput = getAllByRole('textbox')[4] as HTMLInputElement;
 
     // value too large => allowed in field but onChange not called
-    ReactTestUtils.Simulate.input(transparencyInput, mockEvent('123'));
+    userEvent.clear(transparencyInput);
+    userEvent.paste(transparencyInput, '123');
     expect(onChange).toHaveBeenCalledTimes(0);
     expect(colorPicker!.color.a).toBe(30); // original value
     expect(colorPicker!.color.t).toBe(70);
@@ -675,7 +726,7 @@ describe('ColorPicker', () => {
     expect(transparencyInput.value).toBe('123');
 
     // blur => value clamped (with correct alpha/transparency conversion)
-    ReactTestUtils.Simulate.blur(transparencyInput);
+    userEvent.click(container);
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(colorPicker!.color.t).toBe(100);
     expect(updatedColor!.t).toBe(100);

--- a/packages/react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -638,11 +638,11 @@ describe('ColorPicker', () => {
     // input too long "pasted" => use substring
     userEvent.clear(hexInput);
     userEvent.type(hexInput, '1234567');
-    validateChange({ calls: 6, prop: 'hex', value: '123456', input: hexInput });
+    validateChange({ calls: 1, prop: 'hex', value: '123456', input: hexInput });
 
     // invalid new value too long "pasted" => ignore
     userEvent.paste(hexInput, 'hello world');
-    validateChange({ calls: 6, prop: 'hex', value: '123456', input: hexInput });
+    validateChange({ calls: 1, prop: 'hex', value: '123456', input: hexInput });
   });
 
   it('reverts to previous valid hex value on blur if input is too short', () => {

--- a/packages/react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -147,10 +147,10 @@ describe('ColorPicker', () => {
   });
 
   it('hides alpha control slider', () => {
-    const { getAllByRole, queryByRole } = render(<ColorPicker color={white} alphaType="none" />);
+    const { container, getAllByRole, queryByRole } = render(<ColorPicker color={white} alphaType="none" />);
 
     const alphaSlider = queryByRole('slider', { name: 'Alpha' });
-    const tableHeaders = getAllByRole('group')[1].firstElementChild!.firstElementChild!.children;
+    const tableHeaders = container.querySelectorAll('thead td');
 
     // There should only be table headers and inputs for hex, red, green, and blue (no alpha)
     expect(alphaSlider).toBeFalsy();
@@ -160,18 +160,18 @@ describe('ColorPicker', () => {
   });
 
   it('shows preview box', () => {
-    const { container } = render(<ColorPicker color="#FFFFFF" showPreview={true} />);
+    const { getAllByRole } = render(<ColorPicker color="#FFFFFF" showPreview={true} />);
 
-    const previewBox = container.firstElementChild!.querySelector('.is-preview');
+    const previewBox = getAllByRole('group')[0].querySelector('.is-preview');
 
     // There should be one preview box
     expect(previewBox).toBeTruthy();
   });
 
   it('hides preview box', () => {
-    const { container } = render(<ColorPicker color="#FFFFFF" showPreview={false} />);
+    const { getAllByRole } = render(<ColorPicker color="#FFFFFF" showPreview={false} />);
 
-    const previewBox = container.firstElementChild!.querySelector('.is-preview');
+    const previewBox = getAllByRole('group')[0].querySelector('.is-preview');
 
     // There should be one preview box
     expect(previewBox).toBeFalsy();
@@ -229,23 +229,23 @@ describe('ColorPicker', () => {
   });
 
   it('uses default aria label', () => {
-    const { container, rerender } = render(<ColorPicker color="#abcdef" />);
-    expect(container.firstElementChild!.getAttribute('aria-label')).toBe(
+    const { getAllByRole, rerender } = render(<ColorPicker color="#abcdef" />);
+    expect(getAllByRole('group')[0].getAttribute('aria-label')).toBe(
       'Color picker, Red 171 Green 205 Blue 239 Alpha 100% selected.',
     );
 
     rerender(<ColorPicker color="rgba(255, 0, 0, 0.5)" />);
 
-    expect(container.firstElementChild!.getAttribute('aria-label')).toBe(
+    expect(getAllByRole('group')[0].getAttribute('aria-label')).toBe(
       'Color picker, Red 255 Green 0 Blue 0 Alpha 50% selected.',
     );
   });
 
   it('can use custom aria label', () => {
-    const { container } = render(
+    const { getAllByRole } = render(
       <ColorPicker color="#abcdef" strings={{ rootAriaLabelFormat: 'custom color picker {0}' }} />,
     );
-    expect(container.firstElementChild!.getAttribute('aria-label')).toBe(
+    expect(getAllByRole('group')[0].getAttribute('aria-label')).toBe(
       'custom color picker Red 171 Green 205 Blue 239 Alpha 100%',
     );
   });

--- a/packages/react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -161,8 +161,8 @@ describe('ColorPicker', () => {
 
   it('shows preview box', () => {
     const { getAllByRole } = render(<ColorPicker color="#FFFFFF" showPreview={true} />);
-
-    const previewBox = getAllByRole('group')[0].querySelector('.is-preview');
+    const colorPickerRoot = getAllByRole('group')[0];
+    const previewBox = colorPickerRoot.querySelector('.is-preview');
 
     // There should be one preview box
     expect(previewBox).toBeTruthy();
@@ -170,8 +170,8 @@ describe('ColorPicker', () => {
 
   it('hides preview box', () => {
     const { getAllByRole } = render(<ColorPicker color="#FFFFFF" showPreview={false} />);
-
-    const previewBox = getAllByRole('group')[0].querySelector('.is-preview');
+    const colorPickerRoot = getAllByRole('group')[0];
+    const previewBox = colorPickerRoot.querySelector('.is-preview');
 
     // There should be one preview box
     expect(previewBox).toBeFalsy();
@@ -230,22 +230,22 @@ describe('ColorPicker', () => {
 
   it('uses default aria label', () => {
     const { getAllByRole, rerender } = render(<ColorPicker color="#abcdef" />);
-    expect(getAllByRole('group')[0].getAttribute('aria-label')).toBe(
+    const colorPickerRoot = getAllByRole('group')[0];
+    expect(colorPickerRoot.getAttribute('aria-label')).toBe(
       'Color picker, Red 171 Green 205 Blue 239 Alpha 100% selected.',
     );
 
     rerender(<ColorPicker color="rgba(255, 0, 0, 0.5)" />);
 
-    expect(getAllByRole('group')[0].getAttribute('aria-label')).toBe(
-      'Color picker, Red 255 Green 0 Blue 0 Alpha 50% selected.',
-    );
+    expect(colorPickerRoot.getAttribute('aria-label')).toBe('Color picker, Red 255 Green 0 Blue 0 Alpha 50% selected.');
   });
 
   it('can use custom aria label', () => {
     const { getAllByRole } = render(
       <ColorPicker color="#abcdef" strings={{ rootAriaLabelFormat: 'custom color picker {0}' }} />,
     );
-    expect(getAllByRole('group')[0].getAttribute('aria-label')).toBe(
+    const colorPickerRoot = getAllByRole('group')[0];
+    expect(colorPickerRoot.getAttribute('aria-label')).toBe(
       'custom color picker Red 171 Green 205 Blue 239 Alpha 100%',
     );
   });

--- a/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -1,3878 +1,3493 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ColorPicker renders correctly 1`] = `
-<div
-  aria-label="Color picker, Red 171 Green 205 Blue 239 Alpha 100% selected."
-  className=
-      ms-ColorPicker
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        max-width: 300px;
-        position: relative;
-      }
-  role="group"
->
+<div>
   <div
-    className=
-        ms-ColorPicker-panel
+    aria-label="Color picker, Red 171 Green 205 Blue 239 Alpha 100% selected."
+    class=
+        ms-ColorPicker
         {
-          padding-bottom: 16px;
-          padding-left: 16px;
-          padding-right: 16px;
-          padding-top: 16px;
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          max-width: 300px;
+          position: relative;
         }
+    role="group"
   >
     <div
-      aria-describedby="ColorRectangle-description0"
-      aria-label="Saturation and brightness"
-      aria-valuemax={100}
-      aria-valuemin={0}
-      aria-valuenow={28}
-      aria-valuetext="Saturation 28 brightness 94"
-      className=
-          ms-ColorPicker-colorRect
+      class=
+          ms-ColorPicker-panel
           {
-            border-radius: 2px;
-            border: 1px solid #f3f2f1;
-            margin-bottom: 8px;
-            min-height: 220px;
-            min-width: 220px;
-            outline: none;
-            position: relative;
+            padding-bottom: 16px;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 16px;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-            -ms-high-contrast-adjust: none;
-            forced-color-adjust: none;
-          }
-          .ms-Fabric--isFocusVisible &:focus {
-            outline: 1px solid #605e5c;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
-            outline: 2px solid CanvasText;
-          }
-      data-is-focusable={true}
-      onKeyDown={[Function]}
-      onMouseDown={[Function]}
-      role="slider"
-      style={
-        Object {
-          "backgroundColor": "#0080ff",
-        }
-      }
-      tabIndex={0}
     >
       <div
-        className=
+        aria-describedby="ColorRectangle-description0"
+        aria-label="Saturation and brightness"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="28"
+        aria-valuetext="Saturation 28 brightness 94"
+        class=
+            ms-ColorPicker-colorRect
+            {
+              border-radius: 2px;
+              border: 1px solid #f3f2f1;
+              margin-bottom: 8px;
+              min-height: 220px;
+              min-width: 220px;
+              outline: none;
+              position: relative;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              forced-color-adjust: none;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+              outline: 2px solid CanvasText;
+            }
+        data-is-focusable="true"
+        role="slider"
+        style="background-color: rgb(0, 128, 255);"
+        tabindex="0"
+      >
+        <div
+          class=
+
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                white-space: nowrap;
+                width: 1px;
+              }
+          id="ColorRectangle-description0"
+        >
+          Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
+        </div>
+        <div
+          class=
+              ms-ColorPicker-light
+              {
+                background: linear-gradient(to right, white 0%, transparent 100%) /*@noflip*/;
+                bottom: 0px;
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+        />
+        <div
+          class=
+              ms-ColorPicker-dark
+              {
+                background: linear-gradient(to bottom, transparent 0, #000 100%);
+                bottom: 0px;
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+        />
+        <div
+          class=
+              ms-ColorPicker-thumb
+              {
+                background: white;
+                border-radius: 50%;
+                border: 1px solid #8a8886;
+                box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                height: 20px;
+                position: absolute;
+                transform: translate(-50%, -50%);
+                width: 20px;
+              }
+              &:before {
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: 0px;
+                box-sizing: border-box;
+                content: "";
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+          style="left: 28%; top: 6%; background-color: rgb(171, 205, 239);"
+        />
+      </div>
+      <div
+        class=
 
             {
-              border: 0px;
-              height: 1px;
-              margin-bottom: -1px;
-              margin-left: -1px;
-              margin-right: -1px;
-              margin-top: -1px;
-              overflow: hidden;
-              padding-bottom: 0px;
-              padding-left: 0px;
+              display: flex;
+            }
+      >
+        <div
+          class=
+
+              {
+                flex-grow: 1;
+              }
+        >
+          <div
+            aria-label="Hue"
+            aria-valuemax="359"
+            aria-valuemin="0"
+            aria-valuenow="210"
+            aria-valuetext="210"
+            class=
+                ms-ColorPicker-slider
+                is-hue
+                {
+                  background: linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%);
+                  border-radius: 2px;
+                  border: 1px solid #edebe9;
+                  box-sizing: border-box;
+                  forced-color-adjust: none;
+                  height: 20px;
+                  margin-bottom: 8px;
+                  outline: none;
+                  position: relative;
+                }
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #605e5c;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                  outline: 2px solid CanvasText;
+                }
+            data-is-focusable="true"
+            role="slider"
+            tabindex="0"
+          >
+            <div
+              class=
+                  ms-ColorPicker-thumb
+                  is-slider
+                  {
+                    background: white;
+                    border-radius: 50%;
+                    border: 1px solid #8a8886;
+                    box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                    forced-color-adjust: auto;
+                    height: 20px;
+                    position: absolute;
+                    top: 50%;
+                    transform: translate(-50%, -50%);
+                    width: 20px;
+                  }
+              style="left: 58.4958217270195%;"
+            />
+          </div>
+          <div
+            aria-label="Alpha"
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="100"
+            aria-valuetext="100"
+            class=
+                ms-ColorPicker-slider
+                is-alpha
+                {
+                  background-image: url(data;
+                  base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==): ;
+                  border-radius: 2px;
+                  border: 1px solid #edebe9;
+                  box-sizing: border-box;
+                  forced-color-adjust: none;
+                  height: 20px;
+                  margin-bottom: 8px;
+                  outline: none;
+                  position: relative;
+                }
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #605e5c;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                  outline: 2px solid CanvasText;
+                }
+            data-is-focusable="true"
+            role="slider"
+            tabindex="0"
+          >
+            <div
+              class=
+                  ms-ColorPicker-sliderOverlay
+                  {
+                    bottom: 0px;
+                    content: ;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            />
+            <div
+              class=
+                  ms-ColorPicker-thumb
+                  is-slider
+                  {
+                    background: white;
+                    border-radius: 50%;
+                    border: 1px solid #8a8886;
+                    box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                    forced-color-adjust: auto;
+                    height: 20px;
+                    position: absolute;
+                    top: 50%;
+                    transform: translate(-50%, -50%);
+                    width: 20px;
+                  }
+              style="left: 100%;"
+            />
+          </div>
+        </div>
+      </div>
+      <table
+        cellpadding="0"
+        cellspacing="0"
+        class=
+            ms-ColorPicker-table
+            {
+              table-layout: fixed;
+              width: 100%;
+            }
+            & tbody td:last-of-type .ms-ColorPicker-input {
               padding-right: 0px;
-              padding-top: 0px;
-              position: absolute;
-              white-space: nowrap;
-              width: 1px;
             }
-        id="ColorRectangle-description0"
+        role="group"
       >
-        Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
-      </div>
-      <div
-        className=
-            ms-ColorPicker-light
-            {
-              background: linear-gradient(to right, white 0%, transparent 100%) /*@noflip*/;
-              bottom: 0px;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-      />
-      <div
-        className=
-            ms-ColorPicker-dark
-            {
-              background: linear-gradient(to bottom, transparent 0, #000 100%);
-              bottom: 0px;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-      />
-      <div
-        className=
-            ms-ColorPicker-thumb
-            {
-              background: white;
-              border-radius: 50%;
-              border: 1px solid #8a8886;
-              box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
-              height: 20px;
-              position: absolute;
-              transform: translate(-50%, -50%);
-              width: 20px;
-            }
-            &:before {
-              border-radius: 50%;
-              border: 2px solid #ffffff;
-              bottom: 0px;
-              box-sizing: border-box;
-              content: "";
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-        style={
-          Object {
-            "backgroundColor": "#abcdef",
-            "left": "28%",
-            "top": "6%",
-          }
-        }
-      />
-    </div>
-    <div
-      className=
+        <thead>
+          <tr
+            class=
 
-          {
-            display: flex;
-          }
-    >
-      <div
-        className=
-
-            {
-              flex-grow: 1;
-            }
-      >
-        <div
-          aria-label="Hue"
-          aria-valuemax={359}
-          aria-valuemin={0}
-          aria-valuenow={210}
-          aria-valuetext="210"
-          className=
-              ms-ColorPicker-slider
-              is-hue
-              {
-                background: linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%);
-                border-radius: 2px;
-                border: 1px solid #edebe9;
-                box-sizing: border-box;
-                forced-color-adjust: none;
-                height: 20px;
-                margin-bottom: 8px;
-                outline: none;
-                position: relative;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
-                outline: 2px solid CanvasText;
-              }
-          data-is-focusable={true}
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          role="slider"
-          tabIndex={0}
-        >
-          <div
-            className=
-                ms-ColorPicker-thumb
-                is-slider
                 {
-                  background: white;
-                  border-radius: 50%;
-                  border: 1px solid #8a8886;
-                  box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
-                  forced-color-adjust: auto;
-                  height: 20px;
-                  position: absolute;
-                  top: 50%;
-                  transform: translate(-50%, -50%);
-                  width: 20px;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
                 }
-            style={
-              Object {
-                "left": "58.4958217270195%",
-              }
-            }
-          />
-        </div>
-        <div
-          aria-label="Alpha"
-          aria-valuemax={100}
-          aria-valuemin={0}
-          aria-valuenow={100}
-          aria-valuetext="100"
-          className=
-              ms-ColorPicker-slider
-              is-alpha
-              {
-                background-image: url(data;
-                base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==): ;
-                border-radius: 2px;
-                border: 1px solid #edebe9;
-                box-sizing: border-box;
-                forced-color-adjust: none;
-                height: 20px;
-                margin-bottom: 8px;
-                outline: none;
-                position: relative;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
-                outline: 2px solid CanvasText;
-              }
-          data-is-focusable={true}
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          role="slider"
-          tabIndex={0}
-        >
-          <div
-            className=
-                ms-ColorPicker-sliderOverlay
-                {
-                  bottom: 0px;
-                  content: ;
-                  left: 0px;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
-                }
-            style={
-              Object {
-                "background": "linear-gradient(to right, transparent, #abcdef)",
-              }
-            }
-          />
-          <div
-            className=
-                ms-ColorPicker-thumb
-                is-slider
-                {
-                  background: white;
-                  border-radius: 50%;
-                  border: 1px solid #8a8886;
-                  box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
-                  forced-color-adjust: auto;
-                  height: 20px;
-                  position: absolute;
-                  top: 50%;
-                  transform: translate(-50%, -50%);
-                  width: 20px;
-                }
-            style={
-              Object {
-                "left": "100%",
-              }
-            }
-          />
-        </div>
-      </div>
-    </div>
-    <table
-      cellPadding="0"
-      cellSpacing="0"
-      className=
-          ms-ColorPicker-table
-          {
-            table-layout: fixed;
-            width: 100%;
-          }
-          & tbody td:last-of-type .ms-ColorPicker-input {
-            padding-right: 0px;
-          }
-      role="group"
-    >
-      <thead>
-        <tr
-          className=
-
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-              }
-              & td {
-                padding-bottom: 4px;
-              }
-        >
-          <td
-            className=
-
-                {
-                  width: 25%;
+                & td {
+                  padding-bottom: 4px;
                 }
           >
-            Hex
-          </td>
-          <td>
-            Red
-          </td>
-          <td>
-            Green
-          </td>
-          <td>
-            Blue
-          </td>
-          <td
-            className=""
-          >
-            Alpha
-          </td>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
+            <td
+              class=
+
                   {
-                    display: inline;
+                    width: 25%;
                   }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
             >
+              Hex
+            </td>
+            <td>
+              Red
+            </td>
+            <td>
+              Green
+            </td>
+            <td>
+              Blue
+            </td>
+            <td
+              class=""
+            >
+              Alpha
+            </td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
               <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Hex"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField2"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="abcdef"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Hex"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField2"
+                        spellcheck="false"
+                        type="text"
+                        value="abcdef"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip1"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
+            </td>
+            <td>
               <div
-                hidden={true}
-                id="tooltip1"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
-                  {
-                    display: inline;
-                  }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
-            >
-              <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Red"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField8"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="171"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Red"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField8"
+                        spellcheck="false"
+                        type="text"
+                        value="171"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip7"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
+            </td>
+            <td>
               <div
-                hidden={true}
-                id="tooltip7"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
-                  {
-                    display: inline;
-                  }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
-            >
-              <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Green"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField14"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="205"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Green"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField14"
+                        spellcheck="false"
+                        type="text"
+                        value="205"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip13"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
+            </td>
+            <td>
               <div
-                hidden={true}
-                id="tooltip13"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
-                  {
-                    display: inline;
-                  }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
-            >
-              <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Blue"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField20"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="239"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Blue"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField20"
+                        spellcheck="false"
+                        type="text"
+                        value="239"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip19"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
+            </td>
+            <td>
               <div
-                hidden={true}
-                id="tooltip19"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
-                  {
-                    display: inline;
-                  }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
-            >
-              <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Alpha"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField26"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="100"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Alpha"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField26"
+                        spellcheck="false"
+                        type="text"
+                        value="100"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip25"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
-              <div
-                hidden={true}
-                id="tooltip25"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 `;
 
 exports[`ColorPicker renders correctly with preview 1`] = `
-<div
-  aria-label="Color picker, Red 171 Green 205 Blue 239 Alpha 100% selected."
-  className=
-      ms-ColorPicker
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        max-width: 300px;
-        position: relative;
-      }
-  role="group"
->
+<div>
   <div
-    className=
-        ms-ColorPicker-panel
+    aria-label="Color picker, Red 171 Green 205 Blue 239 Alpha 100% selected."
+    class=
+        ms-ColorPicker
         {
-          padding-bottom: 16px;
-          padding-left: 16px;
-          padding-right: 16px;
-          padding-top: 16px;
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          max-width: 300px;
+          position: relative;
         }
+    role="group"
   >
     <div
-      aria-describedby="ColorRectangle-description0"
-      aria-label="Saturation and brightness"
-      aria-valuemax={100}
-      aria-valuemin={0}
-      aria-valuenow={28}
-      aria-valuetext="Saturation 28 brightness 94"
-      className=
-          ms-ColorPicker-colorRect
+      class=
+          ms-ColorPicker-panel
           {
-            border-radius: 2px;
-            border: 1px solid #f3f2f1;
-            margin-bottom: 8px;
-            min-height: 220px;
-            min-width: 220px;
-            outline: none;
-            position: relative;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-            -ms-high-contrast-adjust: none;
-            forced-color-adjust: none;
-          }
-          .ms-Fabric--isFocusVisible &:focus {
-            outline: 1px solid #605e5c;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
-            outline: 2px solid CanvasText;
-          }
-      data-is-focusable={true}
-      onKeyDown={[Function]}
-      onMouseDown={[Function]}
-      role="slider"
-      style={
-        Object {
-          "backgroundColor": "#0080ff",
-        }
-      }
-      tabIndex={0}
-    >
-      <div
-        className=
-
-            {
-              border: 0px;
-              height: 1px;
-              margin-bottom: -1px;
-              margin-left: -1px;
-              margin-right: -1px;
-              margin-top: -1px;
-              overflow: hidden;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
-              position: absolute;
-              white-space: nowrap;
-              width: 1px;
-            }
-        id="ColorRectangle-description0"
-      >
-        Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
-      </div>
-      <div
-        className=
-            ms-ColorPicker-light
-            {
-              background: linear-gradient(to right, white 0%, transparent 100%) /*@noflip*/;
-              bottom: 0px;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-      />
-      <div
-        className=
-            ms-ColorPicker-dark
-            {
-              background: linear-gradient(to bottom, transparent 0, #000 100%);
-              bottom: 0px;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-      />
-      <div
-        className=
-            ms-ColorPicker-thumb
-            {
-              background: white;
-              border-radius: 50%;
-              border: 1px solid #8a8886;
-              box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
-              height: 20px;
-              position: absolute;
-              transform: translate(-50%, -50%);
-              width: 20px;
-            }
-            &:before {
-              border-radius: 50%;
-              border: 2px solid #ffffff;
-              bottom: 0px;
-              box-sizing: border-box;
-              content: "";
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-        style={
-          Object {
-            "backgroundColor": "#abcdef",
-            "left": "28%",
-            "top": "6%",
-          }
-        }
-      />
-    </div>
-    <div
-      className=
-
-          {
-            display: flex;
+            padding-bottom: 16px;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 16px;
           }
     >
       <div
-        className=
-
+        aria-describedby="ColorRectangle-description0"
+        aria-label="Saturation and brightness"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="28"
+        aria-valuetext="Saturation 28 brightness 94"
+        class=
+            ms-ColorPicker-colorRect
             {
-              flex-grow: 1;
+              border-radius: 2px;
+              border: 1px solid #f3f2f1;
+              margin-bottom: 8px;
+              min-height: 220px;
+              min-width: 220px;
+              outline: none;
+              position: relative;
             }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              forced-color-adjust: none;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+              outline: 2px solid CanvasText;
+            }
+        data-is-focusable="true"
+        role="slider"
+        style="background-color: rgb(0, 128, 255);"
+        tabindex="0"
       >
         <div
-          aria-label="Hue"
-          aria-valuemax={359}
-          aria-valuemin={0}
-          aria-valuenow={210}
-          aria-valuetext="210"
-          className=
-              ms-ColorPicker-slider
-              is-hue
-              {
-                background: linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%);
-                border-radius: 2px;
-                border: 1px solid #edebe9;
-                box-sizing: border-box;
-                forced-color-adjust: none;
-                height: 20px;
-                margin-bottom: 8px;
-                outline: none;
-                position: relative;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
-                outline: 2px solid CanvasText;
-              }
-          data-is-focusable={true}
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          role="slider"
-          tabIndex={0}
-        >
-          <div
-            className=
-                ms-ColorPicker-thumb
-                is-slider
-                {
-                  background: white;
-                  border-radius: 50%;
-                  border: 1px solid #8a8886;
-                  box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
-                  forced-color-adjust: auto;
-                  height: 20px;
-                  position: absolute;
-                  top: 50%;
-                  transform: translate(-50%, -50%);
-                  width: 20px;
-                }
-            style={
-              Object {
-                "left": "58.4958217270195%",
-              }
-            }
-          />
-        </div>
-        <div
-          aria-label="Alpha"
-          aria-valuemax={100}
-          aria-valuemin={0}
-          aria-valuenow={100}
-          aria-valuetext="100"
-          className=
-              ms-ColorPicker-slider
-              is-alpha
-              {
-                background-image: url(data;
-                base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==): ;
-                border-radius: 2px;
-                border: 1px solid #edebe9;
-                box-sizing: border-box;
-                forced-color-adjust: none;
-                height: 20px;
-                margin-bottom: 8px;
-                outline: none;
-                position: relative;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
-                outline: 2px solid CanvasText;
-              }
-          data-is-focusable={true}
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          role="slider"
-          tabIndex={0}
-        >
-          <div
-            className=
-                ms-ColorPicker-sliderOverlay
-                {
-                  bottom: 0px;
-                  content: ;
-                  left: 0px;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
-                }
-            style={
-              Object {
-                "background": "linear-gradient(to right, transparent, #abcdef)",
-              }
-            }
-          />
-          <div
-            className=
-                ms-ColorPicker-thumb
-                is-slider
-                {
-                  background: white;
-                  border-radius: 50%;
-                  border: 1px solid #8a8886;
-                  box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
-                  forced-color-adjust: auto;
-                  height: 20px;
-                  position: absolute;
-                  top: 50%;
-                  transform: translate(-50%, -50%);
-                  width: 20px;
-                }
-            style={
-              Object {
-                "left": "100%",
-              }
-            }
-          />
-        </div>
-      </div>
-      <div
-        className=
+          class=
 
-            {
-              flex-grow: 0;
-            }
-      >
-        <div
-          className=
-              ms-ColorPicker-colorSquare
-              is-preview
               {
-                border: 1px solid #c8c6c4;
-                height: 48px;
-                margin-bottom: 0;
-                margin-left: 8px;
-                margin-right: 0;
-                margin-top: 0;
-                width: 48px;
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                white-space: nowrap;
+                width: 1px;
               }
-          style={
-            Object {
-              "backgroundColor": "#abcdef",
-            }
-          }
+          id="ColorRectangle-description0"
+        >
+          Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
+        </div>
+        <div
+          class=
+              ms-ColorPicker-light
+              {
+                background: linear-gradient(to right, white 0%, transparent 100%) /*@noflip*/;
+                bottom: 0px;
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+        />
+        <div
+          class=
+              ms-ColorPicker-dark
+              {
+                background: linear-gradient(to bottom, transparent 0, #000 100%);
+                bottom: 0px;
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+        />
+        <div
+          class=
+              ms-ColorPicker-thumb
+              {
+                background: white;
+                border-radius: 50%;
+                border: 1px solid #8a8886;
+                box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                height: 20px;
+                position: absolute;
+                transform: translate(-50%, -50%);
+                width: 20px;
+              }
+              &:before {
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: 0px;
+                box-sizing: border-box;
+                content: "";
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+          style="left: 28%; top: 6%; background-color: rgb(171, 205, 239);"
         />
       </div>
-    </div>
-    <table
-      cellPadding="0"
-      cellSpacing="0"
-      className=
-          ms-ColorPicker-table
-          {
-            table-layout: fixed;
-            width: 100%;
-          }
-          & tbody td:last-of-type .ms-ColorPicker-input {
-            padding-right: 0px;
-          }
-      role="group"
-    >
-      <thead>
-        <tr
-          className=
+      <div
+        class=
+
+            {
+              display: flex;
+            }
+      >
+        <div
+          class=
 
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-              }
-              & td {
-                padding-bottom: 4px;
+                flex-grow: 1;
               }
         >
-          <td
-            className=
+          <div
+            aria-label="Hue"
+            aria-valuemax="359"
+            aria-valuemin="0"
+            aria-valuenow="210"
+            aria-valuetext="210"
+            class=
+                ms-ColorPicker-slider
+                is-hue
+                {
+                  background: linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%);
+                  border-radius: 2px;
+                  border: 1px solid #edebe9;
+                  box-sizing: border-box;
+                  forced-color-adjust: none;
+                  height: 20px;
+                  margin-bottom: 8px;
+                  outline: none;
+                  position: relative;
+                }
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #605e5c;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                  outline: 2px solid CanvasText;
+                }
+            data-is-focusable="true"
+            role="slider"
+            tabindex="0"
+          >
+            <div
+              class=
+                  ms-ColorPicker-thumb
+                  is-slider
+                  {
+                    background: white;
+                    border-radius: 50%;
+                    border: 1px solid #8a8886;
+                    box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                    forced-color-adjust: auto;
+                    height: 20px;
+                    position: absolute;
+                    top: 50%;
+                    transform: translate(-50%, -50%);
+                    width: 20px;
+                  }
+              style="left: 58.4958217270195%;"
+            />
+          </div>
+          <div
+            aria-label="Alpha"
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="100"
+            aria-valuetext="100"
+            class=
+                ms-ColorPicker-slider
+                is-alpha
+                {
+                  background-image: url(data;
+                  base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==): ;
+                  border-radius: 2px;
+                  border: 1px solid #edebe9;
+                  box-sizing: border-box;
+                  forced-color-adjust: none;
+                  height: 20px;
+                  margin-bottom: 8px;
+                  outline: none;
+                  position: relative;
+                }
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #605e5c;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                  outline: 2px solid CanvasText;
+                }
+            data-is-focusable="true"
+            role="slider"
+            tabindex="0"
+          >
+            <div
+              class=
+                  ms-ColorPicker-sliderOverlay
+                  {
+                    bottom: 0px;
+                    content: ;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            />
+            <div
+              class=
+                  ms-ColorPicker-thumb
+                  is-slider
+                  {
+                    background: white;
+                    border-radius: 50%;
+                    border: 1px solid #8a8886;
+                    box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                    forced-color-adjust: auto;
+                    height: 20px;
+                    position: absolute;
+                    top: 50%;
+                    transform: translate(-50%, -50%);
+                    width: 20px;
+                  }
+              style="left: 100%;"
+            />
+          </div>
+        </div>
+        <div
+          class=
+
+              {
+                flex-grow: 0;
+              }
+        >
+          <div
+            class=
+                ms-ColorPicker-colorSquare
+                is-preview
+                {
+                  border: 1px solid #c8c6c4;
+                  height: 48px;
+                  margin-bottom: 0;
+                  margin-left: 8px;
+                  margin-right: 0;
+                  margin-top: 0;
+                  width: 48px;
+                }
+            style="background-color: rgb(171, 205, 239);"
+          />
+        </div>
+      </div>
+      <table
+        cellpadding="0"
+        cellspacing="0"
+        class=
+            ms-ColorPicker-table
+            {
+              table-layout: fixed;
+              width: 100%;
+            }
+            & tbody td:last-of-type .ms-ColorPicker-input {
+              padding-right: 0px;
+            }
+        role="group"
+      >
+        <thead>
+          <tr
+            class=
 
                 {
-                  width: 25%;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                }
+                & td {
+                  padding-bottom: 4px;
                 }
           >
-            Hex
-          </td>
-          <td>
-            Red
-          </td>
-          <td>
-            Green
-          </td>
-          <td>
-            Blue
-          </td>
-          <td
-            className=""
-          >
-            Alpha
-          </td>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
+            <td
+              class=
+
                   {
-                    display: inline;
+                    width: 25%;
                   }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
             >
+              Hex
+            </td>
+            <td>
+              Red
+            </td>
+            <td>
+              Green
+            </td>
+            <td>
+              Blue
+            </td>
+            <td
+              class=""
+            >
+              Alpha
+            </td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
               <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Hex"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField2"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="abcdef"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Hex"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField2"
+                        spellcheck="false"
+                        type="text"
+                        value="abcdef"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip1"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
+            </td>
+            <td>
               <div
-                hidden={true}
-                id="tooltip1"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
-                  {
-                    display: inline;
-                  }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
-            >
-              <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Red"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField8"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="171"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Red"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField8"
+                        spellcheck="false"
+                        type="text"
+                        value="171"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip7"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
+            </td>
+            <td>
               <div
-                hidden={true}
-                id="tooltip7"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
-                  {
-                    display: inline;
-                  }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
-            >
-              <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Green"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField14"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="205"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Green"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField14"
+                        spellcheck="false"
+                        type="text"
+                        value="205"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip13"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
+            </td>
+            <td>
               <div
-                hidden={true}
-                id="tooltip13"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
-                  {
-                    display: inline;
-                  }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
-            >
-              <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Blue"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField20"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="239"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Blue"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField20"
+                        spellcheck="false"
+                        type="text"
+                        value="239"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip19"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
+            </td>
+            <td>
               <div
-                hidden={true}
-                id="tooltip19"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
-                  {
-                    display: inline;
-                  }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
-            >
-              <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Alpha"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField26"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="100"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Alpha"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField26"
+                        spellcheck="false"
+                        type="text"
+                        value="100"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip25"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
-              <div
-                hidden={true}
-                id="tooltip25"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 `;
 
 exports[`ColorPicker renders correctly with transparency 1`] = `
-<div
-  aria-label="Color picker, Red 171 Green 205 Blue 239 Transparency 0% selected."
-  className=
-      ms-ColorPicker
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        max-width: 300px;
-        position: relative;
-      }
-  role="group"
->
+<div>
   <div
-    className=
-        ms-ColorPicker-panel
+    aria-label="Color picker, Red 171 Green 205 Blue 239 Transparency 0% selected."
+    class=
+        ms-ColorPicker
         {
-          padding-bottom: 16px;
-          padding-left: 16px;
-          padding-right: 16px;
-          padding-top: 16px;
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          max-width: 300px;
+          position: relative;
         }
+    role="group"
   >
     <div
-      aria-describedby="ColorRectangle-description0"
-      aria-label="Saturation and brightness"
-      aria-valuemax={100}
-      aria-valuemin={0}
-      aria-valuenow={28}
-      aria-valuetext="Saturation 28 brightness 94"
-      className=
-          ms-ColorPicker-colorRect
+      class=
+          ms-ColorPicker-panel
           {
-            border-radius: 2px;
-            border: 1px solid #f3f2f1;
-            margin-bottom: 8px;
-            min-height: 220px;
-            min-width: 220px;
-            outline: none;
-            position: relative;
+            padding-bottom: 16px;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 16px;
           }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-            -ms-high-contrast-adjust: none;
-            forced-color-adjust: none;
-          }
-          .ms-Fabric--isFocusVisible &:focus {
-            outline: 1px solid #605e5c;
-          }
-          @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
-            outline: 2px solid CanvasText;
-          }
-      data-is-focusable={true}
-      onKeyDown={[Function]}
-      onMouseDown={[Function]}
-      role="slider"
-      style={
-        Object {
-          "backgroundColor": "#0080ff",
-        }
-      }
-      tabIndex={0}
     >
       <div
-        className=
+        aria-describedby="ColorRectangle-description0"
+        aria-label="Saturation and brightness"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="28"
+        aria-valuetext="Saturation 28 brightness 94"
+        class=
+            ms-ColorPicker-colorRect
+            {
+              border-radius: 2px;
+              border: 1px solid #f3f2f1;
+              margin-bottom: 8px;
+              min-height: 220px;
+              min-width: 220px;
+              outline: none;
+              position: relative;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+              -ms-high-contrast-adjust: none;
+              forced-color-adjust: none;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+              outline: 2px solid CanvasText;
+            }
+        data-is-focusable="true"
+        role="slider"
+        style="background-color: rgb(0, 128, 255);"
+        tabindex="0"
+      >
+        <div
+          class=
+
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                white-space: nowrap;
+                width: 1px;
+              }
+          id="ColorRectangle-description0"
+        >
+          Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
+        </div>
+        <div
+          class=
+              ms-ColorPicker-light
+              {
+                background: linear-gradient(to right, white 0%, transparent 100%) /*@noflip*/;
+                bottom: 0px;
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+        />
+        <div
+          class=
+              ms-ColorPicker-dark
+              {
+                background: linear-gradient(to bottom, transparent 0, #000 100%);
+                bottom: 0px;
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+        />
+        <div
+          class=
+              ms-ColorPicker-thumb
+              {
+                background: white;
+                border-radius: 50%;
+                border: 1px solid #8a8886;
+                box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                height: 20px;
+                position: absolute;
+                transform: translate(-50%, -50%);
+                width: 20px;
+              }
+              &:before {
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: 0px;
+                box-sizing: border-box;
+                content: "";
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+          style="left: 28%; top: 6%; background-color: rgb(171, 205, 239);"
+        />
+      </div>
+      <div
+        class=
 
             {
-              border: 0px;
-              height: 1px;
-              margin-bottom: -1px;
-              margin-left: -1px;
-              margin-right: -1px;
-              margin-top: -1px;
-              overflow: hidden;
-              padding-bottom: 0px;
-              padding-left: 0px;
+              display: flex;
+            }
+      >
+        <div
+          class=
+
+              {
+                flex-grow: 1;
+              }
+        >
+          <div
+            aria-label="Hue"
+            aria-valuemax="359"
+            aria-valuemin="0"
+            aria-valuenow="210"
+            aria-valuetext="210"
+            class=
+                ms-ColorPicker-slider
+                is-hue
+                {
+                  background: linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%);
+                  border-radius: 2px;
+                  border: 1px solid #edebe9;
+                  box-sizing: border-box;
+                  forced-color-adjust: none;
+                  height: 20px;
+                  margin-bottom: 8px;
+                  outline: none;
+                  position: relative;
+                }
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #605e5c;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                  outline: 2px solid CanvasText;
+                }
+            data-is-focusable="true"
+            role="slider"
+            tabindex="0"
+          >
+            <div
+              class=
+                  ms-ColorPicker-thumb
+                  is-slider
+                  {
+                    background: white;
+                    border-radius: 50%;
+                    border: 1px solid #8a8886;
+                    box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                    forced-color-adjust: auto;
+                    height: 20px;
+                    position: absolute;
+                    top: 50%;
+                    transform: translate(-50%, -50%);
+                    width: 20px;
+                  }
+              style="left: 58.4958217270195%;"
+            />
+          </div>
+          <div
+            aria-label="Transparency"
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="0"
+            aria-valuetext="0"
+            class=
+                ms-ColorPicker-slider
+                is-alpha
+                {
+                  background-image: url(data;
+                  base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==): ;
+                  border-radius: 2px;
+                  border: 1px solid #edebe9;
+                  box-sizing: border-box;
+                  forced-color-adjust: none;
+                  height: 20px;
+                  margin-bottom: 8px;
+                  outline: none;
+                  position: relative;
+                }
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #605e5c;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                  outline: 2px solid CanvasText;
+                }
+            data-is-focusable="true"
+            role="slider"
+            tabindex="0"
+          >
+            <div
+              class=
+                  ms-ColorPicker-sliderOverlay
+                  {
+                    bottom: 0px;
+                    content: ;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            />
+            <div
+              class=
+                  ms-ColorPicker-thumb
+                  is-slider
+                  {
+                    background: white;
+                    border-radius: 50%;
+                    border: 1px solid #8a8886;
+                    box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                    forced-color-adjust: auto;
+                    height: 20px;
+                    position: absolute;
+                    top: 50%;
+                    transform: translate(-50%, -50%);
+                    width: 20px;
+                  }
+              style="left: 0%;"
+            />
+          </div>
+        </div>
+      </div>
+      <table
+        cellpadding="0"
+        cellspacing="0"
+        class=
+            ms-ColorPicker-table
+            {
+              table-layout: fixed;
+              width: 100%;
+            }
+            & tbody td:last-of-type .ms-ColorPicker-input {
               padding-right: 0px;
-              padding-top: 0px;
-              position: absolute;
-              white-space: nowrap;
-              width: 1px;
             }
-        id="ColorRectangle-description0"
+        role="group"
       >
-        Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
-      </div>
-      <div
-        className=
-            ms-ColorPicker-light
-            {
-              background: linear-gradient(to right, white 0%, transparent 100%) /*@noflip*/;
-              bottom: 0px;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-      />
-      <div
-        className=
-            ms-ColorPicker-dark
-            {
-              background: linear-gradient(to bottom, transparent 0, #000 100%);
-              bottom: 0px;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-      />
-      <div
-        className=
-            ms-ColorPicker-thumb
-            {
-              background: white;
-              border-radius: 50%;
-              border: 1px solid #8a8886;
-              box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
-              height: 20px;
-              position: absolute;
-              transform: translate(-50%, -50%);
-              width: 20px;
-            }
-            &:before {
-              border-radius: 50%;
-              border: 2px solid #ffffff;
-              bottom: 0px;
-              box-sizing: border-box;
-              content: "";
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-        style={
-          Object {
-            "backgroundColor": "#abcdef",
-            "left": "28%",
-            "top": "6%",
-          }
-        }
-      />
-    </div>
-    <div
-      className=
+        <thead>
+          <tr
+            class=
 
-          {
-            display: flex;
-          }
-    >
-      <div
-        className=
-
-            {
-              flex-grow: 1;
-            }
-      >
-        <div
-          aria-label="Hue"
-          aria-valuemax={359}
-          aria-valuemin={0}
-          aria-valuenow={210}
-          aria-valuetext="210"
-          className=
-              ms-ColorPicker-slider
-              is-hue
-              {
-                background: linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%);
-                border-radius: 2px;
-                border: 1px solid #edebe9;
-                box-sizing: border-box;
-                forced-color-adjust: none;
-                height: 20px;
-                margin-bottom: 8px;
-                outline: none;
-                position: relative;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
-                outline: 2px solid CanvasText;
-              }
-          data-is-focusable={true}
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          role="slider"
-          tabIndex={0}
-        >
-          <div
-            className=
-                ms-ColorPicker-thumb
-                is-slider
                 {
-                  background: white;
-                  border-radius: 50%;
-                  border: 1px solid #8a8886;
-                  box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
-                  forced-color-adjust: auto;
-                  height: 20px;
-                  position: absolute;
-                  top: 50%;
-                  transform: translate(-50%, -50%);
-                  width: 20px;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
                 }
-            style={
-              Object {
-                "left": "58.4958217270195%",
-              }
-            }
-          />
-        </div>
-        <div
-          aria-label="Transparency"
-          aria-valuemax={100}
-          aria-valuemin={0}
-          aria-valuenow={0}
-          aria-valuetext="0"
-          className=
-              ms-ColorPicker-slider
-              is-alpha
-              {
-                background-image: url(data;
-                base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==): ;
-                border-radius: 2px;
-                border: 1px solid #edebe9;
-                box-sizing: border-box;
-                forced-color-adjust: none;
-                height: 20px;
-                margin-bottom: 8px;
-                outline: none;
-                position: relative;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
-                outline: 2px solid CanvasText;
-              }
-          data-is-focusable={true}
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          role="slider"
-          tabIndex={0}
-        >
-          <div
-            className=
-                ms-ColorPicker-sliderOverlay
-                {
-                  bottom: 0px;
-                  content: ;
-                  left: 0px;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
-                }
-            style={
-              Object {
-                "background": "linear-gradient(to right, #abcdef, transparent)",
-              }
-            }
-          />
-          <div
-            className=
-                ms-ColorPicker-thumb
-                is-slider
-                {
-                  background: white;
-                  border-radius: 50%;
-                  border: 1px solid #8a8886;
-                  box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
-                  forced-color-adjust: auto;
-                  height: 20px;
-                  position: absolute;
-                  top: 50%;
-                  transform: translate(-50%, -50%);
-                  width: 20px;
-                }
-            style={
-              Object {
-                "left": "0%",
-              }
-            }
-          />
-        </div>
-      </div>
-    </div>
-    <table
-      cellPadding="0"
-      cellSpacing="0"
-      className=
-          ms-ColorPicker-table
-          {
-            table-layout: fixed;
-            width: 100%;
-          }
-          & tbody td:last-of-type .ms-ColorPicker-input {
-            padding-right: 0px;
-          }
-      role="group"
-    >
-      <thead>
-        <tr
-          className=
-
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-              }
-              & td {
-                padding-bottom: 4px;
-              }
-        >
-          <td
-            className=
-
-                {
-                  width: 25%;
+                & td {
+                  padding-bottom: 4px;
                 }
           >
-            Hex
-          </td>
-          <td>
-            Red
-          </td>
-          <td>
-            Green
-          </td>
-          <td>
-            Blue
-          </td>
-          <td
-            className=
+            <td
+              class=
 
-                {
-                  width: 22%;
-                }
-          >
-            Transparency
-          </td>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
                   {
-                    display: inline;
+                    width: 25%;
                   }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
             >
+              Hex
+            </td>
+            <td>
+              Red
+            </td>
+            <td>
+              Green
+            </td>
+            <td>
+              Blue
+            </td>
+            <td
+              class=
+
+                  {
+                    width: 22%;
+                  }
+            >
+              Transparency
+            </td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
               <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Hex"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField2"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="abcdef"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Hex"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField2"
+                        spellcheck="false"
+                        type="text"
+                        value="abcdef"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip1"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
+            </td>
+            <td>
               <div
-                hidden={true}
-                id="tooltip1"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
-                  {
-                    display: inline;
-                  }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
-            >
-              <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Red"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField8"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="171"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Red"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField8"
+                        spellcheck="false"
+                        type="text"
+                        value="171"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip7"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
+            </td>
+            <td>
               <div
-                hidden={true}
-                id="tooltip7"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
-                  {
-                    display: inline;
-                  }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
-            >
-              <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Green"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField14"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="205"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Green"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField14"
+                        spellcheck="false"
+                        type="text"
+                        value="205"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip13"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
+            </td>
+            <td>
               <div
-                hidden={true}
-                id="tooltip13"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
-                  {
-                    display: inline;
-                  }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
-            >
-              <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Blue"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField20"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="239"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Blue"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField20"
+                        spellcheck="false"
+                        type="text"
+                        value="239"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip19"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
+            </td>
+            <td>
               <div
-                hidden={true}
-                id="tooltip19"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-          <td>
-            <div
-              className=
-                  ms-TooltipHost
-                  {
-                    display: inline;
-                  }
-              onBlurCapture={[Function]}
-              onFocusCapture={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="none"
-            >
-              <div
-                className=
-                    ms-TextField
-                    ms-ColorPicker-input
+                class=
+                    ms-TooltipHost
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      border: none;
-                      box-shadow: none;
-                      box-sizing: border-box;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      width: 100%;
+                      display: inline;
                     }
-                    &.ms-TextField {
-                      padding-right: 4px;
-                    }
-                    & .ms-TextField-field {
-                      min-width: auto;
-                      padding-bottom: 5px;
-                      padding-left: 5px;
-                      padding-right: 5px;
-                      padding-top: 5px;
-                      text-overflow: clip;
-                    }
+                role="none"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  class=
+                      ms-TextField
+                      ms-ColorPicker-input
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        border: none;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 30px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                        width: 100%;
+                      }
+                      &.ms-TextField {
+                        padding-right: 4px;
+                      }
+                      & .ms-TextField-field {
+                        min-width: auto;
+                        padding-bottom: 5px;
+                        padding-left: 5px;
+                        padding-right: 5px;
+                        padding-top: 5px;
+                        text-overflow: clip;
+                      }
                 >
                   <div
-                    className=
-                        ms-TextField-fieldGroup
-                        {
-                          align-items: stretch;
-                          background: #ffffff;
-                          border-radius: 2px;
-                          border: 1px solid #605e5c;
-                          box-shadow: none;
-                          box-sizing: border-box;
-                          cursor: text;
-                          display: flex;
-                          flex-direction: row;
-                          height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: relative;
-                        }
-                        &:hover {
-                          border-color: #323130;
-                        }
-                        @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                          -ms-high-contrast-adjust: none;
-                          border-color: Highlight;
-                          forced-color-adjust: none;
-                        }
+                    class="ms-TextField-wrapper"
                   >
-                    <input
-                      aria-invalid={false}
-                      aria-label="Transparency"
-                      autoComplete="off"
-                      className=
-                          ms-TextField-field
+                    <div
+                      class=
+                          ms-TextField-fieldGroup
                           {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            background-color: transparent;
-                            background: none;
-                            border-radius: 0px;
-                            border: none;
+                            align-items: stretch;
+                            background: #ffffff;
+                            border-radius: 2px;
+                            border: 1px solid #605e5c;
                             box-shadow: none;
                             box-sizing: border-box;
-                            color: #323130;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
+                            cursor: text;
+                            display: flex;
+                            flex-direction: row;
+                            height: 32px;
                             margin-bottom: 0px;
                             margin-left: 0px;
                             margin-right: 0px;
                             margin-top: 0px;
-                            min-width: 0px;
-                            outline: 0px;
-                            padding-bottom: 0;
-                            padding-left: 8px;
-                            padding-right: 8px;
-                            padding-top: 0;
-                            text-overflow: ellipsis;
-                            width: 100%;
-                          }
-                          &:active {
-                            outline: 0px;
-                          }
-                          &:focus {
-                            outline: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: relative;
                           }
                           &:hover {
-                            outline: 0px;
+                            border-color: #323130;
                           }
-                          &::-ms-clear {
-                            display: none;
+                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            border-color: Highlight;
+                            forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                            background: Window;
-                            color: WindowText;
-                          }
-                          &::placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
-                            color: GrayText;
-                          }
-                          &:-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                          &::-ms-input-placeholder {
-                            color: #605e5c;
-                            opacity: 1;
-                          }
-                          @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
-                            color: GrayText;
-                          }
-                      id="TextField26"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      spellCheck={false}
-                      type="text"
-                      value="0"
-                    />
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Transparency"
+                        autocomplete="off"
+                        class=
+                            ms-TextField-field
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              background: none;
+                              border-radius: 0px;
+                              border: none;
+                              box-shadow: none;
+                              box-sizing: border-box;
+                              color: #323130;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              margin-bottom: 0px;
+                              margin-left: 0px;
+                              margin-right: 0px;
+                              margin-top: 0px;
+                              min-width: 0px;
+                              outline: 0px;
+                              padding-bottom: 0;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 0;
+                              text-overflow: ellipsis;
+                              width: 100%;
+                            }
+                            &:active {
+                              outline: 0px;
+                            }
+                            &:focus {
+                              outline: 0px;
+                            }
+                            &:hover {
+                              outline: 0px;
+                            }
+                            &::-ms-clear {
+                              display: none;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                              background: Window;
+                              color: WindowText;
+                            }
+                            &::placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::placeholder {
+                              color: GrayText;
+                            }
+                            &:-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                            &::-ms-input-placeholder {
+                              color: #605e5c;
+                              opacity: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&::-ms-input-placeholder {
+                              color: GrayText;
+                            }
+                        id="TextField26"
+                        spellcheck="false"
+                        type="text"
+                        value="0"
+                      />
+                    </div>
                   </div>
                 </div>
+                <div
+                  hidden=""
+                  id="tooltip25"
+                  style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+                />
               </div>
-              <div
-                hidden={true}
-                id="tooltip25"
-                style={
-                  Object {
-                    "border": 0,
-                    "height": 1,
-                    "margin": -1,
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": 1,
-                  }
-                }
-              />
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
## Current Behavior

- v8 `ColorPicker` tests don't use testing-library

## New Behavior

- Convert `ColorPicker` to fully use testing-library

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

part of #21663 