### PR TITLE
ComboBox: Fix unhandled calloutProps's onScroll callback

### DIFF
--- a/change/@fluentui-react-deb02815-8c60-4011-af46-83f8ae37c233.json
+++ b/change/@fluentui-react-deb02815-8c60-4011-af46-83f8ae37c233.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added onScroll callback for calloutProps in ComboBox.",
+  "packageName": "@fluentui/react",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1653,6 +1653,10 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       this._isScrollIdle = false;
     }
 
+    if (this.props.calloutProps?.onScroll) {
+      this.props.calloutProps.onScroll();
+    }
+
     this._scrollIdleTimeoutId = this._async.setTimeout(() => {
       this._isScrollIdle = true;
     }, ScrollIdleDelay);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently ComboBox does not handle custom `onScroll` events passed down to the `calloutProps`.

## New Behavior

ComboBox now checks the `calloutProps` to see if an `onScroll` callback is given and runs it.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22372
