### PR TITLE
Button: Stop applying active styles when mouse moves away while it is being held and improving styles in High Contrast mode

### DIFF
--- a/change/@fluentui-react-button-f1c210ad-d683-4e21-984c-11b5f0acd349.json
+++ b/change/@fluentui-react-button-f1c210ad-d683-4e21-984c-11b5f0acd349.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Button: Stop applying active styles when mouse moves away while it is being held and ToggleButton: Fixing checked styles in High Contrast mode.",
+  "comment": "Button: Stop applying active styles when mouse moves away while it is being held and improving styles in High Contrast mode.",
   "packageName": "@fluentui/react-button",
   "email": "Humberto.Morimoto@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-button-f1c210ad-d683-4e21-984c-11b5f0acd349.json
+++ b/change/@fluentui-react-button-f1c210ad-d683-4e21-984c-11b5f0acd349.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "ToggleButton: Fixing checked styles in High Contrast mode.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-f1c210ad-d683-4e21-984c-11b5f0acd349.json
+++ b/change/@fluentui-react-button-f1c210ad-d683-4e21-984c-11b5f0acd349.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "ToggleButton: Fixing checked styles in High Contrast mode.",
+  "comment": "Button: Stop applying active styles when mouse moves away while it is being held and ToggleButton: Fixing checked styles in High Contrast mode.",
   "packageName": "@fluentui/react-button",
   "email": "Humberto.Morimoto@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -54,6 +54,24 @@ const useRootStyles = makeStyles({
     },
   },
 
