### PR TITLE
feat: re-export `createFocusOutlineStyle` on `react-components`

### DIFF
--- a/change/@fluentui-react-components-34ab5d49-a13c-40f0-816e-7acfa0abf28e.json
+++ b/change/@fluentui-react-components-34ab5d49-a13c-40f0-816e-7acfa0abf28e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: re-export `createFocusOutlineStyle` on `react-components`",
+  "packageName": "@fluentui/react-components",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -88,8 +88,11 @@ import { counterBadgeClassNames } from '@fluentui/react-badge';
 import { CounterBadgeProps } from '@fluentui/react-badge';
 import { CounterBadgeState } from '@fluentui/react-badge';
 import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
+import { CreateCustomFocusIndicatorStyleOptions } from '@fluentui/react-tabster';
 import { createDarkTheme } from '@fluentui/react-theme';
 import { createDOMRenderer } from '@griffel/react';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
+import { CreateFocusOutlineStyleOptions } from '@fluentui/react-tabster';
 import { createHighContrastTheme } from '@fluentui/react-theme';
 import { createLightTheme } from '@fluentui/react-theme';
 import { createTeamsDarkTheme } from '@fluentui/react-theme';
@@ -627,9 +630,15 @@ export { CounterBadgeState }
 
 export { createCustomFocusIndicatorStyle }
 
+export { CreateCustomFocusIndicatorStyleOptions }
+
 export { createDarkTheme }
 
 export { createDOMRenderer }
+
+export { createFocusOutlineStyle }
+
+export { CreateFocusOutlineStyleOptions }
 
 export { createHighContrastTheme }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -28,6 +28,7 @@ export type {
 } from '@fluentui/react-provider';
 export {
   createCustomFocusIndicatorStyle,
+  createFocusOutlineStyle,
   useArrowNavigationGroup,
   useFocusableGroup,
   useFocusFinders,
@@ -35,6 +36,8 @@ export {
   useModalAttributes,
 } from '@fluentui/react-tabster';
 export type {
+  CreateCustomFocusIndicatorStyleOptions,
+  CreateFocusOutlineStyleOptions,
   UseArrowNavigationGroupOptions,
   UseFocusableGroupOptions,
   UseModalAttributesOptions,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

`createFocusOutlineStyle` is not being exported by `@fluentui/react-components`

## New Behavior

1. re-export `createFocusOutlineStyle`  by `@fluentui/react-components`
2. export types from focus indicator methods on `@fluentui/react-components`

