### PR TITLE
fix(react-card): add `react-components` to vr-tests asset path

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Card.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Card.stories.tsx
@@ -7,7 +7,7 @@ import { Body, Caption } from '@fluentui/react-text';
 import { Button } from '@fluentui/react-button';
 import { action } from '@storybook/addon-actions';
 
-const ASSET_URL = 'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-card';
+const ASSET_URL = 'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
 
 const powerpointLogoURL = ASSET_URL + '/assets/powerpoint_logo.svg';
 


### PR DESCRIPTION
## Current Behavior

Due to the moving of the package, the usage of hardcoded absolute URLs to access GitHub raw assets in our stories is using the wrong path.

## New Behavior

Path now accounts for the `react-components/` move.

## Related Issue(s)

#22692