### PR TITLE
change neutral Divider color in light and dark theme

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,6 +18,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- Change default Divider color in light and dark theme @yuanboxue-amber ([#22665](https://github.com/microsoft/fluentui/pull/22665))
+
 ### Fixes
 - Align `ChatMessageReadStatus` position with `ChatMessage` @Hirse ([#22494](https://github.com/microsoft/fluentui/pull/22494))
 - Align @fluentui/react-northstar (v0) and @fluentui/react-theme (v9) colors @jurokapsiar ([#22483](https://github.com/microsoft/fluentui/pull/22483))

--- a/packages/fluentui/react-northstar/src/themes/teams-dark/components/Divider/dividerVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark/components/Divider/dividerVariables.ts
@@ -12,5 +12,4 @@ export const dividerVariables = (siteVars: any): Partial<DividerVariables> => ({
     dividerColorAreas,
   ),
   textColor: siteVars.colors.grey[250],
-  dividerColor: siteVars.colors.grey[550],
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Divider/dividerVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Divider/dividerVariables.ts
@@ -19,7 +19,7 @@ export interface DividerVariables {
 
 export const dividerVariables = (siteVars: any): DividerVariables => ({
   colorScheme: pickValuesFromColorScheme(siteVars.colorScheme, dividerColorAreas),
-  dividerColor: siteVars.colors.grey[150],
+  dividerColor: siteVars.colorScheme.brand.border,
   textColor: siteVars.colors.grey[450],
   textFontSize: siteVars.fontSizeSmall,
   textLineHeight: siteVars.lineHeightSmall,


### PR DESCRIPTION
Default @fluentui/react-northstar Divider has color #ebebeb in light theme and #3d3d3d in dark theme.

This PR updated it to use brand.border token, which has #e0e0e0 in light theme and #525252 in dark theme, same as  @fluentui/react-components Divider

Result:
<img width="648" alt="Screenshot 2022-04-27 at 15 41 33" src="https://user-images.githubusercontent.com/28751745/165532453-f64c631d-7c93-4677-b400-04f9e26175cd.png">
<img width="650" alt="Screenshot 2022-04-27 at 15 42 20" src="https://user-images.githubusercontent.com/28751745/165532466-b26881ed-fb98-4094-9123-e4cf06e3feb7.png">
