### PR TITLE
SpinButton updates from accessibility testing

### DIFF
--- a/packages/react-spinbutton/etc/react-spinbutton.api.md
+++ b/packages/react-spinbutton/etc/react-spinbutton.api.md
@@ -40,6 +40,7 @@ export type SpinButtonCommons = {
     appearance: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
     size: 'small' | 'medium';
     inputType: 'all' | 'spinners-only';
+    strings?: SpinButtonStrings;
 };
 
 // @public (undocumented)
@@ -66,6 +67,12 @@ export type SpinButtonSpinState = 'rest' | 'up' | 'down';
 export type SpinButtonState = ComponentState<SpinButtonSlots> & Partial<SpinButtonCommons> & Pick<SpinButtonCommons, 'appearance' | 'size'> & {
     spinState: SpinButtonSpinState;
     atBound: SpinButtonBounds;
+};
+
+// @public (undocumented)
+export type SpinButtonStrings = {
+    incrementButtonLabel: string;
+    decrementButtonLabel: string;
 };
 
 // @public

--- a/packages/react-spinbutton/src/components/SpinButton/SpinButton.strings.ts
+++ b/packages/react-spinbutton/src/components/SpinButton/SpinButton.strings.ts
@@ -1,0 +1,6 @@
+import type { SpinButtonStrings } from './SpinButton.types';
+
+export const spinButtonDefaultStrings: SpinButtonStrings = {
+  incrementButtonLabel: 'Increment by {step}',
+  decrementButtonLabel: 'Decrement by {step}',
+};

--- a/packages/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SpinButton } from './SpinButton';
 import { isConformant } from '../../common/isConformant';
 import * as Keys from '@fluentui/keyboard-keys';
