### PR TITLE
feat: re-export useThemeClassName() hook

### DIFF
--- a/change/@fluentui-react-components-28f8cab8-7312-42d6-bb13-261a28a76793.json
+++ b/change/@fluentui-react-components-28f8cab8-7312-42d6-bb13-261a28a76793.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: export `useThemeClassName` hook",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/etc/react-components.api.md
+++ b/packages/react-components/etc/react-components.api.md
@@ -441,6 +441,7 @@ import { useSplitButtonStyles_unstable } from '@fluentui/react-button';
 import { useSSRContext } from '@fluentui/react-utilities';
 import { useText_unstable } from '@fluentui/react-text';
 import { useTextStyles_unstable } from '@fluentui/react-text';
+import { useThemeClassName } from '@fluentui/react-shared-contexts';
 import { useToggleButton_unstable } from '@fluentui/react-button';
 import { useToggleButtonStyles_unstable } from '@fluentui/react-button';
 import { useToggleState } from '@fluentui/react-button';
@@ -1323,6 +1324,8 @@ export { useSSRContext }
 export { useText_unstable }
 
 export { useTextStyles_unstable }
+
+export { useThemeClassName }
 
 export { useToggleButton_unstable }
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -50,6 +50,7 @@
     "@fluentui/react-portal": "9.0.0-rc.7",
     "@fluentui/react-provider": "9.0.0-rc.7",
     "@fluentui/react-radio": "9.0.0-beta.4",
+    "@fluentui/react-shared-contexts": "9.0.0-rc.5",
     "@fluentui/react-slider": "9.0.0-beta.12",
     "@fluentui/react-spinbutton": "9.0.0-beta.7",
     "@fluentui/react-spinner": "9.0.0-beta.7",

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -71,6 +71,7 @@ export type {
   Theme,
   TypeographyStyles,
 } from '@fluentui/react-theme';
+export { useThemeClassName } from '@fluentui/react-shared-contexts';
 export {
   getNativeElementProps,
   getNativeProps,


### PR DESCRIPTION
_Extracted from #22510._

## New Behavior

`useThemeClassName` is re-exported from `@fluentui/react-components`. It's an essential piece to get a `className` that contains CSS variables. Used also by our partners.