### PR TITLE
Link: Adding hrefs to all non-button stories

### DIFF
--- a/packages/react-components/react-link/src/stories/LinkAppearance.stories.tsx
+++ b/packages/react-components/react-link/src/stories/LinkAppearance.stories.tsx
@@ -1,4 +1,8 @@
 import * as React from 'react';
 import { Link } from '../index';
 
-export const Appearance = () => <Link appearance="subtle">Subtle link</Link>;
+export const Appearance = () => (
+  <Link appearance="subtle" href="https://www.bing.com">
+    Subtle link
+  </Link>
+);

--- a/packages/react-components/react-link/src/stories/LinkDefault.stories.tsx
+++ b/packages/react-components/react-link/src/stories/LinkDefault.stories.tsx
@@ -1,4 +1,8 @@
 import * as React from 'react';
 import { Link, LinkProps } from '../index';
 
-export const Default = (props: LinkProps) => <Link {...props}>This is a link</Link>;
+export const Default = (props: LinkProps & { as?: 'a' }) => (
+  <Link href="https://www.bing.com" {...props}>
+    This is a link
+  </Link>
+);

--- a/packages/react-components/react-link/src/stories/LinkDisabled.stories.tsx
+++ b/packages/react-components/react-link/src/stories/LinkDisabled.stories.tsx
@@ -1,4 +1,8 @@
 import * as React from 'react';
 import { Link } from '../index';
 
-export const Disabled = () => <Link disabled>Disabled link</Link>;
+export const Disabled = () => (
+  <Link disabled href="https://www.bing.com">
+    Disabled link
+  </Link>
+);

--- a/packages/react-components/react-link/src/stories/LinkDisabledFocusable.stories.tsx
+++ b/packages/react-components/react-link/src/stories/LinkDisabledFocusable.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Link } from '../index';
 
 export const DisabledFocusable = () => (
-  <Link inline disabled disabledFocusable>
+  <Link inline disabled disabledFocusable href="https://www.bing.com">
     Disabled but still focusable
   </Link>
 );

--- a/packages/react-components/react-link/src/stories/LinkInline.stories.tsx
+++ b/packages/react-components/react-link/src/stories/LinkInline.stories.tsx
@@ -3,6 +3,10 @@ import { Link } from '../index';
 
 export const Inline = () => (
   <div>
-    This is an <Link inline>inline link</Link> used alongside other text
+    This is an{' '}
+    <Link href="https://www.bing.com" inline>
+      inline link
+    </Link>{' '}
+    used alongside other text
   </div>
 );

--- a/packages/react-components/react-link/src/stories/LinkInline.stories.tsx
+++ b/packages/react-components/react-link/src/stories/LinkInline.stories.tsx
@@ -6,7 +6,7 @@ export const Inline = () => (
     This is an{' '}
     <Link href="https://www.bing.com" inline>
       inline link
-    </Link>{' '}
+    </Link>
     used alongside other text
   </div>
 );

--- a/packages/react-components/react-link/src/stories/LinkInline.stories.tsx
+++ b/packages/react-components/react-link/src/stories/LinkInline.stories.tsx
@@ -3,7 +3,7 @@ import { Link } from '../index';
 
 export const Inline = () => (
   <div>
-    This is an{' '}
+    This is an
     <Link href="https://www.bing.com" inline>
       inline link
     </Link>


### PR DESCRIPTION
## Current Behavior

`Link` stories didn't have `hrefs` which made them render as `buttons`.

## New Behavior

`Link` stories now have `hrefs` (except for the render as button one) which makes them render as `a` tags and more correctly reflect their usage.

## Related Issue(s)

Fixes [13993](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/13993)