### PR TITLE
feat: useFirstMount concurrent render support and return closure

### DIFF
--- a/change/@fluentui-react-positioning-e5cc90ef-8479-4fe1-ad4e-c316b34a8a8e.json
+++ b/change/@fluentui-react-positioning-e5cc90ef-8479-4fe1-ad4e-c316b34a8a8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: update usage of useFirstMount which returns a closure",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-69f229cd-8b2f-4797-bbe2-9e49012d626c.json
+++ b/change/@fluentui-react-utilities-69f229cd-8b2f-4797-bbe2-9e49012d626c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Update usage of useFirstMount to support concurrent mode, and returns closure",
+  "packageName": "@fluentui/react-utilities",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-combobox/src/components/Combobox/useCombobox.ts
+++ b/packages/react-combobox/src/components/Combobox/useCombobox.ts
@@ -66,7 +66,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
       return props.value;
     }
 
-    if (isFirstMount && props.defaultValue !== undefined) {
+    if (isFirstMount() && props.defaultValue !== undefined) {
       return props.defaultValue;
     }
 

--- a/packages/react-positioning/src/usePopper.ts
+++ b/packages/react-positioning/src/usePopper.ts
@@ -412,7 +412,7 @@ export function usePopper(
   }, [handlePopperUpdate, options.enabled]);
   useIsomorphicLayoutEffect(
     () => {
-      if (!isFirstMount) {
+      if (!isFirstMount()) {
         popperInstanceRef.current?.setOptions(
           resolvePopperOptions(overrideTargetRef.current ?? targetRef.current, containerRef.current, arrowRef.current),
         );

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -275,8 +275,8 @@ export type UseControllableStateOptions<State> = {
 // @public
 export const useEventCallback: <Args extends unknown[], Return>(fn: (...args: Args) => Return) => (...args: Args) => Return;
 
-// @public
-export function useFirstMount(): boolean;
+// @public (undocumented)
+export function useFirstMount(): () => boolean;
 
 // @public
 export function useForceUpdate(): DispatchWithoutAction;

--- a/packages/react-utilities/src/hooks/useFirstMount.test.ts
+++ b/packages/react-utilities/src/hooks/useFirstMount.test.ts
@@ -10,14 +10,15 @@ describe('useFirstMount', () => {
     rerender();
 
     // Assert
-    expect(result.current).toBe(false);
+    expect(result.current()).toBe(false);
   });
 
   it('should return true after first render', () => {
     // Act
-    const { result } = renderHook(useFirstMount);
+    let result: boolean | undefined = undefined;
+    renderHook(() => (result = useFirstMount()()));
 
     // Assert
-    expect(result.current).toBe(true);
+    expect(result).toBe(true);
   });
 });

--- a/packages/react-utilities/src/hooks/useFirstMount.ts
+++ b/packages/react-utilities/src/hooks/useFirstMount.ts
@@ -1,22 +1,16 @@
 import * as React from 'react';
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 /**
- * Checks if components was mounted the first time.
- * Since concurrent mode will be released in the future this needs to be verified
- * Currently (React 17) will always render the initial mount once
- * https://codesandbox.io/s/heuristic-brook-s4w0q?file=/src/App.jsx
- * https://codesandbox.io/s/holy-grass-8nieu?file=/src/App.jsx
- *
  * @example
  * const isFirstMount = useFirstMount();
  */
-export function useFirstMount(): boolean {
+export function useFirstMount(): () => boolean {
   const isFirst = React.useRef(true);
 
-  if (isFirst.current) {
+  useIsomorphicLayoutEffect(() => {
     isFirst.current = false;
-    return true;
-  }
+  }, []);
 
-  return isFirst.current;
+  return () => isFirst.current;
 }


### PR DESCRIPTION
## Current Behavior

Currently `useFirstMount` writes to a ref during render, which is technically incorrect for concurrent render because there is no guarantee how many times the `render` function can run.

The hook returns a boolean value which will be 'frozen' inside other closures:

```ts
const isFirstMount = useFirstMount();

// This callback will never update and the value of `isFirstMount` will be the same all the time
React.useCallback(() => {
  if (isFirstMount) {
   // do something
  }
}, [])
```

## New Behavior

The boolean ref is now updated in an effect, which will only happen once the render has been committed.

The hook returns a closure which returns the boolean value which reads a ref. It is guaranteed to be the up-to-date value:

```ts
const isFirstMount = useFirstMount();

// This callback will never update and that's fine
React.useCallback(() => {
  if (isFirstMount()) {
   // do something
  }
}, [])
```

## Related Issue(s)

Extracted from #21828
