### PR TITLE
chore: moves focus indicator from hooks folder to it's own

### DIFF
--- a/change/@fluentui-react-tabster-ad843a71-13a9-4633-862f-9eea9c57a59d.json
+++ b/change/@fluentui-react-tabster-ad843a71-13a9-4633-862f-9eea9c57a59d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: moves focus indicator from hooks folder to it's own",
+  "packageName": "@fluentui/react-tabster",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-tabster/e2e/useKeyborg.e2e.tsx
+++ b/packages/react-tabster/e2e/useKeyborg.e2e.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { KEYBOARD_NAV_ATTRIBUTE } from '../src/symbols';
+import { KEYBOARD_NAV_ATTRIBUTE } from '../src/focus/constants';
 import { useKeyboardNavAttribute } from '@fluentui/react-tabster';
 import { mount as mountBase } from '@cypress/react';
 import { FluentProvider } from '@fluentui/react-provider';

--- a/packages/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-tabster/etc/react-tabster.api.md
@@ -9,18 +9,22 @@ import type { RefObject } from 'react';
 import { Types } from 'tabster';
 
 // @public
-export const createCustomFocusIndicatorStyle: (style: GriffelStyle, options?: CreateFocusIndicatorStyleRuleOptions) => GriffelStyle;
+export const createCustomFocusIndicatorStyle: (style: GriffelStyle, { selector }?: CreateCustomFocusIndicatorStyleOptions) => GriffelStyle;
 
 // @public (undocumented)
