### PR TITLE
Remove ecraig12345 from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,8 +69,8 @@ packages/web-components @chrisdholt @EisenbergEffect @nicholasrice
 
 #### Apps
 # component-demo
-public-docsite @ecraig12345 @micahgodbolt
-public-docsite-resources @ecraig12345 @micahgodbolt
+public-docsite @microsoft/fluentui-v8-website
+public-docsite-resources @microsoft/fluentui-v8-website
 perf-test @microsoft/fluentui-react-build
 # ssr-tests
 
@@ -84,8 +84,8 @@ packages/foundation-legacy @microsoft/cxe-red @khmakoto
 # packages/jest-serializer-merge-styles
 
 packages/merge-styles @dzearing
-packages/monaco-editor @ecraig12345
-packages/public-docsite-setup @ecraig12345
+packages/monaco-editor @microsoft/fluentui-v8-website
+packages/public-docsite-setup @microsoft/fluentui-v8-website
 packages/priority-overflow @microsoft/teams-prg
 packages/react-aria @microsoft/teams-prg
 packages/react-cards @microsoft/cxe-red @khmakoto
@@ -93,10 +93,10 @@ packages/react-charting @microsoft/charting-team
 packages/react-conformance-griffel @microsoft/teams-prg
 packages/react-context-selector @microsoft/teams-prg
 packages/react-date-time @ermercer @evlevy
-packages/react-docsite-components @ecraig12345 @micahgodbolt
+packages/react-docsite-components @microsoft/fluentui-v8-website
 packages/react-file-type-icons @jahnp @bigbadcapers
-packages/react-hooks @microsoft/cxe-red @ecraig12345
-packages/react-monaco-editor @ecraig12345
+packages/react-hooks @microsoft/cxe-red
+packages/react-monaco-editor @microsoft/fluentui-v8-website
 packages/react-positioning @microsoft/teams-prg
 packages/react-priority-overflow @microsoft/teams-prg
 packages/react-shared-contexts @microsoft/teams-prg
@@ -132,7 +132,7 @@ packages/react-dialog @microsoft/cxe-prg
 packages/react-divider @microsoft/cxe-coastal
 packages/react-focus @microsoft/cxe-red @khmakoto
 packages/react-image @microsoft/cxe-prg
-packages/react-input @microsoft/cxe-red @ecraig12345
+packages/react-input @microsoft/cxe-red
 packages/react-label @microsoft/cxe-red
 packages/react-link @microsoft/cxe-red @khmakoto @microsoft/cxe-coastal
 packages/react-menu @microsoft/teams-prg
@@ -143,7 +143,7 @@ packages/react-radio @microsoft/cxe-red
 packages/react-select @microsoft/cxe-coastal @smhigley
 packages/react-slider @microsoft/cxe-coastal @micahgodbolt
 packages/react-spinner @microsoft/cxe-red @tomi-msft
-packages/react-switch @microsoft/cxe-red @behowell @khmakoto @ecraig12345
+packages/react-switch @microsoft/cxe-red @behowell @khmakoto
 packages/react-tabs @microsoft/cxe-coastal @geoffcoxmsft
 packages/react-text @microsoft/cxe-prg
 packages/react-textarea @microsoft/cxe-red @sopranopillow
@@ -160,9 +160,9 @@ packages/react/src/components/Calendar @ermercer @evlevy
 packages/react/src/components/CalendarDayGrid @ermercer @evlevy
 packages/react/src/components/Check @microsoft/cxe-red @ThomasMichon @khmakoto
 packages/react/src/components/Checkbox @microsoft/cxe-red @khmakoto
-packages/react/src/components/ChoiceGroup @microsoft/cxe-red @ecraig12345
+packages/react/src/components/ChoiceGroup @microsoft/cxe-red
 packages/react/src/components/Coachmark @microsoft/cxe-red @leddie24
