### PR TITLE
fluentui/utilities: update object tests

### DIFF
--- a/packages/utilities/src/object.test.ts
+++ b/packages/utilities/src/object.test.ts
@@ -41,16 +41,34 @@ describe('mapEnumByName', () => {
       fourth,
     }
 
-    let result: string[] = [];
-    mapEnumByName(Foo, (name: string) => {
-      if (name) {
-        result.push(name);
-      } else {
-        expect(name).not.toBeFalsy;
-      }
+    const result = mapEnumByName(Foo, (name: string) => {
+      return name;
     });
 
     expect(result).toEqual(['first', 'second', 'third', 'fourth']);
+  });
+
+  it('filters undefined values', () => {
+    enum Foo {
+      first,
+      second,
+      third,
+      fourth,
+    }
+
+    const result = mapEnumByName(Foo, (name: string) => {
+      if (name === 'first' || name === 'third') {
+        return name;
+      }
+
+      if (name === 'second') {
+        return undefined;
+      }
+
+      return null;
+    });
+
+    expect(result).toEqual(['first', 'third']);
   });
 });
 


### PR DESCRIPTION
## Current Behavior

The test case for `@fluentui/utilities`' `mapEnumByName()` function has an assertion that is never called as the code is `.toBeFalsey` but should be `.toBeFalsey()`.

See #21599

## New Behavior

On further consideration the assertion in question is unnecessary and the test has been rewritten to eliminate it. As `mapEnumByName()` also has a filtering feature another test case has been added to verify this functionality.

## Related Issue(s)

Fixes #21599
