### PR TITLE
Updated spacing based on figma change

### DIFF
--- a/change/@fluentui-react-tabs-f4b4f066-3119-40ac-a489-f4b940604ca8.json
+++ b/change/@fluentui-react-tabs-f4b4f066-3119-40ac-a489-f4b940604ca8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updated to decrease gap of small vertical tab per figma change",
+  "packageName": "@fluentui/react-tabs",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tabs/src/components/Tab/useTabStyles.ts
+++ b/packages/react-tabs/src/components/Tab/useTabStyles.ts
@@ -57,7 +57,7 @@ const useRootStyles = makeStyles({
     ...shorthands.padding(pendingSpacingTokens.sNudge, pendingSpacingTokens.sNudge),
   },
   smallVertical: {
-    columnGap: pendingSpacingTokens.xs,
+    columnGap: pendingSpacingTokens.xxs,
     ...shorthands.padding(pendingSpacingTokens.xxs, pendingSpacingTokens.sNudge),
   },
   transparent: {


### PR DESCRIPTION
Small vertical tab column gap spacing needs to be updated

## Current Behavior

column gap spacing is xs (4px) per previous figma

## New Behavior

column gap spacing is xxs (2px) per updated figma

## Related Issue(s)

Fixes #22334
