### PR TITLE
public-docsite: Removing v8 release banner

### DIFF
--- a/apps/public-docsite/src/SiteDefinition/SiteDefinition.tsx
+++ b/apps/public-docsite/src/SiteDefinition/SiteDefinition.tsx
@@ -61,15 +61,7 @@ export const SiteDefinition: ISiteDefinition<Platforms> = {
     { from: '#/styles/web/fluent-theme', to: '#/controls/web/themes' },
     { from: '#/examples', to: '#/controls/web' },
   ],
-  messageBars: [
-    {
-      path: '#',
-      text: <span>Fluent UI React version 8 is now available.</span>,
-      linkText: 'Learn more',
-      linkUrl: 'https://github.com/microsoft/fluentui/wiki/Version-8-release-notes',
-      sessionStoragePrefix: 'FluentUI8',
-    },
-  ],
+  messageBars: [],
   // This is defined by loadSite() from @fluentui/public-docsite-setup
   versionSwitcherDefinition: window.__versionSwitcherDefinition,
 };


### PR DESCRIPTION
This PR remove the v8 release banner from the public docsite.

## Current Behavior

<img width="765" alt="image" src="https://user-images.githubusercontent.com/5953191/166335837-98fd6c88-fb44-443e-b5f1-c037a619c78e.png">

## New Behavior

<img width="644" alt="image" src="https://user-images.githubusercontent.com/5953191/166336116-029258c1-4db1-4593-8bad-1282fc1b9849.png">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22418
