### PR TITLE
Remove Enzyme usage in places it's not needed

### DIFF
--- a/packages/react-cards/config/tests.js
+++ b/packages/react-cards/config/tests.js
@@ -9,10 +9,5 @@ setIconOptions({
   disableWarnings: true,
 });
 
-// Mock requestAnimationFrame for React 16+.
-global.requestAnimationFrame = callback => {
-  setTimeout(callback, 0);
-};
-
 // Configure enzyme.
 configure({ adapter: new Adapter() });

--- a/packages/react-icon-provider/config/tests.js
+++ b/packages/react-icon-provider/config/tests.js
@@ -1,12 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Mock requestAnimationFrame for React 16+.
-global.requestAnimationFrame = callback => {
-  setTimeout(callback, 0);
-};
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-icon-provider/src/IconProvider.test.tsx
+++ b/packages/react-icon-provider/src/IconProvider.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { IconProvider, useIconSubset } from './IconProvider';
 import type { IIconSubset } from '@fluentui/style-utilities';
 
@@ -27,7 +27,7 @@ describe('IconProvider', () => {
       resolvedIcon = useIconSubset();
       return null;
     };
-    mount(
+    render(
       <IconProvider icons={testOverride}>
         <TestComponent />
       </IconProvider>,

--- a/packages/react-list/config/tests.js
+++ b/packages/react-list/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-window-provider/config/tests.js
+++ b/packages/react-window-provider/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/packages/react-window-provider/src/WindowProvider.test.tsx
+++ b/packages/react-window-provider/src/WindowProvider.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useWindow, useDocument, WindowProvider } from './WindowProvider';
-import { safeMount } from '@fluentui/test-utilities';
+import { render } from '@testing-library/react';
 
 describe('WindowProvider', () => {
   let lastWindow: Window | undefined;
@@ -14,7 +14,7 @@ describe('WindowProvider', () => {
   };
 
   it('can provide defaults for node', () => {
-    safeMount(<Foo />);
+    render(<Foo />);
 
     expect(lastWindow).toBe(window);
     expect(lastDocument).toBe(document);
@@ -24,7 +24,7 @@ describe('WindowProvider', () => {
     const mockDocument = ({} as unknown) as Document;
     const mockWindow = ({ document: mockDocument } as unknown) as Window;
 
-    safeMount(
+    render(
       <WindowProvider window={mockWindow}>
         <Foo />
       </WindowProvider>,

--- a/packages/theme/config/tests.js
+++ b/packages/theme/config/tests.js
@@ -1,7 +1,1 @@
 /** Jest test setup file. */
-
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-// Configure enzyme.
-configure({ adapter: new Adapter() });

--- a/scripts/jest/jest-resources.js
+++ b/scripts/jest/jest-resources.js
@@ -42,45 +42,49 @@ module.exports = {
     testRegex: '(/__tests__/.*|\\.(test|spec))\\.js$',
   }),
   jestAliases,
-  createConfig: customConfig =>
-    merge(
-      {
-        moduleNameMapper: {
-          'ts-jest': resolve.sync('ts-jest'),
-          '\\.(scss)$': path.resolve(__dirname, 'jest-style-mock.js'),
-          KeyCodes: path.resolve(__dirname, 'jest-mock.js'),
-          ...jestAliases(),
-        },
-
-        transform: {
-          '.(ts|tsx)': resolve.sync('ts-jest/dist'),
-        },
-
-        transformIgnorePatterns: ['/node_modules/', '/lib-commonjs/', '\\.js$'],
-
-        reporters: [path.resolve(__dirname, './jest-reporter.js')],
-
-        testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$',
-        moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
-
-        setupFiles: [path.resolve(__dirname, 'jest-setup.js')],
-
-        moduleDirectories: [
-          'node_modules',
-          path.resolve(packageRoot, 'node_modules'),
-          path.resolve(__dirname, '../node_modules'),
-        ],
-
-        globals: {
-          'ts-jest': {
-            diagnostics: false,
-          },
-        },
-
-        testURL: 'http://localhost',
-
-        watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
+  /**
+   * @param {Partial<import('@jest/types').Config.InitialOptions>} [customConfig]
+   */
+  createConfig: (customConfig = {}) => {
+    /** @type {import('@jest/types').Config.InitialOptions} */
+    const defaultConfig = {
+      moduleNameMapper: {
+        'ts-jest': resolve.sync('ts-jest'),
+        '\\.(scss)$': path.resolve(__dirname, 'jest-style-mock.js'),
+        KeyCodes: path.resolve(__dirname, 'jest-mock.js'),
+        ...jestAliases(),
       },
-      customConfig,
-    ),
+
+      transform: {
+        '.(ts|tsx)': resolve.sync('ts-jest/dist'),
+      },
+
+      transformIgnorePatterns: ['/node_modules/', '/lib-commonjs/', '\\.js$'],
+
+      reporters: [path.resolve(__dirname, './jest-reporter.js')],
+
+      testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$',
+      moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+
+      setupFiles: [path.resolve(__dirname, 'jest-setup.js')],
+
+      moduleDirectories: [
+        'node_modules',
+        path.resolve(packageRoot, 'node_modules'),
+        path.resolve(__dirname, '../node_modules'),
+      ],
+
+      globals: {
+        'ts-jest': {
+          diagnostics: false,
+        },
+      },
+
+      testURL: 'http://localhost',
+
+      watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
+    };
+
+    return merge(defaultConfig, customConfig);
+  },
 };

--- a/scripts/jest/jest-setup.js
+++ b/scripts/jest/jest-setup.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+// Jest setup file for all v8 packages
+
 // Mock requestAnimationFrame and cancelAnimationFrame for all packages
 // @ts-ignore
 global.requestAnimationFrame = callback => {

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -1,9 +1,7 @@
 /**
- * Setup
+ * Setup for northstar/v0 packages (under packages/fluentui).
  * This is the bootstrap code that is run before any tests, utils, mocks.
  */
-
-/* eslint-disable no-console */
 
 const enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');


### PR DESCRIPTION
## Current Behavior

We're trying to move away from Enzyme, but it's still used in a lot of packages. Each of these packages will need to be updated to use a different enzyme adapter when we update to React 17. 

Some of the packages that configure enzyme in their jest setup don't actually use it at all, or only have very minimal usage.

## New Behavior

- Remove enzyme setup from a few packages where enzyme isn't used at all
- In 2 packages with very simple tests (react-icon-provider and react-window-provider), remove enzyme setup and port to testing-library
- Add some comments and types in the jest setup code and helpers

This was part of the React 17 upgrade attempt (#22326) but can be merged now, and will simplify the actual upgrade PR a bit.

## Related Issue(s)

Part of #21663