### PR TITLE
Added button and menu upgrade docs

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Button.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Button.stories.mdx
@@ -49,7 +49,7 @@ Properties with Y in the Shim column are handled when using the button shims.
 | key                      | key                                   |
 | keyTipProps              |                                       |
 | menuAs                   | (use Menu and HTML as)                |
-| menuIconProps            | (use MenuButton menuIcon)             |
+| menuIconProps            | (use MenuButton menuIcon slot)        |
 | menuProps                | (use Menu and MenuButton)             |
 | menuTriggerKeyCode       |                                       |
 | onMenuClick              | HTML onClick                          |

--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Button.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Button.stories.mdx
@@ -1,0 +1,74 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Concepts/Upgrading/from v8/Components/Button Upgrade" />
+
+# Button Upgrade
+
+The v8 button variants share the IButtonProps. When using ButtonBase the resulting variant is rendered based on the buttonType (normal, primary, hero, compound, command, icon, or default) and when using a variant directly then props like primary and split change how the button is rendered.
+
+In v9, there is not a shared button type. Variants have their own props although they may extend ButtonProps. There are not variants for primary and action buttons. This is controlled through the appearance prop.
+
+To upgrade a button replace the v8 usage with the corresponding v9 button variant. Use the property mapping to pass the right properties to the v9 button.
+
+## Button Variant Mapping
+
+| v8 Button variant    | v9 Button variant               |
+| -------------------- | ------------------------------- |
+| DefaultButton        | Button                          |
+| ActionButton         | Button appearance="transparent" |
+| CommandButton        | Button                          |
+| CommandBarButton     | Button                          |
+| CompoundButton       | CompoundButton                  |
+| ContextualMenuButton | Menu / MenuButton               |
+| PrimaryButton        | Button appearance="primary      |
+| Button split         | SplitButton                     |
+| Button toggle        | ToggleButton                    |
+
+## Button Props Mapping
+
+Properties with Y in the Shim column are handled when using the button shims.
+
+| v8 IButtonProps          | v9 ButtonProps (replacements)         |
+| ------------------------ | ------------------------------------- |
+| allowDisabledFocus       | disabledFocusable                     |
+| ariaLabel                | HTML aria-label                       |
+| ariaDescription          | (removed)                             |
+| ariaHidden               | HTML aria-hidden                      |
+| checked                  | (use ToggleButton checked)            |
+| className                | className                             |
+| children                 | children                              |
+| componentRef             | ref                                   |
+| data                     | (removed)                             |
+| defaultRender            | (removed)                             |
+| disabled                 | disabled                              |
+| getClassNames            |                                       |
+| getSplitButtonClassNames | (use SplitButton)                     |
+| href                     | (use Link)                            |
+| iconProps                | icon (slot)                           |
+| disabled                 | disabled                              |
+| key                      | key                                   |
+| keyTipProps              |                                       |
+| menuAs                   | (use Menu and HTML as)                |
+| menuIconProps            | (use MenuButton menuIcon)             |
+| menuProps                | (use Menu and MenuButton)             |
+| menuTriggerKeyCode       |                                       |
+| onMenuClick              | HTML onClick                          |
+| onRenderAriaDescription  | (removed)                             |
+| onRenderChildren         | children                              |
+| onRenderDescription      | (use CompoundButton secondaryContent) |
+| onRenderIcon             | icon (slot)                           |
+| onRenderMenuIcon         | (use MenuButton icon)                 |
+| onRenderText             | children                              |
+| persistMenu              | (use Menu)                            |
+| primary                  | appearance=primary                    |
+| primaryActionButtonProps | (use SplitButton)                     |
+| primaryDisabled          | (use SplitButton)                     |
+| secondaryText            | (use CompoundButton secondaryContent) |
+| split                    | (use SplitButton)                     |
+| splitButtonAriaLabel     | HTML aria-label                       |
+| splitButtonMenuProps     | (use Menu and SplitButton)            |
+| styles                   | (use makeStyles and className)        |
+| text                     | children                              |
+| theme                    | (use FluentProvider)                  |
+| toggle                   | (use ToggleButton)                    |
+| uniqueId                 | HTML key                              |

--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Button.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Button.stories.mdx
@@ -55,7 +55,7 @@ Properties with Y in the Shim column are handled when using the button shims.
 | onMenuClick              | HTML onClick                          |
 | onRenderAriaDescription  | (removed)                             |
 | onRenderChildren         | children                              |
