### PR TITLE
Fix sub menu's focusing first menu item by default

### DIFF
--- a/packages/react/src/components/Button/Button.types.ts
+++ b/packages/react/src/components/Button/Button.types.ts
@@ -31,8 +31,6 @@ export interface IButton {
    *
    * @param shouldFocusOnContainer - override to the ContextualMenu `shouldFocusOnContainer` prop.
    * BaseButton implementation defaults to `undefined`.
-   * Avoid using `shouldFocusOnContainer` as it breaks the default focus behaviour when using
-   * assistive technologies.
    * @param shouldFocusOnMount - override to the ContextualMenu `shouldFocusOnMount` prop.
    * BaseButton implementation defaults to `true`.
    */

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -165,21 +165,25 @@ function useSubMenuState(
 ) {
   const [expandedMenuItemKey, setExpandedMenuItemKey] = React.useState<string>();
   const [submenuTarget, setSubmenuTarget] = React.useState<HTMLElement>();
+  /** True if the menu was expanded by mouse click OR hover (as opposed to by keyboard) */
+  const [expandedByMouseClick, setExpandedByMouseClick] = React.useState<boolean>();
   const subMenuId = useId(COMPONENT_NAME, id);
 
   const closeSubMenu = React.useCallback(() => {
+    setExpandedByMouseClick(undefined);
     setExpandedMenuItemKey(undefined);
     setSubmenuTarget(undefined);
   }, []);
 
   const openSubMenu = React.useCallback(
-    ({ key: submenuItemKey }: IContextualMenuItem, target: HTMLElement) => {
+    ({ key: submenuItemKey }: IContextualMenuItem, target: HTMLElement, openedByMouseClick?: boolean) => {
       if (expandedMenuItemKey === submenuItemKey) {
         return;
       }
 
       target.focus();
 
+      setExpandedByMouseClick(openedByMouseClick);
       setExpandedMenuItemKey(submenuItemKey);
       setSubmenuTarget(target);
     },
@@ -206,6 +210,7 @@ function useSubMenuState(
         isSubMenu: true,
         id: subMenuId,
         shouldFocusOnMount: true,
+        shouldFocusOnContainer: expandedByMouseClick,
         directionalHint: getRTL(theme) ? DirectionalHint.leftTopEdge : DirectionalHint.rightTopEdge,
         className,
         gapSpace: 0,

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -645,13 +645,8 @@ function useMouseHandlers(
         openSubMenu(
           item,
           target,
-          // When Edge + Narrator are used together (regardless of if the button is in a form or not), pressing
-          // "Enter" fires this method and not _onMenuKeyDown. Checking ev.nativeEvent.detail differentiates
-          // between a real click event and a keypress event (detail should be the number of mouse clicks).
-          // ...Plot twist! For a real click event in IE 11, detail is always 0 (Edge sets it properly to 1).
-          // So we also check the pointerType property, which both Edge and IE set to "mouse" for real clicks
-          // and "" for pressing "Enter" with Narrator on.
-          ev.nativeEvent.detail !== 0 || (ev.nativeEvent as PointerEvent).pointerType === 'mouse',
+          // focus on the container by default when the menu is opened with a click event
+          props.shouldFocusOnContainer || (ev.nativeEvent as PointerEvent).pointerType === 'mouse',
         );
       }
     }

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -149,8 +149,6 @@ export interface IContextualMenuProps
 
   /**
    * Whether to focus on the contextual menu container (as opposed to the first menu item).
-   *
-   * Avoid using as it breaks the default focus behaviour when using assistive technologies.
    */
   shouldFocusOnContainer?: boolean;
 


### PR DESCRIPTION
The last revert of PR #20601 was a partial revert and only changed BaseButton.tsx to pass in the correct value for shouldFocusOnContainer if we are a mouse click.

This PR reverts the rest of that one, and additionally reverts the PR that removed the parameter needed from all openSubMenu calls.

This fixes the issue where sub menus were still focusing their first menu item.