### PR TITLE
react-components: add SpinButton to /unstable

### DIFF
--- a/change/@fluentui-react-components-90303c8d-8d65-4d7f-b703-6e3b33ee6153.json
+++ b/change/@fluentui-react-components-90303c8d-8d65-4d7f-b703-6e3b33ee6153.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "react-components: add SpinButton to /unstable",
+  "packageName": "@fluentui/react-components",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-ccaaea73-5c10-43b2-81d0-3ec98e4a70c0.json
+++ b/change/@fluentui-react-spinbutton-ccaaea73-5c10-43b2-81d0-3ec98e4a70c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "react-spinbutton: remove private from package.json",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -51,6 +51,7 @@
     "@fluentui/react-provider": "9.0.0-rc.6",
     "@fluentui/react-radio": "9.0.0-beta.3",
     "@fluentui/react-slider": "9.0.0-beta.11",
+    "@fluentui/react-spinbutton": "9.0.0-beta.6",
     "@fluentui/react-switch": "9.0.0-rc.6",
     "@fluentui/react-tabs": "9.0.0-beta.9",
     "@fluentui/react-tabster": "9.0.0-rc.6",

--- a/packages/react-components/src/unstable/index.ts
+++ b/packages/react-components/src/unstable/index.ts
@@ -105,6 +105,25 @@ export type {
 } from '@fluentui/react-radio';
 
 export {
+  SpinButton,
+  renderSpinButton_unstable,
+  spinButtonClassNames,
+  useSpinButtonStyles_unstable,
+  useSpinButton_unstable,
+} from '@fluentui/react-spinbutton';
+
+export type {
+  SpinButtonOnChangeData,
+  SpinButtonChangeEvent,
+  SpinButtonProps,
+  SpinButtonSlots,
+  SpinButtonState,
+  SpinButtonSpinState,
+  SpinButtonBounds,
+  SpinButtonStrings,
+} from '@fluentui/react-spinbutton';
+
+export {
   Switch,
   switchClassNames,
   renderSwitch_unstable,

--- a/packages/react-spinbutton/package.json
+++ b/packages/react-spinbutton/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluentui/react-spinbutton",
   "version": "9.0.0-beta.6",
-  "private": true,
   "description": "Fluent UI React SpinButton component.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/react-spinbutton/src/stories/SpinButton.stories.tsx
+++ b/packages/react-spinbutton/src/stories/SpinButton.stories.tsx
@@ -34,7 +34,7 @@ const useDecoratorStyles = makeStyles({
 });
 
 const meta: Meta = {
-  title: 'Components/SpinButton',
+  title: 'Preview Components/SpinButton',
   component: SpinButton,
   parameters: {
     docs: {


### PR DESCRIPTION
## Current Behavior

`SpinButton` is not accessible via `@fluentui/react-components/unstable`

## New Behavior

`SpinButton` is accessible via `@fluentui/react-components/unstable`

## Related Issue(s)

Fixes #22307 
