### PR TITLE
feat(tools): provide instructions how to generate change files in batch

### DIFF
--- a/tools/generators/generate-change-file.spec.ts
+++ b/tools/generators/generate-change-file.spec.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @fluentui/max-len */
+import { logger } from '@nrwl/devkit';
+import * as chalk from 'chalk';
+
+import { disableChalk, formatMockedCalls } from '../utils-testing';
+import { generateChangeFilesHelp } from './generate-change-files';
+
+describe(`generate change file task`, () => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const noop = () => {};
+  disableChalk(chalk);
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+
+    jest.spyOn(console, 'log').mockImplementation(noop);
+    jest.spyOn(console, 'info').mockImplementation(noop);
+    jest.spyOn(console, 'warn').mockImplementation(noop);
+  });
+
+  describe(`#generateChangeFilesHelp`, () => {
+    it(`should print help`, () => {
+      const loggerInfoSpy = jest.spyOn(logger, 'info');
+      generateChangeFilesHelp({
+        message: 'it iiiiz wat it iiiz',
+        type: 'none',
+        dependentChangeType: 'none',
+      });
+
+      expect(formatMockedCalls(loggerInfoSpy.mock.calls)).toMatchInlineSnapshot(`
+        ">  Changefiles generation instructions:
+        1. Make sure your files are staged
+        2. Run following command:
+
+        yarn beachball change --scope \\"!packages/fluentui/*\\" --no-commit --message \\"it iiiiz wat it iiiz\\" --type \\"none\\" --dependent-change-type \\"none\\"
+        "
+      `);
+    });
+  });
+});

--- a/tools/generators/generate-change-files.ts
+++ b/tools/generators/generate-change-files.ts
@@ -1,0 +1,62 @@
+import { Tree, logger, joinPathFragments } from '@nrwl/devkit';
+import * as path from 'path';
+import * as childProcess from 'child_process';
+import * as chalk from 'chalk';
+
+import type { CliOptions } from 'beachball/lib/types/BeachballOptions';
+
+type WithoutNullable<T> = {
+  [P in keyof T]-?: NonNullable<T[P]>;
+};
+
+interface ChangeFileOptions
+  extends WithoutNullable<Pick<CliOptions, 'message' | 'type'>>,
+    Partial<NonNullable<Pick<CliOptions, 'dependentChangeType'>>> {}
+
+/**
+ *
+ * This is not intended to be used yet - added this here only for inspiration/reference.
+ *
+ * Beacbball determines changes only on staged files. To make this work as expected (good DX),
+ * we would need to manually git stage all files affected by generator
+ */
+function _generateChangeFiles(tree: Tree, options: { cwd?: string } & ChangeFileOptions) {
+  const { cwd = '', ...generateChangefileOptions } = options;
+  const usedCwd = path.join(tree.root, cwd);
+  const cmd = `yarn ${createCommand(generateChangefileOptions)}`;
+
+  childProcess.execSync(cmd, {
+    cwd: usedCwd,
+    stdio: 'inherit',
+  });
+}
+
+function createCommand(options: ChangeFileOptions) {
+  const cmd = 'beachball change --scope "!packages/fluentui/*" --no-commit';
+  const flags = Object.entries({
+    message: options.message,
+    type: options.type,
+    'dependent-change-type': options.dependentChangeType,
+  })
+    .map(([flag, value]) => {
+      if (value) {
+        return `--${flag} "${value}"`;
+      }
+      return;
+    })
+    .filter(Boolean) as string[];
+
+  return `${cmd} ${flags.join(' ')}`;
+}
+
+export function generateChangeFilesHelp(options: ChangeFileOptions) {
+  const cmd = `yarn ${createCommand(options)}`;
+  logger.info(printTitle('Changefiles generation instructions:'));
+  logger.info(chalk.bold(`\t1. Make sure your files are staged`));
+  logger.info(chalk.bold(`\t2. Run following command:`));
+  logger.info('');
+  logger.info(`\t${chalk.italic.green(cmd)}`);
+  logger.info('');
+}
+
+const printTitle = (title: string) => `${chalk.cyan('>')} ${chalk.inverse(chalk.bold(chalk.cyan(` ${title} `)))}\n`;

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -31,6 +31,7 @@ import {
 import { MigrateConvergedPkgGeneratorSchema } from './schema';
 import { addCodeowner } from '../add-codeowners';
 import { printStats } from '../print-stats';
+import { generateChangeFilesHelp } from '../generate-change-files';
 
 interface ProjectConfiguration extends ReturnType<typeof readProjectConfiguration> {}
 
@@ -74,6 +75,15 @@ export default async function (tree: Tree, schema: MigrateConvergedPkgGeneratorS
 
   return () => {
     printUserLogs(userLog);
+
+    const changedFilesPath = tree.listChanges().map(value => value.path);
+
+    if (changedFilesPath.length > 0) {
+      generateChangeFilesHelp({
+        message: 'chore: update package scaffold',
+        type: 'none',
+      });
+    }
   };
 }
 

--- a/tools/generators/migrate-converged-pkg/schema.json
+++ b/tools/generators/migrate-converged-pkg/schema.json
@@ -27,5 +27,6 @@
       "pattern": "^@[/-\\w]+$"
     }
   },
