### PR TITLE
refactor(tools): make --stats printer generic

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -1034,35 +1034,12 @@ describe('migrate-converged-pkg generator', () => {
   });
 
   describe(`--stats`, () => {
-    beforeEach(() => {
-      setupDummyPackage(tree, { name: '@proj/react-foo', version: '9.0.22' });
-      setupDummyPackage(tree, { name: '@proj/react-bar', version: '9.0.31' });
-      setupDummyPackage(tree, { name: '@proj/react-old', version: '8.1.12' });
-      setupDummyPackage(tree, { name: '@proj/react-older', version: '8.9.12' });
-    });
-
     it(`should print project names and count of how many have been migrated`, async () => {
       const loggerInfoSpy = jest.spyOn(logger, 'info');
 
       await generator(tree, { stats: true });
 
-      expect(loggerInfoSpy.mock.calls[5][0]).toEqual(`Not migrated (4):`);
-      expect(loggerInfoSpy.mock.calls[6][0]).toEqual(
-        expect.stringContaining(stripIndents`
-      - @proj/react-dummy
-      - @proj/babel-make-styles
-      - @proj/react-foo
-      - @proj/react-bar
-      `),
-      );
-
-      loggerInfoSpy.mockClear();
-
-      await generator(tree, options);
-      await generator(tree, { stats: true });
-
-      expect(loggerInfoSpy.mock.calls[2][0]).toEqual('Migrated (1):');
-      expect(loggerInfoSpy.mock.calls[5][0]).toEqual(`Not migrated (3):`);
+      expect(loggerInfoSpy).toHaveBeenCalled();
     });
   });
 

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -18,10 +18,19 @@ import * as path from 'path';
 import * as os from 'os';
 
 import { PackageJson, TsConfig } from '../../types';
-import { arePromptsEnabled, getProjectConfig, getProjects, printUserLogs, prompt, UserLog } from '../../utils';
+import {
+  arePromptsEnabled,
+  getProjectConfig,
+  getProjects,
+  isPackageConverged,
+  printUserLogs,
+  prompt,
+  UserLog,
+} from '../../utils';
 
 import { MigrateConvergedPkgGeneratorSchema } from './schema';
 import { addCodeowner } from '../add-codeowners';
+import { printStats } from '../print-stats';
 
 interface ProjectConfiguration extends ReturnType<typeof readProjectConfiguration> {}
 
@@ -37,7 +46,12 @@ export default async function (tree: Tree, schema: MigrateConvergedPkgGeneratorS
   const validatedSchema = await validateSchema(tree, schema);
 
   if (hasSchemaFlag(validatedSchema, 'stats')) {
-    printStats(tree, validatedSchema);
+    printStats(tree, {
+      projects: getProjects(tree),
+      title: 'Converged DX',
+      isMigratedCheck: isProjectMigrated,
+      shouldProcessPackage: isPackageConverged,
+    });
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     return () => {};
   }
@@ -399,44 +413,6 @@ async function triggerDynamicPrompts() {
       name: 'name',
     },
   ]);
