### PR TITLE
v8 website: make example titles h3, update document title

### DIFF
--- a/change/@fluentui-react-docsite-components-a72db34a-ebc4-4048-a61b-98a23136cdc2.json
+++ b/change/@fluentui-react-docsite-components-a72db34a-ebc4-4048-a61b-98a23136cdc2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Render ExampleCard titles as h3, and update document title to reflect current page",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-docsite-components/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/react-docsite-components/src/components/ExampleCard/ExampleCard.tsx
@@ -77,6 +77,7 @@ export class ExampleCardBase extends React.Component<IExampleCardProps, IExample
   public render(): JSX.Element {
     const {
       title,
+      titleAs: TitleAs = 'h3',
       children,
       styles,
       isRightAligned = false,
@@ -113,7 +114,7 @@ export class ExampleCardBase extends React.Component<IExampleCardProps, IExample
           return (
             <div className={css(classNames.root, isCodeVisible && 'is-codeVisible')}>
               <div className={classNames.header}>
-                <span className={classNames.title}>{title}</span>
+                <TitleAs className={classNames.title}>{title}</TitleAs>
                 <div className={classNames.toggleButtons}>
                   {(codepenJS || this._transformedInitialCode) && (
                     <CodepenComponent

--- a/packages/react-docsite-components/src/components/ExampleCard/ExampleCard.types.ts
+++ b/packages/react-docsite-components/src/components/ExampleCard/ExampleCard.types.ts
@@ -7,6 +7,11 @@ import { IPackageGroup } from '@fluentui/react-monaco-editor';
 export interface IExampleCardProps {
   /** Example title */
   title: string;
+  /**
+   * Element to render the title as. Now defaults to h3 for accessibility.
+   * @default 'h3'
+   */
+  titleAs?: 'h2' | 'h3' | 'h4' | 'span';
   /** Whether this component is experimental */
   isOptIn?: boolean;
   /** Example code as a string */

--- a/packages/react-docsite-components/src/components/Nav/Nav.types.ts
+++ b/packages/react-docsite-components/src/components/Nav/Nav.types.ts
@@ -35,7 +35,7 @@ export interface INavPage<TPlatform extends string = string> extends Pick<IRoute
   title: string;
 
   /**
-   * URL for this page, relative to the site's root. Undefined for categories.
+   * Hash route or full external URL for this page. Undefined for categories.
    */
   url?: string;
 

--- a/packages/react-docsite-components/src/components/TopNav/TopNav.tsx
+++ b/packages/react-docsite-components/src/components/TopNav/TopNav.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { css, FocusZone, Panel, PanelType, ScreenWidthMinUhfMobile, on } from '@fluentui/react';
 import { IconButton } from '@fluentui/react/lib/Button';
-import { hasActiveChild, removeAnchorLink } from '../../utilities/index2';
+import { hasActiveChild, getNormalizedPath } from '../../utilities/index2';
 import { INavPage } from '../Nav/Nav.types';
 import { Badge } from '../Badge/index';
 import { ITopNavProps } from './TopNav.types';
@@ -20,7 +20,7 @@ export class TopNav extends React.Component<ITopNavProps, ITopNavState> {
 
   private _disposables: Function[] = [];
   private _isMounted: boolean = false;
-  private _route: string = removeAnchorLink(location.hash);
+  private _route: string = getNormalizedPath();
 
   public componentDidMount(): void {
     this._isMounted = true;
@@ -103,7 +103,7 @@ export class TopNav extends React.Component<ITopNavProps, ITopNavState> {
   };
 
   private _onHashChange = (): void => {
-    const newRoute = removeAnchorLink(location.hash);
+    const newRoute = getNormalizedPath();
     if (this._isMounted && newRoute !== this._route) {
       this._route = newRoute;
       this.setState({ isNavOpen: false });

--- a/packages/react-docsite-components/src/utilities/getNormalizedPath.ts
+++ b/packages/react-docsite-components/src/utilities/getNormalizedPath.ts
@@ -1,0 +1,26 @@
+import { getDocument } from '@fluentui/react/lib/Utilities';
+import { removeAnchorLink } from './removeAnchorLink';
+
+/**
+ * Get current hash route path, lowercase and without any trailing slash, query, or anchor
+ * (will include leading #)
+ */
+export function getNormalizedPath() {
+  let path = getDocument()?.location.hash;
+  if (!path) {
+    return '';
+  }
+
+  path = removeAnchorLink(path);
+
+  return normalizePath(path);
+}
+
+/** Convert path to lowercase and remove trailing slash (doesn't check for query or anchor) */
+export function normalizePath(path?: string) {
+  path = path || '';
+  if (path.slice(-1) === '/') {
+    path = path.slice(0, -1);
+  }
+  return path.toLowerCase();
+}

--- a/packages/react-docsite-components/src/utilities/getSiteArea.ts
+++ b/packages/react-docsite-components/src/utilities/getSiteArea.ts
@@ -1,15 +1,16 @@
 import { INavPage } from '../components/Nav/index';
+import { getNormalizedPath, normalizePath } from './getNormalizedPath';
 import { removeAnchorLink } from './removeAnchorLink';
 
 /**
  * Retrieves the current top level page name defined in the pages array from the window URL or the passed hash.
  * @param pages - Array of pages.
- * @param hash - The hash.
+ * @param hashOrUrl - The hash or new URL, if getting the area for something besides the current page
  */
-export function getSiteArea(pages?: INavPage[], hash: string = location.hash): string {
-  hash = removeAnchorLink(hash).split('?')[0];
+export function getSiteArea(pages?: INavPage[], hashOrUrl?: string): string {
+  hashOrUrl = hashOrUrl ? normalizePath(removeAnchorLink(hashOrUrl)) : getNormalizedPath();
   // Get the first level from the URL as a fallback. "#/controls/web/button" would be "controls"
-  const topLevel = hash.indexOf('#/') > -1 ? hash.split('#/')[1].split('/')[0] : '';
+  const topLevel = hashOrUrl.indexOf('#/') > -1 ? hashOrUrl.split('#/')[1].split('/')[0] : '';
   const urlRegex = new RegExp(`\^#/${topLevel}\\b`);
   let area = topLevel;
   if (pages) {

--- a/packages/react-docsite-components/src/utilities/index2.ts
+++ b/packages/react-docsite-components/src/utilities/index2.ts
@@ -4,6 +4,7 @@ export * from './activePage';
 export * from './appInsightsHelper';
 export * from './baseDefinition';
 export * from './getEditUrl';
+export * from './getNormalizedPath';
 export * from './getPageFirstPlatform';
 export * from './getSiteArea';
 export * from './jumpToAnchor';

--- a/packages/react-docsite-components/src/utilities/router/Router.tsx
+++ b/packages/react-docsite-components/src/utilities/router/Router.tsx
@@ -1,15 +1,17 @@
 import * as React from 'react';
 import { initializeComponentRef, on } from '@fluentui/react/lib/Utilities';
 import { IRouteProps } from './Route';
+import { getNormalizedPath, normalizePath } from '../getNormalizedPath';
 
 export interface IRouterProps {
   /**
    * Gets the component ref.
    */
   componentRef?: () => void;
-
+  /** @deprecated unused */
   replaceState?: boolean;
   children?: React.ReactNode;
+  /** @deprecated unused */
   onNewRouteLoaded?: () => void;
 }
 
@@ -25,7 +27,7 @@ export class Router extends React.Component<IRouterProps, IRouterState> {
     this._disposables = [];
     initializeComponentRef(this);
     this.state = {
-      path: this._getPath(),
+      path: getNormalizedPath(),
     };
   }
 
@@ -33,7 +35,7 @@ export class Router extends React.Component<IRouterProps, IRouterState> {
     this._disposables.push(
       on(window, 'hashchange', () => {
         // Don't update unless the route itself (not an anchor link) actually changed
-        const path = this._getPath();
+        const path = getNormalizedPath();
         if (path !== this.state.path) {
           this.setState({ path });
         }
@@ -47,24 +49,6 @@ export class Router extends React.Component<IRouterProps, IRouterState> {
 
   public render() {
     return this._resolveRoute();
-  }
-
-  private _getPath(): string {
-    let path = location.hash;
-    const hashIndex = path.lastIndexOf('#');
-    const questionMarkIndex = path.indexOf('?');
-
-    // Look for the start of a query in the currentPath, then strip out the query to find the correct page to render
-    if (questionMarkIndex > -1) {
-      path = path.substr(0, questionMarkIndex);
-    }
-
-    // If the hash has a second # (for an anchor), strip that out since it's not used for routing
-    if (hashIndex > 0) {
-      path = path.substr(0, hashIndex);
-    }
-
-    return _normalizePath(path);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -82,7 +66,7 @@ export class Router extends React.Component<IRouterProps, IRouterState> {
         continue;
       }
       // Use this route if it has no path, or if the path matches the current path (from the hash)
-      const routePath = _normalizePath(route.props.path);
+      const routePath = normalizePath(route.props.path);
       if (!routePath || routePath === path) {
         let { component } = route.props;
 
@@ -126,12 +110,4 @@ export class Router extends React.Component<IRouterProps, IRouterState> {
 
     return null;
   }
-}
-
-/** Normalize path for comparison: strip any trailing slash and convert to lowercase */
-function _normalizePath(path?: string): string {
-  if (path && path.slice(-1) === '/') {
-    path = path.slice(0, -1);
-  }
-  return (path || '').toLowerCase();
 }


### PR DESCRIPTION
## Current Behavior

Among the various long-running issues with the website, @smhigley brought these particularly unfortunate ones to my attention again during FHL:
- The example titles aren't rendered as actual HTML headings (bad for screen reader users)
- The document title doesn't update to reflect the current page title

## New Behavior

Make the ExampleCard titles use `h3` by default, with a prop for customization.

Updating the document title was tricky and actually had to be done in two places:
- `App.tsx` in `react-docsite-components` for the legacy demo app (as seen at aka.ms/fluentdemo)
- `Site.tsx` in `public-docsite` for the actual website (developer.microsoft.com/fluentui). 

Our custom router component already had logic to match the current hash with a route URL, and I factored that out into a `getNormalizedPath` function so it could be used elsewhere. Once you have a normalized route URL, it's possible to get the corresponding page object (with title) from the app/site definition.

I also updated various other places that were comparing URLs to use `getNormalizedPath`, to maximize the chances of correct comparison results.