### PR TITLE
Remove chromatic command from react-components and move alias up to root

### DIFF
--- a/change/@fluentui-react-components-49a401dc-2ff5-47c7-b83e-831d44a16fde.json
+++ b/change/@fluentui-react-components-49a401dc-2ff5-47c7-b83e-831d44a16fde.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove chromatic command from react-components and move alias up to root pointing at new docsite",
+  "packageName": "@fluentui/react-components",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "check:modified-files": "yarn workspace @fluentui/scripts just check-for-modified-files",
     "check:affected-package": "node ./scripts/monorepo/checkIfPackagesAffected.js",
     "check:installed-dependencies-versions": "satisfied --skip-invalid --ignore \"prettier|angular|lit|sass|@storybook/web-components|@storybook/html|svelte|@testing-library|vue|@cypress/react\"",
-    "chromatic": "cd apps/public-docsite-v9 && yarn chromatic",
     "clean": "lage clean --verbose",
     "code-style": "lage code-style --verbose",
     "codepen": "cd packages/react && node ../../scripts/local-codepen.js",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check:modified-files": "yarn workspace @fluentui/scripts just check-for-modified-files",
     "check:affected-package": "node ./scripts/monorepo/checkIfPackagesAffected.js",
     "check:installed-dependencies-versions": "satisfied --skip-invalid --ignore \"prettier|angular|lit|sass|@storybook/web-components|@storybook/html|svelte|@testing-library|vue|@cypress/react\"",
+    "chromatic": "cd apps/public-docsite-v9 && yarn chromatic",
     "clean": "lage clean --verbose",
     "code-style": "lage code-style --verbose",
     "codepen": "cd packages/react && node ../../scripts/local-codepen.js",

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -14,7 +14,6 @@
   "scripts": {
     "build": "just-scripts build",
     "bundle-size": "bundle-size measure",
-    "chromatic": "npx chromatic@6.4.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name build-storybook",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
@@ -23,8 +22,6 @@
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../../scripts/typescript/normalize-import --output ./dist/packages/react-components/react-components/src && yarn docs",
     "storybook": "node ../../../scripts/storybook/runner --port 3000 -s ./public --no-manager-cache",
-    "storybook:docs": "yarn storybook --docs",
-    "build-storybook": "build-storybook -s ./public -o ./dist/storybook --docs",
     "test": "jest --passWithNoTests",
     "type-check": "tsc -b tsconfig.json"
   },


### PR DESCRIPTION
With the website being built out of the new public-docsite-v9 package, there's no need for the chromatic command in react-components. I also created an alias at the root to make publishing easier/more obvious. Maybe have a different name at the root? Or is it even necessary?