### PR TITLE
chore: migrate react-select to new DX

### DIFF
--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -23,7 +23,7 @@
     "test": "jest --passWithNoTests",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../scripts/typescript/normalize-import --output ./dist/packages/react-select/src && yarn docs",
-    "storybook": "start-storybook",
+    "storybook": "node ../../scripts/storybook/runner",
     "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {

--- a/workspace.json
+++ b/workspace.json
@@ -537,7 +537,9 @@
     "@fluentui/react-select": {
       "root": "packages/react-select",
       "projectType": "library",
-      "sourceRoot": "packages/react-select/src"
+      "sourceRoot": "packages/react-select/src",
+      "tags": ["vNext", "platform:web"],
+      "implicitDependencies": []
     },
     "@fluentui/react-shared-contexts": {
       "root": "packages/react-shared-contexts",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- react-select wasn't properly bootstrap thus was violating isMigrated check for vNext

![image](https://user-images.githubusercontent.com/1223799/161593520-ff1b5216-515e-4738-979c-63af6fe46750.png)


## New Behavior

- react-select is now compliant with our vNext setup

![image](https://user-images.githubusercontent.com/1223799/161593023-b647ab47-b8ec-44e5-8568-9f0aa2830c3b.png)


## Related Issue(s)

