### PR TITLE
Updated Overflow component to be divless wrapper

### DIFF
--- a/packages/react-priority-overflow/etc/react-priority-overflow.api.md
+++ b/packages/react-priority-overflow/etc/react-priority-overflow.api.md
@@ -20,12 +20,15 @@ export const DATA_OVERFLOW_MENU = "data-overflow-menu";
 // @public (undocumented)
 export const DATA_OVERFLOWING = "data-overflowing";
 
-// @public (undocumented)
-export const Overflow: React_2.ForwardRefExoticComponent<OverflowProps & React_2.RefAttributes<HTMLDivElement>>;
+// @public
+export const Overflow: React_2.ForwardRefExoticComponent<Partial<Pick<ObserveOptions, "padding" | "overflowDirection" | "overflowAxis" | "minimumVisible">> & {
+    children: React_2.ReactElement;
+} & React_2.RefAttributes<unknown>>;
 
-// @public (undocumented)
-export interface OverflowProps extends React_2.HTMLAttributes<HTMLDivElement>, Pick<ObserveOptions, 'overflowAxis' | 'overflowDirection' | 'padding' | 'minimumVisible'> {
-}
+// @public
+export type OverflowProps = Partial<Pick<ObserveOptions, 'overflowAxis' | 'overflowDirection' | 'padding' | 'minimumVisible'>> & {
+    children: React_2.ReactElement;
+};
 
 // @public (undocumented)
 export const updateVisibilityAttribute: OnUpdateItemVisibility;

--- a/packages/react-priority-overflow/src/components/Overflow.tsx
+++ b/packages/react-priority-overflow/src/components/Overflow.tsx
@@ -52,7 +52,7 @@ export const Overflow = React.forwardRef((props: OverflowProps, ref) => {
       data.invisibleItems.forEach(x => (newState[x.id] = false));
       return newState;
     });
