### PR TITLE
react-radio: update labels in examples

### DIFF
--- a/packages/react-radio/src/stories/RadioGroup.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroup.stories.tsx
@@ -8,6 +8,7 @@ export { Horizontal } from './RadioGroupHorizontal.stories';
 export { HorizontalStacked } from './RadioGroupHorizontalStacked.stories';
 export { ControlledValue } from './RadioGroupControlledValue.stories';
 export { UncontrolledValue } from './RadioGroupUncontrolledValue.stories';
+export { Required } from './RadioGroupRequired.stories';
 export { Disabled } from './RadioGroupDisabled.stories';
 export { DisabledItem } from './RadioGroupDisabledItem.stories';
 export { LabelSubtext } from './RadioGroupLabelSubtext.stories';

--- a/packages/react-radio/src/stories/RadioGroupControlledValue.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroupControlledValue.stories.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
+import { Label } from '@fluentui/react-label';
+import { useId } from '@fluentui/react-utilities';
 import { Radio, RadioGroup } from '../index';
 
 export const ControlledValue = () => {
-  const [value, setValue] = React.useState('C');
+  const [value, setValue] = React.useState('banana');
+  const labelId = useId('label');
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-      <RadioGroup value={value} onChange={(_, data) => setValue(data.value)}>
-        <Radio value="A" label="Option A" />
-        <Radio value="B" label="Option B" />
-        <Radio value="C" label="Option C" />
-        <Radio value="D" label="Option D" />
+      <Label id={labelId}>Favorite Fruit</Label>
+      <RadioGroup value={value} onChange={(_, data) => setValue(data.value)} aria-labelledby={labelId}>
+        <Radio value="apple" label="Apple" />
+        <Radio value="pear" label="Pear" />
+        <Radio value="banana" label="Banana" />
+        <Radio value="orange" label="Orange" />
       </RadioGroup>
       <div>Current value: {value}</div>
     </div>

--- a/packages/react-radio/src/stories/RadioGroupDefault.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroupDefault.stories.tsx
@@ -1,11 +1,19 @@
 import * as React from 'react';
+import { Label } from '@fluentui/react-label';
+import { useId } from '@fluentui/react-utilities';
 import { Radio, RadioGroup, RadioGroupProps } from '../index';
 
-export const Default = (props: Partial<RadioGroupProps>) => (
-  <RadioGroup {...props}>
-    <Radio value="A" label="Option A" />
-    <Radio value="B" label="Option B" />
-    <Radio value="C" label="Option C" />
-    <Radio value="D" label="Option D" />
-  </RadioGroup>
-);
+export const Default = (props: Partial<RadioGroupProps>) => {
+  const labelId = useId('label');
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <Label id={labelId}>Favorite Fruit</Label>
+      <RadioGroup {...props} aria-labelledby={labelId}>
+        <Radio value="apple" label="Apple" />
+        <Radio value="pear" label="Pear" />
+        <Radio value="banana" label="Banana" />
+        <Radio value="orange" label="Orange" />
+      </RadioGroup>
+    </div>
+  );
+};

--- a/packages/react-radio/src/stories/RadioGroupDisabled.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroupDisabled.stories.tsx
@@ -1,14 +1,22 @@
 import * as React from 'react';
+import { Label } from '@fluentui/react-label';
+import { useId } from '@fluentui/react-utilities';
 import { Radio, RadioGroup } from '../index';
 
