### PR TITLE
fix(Detailslist): update docs for `ariaLabel` and `shouldApplyApplicationRole`

### DIFF
--- a/change/@fluentui-react-17f0b7da-0754-402e-b8e8-1c548364cb96.json
+++ b/change/@fluentui-react-17f0b7da-0754-402e-b8e8-1c548364cb96.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix ariaLabel and ariaLabelForGrid weirdness, add deprecation warning for shouldApplyApplicationRole",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -4531,6 +4531,7 @@ export interface IDetailsListCheckboxProps extends IDetailsCheckboxProps {
 
 // @public (undocumented)
 export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewportProps {
+    // @deprecated
     ariaLabel?: string;
     ariaLabelForGrid?: string;
     ariaLabelForListHeader?: string;
@@ -4595,6 +4596,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
     selectionPreservedOnEmptyClick?: boolean;
     selectionZoneProps?: ISelectionZoneProps;
     setKey?: string;
+    // @deprecated
     shouldApplyApplicationRole?: boolean;
     styles?: IStyleFunctionOrObject<IDetailsListStyleProps, IDetailsListStyles>;
     theme?: ITheme;

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -133,9 +133,11 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
     selectionMode = selection.mode,
     selectionPreservedOnEmptyClick,
     selectionZoneProps,
+    // eslint-disable-next-line deprecation/deprecation
     ariaLabel,
     ariaLabelForGrid,
     rowElementEventMap,
+    // eslint-disable-next-line deprecation/deprecation
     shouldApplyApplicationRole = false,
     getKey,
     listProps,

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -659,20 +659,19 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
   );
 
   return (
-    // If shouldApplyApplicationRole is true, role application will be applied to make arrow keys work
-    // with JAWS.
     <div
       ref={rootRef}
       className={classNames.root}
       data-automationid="DetailsList"
       data-is-scrollable="false"
-      aria-label={ariaLabel}
       {...(shouldApplyApplicationRole ? { role: 'application' } : {})}
     >
       <FocusRects />
       <div
         role={role}
-        aria-label={ariaLabelForGrid}
+        // ariaLabel is a legacy prop that used to be applied on the root node, which has poor AT support
+        // it is now treated as a fallback to ariaLabelForGrid for legacy support
+        aria-label={ariaLabelForGrid || ariaLabel}
         aria-rowcount={isPlaceholderData ? -1 : rowCount}
         aria-colcount={colCount}
         aria-readonly="true"

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -251,7 +251,10 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
    */
   getKey?: (item: any, index?: number) => string;
 
-  /** Accessible label describing or summarizing the list. */
+  /**
+   * Accessible label describing or summarizing the list.
+   * @deprecated use `ariaLabelForGrid`
+   */
   ariaLabel?: string;
 
   /** Accessible label for the row check button, e.g. "select row". */
@@ -269,6 +272,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   /**
    * Whether the role `application` should be applied to the list.
    * @defaultvalue false
+   * @deprecated using the application role in this case is an antipattern, and heavily discouraged.
    */
   shouldApplyApplicationRole?: boolean;
 


### PR DESCRIPTION
Opened this after a conversation with a team asking about `ariaLabel` vs. `ariaLabelForGrid`.

It looks like the `shouldApplyApplicationRole` was added based on a misconception about how to solve automatic mode switching for grids in JAWS -- in practice, applying the application role in a case like this makes the experience much worse for screen reader users. I've left it for now to avoid changing behavior, but added a warning and deprecation notice.

The other change is that `ariaLabel` is moved from the wrapper (which should usually be a generic `<div>` that doesn't support naming) to the grid element, where it will actually name the grid container. Even if the application role is set, the grid node should have better or equal support for `aria-label`. I've also added a deprecation warning for `ariaLabel`, since now it is a duplicate of `ariaLabelForGrid`.