-    setGroupVisibility(groupVisibility);
+    setGroupVisibility(data.groupVisibility);
   };
 
   const { containerRef, registerItem, updateOverflow } = useOverflowContainer(update, {

--- a/packages/react-priority-overflow/src/components/Overflow.tsx
+++ b/packages/react-priority-overflow/src/components/Overflow.tsx
@@ -1,23 +1,13 @@
 import * as React from 'react';
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { OnUpdateOverflow, OverflowGroupState, ObserveOptions } from '@fluentui/priority-overflow';
+import { useMergedRefs } from '@fluentui/react-utilities';
+
 import { OverflowContext } from '../overflowContext';
 import { updateVisibilityAttribute, useOverflowContainer } from '../useOverflowContainer';
-import { useMergedRefs } from '@fluentui/react-utilities';
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
-import type { OnUpdateOverflow, OverflowGroupState, ObserveOptions } from '@fluentui/priority-overflow';
 import { DATA_OVERFLOWING, DATA_OVERFLOW_MENU } from '../constants';
 
 const useStyles = makeStyles({
-  container: {
-    display: 'flex',
-    flexWrap: 'nowrap',
-    minWidth: 0,
-    ...shorthands.overflow('hidden'),
-  },
-
-  vertical: {
-    flexDirection: 'column',
-  },
-
   overflowMenu: {
     [`& [${DATA_OVERFLOW_MENU}]`]: {
       flexShrink: 0,
@@ -31,35 +21,41 @@ const useStyles = makeStyles({
   },
 });
 
-export interface OverflowProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    Pick<ObserveOptions, 'overflowAxis' | 'overflowDirection' | 'padding' | 'minimumVisible'> {}
+/**
+ * Overflow Props
+ */
+export type OverflowProps = Partial<
+  Pick<ObserveOptions, 'overflowAxis' | 'overflowDirection' | 'padding' | 'minimumVisible'>
+> & {
+  children: React.ReactElement;
+};
 
-export const Overflow = React.forwardRef<HTMLDivElement, OverflowProps>((props, ref) => {
-  const { overflowAxis = 'horizontal', overflowDirection, padding, minimumVisible, ...rest } = props;
+/**
+ * Provides an OverflowContext for OverflowItem descendants.
+ */
+export const Overflow = React.forwardRef((props: OverflowProps, ref) => {
   const styles = useStyles();
+
+  const { children, minimumVisible, overflowAxis = 'horizontal', overflowDirection, padding } = props;
 
   const [hasOverflow, setHasOverflow] = React.useState(false);
   const [itemVisibility, setItemVisibility] = React.useState<Record<string, boolean>>({});
   const [groupVisibility, setGroupVisibility] = React.useState<Record<string, OverflowGroupState>>({});
 
-  const updateItemVisibility: OnUpdateOverflow = ({
-    visibleItems,
-    invisibleItems,
-    groupVisibility: managerGroupVisibility,
-  }) => {
-    setHasOverflow(invisibleItems.length > 0);
+  // useOverflowContainer wraps this method in a useEventCallback.
+  // TODO: Do we need a useEventCallback here too?
+  const update: OnUpdateOverflow = data => {
+    setHasOverflow(() => data.invisibleItems.length > 0);
     setItemVisibility(() => {
       const newState: Record<string, boolean> = {};
-      visibleItems.forEach(x => (newState[x.id] = true));
-      invisibleItems.forEach(x => (newState[x.id] = false));
+      data.visibleItems.forEach(x => (newState[x.id] = true));
+      data.invisibleItems.forEach(x => (newState[x.id] = false));
       return newState;
     });
-
-    setGroupVisibility(managerGroupVisibility);
+    setGroupVisibility(groupVisibility);
   };
 
-  const { containerRef, registerItem, updateOverflow } = useOverflowContainer<HTMLDivElement>(updateItemVisibility, {
+  const { containerRef, registerItem, updateOverflow } = useOverflowContainer(update, {
     overflowDirection,
     overflowAxis,
     padding,
@@ -67,7 +63,10 @@ export const Overflow = React.forwardRef<HTMLDivElement, OverflowProps>((props, 
     onUpdateItemVisibility: updateVisibilityAttribute,
   });
 
+  const child = React.Children.only(children);
   const mergedRef = useMergedRefs(containerRef, ref);
+  const mergedClassName = mergeClasses(styles.overflowMenu, styles.overflowingItems, child.props.className);
+  const clonedChild = React.cloneElement(child, { ref: mergedRef, className: mergedClassName });
 
   return (
     <OverflowContext.Provider
@@ -79,19 +78,7 @@ export const Overflow = React.forwardRef<HTMLDivElement, OverflowProps>((props, 
         updateOverflow,
       }}
     >
-      <div
-        {...rest}
-        ref={mergedRef}
-        className={mergeClasses(
-          styles.container,
-          styles.overflowMenu,
-          styles.overflowingItems,
-          props.overflowAxis === 'vertical' && styles.vertical,
-          props.className,
-        )}
-      >
-        {props.children}
-      </div>
+      {clonedChild}
     </OverflowContext.Provider>
   );
 });

--- a/packages/react-priority-overflow/src/components/Overflow.tsx
+++ b/packages/react-priority-overflow/src/components/Overflow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeStyles, mergeClasses } from '@griffel/react';
 import type { OnUpdateOverflow, OverflowGroupState, ObserveOptions } from '@fluentui/priority-overflow';
-import { useMergedRefs } from '@fluentui/react-utilities';
+import { applyTriggerPropsToChildren, useMergedRefs } from '@fluentui/react-utilities';
 
 import { OverflowContext } from '../overflowContext';
 import { updateVisibilityAttribute, useOverflowContainer } from '../useOverflowContainer';
@@ -63,10 +63,10 @@ export const Overflow = React.forwardRef((props: OverflowProps, ref) => {
     onUpdateItemVisibility: updateVisibilityAttribute,
   });
 
-  const child = React.Children.only(children);
-  const mergedRef = useMergedRefs(containerRef, ref);
-  const mergedClassName = mergeClasses(styles.overflowMenu, styles.overflowingItems, child.props.className);
-  const clonedChild = React.cloneElement(child, { ref: mergedRef, className: mergedClassName });
+  const clonedChild = applyTriggerPropsToChildren(children, {
+    ref: useMergedRefs(containerRef, ref),
+    className: mergeClasses(styles.overflowMenu, styles.overflowingItems, children.props.className),
+  });
 
   return (
     <OverflowContext.Provider

--- a/packages/react-priority-overflow/src/stories/CustomPriorities.stories.tsx
+++ b/packages/react-priority-overflow/src/stories/CustomPriorities.stories.tsx
@@ -1,16 +1,30 @@
 import * as React from 'react';
+import { makeStyles, shorthands } from '@griffel/react';
 import { Overflow } from '../components/Overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    minWidth: 0,
+    ...shorthands.overflow('hidden'),
+  },
+});
+
 export const CustomPriorities = () => {
+  const styles = useStyles();
+
   const priorities = [2, 3, 6, 1, 4, 5, 0, 7];
 
   return (
     <Overflow>
-      {priorities.map(i => (
-        <TestOverflowItem key={i} id={i.toString()} priority={i} />
-      ))}
-      <OverflowMenu itemIds={priorities.map(x => x.toString())} />
+      <div className={styles.container}>
+        {priorities.map(i => (
+          <TestOverflowItem key={i} id={i.toString()} priority={i} />
+        ))}
+        <OverflowMenu itemIds={priorities.map(x => x.toString())} />
+      </div>
     </Overflow>
   );
 };

--- a/packages/react-priority-overflow/src/stories/Dividers.stories.tsx
+++ b/packages/react-priority-overflow/src/stories/Dividers.stories.tsx
@@ -1,25 +1,39 @@
 import * as React from 'react';
+import { makeStyles, shorthands } from '@griffel/react';
 import { Overflow } from '../components/Overflow';
 import { OverflowMenu, TestOverflowGroupDivider, TestOverflowItem } from './utils.stories';
 
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    minWidth: 0,
+    ...shorthands.overflow('hidden'),
+  },
+});
+
 export const Dividers = () => {
+  const styles = useStyles();
+
   return (
     <Overflow overflowDirection="start" padding={30}>
-      <TestOverflowItem id={'1'} groupId={'1'} />
-      <TestOverflowGroupDivider groupId={'1'} />
-      <TestOverflowItem id={'2'} groupId={'2'} />
-      <TestOverflowGroupDivider groupId={'2'} />
-      <TestOverflowItem id={'3'} groupId={'3'} />
-      <TestOverflowItem id={'4'} groupId={'3'} />
-      <TestOverflowGroupDivider groupId={'3'} />
-      <TestOverflowItem id={'5'} groupId={'4'} />
-      <TestOverflowItem id={'6'} groupId={'4'} />
-      <TestOverflowItem id={'7'} groupId={'4'} />
-      <TestOverflowGroupDivider groupId={'4'} />
-      <TestOverflowItem id={'8'} groupId={'5'} />
-      <OverflowMenu
-        itemIds={['1', 'divider-1', '2', 'divider-2', '3', '4', 'divider-3', '5', '6', '7', 'divider-4', '8']}
-      />
+      <div className={styles.container}>
+        <TestOverflowItem id={'1'} groupId={'1'} />
+        <TestOverflowGroupDivider groupId={'1'} />
+        <TestOverflowItem id={'2'} groupId={'2'} />
+        <TestOverflowGroupDivider groupId={'2'} />
+        <TestOverflowItem id={'3'} groupId={'3'} />
+        <TestOverflowItem id={'4'} groupId={'3'} />
+        <TestOverflowGroupDivider groupId={'3'} />
+        <TestOverflowItem id={'5'} groupId={'4'} />
+        <TestOverflowItem id={'6'} groupId={'4'} />
+        <TestOverflowItem id={'7'} groupId={'4'} />
+        <TestOverflowGroupDivider groupId={'4'} />
+        <TestOverflowItem id={'8'} groupId={'5'} />
+        <OverflowMenu
+          itemIds={['1', 'divider-1', '2', 'divider-2', '3', '4', 'divider-3', '5', '6', '7', 'divider-4', '8']}
+        />
+      </div>
     </Overflow>
   );
 };

--- a/packages/react-priority-overflow/src/stories/DomOrder.stories.tsx
+++ b/packages/react-priority-overflow/src/stories/DomOrder.stories.tsx
@@ -1,16 +1,30 @@
 import * as React from 'react';
+import { makeStyles, shorthands } from '@griffel/react';
 import { Overflow } from '../components/Overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    minWidth: 0,
+    ...shorthands.overflow('hidden'),
+  },
+});
+
 export const DomOrder = () => {
+  const styles = useStyles();
+
   const itemIds = new Array(8).fill(0).map((_, i) => i.toString());
 
   return (
     <Overflow>
-      {itemIds.map(i => (
-        <TestOverflowItem key={i} id={i} />
-      ))}
-      <OverflowMenu itemIds={itemIds} />
+      <div className={styles.container}>
+        {itemIds.map(i => (
+          <TestOverflowItem key={i} id={i} />
+        ))}
+        <OverflowMenu itemIds={itemIds} />
+      </div>
     </Overflow>
   );
 };

--- a/packages/react-priority-overflow/src/stories/MinimumVisible.stories.tsx
+++ b/packages/react-priority-overflow/src/stories/MinimumVisible.stories.tsx
@@ -1,16 +1,30 @@
 import * as React from 'react';
+import { makeStyles, shorthands } from '@griffel/react';
 import { Overflow } from '../components/Overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    minWidth: 0,
+    ...shorthands.overflow('hidden'),
+  },
+});
+
 export const MinimumVisible = () => {
+  const styles = useStyles();
+
   const itemIds = new Array(8).fill(0).map((_, i) => i.toString());
 
   return (
     <Overflow minimumVisible={4}>
-      {itemIds.map(i => (
-        <TestOverflowItem key={i} id={i} />
-      ))}
-      <OverflowMenu itemIds={itemIds} />
+      <div className={styles.container}>
+        {itemIds.map(i => (
+          <TestOverflowItem key={i} id={i} />
+        ))}
+        <OverflowMenu itemIds={itemIds} />
+      </div>
     </Overflow>
   );
 };

