### PR TITLE
ts-minbar-test: explicitly install react 17 to testApp

### DIFF
--- a/apps/ts-minbar-test-react-components/src/index.ts
+++ b/apps/ts-minbar-test-react-components/src/index.ts
@@ -21,9 +21,13 @@ async function performTest() {
     logger(`✔️ Temporary directories created under ${tempPaths.root}`);
 
     // Install dependencies, using the minimum TS version supported for consumers
-    const dependencies = ['@types/react', '@types/react-dom', 'react', 'react-dom', `typescript@${tsVersion}`].join(
-      ' ',
-    );
+    const dependencies = [
+      '@types/react@17',
+      '@types/react-dom@17',
+      'react@17',
+      'react-dom@17',
+      `typescript@${tsVersion}`,
+    ].join(' ');
     await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);
     logger(`✔️ Dependencies were installed`);
 

--- a/apps/ts-minbar-test-react/src/index.ts
+++ b/apps/ts-minbar-test-react/src/index.ts
@@ -23,10 +23,10 @@ async function performTest() {
     // Install dependencies, using the minimum TS version supported for consumers
     const dependencies = [
       '@types/node',
-      '@types/react',
-      '@types/react-dom',
-      'react',
-      'react-dom',
+      '@types/react@17',
+      '@types/react-dom@17',
+      'react@17',
+      'react-dom@17',
       `typescript@${tsVersion}`,
     ].join(' ');
     await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- `ts-minbar-test` for both `@fluentui/react` and `@fluentui/react-components` installs the latest version of react (React 18) to the test app which is causing CI to fail.

## New Behavior

- explicitly install React 17 to test app

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
