### PR TITLE
update react-icons version to ^2.0.166-rc.3 from ^2.0.159-beta.10

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -24,7 +24,7 @@
     "@fluentui/react-card": "9.0.0-beta.10",
     "@fluentui/react-checkbox": "9.0.0-beta.10",
     "@fluentui/react-divider": "9.0.0-rc.5",
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@fluentui/react-image": "9.0.0-rc.5",
     "@fluentui/react-input": "9.0.0-beta.5",
     "@fluentui/react-label": "9.0.0-beta.9",

--- a/change/@fluentui-react-accordion-e7768f8f-04b0-41d3-ab7d-2ff3589c2e11.json
+++ b/change/@fluentui-react-accordion-e7768f8f-04b0-41d3-ab7d-2ff3589c2e11.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update react-icons version to ^2.0.166-rc.3 from ^2.0.159-beta.10",
+  "packageName": "@fluentui/react-accordion",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-b88d5494-14cd-4386-b47b-8f27641d760b.json
+++ b/change/@fluentui-react-avatar-b88d5494-14cd-4386-b47b-8f27641d760b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update react-icons version to ^2.0.166-rc.3 from ^2.0.159-beta.10",
+  "packageName": "@fluentui/react-avatar",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-90ec7035-4195-400a-98c6-f75ca07cb1df.json
+++ b/change/@fluentui-react-badge-90ec7035-4195-400a-98c6-f75ca07cb1df.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update react-icons version to ^2.0.166-rc.3 from ^2.0.159-beta.10",
+  "packageName": "@fluentui/react-badge",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-dbffe0ed-30cf-4b60-8482-e2e155fa0b9b.json
+++ b/change/@fluentui-react-button-dbffe0ed-30cf-4b60-8482-e2e155fa0b9b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update react-icons version to ^2.0.166-rc.3 from ^2.0.159-beta.10",
+  "packageName": "@fluentui/react-button",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-94cc57fc-4f00-457f-a0d3-ddf42a9488aa.json
+++ b/change/@fluentui-react-checkbox-94cc57fc-4f00-457f-a0d3-ddf42a9488aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update react-icons version to ^2.0.166-rc.3 from ^2.0.159-beta.10",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-d17e9a55-7ac2-41c9-aac0-603297ff5f3b.json
+++ b/change/@fluentui-react-menu-d17e9a55-7ac2-41c9-aac0-603297ff5f3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update react-icons version to ^2.0.166-rc.3 from ^2.0.159-beta.10",
+  "packageName": "@fluentui/react-menu",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-e92dbb7e-787d-4b24-90e9-5531933c7397.json
+++ b/change/@fluentui-react-radio-e92dbb7e-787d-4b24-90e9-5531933c7397.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update react-icons version to ^2.0.166-rc.3 from ^2.0.159-beta.10",
+  "packageName": "@fluentui/react-radio",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-639bc3cb-5898-4dca-9e2b-e91868af900a.json
+++ b/change/@fluentui-react-switch-639bc3cb-5898-4dca-9e2b-e91868af900a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update react-icons version to ^2.0.166-rc.3 from ^2.0.159-beta.10",
+  "packageName": "@fluentui/react-switch",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@ctrl/tinycolor": "3.3.4",
     "@cypress/react": "5.12.4",
     "@cypress/webpack-dev-server": "1.8.3",
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@griffel/babel-preset": "1.0.0",
     "@griffel/jest-serializer": "1.0.0",
     "@griffel/react": "1.0.0",

--- a/packages/react-accordion/package.json
+++ b/packages/react-accordion/package.json
@@ -35,7 +35,7 @@
     "@fluentui/react-aria": "9.0.0-rc.5",
     "@fluentui/react-context-selector": "9.0.0-rc.5",
     "@fluentui/react-shared-contexts": "9.0.0-rc.4",
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@griffel/react": "1.0.0",
     "@fluentui/react-tabster": "9.0.0-rc.5",
     "@fluentui/react-theme": "9.0.0-rc.4",

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluentui/react-badge": "9.0.0-rc.5",
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@fluentui/react-theme": "9.0.0-rc.4",
     "@fluentui/react-shared-contexts": "9.0.0-rc.4",
     "@fluentui/react-utilities": "9.0.0-rc.5",

--- a/packages/react-badge/package.json
+++ b/packages/react-badge/package.json
@@ -32,7 +32,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@griffel/react": "1.0.0",
     "@fluentui/react-theme": "9.0.0-rc.4",
     "@fluentui/react-utilities": "9.0.0-rc.5",

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "9.0.0-rc.4",
     "@fluentui/react-aria": "9.0.0-rc.5",
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@fluentui/react-tabster": "9.0.0-rc.5",
     "@fluentui/react-theme": "9.0.0-rc.4",
     "@fluentui/react-utilities": "9.0.0-rc.5",

