### PR TITLE
chore: refactor Portal/Provider to use the same approach as in v9

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### BREAKING CHANGES
 - `mergeThemes()` and other `merge*` functions used for styling accept only two parameters @layershifter ([#22123](https://github.com/microsoft/fluentui/pull/22123))
+- Create portal elements in separate elements @layershifter ([#22329](https://github.com/microsoft/fluentui/pull/22329))
 
 ### Fixes
 - Add transparent borders to slider @ling1726 ([#22089](https://github.com/microsoft/fluentui/pull/22089))

--- a/packages/fluentui/e2e/tests/chatMessageActionMenu-example.tsx
+++ b/packages/fluentui/e2e/tests/chatMessageActionMenu-example.tsx
@@ -2,7 +2,8 @@ import { Avatar, Chat, ChatItemProps, ShorthandCollection } from '@fluentui/reac
 import * as React from 'react';
 import { LikeIcon, MoreIcon, EmojiIcon } from '@fluentui/react-icons-northstar';
 
-const actionMenu = {
+const createActionMenu = (id: string) => ({
+  id,
   iconOnly: true,
   inline: false,
   items: [
@@ -33,14 +34,20 @@ const actionMenu = {
       },
     },
   ],
-};
+});
 
 const items: ShorthandCollection<ChatItemProps> = [
   {
     attached: 'top',
     contentPosition: 'end',
     message: (
-      <Chat.Message actionMenu={actionMenu} content="Hello" author="Cecil Folk" timestamp="Yesterday, 10:15 PM" mine />
+      <Chat.Message
+        actionMenu={createActionMenu('action-menu0')}
+        content="Hello"
+        author="Cecil Folk"
+        timestamp="Yesterday, 10:15 PM"
+        mine
+      />
     ),
     key: 'message-0',
   },
@@ -48,7 +55,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     gutter: <Avatar image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/RobinCounts.jpg" />,
     message: (
       <Chat.Message
-        actionMenu={actionMenu}
+        actionMenu={createActionMenu('action-menu1')}
         content={
           <>
             Hi! check this{' '}

--- a/packages/fluentui/e2e/tests/chatMessageActionMenu.spec.ts
+++ b/packages/fluentui/e2e/tests/chatMessageActionMenu.spec.ts
@@ -12,7 +12,7 @@ describe('Chat message with action menu rendered outside', () => {
       selectors.chatMessageClassName
     }`;
 
-  const getActionMenuAt = index => `${selectors.menuClassName}:nth-child(${index + 1})`;
+  const getActionMenuAt = index => `#action-menu${index}`;
 
   const iconInActionMenu = ['.likeIcon', '.emojiIcon', '.moreIcon'];
 

--- a/packages/fluentui/react-northstar/src/components/Portal/PortalInner.tsx
+++ b/packages/fluentui/react-northstar/src/components/Portal/PortalInner.tsx
@@ -1,11 +1,13 @@
+import { useFluentContext, useIsomorphicLayoutEffect } from '@fluentui/react-bindings';
+import * as customPropTypes from '@fluentui/react-proptypes';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+
 import { isBrowser, ChildrenComponentProps, commonPropTypes } from '../../utils';
-import { PortalBoxContext } from '../Provider/usePortalBox';
-import * as customPropTypes from '@fluentui/react-proptypes';
-import { useIsomorphicLayoutEffect } from '@fluentui/react-bindings';
+import { PortalContext } from '../Provider/portalContext';
+import { usePortalBox } from './usePortalBox';
 
 export interface PortalInnerProps extends ChildrenComponentProps {
   /** Existing element the portal should be bound to. */
@@ -30,18 +32,22 @@ export interface PortalInnerProps extends ChildrenComponentProps {
  * A PortalInner is a container for Portal's content.
  */
 export const PortalInner: React.FC<PortalInnerProps> = props => {
-  const context = React.useContext(PortalBoxContext);
   const { children, mountNode } = props;
 
+  const { className } = React.useContext(PortalContext);
+  const { target, rtl } = useFluentContext();
+
+  const box = usePortalBox({ className, target, rtl });
   // PortalInner should render elements even without a context
   // eslint-disable-next-line
-  const target: HTMLElement | null = isBrowser() ? context || document.body : null;
-  const container: HTMLElement | null = mountNode || target;
+  const container: HTMLElement | null = isBrowser() ? mountNode || box || document.body : null;
+
   useIsomorphicLayoutEffect(() => {
     _.invoke(props, 'onMount', props);
 
     return () => _.invoke(props, 'onUnmount', props);
   }, []);
+
   return container && ReactDOM.createPortal(children, container);
 };
 

--- a/packages/fluentui/react-northstar/src/components/Portal/usePortalBox.ts
+++ b/packages/fluentui/react-northstar/src/components/Portal/usePortalBox.ts
@@ -6,14 +6,14 @@ import { isBrowser } from '../../utils/isBrowser';
 type UsePortalBoxOptions = {
   className: string;
   rtl: boolean;
-  target: Document;
+  target: Document | undefined;
 };
 
 export const usePortalBox = (options: UsePortalBoxOptions): HTMLDivElement | null => {
   const { className, rtl, target } = options;
 
   const element: HTMLDivElement | null = React.useMemo(() => {
-    const newElement = isBrowser() ? target.createElement('div') : null;
+    const newElement = isBrowser() && target ? target.createElement('div') : null;
 
     // Element should be attached to DOM during render to make elements that will be rendered
     // inside accessible in effects of child components

--- a/packages/fluentui/react-northstar/src/components/Portal/usePortalBox.ts
+++ b/packages/fluentui/react-northstar/src/components/Portal/usePortalBox.ts
@@ -9,9 +9,7 @@ type UsePortalBoxOptions = {
   target: Document;
 };
 
-export const PortalBoxContext = React.createContext<HTMLDivElement>(null);
-
-export const usePortalBox = (options: UsePortalBoxOptions): HTMLDivElement => {
+export const usePortalBox = (options: UsePortalBoxOptions): HTMLDivElement | null => {
   const { className, rtl, target } = options;
 
   const element: HTMLDivElement | null = React.useMemo(() => {
@@ -39,7 +37,7 @@ export const usePortalBox = (options: UsePortalBoxOptions): HTMLDivElement => {
   }, [className, element, rtl]);
 
   // This effect should always last as it removes element from HTML tree
-  useIsomorphicLayoutEffect(() => {
+  React.useEffect(() => {
     return () => {
       if (element) {
         target.body.removeChild(element);

--- a/packages/fluentui/react-northstar/src/components/Provider/Provider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Provider/Provider.tsx
@@ -31,7 +31,7 @@ import { ChildrenComponentProps, setUpWhatInput, tryCleanupWhatInput, UIComponen
 
 import { mergeProviderContexts } from '../../utils/mergeProviderContexts';
 import { ProviderConsumer } from './ProviderConsumer';
-import { usePortalBox, PortalBoxContext } from './usePortalBox';
+import { PortalContext, PortalContextValue } from './portalContext';
 
 export interface ProviderProps extends ChildrenComponentProps, UIComponentProps {
   rtl?: boolean;
@@ -167,11 +167,7 @@ export const Provider: ComponentWithAs<'div', ProviderProps> & {
     telemetry: undefined,
   });
 
-  const element = usePortalBox({
-    className: classes.root,
-    target: outgoingContext.target,
-    rtl: outgoingContext.rtl,
-  });
+  const portalContextValue = React.useMemo<PortalContextValue>(() => ({ className: classes.root }), [classes.root]);
 
   useIsomorphicLayoutEffect(() => {
     renderFontFaces(outgoingContext.renderer, props.theme);
@@ -206,9 +202,9 @@ export const Provider: ComponentWithAs<'div', ProviderProps> & {
   return (
     <RenderProvider target={outgoingContext.target}>
       <Unstable_FluentContextProvider value={outgoingContext}>
-        <PortalBoxContext.Provider value={element}>
+        <PortalContext.Provider value={portalContextValue}>
           <ElementType {...elementProps}>{children}</ElementType>
-        </PortalBoxContext.Provider>
+        </PortalContext.Provider>
       </Unstable_FluentContextProvider>
     </RenderProvider>
   );

--- a/packages/fluentui/react-northstar/src/components/Provider/portalContext.ts
+++ b/packages/fluentui/react-northstar/src/components/Provider/portalContext.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export type PortalContextValue = {
+  className: string;
+};
+
+export const PortalContext = React.createContext<PortalContextValue>({
+  className: '',
+});

--- a/packages/fluentui/react-northstar/test/specs/components/Popup/Popup-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Popup/Popup-test.tsx
@@ -253,7 +253,7 @@ describe('Popup', () => {
       // reset body, because then "firstElementChild" was not properly getting right element
       document.body.innerHTML = '';
       mountWithProvider(<Popup trigger={<button />} content="Content" open />);
-      const contentElement = document.body.firstElementChild;
+      const contentElement = document.body.firstElementChild.firstElementChild;
 
       expect(contentElement.classList.contains(popupContentClassName)).toEqual(true);
     });

--- a/packages/fluentui/react-northstar/test/specs/components/Portal/PortalInner-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Portal/PortalInner-test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { PortalContext } from 'src/components/Provider/portalContext';
 import { PortalInner, PortalInnerProps } from 'src/components/Portal/PortalInner';
 import { mountWithProvider } from 'test/utils';
 
@@ -36,6 +37,46 @@ describe('PortalInner', () => {
       wrapper.unmount();
 
       expect(onUnmount).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('document.body', () => {
+    it('adds an element to document.body', () => {
+      const className = 'a-sample-classname';
+      const wrapper = mountWithProvider(
+        <PortalContext.Provider value={{ className }}>
+          <PortalInner>
+            <div />
+          </PortalInner>
+        </PortalContext.Provider>,
+      );
+
+      expect(document.querySelector(`.${className}`)).toBeInTheDocument();
+
+      // element should be removed on unmount
+      wrapper.unmount();
+      expect(document.querySelector(`.${className}`)).not.toBeInTheDocument();
+    });
+
+    it('reacts on "className" update and keeps node in HTML tree', () => {
+      const className = 'a-sample-classname';
+      const wrapper = mountWithProvider(
+        <PortalContext.Provider value={{ className }}>
+          <PortalInner>
+            <div id="sample" />
+          </PortalInner>
+        </PortalContext.Provider>,
+      );
+
+      expect(document.querySelector(`.${className}`)).toBeInTheDocument();
+      expect(document.querySelector(`.${className} #sample`)).toBeInTheDocument();
+
+      const newClassName = 'an-another-classname';
+      wrapper.setProps({ value: { className: newClassName } });
+
+      expect(document.querySelector(`.${className}`)).not.toBeInTheDocument();
+      expect(document.querySelector(`.${newClassName}`)).toBeInTheDocument();
+      expect(document.querySelector(`.${newClassName} #sample`)).toBeInTheDocument();
     });
   });
 });

--- a/packages/fluentui/react-northstar/test/specs/components/Provider/Provider-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Provider/Provider-test.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 
 import { Provider } from 'src/components/Provider/Provider';
 import { ProviderConsumer } from 'src/components/Provider/ProviderConsumer';
-import { PortalInner } from 'src/components/Portal/PortalInner';
 
 const createDocumentMock = (): Document => {
   const externalDocument = document.implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', null);
@@ -304,44 +303,6 @@ describe('Provider', () => {
 
       // mousedown + touchstart + touchend + keyup + keydown
       expect(removeEventListener).toHaveBeenCalledTimes(5);
-    });
-  });
-
-  describe('document.body', () => {
-    it('adds an element to document.body', () => {
-      const className = 'a-sample-classname';
-      const wrapper = mount(
-        <Provider className={className}>
-          <div />
-        </Provider>,
-      );
-
-      expect(document.querySelector(`.${className}`)).toBeInTheDocument();
-
-      // element should be removed on unmount
-      wrapper.unmount();
-      expect(document.querySelector(`.${className}`)).not.toBeInTheDocument();
-    });
-
-    it('reacts on "className" update and keeps node in HTML tree', () => {
-      const className = 'a-sample-classname';
-      const wrapper = mount(
-        <Provider className={className}>
-          <PortalInner>
-            <div id="sample" />
-          </PortalInner>
-        </Provider>,
-      );
-
-      expect(document.querySelector(`.${className}`)).toBeInTheDocument();
-      expect(document.querySelector(`.${className} #sample`)).toBeInTheDocument();
-
-      const newClassName = 'an-another-classname';
-      wrapper.setProps({ className: newClassName });
-
-      expect(document.querySelector(`.${className}`)).not.toBeInTheDocument();
-      expect(document.querySelector(`.${newClassName}`)).toBeInTheDocument();
-      expect(document.querySelector(`.${newClassName} #sample`)).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
### ⚠️ Disclaimer

Potentially this PR introduces a breaking change due changes in layouts, read below.

---

The goal are:
- align behavior with Fluent UI v9 for better compatibility
- pass classes to apply in a context instead on an element to unblock performance optimisations on the app level

## Current Behavior

- In `Provider` we create an element (`usePortalBox()` hook) where all portals created by `PortalInner` will be mounted
- All portals are mounted in an element created by a provider

```html
<body>
  <div class="ui-provider">
    <div class="ui-popup"></div>
    <div class="ui-tooltip"></div>
    <div class="ui-tooltip"></div>
  </div>
</body>
```

## New Behavior

- In `PortalInner` we create an element (`usePortalBox()` hook) where a portal will be mounted
- All portals are mounted in separate elements

```html
<body>
  <div class="ui-provider">
    <div class="ui-popup"></div>
  </div>
  <div class="ui-provider">
    <div class="ui-tooltip"></div>
  </div>
  <div class="ui-provider">
    <div class="ui-tooltip"></div>
  </div>
</body>
```
