### PR TITLE
useThemeProviderState should only memoize on the content but not the reference to the object

### DIFF
--- a/change/@fluentui-react-6be597d9-258c-4f12-bfe5-84919e37c1d2.json
+++ b/change/@fluentui-react-6be597d9-258c-4f12-bfe5-84919e37c1d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "useThemeProviderState should only memoize on the content but not the reference to the object",
+  "packageName": "@fluentui/react",
+  "email": "jarmit@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/utilities/ThemeProvider/useThemeProviderState.tsx
+++ b/packages/react/src/utilities/ThemeProvider/useThemeProviderState.tsx
@@ -39,7 +39,7 @@ export const useThemeProviderState = (draftState: ThemeProviderState) => {
     mergedTheme.id = getThemeId(parentTheme, userTheme);
 
     return mergedTheme;
-  }, [parentTheme, userTheme]));
+  }, [parentTheme, JSON.stringify(userTheme)]));
 
   draftState.customizerContext = React.useMemo<ICustomizerContext>(
     () => ({


### PR DESCRIPTION
…reference to the object

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
