### PR TITLE
fix(Tooltip): fix contrast theme pointing and subtle=false style

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Align @fluentui/react-northstar (v0) and @fluentui/react-theme (v9) colors @jurokapsiar ([#22483](https://github.com/microsoft/fluentui/pull/22483))
 - Add missing export for `PortalContext` @layershifter ([#22448](https://github.com/microsoft/fluentui/pull/22448))
 - Do not stop propagation of letter keys if modifier is used in `Tree` @jurokapsiar ([#22603](https://github.com/microsoft/fluentui/pull/22603))
+- fix `Tooltip` constrast style for pointing and subtle=false @yuanboxue-amber ([#22696](https://github.com/microsoft/fluentui/pull/22696))
 
 <!--------------------------------[ v0.62.0 ]------------------------------- -->
 ## [v0.62.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.62.0) (2022-04-08)

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Tooltip/tooltipContentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Tooltip/tooltipContentVariables.ts
@@ -1,3 +1,4 @@
+import { pxToRem } from '../../../../utils';
 import { TooltipContentVariables } from '../../../teams/components/Tooltip/tooltipContentVariables';
 
 export const tooltipContentVariables = (siteVars): Partial<TooltipContentVariables> => ({
@@ -8,4 +9,8 @@ export const tooltipContentVariables = (siteVars): Partial<TooltipContentVariabl
   borderStyle: 'solid',
   subtleBackgroundColor: siteVars.colors.black,
   subtleForegroundColor: siteVars.colors.white,
+  svgPointer: false,
+  pointerMargin: pxToRem(10),
+  pointerHeight: pxToRem(7),
+  pointerWidth: pxToRem(14),
 });

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Tooltip/tooltipContentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Tooltip/tooltipContentVariables.ts
@@ -4,6 +4,8 @@ export const tooltipContentVariables = (siteVars): Partial<TooltipContentVariabl
   boxShadow: undefined,
   color: siteVars.colors.white,
   backgroundColor: siteVars.colors.black,
+  borderColor: siteVars.colors.white,
+  borderStyle: 'solid',
   subtleBackgroundColor: siteVars.colors.black,
   subtleForegroundColor: siteVars.colors.white,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentStyles.ts
@@ -43,7 +43,7 @@ export const tooltipContentStyles: ComponentSlotStylesPrepared<TooltipContentSty
 
       placement: p.basePlacement,
       rtl,
-      svg: pointerSvgUrl(p.subtle ? v.subtleBackgroundColor : v.backgroundColor),
+      svg: v.svgPointer ? pointerSvgUrl(p.subtle ? v.subtleBackgroundColor : v.backgroundColor) : undefined,
     }),
   }),
   content: ({ props: p, variables: v }): ICSSInJSStyle => ({

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentStyles.ts
@@ -35,7 +35,7 @@ export const tooltipContentStyles: ComponentSlotStylesPrepared<TooltipContentSty
     ...getPointerStyles({
       backgroundColor: p.subtle ? v.subtleBackgroundColor : v.backgroundColor,
       borderSize: v.borderSize,
-      borderColor: p.subtle ? v.subtleBorderColor : 'transparent',
+      borderColor: p.subtle ? v.subtleBorderColor : v.borderColor,
       gap: v.pointerGap,
       padding: v.pointerMargin,
       height: v.pointerHeight,
@@ -55,6 +55,8 @@ export const tooltipContentStyles: ComponentSlotStylesPrepared<TooltipContentSty
     color: v.color,
     background: v.backgroundColor,
     borderRadius: v.borderRadius,
+    borderStyle: v.borderStyle,
+    borderColor: v.borderColor,
     boxShadow: v.boxShadow,
 
     ...(p.subtle && {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentVariables.ts
@@ -4,7 +4,9 @@ export interface TooltipContentVariables {
   boxShadow: string;
 
   borderRadius: string;
+  borderColor: string;
   borderSize: string;
+  borderStyle: string;
   padding: string;
 
   maxWidth: string;
@@ -28,7 +30,9 @@ export const tooltipContentVariables = (siteVars: any): TooltipContentVariables 
   boxShadow: siteVars.shadow8,
 
   borderRadius: siteVars.borderRadiusMedium,
+  borderColor: 'transparent',
   borderSize: '1px',
+  borderStyle: 'none',
   padding: `${pxToRem(5)} ${pxToRem(12)} ${pxToRem(7)} ${pxToRem(12)}`,
 
   maxWidth: pxToRem(246),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentVariables.ts
@@ -11,6 +11,7 @@ export interface TooltipContentVariables {
 
   maxWidth: string;
 
+  svgPointer: boolean;
   pointerMargin: string;
   pointerGap: string;
   pointerWidth: string;
@@ -37,6 +38,7 @@ export const tooltipContentVariables = (siteVars: any): TooltipContentVariables 
 
   maxWidth: pxToRem(246),
 
+  svgPointer: true,
   pointerMargin: pxToRem(6),
   pointerGap: pxToRem(5),
   pointerWidth: pxToRem(16),


### PR DESCRIPTION
Fix subtle=false style.
Before:
<img width="193" alt="Screenshot 2022-04-28 at 16 53 26" src="https://user-images.githubusercontent.com/28751745/165781230-6b313915-a540-40b7-acb3-376f20db0c52.png">
After
<img width="173" alt="Screenshot 2022-04-28 at 16 53 37" src="https://user-images.githubusercontent.com/28751745/165781247-fc8d4963-dab9-4809-9b55-3a96d9e7473c.png">

Fix pointing style.
Before:
<img width="179" alt="Screenshot 2022-04-28 at 16 53 08" src="https://user-images.githubusercontent.com/28751745/165781270-ebf255c9-fc07-41ee-8da6-99cd10017170.png">
After:
<img width="239" alt="Screenshot 2022-04-28 at 16 52 56" src="https://user-images.githubusercontent.com/28751745/165781293-93df7972-5101-41ed-ab45-8efd4c81652a.png">