-packages/react/src/components/ColorPicker @microsoft/cxe-red @ecraig12345
+packages/react/src/components/ColorPicker @microsoft/cxe-red
 packages/react/src/components/DatePicker @ermercer @evlevy
 packages/react/src/components/DetailsList @microsoft/cxe-red @ThomasMichon
 packages/react/src/components/DocumentCard @microsoft/cxe-red @yiminwu
@@ -171,28 +171,28 @@ packages/react/src/components/Facepile @microsoft/cxe-red @markionium @mtennoe
 packages/react/src/components/FolderCover @microsoft/cxe-red @ThomasMichon @bigbadcapers
 packages/react/src/components/FocusTrapZone @microsoft/cxe-red @khmakoto
 packages/react/src/components/GroupedList @microsoft/cxe-red @ThomasMichon
-packages/react/src/components/HoverCard @microsoft/cxe-red @Jahnp @Vitalius1
-packages/react/src/components/Icon @microsoft/cxe-red @dzearing @ecraig12345
+packages/react/src/components/HoverCard @microsoft/cxe-red @Jahnp
+packages/react/src/components/Icon @microsoft/cxe-red @dzearing
 packages/react/src/components/Image @microsoft/cxe-red @dzearing
 packages/react/src/components/Label @microsoft/cxe-red @khmakoto
 packages/react/src/components/Layer @microsoft/cxe-red @ThomasMichon
 packages/react/src/components/Link @microsoft/cxe-red @khmakoto
 packages/react/src/components/List @microsoft/cxe-red @ThomasMichon
 packages/react/src/components/MarqueeSelection @microsoft/cxe-red @ThomasMichon
-packages/react/src/components/MessageBar @microsoft/cxe-red @ecraig12345
-packages/react/src/components/Nav @microsoft/cxe-red @ecraig12345
+packages/react/src/components/MessageBar @microsoft/cxe-red
+packages/react/src/components/Nav @microsoft/cxe-red
 packages/react/src/components/Overlay @microsoft/cxe-red @khmakoto
 packages/react/src/components/Panel @microsoft/cxe-red @khmakoto
 packages/react/src/components/Persona @microsoft/cxe-red @markionium @mtennoe
 packages/react/src/components/PersonaCoin @microsoft/cxe-red @mtennoe @markionium
 packages/react/src/components/Pivot @microsoft/cxe-red @behowell
-packages/react/src/components/SearchBox @microsoft/cxe-red @ecraig12345
-packages/react/src/components/Shimmer @microsoft/cxe-red @Vitalius1
-packages/react/src/components/SpinButton @microsoft/cxe-red @ecraig12345
+packages/react/src/components/SearchBox @microsoft/cxe-red
+packages/react/src/components/Shimmer @microsoft/cxe-red
+packages/react/src/components/SpinButton @microsoft/cxe-red
 packages/react/src/components/Stack @microsoft/cxe-red @khmakoto
-packages/react/src/components/SwatchColorPicker @microsoft/cxe-red @ecraig12345
+packages/react/src/components/SwatchColorPicker @microsoft/cxe-red
 packages/react/src/components/Text @microsoft/cxe-red @khmakoto
-packages/react/src/components/TextField @microsoft/cxe-red @ecraig12345
+packages/react/src/components/TextField @microsoft/cxe-red
 packages/react/src/components/Toggle @microsoft/cxe-red @khmakoto
 packages/react/src/components/Tooltip @microsoft/cxe-red @behowell
 packages/react/src/components/WeeklyDayPicker @ermercer @evlevy


### PR DESCRIPTION
This PR removes me from direct codeowner listings (I'm actually still a codeowner of most of these things via github teams for now).

- Website: replace with `@microsoft/fluentui-v8-website` which includes @micahgodbolt, @khmakoto, @sopranopillow
- v8/9 components: fall back to `@microsoft/cxe-red` with no individual owner

I also noticed we still have a couple codeowner rules for Vitalie who has been working on other things for awhile, so I removed those as well (falling back to cxe-red).