-export const Disabled = () => (
-  <RadioGroup defaultValue="A" disabled>
-    <Radio value="A" label="Option A" />
-    <Radio value="B" label="Option B" />
-    <Radio value="C" label="Option C" />
-    <Radio value="D" label="Option D" />
-  </RadioGroup>
-);
+export const Disabled = () => {
+  const labelId = useId('label');
+  <Label id={labelId}>Favorite Fruit</Label>;
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <RadioGroup defaultValue="apple" disabled aria-labelledby={labelId}>
+        <Radio value="apple" label="Apple" />
+        <Radio value="pear" label="Pear" />
+        <Radio value="banana" label="Banana" />
+        <Radio value="orange" label="Orange" />
+      </RadioGroup>
+    </div>
+  );
+};
 Disabled.parameters = {
   docs: {
     description: {

--- a/packages/react-radio/src/stories/RadioGroupDisabledItem.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroupDisabledItem.stories.tsx
@@ -1,14 +1,22 @@
 import * as React from 'react';
+import { Label } from '@fluentui/react-label';
+import { useId } from '@fluentui/react-utilities';
 import { Radio, RadioGroup } from '../index';
 
-export const DisabledItem = () => (
-  <RadioGroup defaultValue="A">
-    <Radio value="A" label="Option A" />
-    <Radio value="B" label="Option B" />
-    <Radio value="C" label="Option C" disabled />
-    <Radio value="D" label="Option D" />
-  </RadioGroup>
-);
+export const DisabledItem = () => {
+  const labelId = useId('label');
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <Label id={labelId}>Favorite Fruit</Label>
+      <RadioGroup defaultValue="apple" aria-labelledby={labelId}>
+        <Radio value="apple" label="Apple" />
+        <Radio value="pear" label="Pear" />
+        <Radio value="banana" label="Banana" disabled />
+        <Radio value="orange" label="Orange" />
+      </RadioGroup>
+    </div>
+  );
+};
 DisabledItem.parameters = {
   docs: {
     description: {

--- a/packages/react-radio/src/stories/RadioGroupHorizontal.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroupHorizontal.stories.tsx
@@ -1,14 +1,22 @@
 import * as React from 'react';
+import { Label } from '@fluentui/react-label';
+import { useId } from '@fluentui/react-utilities';
 import { Radio, RadioGroup } from '../index';
 
-export const Horizontal = () => (
-  <RadioGroup layout="horizontal">
-    <Radio value="A" label="Option A" />
-    <Radio value="B" label="Option B" />
-    <Radio value="C" label="Option C" />
-    <Radio value="D" label="Option D" />
-  </RadioGroup>
-);
+export const Horizontal = () => {
+  const labelId = useId('label');
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <Label id={labelId}>Favorite Fruit</Label>
+      <RadioGroup layout="horizontal" aria-labelledby={labelId}>
+        <Radio value="apple" label="Apple" />
+        <Radio value="pear" label="Pear" />
+        <Radio value="banana" label="Banana" />
+        <Radio value="orange" label="Orange" />
+      </RadioGroup>
+    </div>
+  );
+};
 Horizontal.storyName = 'Layout: horizontal';
 Horizontal.parameters = {
   docs: {

--- a/packages/react-radio/src/stories/RadioGroupHorizontalStacked.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroupHorizontalStacked.stories.tsx
@@ -1,14 +1,23 @@
 import * as React from 'react';
+import { Label } from '@fluentui/react-label';
+import { useId } from '@fluentui/react-utilities';
 import { Radio, RadioGroup } from '../index';
 
-export const HorizontalStacked = () => (
-  <RadioGroup layout="horizontalStacked">
-    <Radio value="A" label="Option A" />
-    <Radio value="B" label="Option B" />
-    <Radio value="C" label="Option C" />
-    <Radio value="D" label="Option D" />
-  </RadioGroup>
-);
+export const HorizontalStacked = () => {
+  const labelId = useId('label');
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <Label id={labelId}>Favorite Fruit</Label>
+      <RadioGroup layout="horizontalStacked" aria-labelledby={labelId}>
+        <Radio value="apple" label="Apple" />
+        <Radio value="pear" label="Pear" />
+        <Radio value="banana" label="Banana" />
+        <Radio value="orange" label="Orange" />
+      </RadioGroup>
+    </div>
+  );
+};
 HorizontalStacked.storyName = 'Layout: horizontalStacked';
 HorizontalStacked.parameters = {
   docs: {

--- a/packages/react-radio/src/stories/RadioGroupLabelSubtext.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroupLabelSubtext.stories.tsx
@@ -1,29 +1,40 @@
 import * as React from 'react';
 import { Text } from '@fluentui/react-components';
+import { Label } from '@fluentui/react-label';
+import { useId } from '@fluentui/react-utilities';
 import { Radio, RadioGroup } from '../index';
 
-export const LabelSubtext = () => (
-  <RadioGroup>
-    <Radio
-      value="A"
-      label={
-        <>
-          Option A<br />
-          <Text size={200}>This is an example subtext of the first option</Text>
-        </>
-      }
-    />
-    <Radio
-      value="B"
-      label={
-        <>
-          Option B<br />
-          <Text size={200}>This is some more example subtext</Text>
-        </>
-      }
-    />
-  </RadioGroup>
-);
+export const LabelSubtext = () => {
+  const labelId = useId('label');
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <Label id={labelId}>Favorite Fruit</Label>
+      <RadioGroup>
+        <Radio
+          value="A"
+          label={
+            <>
+              Banana
+              <br />
+              <Text size={200}>This is an example subtext of the first option</Text>
+            </>
+          }
+        />
+        <Radio
+          value="B"
+          label={
+            <>
+              Pear
+              <br />
+              <Text size={200}>This is some more example subtext</Text>
+            </>
+          }
+        />
+      </RadioGroup>
+    </div>
+  );
+};
 LabelSubtext.parameters = {
   docs: {
     description: {

--- a/packages/react-radio/src/stories/RadioGroupLabeled.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroupLabeled.stories.tsx
@@ -7,14 +7,12 @@ export const Labeled = () => {
   const labelId = useId('label-');
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-      <Label id={labelId} required>
-        Option
-      </Label>
+      <Label id={labelId}>Favorite Fruit</Label>
       <RadioGroup aria-labelledby={labelId}>
-        <Radio value="A" label="A" />
-        <Radio value="B" label="B" />
-        <Radio value="C" label="C" />
-        <Radio value="D" label="D" />
+        <Radio value="apple" label="Apple" />
+        <Radio value="pear" label="Pear" />
+        <Radio value="banana" label="Banana" />
+        <Radio value="orange" label="Orange" />
       </RadioGroup>
     </div>
   );

--- a/packages/react-radio/src/stories/RadioGroupRequired.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroupRequired.stories.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Label } from '@fluentui/react-label';
+import { useId } from '@fluentui/react-utilities';
+import { Radio, RadioGroup } from '../index';
+
+export const Required = () => {
+  const labelId = useId('label-');
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <Label id={labelId} required>
+        Favorite Fruit
+      </Label>
+      <RadioGroup aria-labelledby={labelId}>
+        <Radio value="apple" label="Apple" required />
+        <Radio value="pear" label="Pear" required />
+        <Radio value="banana" label="Banana" required />
+        <Radio value="orange" label="Orange" required />
+      </RadioGroup>
+    </div>
+  );
+};
+Required.parameters = {
+  docs: {
+    description: {
+      story: 'Use the `required` prop on every `Radio` child of a `RadioGroup` to make the group as required.',
+    },
+  },
+};

--- a/packages/react-radio/src/stories/RadioGroupUncontrolledValue.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroupUncontrolledValue.stories.tsx
@@ -1,14 +1,22 @@
 import * as React from 'react';
+import { Label } from '@fluentui/react-label';
+import { useId } from '@fluentui/react-utilities';
 import { Radio, RadioGroup } from '../index';
 
-export const UncontrolledValue = () => (
-  <RadioGroup defaultValue="B">
-    <Radio value="A" label="Option A" />
-    <Radio value="B" label="Option B" />
-    <Radio value="C" label="Option C" />
-    <Radio value="D" label="Option D" />
-  </RadioGroup>
-);
+export const UncontrolledValue = () => {
+  const labelId = useId('label');
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <Label id={labelId}>Favorite Fruit</Label>
+      <RadioGroup defaultValue="pear" aria-labelledby={labelId}>
+        <Radio value="apple" label="Apple" />
+        <Radio value="pear" label="Pear" />
+        <Radio value="banana" label="Banana" />
+        <Radio value="orange" label="Orange" />
+      </RadioGroup>
+    </div>
+  );
+};
 UncontrolledValue.parameters = {
   docs: {
     description: {


### PR DESCRIPTION
## Current Behavior

`Radio` examples lack clear labels.

## New Behavior

`Radio` example labels are updated to select from a list of fruits. This allows the `RadioGroup` label examples to be clearer and more realistic than "Option" while still being simple to understand.

Additionally, a new story demonstrating how to mark a group as required has been added.

## Related Issue(s)

Fixes #22770
