### PR TITLE
chore(upgrade-examples): opt out from lage orchestration

### DIFF
--- a/apps/upgrade-examples-v8-v9/.eslintrc.json
+++ b/apps/upgrade-examples-v8-v9/.eslintrc.json
@@ -2,9 +2,6 @@
   "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
   "root": true,
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/jsx-no-bind": "off",
-    "deprecation/deprecation": "off",
-    "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../.."] }]
+    "import/no-extraneous-dependencies": "off"
   }
 }

--- a/apps/upgrade-examples-v8-v9/.storybook/main.js
+++ b/apps/upgrade-examples-v8-v9/.storybook/main.js
@@ -1,18 +1,18 @@
-const path = require('path');
-const custom = require('@fluentui/scripts/storybook/webpack.config');
+const rootMain = require('../../../.storybook/main');
+const custom = require('../../../scripts/storybook/webpack.config');
 
-module.exports = {
+module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript' | 'features' | 'previewHead'>} */ ({
   stories: ['../src/**/*.stories.tsx'],
-  core: {
-    builder: 'webpack5',
-  },
-  babel: {},
+  core: rootMain.core,
   typescript: {
-    // disable react-docgen-typescript (totally not needed here, slows things down a lot)
+    // disable react-docgen-typescript (totally not needed here, slows things down a lot) - for v8
     reactDocgen: false,
   },
-  webpackFinal: config => {
-    return custom(config);
+  webpackFinal: (config, options) => {
+    const localConfigV9 = /** @type typeof config */ ({ ...rootMain.webpackFinal(config, options) });
+    const localConfig = custom(localConfigV9);
+
+    return localConfig;
   },
   addons: ['@storybook/addon-actions'],
-};
+});

--- a/apps/upgrade-examples-v8-v9/.storybook/tsconfig.json
+++ b/apps/upgrade-examples-v8-v9/.storybook/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "",
+    "allowJs": true,
+    "checkJs": true,
+    "types": ["static-assets", "environment", "storybook__addons"]
+  },
+  "include": ["../src/**/*.stories.ts", "../src/**/*.stories.tsx", "*.js"]
+}

--- a/apps/upgrade-examples-v8-v9/just.config.ts
+++ b/apps/upgrade-examples-v8-v9/just.config.ts
@@ -1,5 +1,3 @@
-import { preset, task } from '@fluentui/scripts';
+import { preset } from '@fluentui/scripts';
 
 preset();
-
-task('build', 'build:node-lib').cached();

--- a/apps/upgrade-examples-v8-v9/package.json
+++ b/apps/upgrade-examples-v8-v9/package.json
@@ -4,25 +4,21 @@
   "private": true,
   "description": "A collection of examples demonstrating how to upgrade from v8 to v9",
   "scripts": {
-    "build": "just-scripts build",
     "build-storybook": "build-storybook -s ./public -o ./dist/storybook --docs",
     "chromatic": "npx chromatic@6.4.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name build-storybook",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook"
+    "start": "just-scripts dev:storybook",
+    "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "*"
+    "@fluentui/eslint-plugin": "*",
+    "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
-    "@fluentui/react": "^8.66.1",
-    "@fluentui/scripts": "^1.0.0",
-    "@fluentui/storybook": "^1.0.0",
-    "@fluentui/react-components": "^9.0.0-rc.6",
     "react": "16.14.0",
-    "react-dom": "16.14.0",
-    "tslib": "^2.1.0"
+    "react-dom": "16.14.0"
   }
 }

--- a/apps/upgrade-examples-v8-v9/src/stories/ButtonShim.stories.tsx
+++ b/apps/upgrade-examples-v8-v9/src/stories/ButtonShim.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Meta } from '@storybook/react';
+import type { Meta } from '@storybook/react';
 import { Button } from '@fluentui/react-components';
 
 export { DefaultButtonStory as DefaultButton } from './DefaultButtonShim.stories';

--- a/apps/upgrade-examples-v8-v9/src/stories/StackShim.stories.tsx
+++ b/apps/upgrade-examples-v8-v9/src/stories/StackShim.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Meta } from '@storybook/react';
+import type { Meta } from '@storybook/react';
 import { Button, makeStyles } from '@fluentui/react-components';
 import { Checkbox, Dropdown, IDropdownOption, DropdownMenuItemType, Stack, TextField } from '@fluentui/react';
 import { StackShim, StackItemShim } from '../shims/StackShim/index';
