### PR TITLE
change ie11 fix from star selector to span 

### DIFF
--- a/change/@fluentui-react-d8a0826d-8dde-4ea4-95ac-c3ee3d2f43c3.json
+++ b/change/@fluentui-react-d8a0826d-8dde-4ea4-95ac-c3ee3d2f43c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "change ie11 fix from star selector to span to avoid perf issues",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/MicroFeedback/__snapshots__/MicroFeedback.test.tsx.snap
+++ b/packages/react-experiments/src/components/MicroFeedback/__snapshots__/MicroFeedback.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -227,7 +227,7 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -407,7 +407,7 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -535,7 +535,7 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;

--- a/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -195,7 +195,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -325,7 +325,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -431,7 +431,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -537,7 +537,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -643,7 +643,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -749,7 +749,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -851,7 +851,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -992,7 +992,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -1160,7 +1160,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           right: -2px;
           top: -2px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;
@@ -1289,7 +1289,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           right: -2px;
           top: -2px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;
@@ -1638,7 +1638,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -1788,7 +1788,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           right: -2px;
           top: -2px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;
@@ -1915,7 +1915,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           right: -2px;
           top: -2px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -105,7 +105,7 @@ Array [
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -466,7 +466,7 @@ Array [
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -655,7 +655,7 @@ Array [
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -1016,7 +1016,7 @@ Array [
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -1210,7 +1210,7 @@ Array [
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -1571,7 +1571,7 @@ Array [
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -1760,7 +1760,7 @@ Array [
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -2121,7 +2121,7 @@ Array [
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                       right: -2px;
                       top: -2px;
                     }
-                    &:active > * {
+                    &:active > span {
                       left: 0px;
                       position: relative;
                       top: 0px;
@@ -840,7 +840,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                       right: -2px;
                       top: -2px;
                     }
-                    &:active > * {
+                    &:active > span {
                       left: 0px;
                       position: relative;
                       top: 0px;

--- a/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                         right: -2px;
                         top: -2px;
                       }
-                      &:active > * {
+                      &:active > span {
                         left: 0px;
                         position: relative;
                         top: 0px;
@@ -1350,7 +1350,7 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                         right: -2px;
                         top: -2px;
                       }
-                      &:active > * {
+                      &:active > span {
                         left: 0px;
                         position: relative;
                         top: 0px;
@@ -1563,7 +1563,7 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                         right: -2px;
                         top: -2px;
                       }
-                      &:active > * {
+                      &:active > span {
                         left: 0px;
                         position: relative;
                         top: 0px;
@@ -1776,7 +1776,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                         right: -2px;
                         top: -2px;
                       }
-                      &:active > * {
+                      &:active > span {
                         left: 0px;
                         position: relative;
                         top: 0px;
@@ -2277,7 +2277,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                         right: -2px;
                         top: -2px;
                       }
-                      &:active > * {
+                      &:active > span {
                         left: 0px;
                         position: relative;
                         top: 0px;

--- a/packages/react/src/components/Button/BaseButton.styles.ts
+++ b/packages/react/src/components/Button/BaseButton.styles.ts
@@ -55,7 +55,7 @@ export const getStyles = memoizeFunction(
 
           selectors: {
             // IE11 workaround for preventing shift of child elements of a button when active.
-            ':active > *': {
+            ':active > span': {
               position: 'relative',
               left: 0,
               top: 0,

--- a/packages/react/src/components/Button/__snapshots__/Button.deprecated.test.tsx.snap
+++ b/packages/react/src/components/Button/__snapshots__/Button.deprecated.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`Button renders CompoundButton correctly 1`] = `
         right: -2px;
         top: -2px;
       }
-      &:active > * {
+      &:active > span {
         left: 0px;
         position: relative;
         top: 0px;

--- a/packages/react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`Button renders ActionButton correctly 1`] = `
           right: -2px;
           top: -2px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;
@@ -174,7 +174,7 @@ exports[`Button renders CommandBarButton correctly 1`] = `
           right: 4px;
           top: 4px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;
@@ -374,7 +374,7 @@ exports[`Button renders CompoundButton correctly 1`] = `
           right: -2px;
           top: -2px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;
@@ -518,7 +518,7 @@ exports[`Button renders DefaultButton correctly 1`] = `
           right: -2px;
           top: -2px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;
@@ -633,7 +633,7 @@ exports[`Button renders IconButton correctly 1`] = `
           right: -2px;
           top: -2px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;
@@ -756,7 +756,7 @@ exports[`Button renders a DefaultButton with a keytip correctly 1`] = `
           right: -2px;
           top: -2px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -255,7 +255,7 @@ exports[`ComboBox Renders correctly 1`] = `
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -587,7 +587,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -858,7 +858,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                             right: -2px;
                             top: -2px;
                           }
-                          &:active > * {
+                          &:active > span {
                             left: 0px;
                             position: relative;
                             top: 0px;
@@ -1013,7 +1013,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                           right: -2px;
                           top: -2px;
                         }
-                        &:active > * {
+                        &:active > span {
                           left: 0px;
                           position: relative;
                           top: 0px;
@@ -1356,7 +1356,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -2246,7 +2246,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;

--- a/packages/react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
+++ b/packages/react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                     right: 4px;
                     top: 4px;
                   }
-                  &:active > * {
+                  &:active > span {
                     left: 0px;
                     position: relative;
                     top: 0px;
@@ -265,7 +265,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                     right: 4px;
                     top: 4px;
                   }
-                  &:active > * {
+                  &:active > span {
                     left: 0px;
                     position: relative;
                     top: 0px;

--- a/packages/react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                       right: 4px;
                       top: 4px;
                     }
-                    &:active > * {
+                    &:active > span {
                       left: 0px;
                       position: relative;
                       top: 0px;
@@ -248,7 +248,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                       right: 4px;
                       top: 4px;
                     }
-                    &:active > * {
+                    &:active > span {
                       left: 0px;
                       position: relative;
                       top: 0px;
@@ -441,7 +441,7 @@ exports[`CommandBar renders empty farItems correctly 1`] = `
                       right: 4px;
                       top: 4px;
                     }
-                    &:active > * {
+                    &:active > span {
                       left: 0px;
                       position: relative;
                       top: 0px;
@@ -579,7 +579,7 @@ exports[`CommandBar renders empty farItems correctly 1`] = `
                       right: 4px;
                       top: 4px;
                     }
-                    &:active > * {
+                    &:active > span {
                       left: 0px;
                       position: relative;
                       top: 0px;

--- a/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
         right: -2px;
         top: -2px;
       }
-      &:active > * {
+      &:active > span {
         left: 0px;
         position: relative;
         top: 0px;

--- a/packages/react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
+++ b/packages/react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
@@ -923,7 +923,7 @@ exports[`Dialog deprecated props renders Dialog with isBlocking set to true 1`] 
                           right: -2px;
                           top: -2px;
                         }
-                        &:active > * {
+                        &:active > span {
                           left: 0px;
                           position: relative;
                           top: 0px;

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1633,7 +1633,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                             right: -2px;
                             top: -2px;
                           }
-                          &:active > * {
+                          &:active > span {
                             left: 0px;
                             position: relative;
                             top: 0px;
@@ -1811,7 +1811,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                           right: -2px;
                           top: -2px;
                         }
-                        &:active > * {
+                        &:active > span {
                           left: 0px;
                           position: relative;
                           top: 0px;

--- a/packages/react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -320,7 +320,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;

--- a/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -222,7 +222,7 @@ exports[`Nav render Nav with overrides correctly 1`] = `
                         right: -2px;
                         top: -2px;
                       }
-                      &:active > * {
+                      &:active > span {
                         left: 0px;
                         position: relative;
                         top: 0px;
@@ -379,7 +379,7 @@ exports[`Nav render Nav with overrides correctly 1`] = `
                         right: -2px;
                         top: -2px;
                       }
-                      &:active > * {
+                      &:active > span {
                         left: 0px;
                         position: relative;
                         top: 0px;
@@ -598,7 +598,7 @@ exports[`Nav renders Nav correctly 1`] = `
                       right: -2px;
                       top: -2px;
                     }
-                    &:active > * {
+                    &:active > span {
                       left: 0px;
                       position: relative;
                       top: 0px;

--- a/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -219,7 +219,7 @@ exports[`Panel renders Panel correctly 1`] = `
                       right: -2px;
                       top: -2px;
                     }
-                    &:active > * {
+                    &:active > span {
                       left: 0px;
                       position: relative;
                       top: 0px;

--- a/packages/react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
+++ b/packages/react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -259,7 +259,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;

--- a/packages/react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -259,7 +259,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -487,7 +487,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -656,7 +656,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -872,7 +872,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -1041,7 +1041,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -1214,7 +1214,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -1449,7 +1449,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -1618,7 +1618,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -1785,7 +1785,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -2013,7 +2013,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -2182,7 +2182,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -2399,7 +2399,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -2603,7 +2603,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -2851,7 +2851,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -3020,7 +3020,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -3236,7 +3236,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -3440,7 +3440,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -3687,7 +3687,7 @@ exports[`Pivot supports JSX expressions 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;
@@ -3849,7 +3849,7 @@ exports[`Pivot supports JSX expressions 1`] = `
             right: -2px;
             top: -2px;
           }
-          &:active > * {
+          &:active > span {
             left: 0px;
             position: relative;
             top: 0px;

--- a/packages/react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -209,7 +209,7 @@ exports[`SpinButton snapshots renders correctly 1`] = `
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -348,7 +348,7 @@ exports[`SpinButton snapshots renders correctly 1`] = `
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -652,7 +652,7 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;
@@ -791,7 +791,7 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;

--- a/packages/react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -284,7 +284,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -459,7 +459,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -634,7 +634,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -813,7 +813,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -988,7 +988,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -1163,7 +1163,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -1338,7 +1338,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -1517,7 +1517,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -1692,7 +1692,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -1867,7 +1867,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -2042,7 +2042,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -219,7 +219,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -371,7 +371,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -511,7 +511,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -501,7 +501,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -653,7 +653,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -793,7 +793,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
               right: -2px;
               top: -2px;
             }
-            &:active > * {
+            &:active > span {
               left: 0px;
               position: relative;
               top: 0px;

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -686,7 +686,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;

--- a/packages/react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -245,7 +245,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -380,7 +380,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -515,7 +515,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -650,7 +650,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -785,7 +785,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -920,7 +920,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -1055,7 +1055,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -1190,7 +1190,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -1325,7 +1325,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -1460,7 +1460,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -1595,7 +1595,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -1730,7 +1730,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -1865,7 +1865,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -2000,7 +2000,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -2180,7 +2180,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -2319,7 +2319,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -2454,7 +2454,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -2589,7 +2589,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -2724,7 +2724,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -2859,7 +2859,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -2994,7 +2994,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -3129,7 +3129,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -3264,7 +3264,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -3399,7 +3399,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -3534,7 +3534,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -3669,7 +3669,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -3804,7 +3804,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -3939,7 +3939,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -4074,7 +4074,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -4227,7 +4227,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -4362,7 +4362,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -4497,7 +4497,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -4632,7 +4632,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -4767,7 +4767,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -4902,7 +4902,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -5037,7 +5037,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -5172,7 +5172,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -5323,7 +5323,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -5462,7 +5462,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -5597,7 +5597,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -5732,7 +5732,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -5867,7 +5867,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -6002,7 +6002,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;
@@ -6137,7 +6137,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 right: -2px;
                 top: -2px;
               }
-              &:active > * {
+              &:active > span {
                 left: 0px;
                 position: relative;
                 top: 0px;

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
@@ -131,7 +131,7 @@ exports[`TagItem accepts title override 1`] = `
           right: -2px;
           top: -2px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;
@@ -376,7 +376,7 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
           right: -2px;
           top: -2px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;
@@ -597,7 +597,7 @@ exports[`TagItem renders correctly 1`] = `
           right: -2px;
           top: -2px;
         }
-        &:active > * {
+        &:active > span {
           left: 0px;
           position: relative;
           top: 0px;

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -208,7 +208,7 @@ exports[`TagPicker renders correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;
@@ -597,7 +597,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                &:active > * {
+                &:active > span {
                   left: 0px;
                   position: relative;
                   top: 0px;


### PR DESCRIPTION
Fixes #21677

Button's first child is always the flexContainer span, so using a star is unnecessary and causing perf issues in some situations. 