### PR TITLE
react-tabs: fix indicator gap

### DIFF
--- a/change/@fluentui-react-tabs-f12ca354-ca30-43bf-8733-26ae7890102b.json
+++ b/change/@fluentui-react-tabs-f12ca354-ca30-43bf-8733-26ae7890102b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removed unnecessary width and height from indicators",
+  "packageName": "@fluentui/react-tabs",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/src/components/Tab/useTabStyles.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTabStyles.ts
@@ -203,7 +203,7 @@ const usePendingIndicatorStyles = makeStyles({
     ':before': {
       bottom: 0,
       ...shorthands.borderWidth(`calc(${tabIndicatorStrokeWidths.mediumHorizontal} / 2.0)`),
-      height: tabIndicatorStrokeWidths.mediumHorizontal,
+      height: 0,
       left: tabIndicatorPadding.mediumHorizontal,
       right: tabIndicatorPadding.mediumHorizontal,
     },
@@ -214,14 +214,14 @@ const usePendingIndicatorStyles = makeStyles({
       ...shorthands.borderWidth(`calc(${tabIndicatorStrokeWidths.mediumVertical} / 2.0)`),
       left: 0,
       top: tabIndicatorPadding.mediumVertical,
-      width: tabIndicatorStrokeWidths.mediumVertical,
+      width: 0,
     },
   },
   smallHorizontal: {
     ':before': {
       bottom: 0,
       ...shorthands.borderWidth(`calc(${tabIndicatorStrokeWidths.smallHorizontal} / 2.0)`),
-      height: tabIndicatorStrokeWidths.smallHorizontal,
+      height: 0,
       left: tabIndicatorPadding.smallHorizontal,
       right: tabIndicatorPadding.smallHorizontal,
     },
@@ -232,7 +232,7 @@ const usePendingIndicatorStyles = makeStyles({
       ...shorthands.borderWidth(`calc(${tabIndicatorStrokeWidths.smallVertical} / 2.0)`),
       left: 0,
       top: tabIndicatorPadding.smallVertical,
-      width: tabIndicatorStrokeWidths.smallVertical,
+      width: 0,
     },
   },
 });
@@ -269,7 +269,7 @@ const useActiveIndicatorStyles = makeStyles({
     ':after': {
       bottom: '0',
       ...shorthands.borderWidth(`calc(${tabIndicatorStrokeWidths.mediumHorizontal} / 2.0)`),
-      height: tabIndicatorStrokeWidths.mediumHorizontal,
+      height: 0,
       left: tabIndicatorPadding.mediumHorizontal,
       right: tabIndicatorPadding.mediumHorizontal,
     },
@@ -280,14 +280,14 @@ const useActiveIndicatorStyles = makeStyles({
       ...shorthands.borderWidth(`calc(${tabIndicatorStrokeWidths.mediumVertical} / 2.0)`),
       left: 0,
       top: tabIndicatorPadding.mediumVertical,
-      width: tabIndicatorStrokeWidths.mediumVertical,
+      width: 0,
     },
   },
   smallHorizontal: {
     ':after': {
       bottom: 0,
       ...shorthands.borderWidth(`calc(${tabIndicatorStrokeWidths.smallHorizontal} / 2.0)`),
-      height: tabIndicatorStrokeWidths.smallHorizontal,
+      height: 0,
       left: tabIndicatorPadding.smallHorizontal,
       right: tabIndicatorPadding.smallHorizontal,
     },
@@ -298,7 +298,7 @@ const useActiveIndicatorStyles = makeStyles({
       ...shorthands.borderWidth(`calc(${tabIndicatorStrokeWidths.smallVertical} / 2.0)`),
       left: '0',
       top: tabIndicatorPadding.smallVertical,
-      width: tabIndicatorStrokeWidths.smallVertical,
+      width: 0,
     },
   },
 });


### PR DESCRIPTION
## Cause of issue
- Selection indicators are specified to be a particular stroke width.
- We used borders rather than background for selection indicators to allow for system high contrast mode to automatically update border colors.
- The border width of the selection indicators is the stroke width / 2.0.
- Due to some stroke widths being odd numbers, this create sub-pixel border widths.
- When the border widths were rendered they ended up being floor values and so a small gap would show because the height or width was set to the stroke width.

## Changes
- Set the width and height CSS values from the pending and active selection indicator to 0

## Issues

Fixes #22743