### PR TITLE
fix(DocumentCard): add focus styles to DocumentCardTitle

### DIFF
--- a/change/@fluentui-react-82502621-9430-4661-8986-3836b7ee7ce6.json
+++ b/change/@fluentui-react-82502621-9430-4661-8986-3836b7ee7ce6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add focus styles to DocumentCardTitle",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DocumentCard/DocumentCardTitle.styles.ts
+++ b/packages/react/src/components/DocumentCard/DocumentCardTitle.styles.ts
@@ -1,4 +1,5 @@
-import { getGlobalClassNames } from '../../Styling';
+import { getGlobalClassNames, getInputFocusStyle } from '../../Styling';
+import { IsFocusVisibleClassName } from '../../Utilities';
 import type { IDocumentCardTitleStyleProps, IDocumentCardTitleStyles } from './DocumentCardTitle.types';
 
 export const DocumentCardTitleGlobalClassNames = {
@@ -7,7 +8,7 @@ export const DocumentCardTitleGlobalClassNames = {
 
 export const getStyles = (props: IDocumentCardTitleStyleProps): IDocumentCardTitleStyles => {
   const { theme, className, showAsSecondaryTitle } = props;
-  const { palette, fonts } = theme;
+  const { palette, fonts, effects } = theme;
 
   const classNames = getGlobalClassNames(DocumentCardTitleGlobalClassNames, theme);
 
@@ -19,10 +20,17 @@ export const getStyles = (props: IDocumentCardTitleStyleProps): IDocumentCardTit
         padding: '8px 16px',
         display: 'block',
         overflow: 'hidden',
+        position: 'relative',
         wordWrap: 'break-word',
         height: showAsSecondaryTitle ? '45px' : '38px',
         lineHeight: showAsSecondaryTitle ? '18px' : '21px',
         color: showAsSecondaryTitle ? palette.neutralSecondary : palette.neutralPrimary,
+        selectors: {
+          ':focus': {
+            outline: '0px solid',
+          },
+          [`.${IsFocusVisibleClassName} &:focus`]: getInputFocusStyle(palette.neutralSecondary, effects.roundedCorner2),
+        },
       },
       className,
     ],

--- a/packages/react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -71,7 +71,28 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
           padding-left: 16px;
           padding-right: 16px;
           padding-top: 8px;
+          position: relative;
           word-wrap: break-word;
+        }
+        &:focus {
+          outline: 0px solid;
+        }
+        .ms-Fabric--isFocusVisible &:focus {
+          border-color: #605e5c;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border-radius: 2px;
+          border: 2px solid #605e5c;
+          bottom: -1px;
+          content: '';
+          left: -1px;
+          pointer-events: none;
+          position: absolute;
+          right: -1px;
+          top: -1px;
+        }
+        @media screen and (-ms-high-contrast: active), (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border-color: Highlight;
         }
     title=""
   >


### PR DESCRIPTION
Fixes #22608, related to #21461

DocumentCard received a previous a11y fix to move the focus target to the title element so it would be less verbose on focus, and so the focus target would have a logical role. This PR adds visible focus styles to the title component.