-| onRenderDescription      | (use CompoundButton secondaryContent) |
+| onRenderDescription      | (use CompoundButton secondaryContent slot) |
 | onRenderIcon             | icon (slot)                           |
 | onRenderMenuIcon         | (use MenuButton icon)                 |
 | onRenderText             | children                              |

--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Button.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Button.stories.mdx
@@ -26,49 +26,47 @@ To upgrade a button replace the v8 usage with the corresponding v9 button varian
 
 ## Button Props Mapping
 
-Properties with Y in the Shim column are handled when using the button shims.
-
-| v8 IButtonProps          | v9 ButtonProps (replacements)         |
-| ------------------------ | ------------------------------------- |
-| allowDisabledFocus       | disabledFocusable                     |
-| ariaLabel                | HTML aria-label                       |
-| ariaDescription          | (removed)                             |
-| ariaHidden               | HTML aria-hidden                      |
-| checked                  | (use ToggleButton checked)            |
-| className                | className                             |
-| children                 | children                              |
-| componentRef             | ref                                   |
-| data                     | (removed)                             |
-| defaultRender            | (removed)                             |
-| disabled                 | disabled                              |
-| getClassNames            |                                       |
-| getSplitButtonClassNames | (use SplitButton)                     |
-| href                     | (use Link)                            |
-| iconProps                | icon (slot)                           |
-| disabled                 | disabled                              |
-| key                      | key                                   |
-| keyTipProps              |                                       |
-| menuAs                   | (use Menu and HTML as)                |
-| menuIconProps            | (use MenuButton menuIcon slot)        |
-| menuProps                | (use Menu and MenuButton)             |
-| menuTriggerKeyCode       |                                       |
-| onMenuClick              | HTML onClick                          |
-| onRenderAriaDescription  | (removed)                             |
-| onRenderChildren         | children                              |
+| v8 IButtonProps          | v9 ButtonProps (replacements)              |
+| ------------------------ | ------------------------------------------ |
+| allowDisabledFocus       | disabledFocusable                          |
+| ariaLabel                | HTML aria-label                            |
+| ariaDescription          | (removed)                                  |
+| ariaHidden               | HTML aria-hidden                           |
+| checked                  | (use ToggleButton checked)                 |
+| className                | className                                  |
+| children                 | children                                   |
+| componentRef             | ref                                        |
+| data                     | (removed)                                  |
+| defaultRender            | (removed)                                  |
+| disabled                 | disabled                                   |
+| getClassNames            |                                            |
+| getSplitButtonClassNames | (use SplitButton)                          |
+| href                     | (use Link)                                 |
+| iconProps                | icon (slot)                                |
+| disabled                 | disabled                                   |
+| key                      | key                                        |
+| keyTipProps              |                                            |
+| menuAs                   | (use Menu and HTML as)                     |
+| menuIconProps            | (use MenuButton menuIcon slot)             |
+| menuProps                | (use Menu and MenuButton)                  |
+| menuTriggerKeyCode       |                                            |
+| onMenuClick              | HTML onClick                               |
+| onRenderAriaDescription  | (removed)                                  |
+| onRenderChildren         | children                                   |
 | onRenderDescription      | (use CompoundButton secondaryContent slot) |
-| onRenderIcon             | icon (slot)                           |
-| onRenderMenuIcon         | (use MenuButton icon)                 |
-| onRenderText             | children                              |
-| persistMenu              | (use Menu)                            |
-| primary                  | appearance=primary                    |
-| primaryActionButtonProps | (use SplitButton)                     |
-| primaryDisabled          | (use SplitButton)                     |
-| secondaryText            | (use CompoundButton secondaryContent) |
-| split                    | (use SplitButton)                     |
-| splitButtonAriaLabel     | HTML aria-label                       |
-| splitButtonMenuProps     | (use Menu and SplitButton)            |
-| styles                   | (use makeStyles and className)        |
-| text                     | children                              |
-| theme                    | (use FluentProvider)                  |
-| toggle                   | (use ToggleButton)                    |
-| uniqueId                 | HTML key                              |
+| onRenderIcon             | icon (slot)                                |
+| onRenderMenuIcon         | (use MenuButton icon)                      |
+| onRenderText             | children                                   |
+| persistMenu              | (use Menu)                                 |
+| primary                  | appearance=primary                         |
+| primaryActionButtonProps | (use SplitButton)                          |
+| primaryDisabled          | (use SplitButton)                          |
+| secondaryText            | (use CompoundButton secondaryContent)      |
+| split                    | (use SplitButton)                          |
+| splitButtonAriaLabel     | HTML aria-label                            |
+| splitButtonMenuProps     | (use Menu and SplitButton)                 |
+| styles                   | (use makeStyles and className)             |
+| text                     | children                                   |
+| theme                    | (use FluentProvider)                       |
+| toggle                   | (use ToggleButton)                         |
+| uniqueId                 | HTML key                                   |

