### PR TITLE
Revert "Fix screen reader issues in calendar navigation buttons and combobox"

### DIFF
--- a/change/@fluentui-react-4b2eeb3d-df1a-4f18-9cda-e1145636a051.json
+++ b/change/@fluentui-react-4b2eeb3d-df1a-4f18-9cda-e1145636a051.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix live regions in Calendar for JAWS",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-83c86ed8-da9c-4d2d-b8a1-e051c49408d6.json
+++ b/change/@fluentui-react-83c86ed8-da9c-4d2d-b8a1-e051c49408d6.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix screen reader issues on calendar navigation buttons and combobox",
-  "packageName": "@fluentui/react",
-  "email": "conniechen@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1581,7 +1581,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             "fontFamily": "inherit",
           }
         }
-        title="1"
         type="text"
         value="1"
       />

--- a/packages/react/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -60,11 +60,7 @@ export const CalendarDayBase: React.FunctionComponent<ICalendarDayProps> = props
     <div className={classNames.root}>
       <div className={classNames.header}>
         <HeaderButtonComponentType
-          // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
-          aria-live="polite"
-          aria-atomic="true"
           aria-label={onHeaderSelect ? headerAriaLabel : undefined}
-          key={monthAndYear}
           className={classNames.monthAndYear}
           onClick={onHeaderSelect}
           data-is-focusable={!!onHeaderSelect}
@@ -72,7 +68,9 @@ export const CalendarDayBase: React.FunctionComponent<ICalendarDayProps> = props
           onKeyDown={onButtonKeyDown(onHeaderSelect)}
           type="button"
         >
-          <span id={monthAndYearId}>{monthAndYear}</span>
+          <span id={monthAndYearId} aria-live="polite" aria-atomic="true">
+            {monthAndYear}
+          </span>
         </HeaderButtonComponentType>
         <CalendarDayNavigationButtons {...props} classNames={classNames} />
       </div>

--- a/packages/react/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -129,13 +129,6 @@ const CalendarDayNavigationButtons = (props: ICalendarDayNavigationButtonsProps)
   const prevMonthInBounds = minDate ? compareDatePart(minDate, getMonthStart(navigatedDate)) < 0 : true;
   const nextMonthInBounds = maxDate ? compareDatePart(getMonthEnd(navigatedDate), maxDate) < 0 : true;
 
