### PR TITLE
Update initializeIcons to add user defined URL in argument (v7)

### DIFF
--- a/change/@uifabric-icons-388eaadd-8734-4c42-a630-e91ca6353c2f.json
+++ b/change/@uifabric-icons-388eaadd-8734-4c42-a630-e91ca6353c2f.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Cherrypick update initializeIcons call",
+  "comment": "Updating initializeIcons to add user defined URL in argument.",
   "packageName": "@uifabric/icons",
   "email": "ololubek@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@uifabric-icons-388eaadd-8734-4c42-a630-e91ca6353c2f.json
+++ b/change/@uifabric-icons-388eaadd-8734-4c42-a630-e91ca6353c2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Cherrypick update initializeIcons call",
+  "packageName": "@uifabric/icons",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@uifabric/set-version": "^7.0.24",
     "@uifabric/styling": "^7.20.1",
+    "@fluentui/react-window-provider": "^2.2.0",
     "tslib": "^1.10.0"
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@uifabric/set-version": "^7.0.24",
     "@uifabric/styling": "^7.20.1",
-    "@fluentui/react-window-provider": "^2.2.0",
+    "@uifabric/utilities": "^7.34.0",
     "tslib": "^1.10.0"
   }
 }

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -22,7 +22,11 @@ import { IIconOptions } from '@uifabric/styling';
 import { registerIconAliases } from './iconAliases';
 const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
 
-export function initializeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: IIconOptions): void {
+export function initializeIcons(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  baseUrl: string = (window as any)?.FabricConfig.fontBaseUrl ?? DEFAULT_BASE_URL,
+  options?: IIconOptions,
+): void {
   [
     i,
     i0,

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -27,7 +27,9 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   interface Window {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    FabricConfig: any;
+    FabricConfig?: {
+        fontBaseUrl?: string;
+    }
   }
 }
 

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -20,7 +20,7 @@ import { initializeIcons as i17 } from './fabric-icons-17';
 
 import { IIconOptions } from '@uifabric/styling';
 import { registerIconAliases } from './iconAliases';
-import { useWindow } from '@fluentui/react-window-provider';
+import { getWindow } from '@uifabric/utilities';
 const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
 
 declare global {
@@ -31,8 +31,7 @@ declare global {
   }
 }
 
-// eslint-disable-next-line react-hooks/rules-of-hooks
-const win = useWindow();
+const win = getWindow();
 export function initializeIcons(
   baseUrl: string = win?.FabricConfig?.fontBaseUrl ?? DEFAULT_BASE_URL,
   options?: IIconOptions,

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -20,11 +20,21 @@ import { initializeIcons as i17 } from './fabric-icons-17';
 
 import { IIconOptions } from '@uifabric/styling';
 import { registerIconAliases } from './iconAliases';
+import { useWindow } from '@fluentui/react-window-provider';
 const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
 
+declare global {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    FabricConfig: any;
+  }
+}
+
+// eslint-disable-next-line react-hooks/rules-of-hooks
+const win = useWindow();
 export function initializeIcons(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  baseUrl: string = (window as any)?.FabricConfig?.fontBaseUrl ?? DEFAULT_BASE_URL,
+  baseUrl: string = win?.FabricConfig?.fontBaseUrl ?? DEFAULT_BASE_URL,
   options?: IIconOptions,
 ): void {
   [

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -26,10 +26,9 @@ const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_2
 declare global {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   interface Window {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     FabricConfig?: {
-        fontBaseUrl?: string;
-    }
+      fontBaseUrl?: string;
+    };
   }
 }
 

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -24,7 +24,7 @@ const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_2
 
 export function initializeIcons(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  baseUrl: string = (window as any)?.FabricConfig.fontBaseUrl ?? DEFAULT_BASE_URL,
+  baseUrl: string = (window as any)?.FabricConfig?.fontBaseUrl ?? DEFAULT_BASE_URL,
   options?: IIconOptions,
 ): void {
   [


### PR DESCRIPTION
Cherrypick of #22411 

_Original description follows:_

The `initializeIcon` call in font-icons-mdl2 either takes in the default cdn or a user defined URL as an argument. However, in specific cases where a user is using the bundled version of `@fluentui/react`, the default cdn is used, and the user is unable to change the CDN where the icons are served from.

This PR adds the ability for the user to modify `window.FabricConfig` that will then be able to be consumed in the bundled version of `@fluentui/react`.

Simply add a `<script>` tag above the bundled `@fluentui/react` script with the following:
`<script type="text/javascript">
      window.FabricConfig = {
        fontBaseUrl: 'https://cdn.gov/foo/'
      }
</script>`
