### PR TITLE
remove space from markdown causing broken render

### DIFF
--- a/apps/public-docsite/src/pages/Controls/AvatarPage/docs/android/AvatarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/AvatarPage/docs/android/AvatarOverview.md
@@ -1,7 +1,6 @@
 `AvatarView` displays either a photo or the initials of a person, entity, or group on top of a colored circular or square background.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Initials
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/android/updated/img_avatar_02_initials_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/AvatarPage/docs/ios/AvatarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/AvatarPage/docs/ios/AvatarOverview.md
@@ -1,7 +1,6 @@
 `AvatarView` displays either a photo or the initials of a person on circular background and displays entity or group on square background.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Initials
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_avatar_02_initials.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/AvatarPage/docs/mac/AvatarUsage.md
+++ b/apps/public-docsite/src/pages/Controls/AvatarPage/docs/mac/AvatarUsage.md
@@ -1,7 +1,6 @@
 To determine initials for an avatar, the code initially tries to extract two-letter initials from `contactName`. If that isn't successful, it falls back to trying the first initial of the `contactEmail`. If the algorithm fails to extract a character from the `contactEmail`, it falls back to the `#` character to represent the generic user.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Initials
 
 ```Swift

--- a/apps/public-docsite/src/pages/Controls/BottomNavigationPage/docs/android/BottomNavigationOverview.md
+++ b/apps/public-docsite/src/pages/Controls/BottomNavigationPage/docs/android/BottomNavigationOverview.md
@@ -1,7 +1,6 @@
 The bottom navigation displays icons and optional text at the bottom of the screen for switching between different primary destinations in an app.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Bottom Navigation
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/android/updated/img_bottomnavigation_01_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/BottomNavigationPage/docs/ios/BottomNavigationOverview.md
+++ b/apps/public-docsite/src/pages/Controls/BottomNavigationPage/docs/ios/BottomNavigationOverview.md
@@ -3,7 +3,6 @@ The tab bar displays tabs at the bottom of the window for switching between diff
 <!-- prettier-ignore-start -->
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Portrait
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_tabbar_01_portrait_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/ButtonPage/docs/android/ButtonOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ButtonPage/docs/android/ButtonOverview.md
@@ -1,7 +1,6 @@
 Buttons are one of the core controls that make an app feel native to the platform it's on. It’s important to respect the platform's paradigms in order to help the user feel at home on Android and keep the experience quality high.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Primary Filled
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/android/updated/img_button_01_primaryfilled_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/ButtonPage/docs/ios/ButtonOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ButtonPage/docs/ios/ButtonOverview.md
@@ -1,7 +1,6 @@
 Buttons are one of the core controls that make an app feel native to the platform it's on. It’s important to respect the platform's paradigms in order to help the user feel at home on iOS and keep the experience quality high.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Primary Filled
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_button_01_primaryfilled_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/ButtonPage/docs/mac/ButtonOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ButtonPage/docs/mac/ButtonOverview.md
@@ -1,7 +1,6 @@
 Buttons give people a way to trigger an action. They're typically found in windows, alerts, and dialogs. Some buttons are specialized for particular tasks, such as navigation, repeated actions, or presenting menus. The Fluent UI button for macOS adds system-appropriate hover effects when the mouse rests over it.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Primary filled
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric-cdn-prod_20200701.001/fabric-website/images/controls/macos/Button/button_primaryfilled_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/CalendarPage/docs/android/CalendarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/CalendarPage/docs/android/CalendarOverview.md
@@ -1,7 +1,6 @@
 The `CalendarView` is used to display calendar dates and to allow a user to select a date.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Calendar
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/android/updated/img_calendar_01_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/ChipPage/docs/android/ChipOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ChipPage/docs/android/ChipOverview.md
@@ -1,7 +1,6 @@
 Chips are compact representations of entities (most commonly, people) that can be clicked, deleted, or dragged easily. The most common example can be seen in the To field of a new email in Outlook Mobile.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Persona Chips
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/android/updated/img_chip_01_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/ChipPage/docs/ios/ChipOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ChipPage/docs/ios/ChipOverview.md
@@ -3,7 +3,6 @@ Chips are compact representations of entities (most commonly, people) that can b
 The chip field control handles keyboard input, wrapping and truncation automatically.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Small Chip
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_badges_03_small_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/DatePickerPage/docs/mac/DatePickerUsage.md
+++ b/apps/public-docsite/src/pages/Controls/DatePickerPage/docs/mac/DatePickerUsage.md
@@ -1,7 +1,6 @@
 The DatePicker uses the provided [`Calendar`](https://developer.apple.com/documentation/foundation/calendar) instance as a data source. If no calendar is provided, it uses [`Calendar.current`](https://developer.apple.com/documentation/foundation/calendar/2293438-current), which is the system calendar.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Default configuration
 
 ```Swift

