### PR TITLE
v8 website: change class to className in markdown files

### DIFF
--- a/apps/public-docsite/src/pages/Overviews/GetStartedPage/docs/web/GetStartedNextSteps.md
+++ b/apps/public-docsite/src/pages/Overviews/GetStartedPage/docs/web/GetStartedNextSteps.md
@@ -16,8 +16,8 @@ Fluent UI React components are highly customizable using CSS-in-JS. We also supp
 
 For an overview of styling and theming approaches in Fluent UI, see [this page](https://github.com/Microsoft/frontend-bootcamp/tree/master/step2-03/demo). Then check out the links below for more details:
 
-<ul class="md-list--flex">
-  <li class="mdut--full">[Theme designer](https://aka.ms/themedesigner)</li>
-  <li class="mdut--full">[Customizing CSS-in-JS styled components](https://github.com/microsoft/fluentui/wiki/Component-Styling)</li>
-  <li class="mdut--full">[Theming deep dive](https://github.com/microsoft/fluentui/wiki/Theming)</li>
+<ul className="md-list--flex">
+  <li className="mdut--full">[Theme designer](https://aka.ms/themedesigner)</li>
+  <li className="mdut--full">[Customizing CSS-in-JS styled components](https://github.com/microsoft/fluentui/wiki/Component-Styling)</li>
+  <li className="mdut--full">[Theming deep dive](https://github.com/microsoft/fluentui/wiki/Theming)</li>
 </ul>

--- a/apps/public-docsite/src/pages/Overviews/ResourcesPage/docs/default/ResourcesContributionProcess.md
+++ b/apps/public-docsite/src/pages/Overviews/ResourcesPage/docs/default/ResourcesContributionProcess.md
@@ -2,10 +2,10 @@ Reference these step-by-step processes for contributing to Fluent UI.
 
 ### Web
 
-<ul class="md-list--flex">
-  <li class="mdut--full">[Implement a Fluent UI React control](https://github.com/microsoft/fluentui/wiki/New-Components)</li>
-  <li class="mdut--full">[Give feedback on a control by filing an issue on GitHub](https://github.com/microsoft/fluentui/wiki/Reporting-Issues)</li>
-  <li class="mdut--full">[View current GitHub issues for all Fluent UI React controls](https://github.com/microsoft/fluentui/issues)</li>
+<ul className="md-list--flex">
+  <li className="mdut--full">[Implement a Fluent UI React control](https://github.com/microsoft/fluentui/wiki/New-Components)</li>
+  <li className="mdut--full">[Give feedback on a control by filing an issue on GitHub](https://github.com/microsoft/fluentui/wiki/Reporting-Issues)</li>
+  <li className="mdut--full">[View current GitHub issues for all Fluent UI React controls](https://github.com/microsoft/fluentui/issues)</li>
 </ul>
 
 ### Cross-platform

--- a/apps/public-docsite/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDesignResources.md
+++ b/apps/public-docsite/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDesignResources.md
@@ -2,15 +2,15 @@
 
 These design toolkits provide styles, controls and layout templates that enable you to create beautiful and coherent Microsoft experiences.
 
-<ul class="md-list--flex">
-  <li class="mdut--half">[Download Web toolkit (Sketch)](https://aka.ms/FluentToolkits/Web/Sketch)</li>
-  <li class="mdut--half">[Download Web toolkit (Figma)](https://aka.ms/FluentToolkits/Web/Figma)</li>
-  <li class="mdut--half">[Download iOS toolkit (Sketch)](https://aka.ms/FluentToolkits/iOS/Sketch)</li>
-  <li class="mdut--half">[Download iOS toolkit (Figma)](https://aka.ms/FluentToolkits/iOS/Figma)</li>
-  <li class="mdut--half">[Download Android toolkit (Sketch)](https://aka.ms/FluentToolkits/Android/Sketch)</li>
-  <li class="mdut--half">[Download Android toolkit (Figma)](https://aka.ms/FluentToolkits/Android/Figma)</li>
-  <li class="mdut--half">[Download Windows toolkit (Figma)](https://aka.ms/figmatoolkit)</li>
-  <li class="mdut--half">[Download Figma plug-in](https://www.figma.com/community/plugin/794492287931420611/Fluent-Theme-Designer)</li>
+<ul className="md-list--flex">
+  <li className="mdut--half">[Download Web toolkit (Sketch)](https://aka.ms/FluentToolkits/Web/Sketch)</li>
+  <li className="mdut--half">[Download Web toolkit (Figma)](https://aka.ms/FluentToolkits/Web/Figma)</li>
+  <li className="mdut--half">[Download iOS toolkit (Sketch)](https://aka.ms/FluentToolkits/iOS/Sketch)</li>
+  <li className="mdut--half">[Download iOS toolkit (Figma)](https://aka.ms/FluentToolkits/iOS/Figma)</li>
+  <li className="mdut--half">[Download Android toolkit (Sketch)](https://aka.ms/FluentToolkits/Android/Sketch)</li>
+  <li className="mdut--half">[Download Android toolkit (Figma)](https://aka.ms/FluentToolkits/Android/Figma)</li>
+  <li className="mdut--half">[Download Windows toolkit (Figma)](https://aka.ms/figmatoolkit)</li>
+  <li className="mdut--half">[Download Figma plug-in](https://www.figma.com/community/plugin/794492287931420611/Fluent-Theme-Designer)</li>
 
 </ul>
 
@@ -19,36 +19,36 @@ These design toolkits provide styles, controls and layout templates that enable 
 
 These SharePoint design resources provide everything you need to design your web parts, including responsive page grids and columns.
 
-<ul class="md-list--flex">
-  <li class="mdut--half">[Designing SharePoint experiences](https://aka.ms/spdesign)</li>
-  <li class="mdut--half">[SharePoint Toolkit (Figma)](https://aka.ms/SharePointToolkits/Web/Figma)</li>
+<ul className="md-list--flex">
+  <li className="mdut--half">[Designing SharePoint experiences](https://aka.ms/spdesign)</li>
+  <li className="mdut--half">[SharePoint Toolkit (Figma)](https://aka.ms/SharePointToolkits/Web/Figma)</li>
 </ul>
 
 <h3 id="office-add-ins-design">Office Add-ins</h3>
 
 The Add-ins design toolkit provides layouts for interface elements and commonly used patterns in Word, Excel, and PowerPoint. Use it in addition to the Microsoft design toolkits to create an add-in that fits within Office.
 
-<ul class="md-list--flex">
-  <li class="mdut--half">[Add-ins Toolkit (Sketch)](https://aka.ms/addins_sketch_toolkit)</li>
-  <li class="mdut--half">[Designing Office Add-ins](https://docs.microsoft.com/en-us/office/dev/add-ins/design/add-in-design)</li>
-  <li class="mdut--half">[Add-ins Toolkit (XD)](https://aka.ms/addins_toolkit)</li>
+<ul className="md-list--flex">
+  <li className="mdut--half">[Add-ins Toolkit (Sketch)](https://aka.ms/addins_sketch_toolkit)</li>
+  <li className="mdut--half">[Designing Office Add-ins](https://docs.microsoft.com/en-us/office/dev/add-ins/design/add-in-design)</li>
+  <li className="mdut--half">[Add-ins Toolkit (XD)](https://aka.ms/addins_toolkit)</li>
 </ul>
 
 ### Fonts
 
-<ul class="md-list--flex">
-  <li class="mdut--half">[iOS font](https://developer.apple.com/fonts/)</li>
-  <li class="mdut--half">[Download Segoe UI and MDL2 external font](https://aka.ms/WebFluentFonts)</li>
-  <li class="mdut--half">[Android font](https://fonts.google.com/specimen/Roboto)</li>
+<ul className="md-list--flex">
+  <li className="mdut--half">[iOS font](https://developer.apple.com/fonts/)</li>
+  <li className="mdut--half">[Download Segoe UI and MDL2 external font](https://aka.ms/WebFluentFonts)</li>
+  <li className="mdut--half">[Android font](https://fonts.google.com/specimen/Roboto)</li>
 </ul>
 
 ### Native OS platforms
 
-<ul class="md-list--flex">
-  <li class="mdut--half">[iOS Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/ios/overview/themes/)</li>
-  <li class="mdut--half">[Guidelines for iOS app icons](https://developer.apple.com/design/human-interface-guidelines/ios/icons-and-images/app-icon/)</li>
-  <li class="mdut--half">[macOS Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/macos/overview/themes/)</li>
-  <li class="mdut--half">[Guidelines for macOS app icons](https://developer.apple.com/design/human-interface-guidelines/macos/icons-and-images/app-icon/)</li>
-  <li class="mdut--half">[Android Human Interface Guidelines](https://developer.android.com/design/)</li>
-  <li class="mdut--half">[Guidelines for Android app icons](https://developer.android.com/guide/practices/ui_guidelines/icon_design)</li>
+<ul className="md-list--flex">
+  <li className="mdut--half">[iOS Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/ios/overview/themes/)</li>
+  <li className="mdut--half">[Guidelines for iOS app icons](https://developer.apple.com/design/human-interface-guidelines/ios/icons-and-images/app-icon/)</li>
+  <li className="mdut--half">[macOS Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/macos/overview/themes/)</li>
+  <li className="mdut--half">[Guidelines for macOS app icons](https://developer.apple.com/design/human-interface-guidelines/macos/icons-and-images/app-icon/)</li>
+  <li className="mdut--half">[Android Human Interface Guidelines](https://developer.android.com/design/)</li>
+  <li className="mdut--half">[Guidelines for Android app icons](https://developer.android.com/guide/practices/ui_guidelines/icon_design)</li>
 </ul>

--- a/apps/public-docsite/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDeveloperResources.md
+++ b/apps/public-docsite/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDeveloperResources.md
@@ -2,16 +2,16 @@
 
 #### Get started with React and learn how to build your first projects.
 
-<ul class="md-list--flex">
-  <li class="mdut--full">[Get started with Fluent UI React](#/get-started)</li>
-  <li class="mdut--full">[Fluent UI React tutorial](https://github.com/microsoft/fluentui/wiki/Getting-Started-with-UI-Fabric)</li>
+<ul className="md-list--flex">
+  <li className="mdut--full">[Get started with Fluent UI React](#/get-started)</li>
+  <li className="mdut--full">[Fluent UI React tutorial](https://github.com/microsoft/fluentui/wiki/Getting-Started-with-UI-Fabric)</li>
 </ul>
 
 #### Get started with React Native and learn how to build your first projects.
 
-<ul class="md-list--flex">
+<ul className="md-list--flex">
 
-  <li class="mdut--full">[Get started with Fluent UI React Native
+  <li className="mdut--full">[Get started with Fluent UI React Native
 ](https://github.com/microsoft/fluentui-react-native)</li>
 </ul>
 
@@ -19,34 +19,34 @@
 
 In addition to the API documentation and control examples found in the [Controls section](#/controls/web) of this website, you can find a full collection of API references on the docs.microsoft.com portal.
 
-<ul class="md-list--flex">
-  <li class="mdut--full">[API reference on docs.microsoft.com](https://docs.microsoft.com/en-us/javascript/api/office-ui-fabric-react?branch=live&view=office-ui-fabric-react-latest)</li>
+<ul className="md-list--flex">
+  <li className="mdut--full">[API reference on docs.microsoft.com](https://docs.microsoft.com/en-us/javascript/api/office-ui-fabric-react?branch=live&view=office-ui-fabric-react-latest)</li>
 </ul>
 
 ### Release notes and demos
 
 View Fluent UI React's versioned release notes and component demos.
 
-<ul class="md-list--flex">
-  <li class="mdut--full">[Release notes and demos](https://aka.ms/fluentdemo)</li>
+<ul className="md-list--flex">
+  <li className="mdut--full">[Release notes and demos](https://aka.ms/fluentdemo)</li>
 </ul>
 
 <h3 id="sharepoint-framework-dev">SharePoint Framework</h3>
 
 SharePoint uses Fluent UI, so if you’re building on top of or within a SharePoint experience, you can be sure that your UI will blend in.
 
-<ul class="md-list--flex">
-  <li class="mdut--half">[SharePoint Framework overview](https://aka.ms/spfx)</li>
-  <li class="mdut--half">[Use Fluent UI React components in web parts](https://aka.ms/spfx-fabric-react)</li>
-  <li class="mdut--half">[Theme Designer](https://aka.ms/themedesigner)</li>
-  <li class="mdut--half">[Get started with building client-side web parts](https://aka.ms/spfx-tutorials)</li>
+<ul className="md-list--flex">
+  <li className="mdut--half">[SharePoint Framework overview](https://aka.ms/spfx)</li>
+  <li className="mdut--half">[Use Fluent UI React components in web parts](https://aka.ms/spfx-fabric-react)</li>
+  <li className="mdut--half">[Theme Designer](https://aka.ms/themedesigner)</li>
+  <li className="mdut--half">[Get started with building client-side web parts](https://aka.ms/spfx-tutorials)</li>
 </ul>
 
 <h3 id="office-add-ins-dev">Office Add-ins</h3>
 
 Fluent UI is the official UI toolkit for creating Office Add-ins. Check out some of these resources to learn more about how to use Fluent UI in your next Add-in.
 
-<ul class="md-list--flex">
-  <li class="mdut--full">[Add-ins overview](https://docs.microsoft.com/office/dev/add-ins/)</li>
-  <li class="mdut--full">[Using Fluent UI React in your Add-ins](https://docs.microsoft.com/office/dev/add-ins/design/add-in-design)</li>
+<ul className="md-list--flex">
+  <li className="mdut--full">[Add-ins overview](https://docs.microsoft.com/office/dev/add-ins/)</li>
+  <li className="mdut--full">[Using Fluent UI React in your Add-ins](https://docs.microsoft.com/office/dev/add-ins/design/add-in-design)</li>
 </ul>


### PR DESCRIPTION
## Current Behavior

I noticed while working on #22266  that there was a React dev warning in the console about `class` being an invalid React attribute, coming from converted markdown files.

I don't think this happened in the past, so it may have been due to a change in `markdown-to-jsx` 6 => 7.

## New Behavior

Update the markdown files to use `className` instead of `class` (only in the parts that will be rendered as HTML by `markdown-to-jsx`, not in code blocks).