### PR TITLE
compose: Adding ability to use `as` prop to replace a slot with another one that extends the original's props

### DIFF
--- a/change/@fluentui-react-accordion-1192e12e-a72d-45a4-9c49-5468aaa935d9.json
+++ b/change/@fluentui-react-accordion-1192e12e-a72d-45a4-9c49-5468aaa935d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Alphabetically ordering dependencies.",
+  "packageName": "@fluentui/react-accordion",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-2adbd351-5dfe-4bb5-a64c-8c9a293732e3.json
+++ b/change/@fluentui-react-button-2adbd351-5dfe-4bb5-a64c-8c9a293732e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding SplitButtonToggleable example to showcase new composition functionality.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-6722b1a0-972c-4434-b597-167dd1105821.json
+++ b/change/@fluentui-react-utilities-6722b1a0-972c-4434-b597-167dd1105821.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "compose: Adding ability to use `as` prop to replace a slot with another one that extends the original's props",
+  "packageName": "@fluentui/react-utilities",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-accordion/package.json
+++ b/packages/react-accordion/package.json
@@ -36,10 +36,10 @@
     "@fluentui/react-context-selector": "9.0.0-rc.5",
     "@fluentui/react-shared-contexts": "9.0.0-rc.4",
     "@fluentui/react-icons": "^2.0.159-beta.10",
-    "@griffel/react": "1.0.0",
     "@fluentui/react-tabster": "9.0.0-rc.5",
     "@fluentui/react-theme": "9.0.0-rc.4",
     "@fluentui/react-utilities": "9.0.0-rc.5",
+    "@griffel/react": "1.0.0",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-button/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/react-button/src/components/SplitButton/SplitButton.stories.tsx
@@ -14,6 +14,7 @@ export { SizeMedium } from './stories/SplitButtonSizeMedium.stories';
 export { SizeLarge } from './stories/SplitButtonSizeLarge.stories';
 export { Disabled } from './stories/SplitButtonDisabled.stories';
 export { WithLongText } from './stories/SplitButtonWithLongText.stories';
