### PR TITLE
chore: enable React 18 in peerDependencies for react-component-event-listener & react-component-ref

### DIFF
--- a/packages/fluentui/react-component-event-listener/package.json
+++ b/packages/fluentui/react-component-event-listener/package.json
@@ -23,8 +23,8 @@
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",
   "peerDependencies": {
-    "react": "^16.8.0 || ^17",
-    "react-dom": "^16.8.0 || ^17"
+    "react": "^16.8.0 || ^17 || ^18",
+    "react-dom": "^16.8.0 || ^17 || ^18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fluentui/react-component-ref/package.json
+++ b/packages/fluentui/react-component-ref/package.json
@@ -22,8 +22,8 @@
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",
   "peerDependencies": {
-    "react": "^16.8.0 || ^17",
-    "react-dom": "^16.8.0 || ^17"
+    "react": "^16.8.0 || ^17 || ^18",
+    "react-dom": "^16.8.0 || ^17 || ^18"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## New Behavior

React 18 in allowed in `peerDependencies` for `@fluentui/react-component-event-listener` & `@fluentui/react-component-ref`. Unblocks https://github.com/Semantic-Org/Semantic-UI-React/issues/4354.

P.S. I tested these packages with Semantic UI React (types don't throw, event handlers work), they work with React 18.

