### PR TITLE
feat: re-exports positioning types at `react-components`

### DIFF
--- a/change/@fluentui-react-components-0a011e91-2812-4c84-81b2-97aab3f0abc8.json
+++ b/change/@fluentui-react-components-0a011e91-2812-4c84-81b2-97aab3f0abc8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: re-exports positioning types at `react-components`",
+  "packageName": "@fluentui/react-components",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -246,6 +246,9 @@ import { PopoverTriggerState } from '@fluentui/react-popover';
 import { Portal } from '@fluentui/react-portal';
 import { PortalProps } from '@fluentui/react-portal';
 import { PortalState } from '@fluentui/react-portal';
+import { PositioningProps } from '@fluentui/react-positioning';
+import { PositioningShorthand } from '@fluentui/react-positioning';
+import { PositioningShorthandValue } from '@fluentui/react-positioning';
 import { PresenceBadge } from '@fluentui/react-badge';
 import { presenceBadgeClassName } from '@fluentui/react-badge';
 import { presenceBadgeClassNames } from '@fluentui/react-badge';
@@ -934,6 +937,12 @@ export { Portal }
 export { PortalProps }
 
 export { PortalState }
+
+export { PositioningProps }
+
+export { PositioningShorthand }
+
+export { PositioningShorthandValue }
 
 export { PresenceBadge }
 

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -47,6 +47,7 @@
     "@fluentui/react-link": "9.0.0-rc.7",
     "@fluentui/react-menu": "9.0.0-rc.7",
     "@fluentui/react-popover": "9.0.0-rc.7",
+    "@fluentui/react-positioning": "9.0.0-rc.6",
     "@fluentui/react-portal": "9.0.0-rc.7",
     "@fluentui/react-provider": "9.0.0-rc.7",
     "@fluentui/react-radio": "9.0.0-beta.4",

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -527,3 +527,5 @@ export type {
   TooltipState,
   TooltipTriggerProps,
 } from '@fluentui/react-tooltip';
+
+export type { PositioningProps, PositioningShorthand, PositioningShorthandValue } from '@fluentui/react-positioning';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently none of the types in `@fluentui/react-positioning` are exported from react-components.

## New Behavior

Since we have a common `positioning` prop for all positioned components in v9, we should at least export `PositioningProps` and/or other types like `PositioningShorthandValue` that we expect consumers to use when configuring positioned components.

## Related Issue(s)

Fixes #21669