+  // High contrast styles
+  highContrast: {
+    '@media (forced-colors: active)': {
+      ':focus': {
+        ...shorthands.borderColor('ButtonText'),
+      },
+
+      ':hover': {
+        ...shorthands.borderColor('Highlight'),
+        color: 'Highlight',
+      },
+
+      ':hover:active': {
+        color: 'Highlight',
+      },
+    },
+  },
+
   // Block styles
   block: {
     maxWidth: '100%',
@@ -200,6 +218,28 @@ const useRootDisabledStyles = makeStyles({
       color: tokens.colorNeutralForegroundDisabled,
 
       cursor: 'not-allowed',
+    },
+  },
+
+  // High contrast styles
+  highContrast: {
+    '@media (forced-colors: active)': {
+      ...shorthands.borderColor('GrayText'),
+      color: 'GrayText',
+
+      ':focus': {
+        ...shorthands.borderColor('GrayText'),
+      },
+
+      ':hover': {
+        ...shorthands.borderColor('GrayText'),
+        color: 'GrayText',
+      },
+
+      ':hover:active': {
+        ...shorthands.borderColor('GrayText'),
+        color: 'GrayText',
+      },
     },
   },
 
@@ -374,6 +414,7 @@ export const useButtonStyles_unstable = (state: ButtonState): ButtonState => {
 
     // Root styles
     rootStyles.base,
+    rootStyles.highContrast,
     block && rootStyles.block,
     appearance && rootStyles[appearance],
     rootStyles[size],
@@ -381,6 +422,7 @@ export const useButtonStyles_unstable = (state: ButtonState): ButtonState => {
 
     // Disabled styles
     (disabled || disabledFocusable) && rootDisabledStyles.base,
+    (disabled || disabledFocusable) && rootDisabledStyles.highContrast,
     appearance && (disabled || disabledFocusable) && rootDisabledStyles[appearance],
 
     // Focus styles

--- a/packages/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-button/src/components/Button/useButtonStyles.ts
@@ -45,7 +45,7 @@ const useRootStyles = makeStyles({
       cursor: 'pointer',
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorNeutralBackground1Pressed,
       ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
       color: tokens.colorNeutralForeground1,
@@ -68,7 +68,7 @@ const useRootStyles = makeStyles({
       backgroundColor: tokens.colorTransparentBackgroundHover,
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorTransparentBackgroundPressed,
     },
   },
@@ -83,7 +83,7 @@ const useRootStyles = makeStyles({
       color: tokens.colorNeutralForegroundOnBrand,
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorBrandBackgroundPressed,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForegroundOnBrand,
@@ -100,7 +100,7 @@ const useRootStyles = makeStyles({
       color: tokens.colorNeutralForeground2BrandHover,
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorSubtleBackgroundPressed,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2BrandPressed,
@@ -117,7 +117,7 @@ const useRootStyles = makeStyles({
       color: tokens.colorNeutralForeground2BrandHover,
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorTransparentBackgroundPressed,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2BrandPressed,
@@ -194,7 +194,7 @@ const useRootDisabledStyles = makeStyles({
       cursor: 'not-allowed',
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorNeutralBackgroundDisabled,
       ...shorthands.borderColor(tokens.colorNeutralStrokeDisabled),
       color: tokens.colorNeutralForegroundDisabled,
@@ -211,7 +211,7 @@ const useRootDisabledStyles = makeStyles({
       backgroundColor: tokens.colorTransparentBackgroundHover,
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorTransparentBackgroundPressed,
     },
   },
@@ -222,7 +222,7 @@ const useRootDisabledStyles = makeStyles({
       ...shorthands.borderColor('transparent'),
     },
 
-    ':active': {
+    ':hover:active': {
       ...shorthands.borderColor('transparent'),
     },
   },
@@ -235,7 +235,7 @@ const useRootDisabledStyles = makeStyles({
       ...shorthands.borderColor('transparent'),
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: 'transparent',
       ...shorthands.borderColor('transparent'),
     },
@@ -249,7 +249,7 @@ const useRootDisabledStyles = makeStyles({
       ...shorthands.borderColor('transparent'),
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: 'transparent',
       ...shorthands.borderColor('transparent'),
     },

--- a/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
@@ -40,6 +40,23 @@ const useRootStyles = makeStyles({
     },
   },
 
+  // High contrast styles
+  highContrast: {
+    '@media (forced-colors: active)': {
+      ':hover': {
+        [`& .${compoundButtonClassNames.secondaryContent}`]: {
+          color: 'Highlight',
+        },
+      },
+
+      ':hover:active': {
+        [`& .${compoundButtonClassNames.secondaryContent}`]: {
+          color: 'Highlight',
+        },
+      },
+    },
+  },
+
   // Appearance variations
   outline: {
     /* No styles */
@@ -209,6 +226,7 @@ export const useCompoundButtonStyles_unstable = (state: CompoundButtonState): Co
 
     // Root styles
     rootStyles.base,
+    rootStyles.highContrast,
     appearance && rootStyles[appearance],
     rootStyles[size],
 

--- a/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
@@ -151,6 +151,27 @@ const useRootStyles = makeStyles({
       },
     },
   },
+
+  // Disabled high contrast styles
+  disabledHighContrast: {
+    '@media (forced-colors: active)': {
+      [`& .${compoundButtonClassNames.secondaryContent}`]: {
+        color: 'GrayText',
+      },
+
+      ':hover': {
+        [`& .${compoundButtonClassNames.secondaryContent}`]: {
+          color: 'GrayText',
+        },
+      },
+
+      ':hover:active': {
+        [`& .${compoundButtonClassNames.secondaryContent}`]: {
+          color: 'GrayText',
+        },
+      },
+    },
+  },
 });
 
 const useRootIconOnlyStyles = makeStyles({
@@ -232,6 +253,7 @@ export const useCompoundButtonStyles_unstable = (state: CompoundButtonState): Co
 
     // Disabled styles
     (disabled || disabledFocusable) && rootStyles.disabled,
+    (disabled || disabledFocusable) && rootStyles.disabledHighContrast,
 
     // Icon-only styles
     iconOnly && rootIconOnlyStyles[size],

--- a/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
@@ -33,7 +33,7 @@ const useRootStyles = makeStyles({
       },
     },
 
-    ':active': {
+    ':hover:active': {
       [`& .${compoundButtonClassNames.secondaryContent}`]: {
         color: tokens.colorNeutralForeground2Pressed,
       },
@@ -55,7 +55,7 @@ const useRootStyles = makeStyles({
       },
     },
 
-    ':active': {
+    ':hover:active': {
       [`& .${compoundButtonClassNames.secondaryContent}`]: {
         color: tokens.colorNeutralForegroundOnBrand,
       },
@@ -72,7 +72,7 @@ const useRootStyles = makeStyles({
       },
     },
 
-    ':active': {
+    ':hover:active': {
       [`& .${compoundButtonClassNames.secondaryContent}`]: {
         color: tokens.colorNeutralForeground2BrandPressed,
       },
@@ -89,7 +89,7 @@ const useRootStyles = makeStyles({
       },
     },
 
-    ':active': {
+    ':hover:active': {
       [`& .${compoundButtonClassNames.secondaryContent}`]: {
         color: tokens.colorNeutralForeground2BrandPressed,
       },
@@ -128,7 +128,7 @@ const useRootStyles = makeStyles({
       },
     },
 
-    ':active': {
+    ':hover:active': {
       [`& .${compoundButtonClassNames.secondaryContent}`]: {
         color: tokens.colorNeutralForegroundDisabled,
       },

--- a/packages/react-button/src/components/SplitButton/stories/SplitButtonDisabled.stories.tsx
+++ b/packages/react-button/src/components/SplitButton/stories/SplitButtonDisabled.stories.tsx
@@ -22,7 +22,7 @@ export const Disabled = () => {
         <MenuTrigger>
           {(triggerProps: MenuButtonProps) => (
             <SplitButton menuButton={triggerProps} disabled>
-              Disabled stat
+              Disabled state
             </SplitButton>
           )}
         </MenuTrigger>

--- a/packages/react-button/src/components/SplitButton/useSplitButtonStyles.ts
+++ b/packages/react-button/src/components/SplitButton/useSplitButtonStyles.ts
@@ -29,20 +29,18 @@ const useFocusStyles = makeStyles({
 });
 
 const useRootStyles = makeStyles({
-  // Base rootStyles
+  // Base styles
   base: {
     display: 'inline-flex',
     justifyContent: 'stretch',
     position: 'relative',
     verticalAlign: 'middle',
 
-    // Use classnames to increase specificy of rootStyles and avoid collisions.
     [`& .${splitButtonClassNames.primaryActionButton}`]: {
       borderTopRightRadius: 0,
       borderBottomRightRadius: 0,
     },
 
-    // Use classnames to increase specificy of rootStyles and avoid collisions.
     [`& .${splitButtonClassNames.menuButton}`]: {
       borderLeftWidth: 0,
       borderTopLeftRadius: 0,
@@ -50,17 +48,16 @@ const useRootStyles = makeStyles({
     },
   },
 
-  // Block rootStyles
+  // Block styles
   block: {
     width: '100%',
   },
 
   // Appearance variations
   outline: {
-    /* No rootStyles */
+    /* No styles */
   },
   primary: {
-    // Use classnames to increase specificy of rootStyles and avoid collisions.
     [`& .${splitButtonClassNames.primaryActionButton}`]: {
       borderRightColor: tokens.colorNeutralForegroundInverted,
     },
@@ -78,7 +75,6 @@ const useRootStyles = makeStyles({
     },
   },
   subtle: {
-    // Use classnames to increase specificy of rootStyles and avoid collisions.
     [`& .${splitButtonClassNames.primaryActionButton}`]: {
       borderRightColor: tokens.colorNeutralStroke1Hover,
     },
@@ -96,7 +92,6 @@ const useRootStyles = makeStyles({
     },
   },
   transparent: {
-    // Use classnames to increase specificy of rootStyles and avoid collisions.
     [`& .${splitButtonClassNames.primaryActionButton}`]: {
       borderRightColor: tokens.colorNeutralStroke1Hover,
     },
@@ -119,9 +114,8 @@ const useRootStyles = makeStyles({
   rounded: {},
   square: {},
 
-  // Disabled rootStyles
+  // Disabled styles
   disabled: {
-    // Use classnames to increase specificy of rootStyles and avoid collisions.
     [`& .${splitButtonClassNames.primaryActionButton}`]: {
       borderRightColor: tokens.colorNeutralStrokeDisabled,
     },
@@ -135,6 +129,27 @@ const useRootStyles = makeStyles({
     ':hover:active': {
       [`& .${splitButtonClassNames.primaryActionButton}`]: {
         borderRightColor: tokens.colorNeutralStrokeDisabled,
+      },
+    },
+  },
+
+  // Disabled high contrast styles
+  disabledHighContrast: {
+    '@media (forced-colors: active)': {
+      [`& .${splitButtonClassNames.primaryActionButton}`]: {
+        borderRightColor: 'GrayText',
+      },
+
+      ':hover': {
+        [`& .${splitButtonClassNames.primaryActionButton}`]: {
+          borderRightColor: 'GrayText',
+        },
+      },
+
+      ':hover:active': {
+        [`& .${splitButtonClassNames.primaryActionButton}`]: {
+          borderRightColor: 'GrayText',
+        },
       },
     },
   },
@@ -158,6 +173,7 @@ export const useSplitButtonStyles_unstable = (state: SplitButtonState): SplitBut
     block && rootStyles.block,
     appearance && rootStyles[appearance],
     (disabled || disabledFocusable) && rootStyles.disabled,
+    (disabled || disabledFocusable) && rootStyles.disabledHighContrast,
     state.root.className,
   );
 

--- a/packages/react-button/src/components/SplitButton/useSplitButtonStyles.ts
+++ b/packages/react-button/src/components/SplitButton/useSplitButtonStyles.ts
@@ -71,7 +71,7 @@ const useRootStyles = makeStyles({
       },
     },
 
-    ':active': {
+    ':hover:active': {
       [`& .${splitButtonClassNames.primaryActionButton}`]: {
         borderRightColor: tokens.colorNeutralForegroundInverted,
       },
@@ -89,7 +89,7 @@ const useRootStyles = makeStyles({
       },
     },
 
-    ':active': {
+    ':hover:active': {
       [`& .${splitButtonClassNames.primaryActionButton}`]: {
         borderRightColor: tokens.colorNeutralStroke1Hover,
       },
@@ -107,7 +107,7 @@ const useRootStyles = makeStyles({
       },
     },
 
-    ':active': {
+    ':hover:active': {
       [`& .${splitButtonClassNames.primaryActionButton}`]: {
         borderRightColor: tokens.colorNeutralStroke1Hover,
       },
@@ -132,7 +132,7 @@ const useRootStyles = makeStyles({
       },
     },
 
-    ':active': {
+    ':hover:active': {
       [`& .${splitButtonClassNames.primaryActionButton}`]: {
         borderRightColor: tokens.colorNeutralStrokeDisabled,
       },

--- a/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -24,16 +24,29 @@ const useCheckedStyles = makeStyles({
 
     ...shorthands.borderWidth(tokens.strokeWidthThin),
 
+    '@media (forced-colors: active)': {
+      backgroundColor: 'Highlight',
+      forcedColorAdjust: 'none',
+    },
+
     ':hover': {
       backgroundColor: tokens.colorNeutralBackground1Hover,
       ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
       color: tokens.colorNeutralForeground1,
+
+      '@media (forced-colors: active)': {
+        backgroundColor: 'Highlight',
+      },
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorNeutralBackground1Pressed,
       ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
       color: tokens.colorNeutralForeground1,
+
+      '@media (forced-colors: active)': {
+        backgroundColor: 'Highlight',
+      },
     },
   },
 
@@ -45,7 +58,7 @@ const useCheckedStyles = makeStyles({
       backgroundColor: tokens.colorTransparentBackgroundHover,
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorTransparentBackgroundPressed,
     },
   },
@@ -54,16 +67,28 @@ const useCheckedStyles = makeStyles({
     ...shorthands.borderColor('transparent'),
     color: tokens.colorNeutralForegroundOnBrand,
 
+    '@media (forced-colors: active)': {
+      color: 'HighlightText',
+    },
+
     ':hover': {
       backgroundColor: tokens.colorBrandBackgroundHover,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForegroundOnBrand,
+
+      '@media (forced-colors: active)': {
+        color: 'HighlightText',
+      },
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorBrandBackgroundPressed,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForegroundOnBrand,
+
+      '@media (forced-colors: active)': {
+        color: 'HighlightText',
+      },
     },
   },
   subtle: {
@@ -71,16 +96,28 @@ const useCheckedStyles = makeStyles({
     ...shorthands.borderColor('transparent'),
     color: tokens.colorNeutralForeground2BrandSelected,
 
+    '@media (forced-colors: active)': {
+      color: 'HighlightText',
+    },
+
     ':hover': {
       backgroundColor: tokens.colorSubtleBackgroundHover,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2BrandHover,
+
+      '@media (forced-colors: active)': {
+        color: 'HighlightText',
+      },
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorSubtleBackgroundPressed,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2BrandPressed,
+
+      '@media (forced-colors: active)': {
+        color: 'HighlightText',
+      },
     },
   },
   transparent: {
@@ -88,16 +125,28 @@ const useCheckedStyles = makeStyles({
     ...shorthands.borderColor('transparent'),
     color: tokens.colorNeutralForeground2BrandSelected,
 
+    '@media (forced-colors: active)': {
+      color: 'HighlightText',
+    },
+
     ':hover': {
       backgroundColor: tokens.colorTransparentBackgroundHover,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2BrandHover,
+
+      '@media (forced-colors: active)': {
+        color: 'HighlightText',
+      },
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorTransparentBackgroundPressed,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2BrandPressed,
+
+      '@media (forced-colors: active)': {
+        color: 'HighlightText',
+      },
     },
   },
 });
@@ -115,7 +164,7 @@ const useDisabledStyles = makeStyles({
       color: tokens.colorNeutralForegroundDisabled,
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: tokens.colorNeutralBackgroundDisabled,
       ...shorthands.borderColor(tokens.colorNeutralStrokeDisabled),
       color: tokens.colorNeutralForegroundDisabled,
@@ -133,7 +182,7 @@ const useDisabledStyles = makeStyles({
       ...shorthands.borderColor('transparent'),
     },
 
-    ':active': {
+    ':hover:active': {
       ...shorthands.borderColor('transparent'),
     },
   },
@@ -146,7 +195,7 @@ const useDisabledStyles = makeStyles({
       ...shorthands.borderColor('transparent'),
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: 'transparent',
       ...shorthands.borderColor('transparent'),
     },
@@ -160,7 +209,7 @@ const useDisabledStyles = makeStyles({
       ...shorthands.borderColor('transparent'),
     },
 
-    ':active': {
+    ':hover:active': {
       backgroundColor: 'transparent',
       ...shorthands.borderColor('transparent'),
     },

--- a/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -24,28 +24,27 @@ const useCheckedStyles = makeStyles({
 
     ...shorthands.borderWidth(tokens.strokeWidthThin),
 
-    '@media (forced-colors: active)': {
-      backgroundColor: 'Highlight',
-      forcedColorAdjust: 'none',
-    },
-
     ':hover': {
       backgroundColor: tokens.colorNeutralBackground1Hover,
       ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
       color: tokens.colorNeutralForeground1,
-
-      '@media (forced-colors: active)': {
-        backgroundColor: 'Highlight',
-      },
     },
 
     ':hover:active': {
       backgroundColor: tokens.colorNeutralBackground1Pressed,
       ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
       color: tokens.colorNeutralForeground1,
+    },
+  },
 
-      '@media (forced-colors: active)': {
-        backgroundColor: 'Highlight',
+  // High contrast styles
+  highContrast: {
+    '@media (forced-colors: active)': {
+      ...shorthands.borderColor('Highlight'),
+      color: 'Highlight',
+
+      ':focus': {
+        ...shorthands.borderColor('Highlight'),
       },
     },
   },
@@ -67,28 +66,16 @@ const useCheckedStyles = makeStyles({
     ...shorthands.borderColor('transparent'),
     color: tokens.colorNeutralForegroundOnBrand,
 
-    '@media (forced-colors: active)': {
-      color: 'HighlightText',
-    },
-
     ':hover': {
       backgroundColor: tokens.colorBrandBackgroundHover,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForegroundOnBrand,
-
-      '@media (forced-colors: active)': {
-        color: 'HighlightText',
-      },
     },
 
     ':hover:active': {
       backgroundColor: tokens.colorBrandBackgroundPressed,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForegroundOnBrand,
-
-      '@media (forced-colors: active)': {
-        color: 'HighlightText',
-      },
     },
   },
   subtle: {
@@ -96,28 +83,16 @@ const useCheckedStyles = makeStyles({
     ...shorthands.borderColor('transparent'),
     color: tokens.colorNeutralForeground2BrandSelected,
 
-    '@media (forced-colors: active)': {
-      color: 'HighlightText',
-    },
-
     ':hover': {
       backgroundColor: tokens.colorSubtleBackgroundHover,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2BrandHover,
-
-      '@media (forced-colors: active)': {
-        color: 'HighlightText',
-      },
     },
 
     ':hover:active': {
       backgroundColor: tokens.colorSubtleBackgroundPressed,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2BrandPressed,
-
-      '@media (forced-colors: active)': {
-        color: 'HighlightText',
-      },
     },
   },
   transparent: {
@@ -125,28 +100,16 @@ const useCheckedStyles = makeStyles({
     ...shorthands.borderColor('transparent'),
     color: tokens.colorNeutralForeground2BrandSelected,
 
-    '@media (forced-colors: active)': {
-      color: 'HighlightText',
-    },
-
     ':hover': {
       backgroundColor: tokens.colorTransparentBackgroundHover,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2BrandHover,
-
-      '@media (forced-colors: active)': {
-        color: 'HighlightText',
-      },
     },
 
     ':hover:active': {
       backgroundColor: tokens.colorTransparentBackgroundPressed,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2BrandPressed,
-
-      '@media (forced-colors: active)': {
-        color: 'HighlightText',
-      },
     },
   },
 });
@@ -227,6 +190,7 @@ export const useToggleButtonStyles_unstable = (state: ToggleButtonState): Toggle
 
     // Checked styles
     checked && checkedStyles.base,
+    checked && checkedStyles.highContrast,
     appearance && checked && checkedStyles[appearance],
 
     // Disabled styles


### PR DESCRIPTION
## Current Behavior

There are 2 problems with buttons right now:

- `:active` styles apply even when the mouse moves away while being held from the `Buttons`.

![Before](https://user-images.githubusercontent.com/7798177/164337281-08f6edf7-a147-4d02-9d0a-8b0c9f058e27.gif)

- A number of High Contrast styles in Button could be better:
  - Hovering over or clicking the buttons triggers a change in border color but not in color. Clicking on the buttons also leaves the focus border highlighted until clicking outside of the button and hovering over it again or focusing into and away from it via the keyboard.
![Before](https://user-images.githubusercontent.com/7798177/164518267-4ae9093d-4de6-4dfb-a416-bad78270a179.gif)
  - Disabled focusable buttons look like regular buttons.
![image](https://user-images.githubusercontent.com/7798177/164518874-6350a37c-662a-4565-ae6f-98afdad6203b.png)
  - Checked styles for all `ToggleButton` appearances are broken in High Contrast mode, as they remain exactly as if they were unchecked.
![image](https://user-images.githubusercontent.com/7798177/164321869-f7ef2d91-3660-4d4f-bf55-2a0e91b6efea.png)

## New Behavior

This PR does 2 things:
- Changes all of the `:active` styles to be `:hover:active` to better reflect what we actually want to style for all `Button` components.

![After](https://user-images.githubusercontent.com/7798177/164337321-cd25d127-b26c-439e-ab89-fa51a6ed52bd.gif)

- Improves the High Contrast styles mentioned above:
  - Hovering over or clicking the buttons now triggers a border color and color change accordingly. The focus styling sticking is also no longer an issue now.
![After](https://user-images.githubusercontent.com/7798177/164518312-7adc343a-e37a-4407-8a51-c784d9b198f9.gif)
  - Disabled focusable buttons now look like disabled buttons.
![image](https://user-images.githubusercontent.com/7798177/164519446-f06ff272-0782-4d02-83c4-16537b247e9d.png)
  - Checked `ToggleButtons` styles are now distinct from unchecked styles.
![image](https://user-images.githubusercontent.com/7798177/164516978-f8ad7064-3aff-42e7-ad77-f9bba65a82f8.png)

## Related Issue

Fixes #21403, fixes #21406
