### PR TITLE
add v2 colors to sandbox app

### DIFF
--- a/packages/fluentui/code-sandbox/src/SandboxApp.tsx
+++ b/packages/fluentui/code-sandbox/src/SandboxApp.tsx
@@ -7,7 +7,9 @@ import {
   RadioGroup,
   Text,
   teamsTheme,
+  teamsV2Theme,
   teamsDarkTheme,
+  teamsDarkV2Theme,
   teamsHighContrastTheme,
 } from '@fluentui/react-northstar';
 // @ts-ignore
@@ -24,9 +26,19 @@ const items = [
     value: 'teamsTheme',
   },
   {
+    key: 'light_v2',
+    label: 'Teams Light V2',
+    value: 'teamsV2Theme',
+  },
+  {
     key: 'dark',
     label: 'Teams Dark',
     value: 'teamsDarkTheme',
+  },
+  {
+    key: 'dark_v2',
+    label: 'Teams Dark V2',
+    value: 'teamsDarkV2Theme',
   },
   {
     key: 'hc',
@@ -38,6 +50,8 @@ const items = [
 const themes = {
   teamsTheme,
   teamsDarkTheme,
+  teamsV2Theme,
+  teamsDarkV2Theme,
   teamsHighContrastTheme,
 };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

There is no possibility to test v2 colors in sandbox app.

## New Behavior

Add Teams Light V2 and Teams Dark V2 themes:
<img width="817" alt="image" src="https://user-images.githubusercontent.com/20684334/162480122-94fd8de2-5255-48e7-8ef2-c36f2ed6f45b.png">

