### PR TITLE
Fixed Dialogs ability to be draggable

### DIFF
--- a/change/@fluentui-react-bb4f65ba-371a-484a-9964-955da31a5480.json
+++ b/change/@fluentui-react-bb4f65ba-371a-484a-9964-955da31a5480.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed Dialogs ability to be draggable",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/react/src/components/Dialog/Dialog.base.tsx
@@ -102,11 +102,11 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
     };
 
     let dialogDraggableClassName: string | undefined;
-    const dragOptions = modalProps?.dragOptions;
+    const dragOptions = { ...modalProps?.dragOptions };
 
     // if we are draggable, make sure we are using the correct
     // draggable classname and selectors
-    if (dragOptions && !dragOptions.dragHandleSelector) {
+    if (dragOptions && !modalProps?.dragOptions?.dragHandleSelector) {
       dialogDraggableClassName = 'ms-Dialog-draggable-header';
       dragOptions.dragHandleSelector = `.${dialogDraggableClassName}`;
     }

--- a/packages/react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/react/src/components/Dialog/Dialog.base.tsx
@@ -102,16 +102,18 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
     };
 
     let dialogDraggableClassName: string | undefined;
-    const dragOptions = { ...modalProps?.dragOptions };
+    let dragOptions: IModalProps['dragOptions'];
 
-    // if we are draggable, make sure we are using the correct
-    // draggable classname and selectors
-    if (dragOptions && !modalProps?.dragOptions?.dragHandleSelector) {
+    // If dragOptions are provided, but no drag handle is specified, we supply a drag handle,
+    // and inform dialog contents to add class to draggable class to the header
+    if (modalProps?.dragOptions && !modalProps.dragOptions?.dragHandleSelector) {
+      // spread options to avoid mutating props
+      dragOptions = { ...modalProps.dragOptions };
       dialogDraggableClassName = 'ms-Dialog-draggable-header';
       dragOptions.dragHandleSelector = `.${dialogDraggableClassName}`;
     }
 
-    const mergedModalProps = {
+    const mergedModalProps: IModalProps = {
       ...DefaultModalProps,
       elementToFocusOnDismiss,
       firstFocusableSelector,
@@ -125,8 +127,8 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
       isDarkOverlay,
       onDismissed,
       ...modalProps,
-      layerProps: mergedLayerProps,
       dragOptions,
+      layerProps: mergedLayerProps,
       isOpen,
     };
 


### PR DESCRIPTION
Fixes #22218

We were checking on `dragHandleSelector` and then mutating it if it was not set, causing a re-render in which `dragHandleSelector` was always set, causing our default case to not work properly. 

This fix spreads the dragOptions into a new object before changing them, and checks the original modalProps.dragOptions instead of the mutated one.