### PR TITLE
Spin button/alternate appearances

### DIFF
--- a/packages/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -4,7 +4,6 @@ import {
   resolveShorthand,
   useControllableState,
   useMergedEventCallbacks,
-  useMergedRefs,
   useTimeout,
 } from '@fluentui/react-utilities';
 import * as Keys from '@fluentui/keyboard-keys';
@@ -35,16 +34,6 @@ const MAX_SPIN_TIME_MS = 1000;
 // Exact easing it to be defined. Once it is we'll likely
 // pull this out into a util function in the SpinButton package.
 const lerp = (start: number, end: number, percent: number): number => start + (end - start) * percent;
-
-// TODO: discuss this with design
-// const selectEntireRange = (input: HTMLInputElement | null): void => {
-//   if (!input) {
-//     return;
-//   }
-
-//   input.focus();
-//   input.setSelectionRange(0, input.value.length);
-// };
 
 /**
  * Create the state required to render SpinButton.
@@ -104,8 +93,6 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     spinDelay: DEFAULT_SPIN_DELAY_MS,
   });
 
-  const inputRef = React.useRef<HTMLInputElement>(null);
-
   const state: SpinButtonState = {
     size,
     appearance,
@@ -125,7 +112,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     input: resolveShorthand(input, {
       required: true,
       defaultProps: {
-        ref: useMergedRefs(ref, inputRef),
+        ref,
         autoComplete: 'off',
         role: 'spinbutton',
         appearance: appearance,
@@ -168,13 +155,6 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     }
     setTextValue(newTextValue);
   }, [value, displayValue, currentValue, precision, setAtBound, min, max]);
-
-  // TODO: see TODO at the top of this file for selectEntireRange
-  // React.useEffect(() => {
-  //   if (spinState !== 'rest') {
-  //     selectEntireRange(inputRef.current);
-  //   }
-  // }, [textValue, spinState]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (inputType === 'spinners-only') {

--- a/packages/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -4,6 +4,7 @@ import {
   resolveShorthand,
   useControllableState,
   useMergedEventCallbacks,
+  useMergedRefs,
   useTimeout,
 } from '@fluentui/react-utilities';
 import * as Keys from '@fluentui/keyboard-keys';
@@ -34,6 +35,16 @@ const MAX_SPIN_TIME_MS = 1000;
 // Exact easing it to be defined. Once it is we'll likely
 // pull this out into a util function in the SpinButton package.
 const lerp = (start: number, end: number, percent: number): number => start + (end - start) * percent;
+
+// TODO: discuss this with design
+// const selectEntireRange = (input: HTMLInputElement | null): void => {
+//   if (!input) {
+//     return;
+//   }
+
+//   input.focus();
+//   input.setSelectionRange(0, input.value.length);
+// };
 
 /**
  * Create the state required to render SpinButton.
@@ -93,6 +104,8 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     spinDelay: DEFAULT_SPIN_DELAY_MS,
   });
 
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
   const state: SpinButtonState = {
     size,
     appearance,
@@ -112,7 +125,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     input: resolveShorthand(input, {
       required: true,
       defaultProps: {
-        ref,
+        ref: useMergedRefs(ref, inputRef),
         autoComplete: 'off',
         role: 'spinbutton',
         appearance: appearance,
@@ -155,6 +168,13 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     }
     setTextValue(newTextValue);
   }, [value, displayValue, currentValue, precision, setAtBound, min, max]);
+
+  // TODO: see TODO at the top of this file for selectEntireRange
+  // React.useEffect(() => {
+  //   if (spinState !== 'rest') {
+  //     selectEntireRange(inputRef.current);
+  //   }
+  // }, [textValue, spinState]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (inputType === 'spinners-only') {

--- a/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -127,12 +127,21 @@ const useRootStyles = makeStyles({
   },
 
   disabled: {
+    '@media (forced-colors: active)': {
+      ...shorthands.borderColor('GrayText'),
+    },
+  },
+
+  outlineDisabled: {
     '::before': {
       ...shorthands.border('1px', 'solid', tokens.colorNeutralStrokeDisabled),
       ...shorthands.borderRadius(tokens.borderRadiusMedium), // because underline doesn't usually have a radius
-      '@media (forced-colors: active)': {
-        ...shorthands.borderColor('GrayText'),
-      },
+    },
+  },
+
+  underlineDisabled: {
+    '::before': {
+      ...shorthands.borderBottom('1px', 'solid', tokens.colorTransparentStrokeDisabled),
     },
   },
 });
@@ -159,7 +168,7 @@ const useButtonStyles = makeStyles({
     outlineStyle: 'none',
     height: '100%',
 
-    ':hover': {
+    ':enabled:hover': {
       cursor: 'pointer',
     },
 
@@ -247,19 +256,16 @@ const useButtonStyles = makeStyles({
     },
   },
 
-  // These designs are not yet finalized so this is copy-paste for the "outline"
-  // appearance.
   underline: {
     backgroundColor: 'transparent',
     color: tokens.colorNeutralForeground3,
-    ...shorthands.borderRadius(0),
     ':enabled': {
       ':hover': {
-        color: tokens.colorNeutralForeground3Hover,
+        color: tokens.colorNeutralForeground3,
         backgroundColor: tokens.colorSubtleBackgroundHover,
       },
       [`:active,&.${spinButtonExtraClassNames.buttonActive}`]: {
-        color: tokens.colorNeutralForeground3Pressed,
+        color: tokens.colorNeutralForeground3,
         backgroundColor: tokens.colorSubtleBackgroundPressed,
       },
     },
@@ -449,6 +455,8 @@ export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButton
     !disabled && appearance === 'underline' && rootStyles.underlineInteractive,
     !disabled && filled && rootStyles.filledInteractive,
     disabled && rootStyles.disabled,
+    disabled && appearance === 'outline' && rootStyles.outlineDisabled,
+    disabled && appearance === 'underline' && rootStyles.underlineDisabled,
     rootClassName, // Make sure any original class name is applied last
   );
 

--- a/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -246,20 +246,6 @@ const useButtonStyles = makeStyles({
     ':disabled': {
       color: tokens.colorNeutralForegroundDisabled,
     },
-    '@media (forced-colors: active)': {
-      color: 'ButtonText',
-      ':enabled': {
-        ':hover': {
-          color: 'ButtonText',
-        },
-        ':active': {
-          color: 'ButtonText',
-        },
-        [`&.${spinButtonExtraClassNames.buttonActive}`]: {
-          color: 'ButtonText',
-        },
-      },
-    },
   },
 
   underline: {
@@ -350,20 +336,6 @@ const useButtonDisabledStyles = makeStyles({
       [`&.${spinButtonExtraClassNames.buttonActive}`]: {
         color: tokens.colorNeutralForegroundDisabled,
         backgroundColor: 'transparent',
-      },
-    },
-    '@media (forced-colors: active)': {
-      color: 'GrayText',
-      ':enabled': {
-        ':hover': {
-          color: 'GrayText',
-        },
-        ':active': {
-          color: 'GrayText',
-        },
-        [`&.${spinButtonExtraClassNames.buttonActive}`]: {
-          color: 'GrayText',
-        },
       },
     },
   },

--- a/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -267,11 +267,15 @@ const useButtonStyles = makeStyles({
     color: tokens.colorNeutralForeground3,
     ':enabled': {
       ':hover': {
-        color: tokens.colorNeutralForeground3,
+        color: tokens.colorNeutralForeground3Hover,
         backgroundColor: tokens.colorSubtleBackgroundHover,
       },
-      [`:active,&.${spinButtonExtraClassNames.buttonActive}`]: {
-        color: tokens.colorNeutralForeground3,
+      ':active': {
+        color: tokens.colorNeutralForeground3Pressed,
+        backgroundColor: tokens.colorSubtleBackgroundPressed,
+      },
+      [`&.${spinButtonExtraClassNames.buttonActive}`]: {
+        color: tokens.colorNeutralForeground3Pressed,
         backgroundColor: tokens.colorSubtleBackgroundPressed,
       },
     },

--- a/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -302,28 +302,22 @@ const useButtonStyles = makeStyles({
     },
   },
   filledLighter: {
-    color: tokens.colorNeutralForeground3,
     backgroundColor: 'transparent',
+    color: tokens.colorNeutralForeground3,
 
-    ':hover': {
-      color: tokens.colorNeutralForeground3BrandHover,
-      backgroundColor: tokens.colorSubtleBackgroundHover,
-    },
-    [`:active,&.${spinButtonExtraClassNames.buttonActive}`]: {
-      color: tokens.colorNeutralForeground3BrandPressed,
-      backgroundColor: tokens.colorSubtleBackgroundPressed,
+    ':enabled': {
+      ':hover': {
+        color: tokens.colorNeutralForeground3Hover,
+        backgroundColor: tokens.colorNeutralBackground1Hover,
+      },
+      [`:active,&.${spinButtonExtraClassNames.buttonActive}`]: {
+        color: tokens.colorNeutralForeground3Pressed,
+        backgroundColor: tokens.colorNeutralBackground1Pressed,
+      },
     },
     ':disabled': {
       color: tokens.colorNeutralForegroundDisabled,
     },
-  },
-
-  filledIncrement: {
-    // clipPath: `inset(1px 1px 0 0 round 0 ${tokens.borderRadiusMedium} 0 0)`,
-  },
-
-  filledDecrement: {
-    // clipPath: `inset(0 1px 1px 0 round 0 0 ${tokens.borderRadiusMedium} 0)`,
   },
 });
 
@@ -478,7 +472,6 @@ export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButton
     buttonStyles.base,
     buttonStyles.incrementButton,
     buttonStyles[appearance],
-    filled && buttonStyles.filledIncrement,
     size === 'small' ? buttonStyles.incrementButtonSmall : buttonStyles.incrementButtonMedium,
     (atBound === 'max' || atBound === 'both') && buttonDisabledStyles.base,
     (atBound === 'max' || atBound === 'both') && buttonDisabledStyles[appearance],
@@ -490,7 +483,6 @@ export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButton
     buttonStyles.base,
     buttonStyles.decrementButton,
     buttonStyles[appearance],
-    filled && buttonStyles.filledDecrement,
     size === 'small' ? buttonStyles.decrementButtonSmall : buttonStyles.decrementButtonMedium,
     (atBound === 'min' || atBound === 'both') && buttonDisabledStyles.base,
     (atBound === 'min' || atBound === 'both') && buttonDisabledStyles[appearance],

--- a/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -144,6 +144,12 @@ const useRootStyles = makeStyles({
       ...shorthands.borderBottom('1px', 'solid', tokens.colorTransparentStrokeDisabled),
     },
   },
+
+  filledDisabled: {
+    '::before': {
+      ...shorthands.border('1px', 'solid', tokens.colorTransparentStrokeDisabled),
+    },
+  },
 });
 
 const useInputStyles = makeStyles({
@@ -279,12 +285,16 @@ const useButtonStyles = makeStyles({
 
     ':enabled': {
       ':hover': {
-        color: tokens.colorNeutralForeground3BrandHover,
-        backgroundColor: tokens.colorSubtleBackgroundHover,
+        color: tokens.colorNeutralForeground3Hover,
+        backgroundColor: tokens.colorNeutralBackground3Hover,
       },
-      [`:active,&.${spinButtonExtraClassNames.buttonActive}`]: {
-        color: tokens.colorNeutralForeground3BrandPressed,
-        backgroundColor: tokens.colorSubtleBackgroundPressed,
+      ':active': {
+        color: tokens.colorNeutralForeground3Pressed,
+        backgroundColor: tokens.colorNeutralBackground3Pressed,
+      },
+      [`&.${spinButtonExtraClassNames.buttonActive}`]: {
+        color: tokens.colorNeutralForeground3Pressed,
+        backgroundColor: tokens.colorNeutralBackground3Pressed,
       },
     },
     ':disabled': {
@@ -309,11 +319,11 @@ const useButtonStyles = makeStyles({
   },
 
   filledIncrement: {
-    clipPath: `inset(1px 1px 0 0 round 0 ${tokens.borderRadiusMedium} 0 0)`,
+    // clipPath: `inset(1px 1px 0 0 round 0 ${tokens.borderRadiusMedium} 0 0)`,
   },
 
   filledDecrement: {
-    clipPath: `inset(0 1px 1px 0 round 0 0 ${tokens.borderRadiusMedium} 0)`,
+    // clipPath: `inset(0 1px 1px 0 round 0 0 ${tokens.borderRadiusMedium} 0)`,
   },
 });
 
@@ -451,12 +461,14 @@ export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButton
     rootStyles.base,
     appearance === 'outline' && rootStyles.outline,
     appearance === 'underline' && rootStyles.underline,
+    filled && rootStyles.filled,
     !disabled && appearance === 'outline' && rootStyles.outlineInteractive,
     !disabled && appearance === 'underline' && rootStyles.underlineInteractive,
     !disabled && filled && rootStyles.filledInteractive,
     disabled && rootStyles.disabled,
     disabled && appearance === 'outline' && rootStyles.outlineDisabled,
     disabled && appearance === 'underline' && rootStyles.underlineDisabled,
+    disabled && filled && rootStyles.filledDisabled,
     rootClassName, // Make sure any original class name is applied last
   );
 


### PR DESCRIPTION
This should only be merged after #22489 is merged.

## Current Behavior

The styles for the `underline`, `filledDarker` and `filledLighter` appearances are not complete.

## New Behavior

The styles for the `underline`, `filledDarker` and `filledLighter` appearances are complete.

## Related Issue(s)

#22307