--- a/packages/react-priority-overflow/src/stories/Pinned.stories.tsx
+++ b/packages/react-priority-overflow/src/stories/Pinned.stories.tsx
@@ -7,16 +7,23 @@ const useStyles = makeStyles({
   container: {
     display: 'flex',
     justifyContent: 'space-between',
+    minWidth: 0,
+    ...shorthands.overflow('hidden'),
   },
 
   overflowContainer: {
+    display: 'flex',
     flexGrow: 1,
+    flexWrap: 'nowrap',
+    minWidth: 0,
+    ...shorthands.overflow('hidden'),
   },
 
   farItems: {
     dislay: 'flex',
     ...shorthands.gap('4px'),
     flexWrap: 'nowrap',
+    marginRight: '10px', //to allow the resize handle to be grabbed
   },
 });
 
@@ -26,11 +33,13 @@ export const Pinned = () => {
 
   return (
     <div className={styles.container}>
-      <Overflow className={styles.overflowContainer}>
-        {itemIds.map(i => (
-          <TestOverflowItem key={i} id={i} />
-        ))}
-        <OverflowMenu itemIds={itemIds} />
+      <Overflow>
+        <div className={styles.overflowContainer}>
+          {itemIds.map(i => (
+            <TestOverflowItem key={i} id={i} />
+          ))}
+          <OverflowMenu itemIds={itemIds} />
+        </div>
       </Overflow>
 
       <div className={styles.farItems}>

--- a/packages/react-priority-overflow/src/stories/PriorityWithDividers.stories.tsx
+++ b/packages/react-priority-overflow/src/stories/PriorityWithDividers.stories.tsx
@@ -1,25 +1,39 @@
 import * as React from 'react';
+import { makeStyles, shorthands } from '@griffel/react';
 import { Overflow } from '../components/Overflow';
 import { OverflowMenu, TestOverflowGroupDivider, TestOverflowItem } from './utils.stories';
 
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    minWidth: 0,
+    ...shorthands.overflow('hidden'),
+  },
+});
+
 export const PriorityWithDividers = () => {
+  const styles = useStyles();
+
   return (
     <Overflow overflowDirection="start" padding={30}>
-      <TestOverflowItem id={'6'} priority={6} groupId={'1'} />
-      <TestOverflowGroupDivider groupId={'1'} />
-      <TestOverflowItem id={'7'} priority={7} groupId={'2'} />
-      <TestOverflowGroupDivider groupId={'2'} />
-      <TestOverflowItem id={'4'} priority={4} groupId={'3'} />
-      <TestOverflowItem id={'5'} priority={5} groupId={'3'} />
-      <TestOverflowGroupDivider groupId={'3'} />
-      <TestOverflowItem id={'1'} priority={1} groupId={'4'} />
-      <TestOverflowItem id={'2'} priority={2} groupId={'4'} />
-      <TestOverflowItem id={'3'} priority={3} groupId={'4'} />
-      <TestOverflowGroupDivider groupId={'4'} />
-      <TestOverflowItem id={'8'} priority={8} groupId={'5'} />
-      <OverflowMenu
-        itemIds={['6', 'divider-1', '7', 'divider-2', '4', '5', 'divider-3', '1', '2', '3', 'divider-4', '8']}
-      />
+      <div className={styles.container}>
+        <TestOverflowItem id={'6'} priority={6} groupId={'1'} />
+        <TestOverflowGroupDivider groupId={'1'} />
+        <TestOverflowItem id={'7'} priority={7} groupId={'2'} />
+        <TestOverflowGroupDivider groupId={'2'} />
+        <TestOverflowItem id={'4'} priority={4} groupId={'3'} />
+        <TestOverflowItem id={'5'} priority={5} groupId={'3'} />
+        <TestOverflowGroupDivider groupId={'3'} />
+        <TestOverflowItem id={'1'} priority={1} groupId={'4'} />
+        <TestOverflowItem id={'2'} priority={2} groupId={'4'} />
+        <TestOverflowItem id={'3'} priority={3} groupId={'4'} />
+        <TestOverflowGroupDivider groupId={'4'} />
+        <TestOverflowItem id={'8'} priority={8} groupId={'5'} />
+        <OverflowMenu
+          itemIds={['6', 'divider-1', '7', 'divider-2', '4', '5', 'divider-3', '1', '2', '3', 'divider-4', '8']}
+        />
+      </div>
     </Overflow>
   );
 };

