### PR TITLE
fix(tools): don't run invalid migrations on application

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -162,6 +162,30 @@ describe('migrate-converged-pkg generator', () => {
         expect(promptSpy).toHaveBeenCalledTimes(0);
       });
     });
+
+    describe(`projectType execution`, () => {
+      it(`should do limited migration for "application"`, async () => {
+        tree.write('apps/my-app/src/index.ts', `import * as React from 'react';`);
+        writeJson(tree, 'apps/my-app/package.json', { name: '@proj/my-app', private: true, version: '9.0.0' });
+        writeJson(tree, 'apps/my-app/tsconfig.json', { compilerOptions: {}, include: ['src'] });
+        addProjectConfiguration(tree, '@proj/my-app', {
+          root: 'apps/my-app',
+          projectType: 'application',
+          targets: {},
+        });
+
+        const loggerInfoSpy = jest.spyOn(logger, 'warn');
+
+        await generator(tree, { name: '@proj/my-app' });
+
+        expect(loggerInfoSpy.mock.calls.flat()).toMatchInlineSnapshot(`
+          Array [
+            "NOTE: you're trying to migrate an Application - @proj/my-app.
+          We apply limited migration steps at the moment.",
+          ]
+        `);
+      });
+    });
   });
 
   describe(`tsconfig updates`, () => {

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -83,6 +83,16 @@ function runMigrationOnProject(tree: Tree, schema: AssertedSchema, userLog: User
     addCodeowner(tree, { owner: options.owner, packageName: options.name });
   }
 
+  if (options.projectConfig.projectType === 'application') {
+    logger.warn(
+      stripIndents`
+      NOTE: you're trying to migrate an Application - ${options.name}.
+      We apply limited migration steps at the moment.
+      `,
+    );
+    return;
+  }
+
   // 1. update TsConfigs
   updatedLocalTsConfig(tree, options);
   updatedBaseTsConfig(tree, options);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
     "target": "ES2019",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["ES2015", "dom"],
+    "lib": ["ES2019", "dom"],
     "sourceMap": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

migration are executed on applications, which is invalid. we don't provide yet new DX setup for apps

## New Behavior

migration executed on application will bail out with proper message and apply only limited supported set of migrations (codeowners only atm if `--owner` provided)

![image](https://user-images.githubusercontent.com/1223799/165123854-e2a2386f-fa50-4c1a-8858-d76a4ce42956.png)


## Related Issue(s)


