### PR TITLE
react-popover: new prop `closeOnScroll` to close popover on scrolling outside

### DIFF
--- a/change/@fluentui-react-popover-bcf50908-8e7f-47c7-a52e-fc80f8804a08.json
+++ b/change/@fluentui-react-popover-bcf50908-8e7f-47c7-a52e-fc80f8804a08.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "new prop `closeOnScroll` to close popover on scrolling outside",
+  "packageName": "@fluentui/react-popover",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-bcf50908-8e7f-47c7-a52e-fc80f8804a08.json
+++ b/change/@fluentui-react-popover-bcf50908-8e7f-47c7-a52e-fc80f8804a08.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "new prop `closeOnScroll` to close popover on scrolling outside",
+  "comment": "feat: Adds prop `closeOnScroll` to close popover on scrolling outside",
   "packageName": "@fluentui/react-popover",
   "email": "yuanboxue@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-popover/Spec.md
+++ b/packages/react-components/react-popover/Spec.md
@@ -284,6 +284,11 @@ export type PopoverProps = {
    * Do not render an arrow pointing to the target element. This is the `PopoverTrigger` unless `target` prop is used
    */
   noArrow?: boolean;
+
+  /**
+   * Close when scrolling outside of it
+   */
+  closeOnScroll?: boolean;
 };
 ```
 
@@ -444,6 +449,11 @@ The popover closes with the escape key when the trigger or popover content has f
 #### Click outside
 
 The popover closes when a click happens outside the popover trigger or content.
+
+#### Scroll outside
+
+The context menu popover closes when scroll happens outside the popover trigger or content.
+When popover is configured with `closeOnScroll`, popover closes when scroll happens outside the popover trigger or content.
 
 ### Focus trap
 

--- a/packages/react-components/react-popover/e2e/Popover.e2e.tsx
+++ b/packages/react-components/react-popover/e2e/Popover.e2e.tsx
@@ -72,7 +72,7 @@ describe('Popover', () => {
         cy.get(popoverContentSelector).should('not.exist');
       });
 
-      it('should be visible on scroll outside', () => {
+      it('should keep open state on scroll outside', () => {
         cy.get(popoverTriggerSelector).click().get(popoverContentSelector).should('be.visible');
         cy.get('body').trigger('wheel').get(popoverContentSelector).should('be.visible');
       });

--- a/packages/react-components/react-popover/e2e/Popover.e2e.tsx
+++ b/packages/react-components/react-popover/e2e/Popover.e2e.tsx
@@ -71,6 +71,11 @@ describe('Popover', () => {
         cy.get(popoverTriggerSelector).click().realPress('Escape');
         cy.get(popoverContentSelector).should('not.exist');
       });
+
+      it('should be visible on scroll outside', () => {
+        cy.get(popoverTriggerSelector).click().get(popoverContentSelector).should('be.visible');
+        cy.get('body').trigger('wheel').get(popoverContentSelector).should('be.visible');
+      });
     });
   });
 
@@ -93,6 +98,52 @@ describe('Popover', () => {
         </Popover>,
       );
       cy.get(popoverTriggerSelector).get('body').click('bottomRight').get(popoverContentSelector).should('not.exist');
+    });
+  });
+
+  describe('Context popover', () => {
+    beforeEach(() => {
+      mount(
+        <Popover openOnContext>
+          <PopoverTrigger>
+            <button>Trigger</button>
+          </PopoverTrigger>
+          <PopoverSurface>This is a popover</PopoverSurface>
+        </Popover>,
+      );
+      cy.get('body').click('bottomRight');
+    });
+
+    it('should open when right clicked', () => {
+      cy.get(popoverTriggerSelector).rightclick().get(popoverContentSelector).should('be.visible');
+    });
+
+    it('should dismiss on scroll outside', () => {
+      cy.get(popoverTriggerSelector)
+        .rightclick()
+        .get('body')
+        .trigger('wheel')
+        .get(popoverContentSelector)
+        .should('not.exist');
+    });
+  });
+
+  describe('popover with closeOnScroll', () => {
+    beforeEach(() => {
+      mount(
+        <Popover closeOnScroll>
+          <PopoverTrigger>
+            <button>Trigger</button>
+          </PopoverTrigger>
+          <PopoverSurface>This is a popover</PopoverSurface>
+        </Popover>,
+      );
+      cy.get('body').click('bottomRight');
+    });
+
+    it('should dismiss on scroll outside', () => {
+      cy.get(popoverTriggerSelector).click().get(popoverContentSelector).should('be.visible');
+      cy.get('body').trigger('wheel').get(popoverContentSelector).should('not.exist');
     });
   });
 

--- a/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
@@ -54,6 +54,11 @@ type PopoverCommons = Pick<PortalProps, 'mountNode'> & {
    * Configures the position of the Popover
    */
   positioning?: PositioningShorthand;
+
+  /**
+   * Close when scroll outside of it
+   */
+  closeOnScroll?: boolean;
 };
 
 /**

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -83,7 +83,7 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
     element: targetDocument,
     callback: ev => setOpen(ev, false),
     refs: [popperRefs.triggerRef, popperRefs.contentRef],
-    disabled: !closeOnScroll,
+    disabled: !open || !closeOnScroll,
   });
 
   const { findFirstFocusable } = useFocusFinders();

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -75,12 +75,15 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
     refs: [popperRefs.triggerRef, popperRefs.contentRef],
     disabled: !open,
   });
+
+  // only close on scroll for context, or when closeOnScroll is specified
+  const closeOnScroll = open && (initialState.openOnContext || initialState.closeOnScroll);
   useOnScrollOutside({
     contains: elementContains,
     element: targetDocument,
     callback: ev => setOpen(ev, false),
     refs: [popperRefs.triggerRef, popperRefs.contentRef],
-    disabled: !open || !initialState.openOnContext, // only close on scroll for context
+    disabled: !closeOnScroll,
   });
 
   const { findFirstFocusable } = useFocusFinders();

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -77,7 +77,7 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
   });
 
   // only close on scroll for context, or when closeOnScroll is specified
-  const closeOnScroll = open && (initialState.openOnContext || initialState.closeOnScroll);
+  const closeOnScroll = initialState.openOnContext || initialState.closeOnScroll;
   useOnScrollOutside({
     contains: elementContains,
     element: targetDocument,


### PR DESCRIPTION
### Add a new Popover prop `closeOnScroll`.
When it's specified, popover will be closed when scrolling happens outside of the popover content and trigger.

#### Reason for this new prop:
When nested popover is inside a scrollable container, scrolling can cause popup content to appear detached from trigger.
Example https://codesandbox.io/s/fluent-ui-example-forked-y6i2e3?file=/example.js
<img width="238" alt="Screenshot 2022-05-02 at 12 32 09" src="https://user-images.githubusercontent.com/28751745/166429019-c2da5649-05a4-42fc-8926-db4a81e3d563.png">
This happens because trigger element is rendered outside of scrollable container, and floatingui is not able to find the scrollable container from trigger element.
In v0 this is fixed by adding `closeOnScroll`. This PR does the same for v9.