-  const prevMonthAriaLabel = strings.prevMonthAriaLabel
-    ? strings.prevMonthAriaLabel + ' ' + strings.months[addMonths(navigatedDate, -1).getMonth()]
-    : undefined;
-  const nextMonthAriaLabel = strings.nextMonthAriaLabel
-    ? strings.nextMonthAriaLabel + ' ' + strings.months[addMonths(navigatedDate, 1).getMonth()]
-    : undefined;
-
   // use aria-disabled instead of disabled so focus is not lost
   // when a prev/next button becomes disabled after being clicked
   return (
@@ -148,9 +141,12 @@ const CalendarDayNavigationButtons = (props: ICalendarDayNavigationButtonsProps)
         aria-disabled={!prevMonthInBounds}
         onClick={prevMonthInBounds ? onSelectPrevMonth : undefined}
         onKeyDown={prevMonthInBounds ? onButtonKeyDown(onSelectPrevMonth) : undefined}
-        title={prevMonthAriaLabel}
+        title={
+          strings.prevMonthAriaLabel
+            ? strings.prevMonthAriaLabel + ' ' + strings.months[addMonths(navigatedDate, -1).getMonth()]
+            : undefined
+        }
         type="button"
-        aria-label={prevMonthAriaLabel}
       >
         <Icon iconName={leftNavigationIcon} />
       </button>
@@ -162,9 +158,12 @@ const CalendarDayNavigationButtons = (props: ICalendarDayNavigationButtonsProps)
         aria-disabled={!nextMonthInBounds}
         onClick={nextMonthInBounds ? onSelectNextMonth : undefined}
         onKeyDown={nextMonthInBounds ? onButtonKeyDown(onSelectNextMonth) : undefined}
-        title={nextMonthAriaLabel}
+        title={
+          strings.nextMonthAriaLabel
+            ? strings.nextMonthAriaLabel + ' ' + strings.months[addMonths(navigatedDate, 1).getMonth()]
+            : undefined
+        }
         type="button"
-        aria-label={nextMonthAriaLabel}
       >
         <Icon iconName={rightNavigationIcon} />
       </button>

--- a/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -215,11 +215,10 @@ export const CalendarMonthBase: React.FunctionComponent<ICalendarMonthProps> = p
           data-is-focusable={!!props.onHeaderSelect || !yearPickerHidden}
           tabIndex={!!props.onHeaderSelect || !yearPickerHidden ? 0 : -1}
           type="button"
-          aria-atomic={true}
-          // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
-          aria-live="polite"
         >
-          {yearString}
+          <span aria-live="polite" aria-atomic="true">
+            {yearString}
+          </span>
         </button>
         <div className={classNames.navigationButtonsContainer}>
           <button

--- a/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -204,13 +204,6 @@ export const CalendarMonthBase: React.FunctionComponent<ICalendarMonthProps> = p
     ? format(strings.monthPickerHeaderAriaLabel, yearString)
     : yearString;
 
-  const prevYearAriaLabel = strings.prevYearAriaLabel
-    ? strings.prevYearAriaLabel + ' ' + dateFormatter.formatYear(addYears(navigatedDate, -1))
-    : undefined;
-  const nextYearAriaLabel = strings.nextYearAriaLabel
-    ? strings.nextYearAriaLabel + ' ' + dateFormatter.formatYear(addYears(navigatedDate, 1))
-    : undefined;
-
   return (
     <div className={classNames.root}>
       <div className={classNames.headerContainer}>
@@ -225,7 +218,6 @@ export const CalendarMonthBase: React.FunctionComponent<ICalendarMonthProps> = p
           aria-atomic={true}
           // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
           aria-live="polite"
-          key={yearString}
         >
           {yearString}
         </button>
@@ -238,9 +230,12 @@ export const CalendarMonthBase: React.FunctionComponent<ICalendarMonthProps> = p
             tabIndex={isPrevYearInBounds ? undefined : allFocusable ? 0 : -1}
             onClick={isPrevYearInBounds ? onSelectPrevYear : undefined}
             onKeyDown={isPrevYearInBounds ? onButtonKeyDown(onSelectPrevYear) : undefined}
-            title={prevYearAriaLabel}
+            title={
+              strings.prevYearAriaLabel
+                ? strings.prevYearAriaLabel + ' ' + dateFormatter.formatYear(addYears(navigatedDate, -1))
+                : undefined
+            }
             type="button"
-            aria-label={prevYearAriaLabel}
           >
             <Icon iconName={getRTL() ? rightNavigationIcon : leftNavigationIcon} />
           </button>
@@ -252,9 +247,12 @@ export const CalendarMonthBase: React.FunctionComponent<ICalendarMonthProps> = p
             tabIndex={isNextYearInBounds ? undefined : allFocusable ? 0 : -1}
             onClick={isNextYearInBounds ? onSelectNextYear : undefined}
             onKeyDown={isNextYearInBounds ? onButtonKeyDown(onSelectNextYear) : undefined}
-            title={nextYearAriaLabel}
+            title={
+              strings.nextYearAriaLabel
+                ? strings.nextYearAriaLabel + ' ' + dateFormatter.formatYear(addYears(navigatedDate, 1))
+                : undefined
+            }
             type="button"
-            aria-label={nextYearAriaLabel}
           >
             <Icon iconName={getRTL() ? leftNavigationIcon : rightNavigationIcon} />
           </button>

--- a/packages/react/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -347,11 +347,10 @@ const CalendarYearTitle: React.FunctionComponent<ICalendarYearHeaderProps> = pro
         aria-label={ariaLabel}
         role="button"
         type="button"
-        aria-atomic={true}
-        // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
-        aria-live="polite"
       >
-        {onRenderYear(fromYear)} - {onRenderYear(toYear)}
+        <span aria-live="assertive" aria-atomic="true">
+          {onRenderYear(fromYear)} - {onRenderYear(toYear)}
+        </span>
       </button>
     );
   }

--- a/packages/react/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -267,7 +267,6 @@ const CalendarYearNavArrow: React.FunctionComponent<ICalendarYearNavArrowProps> 
       type="button"
       title={ariaLabelString}
       disabled={disabled}
-      aria-label={ariaLabelString}
     >
       <Icon iconName={isLeftNavigation ? navigationIcons.leftNavigation : navigationIcons.rightNavigation} />
     </button>
@@ -351,7 +350,6 @@ const CalendarYearTitle: React.FunctionComponent<ICalendarYearHeaderProps> = pro
         aria-atomic={true}
         // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
         aria-live="polite"
-        key={currentDateRange}
       >
         {onRenderYear(fromYear)} - {onRenderYear(toYear)}
       </button>

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -614,7 +614,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           shouldSelectFullInputValueInComponentDidUpdate={
             this._onShouldSelectFullInputValueInAutofillComponentDidUpdate
           }
-          title={title ? title : this._currentVisibleValue}
+          title={title}
           preventValueSelection={!this._hasFocus()}
           placeholder={placeholder}
           tabIndex={disabled ? -1 : tabIndex}

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -198,7 +198,6 @@ exports[`ComboBox Renders correctly 1`] = `
         role="combobox"
         spellcheck="false"
         style="font-family: inherit;"
-        title="testValue"
         type="text"
         value="testValue"
       />
@@ -530,7 +529,6 @@ exports[`ComboBox Renders correctly when open 1`] = `
         role="combobox"
         spellcheck="false"
         style="font-family: inherit;"
-        title="Option 2"
         type="text"
         value="Option 2"
       />
@@ -1300,7 +1298,6 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
         role="combobox"
         spellcheck="false"
         style="font-family: inherit;"
-        title=""
         type="text"
         value=""
       />
@@ -2192,7 +2189,6 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
         role="combobox"
         spellcheck="false"
         style="font-family: inherit;"
-        title=""
         type="text"
         value=""
       />


### PR DESCRIPTION
Reverts microsoft/fluentui#22613

See comment: https://github.com/microsoft/fluentui/pull/22613#issuecomment-1110139831

Edit: this also adds a fix for the JAWS issue of ignoring the live regions in Calendar. It turns out that JAWS doesn't respect `aria-live` on button elements, so I moved it to a span within the button.