### PR TITLE
22476 Fix panel custom navigation padding

### DIFF
--- a/apps/vr-tests/src/stories/Panel.stories.tsx
+++ b/apps/vr-tests/src/stories/Panel.stories.tsx
@@ -83,6 +83,14 @@ storiesOf('Panel', module)
       hasCloseButton={false}
     />
   ))
+  .addStory('With custom navigation', () => (
+    <Panel
+      {...defaultProps}
+      type={PanelType.smallFixedFar}
+      headerText="custom navigation"
+      onRenderNavigation={() => <DefaultButton>clickme</DefaultButton>}
+    />
+  ))
   .addStory('With no header, close button', () => (
     <Panel {...defaultProps} type={PanelType.smallFixedFar} hasCloseButton={true} />
   ))

--- a/change/@fluentui-react-9c0e56bd-4965-4331-a39d-3d5fc5c5a528.json
+++ b/change/@fluentui-react-9c0e56bd-4965-4331-a39d-3d5fc5c5a528.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Panel: fix extra margin when custom navigation is used",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -268,7 +268,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         },
       },
       hasCustomNavigation && {
-        marginTop: 'inherit',
+        paddingTop: 'inherit',
       },
       // - Ensures that the sticky header always has a background to prevent overlaps on scroll.
       // - Adds consistent behavior with how Footer is being handled


### PR DESCRIPTION
Fixes #22476

Previous PR changed navigation spacing from margin to padding, but did not change the `hasCustomNavigation` margin reset, to a padding reset.

Also added VR test to ensure that this would be caught in the future. 