### PR TITLE
Set background when tab is disabled.

### DIFF
--- a/change/@fluentui-react-tabs-5399b449-6c6d-4276-97d4-22fbf60a4f9d.json
+++ b/change/@fluentui-react-tabs-5399b449-6c6d-4276-97d4-22fbf60a4f9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Set disabled tab background to transparent",
+  "packageName": "@fluentui/react-tabs",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tabs/src/components/Tab/useTabStyles.ts
+++ b/packages/react-tabs/src/components/Tab/useTabStyles.ts
@@ -93,6 +93,8 @@ const useRootStyles = makeStyles({
     },
   },
   disabled: {
+    backgroundColor: tokens.colorTransparentBackground,
+
     '& .fui-Tab__icon': {
       color: tokens.colorNeutralForegroundDisabled,
     },
@@ -336,10 +338,10 @@ export const useTabStyles_unstable = (state: TabState): TabState => {
     size !== 'small' && (vertical ? rootStyles.mediumVertical : rootStyles.mediumHorizontal),
     size === 'small' && (vertical ? rootStyles.smallVertical : rootStyles.smallHorizontal),
     focusStyles.base,
-    disabled && rootStyles.disabled,
     !disabled && appearance === 'subtle' && rootStyles.subtle,
     !disabled && appearance === 'transparent' && rootStyles.transparent,
     !disabled && selected && rootStyles.selected,
+    disabled && rootStyles.disabled,
 
     // pending indicator (before pseudo element)
     pendingIndicatorStyles.base,


### PR DESCRIPTION
## Current Behavior

Disabled tab has background inherited

## New Behavior

Disabled tab has transparent background

## Related Issue(s)

Fixes #22338
