### PR TITLE
Label disabled required

### DIFF
--- a/change/@fluentui-react-label-2d71a384-d1d7-481a-981a-cca5c1d36703.json
+++ b/change/@fluentui-react-label-2d71a384-d1d7-481a-981a-cca5c1d36703.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add style to make required match text when disabled",
+  "packageName": "@fluentui/react-label",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-label/src/components/Label/useLabelStyles.ts
+++ b/packages/react-components/react-label/src/components/Label/useLabelStyles.ts
@@ -30,6 +30,10 @@ const useStyles = makeStyles({
     paddingLeft: '4px', // TODO: Once spacing tokens are added, change this to Horizontal XS
   },
 
+  requiredDisabled: {
+    color: tokens.colorNeutralForegroundDisabled,
+  },
+
   small: {
     fontSize: tokens.fontSizeBase200,
     lineHeight: tokens.lineHeightBase200,
@@ -66,7 +70,12 @@ export const useLabelStyles_unstable = (state: LabelState): LabelState => {
   );
 
   if (state.required) {
-    state.required.className = mergeClasses(labelClassNames.required, styles.required, state.required.className);
+    state.required.className = mergeClasses(
+      labelClassNames.required,
+      styles.required,
+      state.disabled && styles.requiredDisabled,
+      state.required.className,
+    );
   }
 
   return state;

--- a/packages/react-components/react-label/src/stories/LabelDisabled.stories.tsx
+++ b/packages/react-components/react-label/src/stories/LabelDisabled.stories.tsx
@@ -1,4 +1,8 @@
 import * as React from 'react';
 import { Label } from '../index'; // codesandbox-dependency: @fluentui/react-label ^9.0.0-beta
 
-export const Disabled = () => <Label disabled>Disabled label</Label>;
+export const Disabled = () => (
+  <Label disabled required>
+    Disabled label
+  </Label>
+);


### PR DESCRIPTION
Added styles to required slot to make it match text when disabled. This came up during a discussion with design yesterday. Figma was just updated to reflect the change.

![image](https://user-images.githubusercontent.com/1434956/165991556-8f00f83a-ee29-4734-b034-40bdeff3f09e.png)


I also updated the disabled example to include the required asterix to demonstrate that both slots change color