### PR TITLE
docs: setup github issues beta templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility_issue.md
+++ b/.github/ISSUE_TEMPLATE/accessibility_issue.md
@@ -1,5 +1,5 @@
 ---
-name: Accessibility issue
+name: Accessibility issue  (Deprecated)
 about: Have you identified an accessibility issue regarding a Fluent UI React control?
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -15,9 +15,9 @@ body:
       label: Library
       description: Which library is affected
       options:
-        - React Northstart / v0 (@fluentui/react-northstart)
+        - React Northstar / v0 (@fluentui/react-northstar)
         - React / v8 (@fluentui/react)
-        - React Components / vNext (@fluentui/react-components)
+        - React Components / v9 (@fluentui/react-components)
         - Web Components (@fluentui/web-components)
     validations:
       required: true
@@ -53,9 +53,9 @@ body:
       label: Reproduction
       description: |
         Please provide a link to one of following browser tools based on library version:
-        - React Northstart / v0 - https://codesandbox.io/
+        - React Northstar / v0 - https://codesandbox.io/s/fluent-ui-template-8ismt
         - React / v8  - https://aka.ms/fluentpen
-        - React Components / vNext - https://codesandbox.io/
+        - React Components / v9 - https://codesandbox.io/
         - Web Components - https://codesandbox.io/
 
         Or a link to a repo that can reproduce the problem you ran into.

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,129 @@
+name: 🐞 Bug Report
+description: File a bug report
+title: '[Bug]: '
+labels: ['Type: Bug 🐛', 'Needs: Triage 🔍']
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: dropdown
+    id: lib-version
+    attributes:
+      label: Library
+      description: Which library is affected
+      options:
+        - React Northstart / v0 (@fluentui/react-northstart)
+        - React / v8 (@fluentui/react)
+        - React Components / vNext (@fluentui/react-components)
+        - Web Components (@fluentui/web-components)
+    validations:
+      required: true
+
+  - type: textarea
+    id: env-info
+    attributes:
+      label: System Info
+      description: Output of `npx envinfo --system --npmPackages '{@fluent/*}' --browsers`
+      render: shell
+    validations:
+      required: true
+
+  - type: dropdown
+    id: a11y-bug
+    attributes:
+      label: Are you reporting Accessibility issue?
+      description: |
+        **PLEASE NOTE:**
+
+        1. Do not link to, screenshot or reference a Microsoft product in this description.
+        2. Our screen reader support is limited to Edge + Narrator.
+          - Please check ARIA component examples to ensure it is not a screen reader or browser issue.
+          - Issues that do not reproduce in Edge + Narrator, and aren't caused by obvious invalid aria values, should be filed with the respective screen reading software, not the Fluent UI repo.
+        3. There is documentation or best practice that supports your expected behavior (review [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.1/) for accessibility guidance.)
+      options:
+        - 'yes'
+        - 'no'
+
+  - type: input
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: |
+        Please provide a link to one of following browser tools based on library version:
+        - React Northstart / v0 - https://codesandbox.io/
+        - React / v8  - https://aka.ms/fluentpen
+        - React Components / vNext - https://codesandbox.io/
+        - Web Components - https://codesandbox.io/
+
+        Or a link to a repo that can reproduce the problem you ran into.
+
+        **NOTE:**
+
+        A [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) is required.
+        If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "need reproduction" label.
+
+        If no reproduction is provided after 3 days, it will be auto-closed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      value: |
+        ## Actual Behavior
+        fill this out
+
+        ## Expected Behavior
+        fill this out
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+
+  - type: dropdown
+    id: request-priority
+    attributes:
+      label: Requested priority
+      options:
+        - Blocking
+        - High
+        - Normal
+        - Low
+    validations:
+      required: true
+
+  - type: input
+    id: products-affected
+    attributes:
+      label: Products/sites affected
+      placeholder: (provide if applicable)
+
+  - type: dropdown
+    id: requested-help
+    attributes:
+      label: Are you willing to submit a PR to fix?
+      options:
+        - 'yes'
+        - 'no'
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Validations
+      description: Before submitting the issue, please make sure you do the following
+      options:
+        - label: Check that there isn't already an issue that reports the same bug to avoid creating a duplicate.
+          required: true
+        - label: The provided reproduction is a minimal reproducible example of the bug.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: Bug report (Deprecated)
 about: Found a bug in Fluent UI React?
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/microsoft/fluentui/discussions
+    about: Use GitHub discussions for message-board style questions and discussions.
+  - name: Questions via Stack Overflow
+    url: https://stackoverflow.com/questions/tagged/fluentui
+    about: Please use Stack Overflow for questions `#fluentui-react`, `#fluentui`

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -15,9 +15,9 @@ body:
       label: Library
       description: To which library would this be added to
       options:
-        - React Northstart / v0 (@fluentui/react-northstart)
+        - React Northstar / v0 (@fluentui/react-northstar)
         - React / v8 (@fluentui/react)
-        - React Components / vNext (@fluentui/react-components)
+        - React Components / v9 (@fluentui/react-components)
         - Web Components (@fluentui/web-components)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,55 @@
+name: "\U0001F680 New feature proposal"
+description: Propose a new feature to be added to Fluent UI
+title: '[Feature]: '
+labels: ['Type: Feature', 'Needs: Triage 🔍']
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in the project and taking the time to fill out this feature report!
+
+  - type: dropdown
+    id: lib-version
+    attributes:
+      label: Library
+      description: To which library would this be added to
+      options:
+        - React Northstart / v0 (@fluentui/react-northstart)
+        - React / v8 (@fluentui/react)
+        - React Components / vNext (@fluentui/react-components)
+        - Web Components (@fluentui/web-components)
+    validations:
+      required: true
+
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Describe the feature that you would like added
+    validations:
+      required: true
+
+  - type: input
+    id: feature-discussed-with
+    attributes:
+      label: Have you discussed this feature with our team
+      description: Please use particular person or team github handle
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any other context or screenshots about the feature request here.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Validations
+      description: Before submitting the issue, please make sure you do the following
+      options:
+        - label: Check that there isn't already an issue that request the same feature to avoid creating a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: Feature request (Deprecated)
 about: Do you have feature or improvement suggestion for Fluent UI React?
 ---
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

At the moment we identified 2 main issues when having shield duty or doing triaging of new issues:
- when creating issue, contributor has no context/missing guidance for what library in our monorepo is that issue for
- contributors are not enforced to provide proper reproduction and library version that is affected, which leads to additional time spent on our side to triage etc

## New Behavior

- we leverage new github issues templates that provide superb UX to contributors
- we enforce proper reports and issue formats so we can effectively triage and act if needed
- we unify our bug template
- instead creating dummy issues we leverage proper UX to forward contributors to github discsussion and stack overflow

### Preview
 - [🔎 new bug report template](https://github.com/microsoft/fluentui/blob/180f4de91aff95981aaada2ae050b15b9b6d1b95/.github/ISSUE_TEMPLATE/bug-report.yml)
 - [🔎 new feature request template](https://github.com/microsoft/fluentui/blob/180f4de91aff95981aaada2ae050b15b9b6d1b95/.github/ISSUE_TEMPLATE/feature-request.yml)


## Next steps

- as a follow up, github action will be created to properly add tags of library versions etc which will reduce time spend on triaging significantly 