### PR TITLE
fix(Calendar) v7: move gridcell role from button to td element

### DIFF
--- a/change/office-ui-fabric-react-6d057a74-bcd2-45af-a63f-ff0e24a2e733.json
+++ b/change/office-ui-fabric-react-6d057a74-bcd2-45af-a63f-ff0e24a2e733.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "office-fabric-ui-react Calendar: move role=\"gridcell\" to the td element and make it the focus target",
+  "packageName": "office-ui-fabric-react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -328,6 +328,7 @@ export class CalendarDay extends React.Component<ICalendarDayProps, ICalendarDay
                           },
                         )}
                         ref={element => this._setDayCellRef(element, day, isNavigatedDate)}
+                        onKeyDown={this._onDayKeyDown(day.originalDate, weekIndex, dayIndex)}
                         onMouseOver={
                           dateRangeType !== DateRangeType.Day && day.isInBounds
                             ? this._onDayMouseOver(day.originalDate, weekIndex, dayIndex, dateRangeType)
@@ -348,7 +349,11 @@ export class CalendarDay extends React.Component<ICalendarDayProps, ICalendarDay
                             ? this._onDayMouseUp(day.originalDate, weekIndex, dayIndex, dateRangeType)
                             : undefined
                         }
-                        role={'presentation'}
+                        role={'gridcell'}
+                        data-is-focusable={allFocusable || (day.isInBounds ? true : undefined)}
+                        aria-disabled={!day.isInBounds}
+                        aria-current={day.isToday ? 'date' : undefined}
+                        aria-selected={day.isInBounds ? day.isSelected : undefined}
                       >
                         <button
                           key={day.key + 'button'}
@@ -357,18 +362,13 @@ export class CalendarDay extends React.Component<ICalendarDayProps, ICalendarDay
                             ['ms-DatePicker-day--disabled ' + styles.dayIsDisabled]: !day.isInBounds,
                             ['ms-DatePicker-day--today ' + styles.dayIsToday]: day.isToday,
                           })}
-                          onKeyDown={this._onDayKeyDown(day.originalDate, weekIndex, dayIndex)}
                           aria-label={dateTimeFormatter.formatMonthDayYear(day.originalDate, strings)}
                           id={isNavigatedDate ? activeDescendantId : undefined}
-                          aria-readonly={true}
-                          aria-current={day.isToday ? 'date' : undefined}
-                          aria-selected={day.isInBounds ? day.isSelected : undefined}
-                          data-is-focusable={allFocusable || (day.isInBounds ? true : undefined)}
-                          ref={element => this._setDayRef(element, day, isNavigatedDate)}
+                          data-is-focusable={false}
                           disabled={!allFocusable && !day.isInBounds}
                           aria-disabled={!day.isInBounds}
+                          tabIndex={-1}
                           type="button"
-                          role={'gridcell'}
                         >
                           <span aria-hidden="true">{dateTimeFormatter.formatDay(day.originalDate)}</span>
                         </button>
@@ -391,14 +391,12 @@ export class CalendarDay extends React.Component<ICalendarDayProps, ICalendarDay
     }
   }
 
-  private _setDayRef(element: HTMLElement | null, day: IDayInfo, isNavigatedDate: boolean): void {
+  private _setDayCellRef(element: HTMLElement | null, day: IDayInfo, isNavigatedDate: boolean): void {
+    this.days[day.key] = element;
+
     if (isNavigatedDate) {
       this.navigatedDay = element;
     }
-  }
-
-  private _setDayCellRef(element: HTMLElement | null, day: IDayInfo, isNavigatedDate: boolean): void {
-    this.days[day.key] = element;
   }
 
   private _getWeekCornerStyles(weeks: IDayInfo[][], dateRangeType: DateRangeType): IWeekCorners {

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -193,21 +193,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                 <tbody>
                   <tr>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--outfocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="January 30, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -218,21 +219,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--outfocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="January 31, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -243,22 +245,23 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={true}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--highlighted undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 1, 2000"
-                        aria-readonly={true}
-                        aria-selected={true}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         id="DatePickerDay-active0"
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -269,21 +272,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 2, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -294,21 +298,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 3, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -319,21 +324,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 4, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -344,21 +350,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 5, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -371,21 +378,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                   </tr>
                   <tr>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 6, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -396,21 +404,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 7, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -421,21 +430,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 8, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -446,21 +456,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 9, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -471,21 +482,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 10, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -496,21 +508,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 11, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -521,21 +534,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 12, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -548,21 +562,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                   </tr>
                   <tr>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 13, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -573,21 +588,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 14, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -598,21 +614,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 15, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -623,21 +640,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 16, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -648,21 +666,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 17, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -673,21 +692,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 18, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -698,21 +718,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 19, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -725,21 +746,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                   </tr>
                   <tr>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 20, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -750,21 +772,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 21, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -775,21 +798,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 22, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -800,21 +824,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 23, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -825,21 +850,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 24, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -850,21 +876,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 25, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -875,21 +902,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 26, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -902,21 +930,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                   </tr>
                   <tr>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 27, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -927,21 +956,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 28, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -952,21 +982,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="February 29, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -977,21 +1008,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--outfocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="March 1, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -1002,21 +1034,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--outfocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="March 2, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -1027,21 +1060,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--outfocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="March 3, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -1052,21 +1086,22 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                     <td
+                      aria-disabled={false}
+                      aria-selected={false}
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--outfocus undefined"
+                      data-is-focusable={true}
                       onClick={[Function]}
-                      role="presentation"
+                      onKeyDown={[Function]}
+                      role="gridcell"
                     >
                       <button
                         aria-disabled={false}
                         aria-label="March 4, 2000"
-                        aria-readonly={true}
-                        aria-selected={false}
                         className="ms-DatePicker-day-button"
-                        data-is-focusable={true}
+                        data-is-focusable={false}
                         disabled={false}
                         onClick={[Function]}
-                        onKeyDown={[Function]}
-                        role="gridcell"
+                        tabIndex={-1}
                         type="button"
                       >
                         <span

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -198,7 +198,7 @@ describe('DatePicker', () => {
 
     // open calendar and select first day
     textField.simulate('click');
-    const selectableDateInCalender = datePicker.find('.ms-DatePicker td button[data-is-focusable=true]').at(0);
+    const selectableDateInCalender = datePicker.find('.ms-DatePicker td[data-is-focusable=true] button').at(0);
     selectableDateInCalender.simulate('click');
 
     expect(datePicker.state('errorMessage')).toBe('');


### PR DESCRIPTION
Essentially the same fix as #21468, but for `office-fabric-ui-react`'s Calendar

Originally a port of the v8 fix in #20412

fixes [13309](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/13309)
