### PR TITLE
Update react-input and react-spinbutton to use ::after pseudo element

### DIFF
--- a/change/@fluentui-react-input-db8489dc-8d86-492d-b3ee-a17d1edb7d81.json
+++ b/change/@fluentui-react-input-db8489dc-8d86-492d-b3ee-a17d1edb7d81.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use ::after pseudo element in styles",
+  "packageName": "@fluentui/react-input",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-d3163b27-fa21-4821-ac4d-217e0d3488ab.json
+++ b/change/@fluentui-react-spinbutton-d3163b27-fa21-4821-ac4d-217e0d3488ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use ::after pseudo element in styles",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-input/src/components/Input/useInputStyles.ts
@@ -67,7 +67,7 @@ const useRootStyles = makeStyles({
   interactive: {
     // This is all for the bottom focus border.
     // It's supposed to be 2px flat all the way across and match the radius of the field's corners.
-    ':after': {
+    '::after': {
       boxSizing: 'border-box',
       content: '""',
       position: 'absolute',
@@ -96,14 +96,14 @@ const useRootStyles = makeStyles({
       transitionDuration: motionDurations.ultraFast,
       transitionDelay: motionCurves.accelerateMid,
     },
-    ':focus-within:after': {
+    ':focus-within::after': {
       // Animation for focus IN
       transform: 'scaleX(1)',
       transitionProperty: 'transform',
       transitionDuration: motionDurations.normal,
       transitionDelay: motionCurves.decelerateMid,
     },
-    ':focus-within:active:after': {
+    ':focus-within:active::after': {
       // This is if the user clicks the field again while it's already focused
       borderBottomColor: tokens.colorCompoundBrandStrokePressed,
     },
@@ -158,7 +158,7 @@ const useRootStyles = makeStyles({
     ':active,:focus-within': {
       borderBottomColor: tokens.colorNeutralStrokeAccessiblePressed,
     },
-    ':after': shorthands.borderRadius(0), // remove rounded corners from focus underline
+    '::after': shorthands.borderRadius(0), // remove rounded corners from focus underline
   },
   filled: {
     boxShadow: tokens.shadow2, // optional shadow for filled appearances

--- a/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -57,8 +57,7 @@ const useRootStyles = makeStyles({
       zIndex: 10,
     },
 
-    // TODO: change this to `::after`. Needs to be changed at the same time as react-input.
-    ':after': {
+    '::after': {
       right: 0,
       bottom: 0,
       left: 0,


### PR DESCRIPTION
## Current Behavior

`Input` and `SpinButton` use the CSS2 `:after` pseudo element for styling.

## New Behavior

`Input` and `SpinButton` use the CSS3 `::after` pseudo element for styling. [Both syntaxes are acceptable](https://developer.mozilla.org/en-US/docs/Web/CSS/::after) however as we target modern evergreen browsers we should exclusively use the more recent syntax.

Fixes #22365