-}
-
-function printStats(tree: Tree, options: MigrateConvergedPkgGeneratorSchema) {
-  const allProjects = getProjects(tree);
-  const stats = {
-    migrated: [] as Array<ProjectConfiguration & { projectName: string }>,
-    notMigrated: [] as Array<ProjectConfiguration & { projectName: string }>,
-  };
-
-  allProjects.forEach((project, projectName) => {
-    if (!isPackageConverged(tree, project)) {
-      return;
-    }
-
-    if (isProjectMigrated(tree, project)) {
-      stats.migrated.push({ projectName, ...project });
-
-      return;
-    }
-    stats.notMigrated.push({ projectName, ...project });
-  });
-
-  logger.info('Convergence DX migration stats:');
-  logger.info('='.repeat(80));
-
-  logger.info(`Migrated (${stats.migrated.length}):`);
-  logger.info(stats.migrated.map(projectStat => `- ${projectStat.projectName}`).join('\n'));
-
-  logger.info('='.repeat(80));
-  logger.info(`Not migrated (${stats.notMigrated.length}):`);
-  logger.info(stats.notMigrated.map(projectStat => `- ${projectStat.projectName}`).join('\n'));
-
-  return tree;
-}
-
-function isPackageConverged(tree: Tree, project: ProjectConfiguration) {
-  const packageJson = readJson<PackageJson>(tree, joinPathFragments(project.root, 'package.json'));
-  return packageJson.version.startsWith('9.');
 }
 
 function isProjectMigrated<T extends ProjectConfiguration>(

--- a/tools/generators/migrate-v8-pkg/index.spec.ts
+++ b/tools/generators/migrate-v8-pkg/index.spec.ts
@@ -55,46 +55,12 @@ describe('migrate-v8-pkg generator', () => {
   });
 
   describe(`--stats`, () => {
-    beforeEach(() => {
-      setupDummyPackage(tree, {
-        name: '@proj/react-foo',
-        version: '9.0.22',
-        eslintConfig: {
-          extends: ['@proj/eslint-react'],
-        },
-      });
-      setupDummyPackage(tree, {
-        name: '@proj/react-bar',
-        version: '9.0.31',
-        eslintConfig: {
-          extends: ['@proj/eslint-react'],
-        },
-      });
-      setupDummyPackage(tree, { name: '@proj/react-old', version: '8.1.12' });
-      setupDummyPackage(tree, { name: '@proj/react-older', version: '8.9.12' });
-    });
-
     it(`should print project names and count of how many have been migrated`, async () => {
       const loggerInfoSpy = jest.spyOn(logger, 'info');
 
       await generator(tree, { stats: true });
 
-      expect(loggerInfoSpy.mock.calls[5][0]).toEqual(`Not migrated (5):`);
-      expect(loggerInfoSpy.mock.calls[6][0]).toMatchInlineSnapshot(`
-        "- @proj/eight | lint:@proj/react--legacy
-        - @proj/react | lint:['@proj/react--legacy']
-        - @proj/merge-styles | lint:@proj/react--legacy
-        - @proj/react-old | lint:@proj/react--legacy
-        - @proj/react-older | lint:@proj/react--legacy"
-      `);
-
-      loggerInfoSpy.mockClear();
-
-      await generator(tree, options);
-      await generator(tree, { stats: true });
-
-      expect(loggerInfoSpy.mock.calls[2][0]).toEqual('Migrated (0):');
-      expect(loggerInfoSpy.mock.calls[5][0]).toEqual(`Not migrated (5):`);
+      expect(loggerInfoSpy).toHaveBeenCalled();
     });
   });
 });

