### PR TITLE
fix(react-radio): Allow data argument on onChange

### DIFF
--- a/change/@fluentui-react-radio-eec73af1-4507-40ff-990d-62a0622eddeb.json
+++ b/change/@fluentui-react-radio-eec73af1-4507-40ff-990d-62a0622eddeb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow data argument on onChange",
+  "packageName": "@fluentui/react-radio",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-radio/etc/react-radio.api.md
+++ b/packages/react-radio/etc/react-radio.api.md
@@ -67,7 +67,7 @@ export type RadioOnChangeData = {
 };
 
 // @public
-export type RadioProps = Omit<ComponentProps<Partial<RadioSlots>, 'input'>, 'size'> & {
+export type RadioProps = Omit<ComponentProps<Partial<RadioSlots>, 'input'>, 'onChange' | 'size'> & {
     value?: string;
     labelPosition?: 'after' | 'below';
     disabled?: boolean;

--- a/packages/react-radio/src/components/Radio/Radio.types.ts
+++ b/packages/react-radio/src/components/Radio/Radio.types.ts
@@ -33,7 +33,7 @@ export type RadioSlots = {
 /**
  * Radio Props
  */
-export type RadioProps = Omit<ComponentProps<Partial<RadioSlots>, 'input'>, 'size'> & {
+export type RadioProps = Omit<ComponentProps<Partial<RadioSlots>, 'input'>, 'onChange' | 'size'> & {
   /**
    * The value of the RadioGroup when this Radio item is selected.
    */


### PR DESCRIPTION

## Current Behavior

`Radio.onChange(event, data)` results in typescript error, `data` argument is not allowed:

```
TS2322: Type '(e: ChangeEvent<HTMLInputElement>, d: RadioOnChangeData) => void' is not assignable to type 'ChangeEventHandler<HTMLInputElement> & ((ev: ChangeEvent<HTMLInputElement>, data: RadioOnChangeData) => void)'.   Type '(e: ChangeEvent<HTMLInputElement>, d: RadioOnChangeData) => void' is not assignable to type 'ChangeEventHandler<HTMLInputElement>'.  index.d.ts(2217, 9): The expected type comes from property 'onChange' which is declared here on type 'IntrinsicAttributes & Omit<ComponentProps<Partial<RadioSlots>, "input">, "size"> & { value?: string | undefined; labelPosition?: "after" | ... 1 more ... | undefined; disabled?: boolean | undefined; onChange?: ((ev: ChangeEvent<...>, data: RadioOnChangeData) => void) | undefined; } & RefAttributes<...>'
```

## New Behavior

`Radio.onChange` now has two arguments - `event` and `data`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22752