### PR TITLE
react-accordion: remove star exports

### DIFF
--- a/change/@fluentui-react-accordion-4b219078-bd35-477b-815a-330d208e8765.json
+++ b/change/@fluentui-react-accordion-4b219078-bd35-477b-815a-330d208e8765.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove star exports",
+  "packageName": "@fluentui/react-accordion",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-accordion/src/index.ts
+++ b/packages/react-accordion/src/index.ts
@@ -1,4 +1,71 @@
-export * from './Accordion';
-export * from './AccordionItem';
-export * from './AccordionHeader';
-export * from './AccordionPanel';
+export {
+  Accordion,
+  AccordionContext,
+  // eslint-disable-next-line deprecation/deprecation
+  accordionClassName,
+  accordionClassNames,
+  renderAccordion_unstable,
+  useAccordionContextValues_unstable,
+  useAccordionStyles_unstable,
+  useAccordion_unstable,
+} from './Accordion';
+export type {
+  AccordionContextValue,
+  AccordionContextValues,
+  AccordionIndex,
+  AccordionProps,
+  AccordionSlots,
+  AccordionState,
+  AccordionToggleData,
+  AccordionToggleEvent,
+  AccordionToggleEventHandler,
+} from './Accordion';
+export {
+  AccordionItem,
+  AccordionItemContext,
+  // eslint-disable-next-line deprecation/deprecation
+  accordionItemClassName,
+  accordionItemClassNames,
+  renderAccordionItem_unstable,
+  useAccordionItemContextValues_unstable,
+  useAccordionItemContext_unstable,
+  useAccordionItemStyles_unstable,
+  useAccordionItem_unstable,
+} from './AccordionItem';
+export type {
+  AccordionItemContextValue,
+  AccordionItemContextValues,
+  AccordionItemProps,
+  AccordionItemSlots,
+  AccordionItemState,
+  AccordionItemValue,
+} from './AccordionItem';
+export {
+  AccordionHeader,
+  // eslint-disable-next-line deprecation/deprecation
+  accordionHeaderClassName,
+  accordionHeaderClassNames,
+  renderAccordionHeader_unstable,
+  useAccordionHeaderContextValues_unstable,
+  useAccordionHeaderStyles_unstable,
+  useAccordionHeader_unstable,
+} from './AccordionHeader';
+export type {
+  AccordionHeaderContextValue,
+  AccordionHeaderContextValues,
+  AccordionHeaderExpandIconPosition,
+  AccordionHeaderProps,
+  AccordionHeaderSize,
+  AccordionHeaderSlots,
+  AccordionHeaderState,
+} from './AccordionHeader';
+export {
+  AccordionPanel,
+  // eslint-disable-next-line deprecation/deprecation
+  accordionPanelClassName,
+  accordionPanelClassNames,
+  renderAccordionPanel_unstable,
+  useAccordionPanelStyles_unstable,
+  useAccordionPanel_unstable,
+} from './AccordionPanel';
+export type { AccordionPanelProps, AccordionPanelSlots, AccordionPanelState } from './AccordionPanel';


### PR DESCRIPTION
## Current Behavior

`react-accordion` has star exports.

## New Behavior

`react-accordion` does not have star exports.

## Related Issue(s)

#22099
