### PR TITLE
Override outline added by MWF

### DIFF
--- a/apps/public-docsite/src/styles/_base.scss
+++ b/apps/public-docsite/src/styles/_base.scss
@@ -35,6 +35,19 @@
     border: none;
   }
 
+  // Remove dotted outline added by MWF's main.css
+  [contentEditable=true]:focus,
+  [tabindex]:focus,
+  a[href]:focus,
+  area[href]:focus,
+  button:focus,
+  iframe:focus,
+  input:focus,
+  select:focus,
+  textarea:focus {
+    outline: none !important;
+  }
+
   // Example card headers
   .ExampleCard-title {
     @include ms-fontSize-20;


### PR DESCRIPTION
Seems a new MWF set of styles was added to our page recently (Yeah bootstrap). Most of the styles aren't an issue, but this one is pretty painful and confusing for docs consumers. 

Hopefully this hack is temporary as I have opened up a ticket with the MWF team to try to resolve this.

![image](https://user-images.githubusercontent.com/1434956/164071095-587de025-9347-4689-9ed9-e3f988cdd3ec.png)

![image](https://user-images.githubusercontent.com/1434956/164071162-1ce3a77b-acad-429b-a7f5-84fd9d4d95a5.png)

![image](https://user-images.githubusercontent.com/1434956/164071282-dc2f2524-e3e0-4c76-985b-f9ff13a4bc31.png)
