### PR TITLE
Combobox vNext: update useOptionCollection to use DOM ordering instead of React.Children

### DIFF
--- a/packages/react-combobox/Spec.md
+++ b/packages/react-combobox/Spec.md
@@ -89,8 +89,8 @@ In contrast, v9 defines options as children of the Combobox control:
 
 ```tsx
 <Combobox>
-  <Option key="A">Option A</Option>
-  <Option key="B">Option B</Option>
+  <Option>Option A</Option>
+  <Option>Option B</Option>
 </Combobox>
 ```
 
@@ -99,12 +99,12 @@ Groups of options in v9 are also defined as children, rather than through the `o
 ```tsx
 <Combobox>
   <OptionGroup label="Group 1">
-    <Option key="A">Option A</Option>
-    <Option key="B">Option B</Option>
+    <Option>Option A</Option>
+    <Option>Option B</Option>
   </OptionGroup>
   <OptionGroup label="Group 2">
-    <Option key="C">Option C</Option>
-    <Option key="D">Option D</Option>
+    <Option>Option C</Option>
+    <Option>Option D</Option>
   </OptionGroup>
 </Combobox>
 ```
@@ -389,8 +389,8 @@ type SimpleOptionProps = {
   /* Sets an option to the `disabled` state */
   disabled?: boolean;
 
-  /** The key is a required prop for Combobox Options */
-  key: string;
+  /** The id of the Option */
+  id: string;
 
   /** Defines a string value for the option, used for the parent Combobox's value */
   value?: string;

--- a/packages/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-combobox/etc/react-combobox.api.md
@@ -49,7 +49,6 @@ export type ComboboxSlots = {
 // @public
 export type ComboboxState = ComponentState<ComboboxSlots> & Required<Pick<ComboboxCommons, 'appearance' | 'open' | 'inline' | 'size'>> & Pick<ComboboxCommons, 'placeholder' | 'value'> & OptionCollectionState & SelectionState & {
     activeOption?: OptionValue;
-    idBase: string;
     onOptionClick(event: React_2.MouseEvent, option: OptionValue): void;
 };
 
@@ -94,7 +93,6 @@ export type ListboxSlots = {
 // @public
 export type ListboxState = ComponentState<ListboxSlots> & OptionCollectionState & SelectionState & {
     activeOption?: OptionValue;
-    idBase: string;
     onOptionClick(event: React_2.MouseEvent, option: OptionValue): void;
 };
 
@@ -129,7 +127,6 @@ export type OptionGroupState = ComponentState<OptionGroupSlots>;
 
 // @public
 export type OptionProps = ComponentProps<Partial<OptionSlots>> & OptionCommons & {
-    fluentKey?: string;
     value?: string;
 };
 

--- a/packages/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-combobox/etc/react-combobox.api.md
@@ -97,18 +97,14 @@ export type ListboxState = ComponentState<ListboxSlots> & OptionCollectionState 
 };
 
 // @public
-const Option_2: ForwardRefComponent<OptionProps> & {
-    fluentComponentType?: string;
-};
+const Option_2: ForwardRefComponent<OptionProps>;
 export { Option_2 as Option }
 
 // @public (undocumented)
 export const optionClassNames: SlotClassNames<OptionSlots>;
 
 // @public
-export const OptionGroup: ForwardRefComponent<OptionGroupProps> & {
-    fluentComponentType?: string;
-};
+export const OptionGroup: ForwardRefComponent<OptionGroupProps>;
 
 // @public (undocumented)
 export const optionGroupClassNames: SlotClassNames<OptionGroupSlots>;

--- a/packages/react-combobox/src/components/Combobox/Combobox.types.ts
+++ b/packages/react-combobox/src/components/Combobox/Combobox.types.ts
@@ -95,9 +95,6 @@ export type ComboboxState = ComponentState<ComboboxSlots> &
     /* Option data for the currently highlighted option (not the selected option) */
     activeOption?: OptionValue;
 
-    /* Unique id string that can be used as a base for default option ids */
-    idBase: string;
-
     /* Callback when an option is clicked, for internal use */
     onOptionClick(event: React.MouseEvent, option: OptionValue): void;
   };

--- a/packages/react-combobox/src/components/Combobox/useCombobox.ts
+++ b/packages/react-combobox/src/components/Combobox/useCombobox.ts
@@ -37,7 +37,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
     size = 'medium',
   } = props;
   const {
-    collectionData: { count, getOptionAtIndex, getIndexOfId, getOptionById },
+    collectionAPI: { getCount, getOptionAtIndex, getIndexOfId, getOptionById },
   } = optionCollection;
 
   const [activeOption, setActiveOption] = React.useState<OptionValue | undefined>();
@@ -191,7 +191,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
   // handle combobox keyboard interaction
   state.trigger.onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     const action = getDropdownActionFromKey(event, { open, multiselect });
-    const maxIndex = count() - 1;
+    const maxIndex = getCount() - 1;
     const activeIndex = activeOption ? getIndexOfId(activeOption.id) : -1;
     let newIndex = activeIndex;
 

--- a/packages/react-combobox/src/components/Combobox/useCombobox.ts
+++ b/packages/react-combobox/src/components/Combobox/useCombobox.ts
@@ -5,7 +5,6 @@ import {
   resolveShorthand,
   useControllableState,
   useFirstMount,
-  useId,
   useMergedRefs,
 } from '@fluentui/react-utilities';
 import { getDropdownActionFromKey, getIndexFromAction } from '../../utils/dropdownKeyActions';
@@ -26,7 +25,7 @@ import type { ComboboxProps, ComboboxState, ComboboxOpenEvents } from './Combobo
  * @param ref - reference to root HTMLElement of Combobox
  */
 export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLButtonElement>): ComboboxState => {
-  const optionCollection = useOptionCollection(props.children);
+  const optionCollection = useOptionCollection();
 
   const {
     appearance = 'outline',
@@ -38,10 +37,8 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
     size = 'medium',
   } = props;
   const {
-    options,
-    collectionData: { count, getOptionAtIndex, getIndexOfKey, getOptionByKey },
+    collectionData: { count, getOptionAtIndex, getIndexOfId, getOptionById },
   } = optionCollection;
-  const idBase = useId('combobox');
 
   const [activeOption, setActiveOption] = React.useState<OptionValue | undefined>();
   const { selectedOptions, selectOption } = useSelection(props);
@@ -97,7 +94,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
 
   const onOptionClick = (event: React.MouseEvent<HTMLElement>, option: OptionValue) => {
     // clicked option should always become active option
-    setActiveOption(getOptionByKey(option.key));
+    setActiveOption(getOptionById(option.id));
 
     // close on option click for single-select
     !multiselect && setOpen(event, false);
@@ -147,11 +144,9 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
     ...optionCollection,
     activeOption,
     appearance,
-    idBase,
     inline,
     onOptionClick,
     open,
-    options,
     selectedOptions,
     size,
     value,
@@ -196,8 +191,8 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
   // handle combobox keyboard interaction
   state.trigger.onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     const action = getDropdownActionFromKey(event, { open, multiselect });
-    const maxIndex = count - 1;
-    const activeIndex = activeOption ? getIndexOfKey(activeOption.key) : -1;
+    const maxIndex = count() - 1;
+    const activeIndex = activeOption ? getIndexOfId(activeOption.id) : -1;
     let newIndex = activeIndex;
 
     switch (action) {

--- a/packages/react-combobox/src/components/Combobox/useCombobox.ts
+++ b/packages/react-combobox/src/components/Combobox/useCombobox.ts
@@ -4,6 +4,7 @@ import {
   getPartitionedNativeProps,
   resolveShorthand,
   useControllableState,
+  useEventCallback,
   useFirstMount,
   useMergedRefs,
 } from '@fluentui/react-utilities';
@@ -36,9 +37,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
     positioning,
     size = 'medium',
   } = props;
-  const {
-    collectionAPI: { getCount, getOptionAtIndex, getIndexOfId, getOptionById },
-  } = optionCollection;
+  const { getCount, getOptionAtIndex, getIndexOfId, getOptionById } = optionCollection;
 
   const [activeOption, setActiveOption] = React.useState<OptionValue | undefined>();
   const { selectedOptions, selectOption } = useSelection(props);
@@ -92,7 +91,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
     setOpenState(newState);
   };
 
-  const onOptionClick = (event: React.MouseEvent<HTMLElement>, option: OptionValue) => {
+  const onOptionClick = useEventCallback((event: React.MouseEvent<HTMLElement>, option: OptionValue) => {
     // clicked option should always become active option
     setActiveOption(getOptionById(option.id));
 
@@ -101,7 +100,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
 
     // handle selection change
     selectOption(event, option);
-  };
+  });
 
   const { primary: triggerNativeProps, root: rootNativeProps } = getPartitionedNativeProps({
     props,

--- a/packages/react-combobox/src/components/Listbox/Listbox.types.ts
+++ b/packages/react-combobox/src/components/Listbox/Listbox.types.ts
@@ -23,9 +23,6 @@ export type ListboxState = ComponentState<ListboxSlots> &
     /* Option data for the currently highlighted option (not the selected option) */
     activeOption?: OptionValue;
 
-    /* Unique id string that can be used as a base for default option ids */
-    idBase: string;
-
     /* Callback when an option is clicked, for internal use */
     onOptionClick(event: React.MouseEvent, option: OptionValue): void;
   };

--- a/packages/react-combobox/src/components/Listbox/__snapshots__/Listbox.test.tsx.snap
+++ b/packages/react-combobox/src/components/Listbox/__snapshots__/Listbox.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`Listbox renders a default state 1`] = `
     class="fui-Listbox"
     role="listbox"
     tabindex="0"
