### PR TITLE
feat: export useFluentProviderThemeStyleTag from @fluentui/react-provider

### DIFF
--- a/change/@fluentui-react-provider-87e7f793-4dae-4986-b27d-d120a8afe8c7.json
+++ b/change/@fluentui-react-provider-87e7f793-4dae-4986-b27d-d120a8afe8c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: export useFluentProviderThemeStyleTag from @fluentui/react-provider",
+  "packageName": "@fluentui/react-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-provider/etc/react-provider.api.md
+++ b/packages/react-provider/etc/react-provider.api.md
@@ -71,6 +71,9 @@ export function useFluentProviderContextValues_unstable(state: FluentProviderSta
 // @public
 export const useFluentProviderStyles_unstable: (state: FluentProviderState) => FluentProviderState;
 
+// @public
+export const useFluentProviderThemeStyleTag: (options: Pick<FluentProviderState, 'theme' | 'targetDocument'>) => string;
+
 export { useTheme }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-provider/src/components/FluentProvider/index.ts
+++ b/packages/react-provider/src/components/FluentProvider/index.ts
@@ -4,3 +4,4 @@ export * from './renderFluentProvider';
 export * from './useFluentProvider';
 export * from './useFluentProviderStyles';
 export * from './useFluentProviderContextValues';
+export * from './useFluentProviderThemeStyleTag';

--- a/packages/react-provider/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-provider/src/components/FluentProvider/useFluentProvider.ts
@@ -3,7 +3,7 @@ import type { Theme } from '@fluentui/react-theme';
 import { useFluent, useTheme } from '@fluentui/react-shared-contexts';
 import { getNativeElementProps, useMergedRefs } from '@fluentui/react-utilities';
 import * as React from 'react';
-import { useThemeStyleTag } from './useThemeStyleTag';
+import { useFluentProviderThemeStyleTag } from './useFluentProviderThemeStyleTag';
 import type { FluentProviderProps, FluentProviderState } from './FluentProvider.types';
 
 /**
@@ -46,7 +46,7 @@ export const useFluentProvider_unstable = (
     dir,
     targetDocument,
     theme: mergedTheme,
-    themeClassName: useThemeStyleTag({ theme: mergedTheme, targetDocument }),
+    themeClassName: useFluentProviderThemeStyleTag({ theme: mergedTheme, targetDocument }),
 
     components: {
       root: 'div',

--- a/packages/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.ts
+++ b/packages/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.ts
@@ -1,12 +1,12 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { resetIdsForTests } from '@fluentui/react-utilities';
 
-import { useThemeStyleTag } from './useThemeStyleTag';
+import { useFluentProviderThemeStyleTag } from './useFluentProviderThemeStyleTag';
 import type { Theme } from '@fluentui/react-theme';
 
 jest.mock('@fluentui/react-theme');
 
-describe('useThemeStyleTag', () => {
+describe('useFluentProviderThemeStyleTag', () => {
   const defaultTheme = ({
     'css-variable-1': '1',
     'css-variable-2': '2',
@@ -18,7 +18,9 @@ describe('useThemeStyleTag', () => {
 
   it('should render style tag', () => {
     // Act
-    const { result } = renderHook(() => useThemeStyleTag({ theme: defaultTheme, targetDocument: document }));
+    const { result } = renderHook(() =>
+      useFluentProviderThemeStyleTag({ theme: defaultTheme, targetDocument: document }),
+    );
 
     // Assert
     expect(document.getElementById(result.current)).not.toBeNull();
@@ -26,7 +28,9 @@ describe('useThemeStyleTag', () => {
 
   it('should remove style tag on unmount', () => {
     // Arrange
-    const { result, unmount } = renderHook(() => useThemeStyleTag({ theme: defaultTheme, targetDocument: document }));
+    const { result, unmount } = renderHook(() =>
+      useFluentProviderThemeStyleTag({ theme: defaultTheme, targetDocument: document }),
+    );
 
     // Act
     unmount();
@@ -37,7 +41,9 @@ describe('useThemeStyleTag', () => {
 
   it('should render css variables in theme', () => {
     // Act
-    const { result } = renderHook(() => useThemeStyleTag({ theme: defaultTheme, targetDocument: document }));
+    const { result } = renderHook(() =>
+      useFluentProviderThemeStyleTag({ theme: defaultTheme, targetDocument: document }),
+    );
 
     // Assert
     const tag = document.getElementById(result.current) as HTMLStyleElement;
@@ -51,7 +57,7 @@ describe('useThemeStyleTag', () => {
   it('should update style tag on theme change', () => {
     // Arrange
     let theme = defaultTheme;
-    const { result, rerender } = renderHook(() => useThemeStyleTag({ theme, targetDocument: document }));
+    const { result, rerender } = renderHook(() => useFluentProviderThemeStyleTag({ theme, targetDocument: document }));
 
     // Act
     theme = ({ 'css-variable-update': 'xxx' } as unknown) as Theme;

--- a/packages/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -8,7 +8,7 @@ import { fluentProviderClassNames } from './useFluentProviderStyles';
  *
  * @returns CSS class to apply the rule
  */
-export const useThemeStyleTag = (options: Pick<FluentProviderState, 'theme' | 'targetDocument'>) => {
+export const useFluentProviderThemeStyleTag = (options: Pick<FluentProviderState, 'theme' | 'targetDocument'>) => {
   const { targetDocument, theme } = options;
 
   const styleTagId = useId(fluentProviderClassNames.root);

--- a/packages/react-provider/src/index.ts
+++ b/packages/react-provider/src/index.ts
@@ -1,2 +1,19 @@
-export * from './FluentProvider';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  fluentProviderClassName,
+  fluentProviderClassNames,
+  FluentProvider,
+  renderFluentProvider_unstable,
+  useFluentProviderContextValues_unstable,
+  useFluentProvider_unstable,
+  useFluentProviderStyles_unstable,
+  useFluentProviderThemeStyleTag,
+} from './FluentProvider';
+export type {
+  FluentProviderContextValues,
+  FluentProviderProps,
+  FluentProviderState,
+  FluentProviderSlots,
+} from './FluentProvider';
+
 export { useFluent, useTheme } from '@fluentui/react-shared-contexts';


### PR DESCRIPTION
## New Behavior

- We don't use star re-export in `@fluentui/react-provider`
- `useThemeStyleTag` was renamed to `useFluentProviderThemeStyleTag`
- `useFluentProviderThemeStyleTag` is exported from `@fluentui/react-provider`
