### PR TITLE
fix(react-card): allow `CardPreview` to render under the `Card` border

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Card.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Card.stories.tsx
@@ -2,7 +2,7 @@ import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { Card, CardHeader, CardFooter, CardPreview } from '@fluentui/react-card';
-import { Open16Regular, Share16Regular, MoreVertical16Regular } from '@fluentui/react-icons';
+import { Open16Regular, Share16Regular } from '@fluentui/react-icons';
 import { Body, Caption } from '@fluentui/react-text';
 import { Button } from '@fluentui/react-button';
 import { action } from '@storybook/addon-actions';

--- a/apps/vr-tests-react-components/src/stories/Card.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Card.stories.tsx
@@ -1,8 +1,8 @@
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
-import { Card, CardHeader, CardFooter } from '@fluentui/react-card';
-import { Open16Regular, Share16Regular } from '@fluentui/react-icons';
+import { Card, CardHeader, CardFooter, CardPreview } from '@fluentui/react-card';
+import { Open16Regular, Share16Regular, MoreVertical16Regular } from '@fluentui/react-icons';
 import { Body, Caption } from '@fluentui/react-text';
 import { Button } from '@fluentui/react-button';
 import { action } from '@storybook/addon-actions';
@@ -10,6 +10,7 @@ import { action } from '@storybook/addon-actions';
 const ASSET_URL = 'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
 
 const powerpointLogoURL = ASSET_URL + '/assets/powerpoint_logo.svg';
