### PR TITLE
Only initialize sass task when needed

### DIFF
--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -55,7 +55,7 @@ export function preset() {
   task('copy', copy);
   task('jest', jestTask);
   task('jest-watch', jestWatch);
-  task('sass', sass);
+  task('sass', sass());
   task('ts:postprocess', postprocessTask());
   task('postprocess:amd', postprocessAmdTask);
   task('postprocess:commonjs', postprocessCommonjsTask);


### PR DESCRIPTION
## Current Behavior

For every package, the `sass` task takes around 0.3-1.0 seconds in CI, even if there are no sass files. It's not much time but becomes more significant when multiplied by 70 packages. 

The delay is probably because `just-scripts` `sassTask` imports and parses various dependencies before bailing if there are no scss files.

## New Behavior

Add an early bail-out which doesn't even initialize `sassTask()` if there are no scss files in the directory. Packages without sass now finish in < 0.01s. (With our limited number of actual packages with sass files, this probably mitigates the impact of `dart-sass` being a little slower as described in https://github.com/microsoft/fluentui/pull/22352#issuecomment-1090606556.)

Also did some minor cleanup/simplification of the copy task. (I thought about adding a bail-out for this one as well, but it already finishes in < 0.01s, so not important.)