### PR TITLE
Added hook for checking visibility of items or groups

### DIFF
--- a/packages/react-priority-overflow/etc/react-priority-overflow.api.md
+++ b/packages/react-priority-overflow/etc/react-priority-overflow.api.md
@@ -73,6 +73,12 @@ export function useOverflowMenu<TElement extends HTMLElement>(id?: string): {
     isOverflowing: boolean;
 };
 
+// @public
+export const useOverflowVisibility: () => {
+    isItemVisible: (id: string) => boolean;
+    isGroupVisible: (id: string) => OverflowGroupState;
+};
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/react-priority-overflow/src/index.ts
+++ b/packages/react-priority-overflow/src/index.ts
@@ -8,6 +8,7 @@ export { updateVisibilityAttribute, useOverflowContainer } from './useOverflowCo
 export { useOverflowCount } from './useOverflowCount';
 export { useOverflowItem } from './useOverflowItem';
 export { useOverflowMenu } from './useOverflowMenu';
+export { useOverflowVisibility } from './useOverflowVisibility';
 
 export type { OverflowItemProps } from './components/OverflowItem/OverflowItem.types';
 export { OverflowItem } from './components/OverflowItem/OverflowItem';

--- a/packages/react-priority-overflow/src/useOverflowVisibility.ts
+++ b/packages/react-priority-overflow/src/useOverflowVisibility.ts
@@ -1,0 +1,14 @@
+import { useOverflowContext } from './overflowContext';
+
+/**
+ * Provides visibility methods for multiple items or groups.
+ */
+export const useOverflowVisibility = () => {
+  const itemVisibility = useOverflowContext(ctx => ctx.itemVisibility);
+  const groupVisibility = useOverflowContext(ctx => ctx.groupVisibility);
+
+  return {
+    isItemVisible: (id: string) => itemVisibility[id],
+    isGroupVisible: (id: string) => groupVisibility[id],
+  };
+};


### PR DESCRIPTION
## Changes

- Added a hook to allow callers to inspect the visibility of multiple items or groups without accessing the underlying Record<TKey,TItem> structures.
- This is necessary in cases where a component is building a list of the items (like a menu).  Calling the useOverflowItemVisibile or useOverflowGroupVisible hooks for each item would be impractical and possibly create conditional hook calls.