### PR TITLE
Link: Changing styles of focused links to align with design spec

### DIFF
--- a/change/@fluentui-react-link-004dabf8-63c0-47f6-99ef-5358546dd232.json
+++ b/change/@fluentui-react-link-004dabf8-63c0-47f6-99ef-5358546dd232.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Link: Changing styles of focused links to align with design spec.",
+  "packageName": "@fluentui/react-link",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-link/src/components/Link/useLinkStyles.ts
+++ b/packages/react-components/react-link/src/components/Link/useLinkStyles.ts
@@ -14,6 +14,8 @@ export const linkClassNames: SlotClassNames<LinkSlots> = {
 
 const useStyles = makeStyles({
   focusIndicator: createCustomFocusIndicatorStyle({
+    borderBottomColor: 'transparent',
+    textDecorationColor: tokens.colorStrokeFocus2,
     textDecorationLine: 'underline',
     textDecorationStyle: 'double',
   }),


### PR DESCRIPTION
## Current Behavior

The `Link` component has some styles when focused that do not adhere with the design spec (see related issues for more info).

## New Behavior

The `Link` component styles when focused adhere to the design spec.

## Related Issue(s)

Fixes #22723
Fixes #22730