--- a/tools/generators/print-stats.spec.ts
+++ b/tools/generators/print-stats.spec.ts
@@ -1,0 +1,157 @@
+import { addProjectConfiguration, getProjects, logger, stripIndents, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import * as chalk from 'chalk';
+
+import { printStats } from './print-stats';
+
+describe(`print stats`, () => {
+  // @ts-expect-error - chalk ships wrong types. this is standard public API to turn off chalk
+  chalk.level = 0;
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const noop = () => {};
+
+  function formatMockedCalls(values: string[][]) {
+    return values
+      .flat()
+      .map(line => line.trim())
+      .join('\n');
+  }
+
+  let tree: Tree;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+
+    jest.spyOn(console, 'log').mockImplementation(noop);
+    jest.spyOn(console, 'info').mockImplementation(noop);
+    jest.spyOn(console, 'warn').mockImplementation(noop);
+
+    tree = createTreeWithEmptyWorkspace();
+
+    addProjectConfiguration(tree, '@proj/pkg-a', {
+      root: 'packages/pkg-a',
+      projectType: 'library',
+      targets: {},
+    });
+    addProjectConfiguration(tree, '@proj/pkg-b', {
+      root: 'packages/pkg-b',
+      projectType: 'library',
+      targets: {},
+    });
+    addProjectConfiguration(tree, '@proj/app-a', {
+      root: 'apps/app-a',
+      projectType: 'application',
+      targets: {},
+    });
+    addProjectConfiguration(tree, '@proj/app-b', {
+      root: 'apps/app-b',
+      projectType: 'application',
+      targets: {},
+    });
+  });
+
+  it(`should print stats`, () => {
+    const loggerInfoSpy = jest.spyOn(logger, 'info');
+
+    printStats(tree, {
+      projects: getProjects(tree),
+      title: 'IT WORKS',
+      isMigratedCheck: (_tree, project) => {
+        return project.root === 'packages/pkg-a';
+      },
+      shouldProcessPackage: (_tree, _project) => {
+        return true;
+      },
+    });
+
+    expect(formatMockedCalls(loggerInfoSpy.mock.calls)).toMatchInlineSnapshot(`
+      ">  IT WORKS migration stats:
+      Migrated:
+      Libs: (1)
+      - @proj/pkg-a
+      Apps (0):
+
+      Not Migrated:
+      Libs (1):
+      - @proj/pkg-b
+      Apps (2):
+      - @proj/app-a
+      - @proj/app-b"
+    `);
+  });
+
+  it(`should use custom formatter`, () => {
+    const loggerInfoSpy = jest.spyOn(logger, 'info');
+
+    printStats(tree, {
+      projects: getProjects(tree),
+      title: 'IT WORKS',
+      isMigratedCheck: (_tree, project) => {
+        return project.root === 'packages/pkg-a';
+      },
+      shouldProcessPackage: (_tree, _project) => {
+        return true;
+      },
+      projectInfoFormat: data => {
+        return `--- CUSTOM | ${data.root}`;
+      },
+    });
+
+    expect(formatMockedCalls(loggerInfoSpy.mock.calls)).toMatchInlineSnapshot(`
+      ">  IT WORKS migration stats:
+      Migrated:
+      Libs: (1)
+      --- CUSTOM | packages/pkg-a
+      Apps (0):
+
+      Not Migrated:
+      Libs (1):
+      --- CUSTOM | packages/pkg-b
+      Apps (2):
+      --- CUSTOM | apps/app-a
+      --- CUSTOM | apps/app-b"
+    `);
+  });
+
+  it(`should use custom project data`, () => {
+    const loggerInfoSpy = jest.spyOn(logger, 'info');
+
+    const customProjects = new Map(
+      Array.from(getProjects(tree).entries()).map(([projectName, project]) => {
+        const metadata = { ultimateTruth: 'it iz wat it iiiz' };
+        const extendedProject = { ...project, metadata };
+        return [projectName, extendedProject] as const;
+      }),
+    );
+
+    printStats(tree, {
+      projects: customProjects,
+      title: 'IT WORKS',
+      isMigratedCheck: (_tree, project) => {
+        return project.root === 'packages/pkg-a';
+      },
+      shouldProcessPackage: (_tree, _project) => {
+        return true;
+      },
+      projectInfoFormat: data => {
+        return `- ${data.root} | ${data.metadata.ultimateTruth}`;
+      },
+    });
+
+    expect(formatMockedCalls(loggerInfoSpy.mock.calls)).toMatchInlineSnapshot(`
+      ">  IT WORKS migration stats:
+      Migrated:
+      Libs: (1)
+      - packages/pkg-a | it iz wat it iiiz
+      Apps (0):
+
+      Not Migrated:
+      Libs (1):
+      - packages/pkg-b | it iz wat it iiiz
+      Apps (2):
+      - apps/app-a | it iz wat it iiiz
+      - apps/app-b | it iz wat it iiiz"
+    `);
+  });
+});

