### PR TITLE
chore: unify `react-components` ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -128,7 +128,7 @@ packages/react-badge @microsoft/teams-prg @microsoft/cxe-red @behowell
 packages/react-button @microsoft/cxe-red @khmakoto
 packages/react-card @microsoft/cxe-prg
 packages/react-checkbox @microsoft/cxe-red @khmakoto
-packages/react-components @microsoft/teams-prg @microsoft/cxe-prg @microsoft/cxe-red @microsoft/cxe-coastal
+packages/react-components @microsoft/fluentui-react
 packages/react-dialog @microsoft/cxe-prg
 packages/react-divider @microsoft/cxe-coastal
 packages/react-focus @microsoft/cxe-red @khmakoto


### PR DESCRIPTION
## Current Behavior

Any `react-components` change creates an individual dependency on each of our teams to review it. Sometimes when there's a PR for package X, owned by team Y, that has changes on `react-components`, teams A and B will still be marked as reviewers.

## New Behavior

Leveraging the parent team `fluentui-react`, PRs that change the `react-components` package will only mark one team, instead of all teams individually.
This aims to reduce noise to all teams or added responsibility to review when it's not a package other teams own.
With this change, teams are still informed of the change and it's immediately clear that any team can approve it, instead of each team individually.

This can be further leveraged for any cross team ownership to reduce other edge cases like these.

Consider this a proposal and share your thoughts 💭