### PR TITLE
put tabster story into proper hierarchy

### DIFF
--- a/packages/react-tabster/src/tabster.stories.tsx
+++ b/packages/react-tabster/src/tabster.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useKeyboardNavAttribute } from './index';
 
-export const Keyborg = () => {
+export const Default = () => {
   return (
     <div ref={useKeyboardNavAttribute()}>
       <button>Start</button>
@@ -11,6 +11,5 @@ export const Keyborg = () => {
 };
 
 export default {
-  title: 'tabster',
-  id: 'Components/tabster',
+  title: 'Components/Tabster',
 };


### PR DESCRIPTION
1) Not sure why this story started showing up in our storybook just recently but...
2) the story is under the wrong path and is showing up at the top of the storybook

![image](https://user-images.githubusercontent.com/1434956/165559416-bbede053-47b2-4aa2-87be-d5fa8654779b.png)


This PR addresses the 2nd issue. I still question if we actually need this story in its current state or not. 