### PR TITLE
fixes onSelectDate handler firing twice when using keyboard for selec…

### DIFF
--- a/change/@fluentui-react-5f4f2dc4-e56b-4010-978d-df85e87d07a7.json
+++ b/change/@fluentui-react-5f4f2dc4-e56b-4010-978d-df85e87d07a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixes onSelectDate handler firing twice when using keyboard for selection",
+  "packageName": "@fluentui/react",
+  "email": "john.collier4@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/CalendarDayGrid/CalendarGridRow.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarGridRow.tsx
@@ -64,7 +64,7 @@ export const CalendarGridRow: React.FunctionComponent<ICalendarGridRowProps> = p
         </th>
       )}
       {week.map((day: IDayInfo, dayIndex: number) => (
-        <CalendarGridDayCell {...props} key={day.key} day={day} dayIndex={dayIndex} />
+        <CalendarGridDayCell {...props} onSelectDate={undefined} key={day.key} day={day} dayIndex={dayIndex} />
       ))}
     </tr>
   );


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

onSelectDate is firing twice when using the keyboard to select a date from the Calendar pop up

- CalendarGridRow merges its own props (including onSelectDate) to the props supplied to CalendarGridDayCell.
- The CalendarGridDayCell component has a key press handler which calls onSelectDate when the 'Enter' key is pressed.
- This action results in the dismissDatePickerPopup method being called in DatePicker which calls onSelectDate again

## New Behavior

- The onSelectDate prop is excluded from CalendarGridDayCell when it is instantiated in CalendarGridDayCell which prevents the onDayKeyDown function from calling onSelectDate when 'Enter' is pressed
- With this removed, pressing 'Enter' to select a date still works

## Related Issue(s)

Fixes #22283
