### PR TITLE
fix(tools): differentiate migration based on platform

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -900,10 +900,6 @@ describe('migrate-converged-pkg generator', () => {
       const babelConfigPath = `${projectConfig.root}/.babelrc.json`;
       return readJson(tree, babelConfigPath);
     }
-    function getPackageJson(projectConfig: ReadProjectConfiguration) {
-      const packageJsonPath = `${projectConfig.root}/package.json`;
-      return readJson<PackageJson>(tree, packageJsonPath);
-    }
 
     it(`should setup .babelrc.json`, async () => {
       const projectConfig = readProjectConfiguration(tree, options.name);
@@ -959,7 +955,7 @@ describe('migrate-converged-pkg generator', () => {
 
       expect(babelConfig).toEqual({
         presets: [],
-        plugins: ['annotate-pure-calls', '@babel/transform-react-pure-annotations'],
+        plugins: ['annotate-pure-calls'],
       });
     });
   });

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -168,6 +168,7 @@ const templates = {
 
         if (options.platform === 'node') {
           tsConfig.compilerOptions.module = 'CommonJS';
+          tsConfig.compilerOptions.types = uniqueArray([...(tsConfig.compilerOptions.types ?? []), 'node']);
         }
         if (options.platform === 'web') {
           tsConfig.compilerOptions.lib?.push('dom');
@@ -201,16 +202,26 @@ const templates = {
       },
     };
   },
-  babelConfig: (options: { extraPresets: Array<string> }) => {
+  babelConfig: (options: { platform: 'node' | 'web'; extraPresets: Array<string> }) => {
+    const plugins = ['annotate-pure-calls'];
+    if (options.platform === 'web') {
+      plugins.push('@babel/transform-react-pure-annotations');
+    }
+
     return {
       presets: [...options.extraPresets],
-      plugins: ['annotate-pure-calls', '@babel/transform-react-pure-annotations'],
+      plugins,
     };
   },
   jestSetup: stripIndents`
    /** Jest test setup file. */
   `,
-  jest: (options: { pkgName: string; addSnapshotSerializers: boolean; testSetupFilePath: string }) => stripIndents`
+  jest: (options: {
+    platform: 'node' | 'web';
+    pkgName: string;
+    addSnapshotSerializers: boolean;
+    testSetupFilePath: string;
+  }) => stripIndents`
       // @ts-check
 
       /**
@@ -738,6 +749,7 @@ function shouldSetupE2E(tree: Tree, options: NormalizedSchema) {
 
 function updateLocalJestConfig(tree: Tree, options: NormalizedSchema) {
   const jestSetupFilePath = options.paths.jestSetupFile;
+  const packageType = getPackageType(tree, options);
   const packagesThatTriggerAddingSnapshots = [`@griffel/react`];
 
   const packageJson = readJson<PackageJson>(tree, options.paths.packageJson);
@@ -745,11 +757,12 @@ function updateLocalJestConfig(tree: Tree, options: NormalizedSchema) {
 
   const config = {
     pkgName: options.normalizedPkgName,
-    addSnapshotSerializers: Object.keys(packageJson.dependencies).some(pkgDepName =>
-      packagesThatTriggerAddingSnapshots.includes(pkgDepName),
-    ),
+    addSnapshotSerializers:
+      packageType === 'web' &&
+      Object.keys(packageJson.dependencies).some(pkgDepName => packagesThatTriggerAddingSnapshots.includes(pkgDepName)),
     testSetupFilePath: `./${path.basename(options.paths.configRoot)}/tests.js`,
-  };
+    platform: packageType,
+  } as const;
 
   tree.write(options.paths.jestConfig, templates.jest(config));
 
@@ -840,12 +853,13 @@ function updatedBaseTsConfig(tree: Tree, options: NormalizedSchema) {
 
 function setupBabel(tree: Tree, options: NormalizedSchema) {
   const pkgJson = readJson<PackageJson>(tree, options.paths.packageJson);
+  const packageType = getPackageType(tree, options);
   pkgJson.dependencies = pkgJson.dependencies || {};
   pkgJson.devDependencies = pkgJson.devDependencies || {};
 
-  const shouldAddGriffelPreset = pkgJson.dependencies['@griffel/react'];
+  const shouldAddGriffelPreset = pkgJson.dependencies['@griffel/react'] && packageType === 'web';
   const extraPresets = shouldAddGriffelPreset ? ['@griffel'] : [];
-  const config = templates.babelConfig({ extraPresets });
+  const config = templates.babelConfig({ extraPresets, platform: packageType });
 
   tree.write(options.paths.babelConfig, serializeJson(config));
   writeJson(tree, options.paths.packageJson, pkgJson);

--- a/workspace.json
+++ b/workspace.json
@@ -227,6 +227,11 @@
       "projectType": "library",
       "implicitDependencies": []
     },
+    "@fluentui/public-docsite-v9": {
+      "root": "apps/public-docsite-v9",
+      "projectType": "application",
+      "implicitDependencies": []
+    },
     "@fluentui/react": {
       "root": "packages/react",
       "projectType": "library",
@@ -344,7 +349,9 @@
     "@fluentui/react-conformance-griffel": {
       "root": "packages/react-conformance-griffel",
       "projectType": "library",
-      "sourceRoot": "packages/react-conformance-griffel/src"
+      "sourceRoot": "packages/react-conformance-griffel/src",
+      "tags": ["vNext", "platform:node"],
+      "implicitDependencies": []
     },
     "@fluentui/react-context-selector": {
       "root": "packages/react-context-selector",
@@ -748,11 +755,6 @@
       "projectType": "library",
       "sourceRoot": "typings",
       "tags": ["platform:any"]
-    },
-    "@fluentui/public-docsite-v9": {
-      "root": "apps/public-docsite-v9",
-      "projectType": "application",
-      "implicitDependencies": []
     },
     "@fluentui/utilities": {
       "root": "packages/utilities",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- migration generator treats any package in same way
- react-conformance-griffel has status as not migrated

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- migration generator sets things based on platform
- react-conformance-griffel has status as migrated

## Related Issue(s)

- https://github.com/microsoft/fluentui/pull/22510/files/3e82ece6493d6d4cfc7d4b83fa30c5dd585430b6#diff-53d041a38d55bd0f14d2fcfb1d909be13108d8901d833876a0c8d643c9832f67
- https://github.com/microsoft/fluentui/pull/22510/files/d89c99862b1b374572290a7b84ae2411dca75b5a#diff-8e22a885f81c0e7971ea263553a27a4b947e1973a34f649d4768472a8e59338a


