### PR TITLE
docs: Removing deprecated attribute from ContextualMenu's example

### DIFF
--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.CustomMenuList.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.CustomMenuList.Example.tsx
@@ -85,7 +85,7 @@ const menuItems: IContextualMenuItem[] = [
   { key: 'linkWithTarget', text: 'Link new window', href: 'http://bing.com', target: '_blank' },
   {
     key: 'linkWithOnClick',
-    name: 'Link click',
+    text: 'Link click',
     href: 'http://bing.com',
     onClick: (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
       alert('Link clicked');


### PR DESCRIPTION
This PR fixes the example `CustomMenuList` from ContextualMenu where filtering the menu list removes the link item. This is due to the menu item using the property `name` instead of `text`.

## Current Behavior

Link disappears out of the list after filtering the list due to using the deprecated `name` instead of `text`.

## New Behavior

Link will not disappear after being filtered.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21256
