### PR TITLE
Updating TeachingBubble to follow best practices

### DIFF
--- a/change/@fluentui-react-8a577334-1bdb-4a25-b070-81e3ddb6f379.json
+++ b/change/@fluentui-react-8a577334-1bdb-4a25-b070-81e3ddb6f379.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updating TeachingBubble to follow best practices",
+  "packageName": "@fluentui/react",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/TeachingBubble/TeachingBubble.ButtonOrder.Example.tsx
+++ b/packages/react-examples/src/react/TeachingBubble/TeachingBubble.ButtonOrder.Example.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { DefaultButton, IButtonProps } from '@fluentui/react/lib/Button';
+import { TeachingBubble, ITeachingBubbleStyles } from '@fluentui/react/lib/TeachingBubble';
+import { useBoolean, useId } from '@fluentui/react-hooks';
+
+const examplePrimaryButtonProps: IButtonProps = {
+  children: 'Try it out',
+};
+
+export const TeachingBubbleButtonOrderExample: React.FunctionComponent = () => {
+  const buttonId = useId('targetButton');
+  const [teachingBubbleVisible, { toggle: toggleTeachingBubbleVisible }] = useBoolean(false);
+  const exampleSecondaryButtonProps: IButtonProps = React.useMemo(
+    () => ({
+      children: 'Maybe later',
+      onClick: toggleTeachingBubbleVisible,
+    }),
+    [toggleTeachingBubbleVisible],
+  );
+
+  const styles: Partial<ITeachingBubbleStyles> = {
+    footer: {
+      [`& > .ms-StackItem`]: {
+        display: 'flex',
+        flexDirection: 'row-reverse',
+      },
+      [`& > .ms-StackItem > .ms-Button:not(:first-child)`]: {
+        margin: '0 15px 0 0',
+      },
+    },
+  };
+
+  return (
+    <div>
+      <DefaultButton
+        id={buttonId}
+        onClick={toggleTeachingBubbleVisible}
+        text={teachingBubbleVisible ? 'Hide TeachingBubble' : 'Show TeachingBubble'}
+      />
+
+      {teachingBubbleVisible && (
+        <TeachingBubble
+          target={`#${buttonId}`}
+          primaryButtonProps={examplePrimaryButtonProps}
+          secondaryButtonProps={exampleSecondaryButtonProps}
+          onDismiss={toggleTeachingBubbleVisible}
+          headline="Discover what’s trending around you"
+          styles={styles}
+        >
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Facere, nulla, ipsum? Molestiae quis aliquam magni
+          harum non?
+        </TeachingBubble>
+      )}
+    </div>
+  );
+};

