### PR TITLE
Cypress: rebuild on file changes in v8

### DIFF
--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -38,6 +38,10 @@ const baseConfig = {
   fixturesFolder: path.join(__dirname, 'cypress/fixtures'),
   supportFile: path.join(__dirname, './cypress/support/index.js'),
   pluginsFile: path.join(__dirname, './cypress/plugins/index.js'),
+  env: {
+    // Used in ./plugins/index.js to choose the webpack devtool
+    mode: argv.mode,
+  },
 };
 
 const run = () => {

--- a/scripts/cypress/plugins/index.js
+++ b/scripts/cypress/plugins/index.js
@@ -1,11 +1,6 @@
 /// <reference types="cypress" />
 // ***********************************************************
-// This example plugins/index.js can be used to load plugins
-//
-// You can change the location of this file or turn off loading
-// the plugins file with the 'pluginsFile' configuration option.
-//
-// You can read more here:
+// This file is used to load Cypress plugins. More info:
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
 
@@ -13,59 +8,70 @@
 // the project's config changing)
 
 // @ts-check
-const path = require('path');
 const fs = require('fs');
+const jju = require('jju');
+const path = require('path');
 const { startDevServer } = require('@cypress/webpack-dev-server');
 const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
+const applyV8WebpackConfig = require('../../storybook/webpack.config');
 
 /**
- * Cypress Webpack devServer that uses esbuild-loader for speed,
+ * Cypress Webpack devServer that uses esbuild-loader for speed in v9
+ * (still uses ts-loader in v8)
  * @type {Cypress.PluginConfig}
  */
 module.exports = (on, config) => {
-  const tsConfigBasePath = path.resolve(__dirname, '../../../tsconfig.base.json');
-  /**
-   * @type {import("../../../tools/types").TsConfig}
-   */
-  const tsConfigBase = JSON.parse(fs.readFileSync(tsConfigBasePath).toString());
-  const tsPaths = new TsconfigPathsPlugin({
-    configFile: tsConfigBasePath,
-  });
+  // Enable sourcemaps for interactive debugging (config.env.mode is defined in ../index.js)
+  const devtool = config.env.mode === 'open' ? 'eval' : false;
+
   /** @type {import("webpack").Configuration} */
   const webpackConfig = {
     resolve: {
       extensions: ['.js', '.ts', '.jsx', '.tsx'],
-      plugins: [tsPaths],
     },
     mode: 'development',
-    devtool: false,
+    devtool,
     output: {
       publicPath: '/',
       chunkFilename: '[name].bundle.js',
     },
-
     module: {
-      rules: [
-        {
-          test: /\.(ts|tsx)$/,
-          loader: 'esbuild-loader',
-          options: {
-            loader: 'tsx',
-            target: tsConfigBase.compilerOptions.target,
-          },
-        },
-      ],
+      rules: [],
     },
   };
+
+  if (path.basename(process.cwd()) === 'react-examples') {
+    // For v8, reuse the storybook webpack config helper to add required options for building v8,
+    // including the `resolve.alias` config that's currently REQUIRED to make tests re-run when a
+    // component file in @fluentui/react is modified while running in open mode.
+    // (This is different than the v9 config because v8 doesn't use tsconfig paths, so the only way
+    // it can respond to file edits is by using `resolve.alias`, which doesn't work with esbuild.)
+    applyV8WebpackConfig(webpackConfig);
+  } else {
+    // For v9, use tsconfig paths and esbuild-loader
+    const tsConfigBasePath = path.resolve(__dirname, '../../../tsconfig.base.json');
+    /** @type {import("../../../tools/types").TsConfig} */
+    const tsConfigBase = jju.parse(fs.readFileSync(tsConfigBasePath).toString());
+    const tsPaths = new TsconfigPathsPlugin({
+      configFile: tsConfigBasePath,
+    });
+
+    webpackConfig.resolve.plugins = [tsPaths];
+    webpackConfig.module.rules.push({
+      test: /\.(ts|tsx)$/,
+      loader: 'esbuild-loader',
+      options: {
+        loader: 'tsx',
+        target: tsConfigBase.compilerOptions.target,
+      },
+    });
+  }
 
   // Used by cypress https://github.com/cypress-io/cypress/blob/develop/npm/react/examples/webpack-options/cypress/plugins/index.js
   // this is required to load commonjs babel plugin
   process.env.BABEL_ENV = 'test';
 
-  /**
-   * Cypress Webpack devServer that uses esbuild-loader for speed,
-   * @type {import('@cypress/webpack-dev-server').ResolvedDevServerConfig['close'] | undefined}
-   */
+  /** @type {import('@cypress/webpack-dev-server').ResolvedDevServerConfig['close'] | undefined} */
   let closeServer = undefined;
   on('after:run', () => {
     // Generally isn't necessary, but sometimes unexpected errors can cause the

--- a/scripts/storybook/webpack.config.js
+++ b/scripts/storybook/webpack.config.js
@@ -1,10 +1,16 @@
+// @ts-check
 const IgnoreNotFoundExportWebpackPlugin = require('ignore-not-found-export-webpack-plugin');
 const path = require('path');
 const findGitRoot = require('../monorepo/findGitRoot');
 const getResolveAlias = require('../webpack/getResolveAlias');
 const webpack = require('webpack');
 
-module.exports = (/** @type {webpack.Configuration} */ config) => {
+/**
+ * Updates the given webpack config to include resolutions and other options for v8 packages.
+ * @param {webpack.Configuration} config webpack config, WILL BE MUTATED
+ * @returns {webpack.Configuration} the same object that was passed in
+ */
+module.exports = config => {
   config.resolveLoader = {
     ...config.resolveLoader,
     modules: [
@@ -77,20 +83,23 @@ module.exports = (/** @type {webpack.Configuration} */ config) => {
     },
   );
 
-  config.resolve.alias = {
-    // Use the aliases for react-examples since the examples and demo may depend on some things
-    // that the package itself doesn't (and it will include the aliases for all the package's deps)
-    ...getResolveAlias(false, path.join(findGitRoot(), 'packages/react-examples')),
+  config.resolve = {
+    ...config.resolve,
+    alias: {
+      // Use the aliases for react-examples since the examples and demo may depend on some things
+      // that the package itself doesn't (and it will include the aliases for all the package's deps)
+      ...getResolveAlias(false, path.join(findGitRoot(), 'packages/react-examples')),
+    },
   };
 
-  config.plugins.push(new IgnoreNotFoundExportWebpackPlugin({ include: [/\.tsx?$/] }));
+  config.plugins = [...(config.plugins || []), new IgnoreNotFoundExportWebpackPlugin({ include: [/\.tsx?$/] })];
 
   // Disable ProgressPlugin which logs verbose webpack build progress. Warnings and Errors are still logged.
   if (process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME) {
     config.plugins = config.plugins.filter(({ constructor }) => constructor.name !== 'ProgressPlugin');
   }
 
-  config.optimization.minimize = false;
+  config.optimization = { ...config.optimization, minimize: false };
 
   return config;
 };


### PR DESCRIPTION
## Current Behavior

With the Cypress component testing setup using `esbuild-loader`, changes to v8 components no longer triggered a rebuild because v8 doesn't use tsconfig path mapping. This made fixing component issues revealed while writing tests much more challenging (such as while working on #22500).

## New Behavior

For now, **for v8 only**, switch back to using `ts-loader` with a webpack `resolve.alias` config. This is a bit slower but actually not too bad (compared to bundling the whole package) because only a few component files are used in e2e tests at the moment. At least to start out, I reused the v8 storybook webpack config helper because it included all the relevant aliases, loaders, etc. Open to suggestions on that. 

The other possible argument in favor of using ts-loader here is that it can transpile to ES5, which makes the tests run against something closer to the actual code our consumers get. (Not sure how likely this is to make a difference in practice.)

Also enable a `devtool` option for local interactive runs (for v8 and v9) to make debugging easier. It's still not great, at least for v8 (maps back to transpiled JS, not original TS) but probably better than trying to find the part you want in the giant bundle file.