### PR TITLE
Contextualmenu disabled hcm checkmarks

### DIFF
--- a/change/@fluentui-react-6ef35ff6-9b12-444f-873e-eb578898da24.json
+++ b/change/@fluentui-react-6ef35ff6-9b12-444f-873e-eb578898da24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix HCM disabled checkmarks",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Checkmarks.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Checkmarks.Example.tsx
@@ -104,6 +104,7 @@ export const ContextualMenuCheckmarksExample: React.FunctionComponent = () => {
           },
           text: 'Split Button',
           canCheck: true,
+          checked: true,
           isChecked: selection[keys[8]],
           split: true,
           onClick: onToggleSelect,

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
@@ -63,7 +63,6 @@ export const getMenuItemStyles = memoizeFunction(
             // ensure disabled text looks different than enabled
             color: 'GrayText',
             opacity: 1,
-            ...getHighContrastNoAdjustStyle(),
           },
         },
       },


### PR DESCRIPTION
Fixes #22640

ForcedColorAdust: none was unnecessary and breaking disabled icon styles in high contrast

![image](https://user-images.githubusercontent.com/1434956/165343309-a5535866-9535-45c3-9842-e20d34e8eafd.png)