--- a/packages/react-examples/src/react/TeachingBubble/TeachingBubble.doc.tsx
+++ b/packages/react-examples/src/react/TeachingBubble/TeachingBubble.doc.tsx
@@ -15,6 +15,7 @@ const TeachingBubbleIllustrationExampleCode = require('!raw-loader?esModule=fals
 const TeachingBubbleWideIllustrationExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.WideIllustration.Example.tsx') as string;
 const TeachingBubbleSmallHeadlineExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.SmallHeadline.Example.tsx') as string;
 const TeachingBubbleMultiStepExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.MultiStep.Example.tsx') as string;
+const TeachingBubbleButtonOrderExample = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.ButtonPrder.Example.tsx') as string;
 
 export const TeachingBubblePageProps: IDocPageProps = {
   title: 'TeachingBubble',
@@ -30,6 +31,11 @@ export const TeachingBubblePageProps: IDocPageProps = {
       title: 'TeachingBubble Wide',
       code: TeachingBubbleWideExampleCode,
       view: <TeachingBubbleWideExample />,
+    },
+    {
+      title: 'TeachingBubble with custon button order',
+      code: TeachingBubbleButtonOrderExample,
+      view: <TeachingBubbleButtonOrderExample />,
     },
     {
       title: 'TeachingBubble Condensed',

--- a/packages/react-examples/src/react/TeachingBubble/TeachingBubble.doc.tsx
+++ b/packages/react-examples/src/react/TeachingBubble/TeachingBubble.doc.tsx
@@ -15,7 +15,7 @@ const TeachingBubbleIllustrationExampleCode = require('!raw-loader?esModule=fals
 const TeachingBubbleWideIllustrationExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.WideIllustration.Example.tsx') as string;
 const TeachingBubbleSmallHeadlineExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.SmallHeadline.Example.tsx') as string;
 const TeachingBubbleMultiStepExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.MultiStep.Example.tsx') as string;
-const TeachingBubbleButtonOrderExample = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.ButtonPrder.Example.tsx') as string;
+const TeachingBubbleButtonOrderExample = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.ButtonOrder.Example.tsx') as string;
 
 export const TeachingBubblePageProps: IDocPageProps = {
   title: 'TeachingBubble',

--- a/packages/react-examples/src/react/TeachingBubble/TeachingBubble.doc.tsx
+++ b/packages/react-examples/src/react/TeachingBubble/TeachingBubble.doc.tsx
@@ -7,6 +7,7 @@ import { TeachingBubbleIllustrationExample } from './TeachingBubble.Illustration
 import { TeachingBubbleWideIllustrationExample } from './TeachingBubble.WideIllustration.Example';
 import { TeachingBubbleSmallHeadlineExample } from './TeachingBubble.SmallHeadline.Example';
 import { TeachingBubbleMultiStepExample } from './TeachingBubble.MultiStep.Example';
+import { TeachingBubbleButtonOrderExample } from './TeachingBubble.ButtonOrder.Example';
 
 const TeachingBubbleBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.Basic.Example.tsx') as string;
 const TeachingBubbleWideExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.Wide.Example.tsx') as string;
@@ -15,7 +16,7 @@ const TeachingBubbleIllustrationExampleCode = require('!raw-loader?esModule=fals
 const TeachingBubbleWideIllustrationExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.WideIllustration.Example.tsx') as string;
 const TeachingBubbleSmallHeadlineExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.SmallHeadline.Example.tsx') as string;
 const TeachingBubbleMultiStepExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.MultiStep.Example.tsx') as string;
-const TeachingBubbleButtonOrderExample = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.ButtonOrder.Example.tsx') as string;
+const TeachingBubbleButtonOrderExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/TeachingBubble/TeachingBubble.ButtonOrder.Example.tsx') as string;
 
 export const TeachingBubblePageProps: IDocPageProps = {
   title: 'TeachingBubble',
@@ -34,7 +35,7 @@ export const TeachingBubblePageProps: IDocPageProps = {
     },
     {
       title: 'TeachingBubble with custon button order',
-      code: TeachingBubbleButtonOrderExample,
+      code: TeachingBubbleButtonOrderExampleCode,
       view: <TeachingBubbleButtonOrderExample />,
     },
     {

--- a/packages/react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -128,8 +128,8 @@ export const TeachingBubbleContentBase: React.FunctionComponent<ITeachingBubbleP
       <Stack className={classNames.footer} horizontal horizontalAlign={customFooterContent ? 'space-between' : 'end'}>
         <Stack.Item align="center">{<span>{customFooterContent}</span>}</Stack.Item>
         <Stack.Item>
-          {secondaryButtonProps && <DefaultButton {...secondaryButtonProps} className={classNames.secondaryButton} />}
           {primaryButtonProps && <PrimaryButton {...primaryButtonProps} className={classNames.primaryButton} />}
+          {secondaryButtonProps && <DefaultButton {...secondaryButtonProps} className={classNames.secondaryButton} />}
         </Stack.Item>
       </Stack>
     );

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -167,141 +167,6 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
           <button
             className=
                 ms-Button
-                ms-Button--default
-                ms-TeachingBubble-secondaryButton
-                secondary-className
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: #0078d4;
-                  border-color: #ffffff;
-                  border-radius: 2px;
-                  border: 1px solid #8a8886;
-                  box-sizing: border-box;
-                  color: #323130;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  min-width: 80px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 16px;
-                  padding-right: 16px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid transparent;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid transparent;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #106ebe;
-                  border-color: #ffffff;
-                  color: #201f1e;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:focus {
-                  background-color: #005a9e;
-                  border: 1px solid #000000;
-                  outline-offset: -2px;
-                  outline: 1px solid #ffffff;
-                }
-                &:active {
-                  background-color: #0078d4;
-                  border-color: #ffffff;
-                  color: #201f1e;
-                }
-                & .ms-Button-label {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #ffffff;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
-                  }
-              data-automationid="splitbuttonprimary"
-            >
-              <span
-                className=
-                    ms-Button-textContainer
-                    {
-                      display: block;
-                      flex-grow: 1;
-                    }
-              >
-                <span
-                  className=
-                      ms-Button-label
-                      {
-                        display: block;
-                        font-weight: 600;
-                        line-height: 100%;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                      }
-                  id="id__3"
-                >
-                  Test Secondary Button
-                </span>
-              </span>
-            </span>
-          </button>
-          <button
-            className=
-                ms-Button
                 ms-Button--primary
                 ms-TeachingBubble-primaryButton
                 primary-className
@@ -445,9 +310,144 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                         margin-right: 4px;
                         margin-top: 0;
                       }
-                  id="id__6"
+                  id="id__3"
                 >
                   Test Primary Button
+                </span>
+              </span>
+            </span>
+          </button>
+          <button
+            className=
+                ms-Button
+                ms-Button--default
+                ms-TeachingBubble-secondaryButton
+                secondary-className
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #0078d4;
+                  border-color: #ffffff;
+                  border-radius: 2px;
+                  border: 1px solid #8a8886;
+                  box-sizing: border-box;
+                  color: #323130;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid transparent;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid transparent;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                &:hover {
+                  background-color: #106ebe;
+                  border-color: #ffffff;
+                  color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:focus {
+                  background-color: #005a9e;
+                  border: 1px solid #000000;
+                  outline-offset: -2px;
+                  outline: 1px solid #ffffff;
+                }
+                &:active {
+                  background-color: #0078d4;
+                  border-color: #ffffff;
+                  color: #201f1e;
+                }
+                & .ms-Button-label {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+              data-automationid="splitbuttonprimary"
+            >
+              <span
+                className=
+                    ms-Button-textContainer
+                    {
+                      display: block;
+                      flex-grow: 1;
+                    }
+              >
+                <span
+                  className=
+                      ms-Button-label
+                      {
+                        display: block;
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__6"
+                >
+                  Test Secondary Button
                 </span>
               </span>
             </span>

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -449,141 +449,6 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
           <button
             className=
                 ms-Button
-                ms-Button--default
-                ms-TeachingBubble-secondaryButton
-                secondary-className
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: #0078d4;
-                  border-color: #ffffff;
-                  border-radius: 2px;
-                  border: 1px solid #8a8886;
-                  box-sizing: border-box;
-                  color: #323130;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  min-width: 80px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 16px;
-                  padding-right: 16px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  white-space: nowrap;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid transparent;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid transparent;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #106ebe;
-                  border-color: #ffffff;
-                  color: #201f1e;
-                }
-                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:focus {
-                  background-color: #005a9e;
-                  border: 1px solid #000000;
-                  outline-offset: -2px;
-                  outline: 1px solid #ffffff;
-                }
-                &:active {
-                  background-color: #0078d4;
-                  border-color: #ffffff;
-                  color: #201f1e;
-                }
-                & .ms-Button-label {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #ffffff;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
-                  }
-              data-automationid="splitbuttonprimary"
-            >
-              <span
-                className=
-                    ms-Button-textContainer
-                    {
-                      display: block;
-                      flex-grow: 1;
-                    }
-              >
-                <span
-                  className=
-                      ms-Button-label
-                      {
-                        display: block;
-                        font-weight: 600;
-                        line-height: 100%;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                      }
-                  id="id__3"
-                >
-                  Test Secondary Button
-                </span>
-              </span>
-            </span>
-          </button>
-          <button
-            className=
-                ms-Button
                 ms-Button--primary
                 ms-TeachingBubble-primaryButton
                 primary-className
@@ -727,9 +592,144 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                         margin-right: 4px;
                         margin-top: 0;
                       }
-                  id="id__6"
+                  id="id__3"
                 >
                   Test Primary Button
+                </span>
+              </span>
+            </span>
+          </button>
+          <button
+            className=
+                ms-Button
+                ms-Button--default
+                ms-TeachingBubble-secondaryButton
+                secondary-className
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #0078d4;
+                  border-color: #ffffff;
+                  border-radius: 2px;
+                  border: 1px solid #8a8886;
+                  box-sizing: border-box;
+                  color: #323130;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid transparent;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid transparent;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                &:hover {
+                  background-color: #106ebe;
+                  border-color: #ffffff;
+                  color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:focus {
+                  background-color: #005a9e;
+                  border: 1px solid #000000;
+                  outline-offset: -2px;
+                  outline: 1px solid #ffffff;
+                }
+                &:active {
+                  background-color: #0078d4;
+                  border-color: #ffffff;
+                  color: #201f1e;
+                }
+                & .ms-Button-label {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+              data-automationid="splitbuttonprimary"
+            >
+              <span
+                className=
+                    ms-Button-textContainer
+                    {
+                      display: block;
+                      flex-grow: 1;
+                    }
+              >
+                <span
+                  className=
+                      ms-Button-label
+                      {
+                        display: block;
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__6"
+                >
+                  Test Secondary Button
                 </span>
               </span>
             </span>


### PR DESCRIPTION
## PR Details
This PR updates TeachingBubble's primary and secondary buttons to be in the correct order (primary left and secondary right). A new example "TeachingBubble with custom button order" was added as well to give guidance in case the old button order is needed. 
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR. 
-->

## Current Behavior

TeachingBubble has the primary button on the right, which based on its best practices it should be on the left.

## New Behavior

The primary button is now on the left side.

Before:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/5953191/163219707-ce20d865-ae7c-425d-b22d-0912bfed4599.png">


After:
<img width="432" alt="image" src="https://user-images.githubusercontent.com/5953191/163219550-6cba38fd-62c8-403f-8606-2b669732d65b.png">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21978
