### PR TITLE
priority-overflow: remove star exports

### DIFF
--- a/packages/priority-overflow/src/index.ts
+++ b/packages/priority-overflow/src/index.ts
@@ -1,2 +1,13 @@
-export * from './overflowManager';
-export * from './types';
+export { createOverflowManager } from './overflowManager';
+export type {
+  ObserveOptions,
+  OnUpdateItemVisibility,
+  OnUpdateItemVisibilityPayload,
+  OnUpdateOverflow,
+  OverflowAxis,
+  OverflowDirection,
+  OverflowEventPayload,
+  OverflowGroupState,
+  OverflowItemEntry,
+  OverflowManager,
+} from './types';


### PR DESCRIPTION
## Current Behavior

`priority-overflow` uses star exports

## New Behavior

`priority-overflow` does not use star exports.

#22099