@@ -68,8 +68,12 @@ export const StackShimStory = () => {
   const [childrenGapToken, setChildrenGapToken] = React.useState<number | string>('10');
   const [paddingToken, setPaddingToken] = React.useState<number | string>('10px');
 
-  const onCheckboxChange = (ev: React.ChangeEvent<HTMLInputElement>, checked?: boolean) => {
-    const { name } = ev.target;
+  const onCheckboxChange = (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => {
+    if (!ev) {
+      return;
+    }
+
+    const { name } = ev.target as HTMLInputElement;
 
     setState({ ...state, [name]: checked });
   };
@@ -97,6 +101,7 @@ export const StackShimStory = () => {
   };
   const stackItemStyles = { root: { backgroundColor: 'lightblue' } };
   const stackItemShimStyles = shimStyles.stackItem;
+
   return (
     <Stack styles={{ root: { width: '100%' } }}>
       <h1>Stack Playground</h1>

--- a/apps/upgrade-examples-v8-v9/tsconfig.app.json
+++ b/apps/upgrade-examples-v8-v9/tsconfig.app.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": []
+    "lib": ["ES2019", "dom"],
+    "types": ["static-assets", "environment"]
   },
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.stories.ts", "**/*.stories.tsx"],
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/apps/upgrade-examples-v8-v9/tsconfig.app.json
+++ b/apps/upgrade-examples-v8-v9/tsconfig.app.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": []
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/apps/upgrade-examples-v8-v9/tsconfig.json
+++ b/apps/upgrade-examples-v8-v9/tsconfig.json
@@ -1,21 +1,25 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es5",
     "outDir": "lib",
-    "module": "commonjs",
+    "module": "ESNext",
     "jsx": "react",
-    "declaration": true,
     "sourceMap": true,
     "noEmit": true,
     "experimentalDecorators": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
-    "moduleResolution": "node",
     "preserveConstEnums": true,
     "skipLibCheck": true,
-    "types": ["webpack-env", "@storybook/react", "screener-storybook"]
+    "types": []
   },
-  "include": ["src"]
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./.storybook/tsconfig.json"
+    }
+  ]
 }

--- a/apps/upgrade-examples-v8-v9/tsconfig.json
+++ b/apps/upgrade-examples-v8-v9/tsconfig.json
@@ -1,12 +1,17 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2019",
     "outDir": "lib",
     "module": "ESNext",
     "jsx": "react",
     "sourceMap": true,
     "noEmit": true,
+    "isolatedModules": true,
+    "strictPropertyInitialization": false,
+    "strictBindCallApply": false,
+    "strictFunctionTypes": false,
+    "noImplicitThis": false,
     "experimentalDecorators": true,
     "preserveConstEnums": true,
     "skipLibCheck": true,

--- a/scripts/monorepo/findGitRoot.js
+++ b/scripts/monorepo/findGitRoot.js
@@ -3,7 +3,13 @@
 const fs = require('fs');
 const path = require('path');
 
+/**
+ * @type {string}
+ */
 let cwdForGitRoot;
+/**
+ * @type {string}
+ */
 let gitRoot;
 
 function findGitRoot() {

--- a/scripts/read-config.js
+++ b/scripts/read-config.js
@@ -7,16 +7,16 @@ const jju = require('jju');
 /**
  * Read and parse the given config file.
  *
- * @param {string} file Full path to or name of the config file. If no file exists at the location
+ * @param {string} filePath Full path to or name of the config file. If no file exists at the location
  * as given, `file` is assumed to be a config file name and the method will run
  * `findConfig(file)` to find the full path.
  * @param {string} [cwd] optional different cwd
  * @returns {any} Parsed config file contents
  */
-function readConfig(file, cwd) {
-  file = findConfig(file, cwd);
-  if (file && fs.existsSync(file)) {
-    return jju.parse(fs.readFileSync(file, 'utf8'));
+function readConfig(filePath, cwd) {
+  const configFilePath = findConfig(filePath, cwd);
+  if (configFilePath && fs.existsSync(configFilePath)) {
+    return jju.parse(fs.readFileSync(configFilePath, 'utf8'));
   }
 }
 

--- a/scripts/storybook/webpack.config.js
+++ b/scripts/storybook/webpack.config.js
@@ -1,5 +1,12 @@
 // @ts-check
-const IgnoreNotFoundExportWebpackPlugin = require('ignore-not-found-export-webpack-plugin');
+
+/**
+ * @typedef {new (config:{include: RegExp | RegExp[]}) => import('webpack').WebpackPluginInstance} IgnoreNotFoundExportWebpackPlugin
+ */
+
+// @ts-ignore - this plugin ships no types nor are does these exist on DefinitelyTyped repo
+const _IgnoreNotFoundExportWebpackPlugin = require('ignore-not-found-export-webpack-plugin');
+const IgnoreNotFoundExportWebpackPlugin = /** @type {IgnoreNotFoundExportWebpackPlugin} */ (_IgnoreNotFoundExportWebpackPlugin);
 const path = require('path');
 const findGitRoot = require('../monorepo/findGitRoot');
 const getResolveAlias = require('../webpack/getResolveAlias');
@@ -20,68 +27,70 @@ module.exports = config => {
     ],
   };
 
-  config.module.rules.push(
-    {
-      test: /\.(ts|tsx)$/,
-      use: [
-        {
-          loader: require.resolve('ts-loader'),
-          options: {
-            transpileOnly: true,
-            experimentalWatchApi: true,
-            configFile: path.join(process.cwd(), 'tsconfig.json'),
-          },
-        },
-      ],
-    },
-    {
-      test: /\.scss$/,
-      enforce: 'pre',
-      exclude: [/node_modules/],
-      use: [
-        {
-          loader: '@microsoft/loader-load-themed-styles', // creates style nodes from JS strings
-        },
-        {
-          loader: 'css-loader', // translates CSS into CommonJS
-          options: {
-            esModule: false,
-            modules: true,
-            importLoaders: 2,
-          },
-        },
-        {
-          loader: 'postcss-loader',
-          options: {
-            postcssOptions: {
-              plugins: ['autoprefixer'],
+  if (config.module && config.module.rules) {
+    config.module.rules.push(
+      {
+        test: /\.(ts|tsx)$/,
+        use: [
+          {
+            loader: require.resolve('ts-loader'),
+            options: {
+              transpileOnly: true,
+              experimentalWatchApi: true,
+              configFile: path.join(process.cwd(), 'tsconfig.json'),
             },
           },
-        },
-        {
-          loader: 'sass-loader',
-        },
-      ],
-    },
-    {
-      test: /\.(gif|jpg|jpeg|png|svg)$/,
-      loader: 'file-loader',
-      options: {
-        name: '[name].[ext]',
+        ],
       },
-    },
-    {
-      test: /\.(woff|woff2|ttf)$/,
-      loader: 'file-loader',
-      options: {
-        name: '[name].[ext]',
+      {
+        test: /\.scss$/,
+        enforce: 'pre',
+        exclude: [/node_modules/],
+        use: [
+          {
+            loader: '@microsoft/loader-load-themed-styles', // creates style nodes from JS strings
+          },
+          {
+            loader: 'css-loader', // translates CSS into CommonJS
+            options: {
+              esModule: false,
+              modules: true,
+              importLoaders: 2,
+            },
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              postcssOptions: {
+                plugins: ['autoprefixer'],
+              },
+            },
+          },
+          {
+            loader: 'sass-loader',
+          },
+        ],
       },
-    },
-    {
-      test: /\.md$/,
-      loader: 'raw-loader',
-    },
-  );
+      {
+        test: /\.(gif|jpg|jpeg|png|svg)$/,
+        loader: 'file-loader',
+        options: {
+          name: '[name].[ext]',
+        },
+      },
+      {
+        test: /\.(woff|woff2|ttf)$/,
+        loader: 'file-loader',
+        options: {
+          name: '[name].[ext]',
+        },
+      },
+      {
+        test: /\.md$/,
+        loader: 'raw-loader',
+      },
+    );
+  }
 
   config.resolve = {
     ...config.resolve,

--- a/scripts/webpack/getResolveAlias.js
+++ b/scripts/webpack/getResolveAlias.js
@@ -4,6 +4,10 @@ const path = require('path');
 const { findRepoDeps, findGitRoot } = require('../monorepo/index');
 const { readConfig } = require('../read-config');
 
+/**
+ *
+ * @param {string} [entryPoint]
+ */
 function getOutputPath(entryPoint) {
   return entryPoint && entryPoint.includes('dist/es') ? 'dist/es' : 'lib';
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
     "typeRoots": ["node_modules/@types", "./typings"],
     "baseUrl": ".",
     "paths": {
+      "@fluentui/react": ["packages/react/src/index.ts"],
       "@fluentui/keyboard-key": ["packages/keyboard-key/src/index.ts"],
       "@fluentui/keyboard-keys": ["packages/keyboard-keys/src/index.ts"],
       "@fluentui/priority-overflow": ["packages/priority-overflow/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -745,7 +745,9 @@
     "@fluentui/upgrade-examples-v8-v9": {
       "root": "apps/upgrade-examples-v8-v9",
       "projectType": "application",
-      "implicitDependencies": []
+      "sourceRoot": "apps/upgrade-examples-v8-v9/src",
+      "implicitDependencies": [],
+      "tags": ["platform:web", "vNext", "v8"]
     },
     "@fluentui/utilities": {
       "root": "packages/utilities",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- every release of v8 or v9 puts this app into invalid state in terms of versions used as dependency
- any code change in v8 will trigger build for all v9 packages in dep tree and vice versa
- upgrade-examples contains type errors that are not being discovered locally nor on CI
- user needs to build both v8 and v9 to get proper TS DX


## New Behavior

- app is not specifying v9 nor v8 as dependency because it's not needed
- changes in v9 packages wont trigger v8 builds and vice versa
- no type errors
- strict type checking
- no build needed
- TS DX for v9 and v8 like in v9 packages


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22559