--- a/packages/react-checkbox/package.json
+++ b/packages/react-checkbox/package.json
@@ -31,7 +31,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@fluentui/react-label": "9.0.0-beta.9",
     "@fluentui/react-tabster": "9.0.0-rc.5",
     "@fluentui/react-theme": "9.0.0-rc.4",

--- a/packages/react-combobox/package.json
+++ b/packages/react-combobox/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "9.0.0-rc.4",
     "@fluentui/react-context-selector": "9.0.0-rc.5",
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@fluentui/react-portal": "9.0.0-rc.5",
     "@fluentui/react-positioning": "9.0.0-rc.5",
     "@fluentui/react-utilities": "9.0.0-rc.5",

--- a/packages/react-menu/package.json
+++ b/packages/react-menu/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "9.0.0-rc.4",
     "@fluentui/react-context-selector": "9.0.0-rc.5",
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@griffel/react": "1.0.0",
     "@fluentui/react-portal": "9.0.0-rc.5",
     "@fluentui/react-positioning": "9.0.0-rc.5",

--- a/packages/react-radio/package.json
+++ b/packages/react-radio/package.json
@@ -30,7 +30,7 @@
     "@fluentui/react-conformance-griffel": "9.0.0-beta.3"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@fluentui/react-label": "9.0.0-beta.9",
     "@fluentui/react-tabster": "9.0.0-rc.5",
     "@fluentui/react-theme": "9.0.0-rc.4",

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -32,7 +32,7 @@
     "@fluentui/react-conformance-griffel": "9.0.0-beta.3"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@fluentui/react-theme": "9.0.0-rc.4",
     "@fluentui/react-utilities": "9.0.0-rc.5",
     "@griffel/react": "1.0.0",

--- a/packages/react-spinbutton/package.json
+++ b/packages/react-spinbutton/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@griffel/react": "1.0.0",
     "@fluentui/keyboard-keys": "9.0.0-rc.4",
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@fluentui/react-input": "9.0.0-beta.5",
     "@fluentui/react-theme": "9.0.0-rc.4",
     "@fluentui/react-utilities": "9.0.0-rc.5",

--- a/packages/react-switch/package.json
+++ b/packages/react-switch/package.json
@@ -32,7 +32,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.159-beta.10",
+    "@fluentui/react-icons": "^2.0.166-rc.3",
     "@fluentui/react-label": "9.0.0-beta.9",
     "@fluentui/react-tabster": "9.0.0-rc.5",
     "@fluentui/react-theme": "9.0.0-rc.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,10 +1681,10 @@
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
 
-"@fluentui/react-icons@^2.0.159-beta.10":
-  version "2.0.159-beta.10"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.159-beta.10.tgz#8934c05b415bbb1b46f9085c72eaf78fd7bad967"
-  integrity sha512-Y2pDtl6ofeqGI/M/C3T6KbFy+deT1TkQ5aMO3TWN4XgAYQb5Sww56WeuX+sQNnnIXN21HIJOS6Hw1frFtCPv0w==
+"@fluentui/react-icons@^2.0.166-rc.3":
+  version "2.0.166-rc.3"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.166-rc.3.tgz#6a66d104a4809ca9da1982f895bc24abb624e342"
+  integrity sha512-mhTti5DcCvG/UxRD+/P5Qjdo/QDOE57eRcRBVooOpfO2N1Q+9sE44NYczOeOHpV2AufNqomX0QYf5iPYZ1lEtg==
 
 "@griffel/babel-preset@1.0.0":
   version "1.0.0"


### PR DESCRIPTION
## Current Behavior

`react-icons@^2.0.159-beta.10` lacks a CSS media query to support Windows High Contrast Mode.

## New Behavior

Updates `react-icons` to `^2.0.166-rc.3` to support Windows High Contrast Mode.

## Before and After

Note the chevron icon color difference.

### Before
<img width="582" alt="'before' screenshot of Windows High Contrast Mode icons" src="https://user-images.githubusercontent.com/93940821/163436409-96036d9e-7bd9-424f-8679-dcae1133cc0f.png">

### After
<img width="571" alt="'after' screenshot of Windows High Contrast Mode icons" src="https://user-images.githubusercontent.com/93940821/163436501-982246cd-d5c5-41ae-88ed-7c2b029015be.png">