--- a/packages/react-priority-overflow/src/stories/ReverseDomOrder.stories.tsx
+++ b/packages/react-priority-overflow/src/stories/ReverseDomOrder.stories.tsx
@@ -1,16 +1,30 @@
 import * as React from 'react';
+import { makeStyles, shorthands } from '@griffel/react';
 import { Overflow } from '../components/Overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    minWidth: 0,
+    ...shorthands.overflow('hidden'),
+  },
+});
+
 export const ReverseDomOrder = () => {
+  const styles = useStyles();
+
   const itemIds = new Array(8).fill(0).map((_, i) => i.toString());
 
   return (
     <Overflow overflowDirection="start">
-      {itemIds.map(i => (
-        <TestOverflowItem key={i} id={i} />
-      ))}
-      <OverflowMenu itemIds={itemIds} />
+      <div className={styles.container}>
+        {itemIds.map(i => (
+          <TestOverflowItem key={i} id={i} />
+        ))}
+        <OverflowMenu itemIds={itemIds} />
+      </div>
     </Overflow>
   );
 };

--- a/packages/react-priority-overflow/src/stories/Selection.stories.tsx
+++ b/packages/react-priority-overflow/src/stories/Selection.stories.tsx
@@ -1,10 +1,30 @@
 import * as React from 'react';
