### PR TITLE
Align chat read status design

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,6 +18,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Align `ChatMessageReadStatus` position with `ChatMessage` @Hirse ([#22494](https://github.com/microsoft/fluentui/pull/22494))
+
 <!--------------------------------[ v0.62.0 ]------------------------------- -->
 ## [v0.62.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.62.0) (2022-04-08)
 [Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/react-northstar_v0.61.0..@fluentui/react-northstar_v0.62.0)

--- a/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleReadStatus.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleReadStatus.shorthand.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react';
-import { Chat, ReactionGroupProps, ChatProps } from '@fluentui/react-northstar';
-import { EmojiIcon, LikeIcon, EyeFriendlierIcon } from '@fluentui/react-icons-northstar';
 
-const reactions: ReactionGroupProps['items'] = [
-  { key: 'up', icon: <LikeIcon />, content: '1K' },
-  { key: 'smile', icon: <EmojiIcon />, content: 5 },
-];
+import { EyeFriendlierIcon, PresenceAvailableIcon } from '@fluentui/react-icons-northstar';
+import { Chat, ChatProps } from '@fluentui/react-northstar';
 
 const items: ChatProps['items'] = [
   {
@@ -13,10 +9,13 @@ const items: ChatProps['items'] = [
     contentPosition: 'end',
     message: (
       <Chat.Message
-        reactionGroup={reactions}
         content="Hello"
         author="Cecil Folk"
         timestamp="Yesterday, 10:15 PM"
+        readStatus={{
+          title: 'Read by All',
+          content: <EyeFriendlierIcon size="small" />,
+        }}
         mine
       />
     ),
@@ -28,13 +27,12 @@ const items: ChatProps['items'] = [
     key: 'message-2',
     message: (
       <Chat.Message
-        reactionGroup={[{ key: 'up', icon: <LikeIcon />, content: '8' }]}
         content="I'm back!"
         author="Cecil Folk"
         timestamp="Yesterday, 10:15 PM"
         readStatus={{
-          title: 'Read by All',
-          content: <EyeFriendlierIcon size="small" />,
+          title: 'Sent',
+          content: <PresenceAvailableIcon size="small" />,
         }}
         mine
       />

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageReadStatusStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageReadStatusStyles.ts
@@ -10,8 +10,9 @@ export const chatMessageReadStatusStyles: ComponentSlotStylesPrepared<
 > = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => ({
     color: v.color,
+    display: 'flex',
     position: 'absolute',
-    right: p.density === 'compact' ? v.rightPositionCompact : v.rightPosition,
+    right: v.rightPosition,
     bottom: p.density === 'compact' ? v.bottomPositionCompact : v.bottomPosition,
     ':after': {
       content: `"${p.title}"`,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageReadStatusVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageReadStatusVariables.ts
@@ -5,13 +5,11 @@ export interface ChatMessageReadStatusVariables {
   bottomPositionCompact: string;
   color?: string;
   rightPosition?: string;
-  rightPositionCompact: string;
 }
 
 export const chatMessageReadStatusVariables = (siteVars): ChatMessageReadStatusVariables => ({
-  bottomPosition: pxToRem(0),
-  bottomPositionCompact: pxToRem(2),
+  bottomPosition: '0',
+  bottomPositionCompact: pxToRem(-1), // Offset border around compact message
   color: siteVars.colorScheme.brand.foreground1,
-  rightPosition: pxToRem(-24),
-  rightPositionCompact: pxToRem(-16),
+  rightPosition: pxToRem(-17),
 });


### PR DESCRIPTION
Align ReadStatus design with its usage in Teams.

* Align vertically with bottom of message body
* Set horizontal spacing based on density
  * Comfy: 12px to 5px
  * Compact: 3px to 4px

*Comfy*
![image](https://user-images.githubusercontent.com/2564094/163270430-a3a342fa-0b7c-49b8-ad5d-0c2c7d86f608.png) ![image](https://user-images.githubusercontent.com/2564094/163270562-99a31c50-87a5-4a02-b1d0-3f84243ca8fe.png)

*Compact*
![image](https://user-images.githubusercontent.com/2564094/163270826-d953d140-d6f8-428d-b583-4fbb8af6850b.png) ![image](https://user-images.githubusercontent.com/2564094/163270868-93c2490e-6c3f-4343-9622-dbae291b1570.png)
