### PR TITLE
Update initializeIcons to add user defined URL in argument

### DIFF
--- a/change/@fluentui-font-icons-mdl2-e7773ae4-3eff-4f71-a848-89c5691e5bc0.json
+++ b/change/@fluentui-font-icons-mdl2-e7773ae4-3eff-4f71-a848-89c5691e5bc0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update initializeIcons to add user defined URL in argument",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/font-icons-mdl2/package.json
+++ b/packages/font-icons-mdl2/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@fluentui/set-version": "^8.2.0",
     "@fluentui/style-utilities": "^8.6.5",
+    "@fluentui/react-window-provider": "^2.2.0",
     "tslib": "^2.1.0"
   },
   "exports": {

--- a/packages/font-icons-mdl2/package.json
+++ b/packages/font-icons-mdl2/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@fluentui/set-version": "^8.2.0",
     "@fluentui/style-utilities": "^8.6.5",
-    "@fluentui/react-window-provider": "^2.2.0",
+    "@fluentui/utilities": "^8.8.1",
     "tslib": "^2.1.0"
   },
   "exports": {

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -22,9 +22,15 @@ import { IIconOptions } from '@fluentui/style-utilities';
 import { registerIconAliases } from './iconAliases';
 const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
 
+declare global {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    FabricConfig: any;
+  }
+}
 export function initializeIcons(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  baseUrl: string = (window as any)?.FabricConfig?.fontBaseUrl ?? DEFAULT_BASE_URL,
+  baseUrl: string = window.FabricConfig?.fontBaseUrl ?? DEFAULT_BASE_URL,
   options?: IIconOptions,
 ): void {
   [

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -20,6 +20,7 @@ import { initializeIcons as i17 } from './fabric-icons-17';
 
 import { IIconOptions } from '@fluentui/style-utilities';
 import { registerIconAliases } from './iconAliases';
+import { useWindow } from '@fluentui/react-window-provider';
 const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
 
 declare global {
@@ -29,8 +30,12 @@ declare global {
     FabricConfig: any;
   }
 }
+
+// eslint-disable-next-line react-hooks/rules-of-hooks
+const win = useWindow();
+
 export function initializeIcons(
-  baseUrl: string = window.FabricConfig?.fontBaseUrl ?? DEFAULT_BASE_URL,
+  baseUrl: string = win?.FabricConfig?.fontBaseUrl ?? DEFAULT_BASE_URL,
   options?: IIconOptions,
 ): void {
   [

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -20,7 +20,7 @@ import { initializeIcons as i17 } from './fabric-icons-17';
 
 import { IIconOptions } from '@fluentui/style-utilities';
 import { registerIconAliases } from './iconAliases';
-import { useWindow } from '@fluentui/react-window-provider';
+import { getWindow } from '@fluentui/utilities';
 const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
 
 declare global {
@@ -31,8 +31,7 @@ declare global {
   }
 }
 
-// eslint-disable-next-line react-hooks/rules-of-hooks
-const win = useWindow();
+const win = getWindow();
 
 export function initializeIcons(
   baseUrl: string = win?.FabricConfig?.fontBaseUrl ?? DEFAULT_BASE_URL,

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -22,7 +22,11 @@ import { IIconOptions } from '@fluentui/style-utilities';
 import { registerIconAliases } from './iconAliases';
 const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
 
-export function initializeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: IIconOptions): void {
+export function initializeIcons(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  baseUrl: string = (window as any)?.FabricConfig.fontBaseUrl ?? DEFAULT_BASE_URL,
+  options?: IIconOptions,
+): void {
   [
     i,
     i0,

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -24,7 +24,7 @@ const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_2
 
 export function initializeIcons(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  baseUrl: string = (window as any)?.FabricConfig.fontBaseUrl ?? DEFAULT_BASE_URL,
+  baseUrl: string = (window as any)?.FabricConfig?.fontBaseUrl ?? DEFAULT_BASE_URL,
   options?: IIconOptions,
 ): void {
   [


### PR DESCRIPTION
The `initializeIcon` call in font-icons-mdl2 either takes in the default cdn or a user defined URL as an argument. However, in specific cases where a user is using the bundled version of `@fluentui/react`, the default cdn is used, and the user is unable to change the CDN where the icons are served from.

This PR adds the ability for the user to modify `window.FabricConfig` that will then be able to be consumed in the bundled version of `@fluentui/react`.

Simply add a `<script>` tag above the bundled `@fluentui/react` script with the following:
`<script type="text/javascript">
      window.FabricConfig = {
        fontBaseUrl: 'https://cdn.gov/foo/'
      }
</script>`

Fixes #22412 