-import { makeStyles, mergeClasses, Button, Menu, MenuTrigger, MenuPopover, MenuList } from '@fluentui/react-components';
+import {
+  makeStyles,
+  mergeClasses,
+  Button,
+  Menu,
+  MenuTrigger,
+  MenuPopover,
+  MenuList,
+  shorthands,
+} from '@fluentui/react-components';
 import { Overflow } from '../components/Overflow';
 import { useOverflowMenu } from '../useOverflowMenu';
 import { TestOverflowItem, TestOverflowItemProps, TestOverflowMenuItem } from './utils.stories';
 
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    minWidth: 0,
+    ...shorthands.overflow('hidden'),
+  },
+});
+
 export const Selection = () => {
+  const styles = useStyles();
+
   const [selected, setSelected] = React.useState<string>('0');
 
   const onSelect = (itemId: string) => {
@@ -15,10 +35,12 @@ export const Selection = () => {
 
   return (
     <Overflow>
-      {itemIds.map(i => (
-        <OverflowSelectionItem onSelectItem={onSelect} key={i} id={i} selected={selected === i} />
-      ))}
-      <OverflowMenu itemIds={itemIds} onSelect={onSelect} />
+      <div className={styles.container}>
+        {itemIds.map(i => (
+          <OverflowSelectionItem onSelectItem={onSelect} key={i} id={i} selected={selected === i} />
+        ))}
+        <OverflowMenu itemIds={itemIds} onSelect={onSelect} />
+      </div>
     </Overflow>
   );
 };


### PR DESCRIPTION
## Current Behavior

Overflow renders a div

## New Behavior

Overflow takes a single child element that it clones to add the overflow container behavior.
Note: Fixed the issue with the dividers doubling up.

Updates #22313