--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Button.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Button.stories.mdx
@@ -20,7 +20,7 @@ To upgrade a button replace the v8 usage with the corresponding v9 button varian
 | CommandBarButton     | Button                          |
 | CompoundButton       | CompoundButton                  |
 | ContextualMenuButton | Menu / MenuButton               |
-| PrimaryButton        | Button appearance="primary      |
+| PrimaryButton        | Button appearance="primary"     |
 | Button split         | SplitButton                     |
 | Button toggle        | ToggleButton                    |
 

--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Menu.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Menu.stories.mdx
@@ -1,0 +1,130 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Concepts/Upgrading/from v8/Components/Menu Upgrade" />
+
+# Menu Upgrade
+
+**v8**
+
+- A menu can be displayed by passing menuProps to Button, or by showing/hiding a ContextualMenu.
+  In both cases, the menu items are specified as an IContextualMenuItem array passed in props.
+- Different types of menu items are created by setting the IContextualMenuItem.itemType property.
+
+**v9**
+
+- A menu can be displayed by creating a hierarchy of children under Menu.
+- There are children that act as containers and coordinate behavior including MenuTrigger, MenuPopover, MenuList, and MenuGroup.
+- There are individual components for different types of items including MenuItem, MenuDivider, MenuItemCheckbox, MenuItemRadio, MenuGroup, and MenuSplitGroup.
+
+## Types -> Component props
+
+| v8 menu type                                  | v9 props                                |
+| --------------------------------------------- | --------------------------------------- |
+| IContextualMenuProps                          | MenuProps, MenuListProps (for submenus) |
+| IContextualMenuItemProps, IContextualMenuItem | MenuItemProps                           |
+| IContextualMenuItem itemType=Normal           | MenuItemProps                           |
+| IContextualMenuItem itemType=Divider          | MenuDividerProps                        |
+| IContextualMenuItem itemType=Header           | MenuGroupHeaderProps                    |
+| IContextualMenuItem itemType=Section          | MenuGroupProps                          |
+| IContextualMenuProps.hidden                   | MenuTrigger, MenuPopover                |
+| Button menuProps={...}                        | MenuButton                              |
+
+## IContextualMenuProps -> MenuProps
+
+| v8 IContextualMenuProps | v9 MenuProps (replacements) |
+| ----------------------- | --------------------------- |
+| alignTargetEdge         |                             |
+| ariaLabel               |                             |
+| beakWidth               |                             |
+| bounds                  |                             |
+| className               |                             |
+| componentRef            |                             |
+| contextualMenuItemAs    |                             |
+| coverTarget             |                             |
+| delayUpdateFocusOnHover |                             |
+| directionalHint         | positioning                 |
+| directionalHintFixed    |                             |
+| directionalHintForRTL   |                             |
+| focusZoneAs             |                             |
+| focusZoneProps          |                             |
+| gapSpace                |                             |
+| getMenuClassNames       |                             |
+| hidden                  |                             |
+| id                      |                             |
+| labelElementId          |                             |
+| isBeakVisible           |                             |
+| isSubMenu               |                             |
+| items                   |                             |
+| onDismiss               |                             |
+| onItemClick             |                             |
+| onRenderMenuList        |                             |
+| onRenderSubMenu         |                             |
+| onRestoreFocus          |                             |
+| doNotLayer              |                             |
+| onMenuOpened            |                             |
+| onMenuDismissed         |                             |
+| calloutProps            |                             |
+| shouldFocusOnMount      |                             |
+| shouldFocusOnContainer  |                             |
+| shouldUpdateWhenHidden  |                             |
+| styles                  |                             |
+| subMenuHoverDelay       |                             |
+| target                  |                             |
+| theme                   |                             |
+| title                   |                             |
+| useTargetAsMinWidth     |                             |
+| useTargetWidth          |                             |
+
+## IContextualMenuItem -> MenuItemProps
+
+| v8 IContextualMenuItem                  | v9 MenuItemProps+                                                  |
+| --------------------------------------- | ------------------------------------------------------------------ |
+| ariaDescribedBy                         | (removed)                                                          |
+| ariaDescription                         | (removed)                                                          |
+| ariaLabel                               | HTML aria-label                                                    |
+| canCheck                                | (use MenuItemRadio, MenuItemCheckbox)                              |
+| checked                                 | (use MenuItemRadio, MenuItemCheckbox)                              |
+| className                               | className                                                          |
+| componentRef                            | ref                                                                |
+| customOnRenderListLength                |                                                                    |
+| data                                    |                                                                    |
+| disabled                                | disabled                                                           |
+| getItemClassNames                       |                                                                    |
+| getSplitButtonVerticalDividerClassNames |                                                                    |
+| href                                    |                                                                    |
+| iconProps                               | icon (slot)                                                        |
+| inactive                                | (removed)                                                          |
+| itemProps                               | (use makeStyles and className)                                     |
+| items                                   | children                                                           |
+| itemType                                | children (MenuDivider, MenuGroup, MenuGroupHeader, MenuSplitGroup) |
+| key                                     |                                                                    |
+| keytipProps                             |                                                                    |
+| name (deprecated)                       | name & value (MenuItemCheckbox, MenuItemRadio)                     |
+| onClick                                 | onClick                                                            |
+| onMouseDown                             | onMouseDown                                                        |
+| onRender                                | children                                                           |
+| onRenderContent                         | children                                                           |
+| onRenderIcon                            | icon (slot)                                                        |
+| preferMenuTargetAsEventTarget           |                                                                    |
+| primaryDisabled                         |                                                                    |
+| rel                                     |                                                                    |
+| role                                    | (removed - set by component)                                       |
+| secondaryText                           | secondaryContent (slot)                                            |
+| sectionProps                            | (MenuGroup, MenuGroupHeader)                                       |
+| split                                   | children (MenuSplitGroup)                                          |
+| style                                   | (use makeStyles and className)                                     |
+| subMenuIconProps                        |                                                                    |
+| subMenuProps                            | children (Menu), hasSubmenu                                        |
+| target                                  |                                                                    |
+| text                                    | children                                                           |
+| title                                   | title                                                              |
+| [propertyName: string]                  | (removed)                                                          |
+
+## IContextualMenuSection -> MenuGroupProps
+
+| v8 IContextualMenuSection | v9 MenuGroupProps, MenuGroupHeaderProps |
+| ------------------------- | --------------------------------------- |
+| items                     | (use MenuGroup children)                |
+| title                     | (use MenuGroupHeader children)          |
+| topDivider                | (removed)                               |
+| bottomDivider             | (removed)                               |

