### PR TITLE
react-tabs: Added content and icon styles to subtle appearance

### DIFF
--- a/change/@fluentui-react-tabs-93161aea-6653-4d44-aee3-07824d728aaa.json
+++ b/change/@fluentui-react-tabs-93161aea-6653-4d44-aee3-07824d728aaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix subtle style on tabs",
+  "packageName": "@fluentui/react-tabs",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tabs/src/components/Tab/useTabStyles.ts
+++ b/packages/react-tabs/src/components/Tab/useTabStyles.ts
@@ -93,7 +93,25 @@ const useRootStyles = makeStyles({
       backgroundColor: tokens.colorSubtleBackgroundHover,
     },
     ':active': {
-      backgroundColor: tokens.colorTransparentBackgroundPressed,
+      backgroundColor: tokens.colorSubtleBackgroundPressed,
+    },
+    '& .fui-Tab__icon': {
+      color: tokens.colorNeutralForeground2,
+    },
+    ':hover .fui-Tab__icon': {
+      color: tokens.colorNeutralForeground2Hover,
+    },
+    ':active .fui-Tab__icon': {
+      color: tokens.colorNeutralForeground2Pressed,
+    },
+    '& .fui-Tab__content': {
+      color: tokens.colorNeutralForeground2,
+    },
+    ':hover .fui-Tab__content': {
+      color: tokens.colorNeutralForeground2Hover,
+    },
+    ':active .fui-Tab__content': {
+      color: tokens.colorNeutralForeground2Pressed,
     },
   },
   disabled: {


### PR DESCRIPTION
## Current Behavior

Subtle tab content and icon not set.
This was due to moving styles into transparent that previously were on base.

## New Behavior

Subtle tab content and icon styles applied per figma

## Related Issue(s)

Related to #22336
