### PR TITLE
Fixed onRenderOption docs to note that regular AND header types are affected

### DIFF
--- a/change/@fluentui-react-5ac41ceb-4ad3-4aff-8c8f-907205be658e.json
+++ b/change/@fluentui-react-5ac41ceb-4ad3-4aff-8c8f-907205be658e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed onRenderOption docs to note that regular AND header types are affected",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/utilities/selectableOption/SelectableDroppableText.types.ts
+++ b/packages/react/src/utilities/selectableOption/SelectableDroppableText.types.ts
@@ -83,8 +83,8 @@ export interface ISelectableDroppableTextProps<TComponent, TListenerElement>
   onRenderItem?: IRenderFunction<ISelectableOption>;
 
   /**
-   * Optional custom renderer for normal options only.
-   * Use `onRenderItem` to control rendering for separators and headers as well.
+   * Optional custom renderer for normal and header options only.
+   * Use `onRenderItem` to control rendering for separators as well.
    */
   onRenderOption?: IRenderFunction<ISelectableOption>;
 


### PR DESCRIPTION
Updated prop docs to correctly state that onRenderOption affects both regular items AND header items. onRenderItem still is the only way to affect dividers. 

Fixes #22454