### PR TITLE
7.0 Azure Theme textfield password bug fix 

### DIFF
--- a/change/@uifabric-azure-themes-611af180-2cab-4ada-aa31-280096b83604.json
+++ b/change/@uifabric-azure-themes-611af180-2cab-4ada-aa31-280096b83604.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Textfield password reveal button bug fix",
+  "packageName": "@uifabric/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/styles/TextField.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TextField.styles.ts
@@ -9,6 +9,13 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
 
   return {
     fieldGroup: [
+      {
+        selectors: {
+          '.ms-TextField-reveal': {
+            height: 22,
+          },
+        },
+      },
       !multiline && {
         height: StyleConstants.inputControlHeight,
       },

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -48,6 +48,12 @@ const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
     <Stack gap={8} horizontalAlign="center">
       <Text>13px body text</Text>
+      <TextField
+        label="Password with reveal button"
+        type="password"
+        canRevealPassword
+        revealPasswordAriaLabel="Show password"
+      />
       <Label>MessageBar / InfoBox</Label>
       <MessageBarBasicExample />
       <Label>TeachingBubble</Label>

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -48,12 +48,6 @@ const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
     <Stack gap={8} horizontalAlign="center">
       <Text>13px body text</Text>
-      <TextField
-        label="Password with reveal button"
-        type="password"
-        canRevealPassword
-        revealPasswordAriaLabel="Show password"
-      />
       <Label>MessageBar / InfoBox</Label>
       <MessageBarBasicExample />
       <Label>TeachingBubble</Label>
@@ -147,6 +141,12 @@ const Example = () => (
       <TextField placeholder="Hello" />
       <TextField label="Standard" multiline rows={3} />
       <TextField errorMessage="Error message!" />
+      <TextField
+        label="Password with reveal button"
+        type="password"
+        canRevealPassword
+        revealPasswordAriaLabel="Show password"
+      />
     </Stack>
 
     <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
On hover exposes the password reveal button to be too large
![image](https://user-images.githubusercontent.com/30805892/165388848-b83cca27-fff3-4102-ac54-b10a1fa07198.png)

<!-- This is the behavior we have today -->

## New Behavior
Fixed the size of the reveal button (on hover state pictured)
![image](https://user-images.githubusercontent.com/30805892/165388900-8822ff67-c3c0-4217-81f3-ed44d7914dda.png)

Cherry picked into 8.0 branch, 
