### PR TITLE
Dropdown: add dismissMenu handle to match Combobox

### DIFF
--- a/change/@fluentui-react-79ae01f0-33af-4c17-99c0-af759fff0142.json
+++ b/change/@fluentui-react-79ae01f0-33af-4c17-99c0-af759fff0142.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add dismissMenu prop to Dropdown",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -5409,6 +5409,7 @@ export interface IDragOptions {
 
 // @public (undocumented)
 export interface IDropdown {
+    dismissMenu: () => void;
     // (undocumented)
     focus: (shouldOpenOnFocus?: boolean) => void;
     readonly selectedOptions: IDropdownOption[];

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -411,6 +411,14 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     );
   }
 
+  /**
+   * Close menu callout if it is open
+   */
+  public dismissMenu = (): void => {
+    const { isOpen } = this.state;
+    isOpen && this.setState({ isOpen: false });
+  };
+
   public focus(shouldOpenOnFocus?: boolean): void {
     if (this._dropDown.current) {
       this._dropDown.current.focus();

--- a/packages/react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.test.tsx
@@ -410,6 +410,18 @@ describe('Dropdown', () => {
       expect(queryByRole('listbox')).toBeFalsy();
     });
 
+    it('closes when dismissMenu() is called', () => {
+      const dropdown = React.createRef<IDropdown>();
+      const { getByRole, queryByRole } = render(<Dropdown componentRef={dropdown} options={DEFAULT_OPTIONS} />);
+
+      userEvent.click(getByRole('combobox'));
+      expect(queryByRole('listbox')).toBeTruthy();
+
+      dropdown.current?.dismissMenu();
+
+      expect(queryByRole('listbox')).toBeFalsy();
+    });
+
     it('uses item title attribute if provided', () => {
       const options: IDropdownOption[] = [{ key: 'a', text: 'a', title: 'b' }];
       const { getByRole } = render(<Dropdown options={options} />);

--- a/packages/react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.types.ts
@@ -19,6 +19,11 @@ export interface IDropdown {
    */
   readonly selectedOptions: IDropdownOption[];
 
+  /**
+   * An imperative handle to dismiss the popup if it is open
+   */
+  dismissMenu: () => void;
+
   focus: (shouldOpenOnFocus?: boolean) => void;
 }
 


### PR DESCRIPTION
A team requested a means to close the listbox popup for the Dropdown control. We currently have `dismissMenu` [on Combobox](https://github.com/microsoft/fluentui/blob/master/packages/react/src/components/ComboBox/ComboBox.tsx#L510), but not Dropdown, this PR adds the same handle to Dropdown.