### PR TITLE
react-radio: add bundle size fixtures

### DIFF
--- a/change/@fluentui-react-radio-996aa647-972f-4498-8cb5-e22527f7a82e.json
+++ b/change/@fluentui-react-radio-996aa647-972f-4498-8cb5-e22527f7a82e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add bundle size fixtures",
+  "packageName": "@fluentui/react-radio",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-radio/bundle-size/Radio.fixture.js
+++ b/packages/react-radio/bundle-size/Radio.fixture.js
@@ -1,0 +1,7 @@
+import { Radio } from '@fluentui/react-radio';
+
+console.log(Radio);
+
+export default {
+  name: 'Radio',
+};

--- a/packages/react-radio/bundle-size/RadioGroup.fixture.js
+++ b/packages/react-radio/bundle-size/RadioGroup.fixture.js
@@ -1,0 +1,7 @@
+import { RadioGroup } from '@fluentui/react-radio';
+
+console.log(RadioGroup);
+
+export default {
+  name: 'RadioGroup',
+};

--- a/packages/react-radio/package.json
+++ b/packages/react-radio/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",


### PR DESCRIPTION
## Current Behavior

`react-radio` package did not have bundle size fixtures.

## New Behavior

`react-radio` package does have bundle size fixtures.

## Related Issue(s)

#19953