+import { SpinButtonStrings } from './SpinButton.types';
 
 const getSpinButtonInput = (): HTMLInputElement => {
   return screen.getByRole('spinbutton') as HTMLInputElement;
@@ -18,7 +19,7 @@ describe('SpinButton', () => {
   });
 
   it('renders a default uncontrolled state', () => {
-    render(<SpinButton defaultValue={10} />);
+    const { getAllByRole } = render(<SpinButton defaultValue={10} />);
 
     const spinButton = getSpinButtonInput();
     expect(spinButton.value).toEqual('10');
@@ -26,10 +27,14 @@ describe('SpinButton', () => {
     expect(spinButton.getAttribute('aria-valuetext')).toBeNull();
     expect(spinButton.getAttribute('aria-valuemin')).toBeNull();
     expect(spinButton.getAttribute('aria-valuemax')).toBeNull();
+
+    const [incrementButton, decrementButton] = getAllByRole('button');
+    expect(incrementButton.getAttribute('aria-label')).toEqual('Increment by 1');
+    expect(decrementButton.getAttribute('aria-label')).toEqual('Decrement by 1');
   });
 
   it('renders a default controlled state', () => {
-    render(<SpinButton value={1} onChange={jest.fn()} />);
+    const { getAllByRole } = render(<SpinButton value={1} onChange={jest.fn()} />);
 
     const spinButton = getSpinButtonInput();
     expect(spinButton.value).toEqual('1');
@@ -37,6 +42,10 @@ describe('SpinButton', () => {
     expect(spinButton.getAttribute('aria-valuetext')).toBeNull();
     expect(spinButton.getAttribute('aria-valuemin')).toBeNull();
     expect(spinButton.getAttribute('aria-valuemax')).toBeNull();
+
+    const [incrementButton, decrementButton] = getAllByRole('button');
+    expect(incrementButton.getAttribute('aria-label')).toEqual('Increment by 1');
+    expect(decrementButton.getAttribute('aria-label')).toEqual('Decrement by 1');
   });
 
   it('does not render `displayValue` when uncontrolled', () => {
@@ -500,5 +509,33 @@ describe('SpinButton', () => {
 
     userEvent.type(spinButton, '23');
     expect(onChange).toHaveBeenCalledTimes(6); // no change should fire
+  });
+
+  it('applies custom strings', () => {
+    const strings: SpinButtonStrings = {
+      incrementButtonLabel: `Increment SpinButton by {step}`,
+      decrementButtonLabel: `Decrement It`,
+    };
+
+    const { getAllByRole } = render(<SpinButton strings={strings} defaultValue={0} />);
+
+    const [incrementButton, decrementButton] = getAllByRole('button');
+    expect(incrementButton.getAttribute('aria-label')).toEqual('Increment SpinButton by 1');
+    expect(decrementButton.getAttribute('aria-label')).toEqual('Decrement It');
+  });
+
+  it('overrides custom strings with slot props', () => {
+    const strings: SpinButtonStrings = {
+      incrementButtonLabel: `Increment SpinButton by {step}`,
+      decrementButtonLabel: `Decrement It`,
+    };
+
+    const { getAllByRole } = render(
+      <SpinButton strings={strings} defaultValue={0} incrementButton={{ 'aria-label': 'Increment Override' }} />,
+    );
+
+    const [incrementButton, decrementButton] = getAllByRole('button');
+    expect(incrementButton.getAttribute('aria-label')).toEqual('Increment Override');
+    expect(decrementButton.getAttribute('aria-label')).toEqual('Decrement It');
   });
 });

--- a/packages/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
@@ -121,6 +121,11 @@ export type SpinButtonCommons = {
    * @default all
    */
   inputType: 'all' | 'spinners-only';
+
+  /**
+   * Strings for localizing text in the control.
+   */
+  strings?: SpinButtonStrings;
 };
 
 /**
@@ -161,3 +166,17 @@ export type SpinButtonOnChangeData = {
 
 export type SpinButtonSpinState = 'rest' | 'up' | 'down';
 export type SpinButtonBounds = 'none' | 'min' | 'max' | 'both';
+
+export type SpinButtonStrings = {
+  /**
+   * Label applied to the increment button.
+   * Can include the token "\{step\}" which will be replaced with the value of the `step` prop.
+   */
+  incrementButtonLabel: string;
+
+  /**
+   * Label applied to the decrement button.
+   * Can include the token "\{step\}" which will be replaced with the value of the `step` prop.
+   */
+  decrementButtonLabel: string;
+};

--- a/packages/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -4,7 +4,6 @@ import {
   resolveShorthand,
   useControllableState,
   useMergedEventCallbacks,
-  useMergedRefs,
   useTimeout,
 } from '@fluentui/react-utilities';
 import * as Keys from '@fluentui/keyboard-keys';
@@ -35,16 +34,6 @@ const MAX_SPIN_TIME_MS = 1000;
 // Exact easing it to be defined. Once it is we'll likely
 // pull this out into a util function in the SpinButton package.
 const lerp = (start: number, end: number, percent: number): number => start + (end - start) * percent;
-
-// TODO: discuss this with design
-// const selectEntireRange = (input: HTMLInputElement | null): void => {
-//   if (!input) {
-//     return;
-//   }
-
-//   input.focus();
-//   input.setSelectionRange(0, input.value.length);
-// };
 
 /**
  * Create the state required to render SpinButton.
@@ -104,8 +93,6 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     spinDelay: DEFAULT_SPIN_DELAY_MS,
   });
 
-  const inputRef = React.useRef<HTMLInputElement>(null);
-
   const state: SpinButtonState = {
     size,
     appearance,
@@ -125,7 +112,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     input: resolveShorthand(input, {
       required: true,
       defaultProps: {
-        ref: useMergedRefs(ref, inputRef),
+        ref,
         autoComplete: 'off',
         role: 'spinbutton',
         appearance: appearance,
@@ -168,13 +155,6 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     }
     setTextValue(newTextValue);
   }, [value, displayValue, currentValue, precision, setAtBound, min, max]);
-
-  // TODO: see TODO at the top of this file for selectEntireRange
-  // React.useEffect(() => {
-  //   if (spinState !== 'rest') {
-  //     selectEntireRange(inputRef.current);
-  //   }
-  // }, [textValue, spinState]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (inputType === 'spinners-only') {

--- a/packages/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -4,6 +4,7 @@ import {
   resolveShorthand,
   useControllableState,
   useMergedEventCallbacks,
+  useMergedRefs,
   useTimeout,
 } from '@fluentui/react-utilities';
 import * as Keys from '@fluentui/keyboard-keys';
@@ -34,6 +35,16 @@ const MAX_SPIN_TIME_MS = 1000;
 // pull this out into a util function in the SpinButton package.
 const lerp = (start: number, end: number, percent: number): number => start + (end - start) * percent;
 
+// TODO: discuss this with design
+// const selectEntireRange = (input: HTMLInputElement | null): void => {
+//   if (!input) {
+//     return;
+//   }
+
+//   input.focus();
+//   input.setSelectionRange(0, input.value.length);
+// };
+
 /**
  * Create the state required to render SpinButton.
  *
@@ -47,7 +58,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
   const nativeProps = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'input',
-    excludedPropNames: ['onChange', 'size'],
+    excludedPropNames: ['onChange', 'size', 'min', 'max'],
   });
 
   const {
@@ -91,6 +102,8 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     spinDelay: DEFAULT_SPIN_DELAY_MS,
   });
 
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
   const state: SpinButtonState = {
     size,
     appearance,
@@ -110,10 +123,11 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     input: resolveShorthand(input, {
       required: true,
       defaultProps: {
-        ref,
+        ref: useMergedRefs(ref, inputRef),
         autoComplete: 'off',
         role: 'spinbutton',
         appearance: appearance,
+        type: 'text',
         ...nativeProps.primary,
       },
     }),
@@ -150,6 +164,13 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     }
     setTextValue(newTextValue);
   }, [value, displayValue, currentValue, precision, setAtBound, min, max]);
+
+  // TODO: see TODO at the top of this file for selectEntireRange
+  // React.useEffect(() => {
+  //   if (spinState !== 'rest') {
+  //     selectEntireRange(inputRef.current);
+  //   }
+  // }, [textValue, spinState]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (inputType === 'spinners-only') {

--- a/packages/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -15,6 +15,7 @@ import {
   SpinButtonChangeEvent,
   SpinButtonBounds,
 } from './SpinButton.types';
+import { spinButtonDefaultStrings } from './SpinButton.strings';
 import { calculatePrecision, precisionRound, getBound, clampWhenInRange } from '../../utils/index';
 import { ChevronUp16Regular, ChevronDown16Regular } from '@fluentui/react-icons';
 
@@ -78,6 +79,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     incrementButton,
     decrementButton,
     inputType = 'all',
+    strings = spinButtonDefaultStrings,
   } = props;
 
   const precision = React.useMemo(() => {
@@ -137,6 +139,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
         tabIndex: -1,
         children: <ChevronUp16Regular />,
         disabled: nativeProps.primary.disabled,
+        'aria-label': strings.incrementButtonLabel.replace('{step}', step.toString()),
       },
     }),
     decrementButton: resolveShorthand(decrementButton, {
@@ -145,6 +148,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
         tabIndex: -1,
         children: <ChevronDown16Regular />,
         disabled: nativeProps.primary.disabled,
+        'aria-label': strings.decrementButtonLabel.replace('{step}', step.toString()),
       },
     }),
   };

--- a/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -231,6 +231,20 @@ const useButtonStyles = makeStyles({
     ':disabled': {
       color: tokens.colorNeutralForegroundDisabled,
     },
+    '@media (forced-colors: active)': {
+      color: 'ButtonText',
+      ':enabled': {
+        ':hover': {
+          color: 'ButtonText',
+        },
+        ':active': {
+          color: 'ButtonText',
+        },
+        [`&.${spinButtonExtraClassNames.buttonActive}`]: {
+          color: 'ButtonText',
+        },
+      },
+    },
   },
 
   // These designs are not yet finalized so this is copy-paste for the "outline"
@@ -322,6 +336,20 @@ const useButtonDisabledStyles = makeStyles({
       [`&.${spinButtonExtraClassNames.buttonActive}`]: {
         color: tokens.colorNeutralForegroundDisabled,
         backgroundColor: 'transparent',
+      },
+    },
+    '@media (forced-colors: active)': {
+      color: 'GrayText',
+      ':enabled': {
+        ':hover': {
+          color: 'GrayText',
+        },
+        ':active': {
+          color: 'GrayText',
+        },
+        [`&.${spinButtonExtraClassNames.buttonActive}`]: {
+          color: 'GrayText',
+        },
       },
     },
   },

--- a/packages/react-spinbutton/src/index.ts
+++ b/packages/react-spinbutton/src/index.ts
@@ -14,4 +14,5 @@ export type {
   SpinButtonState,
   SpinButtonSpinState,
   SpinButtonBounds,
+  SpinButtonStrings,
 } from './SpinButton';

--- a/packages/react-spinbutton/src/stories/SpinButton.stories.tsx
+++ b/packages/react-spinbutton/src/stories/SpinButton.stories.tsx
@@ -15,6 +15,8 @@ export { Appearance } from './SpinButtonAppearance.stories';
 export { RTL } from './SpinButtonRTL.stories';
 export { Disabled } from './SpinButtonDisabled.stories';
 export { InputType } from './SpinButtonInputType.stories';
+export { Strings } from './SpinButtonStrings.stories';
+
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 
 const useDecoratorStyles = makeStyles({

--- a/packages/react-spinbutton/src/stories/SpinButtonBounds.stories.tsx
+++ b/packages/react-spinbutton/src/stories/SpinButtonBounds.stories.tsx
@@ -27,8 +27,9 @@ export const Bounds = () => {
 
   return (
     <>
-      <Label htmlFor={id}>Bounded SpinButton (min: 0, max: 20)</Label>
+      <Label htmlFor={id}>Bounded SpinButton</Label>
       <SpinButton value={spinButtonValue} min={0} max={20} onChange={onSpinButtonChange} id={id} />
+      <p>min: 0, max: 20</p>
     </>
   );
 };

--- a/packages/react-spinbutton/src/stories/SpinButtonDisplayValue.stories.tsx
+++ b/packages/react-spinbutton/src/stories/SpinButtonDisplayValue.stories.tsx
@@ -8,7 +8,7 @@ type ParserFn = (formattedValue: string) => number;
 
 export const DisplayValue = () => {
   const formatter: FormatterFn = value => {
-    return `${value}"`;
+    return `$${value}`;
   };
 
   const parser: ParserFn = formattedValue => {

--- a/packages/react-spinbutton/src/stories/SpinButtonStrings.stories.tsx
+++ b/packages/react-spinbutton/src/stories/SpinButtonStrings.stories.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { SpinButton } from '../index';
+import { Label } from '@fluentui/react-label';
+import { useId } from '@fluentui/react-utilities';
+import type { SpinButtonStrings } from '../SpinButton';
+
+export const Strings = () => {
+  const id = useId();
+
+  const strings: SpinButtonStrings = {
+    // Uses the `{step}` token which will be replaced by the `step` prop.
+    incrementButtonLabel: 'Increment the SpinButton by {step}',
+    // Omits the `{step}` token.
+    decrementButtonLabel: 'Decrement',
+  };
+
+  return (
+    <>
+      <Label htmlFor={id}>Custom Strings</Label>
+      <SpinButton strings={strings} defaultValue={0} id={id} />
+      <p>
+        Inspect the <code>aria-label</code> attributes for the increment and decrement buttons in dev tools, or use a
+        tool like a screen reader to hear the labels announced.
+      </p>
+    </>
+  );
+};
+
+Strings.parameters = {
+  docs: {
+    description: {
+      story: `SpinButton increment and decrement button \`aria-label\`s can be customized with the \`strings\` prop.
+      This feature allows labels to be localized.`,
+    },
+  },
+};


### PR DESCRIPTION
## Current Behavior

1. SpinButton has some styling issues in Windows High Contrast Mode
2. Increment and decrement buttons do not have labels

## New Behavior

1. Styling has been added for address the WHCM issues. A follow up PR will be made to make icons do this be default.
2. A `strings` prop has been added to SpinButton allowing labels be applied to the increment and decrement buttons. These strings support a token, `{step}`, that will be replaced with the value of the `step` prop when present in the string. This allows the labels to be localized as needed. By default the English localization is included.

## Related Issue(s)

#22307
