### PR TITLE
Add inline styles to tooltip demo to ensure button styles are visible

### DIFF
--- a/packages/react-examples/src/react/Tooltip/Tooltip.Display.Example.tsx
+++ b/packages/react-examples/src/react/Tooltip/Tooltip.Display.Example.tsx
@@ -4,7 +4,13 @@ import { getTheme } from '@fluentui/react/lib/Styling';
 import { useId } from '@fluentui/react-hooks';
 
 const theme = getTheme();
-const buttonStyle = { fontSize: theme.fonts.medium.fontSize, padding: 10 };
+const buttonStyle = {
+  fontSize: theme.fonts.medium.fontSize,
+  padding: 10,
+  // Background and border set to override some global website styles
+  background: '#f0f0f0',
+  border: '2px solid black',
+};
 const calloutProps = { gapSpace: 0 };
 
 // Important for correct positioning--see below


### PR DESCRIPTION
Our global styles are overriding button background and border, so this PR adds explicit styles to this demo.

https://github.com/microsoft/fluentui/blob/master/apps/public-docsite/src/styles/_base.scss#L32-L36

![image](https://user-images.githubusercontent.com/1434956/163274565-acdbfd3a-d8bd-4603-8d3f-d11ee8c1804a.png)

These styles ensure that the border/background is visible and the demo makes sense

![image](https://user-images.githubusercontent.com/1434956/163274630-55efb0b3-6d6f-4632-a7d5-3d268b90586e.png)
