### PR TITLE
Updated docstring for SelectableDroppableText onRenderOption

### DIFF
--- a/packages/react/src/utilities/selectableOption/SelectableDroppableText.types.ts
+++ b/packages/react/src/utilities/selectableOption/SelectableDroppableText.types.ts
@@ -83,8 +83,12 @@ export interface ISelectableDroppableTextProps<TComponent, TListenerElement>
   onRenderItem?: IRenderFunction<ISelectableOption>;
 
   /**
-   * Optional custom renderer for normal options only.
-   * Use `onRenderItem` to control rendering for separators and headers as well.
+   * Optional custom renderer for normal and header options.
+   * @remarks
+   * Param `option: ISelectableOption` has attribute `itemType`,
+   * use this to specify normal vs. header option render logic.
+   * @remarks
+   * Use `onRenderItem` to control rendering for separators as well.
    */
   onRenderOption?: IRenderFunction<ISelectableOption>;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

onRenderOption docstring incorrectly indicates that this prop only affects normal dropdown options.

## New Behavior

onRenderOption docstring correctly states that this render function will affect both normal and header options, and provides info on use.

## Related Issue(s)

Fixes #[22454](https://github.com/microsoft/fluentui/issues/22454#issuecomment-1097074678)
