### PR TITLE
react-spinbutton: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -143,6 +143,7 @@ packages/react-provider @microsoft/teams-prg
 packages/react-radio @microsoft/cxe-red
 packages/react-select @microsoft/cxe-coastal @smhigley
 packages/react-slider @microsoft/cxe-coastal @micahgodbolt
+packages/react-spinbutton @microsoft/cxe-red @spmonahan
 packages/react-spinner @microsoft/cxe-red @tomi-msft
 packages/react-switch @microsoft/cxe-red @behowell @khmakoto
 packages/react-tabs @microsoft/cxe-coastal @geoffcoxmsft


### PR DESCRIPTION
## Current Behavior

`react-spinbutton` does not have CODEOWNERS.

## New Behavior

`react-spinbutton` has CODEOWNERS.

## Related Issue(s)

- #22307
- #20930
