### PR TITLE
react-textarea: Re-exporting Textarea in react-components

### DIFF
--- a/change/@fluentui-react-components-40b86f61-aa0f-4126-8d2d-a3151f06f577.json
+++ b/change/@fluentui-react-components-40b86f61-aa0f-4126-8d2d-a3151f06f577.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding Textarea to react-components.",
+  "packageName": "@fluentui/react-components",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-67fb3a48-2e9e-4fbe-be50-367d7abb703d.json
+++ b/change/@fluentui-react-textarea-67fb3a48-2e9e-4fbe-be50-367d7abb703d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Adding label to Default story and making package public.",
+  "packageName": "@fluentui/react-textarea",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -53,6 +53,7 @@
     "@fluentui/react-slider": "9.0.0-beta.10",
     "@fluentui/react-switch": "9.0.0-rc.5",
     "@fluentui/react-tabs": "9.0.0-beta.8",
+    "@fluentui/react-textarea": "9.0.0-alpha.0",
     "@fluentui/react-theme": "9.0.0-rc.4",
     "@fluentui/react-tooltip": "9.0.0-rc.5",
     "@fluentui/react-utilities": "9.0.0-rc.5",

--- a/packages/react-components/src/unstable/index.ts
+++ b/packages/react-components/src/unstable/index.ts
@@ -113,6 +113,15 @@ export {
 } from '@fluentui/react-switch';
 export type { SwitchOnChangeData, SwitchProps, SwitchSlots, SwitchState } from '@fluentui/react-switch';
 
+export {
+  Textarea,
+  textareaClassNames,
+  renderTextarea_unstable,
+  useTextarea_unstable,
+  useTextareaStyles_unstable,
+} from '@fluentui/react-textarea';
+export type { TextareaProps, TextareaSlots, TextareaState } from '@fluentui/react-textarea';
+
 export type {
   TabProps,
   TabSlots,

--- a/packages/react-textarea/README.md
+++ b/packages/react-textarea/README.md
@@ -2,4 +2,29 @@
 
 **React Textarea components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
 
+The Textarea component is a multiline text input that allows the user to enter
+
+## STATUS: WIP 🚧
+
 These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+
+## Usage
+
+To import Textarea:
+
+```js
+import { Textarea } from '@fluentui/react-textarea';
+```
+
+Once the Textarea component is ready for production use, the component will be available at:
+
+```js
+import { Textarea } from '@fluentui/react-components';
+```
+
+### Examples
+
+```js
+<Textarea placeholder="Enter text here..." />
+<Textarea defaultValue="Lorem ipsum dolor" />
+```

--- a/packages/react-textarea/package.json
+++ b/packages/react-textarea/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluentui/react-textarea",
   "version": "9.0.0-alpha.0",
-  "private": false,
   "description": "Fluent UI TextArea component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/react-textarea/package.json
+++ b/packages/react-textarea/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluentui/react-textarea",
   "version": "9.0.0-alpha.0",
-  "private": true,
+  "private": false,
   "description": "Fluent UI TextArea component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/react-textarea/src/stories/TextareaDefault.stories.tsx
+++ b/packages/react-textarea/src/stories/TextareaDefault.stories.tsx
@@ -1,4 +1,26 @@
 import * as React from 'react';
+import { useId } from '@fluentui/react-utilities';
 import { Textarea, TextareaProps } from '../index';
+import { Label } from '@fluentui/react-label';
+import { makeStyles, shorthands } from '@griffel/react';
 
-export const Default = (props: Partial<TextareaProps>) => <Textarea {...props} />;
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    ...shorthands.gap('10px'),
+    '& > div': { display: 'flex', flexDirection: 'column', ...shorthands.gap('10px'), ...shorthands.padding('10px') },
+  },
+});
+
+export const Default = (props: Partial<TextareaProps>) => {
+  const textareaId = useId('textarea');
+  const styles = useStyles();
+
+  return (
+    <div className={styles.container}>
+      <Label htmlFor={textareaId}>Default Textarea</Label>
+      <Textarea id={textareaId} {...props} />
+    </div>
+  );
+};


### PR DESCRIPTION
## PR details

This PR introduces `react-textarea` to `react-components`, adds more detail to the readme, and adds a label to the default example.

## Related issues
Issues: #21845 and #22320