+export { Toggleable } from './stories/SplitButtonToggleable.stories';
 
 export default {
   title: 'Components/SplitButton',

--- a/packages/react-button/src/components/SplitButton/SplitButton.types.ts
+++ b/packages/react-button/src/components/SplitButton/SplitButton.types.ts
@@ -3,7 +3,6 @@ import { MenuButton } from '../MenuButton/MenuButton';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import type { ButtonProps, ButtonState } from '../Button/Button.types';
 import type { MenuButtonProps, MenuButtonState } from '../MenuButton/MenuButton.types';
-// import * as React from 'react';
 
 export type SplitButtonSlots = {
   /**
@@ -28,13 +27,3 @@ export type SplitButtonProps = ComponentProps<SplitButtonSlots> &
 export type SplitButtonState = ComponentState<SplitButtonSlots> &
   Omit<ButtonState, 'components' | 'iconOnly' | 'root'> &
   Omit<MenuButtonState, 'components' | 'iconOnly' | 'root'>;
-
-// type MenuButtonSlot = SplitButtonSlots['menuButton'];
-// type TestType = ExtractSlotProps<SplitButtonSlots['menuButton']>;
-// type OmittedComponentType<T extends { as?: unknown }> = Omit<T, 'as'> & { as?: Exclude<T['as'],
-// React.ComponentType> };
-
-// export type As1 = TestType['as'];
-// export type As2 = OmittedComponentType<TestType>['as'];
-// export const test: React.ComponentType<TestType> = MenuButton;
-// export const test2: React.ComponentType<OmittedComponentType<TestType>> = MenuButton;

--- a/packages/react-button/src/components/SplitButton/SplitButton.types.ts
+++ b/packages/react-button/src/components/SplitButton/SplitButton.types.ts
@@ -3,6 +3,7 @@ import { MenuButton } from '../MenuButton/MenuButton';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import type { ButtonProps, ButtonState } from '../Button/Button.types';
 import type { MenuButtonProps, MenuButtonState } from '../MenuButton/MenuButton.types';
+// import * as React from 'react';
 
 export type SplitButtonSlots = {
   /**
@@ -27,3 +28,13 @@ export type SplitButtonProps = ComponentProps<SplitButtonSlots> &
 export type SplitButtonState = ComponentState<SplitButtonSlots> &
   Omit<ButtonState, 'components' | 'iconOnly' | 'root'> &
   Omit<MenuButtonState, 'components' | 'iconOnly' | 'root'>;
+
+// type MenuButtonSlot = SplitButtonSlots['menuButton'];
+// type TestType = ExtractSlotProps<SplitButtonSlots['menuButton']>;
+// type OmittedComponentType<T extends { as?: unknown }> = Omit<T, 'as'> & { as?: Exclude<T['as'],
+// React.ComponentType> };
+
+// export type As1 = TestType['as'];
+// export type As2 = OmittedComponentType<TestType>['as'];
+// export const test: React.ComponentType<TestType> = MenuButton;
+// export const test2: React.ComponentType<OmittedComponentType<TestType>> = MenuButton;

--- a/packages/react-button/src/components/SplitButton/stories/SplitButtonToggleable.stories.tsx
+++ b/packages/react-button/src/components/SplitButton/stories/SplitButtonToggleable.stories.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
+import { SplitButton, ToggleButton } from '../../../index';
+import type { MenuButtonProps } from '../../../index';
+
+export const Toggleable = () => {
+  return (
+    <Menu positioning="below-end">
+      <MenuTrigger>
+        {(triggerProps: MenuButtonProps) => (
+          <SplitButton primaryActionButton={{ as: ToggleButton }} menuButton={triggerProps}>
+            Example
+          </SplitButton>
+        )}
+      </MenuTrigger>
+
+      <MenuPopover>
+        <MenuList>
+          <MenuItem>Item a</MenuItem>
+          <MenuItem>Item b</MenuItem>
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+};

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -247,7 +247,6 @@ export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) e
 // @public
 export type UnknownSlotProps = Pick<React_2.HTMLAttributes<HTMLElement>, 'children' | 'className' | 'style'> & {
     as?: keyof JSX.IntrinsicElements | React_2.ComponentType<any>;
-    componentAs?: React_2.ComponentType<unknown>;
 };
 
 // @public

--- a/packages/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-utilities/etc/react-utilities.api.md
@@ -48,7 +48,7 @@ export type ComponentProps<Slots extends SlotPropsRecord, Primary extends keyof 
 // @public
 export type ComponentState<Slots extends SlotPropsRecord> = {
     components: {
-        [Key in keyof Slots]-?: React_2.ComponentType<ExtractSlotProps<Slots[Key]>> | (ExtractSlotProps<Slots[Key]> extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
+        [Key in keyof Slots]-?: React_2.ComponentType<WithoutComponentType<ExtractSlotProps<Slots[Key]>>> | (ExtractSlotProps<Slots[Key]> extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
     };
 } & {
     [Key in keyof Slots]: ReplaceNullWithUndefined<Exclude<Slots[Key], SlotShorthandValue | (Key extends 'root' ? null : never)>>;
@@ -186,10 +186,10 @@ export function shouldPreventDefaultOnKeyDown(e: KeyboardEvent | React_2.Keyboar
 // @public
 export type Slot<Type extends keyof JSX.IntrinsicElements | React_2.ComponentType | UnknownSlotProps, AlternateAs extends keyof JSX.IntrinsicElements = never> = IsSingleton<Extract<Type, string>> extends true ? WithSlotShorthandValue<Type extends keyof JSX.IntrinsicElements ? {
     as?: Type;
-} & WithSlotRenderFunction<IntrisicElementProps<Type>> : Type extends React_2.ComponentType<infer Props> ? WithSlotRenderFunction<Props> : Type> | {
+} & WithSlotRenderFunction<IntrinsicElementProps<Type>> : Type extends React_2.ComponentType<infer Props> ? WithComponentType<Props, Type> : Type> | {
     [As in AlternateAs]: {
         as: As;
-    } & WithSlotRenderFunction<IntrisicElementProps<As>>;
+    } & WithSlotRenderFunction<IntrinsicElementProps<As>>;
 }[AlternateAs] | null : 'Error: First parameter to Slot must not be not a union of types. See documentation of Slot type.';
 
 // @public
@@ -246,7 +246,8 @@ export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) e
 
 // @public
 export type UnknownSlotProps = Pick<React_2.HTMLAttributes<HTMLElement>, 'children' | 'className' | 'style'> & {
-    as?: keyof JSX.IntrinsicElements;
+    as?: keyof JSX.IntrinsicElements | React_2.ComponentType<any>;
+    componentAs?: React_2.ComponentType<unknown>;
 };
 
 // @public

--- a/packages/react-utilities/src/compose/getSlots.ts
+++ b/packages/react-utilities/src/compose/getSlots.ts
@@ -75,7 +75,7 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
 
   const slot = (state.components?.[slotName] === undefined || typeof state.components[slotName] === 'string'
     ? asProp || state.components?.[slotName] || 'div'
-    : state.components[slotName]) as React.ElementType<R[K]>;
+    : asProp || state.components[slotName]) as React.ElementType<R[K]>;
 
   if (typeof children === 'function') {
     const render = children as SlotRenderFunction<R[K]>;
@@ -87,7 +87,7 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
     ];
   }
 
-  const shouldOmitAsProp = typeof slot === 'string' && state[slotName]?.as;
+  const shouldOmitAsProp = state[slotName]?.as;
   const slotProps = (shouldOmitAsProp ? omit(state[slotName]!, ['as']) : state[slotName]) as R[K];
 
   return [slot, slotProps];

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -73,9 +73,15 @@ type EmptyIntrinsicElements =
 type IntrinsicElementProps<Type extends keyof JSX.IntrinsicElements> = React.PropsWithRef<JSX.IntrinsicElements[Type]> &
   (Type extends EmptyIntrinsicElements ? { children?: never } : {});
 
+/**
+ * Helper type for {@link Slot}.
+ * Used when the type passed to Slot is a component type like `typeof Button`.
+ * Adds the component type as a possible value for `as` while maintaining its union discriminator property.
+ */
 type WithComponentType<Props, Type> = Props extends AsIntrinsicElement<infer AsList>
   ? {
       [As in AsList]: WithSlotRenderFunction<
+        // Determine if `as` is optional or not to be able to properly discriminate the union.
         (Props extends { as: unknown }
           ? { as: As | Type; children?: unknown }
           : Props extends { as?: unknown }
@@ -186,39 +192,15 @@ export type ComponentProps<Slots extends SlotPropsRecord, Primary extends keyof 
  */
 export type ReplaceNullWithUndefined<T> = T extends null ? Exclude<T, null> | undefined : T;
 
+/**
+ * Helper type for {@link ComponentState}.
+ * Removes the `React.ComponentType` type that might have been added earlier from the `as` prop as that pertains to the
+ * component props API we want to surface but does not pertain the `components` definition inside of component state.
+ */
 type WithoutComponentType<Props> = Props extends { as?: unknown }
   ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Omit<Props, 'as'> & { as: Exclude<Props['as'], React.ComponentType<any>> }
   : Props;
-
-// type Test = {
-//   as?:
-//     | 'button'
-//     | React.ForwardRefExoticComponent<
-//         { children: React.ReactNode } & React.RefAttributes<HTMLButtonElement | HTMLAnchorElement>
-//       >;
-//   prop1?: string;
-//   prop2?: number;
-// };
-// type Test2 = WithoutComponentType<Test>;
-// type Test3 = {
-//   as:
-//     | 'button'
-//     | React.ForwardRefExoticComponent<
-//         { children: React.ReactNode } & React.RefAttributes<HTMLButtonElement | HTMLAnchorElement>
-//       >;
-//   prop1?: string;
-//   prop2?: number;
-// };
-// type Test4 = WithoutComponentType<Test3>;
-// type Test5<Props> = Props extends { as: infer As } ? As : Props extends { as?: infer As2 } ? As2 | undefined : never;
-// type Test6 = Test5<{ as?: 'a' }>;
-// type Test7 = Test5<{ as: 'button' }>;
-// type CheckUndefined<Type> = Type extends undefined ? undefined : Type;
-// type Test8 = CheckUndefined<'button' | undefined>;
-// type Test9 = CheckUndefined<'button'>;
-// type Test10 = WithComponentType<{ as?: 'button' }, React.ComponentType>;
-// type Test11 = WithComponentType<{ as: 'a' }, React.ComponentType>;
 
 /**
  * Defines the State object of a component given its slots.

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -90,7 +90,7 @@ type WithComponentType<Props, Type> = Props extends AsIntrinsicElement<infer AsL
           Omit<Props, 'as'>
       >;
     }[AsList]
-  : { as?: Type | undefined } & WithSlotRenderFunction<Omit<Props, 'as'>>;
+  : { as?: Type } & WithSlotRenderFunction<Omit<Props, 'as'>>;
 
 /**
  * The props type and shorthand value for a slot. Type is either a single intrinsic element like `'div'`,


### PR DESCRIPTION
## PR Description

This PR adds the ability to use `as` to replace a slot with a component that extends the props of the original component in that slot.

An example of this would be:

```jsx
import { SplitButton, ToggleButton } from '@fluentui/react-button';

...

<SplitButton primaryActionButton={{ as: ToggleButton }}>
```

Since `primaryActionButton` is defined as `Slot<typeof Button>`, and `ToggleButtonProps` is an extension of `ButtonProps`.

This also means that passing a component that does not extend the original props of the slot will error out:

![image](https://user-images.githubusercontent.com/7798177/162783613-b43b0383-ae18-42ed-9353-d7d98b098643.png)
