### PR TITLE
ContextualMenu: change default focus target when opened by click event

### DIFF
--- a/change/@fluentui-react-acfcd924-0080-4312-8cc7-8239a4d2c416.json
+++ b/change/@fluentui-react-acfcd924-0080-4312-8cc7-8239a4d2c416.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: Focus container by default when opened by click event.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -936,8 +936,12 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       onMenuClick(ev, this.props);
     }
 
+    // focus on the container by default when the menu is opened with a click event
+    const shouldFocusOnContainer =
+      menuProps?.shouldFocusOnContainer || (ev.nativeEvent as PointerEvent).pointerType === 'mouse';
+
     if (!ev.defaultPrevented) {
-      this._onToggleMenu(menuProps?.shouldFocusOnContainer || false);
+      this._onToggleMenu(shouldFocusOnContainer);
       ev.preventDefault();
       ev.stopPropagation();
     }


### PR DESCRIPTION
## Context

We previously updated ContextualMenu to always set focus on the first menu item to fix a Narrator bug (#20601), and minor poor experiences in other screen readers (e.g. JAWS announcing the role/name of the menu twice). Before that, it set the focus to the container on click, and to the first menu item on keyboard activation.

This is relevant to screen reader behavior, since screen readers in virtual cursor mode (and VoiceOver on macOS) send a click event to the button.

## New Behavior

Based on conversations with partner teams, setting focus to the first menu item can create visual regressions, particularly when menuitems have a tooltip that shows on focus. Previously opening the menu with the keyboard would focus the first item and show the tooltip, but that would not happen on click.

We're reverting the behavior back to focusing the menu container on click for v8, though v9 will always focus the first menuitem.

## future behavior

It's probably worth noting that JAWS will manually force the first menuitem into focus on Windows desktop for e.g. the contextmenu on desktop icons when running (vs. the non-JAWS experience of focusing the menu container), which adds more weight towards focusing the first item as a best practice in future versions.

A separate bug has been filed on Narrator for its behavior when the menu container is focused.