--- a/apps/public-docsite/src/pages/Controls/DrawerPage/docs/ios/DrawerOverview.md
+++ b/apps/public-docsite/src/pages/Controls/DrawerPage/docs/ios/DrawerOverview.md
@@ -1,7 +1,6 @@
 Drawers let you reveal lightweight views inside your application without being a full-screen view that takes over the navigation hierarchy. They are easy to dismiss & resize, and may leave space on-screen that shows the content behind them.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Veritcal
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_drawer_03_floatingsheet_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/ListCellsPage/docs/android/ListCellsOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ListCellsPage/docs/android/ListCellsOverview.md
@@ -1,7 +1,6 @@
 When displaying fundamental content types like files or people, it's important to provide a consistent appearance across every screen. These list cells have been designed to represent commonly used entities using a consistent system for representing their icons, metadata and secondary states.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### One line
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/android/updated/img_list_01_oneline_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/ListCellsPage/docs/ios/ListCellsOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ListCellsPage/docs/ios/ListCellsOverview.md
@@ -1,7 +1,6 @@
 When displaying fundamental content types like files or people, it's important to provide a consistent appearance across every screen. These list cells have been designed to represent commonly used entities using a consistent system for representing their icons, metadata and secondary states.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### One line
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_list_02_oneline_sharedleft_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/MessageBarPage/docs/ios/MessageBarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/MessageBarPage/docs/ios/MessageBarOverview.md
@@ -1,7 +1,6 @@
 `NotificationView` can be used to present a toast (`.primaryToast` and `.neutralToast` styles) or a message bar (`.primaryBar`, `.primaryOutlineBar`, and `.neutralBar` styles) with information and actions at the bottom of the screen.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Toast
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_notifications_03_toast_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/NavBarPage/docs/ios/NavBarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/NavBarPage/docs/ios/NavBarOverview.md
@@ -2,7 +2,6 @@ This navigation controller provides supports the Large Title presentation and an
 
 <!-- prettier-ignore-start -->
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Portrait
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_navigation_01_iphoneportrait_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/PeoplePickerPage/docs/android/PeoplePickerOverview.md
+++ b/apps/public-docsite/src/pages/Controls/PeoplePickerPage/docs/android/PeoplePickerOverview.md
@@ -3,7 +3,6 @@ The `PeoplePicker` is used to select one or more entities, such as people or gro
 The `PeoplePicker` control handles keyboard input, field expanding and collapsing, and truncation automatically.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### People Picker
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/android/updated/img_peoplepicker_01_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/PivotPage/docs/ios/PivotOverview.md
+++ b/apps/public-docsite/src/pages/Controls/PivotPage/docs/ios/PivotOverview.md
@@ -1,7 +1,6 @@
 Pivots are used for switching between sub-views or different pre-defined filtering or sorting configurations for a given view. Variants may also use a combination of icons and text or just icons to articulate section content.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Two
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_pivot_03_twosegments_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/PopupMenuPage/docs/ios/PopupMenuOverview.md
+++ b/apps/public-docsite/src/pages/Controls/PopupMenuPage/docs/ios/PopupMenuOverview.md
@@ -2,7 +2,6 @@ PopupMenus provide a set of commands or options inside of a drawer. Two types of
 
 <!-- prettier-ignore-start -->
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Top down
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_drawer_02_topsheet_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/SpinnerPage/docs/ios/SpinnerOverview.md
+++ b/apps/public-docsite/src/pages/Controls/SpinnerPage/docs/ios/SpinnerOverview.md
@@ -7,7 +7,6 @@ Use a standalone spinner when you need a progress indicator on an existing surfa
 For actions that happen "between views", you can use the progress indicator that lives in its own overlay, the `HUD`.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### Activity Indicator
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_spinner_01_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/TooltipPage/docs/android/TooltipOverview.md
+++ b/apps/public-docsite/src/pages/Controls/TooltipPage/docs/android/TooltipOverview.md
@@ -1,7 +1,6 @@
 Use tooltips to show small unobtrusive hints on top of your app's UI. These can appear as a result of user interaction, or triggered thoughtfully to assist the user in learning the details of a new feature they have shown interest in.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### One line
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/android/updated/img_tooltip_01_oneline_light.png?text=LightMode" />

--- a/apps/public-docsite/src/pages/Controls/TooltipPage/docs/ios/TooltipOverview.md
+++ b/apps/public-docsite/src/pages/Controls/TooltipPage/docs/ios/TooltipOverview.md
@@ -1,7 +1,6 @@
 Use tooltips to show small unobtrusive hints on top of your app's UI. These can appear as a result of user interaction, or be triggered thoughtfully to assist the user in learning the details of a new feature they have shown interest in.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
-
 ### One line
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_tooltip_01_oneline_light.png?text=LightMode" />


### PR DESCRIPTION
Empty space between DisplayToggle and first line of markdown was causing the Markdown parser to fail.

I'm curious if this is a bug in the new Markdown parser, or just a bad interaction between Markdown and the custom JSX. I'll create a backlog item to look at it later. For now, working is best. https://github.com/microsoft/fluentui/issues/22349

**Before**
![image](https://user-images.githubusercontent.com/1434956/161820663-6b2df466-4be9-49c8-a119-0fa1aec32577.png)

**After**

![image](https://user-images.githubusercontent.com/1434956/161820704-befa90a3-9911-4498-b8a5-d08323b27e89.png)
