### PR TITLE
Allow tab to animate when value is numeric zero

### DIFF
--- a/change/@fluentui-react-tabs-fe4d1dbf-ceb2-4516-b2c4-36f9a46c3910.json
+++ b/change/@fluentui-react-tabs-fe4d1dbf-ceb2-4516-b2c4-36f9a46c3910.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow tab to animate when value is numeric zero",
+  "packageName": "@fluentui/react-tabs",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/src/components/Tab/useTabAnimatedIndicator.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTabAnimatedIndicator.ts
@@ -63,7 +63,8 @@ const calculateTabRect = (element: HTMLElement) => {
 };
 
 const getRegisteredTabRect = (registeredTabs: Record<string, TabRegisterData>, value?: TabValue) => {
-  const element = value ? registeredTabs[JSON.stringify(value)]?.ref.current : undefined;
+  const element =
+    value !== undefined && value !== null ? registeredTabs[JSON.stringify(value)]?.ref.current : undefined;
   return element ? calculateTabRect(element) : undefined;
 };
 


### PR DESCRIPTION
## Changes
- Updated the check of value to be against undefined and null so that a tab value of 0 doesn't prevent animation of the selection indicator

## Issues

Fixes #22630 