### PR TITLE
set specific version of react to be used in cra-template

### DIFF
--- a/change/@fluentui-cra-template-d2c1dcf7-33f1-427f-8c95-94e1c77b959f.json
+++ b/change/@fluentui-cra-template-d2c1dcf7-33f1-427f-8c95-94e1c77b959f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "set specific version of react to be used in cra-template",
+  "packageName": "@fluentui/cra-template",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -9,6 +9,8 @@
       "@types/react": "^17.0.0",
       "@types/react-dom": "^17.0.0",
       "@types/jest": "^26.0.15",
+      "react": "^17.0.0",
+      "react-dom": "^17.0.0",
       "typescript": "^4.1.2",
       "web-vitals": "^1.0.1"
     },


### PR DESCRIPTION
Our packages do not yet support React 18, and therefore our CRA template fails because it now defaults to React 18. This PR changes the installed version of React to 17, and allows @fluentui/react to properly be installed.

This doesn't fix #22241, but it at least helps users avoid it when installing with our template.