-  "required": []
+  "required": [],
+  "additionalProperties": false
 }

--- a/tools/generators/print-stats.spec.ts
+++ b/tools/generators/print-stats.spec.ts
@@ -1,22 +1,14 @@
 import { addProjectConfiguration, getProjects, logger, stripIndents, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import * as chalk from 'chalk';
+import { disableChalk, formatMockedCalls } from '../utils-testing';
 
 import { printStats } from './print-stats';
 
 describe(`print stats`, () => {
-  // @ts-expect-error - chalk ships wrong types. this is standard public API to turn off chalk
-  chalk.level = 0;
-
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const noop = () => {};
-
-  function formatMockedCalls(values: string[][]) {
-    return values
-      .flat()
-      .map(line => line.trim())
-      .join('\n');
-  }
+  disableChalk(chalk);
 
   let tree: Tree;
 

--- a/tools/utils-testing.ts
+++ b/tools/utils-testing.ts
@@ -1,4 +1,5 @@
 import { stripIndents, Tree } from '@nrwl/devkit';
+import type { Chalk } from 'chalk';
 
 import { workspacePaths } from './utils';
 
@@ -14,4 +15,15 @@ export function setupCodeowners(tree: Tree, options: { withPlaceholder?: boolean
   );
 
   return tree;
+}
+
+export function disableChalk(chalkInstance: Chalk) {
+  chalkInstance.level = 0;
+}
+
+export function formatMockedCalls(values: string[][]) {
+  return values
+    .flat()
+    .map(line => line.trim())
+    .join('\n');
 }

--- a/tools/utils.spec.ts
+++ b/tools/utils.spec.ts
@@ -1,0 +1,40 @@
+import { logger } from '@nrwl/devkit';
+import { printUserLogs } from './utils';
+
+describe(`utils`, () => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const noop = () => {};
+
+  describe(`#printUserLogs`, () => {
+    beforeEach(() => {
+      jest.restoreAllMocks();
+
+      jest.spyOn(console, 'log').mockImplementation(noop);
+      jest.spyOn(console, 'info').mockImplementation(noop);
+      jest.spyOn(console, 'warn').mockImplementation(noop);
+      jest.spyOn(console, 'error').mockImplementation(noop);
+    });
+
+    it(`should print nothing if logs are empty`, () => {
+      const loggerInfoSpy = jest.spyOn(logger, 'info');
+      printUserLogs([]);
+
+      expect(loggerInfoSpy).not.toHaveBeenCalled();
+    });
+
+    it(`should print logs based on type`, () => {
+      const loggerInfoSpy = jest.spyOn(logger, 'info');
+      const loggerWarnSpy = jest.spyOn(logger, 'warn');
+      const loggerErrorSpy = jest.spyOn(logger, 'error');
+      printUserLogs([
+        { type: 'info', message: 'info log' },
+        { type: 'warn', message: 'warn log' },
+        { type: 'error', message: 'error log' },
+      ]);
+
+      expect(loggerInfoSpy).toHaveBeenCalledWith('info log');
+      expect(loggerWarnSpy).toHaveBeenCalledWith('warn log');
+      expect(loggerErrorSpy).toHaveBeenCalledWith('error log');
+    });
+  });
+});

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -143,6 +143,10 @@ export const workspacePaths = {
 
 export type UserLog = Array<{ type: keyof typeof logger; message: string }>;
 export function printUserLogs(logs: UserLog) {
+  if (logs.length === 0) {
+    return;
+  }
+
   logger.log(`${'='.repeat(80)}\n`);
 
   logs.forEach(log => logger[log.type](log.message));


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

After migration is executed, user is missing instructions regarding change files. Based on lack of user knowledge of beachball apis, if we run migration on many packages we might end up manually going through beachball prompts which tend to be very tedious manual work. 

## New Behavior

After migration execution, if there are any changed files in particular package, generator will provide command that user should invoke on his convenience, which will create change files if needed for all packages that have been affected.

- This PR also adds more tests for tools and fixes redundant console spam created by userLogs

![image](https://user-images.githubusercontent.com/1223799/165475742-c7a8fcc3-8289-4fec-a36e-ea9342faf706.png)


## Related Issue(s)


