### PR TITLE
react-radio: write readme

### DIFF
--- a/change/@fluentui-react-radio-c738372a-484c-42ab-b64c-20287e3f4373.json
+++ b/change/@fluentui-react-radio-c738372a-484c-42ab-b64c-20287e3f4373.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "write readme",
+  "packageName": "@fluentui/react-radio",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-radio/README.md
+++ b/packages/react-radio/README.md
@@ -3,3 +3,42 @@
 **React Radio components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
 
 These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+
+A Radio allows a user to select a single value from two or more options. All Radios with the same `name` are considered to be part of the same group. However, a `RadioGroup` is recommended to add a group label, formatting, and other functionality.
+
+### Usage
+
+Import `Radio` and `RadioGroup`:
+
+```js
+import { Radio, RadioGroup } from '@fluentui/react-radio';
+```
+
+#### Examples
+
+```jsx
+<RadioGroup defaultValue="B">
+  <Radio value="A" label="Option A" />
+  <Radio value="B" label="Option B" />
+  <Radio value="C" label="Option C" />
+  <Radio value="D" label="Option D" />
+</RadioGroup>
+
+<RadioGroup value={value} onChange={(_, data) => setValue(data.value)}>
+  <Radio value="A" label="Option A" />
+  <Radio value="B" label="Option B" />
+  <Radio value="C" label="Option C" />
+  <Radio value="D" label="Option D" />
+</RadioGroup>
+```
+
+See [Fluent UI Storybook](https://aka.ms/fluentui-storybook) for more detailed usage examples.
+
+Alternatively, run Storybook locally with:
+
+1. `yarn start`
+2. Select `react-radio` from the list.
+
+### Specification
+
+See [Spec.md](./Spec.md).


### PR DESCRIPTION
## Current Behavior

`react-radio` only had the generated boilerplate readme.

## New Behavior

`react-radio` now has a readme with basic usage and links to other relevant information.

## Related Issue(s)

#19953

