### PR TITLE
Fix tab subtle background

### DIFF
--- a/change/@fluentui-react-tabs-c4411795-459a-4614-bbb0-128211b1e806.json
+++ b/change/@fluentui-react-tabs-c4411795-459a-4614-bbb0-128211b1e806.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Set subtle tab background to subtle background tokens",
+  "packageName": "@fluentui/react-tabs",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tabs/src/components/Tab/useTabStyles.ts
+++ b/packages/react-tabs/src/components/Tab/useTabStyles.ts
@@ -88,8 +88,12 @@ const useRootStyles = makeStyles({
     },
   },
   subtle: {
+    backgroundColor: tokens.colorSubtleBackground,
     ':hover': {
-      backgroundColor: tokens.colorNeutralBackground1Hover,
+      backgroundColor: tokens.colorSubtleBackgroundHover,
+    },
+    ':active': {
+      backgroundColor: tokens.colorTransparentBackgroundPressed,
     },
   },
   disabled: {


### PR DESCRIPTION
## Current Behavior

Subtle tab background set only on hover to outdated token.

## New Behavior

Subtle tab background uses subtle tokens per figma

## Related Issue(s)

Fixes #22336
