### PR TITLE
Tooltip text size should be 12 by default

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Do not render styles in Provider when "as" is "React.Fragment" @layershifter ([#22359](https://github.com/microsoft/fluentui/pull/22359))
 
 ### Fixes
+- `Tooltip` text size should be 12 by default @petr-duda ([#22407](https://github.com/microsoft/fluentui/pull/22407))
 - Add transparent borders to slider @ling1726 ([#22089](https://github.com/microsoft/fluentui/pull/22089))
 - Fix `Popup` opened from right click (on `context`), to not dismiss when scrolling happens in nested Popup @yaunboxue-amber ([#22087](https://github.com/microsoft/fluentui/pull/22087))
 - Fix `Dropdown` not annoucing placeholder/default value with VoiceOver on macOS @aubreyquinn ([#22173](https://github.com/microsoft/fluentui/pull/22173))

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentStyles.ts
@@ -47,6 +47,7 @@ export const tooltipContentStyles: ComponentSlotStylesPrepared<TooltipContentSty
   }),
   content: ({ props: p, variables: v }): ICSSInJSStyle => ({
     display: 'block',
+    fontSize: '12px',
     padding: v.padding,
     textAlign: 'left',
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentStyles.ts
@@ -3,6 +3,7 @@ import { TooltipContentStylesProps } from '../../../../components/Tooltip/Toolti
 import { TooltipContentVariables } from './tooltipContentVariables';
 import { getContainerStyles, getPointerStyles } from '../../getPointerStyles';
 import { pointerSvgUrl } from '../../pointerSvgUrl';
+import { pxToRem } from '../../../../utils';
 
 export const tooltipContentStyles: ComponentSlotStylesPrepared<TooltipContentStylesProps, TooltipContentVariables> = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => ({
@@ -47,7 +48,7 @@ export const tooltipContentStyles: ComponentSlotStylesPrepared<TooltipContentSty
   }),
   content: ({ props: p, variables: v }): ICSSInJSStyle => ({
     display: 'block',
-    fontSize: '12px',
+    fontSize: pxToRem(12),
     padding: v.padding,
     textAlign: 'left',
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Tooltip has the same font-size as the general text (inherited from body)

![Screenshot 2022-04-07 at 8 07 26 PM](https://user-images.githubusercontent.com/13124780/162268756-150b9207-c035-4721-aeb1-3fb7dea75370.png)

## New Behavior

Tooltip with font-size 12px will look smaller than the general text

![Screenshot 2022-04-07 at 8 07 38 PM](https://user-images.githubusercontent.com/13124780/162268721-7f34acd6-81eb-4685-ab14-3f30712202de.png)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