+const salesPresentationTemplateURL = ASSET_URL + '/assets/sales_template.png';
 
 const SampleCardContent = () => (
   <>
@@ -22,7 +23,9 @@ const SampleCardContent = () => (
       }
       description={<Caption>Developer</Caption>}
     />
-    Donut chocolate bar oat cake. Dragée tiramisu lollipop bear claw. Marshmallow pastry jujubes toffee sugar plum.
+    <div>
+      Donut chocolate bar oat cake. Dragée tiramisu lollipop bear claw. Marshmallow pastry jujubes toffee sugar plum.
+    </div>
     <CardFooter>
       <Button appearance="primary" icon={<Open16Regular />}>
         Open
@@ -39,6 +42,24 @@ storiesOf('Card Converged', module)
         {story()}
       </div>
     </Screener>
+  ))
+  .addStory('card templates', () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <Card>
+        <CardPreview>
+          <img src={salesPresentationTemplateURL} alt="sales presentation preview" />
+        </CardPreview>
+        <CardHeader
+          image={<img src={powerpointLogoURL} alt="Microsoft PowerPoint logo" />}
+          header={
+            <Body>
+              <b>Sales analysis 2019 presentation</b>
+            </Body>
+          }
+          description={<Caption>Folder &gt; Presentations</Caption>}
+        />
+      </Card>
+    </div>
   ))
   .addStory(
     'appearance',

--- a/change/@fluentui-react-card-87333a08-0070-46b8-9c38-a818b59814f6.json
+++ b/change/@fluentui-react-card-87333a08-0070-46b8-9c38-a818b59814f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "CardPreview now expands properly, all the way to the Card's edges",
+  "packageName": "@fluentui/react-card",
+  "email": "39736248+andrefcdias@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.ts
@@ -18,104 +18,161 @@ export const cardClassNames: SlotClassNames<CardSlots> = {
 const useStyles = makeStyles({
   root: {
     display: 'block',
-    ...shorthands.overflow('clip'),
-    overflowClipMargin: tokens.strokeWidthThin,
-
+    position: 'relative',
+    ...shorthands.overflow('hidden'),
     color: tokens.colorNeutralForeground1,
-    ...shorthands.borderStyle('solid'),
-    ...shorthands.borderWidth(tokens.strokeWidthThin),
-
     // Size: medium
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
+
+    '::after': {
+      content: '""',
+      position: 'absolute',
+      top: '0px',
+      left: '0px',
+      bottom: '0px',
+      right: '0px',
+
+      ...shorthands.borderStyle('solid'),
+      ...shorthands.borderWidth(tokens.strokeWidthThin),
+      // Size: medium
+      ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    },
 
     [`> *:not(.${cardPreviewClassNames.root})`]: {
       // Size: medium
       ...shorthands.margin('12px'),
-    },
-    [`> .${cardPreviewClassNames.root}`]: {
-      ...shorthands.margin(`calc(${tokens.strokeWidthThin} * -1)`),
     },
   },
 
   filledInteractive: {
     cursor: 'pointer',
     backgroundColor: tokens.colorNeutralBackground1,
-    ...shorthands.borderColor(tokens.colorTransparentStroke),
     boxShadow: tokens.shadow4,
+
+    '::after': {
+      ...shorthands.borderColor(tokens.colorTransparentStroke),
+    },
 
     ':hover': {
       backgroundColor: tokens.colorNeutralBackground1Hover,
-      ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
       boxShadow: tokens.shadow8,
+
+      '::after': {
+        ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
+      },
     },
     ':active': {
       backgroundColor: tokens.colorNeutralBackground1Pressed,
-      ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
+
+      '::after': {
+        ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
+      },
     },
   },
   filled: {
     backgroundColor: tokens.colorNeutralBackground1,
-    ...shorthands.borderColor(tokens.colorTransparentStroke),
     boxShadow: tokens.shadow4,
+
+    '::after': {
+      ...shorthands.borderColor(tokens.colorTransparentStroke),
+    },
   },
   filledAlternativeInteractive: {
     cursor: 'pointer',
     backgroundColor: tokens.colorNeutralBackground2,
-    ...shorthands.borderColor(tokens.colorTransparentStroke),
     boxShadow: tokens.shadow4,
+
+    '::after': {
+      ...shorthands.borderColor(tokens.colorTransparentStroke),
+    },
 
     ':hover': {
       backgroundColor: tokens.colorNeutralBackground2Hover,
-      ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
       boxShadow: tokens.shadow8,
+
+      '::after': {
+        ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
+      },
     },
     ':active': {
       backgroundColor: tokens.colorNeutralBackground2Pressed,
-      ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
+
+      '::after': {
+        ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
+      },
     },
   },
   filledAlternative: {
     backgroundColor: tokens.colorNeutralBackground2,
-    ...shorthands.borderColor(tokens.colorTransparentStroke),
     boxShadow: tokens.shadow4,
+
+    '::after': {
+      ...shorthands.borderColor(tokens.colorTransparentStroke),
+    },
   },
   outlineInteractive: {
     cursor: 'pointer',
     backgroundColor: tokens.colorTransparentBackground,
-    ...shorthands.borderColor(tokens.colorNeutralStroke1),
     boxShadow: 'none',
+
+    '::after': {
+      ...shorthands.borderColor(tokens.colorNeutralStroke1),
+    },
 
     ':hover': {
       backgroundColor: tokens.colorTransparentBackgroundHover,
-      ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
+
+      '::after': {
+        ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
+      },
     },
     ':active': {
       backgroundColor: tokens.colorTransparentBackgroundPressed,
-      ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
+
+      '::after': {
+        ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
+      },
     },
   },
   outline: {
     backgroundColor: tokens.colorTransparentBackground,
-    ...shorthands.borderColor(tokens.colorNeutralStroke1),
     boxShadow: 'none',
+
+    '::after': {
+      ...shorthands.borderColor(tokens.colorNeutralStroke1),
+    },
   },
   subtleInteractive: {
     cursor: 'pointer',
     backgroundColor: tokens.colorSubtleBackground,
-    ...shorthands.borderColor(tokens.colorTransparentStroke),
     boxShadow: 'none',
+
+    '::after': {
+      ...shorthands.borderColor(tokens.colorTransparentStroke),
+    },
 
     ':hover': {
       backgroundColor: tokens.colorSubtleBackgroundHover,
+
+      '::after': {
+        ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
+      },
     },
     ':active': {
       backgroundColor: tokens.colorSubtleBackgroundPressed,
+
+      '::after': {
+        ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
+      },
     },
   },
   subtle: {
     backgroundColor: tokens.colorSubtleBackground,
-    ...shorthands.borderColor(tokens.colorTransparentStroke),
     boxShadow: 'none',
+
+    '::after': {
+      ...shorthands.borderColor(tokens.colorTransparentStroke),
+    },
   },
 });
 

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.ts
@@ -22,7 +22,7 @@ const useStyles = makeStyles({
     ...shorthands.overflow('hidden'),
     color: tokens.colorNeutralForeground1,
 
-    // Size: medium
+    // TODO: Extract this to separate stiles when tackling the `size` prop
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
 
     '::after': {
@@ -36,12 +36,12 @@ const useStyles = makeStyles({
 
       ...shorthands.borderStyle('solid'),
       ...shorthands.borderWidth(tokens.strokeWidthThin),
-      // Size: medium
+      // TODO: Extract this to separate stiles when tackling the `size` prop
       ...shorthands.borderRadius(tokens.borderRadiusMedium),
     },
 
     [`> *:not(.${cardPreviewClassNames.root})`]: {
-      // Size: medium
+      // TODO: Extract this to separate stiles when tackling the `size` prop
       ...shorthands.margin('12px'),
     },
   },

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.ts
@@ -46,6 +46,15 @@ const useStyles = makeStyles({
     },
   },
 
+  interactiveNoOutline: {
+    ':hover::after': {
+      ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
+    },
+    ':active::after': {
+      ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
+    },
+  },
+
   filledInteractive: {
     cursor: 'pointer',
     backgroundColor: tokens.colorNeutralBackground1,
@@ -58,17 +67,9 @@ const useStyles = makeStyles({
     ':hover': {
       backgroundColor: tokens.colorNeutralBackground1Hover,
       boxShadow: tokens.shadow8,
-
-      '::after': {
-        ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
-      },
     },
     ':active': {
       backgroundColor: tokens.colorNeutralBackground1Pressed,
-
-      '::after': {
-        ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
-      },
     },
   },
   filled: {
@@ -91,17 +92,9 @@ const useStyles = makeStyles({
     ':hover': {
       backgroundColor: tokens.colorNeutralBackground2Hover,
       boxShadow: tokens.shadow8,
-
-      '::after': {
-        ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
-      },
     },
     ':active': {
       backgroundColor: tokens.colorNeutralBackground2Pressed,
-
-      '::after': {
-        ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
-      },
     },
   },
   filledAlternative: {
@@ -155,17 +148,9 @@ const useStyles = makeStyles({
 
     ':hover': {
       backgroundColor: tokens.colorSubtleBackgroundHover,
-
-      '::after': {
-        ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
-      },
     },
     ':active': {
       backgroundColor: tokens.colorSubtleBackgroundPressed,
-
-      '::after': {
-        ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
-      },
     },
   },
   subtle: {
@@ -204,6 +189,7 @@ export const useCardStyles_unstable = (state: CardState): CardState => {
     interactive && state.appearance === 'filled-alternative' && styles.filledAlternativeInteractive,
     interactive && state.appearance === 'outline' && styles.outlineInteractive,
     interactive && state.appearance === 'subtle' && styles.subtleInteractive,
+    interactive && state.appearance !== 'outline' && styles.interactiveNoOutline,
     state.root.className,
   );
 

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.ts
@@ -18,7 +18,8 @@ export const cardClassNames: SlotClassNames<CardSlots> = {
 const useStyles = makeStyles({
   root: {
     display: 'block',
-    ...shorthands.overflow('hidden'),
+    ...shorthands.overflow('clip'),
+    overflowClipMargin: tokens.strokeWidthThin,
 
     color: tokens.colorNeutralForeground1,
     ...shorthands.borderStyle('solid'),
@@ -30,6 +31,9 @@ const useStyles = makeStyles({
     [`> *:not(.${cardPreviewClassNames.root})`]: {
       // Size: medium
       ...shorthands.margin('12px'),
+    },
+    [`> .${cardPreviewClassNames.root}`]: {
+      ...shorthands.margin(`calc(${tokens.strokeWidthThin} * -1)`),
     },
   },
 

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.ts
@@ -36,7 +36,7 @@ const useStyles = makeStyles({
 
       ...shorthands.borderStyle('solid'),
       ...shorthands.borderWidth(tokens.strokeWidthThin),
-      // TODO: Extract this to separate stiles when tackling the `size` prop
+      // TODO: Extract this to separate styles when tackling the `size` prop
       ...shorthands.borderRadius(tokens.borderRadiusMedium),
     },
 

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.ts
@@ -21,16 +21,18 @@ const useStyles = makeStyles({
     position: 'relative',
     ...shorthands.overflow('hidden'),
     color: tokens.colorNeutralForeground1,
+
     // Size: medium
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
 
     '::after': {
-      content: '""',
       position: 'absolute',
-      top: '0px',
-      left: '0px',
-      bottom: '0px',
-      right: '0px',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      content: '""',
+      pointerEvents: 'none',
 
       ...shorthands.borderStyle('solid'),
       ...shorthands.borderWidth(tokens.strokeWidthThin),

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.ts
@@ -41,7 +41,7 @@ const useStyles = makeStyles({
     },
 
     [`> *:not(.${cardPreviewClassNames.root})`]: {
-      // TODO: Extract this to separate stiles when tackling the `size` prop
+      // TODO: Extract this to separate styles when tackling the `size` prop
       ...shorthands.margin('12px'),
     },
   },

--- a/packages/react-components/react-card/src/stories/CardAppearance.stories.tsx
+++ b/packages/react-components/react-card/src/stories/CardAppearance.stories.tsx
@@ -1,16 +1,20 @@
 import * as React from 'react';
-
 import { action } from '@storybook/addon-actions';
 import { Headline } from '@fluentui/react-text';
 import { makeStyles, shorthands } from '@griffel/react';
-
 import { SampleCard } from './SampleCard.stories';
+import { FluentProvider } from '@fluentui/react-provider';
+import { webDarkTheme, webHighContrastTheme, webLightTheme } from '@fluentui/react-theme';
 
 const useStyles = makeStyles({
   container: {
     display: 'flex',
     flexDirection: 'row',
-    flexWrap: 'wrap',
+  },
+  themeContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    ...shorthands.padding('16px'),
     ...shorthands.gap('16px'),
   },
   header: {
@@ -28,11 +32,11 @@ const Title = (props: { children: React.ReactNode }) => {
   );
 };
 
-export const Appearance = () => {
+const AppearanceExamples = () => {
   const styles = useStyles();
 
   return (
-    <div className={styles.container}>
+    <div className={styles.themeContainer}>
       <div>
         <Title>Filled (default)</Title>
         <SampleCard appearance="filled" />
@@ -65,6 +69,24 @@ export const Appearance = () => {
         <Title>Subtle - Interactive</Title>
         <SampleCard onClick={action('Subtle Card clicked')} appearance="subtle" />
       </div>
+    </div>
+  );
+};
+
+export const Appearance = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.container}>
+      <FluentProvider theme={webLightTheme}>
+        <AppearanceExamples />
+      </FluentProvider>
+      <FluentProvider theme={webDarkTheme}>
+        <AppearanceExamples />
+      </FluentProvider>
+      <FluentProvider theme={webHighContrastTheme}>
+        <AppearanceExamples />
+      </FluentProvider>
     </div>
   );
 };

--- a/packages/react-components/react-card/src/stories/CardAppearance.stories.tsx
+++ b/packages/react-components/react-card/src/stories/CardAppearance.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { action } from '@storybook/addon-actions';
-import { Headline } from '@fluentui/react-text';
+import { Headline, Title3 } from '@fluentui/react-text';
 import { makeStyles, shorthands } from '@griffel/react';
 import { SampleCard } from './SampleCard.stories';
 import { FluentProvider } from '@fluentui/react-provider';
@@ -32,11 +32,12 @@ const Title = (props: { children: React.ReactNode }) => {
   );
 };
 
-const AppearanceExamples = () => {
+const AppearanceExamples = (props: { title: string }) => {
   const styles = useStyles();
 
   return (
     <div className={styles.themeContainer}>
+      <Title3>{props.title}</Title3>
       <div>
         <Title>Filled (default)</Title>
         <SampleCard appearance="filled" />
@@ -79,13 +80,13 @@ export const Appearance = () => {
   return (
     <div className={styles.container}>
       <FluentProvider theme={webLightTheme}>
-        <AppearanceExamples />
+        <AppearanceExamples title="Light theme" />
       </FluentProvider>
       <FluentProvider theme={webDarkTheme}>
-        <AppearanceExamples />
+        <AppearanceExamples title="Dark theme" />
       </FluentProvider>
       <FluentProvider theme={webHighContrastTheme}>
-        <AppearanceExamples />
+        <AppearanceExamples title="High contrast theme" />
       </FluentProvider>
     </div>
   );

--- a/packages/react-components/react-card/src/stories/SampleCard.stories.tsx
+++ b/packages/react-components/react-card/src/stories/SampleCard.stories.tsx
@@ -9,14 +9,12 @@ export const ASSET_URL =
   'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
 
 const powerpointLogoURL = ASSET_URL + '/assets/powerpoint_logo.svg';
+const previewURL = ASSET_URL + '/assets/sales_template.png';
 
 export const SampleCard = (props: CardProps) => (
   <Card {...props}>
     <CardPreview>
-      <img
-        src="https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE4RbvH?ver=6355"
-        alt="preview image"
-      />
+      <img src={previewURL} alt="preview image" />
     </CardPreview>
     <CardHeader
       image={<img src={powerpointLogoURL} alt="Microsoft PowerPoint logo" />}

--- a/packages/react-components/react-card/src/stories/SampleCard.stories.tsx
+++ b/packages/react-components/react-card/src/stories/SampleCard.stories.tsx
@@ -9,12 +9,12 @@ export const ASSET_URL =
   'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
 
 const powerpointLogoURL = ASSET_URL + '/assets/powerpoint_logo.svg';
-const previewURL = ASSET_URL + '/assets/sales_template.png';
+const salesPresentationTemplateURL = ASSET_URL + '/assets/sales_template.png';
 
 export const SampleCard = (props: CardProps) => (
   <Card {...props}>
     <CardPreview>
-      <img src={previewURL} alt="preview image" />
+      <img src={salesPresentationTemplateURL} alt="sales presentation preview" />
     </CardPreview>
     <CardHeader
       image={<img src={powerpointLogoURL} alt="Microsoft PowerPoint logo" />}

--- a/packages/react-components/react-card/src/stories/SampleCard.stories.tsx
+++ b/packages/react-components/react-card/src/stories/SampleCard.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { makeStyles } from '@griffel/react';
 import { Button } from '@fluentui/react-button';
 import { Open16Regular, Share16Regular } from '@fluentui/react-icons';
 import { Body, Caption } from '@fluentui/react-text';
@@ -11,41 +10,31 @@ export const ASSET_URL =
 
 const powerpointLogoURL = ASSET_URL + '/assets/powerpoint_logo.svg';
 
-const useStyles = makeStyles({
-  card: {
-    width: '240px',
-  },
-});
-
-export const SampleCard = (props: CardProps) => {
-  const styles = useStyles();
-
-  return (
-    <Card className={styles.card} {...props}>
-      <CardPreview>
-        <img
-          src="https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE4RbvH?ver=6355"
-          alt="preview image"
-        />
-      </CardPreview>
-      <CardHeader
-        image={<img src={powerpointLogoURL} alt="Microsoft PowerPoint logo" />}
-        header={
-          <Body>
-            <b>App Name</b>
-          </Body>
-        }
-        description={<Caption>Developer</Caption>}
+export const SampleCard = (props: CardProps) => (
+  <Card {...props}>
+    <CardPreview>
+      <img
+        src="https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE4RbvH?ver=6355"
+        alt="preview image"
       />
-      <div>
-        Donut chocolate bar oat cake. Dragée tiramisu lollipop bear claw. Marshmallow pastry jujubes toffee sugar plum.
-      </div>
-      <CardFooter>
-        <Button appearance="primary" icon={<Open16Regular />}>
-          Open
-        </Button>
-        <Button icon={<Share16Regular />}>Share</Button>
-      </CardFooter>
-    </Card>
-  );
-};
+    </CardPreview>
+    <CardHeader
+      image={<img src={powerpointLogoURL} alt="Microsoft PowerPoint logo" />}
+      header={
+        <Body>
+          <b>App Name</b>
+        </Body>
+      }
+      description={<Caption>Developer</Caption>}
+    />
+    <div>
+      Donut chocolate bar oat cake. Dragée tiramisu lollipop bear claw. Marshmallow pastry jujubes toffee sugar plum.
+    </div>
+    <CardFooter>
+      <Button appearance="primary" icon={<Open16Regular />}>
+        Open
+      </Button>
+      <Button icon={<Share16Regular />}>Share</Button>
+    </CardFooter>
+  </Card>
+);

--- a/packages/react-components/react-card/src/stories/SampleCard.stories.tsx
+++ b/packages/react-components/react-card/src/stories/SampleCard.stories.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@griffel/react';
 import { Button } from '@fluentui/react-button';
 import { Open16Regular, Share16Regular } from '@fluentui/react-icons';
 import { Body, Caption } from '@fluentui/react-text';
-import { Card, CardHeader, CardFooter } from '../index';
+import { Card, CardHeader, CardFooter, CardPreview } from '../index';
 import type { CardProps } from '../index';
 
 export const ASSET_URL =
@@ -22,6 +22,12 @@ export const SampleCard = (props: CardProps) => {
 
   return (
     <Card className={styles.card} {...props}>
+      <CardPreview>
+        <img
+          src="https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE4RbvH?ver=6355"
+          alt="preview image"
+        />
+      </CardPreview>
       <CardHeader
         image={<img src={powerpointLogoURL} alt="Microsoft PowerPoint logo" />}
         header={


### PR DESCRIPTION
## Current Behavior

Due to the usage of `overflow: hidden`, the image doesn't fully overflow the parent and will not grow farther than the border, even though the border is transparent.

![image](https://user-images.githubusercontent.com/39736248/166304113-f977cea8-3b71-42f6-bae7-43e5b7ab0827.png)


## New Behavior

Given that we shouldn't show the content over the border, as high contrast themes show borders regardless of transparency, I've moved the border into the `::after` pseudo-element so that the border can render over the content.
This way, there's no 1px spacing on light/dark themes and the image doesn't cover the border on high contrast themes: 

![image](https://user-images.githubusercontent.com/39736248/166304383-5d48ed9a-0428-40ac-947a-21399330afb7.png)
![image](https://user-images.githubusercontent.com/39736248/166324440-363d4a4e-c797-48b2-a962-91e50e159a55.png)

## Related Issue(s)

#19336
