### PR TITLE
fix(react): Panel - make theming work and sticky styling consistent

### DIFF
--- a/change/@fluentui-react-be6d794a-f2d4-4abf-8bac-137b469d95e9.json
+++ b/change/@fluentui-react-be6d794a-f2d4-4abf-8bac-137b469d95e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react): Panel - make theming work and sticky styling consistent",
+  "packageName": "@fluentui/react",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -258,9 +258,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     commands: [
       classNames.commands,
       {
-        marginTop: 18,
-        //Ensures that the stickied header always has a background to prevent overlaps on scroll.
-        background: 'inherit',
+        paddingTop: 18,
         selectors: {
           [`@media (min-height: ${ScreenWidthMinMedium}px)`]: {
             position: 'sticky',
@@ -271,6 +269,11 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       },
       hasCustomNavigation && {
         marginTop: 'inherit',
+      },
+      // - Ensures that the sticky header always has a background to prevent overlaps on scroll.
+      // - Adds consistent behavior with how Footer is being handled
+      isFooterSticky && {
+        backgroundColor: semanticColors.bodyBackground,
       },
     ],
     navigation: [
@@ -290,7 +293,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         flexDirection: 'column',
         flexGrow: 1,
         overflowY: 'hidden',
-        background: 'inherit',
       },
     ],
     header: [
@@ -325,7 +327,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       classNames.scrollableContent,
       {
         overflowY: 'auto',
-        background: 'inherit',
       },
       isFooterAtBottom && {
         flexGrow: 1,
@@ -362,7 +363,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         },
       },
       isFooterSticky && {
-        background: semanticColors.bodyBackground,
+        backgroundColor: semanticColors.bodyBackground,
         borderTopColor: semanticColors.variantBorder,
       },
     ],

--- a/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -97,7 +97,6 @@ exports[`Panel renders Panel correctly 1`] = `
         class=
             ms-Panel-contentInner
             {
-              background: inherit;
               display: flex;
               flex-direction: column;
               flex-grow: 1;
@@ -108,7 +107,6 @@ exports[`Panel renders Panel correctly 1`] = `
           class=
               ms-Panel-scrollableContent
               {
-                background: inherit;
                 overflow-y: auto;
               }
           data-is-scrollable="true"
@@ -117,8 +115,7 @@ exports[`Panel renders Panel correctly 1`] = `
             class=
                 ms-Panel-commands
                 {
-                  background: inherit;
-                  margin-top: 18px;
+                  padding-top: 18px;
                 }
                 @media (min-height: 480px){& {
                   position: sticky;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- CSS `inherit` is broken in chromium engines when styles are dynamically re-computed ( for example changing theme )
- Commands ( Panel Header ) has inconsistent styling behaviour with Footer when item content forces scrollable behaviour
- Commands is adding empty space at the top which delays snapping behaviour/incorrectly renders colors if user re-styles Commands via `styles`

## New Behavior

- `backgroundColor` is used instead of destructive `background`
- `inherit` is not used, re-computation works and themes and custom colors via styles slots are properly applied

https://user-images.githubusercontent.com/1223799/162282064-74bb76a5-54f7-42d3-b88f-4a4d65b96e39.mov


- Commands and Footer implement consistent behaviour when scrollable behaviour is in place

```tsx
<Panel styles={{main: { backgroundColor:'red' } }}>...</Panel>
```

↓↓ properly renders red for whole panel ↓↓

![image](https://user-images.githubusercontent.com/1223799/162282323-13291ff3-f909-4381-9492-ab0dbf346b2f.png)


↓↓ Commands and Footer maintain consistent behaviour - they don't use `inherit` for background-color ↓↓

![image](https://user-images.githubusercontent.com/1223799/162282543-f88ab968-655c-4b3f-b98e-e3a24ba542e8.png)


If users want to manually re-color Panel and have consistent styling for both scrollable and non scrollable behaviours, they need to explicitly apply styles for both `commands` and `footer`

```tsx
const overridePanelStyles = {backgroundColor:'red'}
<Panel styles={{ main: overridePanelStyles, command:overridePanelStyles, footer: overridePanelStyles }}>...</Panel>
```

↓↓↓↓

![image](https://user-images.githubusercontent.com/1223799/162283130-d86d9678-4921-455a-a519-3cb26720acc9.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/microsoft/fluentui/issues/22214
Updates https://github.com/microsoft/fluentui/pull/21466 
