### PR TITLE
theming-designer: Adding neutralSecondaryAlt to theming-designer and removing deprecation from neutralSecondaryAlt

### DIFF
--- a/apps/theming-designer/src/components/FabricPalette.tsx
+++ b/apps/theming-designer/src/components/FabricPalette.tsx
@@ -233,15 +233,16 @@ export const FabricPalette: React.FunctionComponent<IFabricPaletteProps> = (prop
               />
             </Text>
             <Text as="td">{themeRules[FabricSlots[FabricSlots.themeLight]].color.str}</Text>
+
             <Text as="td">
               <FabricSlotWidget
-                slotRule={themeRules[FabricSlots[FabricSlots.white]]}
-                slot={FabricSlots.white}
+                slotRule={themeRules[FabricSlots[FabricSlots.neutralSecondaryAlt]]}
+                slot={FabricSlots.neutralSecondaryAlt}
                 onFabricPaletteColorChange={onFabricPaletteColorChange}
                 directionalHint={DirectionalHint.leftCenter}
               />
             </Text>
-            <Text as="td">{themeRules[FabricSlots[FabricSlots.white]].color.str}</Text>
+            <Text as="td">{themeRules[FabricSlots[FabricSlots.neutralSecondaryAlt]].color.str}</Text>
           </tr>
           <tr>
             <Text as="td">
@@ -253,6 +254,15 @@ export const FabricPalette: React.FunctionComponent<IFabricPaletteProps> = (prop
               />
             </Text>
             <Text as="td">{themeRules[FabricSlots[FabricSlots.themeLighter]].color.str}</Text>
+            <Text as="td">
+              <FabricSlotWidget
+                slotRule={themeRules[FabricSlots[FabricSlots.white]]}
+                slot={FabricSlots.white}
+                onFabricPaletteColorChange={onFabricPaletteColorChange}
+                directionalHint={DirectionalHint.leftCenter}
+              />
+            </Text>
+            <Text as="td">{themeRules[FabricSlots[FabricSlots.white]].color.str}</Text>
           </tr>
           <tr>
             <Text as="td">

--- a/change/@fluentui-react-c3023df6-2bb7-4f00-a349-3e42553cce2d.json
+++ b/change/@fluentui-react-c3023df6-2bb7-4f00-a349-3e42553cce2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding neutralSecondaryAlt to Theming designer and 'dedeprecating' it from Fabric slots.",
+  "packageName": "@fluentui/react",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1549,9 +1549,9 @@ export { FabricPerformance }
 // @public (undocumented)
 export enum FabricSlots {
     // (undocumented)
-    black = 20,
+    black = 21,
     // (undocumented)
-    neutralDark = 19,
+    neutralDark = 20,
     // (undocumented)
     neutralLight = 11,
     // (undocumented)
@@ -1559,15 +1559,17 @@ export enum FabricSlots {
     // (undocumented)
     neutralLighterAlt = 9,
     // (undocumented)
-    neutralPrimary = 18,
+    neutralPrimary = 19,
     // (undocumented)
-    neutralPrimaryAlt = 17,
+    neutralPrimaryAlt = 18,
     // (undocumented)
     neutralQuaternary = 13,
     // (undocumented)
     neutralQuaternaryAlt = 12,
     // (undocumented)
-    neutralSecondary = 16,
+    neutralSecondary = 17,
+    // (undocumented)
+    neutralSecondaryAlt = 16,
     // (undocumented)
     neutralTertiary = 15,
     // (undocumented)
@@ -1591,7 +1593,7 @@ export enum FabricSlots {
     // (undocumented)
     themeTertiary = 4,
     // (undocumented)
-    white = 21
+    white = 22
 }
 
 // @public

--- a/packages/react/src/components/ThemeGenerator/ThemeRulesStandard.ts
+++ b/packages/react/src/components/ThemeGenerator/ThemeRulesStandard.ts
@@ -38,7 +38,7 @@ export enum FabricSlots {
   neutralQuaternary, // BaseSlots.backgroundColor, Shade[Shade.Shade5]);
   neutralTertiaryAlt, // BaseSlots.backgroundColor, Shade[Shade.Shade6]); // bg6 or fg2
   neutralTertiary, // BaseSlots.foregroundColor, Shade[Shade.Shade3]);
-  // deprecated: neutralSecondaryAlt, // BaseSlots.foregroundColor, Shade[Shade.Shade4]);
+  neutralSecondaryAlt, // BaseSlots.foregroundColor, Shade[Shade.Shade4]);
   neutralSecondary, // BaseSlots.foregroundColor, Shade[Shade.Shade5]);
   neutralPrimaryAlt, // BaseSlots.foregroundColor, Shade[Shade.Shade6]);
   neutralPrimary, // BaseSlots.foregroundColor, Shade[Shade.Unshaded]);
@@ -135,6 +135,7 @@ export function themeRulesStandardCreator(): IThemeRules {
   _makeFabricSlotRule(FabricSlots[FabricSlots.neutralTertiaryAlt], BaseSlots.backgroundColor, Shade.Shade6, true);
   _makeFabricSlotRule(FabricSlots[FabricSlots.neutralTertiary], BaseSlots.foregroundColor, Shade.Shade3);
   _makeFabricSlotRule(FabricSlots[FabricSlots.neutralSecondary], BaseSlots.foregroundColor, Shade.Shade4);
+  _makeFabricSlotRule(FabricSlots[FabricSlots.neutralSecondaryAlt], BaseSlots.foregroundColor, Shade.Shade4);
   _makeFabricSlotRule(FabricSlots[FabricSlots.neutralPrimaryAlt], BaseSlots.foregroundColor, Shade.Shade5);
   _makeFabricSlotRule(FabricSlots[FabricSlots.neutralPrimary], BaseSlots.foregroundColor, Shade.Unshaded);
   _makeFabricSlotRule(FabricSlots[FabricSlots.neutralDark], BaseSlots.foregroundColor, Shade.Shade7);
@@ -153,6 +154,7 @@ export function themeRulesStandardCreator(): IThemeRules {
   slotRules[FabricSlots[FabricSlots.neutralDark]].color = getColorFromString('#201f1e');
   slotRules[FabricSlots[FabricSlots.neutralPrimaryAlt]].color = getColorFromString('#3b3a39');
   slotRules[FabricSlots[FabricSlots.neutralSecondary]].color = getColorFromString('#605e5c');
+  slotRules[FabricSlots[FabricSlots.neutralSecondaryAlt]].color = getColorFromString('#8a8886');
   slotRules[FabricSlots[FabricSlots.neutralTertiary]].color = getColorFromString('#a19f9d');
   slotRules[FabricSlots[FabricSlots.white]].color = getColorFromString('#ffffff');
 
@@ -176,6 +178,7 @@ export function themeRulesStandardCreator(): IThemeRules {
   slotRules[FabricSlots[FabricSlots.neutralDark]].isCustomized = true;
   slotRules[FabricSlots[FabricSlots.neutralPrimaryAlt]].isCustomized = true;
   slotRules[FabricSlots[FabricSlots.neutralSecondary]].isCustomized = true;
+  slotRules[FabricSlots[FabricSlots.neutralSecondaryAlt]].isCustomized = true;
   slotRules[FabricSlots[FabricSlots.neutralTertiary]].isCustomized = true;
   slotRules[FabricSlots[FabricSlots.white]].isCustomized = true;
 


### PR DESCRIPTION
This PR adds neutralSecondaryAlt to the theming designer and dedeprecates it from FabricSlots inside Theme Generator.

## Current Behavior

Theme table
<img width="847" alt="image" src="https://user-images.githubusercontent.com/5953191/163700280-51b5c014-0439-4908-8f4a-1eb3ae2663a0.png">

Theme export
<img width="225" alt="image" src="https://user-images.githubusercontent.com/5953191/163700325-ecb9dabb-78db-4397-958e-fd32c5edfb51.png">


## New Behavior

Theme table
<img width="897" alt="image" src="https://user-images.githubusercontent.com/5953191/163700232-a6db362f-7fd8-4e83-b97e-275eef3d681d.png">

Theme export
<img width="255" alt="image" src="https://user-images.githubusercontent.com/5953191/163700215-f9b4c6ca-97ad-481e-9af9-34e17ef9672a.png">

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22222
