### PR TITLE
fix: restore SSRProvider export

### DIFF
--- a/change/@fluentui-react-components-cfd10498-0aa4-45a0-b27f-137c646d3073.json
+++ b/change/@fluentui-react-components-cfd10498-0aa4-45a0-b27f-137c646d3073.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: restore SSRProvider export",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/etc/react-components.api.md
+++ b/packages/react-components/etc/react-components.api.md
@@ -311,6 +311,7 @@ import { splitButtonClassNames } from '@fluentui/react-button';
 import { SplitButtonProps } from '@fluentui/react-button';
 import { SplitButtonSlots } from '@fluentui/react-button';
 import { SplitButtonState } from '@fluentui/react-button';
+import { SSRProvider } from '@fluentui/react-utilities';
 import { StrokeWidthTokens } from '@fluentui/react-theme';
 import { Subheadline } from '@fluentui/react-text';
 import { subheadlineClassName } from '@fluentui/react-text';
@@ -1059,6 +1060,8 @@ export { SplitButtonProps }
 export { SplitButtonSlots }
 
 export { SplitButtonState }
+
+export { SSRProvider }
 
 export { StrokeWidthTokens }
 

--- a/packages/react-components/src/Concepts/SSR.stories.mdx
+++ b/packages/react-components/src/Concepts/SSR.stories.mdx
@@ -14,7 +14,7 @@ For basic instructions on getting Next.js set up, see [Getting Started](https://
 2. Add the Fluent UI dependencies: `@fluentui/react-components`.
 
 ```sh
-yarn add @fluentui/react-components@alpha
+yarn add @fluentui/react-components
 ```
 
 1. Create a `_document.js` file under your `pages` folder with the following content:

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -76,6 +76,7 @@ export {
   getSlots,
   resetIdsForTests,
   resolveShorthand,
+  SSRProvider,
   useId,
   useIsSSR,
   useMergedRefs,


### PR DESCRIPTION
## New Behavior

Restores an export for `SSRProvider` i.e. a regression introduced in #22367.

For context: `SSRProvider` is required for SSR configuration:

![image](https://user-images.githubusercontent.com/14183168/164185788-99b0c4e5-3a0c-4c52-b169-9af24811024d.png)


