### PR TITLE
Use https for Embed and Video examples

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -28,6 +28,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Do not stop propagation of letter keys if modifier is used in `Tree` @jurokapsiar ([#22603](https://github.com/microsoft/fluentui/pull/22603))
 - fix `Tooltip` constrast style for pointing and subtle=false @yuanboxue-amber ([#22696](https://github.com/microsoft/fluentui/pull/22696))
 
+### Documentation
+- Use https for Embed and Video examples @Hirse ([#22738](https://github.com/microsoft/fluentui/pull/22738))
+
 <!--------------------------------[ v0.62.0 ]------------------------------- -->
 ## [v0.62.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.62.0) (2022-04-08)
 [Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/react-northstar_v0.61.0..@fluentui/react-northstar_v0.62.0)

--- a/packages/fluentui/docs/src/components/ComponentPlayground/componentGenerators.tsx
+++ b/packages/fluentui/docs/src/components/ComponentPlayground/componentGenerators.tsx
@@ -91,7 +91,7 @@ export const Embed: KnobComponentGenerators<EmbedProps> = {
     hook: useStringKnob,
     name: propName,
     initialValue:
-      'http://fabricweb.azureedge.net/fabric-website/assets/images/2020_MSFT_Icon_Celebration_placeholder.jpg',
+      'https://fabricweb.azureedge.net/fabric-website/assets/images/2020_MSFT_Icon_Celebration_placeholder.jpg',
   }),
   // Hack until `size` prop will not supported
   variables: () => ({
@@ -120,12 +120,13 @@ export const Video: KnobComponentGenerators<VideoProps> = {
   poster: ({ componentInfo, propName }) => ({
     hook: useStringKnob,
     name: propName,
-    initialValue: 'public/images/2020_MSFT_Icon_Celebration_placeholder.jpg',
+    initialValue:
+      'https://fabricweb.azureedge.net/fabric-website/assets/images/2020_MSFT_Icon_Celebration_placeholder.jpg',
   }),
   src: ({ propName }) => ({
     hook: useStringKnob,
     name: propName,
-    initialValue: 'http://fabricweb.azureedge.net/fabric-website/assets/videos/2020_MSFT_Icon_Celebration.mp4',
+    initialValue: 'https://fabricweb.azureedge.net/fabric-website/assets/videos/2020_MSFT_Icon_Celebration.mp4',
   }),
   // Hack until `size` prop will not supported
   variables: () => ({

--- a/packages/fluentui/docs/src/examples/components/Embed/Slots/EmbedExampleVideo.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Embed/Slots/EmbedExampleVideo.shorthand.tsx
@@ -4,9 +4,9 @@ import { Embed, Flex, Text } from '@fluentui/react-northstar';
 const EmbedExampleVideo = () => (
   <Flex column>
     <Embed
-      placeholder="http://fabricweb.azureedge.net/fabric-website/assets/images/2020_MSFT_Icon_Celebration_placeholder.jpg"
+      placeholder="https://fabricweb.azureedge.net/fabric-website/assets/images/2020_MSFT_Icon_Celebration_placeholder.jpg"
       title="The new Microsoft icons: diverse and connected"
-      video="http://fabricweb.azureedge.net/fabric-website/assets/videos/2020_MSFT_Icon_Celebration.mp4"
+      video="https://fabricweb.azureedge.net/fabric-website/assets/videos/2020_MSFT_Icon_Celebration.mp4"
       variables={{ height: '400px', width: '711.11px' }}
     />
     <Text>(c) copyright 2020, Microsoft</Text>

--- a/packages/fluentui/docs/src/examples/components/Video/Types/VideoExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Video/Types/VideoExample.shorthand.tsx
@@ -4,10 +4,10 @@ import { Video, Text, Flex } from '@fluentui/react-northstar';
 const VideoExample = () => (
   <Flex column>
     <Video
-      src="https://raw.githubusercontent.com/bower-media-samples/big-buck-bunny-480p-30s/master/video.mp4"
+      src="https://fabricweb.azureedge.net/fabric-website/assets/videos/2020_MSFT_Icon_Celebration.mp4"
       variables={{ width: '600px' }}
     />
-    <Text>(c) copyright 2008, Blender Foundation / www.bigbuckbunny.org</Text>
+    <Text>(c) copyright 2020, Microsoft</Text>
   </Flex>
 );
 


### PR DESCRIPTION
Use `https` links in the Embed examples to fix "Unsecure Site" warnings:
![image](https://user-images.githubusercontent.com/2564094/166090679-f0dfa60b-24bd-4017-96d0-a7d2aa4d912e.png)

fyi @TanelVari 