### PR TITLE
fix: Bump ts-minbar-react-components to v9

### DIFF
--- a/apps/ts-minbar-test-react-components/package.json
+++ b/apps/ts-minbar-test-react-components/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@fluentui/ts-minbar-test-react-components",
-  "version": "1.0.0",
+  "version": "9.0.0-rc.0",
   "private": true,
   "description": "Testing Fluent UI React Components compatibility with Typescript 3.9",
   "license": "MIT",
   "dependencies": {
-    "@fluentui/react-components": "^9.0.0-rc.6"
+    "@fluentui/react-components": "^9.0.0-rc.7"
   },
   "scripts": {
     "build": "just-scripts build",

--- a/apps/upgrade-examples-v8-v9/package.json
+++ b/apps/upgrade-examples-v8-v9/package.json
@@ -20,7 +20,7 @@
     "@fluentui/react": "^8.66.1",
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/storybook": "^1.0.0",
-    "@fluentui/react-components": "^9.0.0-rc.6",
+    "@fluentui/react-components": "^9.0.0-rc.7",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "tslib": "^2.1.0"

--- a/apps/upgrade-examples-v8-v9/package.json
+++ b/apps/upgrade-examples-v8-v9/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/upgrade-examples-v8-v9",
-  "version": "1.0.0",
+  "version": "9.0.0-rc.0",
   "private": true,
   "description": "A collection of examples demonstrating how to upgrade from v8 to v9",
   "scripts": {
@@ -20,7 +20,7 @@
     "@fluentui/react": "^8.66.1",
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/storybook": "^1.0.0",
-    "@fluentui/react-components": "^9.0.0-rc.6",
+    "@fluentui/react-components": "^9.0.0-rc.7",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "tslib": "^2.1.0"

--- a/apps/upgrade-examples-v8-v9/package.json
+++ b/apps/upgrade-examples-v8-v9/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/upgrade-examples-v8-v9",
-  "version": "9.0.0-rc.0",
+  "version": "1.0.0",
   "private": true,
   "description": "A collection of examples demonstrating how to upgrade from v8 to v9",
   "scripts": {
@@ -20,7 +20,7 @@
     "@fluentui/react": "^8.66.1",
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/storybook": "^1.0.0",
-    "@fluentui/react-components": "^9.0.0-rc.7",
+    "@fluentui/react-components": "^9.0.0-rc.6",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "tslib": "^2.1.0"


### PR DESCRIPTION
So that react-components will get bumped on release

Fixes partially https://github.com/microsoft/fluentui/issues/22559