### PR TITLE
Input: Update Content Before and After Stories, Labels on Stories

### DIFF
--- a/change/@fluentui-react-input-e61e5457-520b-43b6-b42f-75e3b50ede61.json
+++ b/change/@fluentui-react-input-e61e5457-520b-43b6-b42f-75e3b50ede61.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update content before/after stories; label usage in stories",
+  "packageName": "@fluentui/react-input",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-components/react-input/src/components/Input/useInputStyles.ts
@@ -139,6 +139,7 @@ const useRootStyles = makeStyles({
       ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
       borderBottomColor: tokens.colorNeutralStrokeAccessibleHover,
     },
+    // DO NOT add a space between the selectors! It changes the behavior of make-styles.
     ':active,:focus-within': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
       borderBottomColor: tokens.colorNeutralStrokeAccessiblePressed,

--- a/packages/react-components/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-components/react-input/src/components/Input/useInputStyles.ts
@@ -139,7 +139,6 @@ const useRootStyles = makeStyles({
       ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
       borderBottomColor: tokens.colorNeutralStrokeAccessibleHover,
     },
-    // DO NOT add a space between the selectors! It changes the behavior of make-styles.
     ':active,:focus-within': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
       borderBottomColor: tokens.colorNeutralStrokeAccessiblePressed,

--- a/packages/react-components/react-input/src/stories/InputAppearance.stories.tsx
+++ b/packages/react-components/react-input/src/stories/InputAppearance.stories.tsx
@@ -41,22 +41,22 @@ export const Appearance = () => {
   return (
     <div className={styles.root}>
       <div>
-        <Label htmlFor={outlineId}>Outline (default)</Label>
+        <Label htmlFor={outlineId}>Outline Input Appearance (default)</Label>
         <Input appearance="outline" id={outlineId} />
       </div>
 
       <div>
-        <Label htmlFor={underlineId}>Underline</Label>
+        <Label htmlFor={underlineId}>Underline Input Appearance </Label>
         <Input appearance="underline" id={underlineId} />
       </div>
 
       <div className={styles.filledLighter}>
-        <Label htmlFor={filledLighterId}>Filled lighter</Label>
+        <Label htmlFor={filledLighterId}>Filled Lighter Input Appearance </Label>
         <Input appearance="filledLighter" id={filledLighterId} />
       </div>
 
       <div className={styles.filledDarker}>
-        <Label htmlFor={filledDarkerId}>Filled darker</Label>
+        <Label htmlFor={filledDarkerId}>Filled Darker Input Appearance </Label>
         <Input appearance="filledDarker" id={filledDarkerId} />
       </div>
     </div>

--- a/packages/react-components/react-input/src/stories/InputContentBeforeAfter.stories.tsx
+++ b/packages/react-components/react-input/src/stories/InputContentBeforeAfter.stories.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
 import { makeStyles, shorthands } from '@griffel/react';
-import { SearchRegular, DismissRegular } from '@fluentui/react-icons';
+import { PersonRegular, MicRegular } from '@fluentui/react-icons';
+import { Button } from '@fluentui/react-button';
+import type { ButtonProps } from '@fluentui/react-button';
+import { Body, Text } from '@fluentui/react-text';
 import { Input } from '../index';
 
 const useStyles = makeStyles({
@@ -17,27 +20,83 @@ const useStyles = makeStyles({
   },
 });
 
+const MicButton: React.FC<ButtonProps> = props => {
+  return <Button {...props} appearance="transparent" icon={<MicRegular />} size="small" />;
+};
+
+const ContentBefore = () => {
+  const id = useId('content-before');
+
+  return (
+    <>
+      <Label htmlFor={id}>Full Name</Label>
+      <Input contentBefore={<PersonRegular />} id={id} />
+      <Body>
+        An input with a decorative icon in the <code>contentBefore</code> slot.
+      </Body>
+    </>
+  );
+};
+
+const ContentAfter = () => {
+  const id = useId('content-after');
+
+  return (
+    <>
+      <Label htmlFor={id}>First Name</Label>
+      <Input contentAfter={<MicButton aria-label="Enter by voice" />} id={id} />
+      <Body>
+        An input with a button in the <code>contentAfter</code> slot.
+      </Body>
+    </>
+  );
+};
+
+const ContentBeforeAndAfter = () => {
+  const id = useId('content-before-and-after');
+  const beforeId = useId('before-id');
+  const afterId = useId('after-id');
+
+  return (
+    <>
+      <Label htmlFor={id}>Amount to Pay</Label>
+      <Input
+        contentBefore={
+          <Text size={400} id={beforeId}>
+            $
+          </Text>
+        }
+        contentAfter={
+          <Text size={400} id={afterId}>
+            .00
+          </Text>
+        }
+        aria-labelledby={`${id} ${beforeId} ${afterId}`}
+        id={id}
+      />
+      <Body>
+        An input with a presentational value in the <code>contentBefore</code> slot and another presentational value in
+        the <code>contentAfter</code> slot.
+      </Body>
+    </>
+  );
+};
+
 export const ContentBeforeAfter = () => {
-  const beforeId = useId('input-before');
-  const afterId = useId('input-after');
-  const bothId = useId('input-both');
   const styles = useStyles();
 
   return (
     <div className={styles.root}>
       <div>
-        <Label htmlFor={beforeId}>Content before</Label>
-        <Input contentBefore={<SearchRegular />} id={beforeId} />
+        <ContentBefore />
       </div>
 
       <div>
-        <Label htmlFor={afterId}>Content after</Label>
-        <Input contentAfter={<DismissRegular />} id={afterId} />
+        <ContentAfter />
       </div>
 
       <div>
-        <Label htmlFor={bothId}>Content before and after</Label>
-        <Input contentBefore={<SearchRegular />} contentAfter={<DismissRegular />} id={bothId} />
+        <ContentBeforeAndAfter />
       </div>
     </div>
   );
@@ -47,8 +106,8 @@ ContentBeforeAfter.parameters = {
   docs: {
     description: {
       story:
-        'An input can have visual content (such as an icon) before or after the entered text, ' +
-        'within the input border.',
+        'An input can have elements such as an icon or a button before or after the entered text. ' +
+        'These elements are displayed inside the input border.',
     },
   },
 };

--- a/packages/react-components/react-input/src/stories/InputDefault.stories.tsx
+++ b/packages/react-components/react-input/src/stories/InputDefault.stories.tsx
@@ -25,7 +25,7 @@ export const Default = (props: InputProps) => {
   return (
     <div className={styles.root}>
       <Label htmlFor={inputId} size={props.size} disabled={props.disabled}>
-        Sample input
+        Sample Input
       </Label>
       <Input id={inputId} {...props} />
     </div>

--- a/packages/react-components/react-input/src/stories/InputDisabled.stories.tsx
+++ b/packages/react-components/react-input/src/stories/InputDisabled.stories.tsx
@@ -23,7 +23,7 @@ export const Disabled = () => {
   return (
     <div className={styles.root}>
       <Label disabled htmlFor={inputId}>
-        Disabled input
+        Disabled Input
       </Label>
       <Input disabled id={inputId} defaultValue="disabled value" />
     </div>

--- a/packages/react-components/react-input/src/stories/InputInline.stories.tsx
+++ b/packages/react-components/react-input/src/stories/InputInline.stories.tsx
@@ -9,7 +9,7 @@ export const Inline = () => {
   return (
     <div>
       <Label htmlFor={inputId} style={{ paddingInlineEnd: '12px' }}>
-        Sample input
+        Sample Inline Input
       </Label>
       <Input id={inputId} />
 

--- a/packages/react-components/react-input/src/stories/InputPlaceholder.stories.tsx
+++ b/packages/react-components/react-input/src/stories/InputPlaceholder.stories.tsx
@@ -1,8 +1,28 @@
 import * as React from 'react';
 import { Input } from '../index';
+import { Label } from '@fluentui/react-label';
+import { useId } from '@fluentui/react-utilities';
+import { makeStyles } from '@griffel/react';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '5px',
+    maxWidth: '300px',
+  },
+});
 
 export const Placeholder = () => {
-  return <Input placeholder="input with placeholder" aria-label="input with placeholder" />;
+  const placeholderId = useId('input-placeholder');
+  const styles = useStyles();
+
+  return (
+    <div className={styles.root}>
+      <Label htmlFor={placeholderId}>Input With a Placeholder</Label>
+      <Input placeholder="This is a placeholder" id={placeholderId} />
+    </div>
+  );
 };
 
 Placeholder.parameters = {

--- a/packages/react-components/react-input/src/stories/InputPlaceholder.stories.tsx
+++ b/packages/react-components/react-input/src/stories/InputPlaceholder.stories.tsx
@@ -14,13 +14,13 @@ const useStyles = makeStyles({
 });
 
 export const Placeholder = () => {
-  const placeholderId = useId('input-placeholder');
+  const inputId = useId('input-with-placeholder');
   const styles = useStyles();
 
   return (
     <div className={styles.root}>
-      <Label htmlFor={placeholderId}>Input With a Placeholder</Label>
-      <Input placeholder="This is a placeholder" id={placeholderId} />
+      <Label htmlFor={inputId}>Input With a Placeholder</Label>
+      <Input placeholder="This is a placeholder" id={inputId} />
     </div>
   );
 };

--- a/packages/react-components/react-input/src/stories/InputSize.stories.tsx
+++ b/packages/react-components/react-input/src/stories/InputSize.stories.tsx
@@ -25,21 +25,21 @@ export const Size = () => {
     <div className={styles.root}>
       <div>
         <Label size="small" htmlFor={smallId}>
-          Small input
+          Small Input
         </Label>
         <Input size="small" id={smallId} />
       </div>
 
       <div>
         <Label size="medium" htmlFor={mediumId}>
-          Medium input
+          Medium Input
         </Label>
         <Input size="medium" id={mediumId} />
       </div>
 
       <div>
         <Label size="large" htmlFor={largeId}>
-          Large input
+          Large Input
         </Label>
         <Input size="large" id={largeId} />
       </div>

--- a/packages/react-components/react-input/src/stories/InputType.stories.tsx
+++ b/packages/react-components/react-input/src/stories/InputType.stories.tsx
@@ -24,17 +24,17 @@ export const Type = () => {
   return (
     <div className={styles.root}>
       <div>
-        <Label htmlFor={emailId}>Email</Label>
+        <Label htmlFor={emailId}>Email Input</Label>
         <Input type="email" id={emailId} />
       </div>
 
       <div>
-        <Label htmlFor={urlId}>URL</Label>
+        <Label htmlFor={urlId}>URL Input</Label>
         <Input type="url" id={urlId} />
       </div>
 
       <div>
-        <Label htmlFor={passwordId}>Password</Label>
+        <Label htmlFor={passwordId}>Password Input</Label>
         <Input type="password" defaultValue="password" id={passwordId} />
       </div>
     </div>


### PR DESCRIPTION
## Current Behavior

- Input's `contentBefore` and `contentAfter` stories did not show how to use these slots in an accessible manner.
- Placeholder story lacked a visual label, but did have `aria-label` set.

## New Behavior

- Input's `contentBefore` and `contentAfter` demonstrate simple examples of how to use these slots accessibly.
- Placeholder story has a visual label.
- Labels used in stories have been received minor copy updates

## Related Issue(s)

- #21174
- #18131

Fixes #21450
