### PR TITLE
SVG Icons, support color adjust in high contrast mode

### DIFF
--- a/change/@fluentui-react-icons-mdl2-9b3f13b2-0adb-4a90-99f8-beb87634435d.json
+++ b/change/@fluentui-react-icons-mdl2-9b3f13b2-0adb-4a90-99f8-beb87634435d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add forced-color-adjust to icon styles to ensure high contrast color works as expected",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-icons-mdl2/src/utils/SvgIcon.scss
+++ b/packages/react-icons-mdl2/src/utils/SvgIcon.scss
@@ -13,5 +13,4 @@
   // Temporary forcing color to adjust in HCM until browsers do this properly
   // https://github.com/microsoft/fluentui/issues/22410
   forced-color-adjust: auto;
-  --ms-forced-color-adjust: auto;
 }

--- a/packages/react-icons-mdl2/src/utils/SvgIcon.scss
+++ b/packages/react-icons-mdl2/src/utils/SvgIcon.scss
@@ -10,4 +10,8 @@
   height: 100%;
   fill: currentColor;
   vertical-align: top;
+  // Temporary forcing color to adjust in HCM until browsers do this properly
+  // https://github.com/microsoft/fluentui/issues/22410
+  forced-color-adjust: auto;
+  --ms-forced-color-adjust: auto;
 }


### PR DESCRIPTION
fixes #22410


after fix:

![image](https://user-images.githubusercontent.com/1434956/163272216-40eb2b4b-b0fd-45d1-95ed-a91cd0f23f2c.png)
