### PR TITLE
Use options object in overflow manager

### DIFF
--- a/packages/react-priority-overflow/src/useOverflowContainer.ts
+++ b/packages/react-priority-overflow/src/useOverflowContainer.ts
@@ -34,12 +34,12 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
     }
 
     overflowManager.observe(containerRef.current, {
-      overflowDirection,
-      overflowAxis,
-      padding,
-      minimumVisible,
-      onUpdateItemVisibility,
-      onUpdateOverflow: updateOverflowItems,
+      overflowDirection: overflowDirection ?? 'end',
+      overflowAxis: overflowAxis ?? 'horizontal',
+      padding: padding ?? 10,
+      minimumVisible: minimumVisible ?? 0,
+      onUpdateItemVisibility: onUpdateItemVisibility ?? (() => undefined),
+      onUpdateOverflow: updateOverflowItems ?? (() => undefined),
     });
 
     return () => {


### PR DESCRIPTION
## Changes
Updated to use an object for the overflow options in the overflow managers.
This keeps the options in sync with those passed to observe.