--- a/apps/public-docsite-v9/src/stories/ButtonShim.stories.tsx
+++ b/apps/public-docsite-v9/src/stories/ButtonShim.stories.tsx
@@ -10,7 +10,7 @@ export { CompoundButtonStory as CompoundButton } from './CompoundButtonShim.stor
 export { ToggleButtonStory as ToggleButton } from './ToggleButtonShim.stories';
 
 export default {
-  title: 'Concepts/Upgrading/from v8/Button/Shims',
+  title: 'Concepts/Upgrading/from v8/Shims/Button',
   component: Button,
   decorators: [
     Story => (

--- a/apps/public-docsite-v9/src/stories/StackShim.stories.tsx
+++ b/apps/public-docsite-v9/src/stories/StackShim.stories.tsx
@@ -209,7 +209,7 @@ export const StackShimStory = () => {
 };
 
 export default {
-  title: 'Concepts/Upgrading/from v8/Stack/Shims',
+  title: 'Concepts/Upgrading/from v8/Shims/Stack',
   component: Button,
   decorators: [
     Story => (


### PR DESCRIPTION
## Changes
- Moved shim stories under a common shims folder (instead of Button/Shims and Stack/Shims => Shims/Button and Shims/Stack)
- Added Button upgrade doc
- Added Menu upgrade doc

## Related Issue(s)

Update #22314
