### PR TITLE
Update Window interface to add FabricConfig

### DIFF
--- a/change/@fluentui-font-icons-mdl2-e8c50c7c-8ceb-4308-9be1-27a2797a7a1e.json
+++ b/change/@fluentui-font-icons-mdl2-e8c50c7c-8ceb-4308-9be1-27a2797a7a1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Window interface to add FabricConfig",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -26,8 +26,9 @@ const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_2
 declare global {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   interface Window {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    FabricConfig: any;
+    FabricConfig?: {
+      fontBaseUrl?: string;
+    };
   }
 }
 


### PR DESCRIPTION
This PR aligns the `Window` interface in v8 font-icons-mdl2 with the interface in v7