### PR TITLE
Try fix #22474

### DIFF
--- a/change/@fluentui-react-aa864f7b-380f-4c05-80bc-94cd0006062e.json
+++ b/change/@fluentui-react-aa864f7b-380f-4c05-80bc-94cd0006062e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix memory leak in makeStyles.ts (#22474)",
+  "packageName": "@fluentui/react",
+  "email": "jisong@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/utilities/ThemeProvider/makeStyles.ts
+++ b/packages/react/src/utilities/ThemeProvider/makeStyles.ts
@@ -69,7 +69,7 @@ export function makeStyles<TStyleSet extends { [key in keyof TStyleSet]: IStyle 
 
     const id = renderer.getId();
     const isStyleFunction = typeof styleOrFunction === 'function';
-    const path = isStyleFunction ? [id, win, theme] : [id, win];
+    const path = isStyleFunction ? [id, theme] : [id];
     let value = graphGet(graph, path);
 
     if (!value) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

makeStyles.ts can cause memory leak when run it in a component mounted under projection popout window

## New Behavior

No leaking from here.

## Related Issue(s)

#22474 

Fixes #

Remove "win" object from the graph path. I'm not sure if this can lead to other issues, but at least I didn't see anywhere it is used, but just always hold the window object which causes memory leak.
