### PR TITLE
DRAFT, DO NOT MERGEExample updated Slot type

### DIFF
--- a/packages/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
@@ -1,5 +1,5 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-// import { Input } from '@fluentui/react-input';
+import { Input } from '@fluentui/react-input';
 import * as React from 'react';
 
 export type SpinButtonSlots = {
@@ -17,6 +17,8 @@ export type SpinButtonSlots = {
    * This is the primary slot.
    */
   input: NonNullable<Slot<'input'>>;
+
+  inputExample: NonNullable<Slot<typeof Input>>;
 
   /**
    * Renders the increment control.

--- a/packages/react-utilities/src/compose/types.ts
+++ b/packages/react-utilities/src/compose/types.ts
@@ -95,7 +95,7 @@ type IntrisicElementProps<Type extends keyof JSX.IntrinsicElements> = React.Prop
  * ```
  */
 export type Slot<
-  Type extends keyof JSX.IntrinsicElements | React.ComponentType | UnknownSlotProps,
+  Type extends keyof JSX.IntrinsicElements | React.ComponentType | React.VoidFunctionComponent | UnknownSlotProps,
   AlternateAs extends keyof JSX.IntrinsicElements = never
 > = IsSingleton<Extract<Type, string>> extends true
   ?


### PR DESCRIPTION
## Current Behavior

The `Slot` helper type does not allow components that include `children?: never` in their type.

## New Behavior

The `Slot` helper type allows components with `children?: never` in their type.

