### PR TITLE
Change combobox aria-autocomplete to 'list' when autoComplete is off

### DIFF
--- a/change/@fluentui-react-c438a225-3740-4f59-9009-a25fc06478c1.json
+++ b/change/@fluentui-react-c438a225-3740-4f59-9009-a25fc06478c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Change combobox aria-autocomplete to 'list' when autoComplete is off",
+  "packageName": "@fluentui/react",
+  "email": "dennisgeorge.mec@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -2337,11 +2337,11 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
   /**
    * Get the aria autocomplete value for the combo box
    * @returns 'inline' if auto-complete automatically dynamic, 'both' if we have a list of possible values to pick from
-   * and can dynamically populate input, and 'none' if auto-complete is not enabled as we can't give user inputs.
+   * and can dynamically populate input, and 'list' if auto-complete is not enabled as selection is the only option.
    */
   private _getAriaAutoCompleteValue(): 'none' | 'inline' | 'list' | 'both' | undefined {
     const autoComplete = !this.props.disabled && this.props.autoComplete === 'on';
-    return autoComplete ? (this.props.allowFreeform ? 'inline' : 'both') : 'none';
+    return autoComplete ? (this.props.allowFreeform ? 'inline' : 'both') : 'list';
   }
 
   private _isPendingOption(item: IComboBoxOption): boolean {

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -2338,6 +2338,8 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
    * Get the aria autocomplete value for the combo box
    * @returns 'inline' if auto-complete automatically dynamic, 'both' if we have a list of possible values to pick from
    * and can dynamically populate input, and 'list' if auto-complete is not enabled as selection is the only option.
+   * Ideally, this should be 'none' if auto-complete is not enabled, but there is a known bug in Edge
+   * where the callout may appear over the combo box if this attribute is set to 'none'
    */
   private _getAriaAutoCompleteValue(): 'none' | 'inline' | 'list' | 'both' | undefined {
     const autoComplete = !this.props.disabled && this.props.autoComplete === 'on';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->
Pull request checklist
* [x]  Addresses an existing issue: Fixes https://github.com/microsoft/fluentui/issues/22084
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (skipped - very minor change)
* [x] You've run `yarn change` locally

## Current behavior

Edge shows autofill info for ComboBox inputs having id or aria-label starting with "name", which isn't the desired behavior for combo boxes since it will result in two overlapping menus. On investigating the attributes, [aria-autocomplete flag](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) seems to be initialized incorrectly for the underlying [autofill](https://github.com/microsoft/fluentui/blob/83a08f167c8d8535f4e15ab2b760bec1a1a486be/packages/react/src/components/ComboBox/ComboBox.tsx#L2344). It should be "list" here rather than "none" as per the definition of the values of this attribute.

## New Behavior

aria-autocomplete should be "list" in case of allowFreeform==true && autoComplete==false
When this attribute is changed, Edge does not display the autofill.


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22084
