### PR TITLE
Enable more conformance tests for Tooltip

### DIFF
--- a/change/@fluentui-react-conformance-785a243f-f41d-4887-ae88-a779ee586235.json
+++ b/change/@fluentui-react-conformance-785a243f-f41d-4887-ae88-a779ee586235.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add comment to react-conformance Portal docs",
+  "packageName": "@fluentui/react-conformance",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-conformance/README.md
+++ b/packages/react-conformance/README.md
@@ -72,6 +72,11 @@ Portals can be inspected by providing a `getTargetElement` function to `isConfor
 
 ```jsx
 
+// Assume that `Foo` is a component that renders a Portal.
+// It takes a prop called `idForPortal` that renders the
+// provided id in the Portal, allowing it to be looked up
+// via `getPortalElement()`.
+
 const getPortalElement = (result, attr) => {
   return result.baseElement.querySelector("#portal-id");
 };

--- a/packages/react-conformance/README.md
+++ b/packages/react-conformance/README.md
@@ -63,3 +63,25 @@ describe('Foo', () => {
   });
 });
 ```
+
+### isConformant with React Portals
+
+By default `isConformant` inspects a component's immediate parent container. Because React Portals are typically rendered outside this container components using Portals will fail conformance. For example the `component-has-static-classnames-object` tests inspect the rendered DOM for certain class names but, with default settings, will fail for anything rendered into a Portal.
+
+Portals can be inspected by providing a `getTargetElement` function to `isConformant`.
+
+```jsx
+
+const getPortalElement = (result, attr) => {
+  return result.baseElement.querySelector("#portal-id");
+};
+
+describe('Foo', () => {
+  isConformant({
+    Component: Foo,
+    displayName: 'Foo'
+    requiredProps: { idForPortal: "portal-id" },
+    getTargetElement: getPortalElement
+  });
+});
+```

--- a/packages/react-tooltip/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-tooltip/src/components/Tooltip/Tooltip.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Tooltip } from './Tooltip';
 import { isConformant } from '../../common/isConformant';
+import type { IsConformantOptions } from '@fluentui/react-conformance';
 import { render, RenderResult } from '@testing-library/react';
 import { resetIdsForTests } from '@fluentui/react-utilities';
 
@@ -22,19 +23,21 @@ function getByRoleTooltip(result: RenderResult) {
   return tooltip!;
 }
 
+export const getTooltipElement: IsConformantOptions['getTargetElement'] = (result, attr) => {
+  return queryByRoleTooltip(result)!;
+};
+
 describe('Tooltip', () => {
   isConformant({
     Component: Tooltip,
     displayName: 'Tooltip',
-    requiredProps: { content: 'Example', children: <button /> },
+    requiredProps: { content: 'Example', children: <button />, visible: true },
+    getTargetElement: getTooltipElement,
     disabledTests: [
       // Tooltip renders into a Portal, which confuses these tests
       'component-handles-ref',
       'component-has-root-ref',
       'component-handles-classname',
-      'component-has-static-classname',
-      'component-has-static-classnames-object',
-      'component-has-static-classname-exported',
     ],
   });
 


### PR DESCRIPTION
## Current Behavior

When examining the DOM, conformance tests typically only look at the tree starting from the component root. This causes problems when trying to inspect content rendered into React Portals as Portals are typically rendered as sibling nodes the component that triggers their rendering.

## New Behavior

Conformance tests provide a mechanism to override the root that is examined by tests by providing an override to `testInfo.getTargetElement`.

Tooltip tests already have a `queryByRoleTooltip` function to retrieve the rendered tooltip and this has been provided to the conformance test so the rendered tip can be inspected allowing the following conformance tests to be enabled:

    - component-has-static-classname
    - component-has-static-classnames-object
    - component-has-static-classname-exported

The README in react-conformance has been updated with a section describing how to configure tests to work with Portals.
