### PR TITLE
merge-styles: Adding missing export to package.json for ssr

### DIFF
--- a/change/@fluentui-merge-styles-ca3053dc-44f0-4f74-ac01-921bd27865e0.json
+++ b/change/@fluentui-merge-styles-ca3053dc-44f0-4f74-ac01-921bd27865e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding missing package.json export for ssr",
+  "packageName": "@fluentui/merge-styles",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/merge-styles/package.json
+++ b/packages/merge-styles/package.json
@@ -62,6 +62,11 @@
       "types": "./lib/mergeStyleSets.d.ts",
       "import": "./lib/mergeStyleSets.js",
       "require": "./lib-commonjs/mergeStyleSets.js"
+    },
+    "./lib/server": {
+      "types": "./lib/server.d.ts",
+      "import": "./lib/server.js",
+      "require": "./lib-commonjs/server.js"
     }
   }
 }


### PR DESCRIPTION
This PR adds missing export in package.json for ssr. This missing export wouldn't let you import `renderStatic`.

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22288
