### PR TITLE
Remove active focus styles from Chevron because link already has them

### DIFF
--- a/change/@fluentui-react-c3dd6c69-707e-4278-8aec-854fa72b5279.json
+++ b/change/@fluentui-react-c3dd6c69-707e-4278-8aec-854fa72b5279.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Nav: Remove duplicative active focus styles from chevron",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Nav/Nav.styles.ts
+++ b/packages/react/src/components/Nav/Nav.styles.ts
@@ -195,22 +195,6 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
         padding: 0,
         margin: 0,
       },
-      isSelected && {
-        color: palette.themePrimary,
-        backgroundColor: palette.neutralLighterAlt,
-        selectors: {
-          '&:after': {
-            borderLeft: `2px solid ${palette.themePrimary}`,
-            content: '""',
-            position: 'absolute',
-            top: 0,
-            right: 0,
-            bottom: 0,
-            left: 0,
-            pointerEvents: 'none',
-          },
-        },
-      },
     ],
     chevronIcon: [
       classNames.chevronIcon,

--- a/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -70,6 +70,17 @@ exports[`Nav render Nav with overrides correctly 1`] = `
               &::-moz-focus-inner {
                 border: 0;
               }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #605e5c;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
               &:visited {
                 color: #323130;
               }
@@ -653,7 +664,7 @@ exports[`Nav renders Nav correctly 1`] = `
                           vertical-align: middle;
                         }
                   >
-
+                    
                   </div>
                 </span>
               </button>

--- a/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -70,17 +70,6 @@ exports[`Nav render Nav with overrides correctly 1`] = `
               &::-moz-focus-inner {
                 border: 0;
               }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 1px;
-                top: 1px;
-                z-index: 1;
-              }
               &:visited {
                 color: #323130;
               }
@@ -664,7 +653,7 @@ exports[`Nav renders Nav correctly 1`] = `
                           vertical-align: middle;
                         }
                   >
-                    
+
                   </div>
                 </span>
               </button>


### PR DESCRIPTION
Fixes #21971

before 

![image](https://user-images.githubusercontent.com/1434956/163456715-c84d8c98-388d-4704-aac8-cc5765eb9e75.png)


after 

![image](https://user-images.githubusercontent.com/1434956/163456539-c42874f0-0011-4eaa-b7b1-8769489dc53e.png)