--- a/tools/generators/print-stats.ts
+++ b/tools/generators/print-stats.ts
@@ -1,0 +1,63 @@
+import * as chalk from 'chalk';
+import { Tree, ProjectConfiguration, logger } from '@nrwl/devkit';
+
+interface Options<T extends ProjectConfiguration> {
+  title: string;
+  projects: Map<string, T>;
+  shouldProcessPackage: (tree: Tree, project: ProjectConfiguration) => boolean;
+  isMigratedCheck: (tree: Tree, project: ProjectConfiguration) => boolean;
+  projectInfoFormat?: (data: StatData<T>) => string;
+}
+type StatData<T extends ProjectConfiguration> = T & { projectName: string };
+
+export function printStats<T extends ProjectConfiguration>(tree: Tree, options: Options<T>) {
+  const { isMigratedCheck, projectInfoFormat, shouldProcessPackage, title, projects } = {
+    projectInfoFormat: defaultProjectInfoFormat,
+    ...options,
+  };
+
+  const stats = {
+    migrated: { application: [] as Array<StatData<T>>, library: [] as Array<StatData<T>> },
+    notMigrated: { application: [] as Array<StatData<T>>, library: [] as Array<StatData<T>> },
+  };
+
+  projects.forEach((project, projectName) => {
+    if (!project.projectType) {
+      throw new Error(`${projectName}: is missing "projectType" categorization in workspace.json!`);
+    }
+    if (!shouldProcessPackage(tree, project)) {
+      return;
+    }
+
+    if (isMigratedCheck(tree, project)) {
+      stats.migrated[project.projectType].push({ projectName, ...project });
+
+      return;
+    }
+
+    stats.notMigrated[project.projectType].push({ projectName, ...project });
+  });
+
+  const heading = printTitle(`${title} migration stats:`);
+
+  logger.info(heading);
+
+  logger.info(chalk.reset.inverse.bold.green(` Migrated: `));
+  logger.info(`Libs: (${stats.migrated.library.length})`);
+  logger.info(stats.migrated.library.map(projectInfoFormat).join('\n'));
+  logger.info(`Apps (${stats.migrated.application.length}):`);
+  logger.info(stats.migrated.application.map(projectInfoFormat).join('\n'));
+
+  logger.info(chalk.reset.hex('#FFF').bgHex('#FF8800').bold(` Not Migrated: `));
+  logger.info(`Libs (${stats.notMigrated.library.length}):`);
+  logger.info(stats.notMigrated.library.map(projectInfoFormat).join('\n'));
+  logger.info(`Apps (${stats.notMigrated.application.length}):`);
+  logger.info(stats.notMigrated.application.map(projectInfoFormat).join('\n'));
+
+  return tree;
+}
+
+const printTitle = (title: string) => `${chalk.cyan('>')} ${chalk.inverse(chalk.bold(chalk.cyan(` ${title} `)))}\n`;
+function defaultProjectInfoFormat<T extends ProjectConfiguration>(data: StatData<T>) {
+  return `- ${data.projectName}`;
+}

--- a/tools/tsconfig.tools.json
+++ b/tools/tsconfig.tools.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "outDir": "../dist/out-tsc/tools",
     "rootDir": ".",
-    "module": "commonjs",
-    "target": "es5",
+    "module": "CommonJS",
+    "target": "ES2015",
     "types": ["node"],
     "importHelpers": false,
     "downlevelIteration": true

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
     "target": "ES2019",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["ES2015", "dom"],
+    "lib": ["ES2019", "dom"],
     "sourceMap": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

v8 and converged migration generator:
- implement `--stats` on its own
- implement `is*` check on its own
- don't distinguish between applications and libraries when `--stats` flag is used 

![image](https://user-images.githubusercontent.com/1223799/165105817-b3b06d96-13fe-43bb-aeff-e5d6ecd1c8e2.png)


## New Behavior

- leverages encapsulated `is*` from utils
- `printStats` is now generic function
- more terminal colors
- distinguish applications and libraries

![image](https://user-images.githubusercontent.com/1223799/165105657-fee222be-e815-4c3f-9aa9-290490fb2e77.png)


## Related Issue(s)
