### PR TITLE
8.0 Azure Theme textfield password bug fix cherry picked from7.0 branch #22645

### DIFF
--- a/change/@fluentui-azure-themes-00b4d995-2f97-456a-b00e-fd584595d81c.json
+++ b/change/@fluentui-azure-themes-00b4d995-2f97-456a-b00e-fd584595d81c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Textfield password button bug fix",
+  "packageName": "@fluentui/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/styles/TextField.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TextField.styles.ts
@@ -9,6 +9,13 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
 
   return {
     fieldGroup: [
+      {
+        selectors: {
+          '.ms-TextField-reveal': {
+            height: 22,
+          },
+        },
+      },
       !multiline && {
         height: StyleConstants.inputControlHeight,
       },

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -128,6 +128,12 @@ const Example = () => (
       <TextField disabled value="disabled text" />
       <TextField placeholder="Hello" />
       <TextField errorMessage="Error message!" />
+      <TextField
+        label="Password with reveal button"
+        type="password"
+        canRevealPassword
+        revealPasswordAriaLabel="Show password"
+      />
     </Stack>
 
     <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
On hover exposes the password reveal button to be too large
![image](https://user-images.githubusercontent.com/30805892/165388848-b83cca27-fff3-4102-ac54-b10a1fa07198.png)

<!-- This is the behavior we have today -->

## New Behavior
Fixed the size of the reveal button (on hover state pictured)
![image](https://user-images.githubusercontent.com/30805892/165388900-8822ff67-c3c0-4217-81f3-ed44d7914dda.png)

Cherry picked from #22645