### PR TITLE
Update CODEOWNERS for Facepile and Persona in master branch (v8)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -170,7 +170,7 @@ packages/react/src/components/DatePicker @ermercer @evlevy
 packages/react/src/components/DetailsList @microsoft/cxe-red @ThomasMichon
 packages/react/src/components/DocumentCard @microsoft/cxe-red @yiminwu
 packages/react/src/components/Fabric @microsoft/cxe-red @dzearing
-packages/react/src/components/Facepile @microsoft/cxe-red @markionium @mtennoe
+packages/react/src/components/Facepile @microsoft/cxe-red
 packages/react/src/components/FolderCover @microsoft/cxe-red @ThomasMichon @bigbadcapers
 packages/react/src/components/FocusTrapZone @microsoft/cxe-red @khmakoto
 packages/react/src/components/GroupedList @microsoft/cxe-red @ThomasMichon
@@ -186,8 +186,8 @@ packages/react/src/components/MessageBar @microsoft/cxe-red
 packages/react/src/components/Nav @microsoft/cxe-red
 packages/react/src/components/Overlay @microsoft/cxe-red @khmakoto
 packages/react/src/components/Panel @microsoft/cxe-red @khmakoto
-packages/react/src/components/Persona @microsoft/cxe-red @markionium @mtennoe
-packages/react/src/components/PersonaCoin @microsoft/cxe-red @mtennoe @markionium
+packages/react/src/components/Persona @microsoft/cxe-red
+packages/react/src/components/PersonaCoin @microsoft/cxe-red
 packages/react/src/components/Pivot @microsoft/cxe-red @behowell
 packages/react/src/components/SearchBox @microsoft/cxe-red
 packages/react/src/components/Shimmer @microsoft/cxe-red


### PR DESCRIPTION
## Current Behavior

CODEOWNERS for Facepile and Persona on the master branch are outdated.

## New Behavior

CODEOWNERS for Facepile and Persona on the master branch are updated.
