### PR TITLE
react-spinbutton: add bundle-size script

### DIFF
--- a/packages/react-spinbutton/bundle-size/SpinButton.fixture.js
+++ b/packages/react-spinbutton/bundle-size/SpinButton.fixture.js
@@ -1,0 +1,7 @@
+import { SpinButton } from '@fluentui/react-spinbutton';
+
+console.log(SpinButton);
+
+export default {
+  name: 'SpinButton',
+};

--- a/packages/react-spinbutton/package.json
+++ b/packages/react-spinbutton/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",


### PR DESCRIPTION
## Current Behavior

`react-spinbutton` does not track its bundle size.

## New Behavior

`react-spinbutton` tracks its bundle size.

## Related Issue(s)

- #22307
- #20930
