### PR TITLE
Dropdown: Fixing issue where, if previous/next tabbable element is inside FocusZone then tabbing with Dropdown open will skip it

### DIFF
--- a/change/@fluentui-react-d7c60de7-8e2e-4f2b-9bcb-489bf1ed51e1.json
+++ b/change/@fluentui-react-d7c60de7-8e2e-4f2b-9bcb-489bf1ed51e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: Fixing issue where, if previous/next tabbable element is inside FocusZone then tabbing with Dropdown open will skip it.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Dropdown/Dropdown.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Dropdown/Dropdown.Basic.Example.tsx
@@ -1,60 +1,52 @@
 import * as React from 'react';
-import { PrimaryButton } from '@fluentui/react/lib/Button';
-import { Nav, INavLinkGroup } from '@fluentui/react/lib/Nav';
-import { Dropdown, IDropdownOption } from '@fluentui/react/lib/Dropdown';
+import { IStackTokens, Stack } from '@fluentui/react/lib/Stack';
+import { Dropdown, DropdownMenuItemType, IDropdownStyles, IDropdownOption } from '@fluentui/react/lib/Dropdown';
 
-const NavBasicExample: React.FunctionComponent = () => {
-  const navLinkGroups: INavLinkGroup[] = [
-    {
-      links: [
-        {
-          name: 'Foo',
-          url: 'http://example.com/foo',
-          key: 'key1',
-        },
-        {
-          name: 'Bar',
-          url: 'http://example.com/bar',
-          key: 'key2',
-        },
-        {
-          name: 'Baz',
-          url: 'http://example.com/baz',
-          key: 'key3',
-        },
-      ],
-    },
-  ];
-  return <Nav groups={navLinkGroups} />;
+const dropdownStyles: Partial<IDropdownStyles> = {
+  dropdown: { width: 300 },
 };
 
+const options: IDropdownOption[] = [
+  { key: 'fruitsHeader', text: 'Fruits', itemType: DropdownMenuItemType.Header },
+  { key: 'apple', text: 'Apple' },
+  { key: 'banana', text: 'Banana' },
+  { key: 'orange', text: 'Orange', disabled: true },
+  { key: 'grape', text: 'Grape' },
+  { key: 'divider_1', text: '-', itemType: DropdownMenuItemType.Divider },
+  { key: 'vegetablesHeader', text: 'Vegetables', itemType: DropdownMenuItemType.Header },
+  { key: 'broccoli', text: 'Broccoli' },
+  { key: 'carrot', text: 'Carrot' },
+  { key: 'lettuce', text: 'Lettuce' },
+];
+
+const stackTokens: IStackTokens = { childrenGap: 20 };
+
 export const DropdownBasicExample: React.FunctionComponent = () => {
-  const options: IDropdownOption[] = [
-    { key: 'a', text: 'Option A' },
-    { key: 'b', text: 'Option B' },
-    { key: 'c', text: 'Option C' },
-  ];
   return (
-    <div className="app">
-      <div className="left-panel">
-        <Dropdown label="Example Dropdown" options={options} />
-        <NavBasicExample />
-      </div>
-      <div className="right-panel">
-        <p>
-          When pressing TAB while the Example Dropdown is open and an option has focus, the below Focusable Control
-          receives focus even though the Nav menu has focusable items ordered in between.
-        </p>
-        <p>
-          Pressing Shift+TAB from the Focusable Control demonstrates the correct behavior (moving focus back into the{' '}
-          <code>&lt;Nav&gt;</code> component)
-        </p>
-        <p>
-          Pressing TAB from the <em>collapsed</em> Dropdown control also demonstrates the correct behavior (moving focus
-          forward into the <code>&lt;Nav&gt;</code> component)
-        </p>
-        <PrimaryButton>Focusable Control</PrimaryButton>
-      </div>
-    </div>
+    <Stack tokens={stackTokens}>
+      <Dropdown
+        placeholder="Select an option"
+        label="Basic uncontrolled example"
+        options={options}
+        styles={dropdownStyles}
+      />
+
+      <Dropdown
+        label="Disabled example with defaultSelectedKey"
+        defaultSelectedKey="broccoli"
+        options={options}
+        disabled={true}
+        styles={dropdownStyles}
+      />
+
+      <Dropdown
+        placeholder="Select options"
+        label="Multi-select uncontrolled example"
+        defaultSelectedKeys={['apple', 'banana', 'grape']}
+        multiSelect
+        options={options}
+        styles={dropdownStyles}
+      />
+    </Stack>
   );
 };

--- a/packages/react-examples/src/react/Dropdown/Dropdown.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Dropdown/Dropdown.Basic.Example.tsx
@@ -1,52 +1,60 @@
 import * as React from 'react';
-import { IStackTokens, Stack } from '@fluentui/react/lib/Stack';
-import { Dropdown, DropdownMenuItemType, IDropdownStyles, IDropdownOption } from '@fluentui/react/lib/Dropdown';
+import { PrimaryButton } from '@fluentui/react/lib/Button';
+import { Nav, INavLinkGroup } from '@fluentui/react/lib/Nav';
+import { Dropdown, IDropdownOption } from '@fluentui/react/lib/Dropdown';
 
-const dropdownStyles: Partial<IDropdownStyles> = {
-  dropdown: { width: 300 },
+const NavBasicExample: React.FunctionComponent = () => {
+  const navLinkGroups: INavLinkGroup[] = [
+    {
+      links: [
+        {
+          name: 'Foo',
+          url: 'http://example.com/foo',
+          key: 'key1',
+        },
+        {
+          name: 'Bar',
+          url: 'http://example.com/bar',
+          key: 'key2',
+        },
+        {
+          name: 'Baz',
+          url: 'http://example.com/baz',
+          key: 'key3',
+        },
+      ],
+    },
+  ];
+  return <Nav groups={navLinkGroups} />;
 };
 
-const options: IDropdownOption[] = [
-  { key: 'fruitsHeader', text: 'Fruits', itemType: DropdownMenuItemType.Header },
-  { key: 'apple', text: 'Apple' },
-  { key: 'banana', text: 'Banana' },
-  { key: 'orange', text: 'Orange', disabled: true },
-  { key: 'grape', text: 'Grape' },
-  { key: 'divider_1', text: '-', itemType: DropdownMenuItemType.Divider },
-  { key: 'vegetablesHeader', text: 'Vegetables', itemType: DropdownMenuItemType.Header },
-  { key: 'broccoli', text: 'Broccoli' },
-  { key: 'carrot', text: 'Carrot' },
-  { key: 'lettuce', text: 'Lettuce' },
-];
-
-const stackTokens: IStackTokens = { childrenGap: 20 };
-
 export const DropdownBasicExample: React.FunctionComponent = () => {
+  const options: IDropdownOption[] = [
+    { key: 'a', text: 'Option A' },
+    { key: 'b', text: 'Option B' },
+    { key: 'c', text: 'Option C' },
+  ];
   return (
-    <Stack tokens={stackTokens}>
-      <Dropdown
-        placeholder="Select an option"
-        label="Basic uncontrolled example"
-        options={options}
-        styles={dropdownStyles}
-      />
-
-      <Dropdown
-        label="Disabled example with defaultSelectedKey"
-        defaultSelectedKey="broccoli"
-        options={options}
-        disabled={true}
-        styles={dropdownStyles}
-      />
-
-      <Dropdown
-        placeholder="Select options"
-        label="Multi-select uncontrolled example"
-        defaultSelectedKeys={['apple', 'banana', 'grape']}
-        multiSelect
-        options={options}
-        styles={dropdownStyles}
-      />
-    </Stack>
+    <div className="app">
+      <div className="left-panel">
+        <Dropdown label="Example Dropdown" options={options} />
+        <NavBasicExample />
+      </div>
+      <div className="right-panel">
+        <p>
+          When pressing TAB while the Example Dropdown is open and an option has focus, the below Focusable Control
+          receives focus even though the Nav menu has focusable items ordered in between.
+        </p>
+        <p>
+          Pressing Shift+TAB from the Focusable Control demonstrates the correct behavior (moving focus back into the{' '}
+          <code>&lt;Nav&gt;</code> component)
+        </p>
+        <p>
+          Pressing TAB from the <em>collapsed</em> Dropdown control also demonstrates the correct behavior (moving focus
+          forward into the <code>&lt;Nav&gt;</code> component)
+        </p>
+        <PrimaryButton>Focusable Control</PrimaryButton>
+      </div>
+    </div>
   );
 };

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -1185,9 +1185,9 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
         if (document) {
           if (ev.shiftKey) {
-            getPreviousElement(document.body, this._dropDown.current)?.focus();
+            getPreviousElement(document.body, this._dropDown.current, false, false, true, true)?.focus();
           } else {
-            getNextElement(document.body, this._dropDown.current)?.focus();
+            getNextElement(document.body, this._dropDown.current, false, false, true, true)?.focus();
           }
         }
         break;


### PR DESCRIPTION
## Current Behavior

If you tab to the previous/next focusable element while a `Dropdown` is open and that element is inside of a `FocusZone`, the tab will skip that element and go to the previous/next one.

## New Behavior

Tabbing to the previous/next focusable element while a `Dropdown` is open will correctly go to that element, even if it is inside of a `FocusZone`.

## Related Issue(s)

Fixes #22477
