### PR TITLE
ComboBox: Fixing onScrollToItem to scroll to pending selected index

### DIFF
--- a/change/@fluentui-react-753464fb-ab47-4d62-b356-63d6f2499694.json
+++ b/change/@fluentui-react-753464fb-ab47-4d62-b356-63d6f2499694.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing onScrollToItem in ComboBox by using the getPendingSelectedIndex instead of checking state.",
+  "packageName": "@fluentui/react",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1668,15 +1668,11 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
   private _scrollIntoView(): void {
     const { onScrollToItem, scrollSelectedToTop } = this.props;
 
-    const { currentPendingValueValidIndex, currentPendingValue } = this.state;
+    const currentPendingSelectedInded = this._getPendingSelectedIndex(true);
 
     if (onScrollToItem) {
       // Use the custom scroll handler
-      onScrollToItem(
-        currentPendingValueValidIndex >= 0 || currentPendingValue !== ''
-          ? currentPendingValueValidIndex
-          : this._getFirstSelectedIndex(),
-      );
+      onScrollToItem(currentPendingSelectedInded >= 0 ? currentPendingSelectedInded : this._getFirstSelectedIndex());
     } else if (this._selectedElement.current && this._selectedElement.current.offsetParent) {
       let alignToTop = true;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

ComboBox is not scrolling to the selected index, instead it stays in the first item. This is due to checking the state for the pending selected index instead of using the `_getPendingSelectedIndex`.

## New Behavior

Use `_getPendingSelectedIndex` to find the right index to jump to.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22228
