### PR TITLE
ContextualMenu v8: update to focus submenu containers on click or hover

### DIFF
--- a/change/@fluentui-react-fbe29567-6419-4977-b5b2-c5b9cbf29cc1.json
+++ b/change/@fluentui-react-fbe29567-6419-4977-b5b2-c5b9cbf29cc1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update contextmenu to focus submenu containers on click or hover",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -937,8 +937,11 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     }
 
     // focus on the container by default when the menu is opened with a click event
+    // this differentiates from a keyboard interaction triggering the click event
     const shouldFocusOnContainer =
-      menuProps?.shouldFocusOnContainer || (ev.nativeEvent as PointerEvent).pointerType === 'mouse';
+      typeof menuProps?.shouldFocusOnContainer === 'boolean'
+        ? menuProps.shouldFocusOnContainer
+        : (ev.nativeEvent as PointerEvent).pointerType === 'mouse';
 
     if (!ev.defaultPrevented) {
       this._onToggleMenu(shouldFocusOnContainer);

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -166,24 +166,24 @@ function useSubMenuState(
   const [expandedMenuItemKey, setExpandedMenuItemKey] = React.useState<string>();
   const [submenuTarget, setSubmenuTarget] = React.useState<HTMLElement>();
   /** True if the menu was expanded by mouse click OR hover (as opposed to by keyboard) */
-  const [expandedByMouseClick, setExpandedByMouseClick] = React.useState<boolean>();
+  const [shouldFocusOnContainer, setShouldFocusOnContainer] = React.useState<boolean>();
   const subMenuId = useId(COMPONENT_NAME, id);
 
   const closeSubMenu = React.useCallback(() => {
-    setExpandedByMouseClick(undefined);
+    setShouldFocusOnContainer(undefined);
     setExpandedMenuItemKey(undefined);
     setSubmenuTarget(undefined);
   }, []);
 
   const openSubMenu = React.useCallback(
-    ({ key: submenuItemKey }: IContextualMenuItem, target: HTMLElement, openedByMouseClick?: boolean) => {
+    ({ key: submenuItemKey }: IContextualMenuItem, target: HTMLElement, focusContainer?: boolean) => {
       if (expandedMenuItemKey === submenuItemKey) {
         return;
       }
 
       target.focus();
 
-      setExpandedByMouseClick(openedByMouseClick);
+      setShouldFocusOnContainer(focusContainer);
       setExpandedMenuItemKey(submenuItemKey);
       setSubmenuTarget(target);
     },
@@ -210,7 +210,7 @@ function useSubMenuState(
         isSubMenu: true,
         id: subMenuId,
         shouldFocusOnMount: true,
-        shouldFocusOnContainer: expandedByMouseClick,
+        shouldFocusOnContainer,
         directionalHint: getRTL(theme) ? DirectionalHint.leftTopEdge : DirectionalHint.rightTopEdge,
         className,
         gapSpace: 0,

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -165,21 +165,25 @@ function useSubMenuState(
 ) {
   const [expandedMenuItemKey, setExpandedMenuItemKey] = React.useState<string>();
   const [submenuTarget, setSubmenuTarget] = React.useState<HTMLElement>();
+  /** True if the menu was expanded by mouse click OR hover (as opposed to by keyboard) */
+  const [expandedByMouseClick, setExpandedByMouseClick] = React.useState<boolean>();
   const subMenuId = useId(COMPONENT_NAME, id);
 
   const closeSubMenu = React.useCallback(() => {
+    setExpandedByMouseClick(undefined);
     setExpandedMenuItemKey(undefined);
     setSubmenuTarget(undefined);
   }, []);
 
   const openSubMenu = React.useCallback(
-    ({ key: submenuItemKey }: IContextualMenuItem, target: HTMLElement) => {
+    ({ key: submenuItemKey }: IContextualMenuItem, target: HTMLElement, openedByMouseClick?: boolean) => {
       if (expandedMenuItemKey === submenuItemKey) {
         return;
       }
 
       target.focus();
 
+      setExpandedByMouseClick(openedByMouseClick);
       setExpandedMenuItemKey(submenuItemKey);
       setSubmenuTarget(target);
     },
@@ -206,6 +210,7 @@ function useSubMenuState(
         isSubMenu: true,
         id: subMenuId,
         shouldFocusOnMount: true,
+        shouldFocusOnContainer: expandedByMouseClick,
         directionalHint: getRTL(theme) ? DirectionalHint.leftTopEdge : DirectionalHint.rightTopEdge,
         className,
         gapSpace: 0,
@@ -504,7 +509,7 @@ function useMouseHandlers(
   hostElement: React.RefObject<HTMLDivElement>,
   startSubmenuTimer: (onTimerExpired: () => void) => void,
   cancelSubMenuTimer: () => void,
-  openSubMenu: (submenuItemKey: IContextualMenuItem, target: HTMLElement) => void,
+  openSubMenu: (submenuItemKey: IContextualMenuItem, target: HTMLElement, openedByMouseClick?: boolean) => void,
   onSubMenuDismiss: (ev?: any, dismissAll?: boolean) => void,
   dismiss: (ev?: any, dismissAll?: boolean) => void,
 ) {
@@ -603,7 +608,7 @@ function useMouseHandlers(
       ev.stopPropagation();
       startSubmenuTimer(() => {
         targetElement.focus();
-        openSubMenu(item, targetElement);
+        openSubMenu(item, targetElement, true);
       });
     } else {
       startSubmenuTimer(() => {
@@ -637,7 +642,14 @@ function useMouseHandlers(
     } else {
       if (item.key !== expandedMenuItemKey) {
         // This has a collapsed sub menu. Expand it.
-        openSubMenu(item, target);
+
+        // focus on the container by default when the menu is opened with a click event
+        // this differentiates from a keyboard interaction triggering the click event
+        const shouldFocusOnContainer =
+          typeof props.shouldFocusOnContainer === 'boolean'
+            ? props.shouldFocusOnContainer
+            : (ev.nativeEvent as PointerEvent).pointerType === 'mouse';
+        openSubMenu(item, target, shouldFocusOnContainer);
       }
     }
 


### PR DESCRIPTION
Related to #22499

This updates ContextualMenu to also apply the same mouse focus behavior to submenu open events.