-  />
+  >
+    Default Listbox
+  </div>
 </div>
 `;

--- a/packages/react-combobox/src/components/Listbox/renderListbox.tsx
+++ b/packages/react-combobox/src/components/Listbox/renderListbox.tsx
@@ -10,8 +10,8 @@ export const renderListbox_unstable = (state: ListboxState, contextValues: Listb
   const { slots, slotProps } = getSlots<ListboxSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      <ListboxContext.Provider value={contextValues.listbox}>{state.children}</ListboxContext.Provider>
-    </slots.root>
+    <ListboxContext.Provider value={contextValues.listbox}>
+      <slots.root {...slotProps.root} />
+    </ListboxContext.Provider>
   );
 };

--- a/packages/react-combobox/src/components/Listbox/useListbox.ts
+++ b/packages/react-combobox/src/components/Listbox/useListbox.ts
@@ -20,9 +20,7 @@ import { OptionValue } from '../../utils/OptionCollection.types';
 export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElement>): ListboxState => {
   const { multiselect } = props;
   const optionCollection = useOptionCollection();
-  const {
-    collectionAPI: { getCount, getOptionAtIndex, getOptionById, getIndexOfId },
-  } = optionCollection;
+  const { getCount, getOptionAtIndex, getOptionById, getIndexOfId } = optionCollection;
 
   const { selectedOptions, selectOption } = useSelection(props);
 

--- a/packages/react-combobox/src/components/Listbox/useListbox.ts
+++ b/packages/react-combobox/src/components/Listbox/useListbox.ts
@@ -21,7 +21,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
   const { multiselect } = props;
   const optionCollection = useOptionCollection();
   const {
-    collectionData: { count, getOptionAtIndex, getOptionById, getIndexOfId },
+    collectionAPI: { getCount, getOptionAtIndex, getOptionById, getIndexOfId },
   } = optionCollection;
 
   const { selectedOptions, selectOption } = useSelection(props);
@@ -38,7 +38,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     const action = getDropdownActionFromKey(event, { open: true });
-    const maxIndex = count() - 1;
+    const maxIndex = getCount() - 1;
     const activeIndex = activeOption ? getIndexOfId(activeOption.id) : -1;
     let newIndex = activeIndex;
 
@@ -62,7 +62,6 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
   const hasComboboxContext = useHasParentContext(ComboboxContext);
   const comboboxActiveOption = useContextSelector(ComboboxContext, ctx => ctx.activeOption);
   const comboboxOnOptionClick = useContextSelector(ComboboxContext, ctx => ctx.onOptionClick);
-  // const comboboxRegisterOption = useContextSelector(ComboboxContext, ctx => ctx.registerOption);
   const comboboxSelectedOptions = useContextSelector(ComboboxContext, ctx => ctx.selectedOptions);
 
   // without a parent combobox context, provide values directly from Listbox

--- a/packages/react-combobox/src/components/Listbox/useListbox.ts
+++ b/packages/react-combobox/src/components/Listbox/useListbox.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps } from '@fluentui/react-utilities';
 import { useContextSelector, useHasParentContext } from '@fluentui/react-context-selector';
 import { useSelection } from '../../utils/useSelection';
 import { getDropdownActionFromKey, getIndexFromAction } from '../../utils/dropdownKeyActions';
@@ -19,11 +19,10 @@ import { OptionValue } from '../../utils/OptionCollection.types';
  */
 export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElement>): ListboxState => {
   const { multiselect } = props;
-  const optionCollection = useOptionCollection(props.children);
+  const optionCollection = useOptionCollection();
   const {
-    collectionData: { count, getOptionAtIndex, getOptionByKey, getIndexOfKey },
+    collectionData: { count, getOptionAtIndex, getOptionById, getIndexOfId },
   } = optionCollection;
-  const idBase = useId('listbox');
 
   const { selectedOptions, selectOption } = useSelection(props);
 
@@ -31,7 +30,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
 
   const onOptionClick = (event: React.MouseEvent<HTMLElement>, option: OptionValue) => {
     // clicked option should always become active option
-    setActiveOption(getOptionByKey(option.key));
+    setActiveOption(getOptionById(option.id));
 
     // handle selection change
     selectOption(event, option);
@@ -39,8 +38,8 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     const action = getDropdownActionFromKey(event, { open: true });
-    const maxIndex = count - 1;
-    const activeIndex = activeOption ? getIndexOfKey(activeOption.key) : -1;
+    const maxIndex = count() - 1;
+    const activeIndex = activeOption ? getIndexOfId(activeOption.id) : -1;
     let newIndex = activeIndex;
 
     switch (action) {
@@ -62,7 +61,6 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
   // get state from parent combobox, if it exists
   const hasComboboxContext = useHasParentContext(ComboboxContext);
   const comboboxActiveOption = useContextSelector(ComboboxContext, ctx => ctx.activeOption);
-  const comboboxIdBase = useContextSelector(ComboboxContext, ctx => ctx.idBase);
   const comboboxOnOptionClick = useContextSelector(ComboboxContext, ctx => ctx.onOptionClick);
   // const comboboxRegisterOption = useContextSelector(ComboboxContext, ctx => ctx.registerOption);
   const comboboxSelectedOptions = useContextSelector(ComboboxContext, ctx => ctx.selectedOptions);
@@ -71,13 +69,11 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
   const optionContextValues = hasComboboxContext
     ? {
         activeOption: comboboxActiveOption,
-        idBase: comboboxIdBase,
         onOptionClick: comboboxOnOptionClick,
         selectedOptions: comboboxSelectedOptions,
       }
     : {
         activeOption,
-        idBase,
         onOptionClick,
         selectedOptions,
       };

--- a/packages/react-combobox/src/components/Option/Option.test.tsx
+++ b/packages/react-combobox/src/components/Option/Option.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { resetIdsForTests } from '@fluentui/react-utilities';
 import { render } from '@testing-library/react';
 import { Option } from './Option';
 import { isConformant } from '../../common/isConformant';
@@ -9,6 +10,10 @@ describe('Option', () => {
     displayName: 'Option',
     // don't test deprecated className export on new components
     disabledTests: ['component-has-static-classname-exported'],
+  });
+
+  afterEach(() => {
+    resetIdsForTests();
   });
 
   // TODO add more tests here, and create visual regression tests in /apps/vr-tests

--- a/packages/react-combobox/src/components/Option/Option.tsx
+++ b/packages/react-combobox/src/components/Option/Option.tsx
@@ -8,15 +8,11 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 /**
  * Option component: a styled child option of a Combobox
  */
-export const Option: ForwardRefComponent<OptionProps> & { fluentComponentType?: string } = React.forwardRef(
-  (props, ref) => {
-    const state = useOption_unstable(props, ref);
+export const Option: ForwardRefComponent<OptionProps> = React.forwardRef((props, ref) => {
+  const state = useOption_unstable(props, ref);
 
-    useOptionStyles_unstable(state);
-    return renderOption_unstable(state);
-  },
-);
-
-Option.fluentComponentType = 'Option';
+  useOptionStyles_unstable(state);
+  return renderOption_unstable(state);
+});
 
 Option.displayName = 'Option';

--- a/packages/react-combobox/src/components/Option/Option.types.ts
+++ b/packages/react-combobox/src/components/Option/Option.types.ts
@@ -22,12 +22,6 @@ type OptionCommons = {
 export type OptionProps = ComponentProps<Partial<OptionSlots>> &
   OptionCommons & {
     /*
-     * Internal use only: used to associate Options with their parent Combobox context.
-     * Manually setting this prop is not recommended.
-     */
-    fluentKey?: string;
-
-    /*
      * Defines a string value for the option, used for the parent Combobox's value.
      * Use this if the children are not a string, or you wish the value to differ from the displayed text.
      */

--- a/packages/react-combobox/src/components/Option/__snapshots__/Option.test.tsx.snap
+++ b/packages/react-combobox/src/components/Option/__snapshots__/Option.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Option renders a default state 1`] = `
   <div
     aria-selected="false"
     class="fui-Option"
-    id="fluent-option9"
+    id="fluent-option1"
     role="option"
   >
     <span

--- a/packages/react-combobox/src/components/Option/__snapshots__/Option.test.tsx.snap
+++ b/packages/react-combobox/src/components/Option/__snapshots__/Option.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Option renders a default state 1`] = `
   <div
     aria-selected="false"
     class="fui-Option"
-    id=""
+    id="fluent-option9"
     role="option"
   >
     <span

--- a/packages/react-combobox/src/components/Option/useOption.tsx
+++ b/packages/react-combobox/src/components/Option/useOption.tsx
@@ -32,30 +32,28 @@ function getValueString(value: string | undefined, children: React.ReactNode) {
 export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElement>): OptionState => {
   const { disabled, value } = props;
   const optionRef = React.useRef<HTMLElement>(null);
+  const optionValue = getValueString(value, props.children);
 
   // context values
   const multiselect = useContextSelector(ListboxContext, ctx => ctx.multiselect);
   const onOptionClick = useContextSelector(ListboxContext, ctx => ctx.onOptionClick);
   const registerOption = useContextSelector(ListboxContext, ctx => ctx.registerOption);
-  const selectedOptions = useContextSelector(ListboxContext, ctx => ctx.selectedOptions);
+  const selected = useContextSelector(ListboxContext, ctx => {
+    const selectedOptions = ctx.selectedOptions;
+
+    return !!optionValue && !!selectedOptions.find(option => option.value === optionValue);
+  });
 
   // use the id if provided, otherwise use a generated id
   const defaultId = useId('fluent-option');
   const id = React.useMemo(() => {
     return props.id || defaultId;
-
-    // we only want the id to change if props.id changes
-    // otherwise it needs to be consistent across renders for screen readers
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.id]);
+  }, [props.id, defaultId]);
 
   // current active option?
   const active = useContextSelector(ListboxContext, ctx => {
     return ctx.activeOption?.id !== undefined && ctx.activeOption?.id === id;
   });
-
-  const optionValue = getValueString(value, props.children);
-  const selected = !!optionValue && !!selectedOptions.find(option => option.value === optionValue);
 
   // check icon
   let CheckIcon = <CheckmarkFilled />;
@@ -76,9 +74,7 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
   // register option data with context
   React.useEffect(() => {
     if (id && optionRef.current) {
-      const unregister = registerOption({ id, value: optionValue }, optionRef.current);
-
-      return () => unregister(id);
+      return registerOption({ id, value: optionValue }, optionRef.current);
     }
   }, [registerOption, id, optionValue]);
 

--- a/packages/react-combobox/src/components/Option/useOption.tsx
+++ b/packages/react-combobox/src/components/Option/useOption.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, resolveShorthand, useId, useMergedRefs } from '@fluentui/react-utilities';
 import { useContextSelector } from '@fluentui/react-context-selector';
 import { CheckmarkFilled, CheckboxUncheckedFilled, CheckboxCheckedFilled } from '@fluentui/react-icons';
 import { ListboxContext } from '../../contexts/ListboxContext';
@@ -30,25 +30,32 @@ function getValueString(value: string | undefined, children: React.ReactNode) {
  * @param ref - reference to root HTMLElement of Option
  */
 export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElement>): OptionState => {
-  const { id, fluentKey: key, disabled, value } = props;
+  const { disabled, value } = props;
+  const optionRef = React.useRef<HTMLElement>(null);
 
   // context values
-  const idBase = useContextSelector(ListboxContext, ctx => ctx.idBase);
   const multiselect = useContextSelector(ListboxContext, ctx => ctx.multiselect);
   const onOptionClick = useContextSelector(ListboxContext, ctx => ctx.onOptionClick);
   const registerOption = useContextSelector(ListboxContext, ctx => ctx.registerOption);
   const selectedOptions = useContextSelector(ListboxContext, ctx => ctx.selectedOptions);
 
-  // use the id if provided, otherwise construct id from key & idBase
-  const optionId = id || key ? `${idBase}-${key}` : '';
+  // use the id if provided, otherwise use a generated id
+  const defaultId = useId('fluent-option');
+  const id = React.useMemo(() => {
+    return props.id || defaultId;
+
+    // we only want the id to change if props.id changes
+    // otherwise it needs to be consistent across renders for screen readers
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.id]);
 
   // current active option?
   const active = useContextSelector(ListboxContext, ctx => {
-    return ctx.activeOption?.id !== undefined && ctx.activeOption?.id === optionId;
+    return ctx.activeOption?.id !== undefined && ctx.activeOption?.id === id;
   });
 
-  const selected = key ? !!selectedOptions.find(option => option.key === key) : false;
   const optionValue = getValueString(value, props.children);
+  const selected = !!optionValue && !!selectedOptions.find(option => option.value === optionValue);
 
   // check icon
   let CheckIcon = <CheckmarkFilled />;
@@ -62,16 +69,18 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
       return;
     }
 
-    key && onOptionClick(event, { key, id: optionId, value: optionValue });
+    onOptionClick(event, { id, value: optionValue });
     props.onClick?.(event);
   };
 
   // register option data with context
   React.useEffect(() => {
-    if (key && optionId) {
-      return registerOption({ key, id: optionId, value: optionValue });
+    if (id && optionRef.current) {
+      const unregister = registerOption({ id, value: optionValue }, optionRef.current);
+
+      return () => unregister(id);
     }
-  }, [registerOption, optionId, key, optionValue]);
+  }, [registerOption, id, optionValue]);
 
   return {
     components: {
@@ -79,11 +88,11 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
       checkIcon: 'span',
     },
     root: getNativeElementProps('div', {
-      ref,
+      ref: useMergedRefs(ref, optionRef),
       role: 'option',
       'aria-disabled': disabled ? 'true' : undefined,
       'aria-selected': `${selected}`,
-      id: optionId,
+      id,
       ...props,
       onClick,
     }),

--- a/packages/react-combobox/src/components/OptionGroup/OptionGroup.tsx
+++ b/packages/react-combobox/src/components/OptionGroup/OptionGroup.tsx
@@ -8,15 +8,11 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 /**
  * OptionGroup component: allows grouping of Option components within a Combobox
  */
-export const OptionGroup: ForwardRefComponent<OptionGroupProps> & { fluentComponentType?: string } = React.forwardRef(
-  (props, ref) => {
-    const state = useOptionGroup_unstable(props, ref);
+export const OptionGroup: ForwardRefComponent<OptionGroupProps> = React.forwardRef((props, ref) => {
+  const state = useOptionGroup_unstable(props, ref);
 
-    useOptionGroupStyles_unstable(state);
-    return renderOptionGroup_unstable(state);
-  },
-);
-
-OptionGroup.fluentComponentType = 'OptionGroup';
+  useOptionGroupStyles_unstable(state);
+  return renderOptionGroup_unstable(state);
+});
 
 OptionGroup.displayName = 'OptionGroup';

--- a/packages/react-combobox/src/contexts/ComboboxContext.ts
+++ b/packages/react-combobox/src/contexts/ComboboxContext.ts
@@ -6,20 +6,19 @@ import { ComboboxState } from '../components/Combobox/Combobox.types';
  */
 export type ComboboxContextValue = Pick<
   ComboboxState,
-  'activeOption' | 'appearance' | 'idBase' | 'onOptionClick' | 'open' | 'registerOption' | 'selectedOptions' | 'size'
+  'activeOption' | 'appearance' | 'onOptionClick' | 'open' | 'registerOption' | 'selectedOptions' | 'size'
 >;
 
 export const ComboboxContext = createContext<ComboboxContextValue>({
   activeOption: undefined,
   appearance: 'outline',
-  idBase: '',
   onOptionClick() {
     // noop
   },
   open: false,
   selectedOptions: [],
   registerOption() {
-    // noop
+    return () => undefined;
   },
   size: 'medium',
 });

--- a/packages/react-combobox/src/contexts/ListboxContext.ts
+++ b/packages/react-combobox/src/contexts/ListboxContext.ts
@@ -6,18 +6,17 @@ import { ListboxState } from '../components/Listbox/Listbox.types';
  */
 export type ListboxContextValue = Pick<
   ListboxState,
-  'activeOption' | 'idBase' | 'multiselect' | 'onOptionClick' | 'registerOption' | 'selectedOptions'
+  'activeOption' | 'multiselect' | 'onOptionClick' | 'registerOption' | 'selectedOptions'
 >;
 
 export const ListboxContext = createContext<ListboxContextValue>({
   activeOption: undefined,
-  idBase: '',
   multiselect: false,
   onOptionClick() {
     // noop
   },
   registerOption() {
-    // noop
+    return () => undefined;
   },
   selectedOptions: [],
 });

--- a/packages/react-combobox/src/contexts/useComboboxContextValues.ts
+++ b/packages/react-combobox/src/contexts/useComboboxContextValues.ts
@@ -1,12 +1,11 @@
 import { ComboboxContextValues, ComboboxState } from '../components/Combobox/Combobox.types';
 
 export function useComboboxContextValues(state: ComboboxState): ComboboxContextValues {
-  const { activeOption, appearance, idBase, onOptionClick, open, registerOption, selectedOptions, size } = state;
+  const { activeOption, appearance, onOptionClick, open, registerOption, selectedOptions, size } = state;
 
   const combobox = {
     activeOption,
     appearance,
-    idBase,
     open,
     onOptionClick,
     registerOption,

--- a/packages/react-combobox/src/contexts/useListboxContextValues.ts
+++ b/packages/react-combobox/src/contexts/useListboxContextValues.ts
@@ -4,7 +4,7 @@ import { ComboboxContext } from './ComboboxContext';
 
 export function useListboxContextValues(state: ListboxState): ListboxContextValues {
   const hasComboboxContext = useHasParentContext(ComboboxContext);
-  const { activeOption, idBase, multiselect, onOptionClick, registerOption, selectedOptions } = state;
+  const { activeOption, multiselect, onOptionClick, registerOption, selectedOptions } = state;
 
   // get register/unregister functions from parent combobox context
   const comboboxRegisterOption = useContextSelector(ComboboxContext, ctx => ctx.registerOption);
@@ -13,7 +13,6 @@ export function useListboxContextValues(state: ListboxState): ListboxContextValu
 
   const listbox = {
     activeOption,
-    idBase,
     multiselect,
     onOptionClick,
     selectedOptions,

--- a/packages/react-combobox/src/stories/Combobox.stories.tsx
+++ b/packages/react-combobox/src/stories/Combobox.stories.tsx
@@ -5,6 +5,7 @@ import descriptionMd from './ComboboxDescription.md';
 import bestPracticesMd from './ComboboxBestPractices.md';
 
 export { Default } from './ComboboxDefault.stories';
+export { CustomOptions } from './ComboboxCustomOptions.stories';
 export { Multiselect } from './ComboboxMultiselect.stories';
 
 export default {

--- a/packages/react-combobox/src/stories/ComboboxCustomOptions.stories.tsx
+++ b/packages/react-combobox/src/stories/ComboboxCustomOptions.stories.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { useId } from '@fluentui/react-utilities';
+import { CheckmarkCircle20Filled } from '@fluentui/react-icons';
+import { Combobox, ComboboxProps, Option, OptionProps, OptionGroup, OptionGroupProps } from '../index';
+
+const CustomOption = (props: OptionProps) => {
+  return <Option {...props} checkIcon={<CheckmarkCircle20Filled />} />;
+};
+
+const CustomOptionGroup = (props: Partial<OptionGroupProps> & { options: string[] }) => {
+  const labelSlot = typeof props.label === 'object' ? props.label : { children: props.label };
+
+  return (
+    <OptionGroup label={{ style: { fontStyle: 'italic' }, ...labelSlot }}>
+      {props.options.map(option => (
+        <CustomOption key={option} disabled={option === 'Ferret'}>
+          {option}
+        </CustomOption>
+      ))}
+    </OptionGroup>
+  );
+};
+
+export const CustomOptions = (props: Partial<ComboboxProps>) => {
+  const comboId = useId('combo-default');
+  const land = ['Cat', 'Dog', 'Ferret', 'Hamster'];
+  const water = ['Fish', 'Jellyfish', 'Octopus', 'Seal'];
+  return (
+    <>
+      <label id={comboId}>Best pet</label>
+      <Combobox aria-labelledby={comboId} placeholder="Select an animal" {...props}>
+        <CustomOptionGroup label="Land" options={land} />
+        <CustomOptionGroup label="Sea" options={water} />
+      </Combobox>
+    </>
+  );
+};

--- a/packages/react-combobox/src/utils/OptionCollection.types.ts
+++ b/packages/react-combobox/src/utils/OptionCollection.types.ts
@@ -8,25 +8,25 @@ export type OptionValue = {
 
 export type OptionCollectionValue = {
   /** The total number of options in the collection. */
-  count: () => number;
-
-  /** Returns the option data for the nth option. */
-  getOptionAtIndex(index: number): OptionValue | undefined;
+  getCount: () => number;
 
   /** Returns the index of an option by key. */
   getIndexOfId(id: string): number;
+
+  /** Returns the option data for the nth option. */
+  getOptionAtIndex(index: number): OptionValue | undefined;
 
   /** Returns the option data by key. */
   getOptionById(id: string): OptionValue | undefined;
 };
 
 export type OptionCollectionState = {
-  /** A set collection utilties for accessing options by index or key. */
-  collectionData: OptionCollectionValue;
+  /** A set collection utilities for accessing options by index or key. */
+  collectionAPI: OptionCollectionValue;
 
   /** The unordered option data. */
   options: OptionValue[];
 
   /* A function that child options call to register their values. Returns a function to unregister the option. */
-  registerOption: (option: OptionValue, element: HTMLElement) => (id: string) => void;
+  registerOption: (option: OptionValue, element: HTMLElement) => () => void;
 };

--- a/packages/react-combobox/src/utils/OptionCollection.types.ts
+++ b/packages/react-combobox/src/utils/OptionCollection.types.ts
@@ -1,9 +1,4 @@
-import * as React from 'react';
-
 export type OptionValue = {
-  /** The `key` prop of the option. */
-  key: string;
-
   /** The `id` attribute of the option. */
   id: string;
 
@@ -13,32 +8,25 @@ export type OptionValue = {
 
 export type OptionCollectionValue = {
   /** The total number of options in the collection. */
-  count: number;
+  count: () => number;
 
   /** Returns the option data for the nth option. */
-  getOptionAtIndex(index: number): OptionValue;
+  getOptionAtIndex(index: number): OptionValue | undefined;
 
   /** Returns the index of an option by key. */
-  getIndexOfKey(key: string): number;
+  getIndexOfId(id: string): number;
 
   /** Returns the option data by key. */
-  getOptionByKey(key: string): OptionValue;
-};
-
-export type OptionData = {
-  [key: string]: OptionValue;
+  getOptionById(id: string): OptionValue | undefined;
 };
 
 export type OptionCollectionState = {
-  /** The processed children of the option collection. */
-  children: React.ReactNode;
-
   /** A set collection utilties for accessing options by index or key. */
   collectionData: OptionCollectionValue;
 
   /** The unordered option data. */
-  options: OptionData;
+  options: OptionValue[];
 
   /* A function that child options call to register their values. Returns a function to unregister the option. */
-  registerOption: (option: OptionValue) => void;
+  registerOption: (option: OptionValue, element: HTMLElement) => (id: string) => void;
 };

--- a/packages/react-combobox/src/utils/OptionCollection.types.ts
+++ b/packages/react-combobox/src/utils/OptionCollection.types.ts
@@ -6,7 +6,7 @@ export type OptionValue = {
   value: string;
 };
 
-export type OptionCollectionValue = {
+export type OptionCollectionState = {
   /** The total number of options in the collection. */
   getCount: () => number;
 
@@ -18,11 +18,6 @@ export type OptionCollectionValue = {
 
   /** Returns the option data by key. */
   getOptionById(id: string): OptionValue | undefined;
-};
-
-export type OptionCollectionState = {
-  /** A set collection utilities for accessing options by index or key. */
-  collectionAPI: OptionCollectionValue;
 
   /** The unordered option data. */
   options: OptionValue[];

--- a/packages/react-combobox/src/utils/Selection.types.ts
+++ b/packages/react-combobox/src/utils/Selection.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export type SelectedOption = {
   /** The `key` prop of the option. */
-  key: string;
+  id: string;
 
   /** The desired display value of the options */
   value: string;

--- a/packages/react-combobox/src/utils/useOptionCollection.ts
+++ b/packages/react-combobox/src/utils/useOptionCollection.ts
@@ -7,8 +7,8 @@ import type { OptionCollectionState, OptionValue } from './OptionCollection.type
 export const useOptionCollection = (): OptionCollectionState => {
   const nodes = React.useRef<{ option: OptionValue; element: HTMLElement }[]>([]);
 
-  const collectionData = React.useMemo(() => {
-    const count = () => nodes.current.length;
+  const collectionAPI = React.useMemo(() => {
+    const getCount = () => nodes.current.length;
     const getOptionAtIndex = (index: number) => nodes.current[index]?.option;
     const getIndexOfId = (id: string) => nodes.current.findIndex(node => node.option.id === id);
     const getOptionById = (id: string) => {
@@ -17,55 +17,52 @@ export const useOptionCollection = (): OptionCollectionState => {
     };
 
     return {
-      count,
+      getCount,
       getOptionAtIndex,
       getIndexOfId,
       getOptionById,
     };
   }, []);
 
-  const registerOption = React.useMemo(() => {
-    const register = (option: OptionValue, element: HTMLElement) => {
-      const index = nodes.current.findIndex(node => {
-        if (!node.element || !element) {
-          return false;
-        }
-
-        if (node.option.id === option.id) {
-          return true;
-        }
-
-        // use the DOM method compareDocumentPosition to order the current node against registered nodes
-        return Boolean(node.element.compareDocumentPosition(element) === Node.DOCUMENT_POSITION_PRECEDING);
-      });
-
-      // do not register the option if it already exists
-      if (nodes.current[index]?.option.id !== option.id) {
-        const newItem = {
-          element,
-          option,
-        };
-
-        // If an index is not found we will push the element to the end.
-        if (index === -1) {
-          nodes.current = [...nodes.current, newItem];
-        } else {
-          nodes.current = [...nodes.current.slice(0, index), newItem, ...nodes.current.slice(index)];
-        }
+  const registerOption = React.useCallback((option: OptionValue, element: HTMLElement) => {
+    const index = nodes.current.findIndex(node => {
+      if (!node.element || !element) {
+        return false;
       }
 
-      // return the unregister function
-      return (id: string) => {
-        nodes.current = nodes.current.filter(node => node.option.id !== id);
-      };
-    };
+      if (node.option.id === option.id) {
+        return true;
+      }
 
-    return register;
+      // use the DOM method compareDocumentPosition to order the current node against registered nodes
+      // eslint-disable-next-line no-bitwise
+      return node.element.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_PRECEDING;
+    });
+
+    // do not register the option if it already exists
+    if (nodes.current[index]?.option.id !== option.id) {
+      const newItem = {
+        element,
+        option,
+      };
+
+      // If an index is not found we will push the element to the end.
+      if (index === -1) {
+        nodes.current = [...nodes.current, newItem];
+      } else {
+        nodes.current.splice(index, 0, newItem);
+      }
+    }
+
+    // return the unregister function
+    return () => {
+      nodes.current = nodes.current.filter(node => node.option.id !== option.id);
+    };
   }, []);
 
   return {
-    collectionData,
+    collectionAPI,
     options: nodes.current.map(node => node.option),
-    registerOption: registerOption,
+    registerOption,
   };
 };

--- a/packages/react-combobox/src/utils/useOptionCollection.ts
+++ b/packages/react-combobox/src/utils/useOptionCollection.ts
@@ -61,7 +61,7 @@ export const useOptionCollection = (): OptionCollectionState => {
   }, []);
 
   return {
-    collectionAPI,
+    ...collectionAPI,
     options: nodes.current.map(node => node.option),
     registerOption,
   };

--- a/packages/react-combobox/src/utils/useSelection.ts
+++ b/packages/react-combobox/src/utils/useSelection.ts
@@ -16,7 +16,7 @@ export const useSelection = (props: SelectionProps): SelectionValue => {
 
     // toggle selected state of the option for multiselect
     if (multiselect) {
-      const selectedIndex = selectedOptions.findIndex(o => o.key === option.key);
+      const selectedIndex = selectedOptions.findIndex(o => o.id === option.id);
       if (selectedIndex > -1) {
         // deselect option
         newSelection = [...selectedOptions.slice(0, selectedIndex), ...selectedOptions.slice(selectedIndex + 1)];


### PR DESCRIPTION
Resolves #22055

I also added a story to show that this works when wrapping `OptionGroup` and `Option`.

The most relevant changes are in `useOptionCollection.ts` and `useOption.tsx`