### PR TITLE
projects-test: Explicitly install React 17 to package

### DIFF
--- a/apps/ts-minbar-test-react-components/assets/index.tsx
+++ b/apps/ts-minbar-test-react-components/assets/index.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 const App = () => (
   <FluentProvider>
-    <Button children={{ text: 'Press Me' }} />
+    <Button>Press Me</Button>
   </FluentProvider>
 );
 

--- a/packages/fluentui/projects-test/src/nextjs.ts
+++ b/packages/fluentui/projects-test/src/nextjs.ts
@@ -19,7 +19,7 @@ export async function nextjs() {
   logger(`✔️ Temporary directories created under ${tempPaths.root}`);
 
   logger('STEP 1. Add dependencies to test project');
-  const dependencies = ['next', 'react', 'react-dom'].join(' ');
+  const dependencies = ['next', 'react@17', 'react-dom@17'].join(' ');
   await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);
   logger(`✔️ Dependencies were installed`);
 

--- a/packages/fluentui/projects-test/src/rollup.ts
+++ b/packages/fluentui/projects-test/src/rollup.ts
@@ -27,8 +27,8 @@ export async function rollup() {
     'rollup-plugin-commonjs',
     'rollup-plugin-node-resolve',
     'rollup-plugin-json',
-    'react',
-    'react-dom',
+    'react@17',
+    'react-dom@17',
   ].join(' ');
 
   await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);

--- a/packages/fluentui/projects-test/src/typings.ts
+++ b/packages/fluentui/projects-test/src/typings.ts
@@ -21,7 +21,13 @@ export async function typings() {
   const rootPkgJson: { devDependencies: Record<string, string> } = fs.readJSONSync(config.paths.base('package.json'));
   const { typescript: tsVersion } = rootPkgJson.devDependencies;
 
-  const dependencies = ['@types/react', '@types/react-dom', 'react', 'react-dom', `typescript@${tsVersion}`].join(' ');
+  const dependencies = [
+    '@types/react@17',
+    '@types/react-dom@17',
+    'react@17',
+    'react-dom@17',
+    `typescript@${tsVersion}`,
+  ].join(' ');
   await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);
   logger(`✔️ Dependencies were installed`);
 


### PR DESCRIPTION
## Current Behavior

- `@fluentui/projects-test` installs the latest version of react (React 18) which is causing CI to fail.

## New Behavior

- Explicitly install React 17 to `@fluentui/projectst-test` app.
- This also fixes an issue with an incorrect usage of `Button` in `@fluentui/ts-minbar-test-react-components`.
