### PR TITLE
react-radio: remove required indicator from label

### DIFF
--- a/change/@fluentui-react-radio-ba7295a8-ed08-45fc-b25c-8bb407e8fd2b.json
+++ b/change/@fluentui-react-radio-ba7295a8-ed08-45fc-b25c-8bb407e8fd2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "react-radio: remove required indicator from label",
+  "packageName": "@fluentui/react-radio",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-radio/src/components/Radio/Radio.test.tsx
+++ b/packages/react-radio/src/components/Radio/Radio.test.tsx
@@ -31,6 +31,11 @@ describe('Radio', () => {
     const { getByRole, getByLabelText } = render(<Radio label="Test Label" />);
     expect(getByRole('radio')).toBe(getByLabelText('Test Label'));
   });
+  it('renders a required radio', () => {
+    const { getByRole, getByLabelText } = render(<Radio label="Required Label" required />);
+    expect(getByRole('radio')).toBe(getByLabelText('Required Label'));
+    expect((getByRole('radio') as HTMLInputElement).required).toBe(true);
+  });
 
   it('forwards ID to input element', () => {
     const { getByRole } = render(<Radio id="test-id" />);

--- a/packages/react-radio/src/components/Radio/useRadio.tsx
+++ b/packages/react-radio/src/components/Radio/useRadio.tsx
@@ -23,7 +23,6 @@ export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLInputEle
     defaultChecked = group.defaultValue !== undefined ? group.defaultValue === props.value : undefined,
     labelPosition = group.layout === 'horizontalStacked' ? 'below' : 'after',
     disabled = group.disabled,
-    required,
     onChange,
   } = props;
 
@@ -58,7 +57,6 @@ export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLInputEle
     defaultProps: {
       htmlFor: input.id,
       disabled,
-      required,
     },
   });
 


### PR DESCRIPTION
## Current Behavior

`Radio`s inside a required `RadioGroup` each display a red "required asterisk" after each of their labels. This means users see a required asterisk for the RadioGroup label and for each of the Radios.

## New Behavior

`Radio` labels do not show the visual required asterisk. They continue to mark the `input` element as `required`

### Before
<img width="117" alt="RadioGroup before the change" src="https://user-images.githubusercontent.com/93940821/166390023-0503bf87-1184-45e9-b675-259a3e3dec94.png">

### After
<img width="133" alt="RadioGroup after the change" src="https://user-images.githubusercontent.com/93940821/166390033-4e5235f0-699c-4bf1-81f4-200f0bb60fa9.png">


## Related Issue(s)

Fixes #22770
