### PR TITLE
fix(Tree): Do not stop propagation of letter keys if modifier is used

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Align `ChatMessageReadStatus` position with `ChatMessage` @Hirse ([#22494](https://github.com/microsoft/fluentui/pull/22494))
 - Align @fluentui/react-northstar (v0) and @fluentui/react-theme (v9) colors @jurokapsiar ([#22483](https://github.com/microsoft/fluentui/pull/22483))
 - Add missing export for `PortalContext` @layershifter ([#22448](https://github.com/microsoft/fluentui/pull/22448))
+- Do not stop propagation of letter keys if modifier is used in `Tree` @jurokapsiar ([#22603](https://github.com/microsoft/fluentui/pull/22603))
 
 <!--------------------------------[ v0.62.0 ]------------------------------- -->
 ## [v0.62.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.62.0) (2022-04-08)

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -268,7 +268,7 @@ export const TreeItem = (React.forwardRef<HTMLDivElement, TreeItemProps>((props,
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key && e.key.length === 1 && e.key.match(/\S/) && e.key !== '*') {
+    if (e.key && e.key.length === 1 && e.key.match(/\S/) && e.key !== '*' && !e.altKey && !e.ctrlKey && !e.metaKey) {
       e.preventDefault();
       e.stopPropagation();
       const toFocusID = getToFocusIDByFirstCharacter(e, props.id);


### PR DESCRIPTION
Tree was stoping propagation of all letter key key down events, even if modifiers were used.
This was preventing shortcuts to work when the focus was inside of the tree.