### PR TITLE
Storybook: fix theme for local mac development

### DIFF
--- a/apps/public-docsite-v9/.storybook/preview.js
+++ b/apps/public-docsite-v9/.storybook/preview.js
@@ -2,6 +2,9 @@ import { FluentDocsContainer } from '../src/DocsComponents/FluentDocsContainer.s
 import { FluentDocsPage } from '../src/DocsComponents/FluentDocsPage.stories';
 import * as rootPreview from '../../../.storybook/preview';
 
+/** @type {NonNullable<import('@storybook/react').Story['decorators']>} */
+export const decorators = rootPreview.decorators;
+
 /** @type {typeof rootPreview.parameters} */
 export const parameters = {
   ...rootPreview.parameters,

--- a/change/@fluentui-react-components-961b7c91-fee6-4aa4-aa99-cf134e248438.json
+++ b/change/@fluentui-react-components-961b7c91-fee6-4aa4-aa99-cf134e248438.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add manual decorators for mac which does not work with current addon",
+  "packageName": "@fluentui/react-components",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/.storybook/preview.js
+++ b/packages/react-components/react-components/.storybook/preview.js
@@ -1,5 +1,8 @@
 import * as rootPreview from '../../../../.storybook/preview';
 
+/** @type {NonNullable<import('@storybook/react').Story['decorators']>} */
+export const decorators = rootPreview.decorators;
+
 /** @type {typeof rootPreview.parameters} */
 export const parameters = {
   ...rootPreview.parameters,


### PR DESCRIPTION
For SOME reason, the storybook-react-addon is not working on Mac. We didn't notice this before because we were adding a 2nd theme provider decorator from the storybook-react package. I removed that decorator seeing it as redundant (2 of them show up on PC), but this obvious broke mac development and mac deployment of chromatic. 

This PR pulls that decorator back in, and I will open an issue to track the mac compat issue with storybook-react-addons