### PR TITLE
fix(tools): update CODEOWNERS relative path of moved package

### DIFF
--- a/tools/generators/move-packages/index.spec.ts
+++ b/tools/generators/move-packages/index.spec.ts
@@ -136,10 +136,10 @@ describe('move-packages generator', () => {
     it('should update the CODEOWNERS file with the new relative path', async () => {
       await generator(tree, options);
       const newPath = `packages/${options.destination}`;
-      const oldPath = `packages/${options.name}`;
+      const oldPath = `packages/test`;
       const codeOwnersFile = tree.read(joinPathFragments('/.github', 'CODEOWNERS'), 'utf8') as string;
-      expect(codeOwnersFile.split(' ').filter(s => s.includes(oldPath))).toHaveLength(0);
-      expect(codeOwnersFile.split(' ').filter(s => s.includes(newPath))).toHaveLength(1);
+      expect(codeOwnersFile.split(' ').filter(s => s === oldPath)).toHaveLength(0);
+      expect(codeOwnersFile.split(' ').filter(s => s === newPath)).toHaveLength(1);
     });
   });
 

--- a/tools/generators/move-packages/index.spec.ts
+++ b/tools/generators/move-packages/index.spec.ts
@@ -49,6 +49,9 @@ describe('move-packages generator', () => {
     };
     tree.write(`nx.json`, serializeJson(nxJsonConfig));
 
+    const codeOwners = `packages/test @dummyOwner`;
+    tree.write(`/.github/CODEOWNERS`, codeOwners);
+
     tree = setupDummyPackage(tree, {
       ...options,
       name: options.name!,
@@ -129,6 +132,14 @@ describe('move-packages generator', () => {
       const storybookMainJsPath = joinPathFragments(project.root, '/.storybook/main.js');
       const storybookMainJsFile = tree.read(storybookMainJsPath, 'utf8') as string;
       expect(storybookMainJsFile.split(' ').filter(s => s.includes(newPath))).toHaveLength(2);
+    });
+    it('should update the CODEOWNERS file with the new relative path', async () => {
+      await generator(tree, options);
+      const newPath = `packages/${options.destination}`;
+      const oldPath = `packages/${options.name}`;
+      const codeOwnersFile = tree.read(joinPathFragments('/.github', 'CODEOWNERS'), 'utf8') as string;
+      expect(codeOwnersFile.split(' ').filter(s => s.includes(oldPath))).toHaveLength(0);
+      expect(codeOwnersFile.split(' ').filter(s => s.includes(newPath))).toHaveLength(1);
     });
   });
 

--- a/tools/generators/move-packages/index.spec.ts
+++ b/tools/generators/move-packages/index.spec.ts
@@ -16,6 +16,7 @@ import {
 import generator from './index';
 import { MovePackagesGeneratorSchema } from './schema';
 import { TsConfig } from '../../types';
+import { setupCodeowners } from '../../utils-testing';
 
 type ReadProjectConfiguration = ReturnType<typeof readProjectConfiguration>;
 const noop = () => null;
@@ -34,6 +35,8 @@ describe('move-packages generator', () => {
 
     tree = createTreeWithEmptyWorkspace();
 
+    setupCodeowners(tree, { content: `packages/test @dummyOwner` });
+
     const nxJsonConfig = {
       npmScope: 'proj',
       affected: { defaultBase: 'main' },
@@ -48,9 +51,6 @@ describe('move-packages generator', () => {
       },
     };
     tree.write(`nx.json`, serializeJson(nxJsonConfig));
-
-    const codeOwners = `packages/test @dummyOwner`;
-    tree.write(`/.github/CODEOWNERS`, codeOwners);
 
     tree = setupDummyPackage(tree, {
       ...options,
@@ -126,20 +126,33 @@ describe('move-packages generator', () => {
       expect(tree.exists(`packages/${options.name}/config/tests.js`)).toBeFalsy();
     });
     it('should update storybook main.js module.exports type to the new relative path', async () => {
-      await generator(tree, options);
       const newPath = '../../../../.storybook/main';
-      const project = getProjects(tree).get(options.name as string) as ProjectConfiguration;
-      const storybookMainJsPath = joinPathFragments(project.root, '/.storybook/main.js');
-      const storybookMainJsFile = tree.read(storybookMainJsPath, 'utf8') as string;
-      expect(storybookMainJsFile.split(' ').filter(s => s.includes(newPath))).toHaveLength(2);
+      let project = getProjects(tree).get(options.name as string) as ProjectConfiguration;
+      let storybookMainJsPath = joinPathFragments(project.root, '/.storybook/main.js');
+
+      let storybookMainJsFile = tree.read(storybookMainJsPath, 'utf8') as string;
+      expect(storybookMainJsFile.indexOf(newPath) !== -1).toBeFalsy();
+
+      await generator(tree, options);
+
+      project = getProjects(tree).get(options.name as string) as ProjectConfiguration;
+      storybookMainJsPath = joinPathFragments(project.root, '/.storybook/main.js');
+      storybookMainJsFile = tree.read(storybookMainJsPath, 'utf8') as string;
+      expect(storybookMainJsFile.indexOf(newPath) !== -1).toBeTruthy();
     });
     it('should update the CODEOWNERS file with the new relative path', async () => {
+      const oldOwnerDeclaration = `packages/test @dummyOwner`;
+      const newOwnerDeclaration = `packages/${options.destination} @dummyOwner`;
+      const codeOwnersPath = joinPathFragments('/.github', 'CODEOWNERS');
+
+      let codeOwnersFile = tree.read(codeOwnersPath, 'utf8') as string;
+      expect(codeOwnersFile.indexOf(oldOwnerDeclaration) !== -1).toBeTruthy();
+
       await generator(tree, options);
-      const newPath = `packages/${options.destination}`;
-      const oldPath = `packages/test`;
-      const codeOwnersFile = tree.read(joinPathFragments('/.github', 'CODEOWNERS'), 'utf8') as string;
-      expect(codeOwnersFile.split(' ').filter(s => s === oldPath)).toHaveLength(0);
-      expect(codeOwnersFile.split(' ').filter(s => s === newPath)).toHaveLength(1);
+
+      codeOwnersFile = tree.read(codeOwnersPath, 'utf8') as string;
+      expect(codeOwnersFile.indexOf(oldOwnerDeclaration) !== -1).toBeFalsy();
+      expect(codeOwnersFile.indexOf(newOwnerDeclaration) !== -1).toBeTruthy();
     });
   });
 

--- a/tools/generators/move-packages/index.ts
+++ b/tools/generators/move-packages/index.ts
@@ -142,9 +142,7 @@ function updateStorybookTypeImport(tree: Tree, schema: MovePackagesGeneratorSche
 function updateCodeOwners(tree: Tree, schema: MovePackagesGeneratorSchema) {
   const { name, destination } = schema;
   if (name) {
-    const project = getProjects(tree).get(name) as ProjectConfiguration;
-    const oldPackagePath = 'packages/' + name.split('/')[1];
-    const newPackagePath = project.root;
+    const oldPackageName = name.split('/')[1];
     const codeownersPath = joinPathFragments('/.github', 'CODEOWNERS');
 
     if (!tree.exists(codeownersPath)) {
@@ -152,7 +150,7 @@ function updateCodeOwners(tree: Tree, schema: MovePackagesGeneratorSchema) {
     }
 
     const codeOwnersFile = tree.read(codeownersPath, 'utf8') as string;
-    const updatedCodeOwnersFile = codeOwnersFile.replace(oldPackagePath, newPackagePath);
+    const updatedCodeOwnersFile = codeOwnersFile.replace(oldPackageName, destination);
     tree.write(codeownersPath, updatedCodeOwnersFile);
   }
 }

--- a/tools/generators/move-packages/index.ts
+++ b/tools/generators/move-packages/index.ts
@@ -152,7 +152,7 @@ function updateCodeOwners(tree: Tree, schema: MovePackagesGeneratorSchema) {
     }
 
     const codeOwnersFile = tree.read(codeownersPath, 'utf8') as string;
-    const updateCodeOwndersFile = codeOwnersFile.replace(oldPackagePath, newPackagePath);
-    tree.write(codeownersPath, updateCodeOwndersFile);
+    const updatedCodeOwnersFile = codeOwnersFile.replace(oldPackagePath, newPackagePath);
+    tree.write(codeownersPath, updatedCodeOwnersFile);
   }
 }

--- a/tools/generators/move-packages/index.ts
+++ b/tools/generators/move-packages/index.ts
@@ -142,7 +142,7 @@ function updateStorybookTypeImport(tree: Tree, schema: MovePackagesGeneratorSche
 function updateCodeOwners(tree: Tree, schema: MovePackagesGeneratorSchema) {
   const { name, destination } = schema;
   if (name) {
-    const oldPackageName = name.split('/')[1];
+    const pkgName = name.split('/')[1];
     const codeownersPath = joinPathFragments('/.github', 'CODEOWNERS');
 
     if (!tree.exists(codeownersPath)) {
@@ -150,7 +150,7 @@ function updateCodeOwners(tree: Tree, schema: MovePackagesGeneratorSchema) {
     }
 
     const codeOwnersFile = tree.read(codeownersPath, 'utf8') as string;
-    const updatedCodeOwnersFile = codeOwnersFile.replace(oldPackageName, destination);
+    const updatedCodeOwnersFile = codeOwnersFile.replace(pkgName, destination);
     tree.write(codeownersPath, updatedCodeOwnersFile);
   }
 }


### PR DESCRIPTION
## Current Behavior: 
The `move-packages` nx generator was not updating the CODEOWNERS file with the moved package's new relative path

## New Behavior:
`move-packages` generator now updates CODEOWNERS file after package move.

## Fixes:
Follow-up to https://github.com/microsoft/fluentui/pull/22506#discussion_r857426868