### PR TITLE
Contextmenu high contrast styles update

### DIFF
--- a/change/@fluentui-react-e7c88860-cc68-4ecc-9d1c-6724461f0b5f.json
+++ b/change/@fluentui-react-e7c88860-cc68-4ecc-9d1c-6724461f0b5f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: Fix high contrast colors",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
@@ -8,27 +8,12 @@ import {
   getHighContrastNoAdjustStyle,
 } from '../../Styling';
 import { memoizeFunction } from '../../Utilities';
-import type { IRawStyle, ITheme } from '../../Styling';
+import type { ITheme } from '../../Styling';
 import type { IMenuItemStyles } from './ContextualMenu.types';
 
 export const CONTEXTUAL_MENU_ITEM_HEIGHT = 36;
 
 const MediumScreenSelector = getScreenSelector(0, ScreenWidthMaxMedium);
-
-const getItemHighContrastStyles = memoizeFunction(
-  (): IRawStyle => {
-    return {
-      selectors: {
-        [HighContrastSelector]: {
-          backgroundColor: 'Highlight',
-          borderColor: 'Highlight',
-          color: 'HighlightText',
-          ...getHighContrastNoAdjustStyle(),
-        },
-      },
-    };
-  },
-);
 
 export const getMenuItemStyles = memoizeFunction(
   (theme: ITheme): IMenuItemStyles => {
@@ -75,6 +60,7 @@ export const getMenuItemStyles = memoizeFunction(
         pointerEvents: 'none',
         selectors: {
           [HighContrastSelector]: {
+            // ensure disabled text looks different than enabled
             color: 'GrayText',
             opacity: 1,
             ...getHighContrastNoAdjustStyle(),
@@ -92,11 +78,9 @@ export const getMenuItemStyles = memoizeFunction(
             color: palette.neutralPrimary,
           },
         },
-        ...getItemHighContrastStyles(),
       },
       rootFocused: {
         backgroundColor: palette.white,
-        ...getItemHighContrastStyles(),
       },
       rootChecked: {
         selectors: {
@@ -104,7 +88,6 @@ export const getMenuItemStyles = memoizeFunction(
             color: palette.neutralPrimary,
           },
         },
-        ...getItemHighContrastStyles(),
       },
       rootPressed: {
         backgroundColor: ContextualMenuItemBackgroundSelectedColor,
@@ -116,12 +99,22 @@ export const getMenuItemStyles = memoizeFunction(
             color: palette.neutralPrimary,
           },
         },
-        ...getItemHighContrastStyles(),
       },
       rootExpanded: {
         backgroundColor: ContextualMenuItemBackgroundSelectedColor,
         color: semanticColors.bodyTextChecked,
-        ...getItemHighContrastStyles(),
+        selectors: {
+          '.ms-ContextualMenu-submenuIcon': {
+            [HighContrastSelector]: {
+              // icons inside of anchor tags are not properly inheriting color in high contrast
+              color: 'inherit',
+            },
+          },
+          [HighContrastSelector]: {
+            // allow change in background/text to be visible
+            ...getHighContrastNoAdjustStyle(),
+          },
+        },
       },
       linkContent: {
         whiteSpace: 'nowrap',
@@ -173,36 +166,13 @@ export const getMenuItemStyles = memoizeFunction(
       },
       iconColor: {
         color: semanticColors.menuIcon,
-        selectors: {
-          [HighContrastSelector]: {
-            color: 'inherit',
-          },
-          ['$root:hover &']: {
-            selectors: {
-              [HighContrastSelector]: {
-                color: 'HighlightText',
-              },
-            },
-          },
-          ['$root:focus &']: {
-            selectors: {
-              [HighContrastSelector]: {
-                color: 'HighlightText',
-              },
-            },
-          },
-        },
       },
       iconDisabled: {
         color: semanticColors.disabledBodyText,
       },
       checkmarkIcon: {
         color: semanticColors.bodySubtext,
-        selectors: {
-          [HighContrastSelector]: {
-            color: 'HighlightText',
-          },
-        },
+        selectors: {},
       },
       subMenuIcon: {
         height: CONTEXTUAL_MENU_ITEM_HEIGHT,
@@ -222,9 +192,6 @@ export const getMenuItemStyles = memoizeFunction(
           },
           [MediumScreenSelector]: {
             fontSize: IconFontSizes.medium, // 16px
-          },
-          [HighContrastSelector]: {
-            color: 'HighlightText',
           },
         },
       },

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
@@ -172,7 +172,6 @@ export const getMenuItemStyles = memoizeFunction(
       },
       checkmarkIcon: {
         color: semanticColors.bodySubtext,
-        selectors: {},
       },
       subMenuIcon: {
         height: CONTEXTUAL_MENU_ITEM_HEIGHT,

--- a/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -374,42 +374,26 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                               background-color: #f3f2f1;
                               color: #201f1e;
                             }
-                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:hover {
-                              -ms-high-contrast-adjust: none;
-                              background-color: Highlight;
-                              border-color: Highlight;
-                              color: HighlightText;
-                              forced-color-adjust: none;
+                            &:hover .ms-ContextualMenu-icon {
+                              color: #106ebe;
+                            }
+                            &:hover .ms-ContextualMenu-submenuIcon {
+                              color: #323130;
                             }
                             &:active {
                               background-color: #edebe9;
                             }
-                            @media screen and (-ms-high-contrast: active), (forced-colors: active){&:active {
-                              -ms-high-contrast-adjust: none;
-                              background-color: Highlight;
-                              border-color: Highlight;
-                              color: HighlightText;
-                              forced-color-adjust: none;
+                            &:active .ms-ContextualMenu-icon {
+                              color: #005a9e;
+                            }
+                            &:active .ms-ContextualMenu-submenuIcon {
+                              color: #323130;
                             }
                             .ms-Fabric--isFocusVisible &:focus {
                               background-color: #ffffff;
                             }
-                            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
-                              -ms-high-contrast-adjust: none;
-                              background-color: Highlight;
-                              border-color: Highlight;
-                              color: HighlightText;
-                              forced-color-adjust: none;
-                            }
                             .ms-Fabric--isFocusVisible &:focus:hover {
                               background-color: #ffffff;
-                            }
-                            @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:hover {
-                              -ms-high-contrast-adjust: none;
-                              background-color: Highlight;
-                              border-color: Highlight;
-                              color: HighlightText;
-                              forced-color-adjust: none;
                             }
                             .ms-Fabric--isFocusVisible &:hover {
                               background: inherit;
@@ -478,9 +462,6 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                                 }
                                 @media only screen and (min-width: 0px) and (max-width: 639px){& {
                                   font-size: 16px;
-                                }
-                                @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
-                                  color: HighlightText;
                                 }
                             data-icon-name="ChevronRight"
                           >


### PR DESCRIPTION
fixes #22137

- [ ] Merge into 8.x
- [ ] Cherry-pick into 7.x

Removed most of the focus overrides so that control would have normal high contrast focus styles. The "selected blue" high contrast color should only be used for denoting selection as in dropdown or combobox. 

This change drastically reduces the number of overrides we are doing, and fixes a number of high contrast color issues

OLD
![HCM_contextMenu_old](https://user-images.githubusercontent.com/1434956/163489238-5fcf0fec-c773-4f7a-945f-0d2b0661ae01.gif)


NEW
![HCM_contextMenu](https://user-images.githubusercontent.com/1434956/163489268-2a670c47-426f-484a-9804-ead3c399e3d8.gif)

