### PR TITLE
chore(react-components): fix build:local task

### DIFF
--- a/change/@fluentui-react-components-2bd5794e-c0db-4859-9af4-86499b5eca4f.json
+++ b/change/@fluentui-react-components-2bd5794e-c0db-4859-9af4-86499b5eca4f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(react-components): fix build:local task",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/config/api-extractor.local.json
+++ b/packages/react-components/react-components/config/api-extractor.local.json
@@ -1,29 +1,16 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "extends": "./api-extractor.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/packages/<unscopedPackageName>/src/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/dist/packages/react-components/<unscopedPackageName>/src/index.d.ts",
   "compiler": {
     /**
      * This is a quickfix to make build:local work
      * - @see https://github.com/microsoft/fluentui/issues/19360
-     * - config copied/mirrored from package tsconfig.json
+     * - config uses standard tsconfig.lib.json and overrides path aliases
      */
     "overrideTsconfig": {
-      "extends": "../../tsconfig.base.json",
-      "include": ["src"],
+      "extends": "./tsconfig.lib.json",
       "compilerOptions": {
-        "target": "ES5",
-        "module": "CommonJS",
-        "lib": ["ES2016", "dom"],
-        "outDir": "dist",
-        "jsx": "react",
-        "declaration": true,
-        "experimentalDecorators": true,
-        "importHelpers": true,
-        "noUnusedLocals": true,
-        "preserveConstEnums": true,
-        "types": ["jest", "custom-global", "storybook__addons"],
-        "baseUrl": ".",
         "paths": {
           "@fluentui/*": ["dist/*/src/index.d.ts"]
         }

--- a/tools/generators/move-packages/index.spec.ts
+++ b/tools/generators/move-packages/index.spec.ts
@@ -12,6 +12,8 @@ import {
   joinPathFragments,
   ProjectConfiguration,
   readJson,
+  updateJson,
+  NxJsonConfiguration,
 } from '@nrwl/devkit';
 
 import generator from './index';
@@ -38,20 +40,13 @@ describe('move-packages generator', () => {
 
     setupCodeowners(tree, { content: `packages/test @dummyOwner` });
 
-    const nxJsonConfig = {
-      npmScope: 'proj',
-      affected: { defaultBase: 'main' },
-      tasksRunnerOptions: {
-        default: {
-          runner: '@nrwl/workspace/tasks-runners/default',
-          options: { cacheableOperations: ['build', 'lint', 'test', 'e2e'] },
-        },
-      },
-      workspaceLayout: {
+    updateJson(tree, '/nx.json', (json: NxJsonConfiguration) => {
+      json.workspaceLayout = {
+        appsDir: 'apps',
         libsDir: 'packages',
-      },
-    };
-    tree.write(`nx.json`, serializeJson(nxJsonConfig));
+      };
+      return json;
+    });
 
     tree = setupDummyPackage(tree, {
       ...options,
@@ -155,6 +150,7 @@ describe('move-packages generator', () => {
       expect(codeOwnersFile.indexOf(oldOwnerDeclaration) !== -1).toBeFalsy();
       expect(codeOwnersFile.indexOf(newOwnerDeclaration) !== -1).toBeTruthy();
     });
+
     it(`should update api-extractor.local.json`, async () => {
       let project = getProjects(tree).get(options.name) as ProjectConfiguration;
       let apiExtractorLocalPath = joinPathFragments(project.root, 'config/api-extractor.local.json');
@@ -179,7 +175,7 @@ describe('move-packages generator', () => {
         Object {
           "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
           "extends": "./api-extractor.json",
-          "mainEntryPointFilePath": "<projectFolder>/dist/packages/testFolder/test/<unscopedPackageName>/src/index.d.ts",
+          "mainEntryPointFilePath": "<projectFolder>/dist/packages/testFolder/<unscopedPackageName>/src/index.d.ts",
         }
       `);
       /* eslint-enable @fluentui/max-len */

--- a/tools/generators/move-packages/index.ts
+++ b/tools/generators/move-packages/index.ts
@@ -169,9 +169,10 @@ function updateApiExtractor(tree: Tree, schema: MovePackagesGeneratorSchema) {
   const apiExtractorLocalPath = joinPathFragments(projectConfig.paths.configRoot, 'api-extractor.local.json');
   const apiExtractorLocal = readJson(tree, apiExtractorLocalPath);
   const originalEntryPointPath = apiExtractorLocal.mainEntryPointFilePath;
+  const normalizeFolderDestination = schema.destination.split('/').slice(0, -1);
   const updatedEntryPointPath = originalEntryPointPath.replace(
     'packages/<unscopedPackageName>',
-    `packages/${schema.destination}/<unscopedPackageName>`,
+    `packages/${normalizeFolderDestination}/<unscopedPackageName>`,
   );
   apiExtractorLocal.mainEntryPointFilePath = updatedEntryPointPath;
 

--- a/tools/generators/move-packages/index.ts
+++ b/tools/generators/move-packages/index.ts
@@ -169,7 +169,7 @@ function updateApiExtractor(tree: Tree, schema: MovePackagesGeneratorSchema) {
   const apiExtractorLocalPath = joinPathFragments(projectConfig.paths.configRoot, 'api-extractor.local.json');
   const apiExtractorLocal = readJson(tree, apiExtractorLocalPath);
   const originalEntryPointPath = apiExtractorLocal.mainEntryPointFilePath;
-  const normalizeFolderDestination = schema.destination.split('/').slice(0, -1);
+  const normalizeFolderDestination = schema.destination.split('/').slice(0, -1).join("/");
   const updatedEntryPointPath = originalEntryPointPath.replace(
     'packages/<unscopedPackageName>',
     `packages/${normalizeFolderDestination}/<unscopedPackageName>`,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- after migration of `react-components` to `react-components` parent folder `build:local` is broken

## New Behavior

- `local:build` works
- `move` generator has been updated to accommodate this behaviour for other packages
- updates `react-components` tsConfig override in api extractor config

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21910
