### PR TITLE
fix(react-card): change storybook asset url

### DIFF
--- a/packages/react-components/react-card/src/stories/CardDefault.stories.tsx
+++ b/packages/react-components/react-card/src/stories/CardDefault.stories.tsx
@@ -5,8 +5,7 @@ import { Body, Caption } from '@fluentui/react-text';
 import { Button } from '@fluentui/react-button';
 import { ArrowReplyRegular, ShareRegular } from '@fluentui/react-icons';
 import { Card, CardFooter, CardHeader, CardPreview } from '../index'; // codesandbox-dependency: @fluentui/react-card ^9.0.0-beta
-
-const ASSET_URL = 'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-card';
+import { ASSET_URL } from './SampleCard.stories';
 
 const avatarElviaURL = ASSET_URL + '/assets/avatar_elvia.svg';
 const wordLogoURL = ASSET_URL + '/assets/word_logo.svg';

--- a/packages/react-components/react-card/src/stories/SampleCard.stories.tsx
+++ b/packages/react-components/react-card/src/stories/SampleCard.stories.tsx
@@ -6,7 +6,8 @@ import { Body, Caption } from '@fluentui/react-text';
 import { Card, CardHeader, CardFooter } from '../index';
 import type { CardProps } from '../index';
 
-const ASSET_URL = 'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-card';
+export const ASSET_URL =
+  'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
 
 const powerpointLogoURL = ASSET_URL + '/assets/powerpoint_logo.svg';
 


### PR DESCRIPTION
## Current Behavior

Story asset URL is still pointing to the old path

## New Behavior

Story asset URL now pointing to /react-components/react-card

## Related Issue(s)

#22692
