### PR TITLE
Pivot: Fixed overflow render issue on focus

### DIFF
--- a/change/@fluentui-react-b24effe5-f9e7-4d34-b12c-7f11576dd23e.json
+++ b/change/@fluentui-react-b24effe5-f9e7-4d34-b12c-7f11576dd23e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Moved focus pivot styles to only effect links not in overflow",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/react/src/components/Pivot/Pivot.styles.ts
@@ -56,14 +56,6 @@ const getLinkStyles = (
         ':focus': {
           outline: 'none',
         },
-        [`.${IsFocusVisibleClassName} &:focus`]: {
-          outline: `1px solid ${semanticColors.focusBorder}`,
-        },
-        [`.${IsFocusVisibleClassName} &:focus:after`]: {
-          content: 'attr(data-content)',
-          position: 'relative',
-          border: 0,
-        },
       },
     },
     !isLinkInOverflowMenu && [
@@ -74,6 +66,15 @@ const getLinkStyles = (
         marginRight: 8,
         textAlign: 'center',
         selectors: {
+          [`.${IsFocusVisibleClassName} &:focus`]: {
+            outline: `1px solid ${semanticColors.focusBorder}`,
+          },
+
+          [`.${IsFocusVisibleClassName} &:focus:after`]: {
+            content: 'attr(data-content)',
+            position: 'relative',
+            border: 0,
+          },
           ':before': {
             backgroundColor: 'transparent',
             bottom: 0,


### PR DESCRIPTION
fixes #20664

Some custom pivot pseudo styles meant to force pivots to be as wide as they bolded text, was spilling over into the overflow menu causing rendering issues.

Moved the styles into the "not a link in overflow" set of styles

before:

![image](https://user-images.githubusercontent.com/1434956/163247209-3d704350-b634-4dce-91a6-ed69b25610bd.png)


after:

![image](https://user-images.githubusercontent.com/1434956/163247242-aec50514-e569-4531-aaca-c7c0cec44367.png)