-export interface CreateFocusIndicatorStyleRuleOptions {
+export interface CreateCustomFocusIndicatorStyleOptions {
     // (undocumented)
     selector?: 'focus' | 'focus-within';
 }
 
 // @public
-export const createFocusOutlineStyle: (options?: {
-    style: Partial<FocusOutlineStyleOptions>;
-} & CreateFocusIndicatorStyleRuleOptions) => GriffelStyle;
+export const createFocusOutlineStyle: ({ selector, style, }?: CreateFocusOutlineStyleOptions) => GriffelStyle;
+
+// @public (undocumented)
+export interface CreateFocusOutlineStyleOptions extends CreateCustomFocusIndicatorStyleOptions {
+    // (undocumented)
+    style?: Partial<FocusOutlineStyleOptions>;
+}
 
 // @public (undocumented)
 export type FocusOutlineOffset = Record<'top' | 'bottom' | 'left' | 'right', string>;

--- a/packages/react-tabster/src/focus/constants.ts
+++ b/packages/react-tabster/src/focus/constants.ts
@@ -1,2 +1,6 @@
 export const KEYBOARD_NAV_ATTRIBUTE = 'data-keyboard-nav' as const;
 export const KEYBOARD_NAV_SELECTOR = `:global([${KEYBOARD_NAV_ATTRIBUTE}])` as const;
+export const defaultOptions = {
+  style: {},
+  selector: 'focus',
+} as const;

--- a/packages/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
+++ b/packages/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
@@ -1,0 +1,23 @@
+import { KEYBOARD_NAV_SELECTOR, defaultOptions } from './constants';
+import type { GriffelStyle } from '@griffel/react';
+
+export interface CreateCustomFocusIndicatorStyleOptions {
+  selector?: 'focus' | 'focus-within';
+}
+
+/**
+ * Creates a style for @see makeStyles that includes the necessary selectors for focus.
+ * Should be used only when @see createFocusOutlineStyle does not fit requirements
+ *
+ * @param style - styling applied on focus, defaults to @see getDefaultFocusOutlineStyes
+ * @param options - Configure the style of the focus outline
+ */
+export const createCustomFocusIndicatorStyle = (
+  style: GriffelStyle,
+  { selector = defaultOptions.selector }: CreateCustomFocusIndicatorStyleOptions = defaultOptions,
+): GriffelStyle => ({
+  ':focus-visible': {
+    outlineStyle: 'none',
+  },
+  [`${KEYBOARD_NAV_SELECTOR} :${selector}`]: style,
+});

--- a/packages/react-tabster/src/focus/createFocusOutlineStyle.ts
+++ b/packages/react-tabster/src/focus/createFocusOutlineStyle.ts
@@ -1,7 +1,11 @@
 import { tokens } from '@fluentui/react-theme';
-import { KEYBOARD_NAV_SELECTOR } from '../symbols';
 import { shorthands } from '@griffel/react';
 import type { GriffelStyle } from '@griffel/react';
+import {
+  createCustomFocusIndicatorStyle,
+  CreateCustomFocusIndicatorStyleOptions,
+} from './createCustomFocusIndicatorStyle';
+import { defaultOptions } from './constants';
 
 export type FocusOutlineOffset = Record<'top' | 'bottom' | 'left' | 'right', string>;
 export type FocusOutlineStyleOptions = {
@@ -14,6 +18,9 @@ export type FocusOutlineStyleOptions = {
   outlineWidth: string;
   outlineOffset?: string | FocusOutlineOffset;
 };
+export interface CreateFocusOutlineStyleOptions extends CreateCustomFocusIndicatorStyleOptions {
+  style?: Partial<FocusOutlineStyleOptions>;
+}
 
 /**
  * NOTE: the element with the focus outline needs to have `position: relative` so that the
@@ -51,14 +58,6 @@ const getFocusOutlineStyles = (options: FocusOutlineStyleOptions): GriffelStyle 
   };
 };
 
-export interface CreateFocusIndicatorStyleRuleOptions {
-  selector?: 'focus' | 'focus-within';
-}
-
-const defaultOptions: CreateFocusIndicatorStyleRuleOptions = {
-  selector: 'focus',
-};
-
 /**
  * NOTE: The element with the focus outline needs to have `position: relative` so that the
  * pseudo element can be properly positioned.
@@ -66,36 +65,17 @@ const defaultOptions: CreateFocusIndicatorStyleRuleOptions = {
  * @param options - Configure the style of the focus outline
  * @returns focus outline styles object for @see makeStyles
  */
-export const createFocusOutlineStyle = (
-  options: {
-    style: Partial<FocusOutlineStyleOptions>;
-  } & CreateFocusIndicatorStyleRuleOptions = { style: {}, ...defaultOptions },
-): GriffelStyle => ({
-  ':focus-visible': {
-    outlineStyle: 'none',
-  },
-  [`${KEYBOARD_NAV_SELECTOR} :${options.selector || defaultOptions.selector}`]: getFocusOutlineStyles({
-    outlineColor: tokens.colorStrokeFocus2,
-    outlineRadius: tokens.borderRadiusMedium,
-    // FIXME: tokens.strokeWidthThick causes some weird bugs
-    outlineWidth: '2px',
-    ...options.style,
-  }),
-});
-
-/**
- * Creates a style for @see makeStyles that includes the necessary selectors for focus.
- * Should be used only when @see createFocusOutlineStyle does not fit requirements
- *
- * @param style - styling applied on focus, defaults to @see getDefaultFocusOutlineStyes
- * @param options - Configure the style of the focus outline
- */
-export const createCustomFocusIndicatorStyle = (
-  style: GriffelStyle,
-  options: CreateFocusIndicatorStyleRuleOptions = defaultOptions,
-): GriffelStyle => ({
-  ':focus-visible': {
-    outlineStyle: 'none',
-  },
-  [`${KEYBOARD_NAV_SELECTOR} :${options.selector || defaultOptions.selector}`]: style,
-});
+export const createFocusOutlineStyle = ({
+  selector = defaultOptions.selector,
+  style = defaultOptions.style,
+}: CreateFocusOutlineStyleOptions = defaultOptions): GriffelStyle =>
+  createCustomFocusIndicatorStyle(
+    getFocusOutlineStyles({
+      outlineColor: tokens.colorStrokeFocus2,
+      outlineRadius: tokens.borderRadiusMedium,
+      // FIXME: tokens.strokeWidthThick causes some weird bugs
+      outlineWidth: '2px',
+      ...style,
+    }),
+    { selector },
+  );

--- a/packages/react-tabster/src/focus/index.ts
+++ b/packages/react-tabster/src/focus/index.ts
@@ -1,0 +1,2 @@
+export * from './createCustomFocusIndicatorStyle';
+export * from './createFocusOutlineStyle';

--- a/packages/react-tabster/src/hooks/index.ts
+++ b/packages/react-tabster/src/hooks/index.ts
@@ -1,7 +1,6 @@
 export * from './useArrowNavigationGroup';
 export * from './useFocusableGroup';
 export * from './useFocusFinders';
-export * from './useFocusIndicatorStyle';
 export * from './useKeyboardNavAttribute';
 export * from './useModalAttributes';
 export * from './useTabsterAttributes';

--- a/packages/react-tabster/src/hooks/useKeyboardNavAttribute.ts
+++ b/packages/react-tabster/src/hooks/useKeyboardNavAttribute.ts
@@ -1,6 +1,6 @@
 import { createKeyborg } from 'keyborg';
 import { useEffect, useMemo, useRef } from 'react';
-import { KEYBOARD_NAV_ATTRIBUTE } from '../symbols';
+import { KEYBOARD_NAV_ATTRIBUTE } from '../focus/constants';
 import { useFluent } from '@fluentui/react-shared-contexts';
 import type { KeyborgCallback } from 'keyborg/dist/Keyborg';
 import type { RefObject } from 'react';

--- a/packages/react-tabster/src/index.ts
+++ b/packages/react-tabster/src/index.ts
@@ -1,6 +1,4 @@
 export {
-  createCustomFocusIndicatorStyle,
-  createFocusOutlineStyle,
   useArrowNavigationGroup,
   useFocusableGroup,
   useFocusFinders,
@@ -9,10 +7,16 @@ export {
   useTabsterAttributes,
 } from './hooks/index';
 export type {
-  CreateFocusIndicatorStyleRuleOptions,
-  FocusOutlineOffset,
-  FocusOutlineStyleOptions,
   UseArrowNavigationGroupOptions,
   UseFocusableGroupOptions,
   UseModalAttributesOptions,
 } from './hooks/index';
+
+export { createCustomFocusIndicatorStyle, createFocusOutlineStyle } from './focus/index';
+
+export type {
+  CreateCustomFocusIndicatorStyleOptions,
+  CreateFocusOutlineStyleOptions,
+  FocusOutlineOffset,
+  FocusOutlineStyleOptions,
+} from './focus/index';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

`createCustomFocusIndicatorStyle` and `createFocusOutlineStyle` functions are being exported from `hooks/useFocusIndicatorStyle.ts` file, which is a legacy of the first implementation of focus indicator, which was actually a hook.

## New Behavior

Moves `createCustomFocusIndicatorStyle` and `createFocusOutlineStyle` to `focus/createCustomFocusIndicatorStyle.ts` and `focus/createFocusOutlineStyle.ts` and delete `hooks/useFocusIndicatorStyle.ts`


This PR also resolves some typings that weren't _clear_
