### PR TITLE
react-combobox: dismiss on blur, fix tab-to-select

### DIFF
--- a/packages/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-combobox/etc/react-combobox.api.md
@@ -32,7 +32,7 @@ export type ComboboxOpenChangeData = {
 };
 
 // @public (undocumented)
-export type ComboboxOpenEvents = React_2.MouseEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement>;
+export type ComboboxOpenEvents = React_2.MouseEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement> | React_2.FocusEvent<HTMLElement>;
 
 // @public
 export type ComboboxProps = ComponentProps<Partial<ComboboxSlots>, 'trigger'> & ComboboxCommons & SelectionProps & {

--- a/packages/react-combobox/src/components/Combobox/Combobox.types.ts
+++ b/packages/react-combobox/src/components/Combobox/Combobox.types.ts
@@ -108,4 +108,7 @@ export type ComboboxOpenChangeData = {
 };
 
 /* Possible event types for onOpen */
-export type ComboboxOpenEvents = React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;
+export type ComboboxOpenEvents =
+  | React.MouseEvent<HTMLElement>
+  | React.KeyboardEvent<HTMLElement>
+  | React.FocusEvent<HTMLElement>;

--- a/packages/react-combobox/src/utils/dropdownKeyActions.ts
+++ b/packages/react-combobox/src/utils/dropdownKeyActions.ts
@@ -17,6 +17,7 @@ export type DropdownActions =
   | 'PageUp'
   | 'Previous'
   | 'Select'
+  | 'Tab'
   | 'Type';
 
 export interface DropdownActionOptions {
@@ -54,7 +55,7 @@ export function getDropdownActionFromKey(
   if ((code === keys.ArrowUp && altKey) || code === keys.Enter || (!multiselect && code === keys.Space)) {
     return 'CloseSelect';
   }
-  if (code === keys.Tab || (multiselect && code === keys.Space)) {
+  if (multiselect && code === keys.Space) {
     return 'Select';
   }
   if (code === keys.Escape) {
@@ -79,6 +80,9 @@ export function getDropdownActionFromKey(
   }
   if (code === keys.PageDown) {
     return 'PageDown';
+  }
+  if (code === keys.Tab) {
+    return 'Tab';
   }
 
   // if nothing matched, return none


### PR DESCRIPTION
This fixes a few behavior issues in Combobox vNext:
- The popup should dismiss on blur
- clicking listbox options shouldn't move focus away from the trigger
- Tabbing away from the open listbox should select the current item and close the listbox (previously it wasn't closing the listbox)