### PR TITLE
feat: Add inline prop to Popover

### DIFF
--- a/change/@fluentui-react-popover-02cd6106-6a48-483d-91df-6df652f6b43b.json
+++ b/change/@fluentui-react-popover-02cd6106-6a48-483d-91df-6df652f6b43b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Add inline prop to Popover",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/e2e/Popover.e2e.tsx
+++ b/packages/react-components/react-popover/e2e/Popover.e2e.tsx
@@ -256,4 +256,33 @@ describe('Popover', () => {
         .should('exist');
     });
   });
+
+  describe('with inline prop', () => {
+    it('should render PopoverSurface in DOM order', () => {
+      mount(
+        <>
+          <div>
+            <Popover inline>
+              <PopoverTrigger>
+                <button>Popover trigger</button>
+              </PopoverTrigger>
+
+              <PopoverSurface>This is a Popover</PopoverSurface>
+            </Popover>
+          </div>
+          <div>Outside content</div>
+        </>,
+      );
+
+      cy.get(popoverTriggerSelector)
+        .click()
+        .get(popoverContentSelector)
+        .prev()
+        .then(popoverSurfacePrev => {
+          cy.get(popoverTriggerSelector).then(popoverTrigger => {
+            expect(popoverTrigger[0]).eq(popoverSurfacePrev[0]);
+          });
+        });
+    });
+  });
 });

--- a/packages/react-components/react-popover/etc/react-popover.api.md
+++ b/packages/react-components/react-popover/etc/react-popover.api.md
@@ -38,7 +38,7 @@ export const Popover: React_2.FC<PopoverProps>;
 export const PopoverContext: Context<PopoverContextValue>;
 
 // @public
-export type PopoverContextValue = Pick<PopoverState, 'toggleOpen' | 'setOpen' | 'triggerRef' | 'contentRef' | 'openOnHover' | 'openOnContext' | 'mountNode' | 'noArrow' | 'arrowRef' | 'size' | 'appearance' | 'trapFocus'>;
+export type PopoverContextValue = Pick<PopoverState, 'toggleOpen' | 'setOpen' | 'triggerRef' | 'contentRef' | 'openOnHover' | 'openOnContext' | 'mountNode' | 'noArrow' | 'arrowRef' | 'size' | 'appearance' | 'trapFocus' | 'inline'>;
 
 // @public
 export type PopoverProps = Partial<PopoverCommons> & {
@@ -80,7 +80,7 @@ export type PopoverSurfaceSlots = {
 };
 
 // @public
-export type PopoverSurfaceState = ComponentState<PopoverSurfaceSlots> & Pick<PopoverContextValue, 'mountNode' | 'noArrow' | 'size' | 'appearance' | 'arrowRef'> & {
+export type PopoverSurfaceState = ComponentState<PopoverSurfaceSlots> & Pick<PopoverContextValue, 'mountNode' | 'noArrow' | 'size' | 'appearance' | 'arrowRef' | 'inline'> & {
     arrowClassName?: string;
 };
 

--- a/packages/react-components/react-popover/src/common/mockUsePopoverContext.ts
+++ b/packages/react-components/react-popover/src/common/mockUsePopoverContext.ts
@@ -16,6 +16,7 @@ export const mockPopoverContext = (options: Partial<PopoverContextValue> = {}) =
     openOnContext: false,
     openOnHover: false,
     size: 'medium',
+    inline: false,
     ...options,
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
@@ -9,6 +9,11 @@ export type PopoverSize = 'small' | 'medium' | 'large';
 
 type PopoverCommons = Pick<PortalProps, 'mountNode'> & {
   /**
+   * Popovers are rendered out of DOM order on `document.body` by default, use this to render the popover in DOM order
+   */
+  inline: boolean;
+
+  /**
    * Controls the opening of the Popover
    */
   open: boolean;

--- a/packages/react-components/react-popover/src/components/Popover/renderPopover.tsx
+++ b/packages/react-components/react-popover/src/components/Popover/renderPopover.tsx
@@ -19,6 +19,7 @@ export const renderPopover_unstable = (state: PopoverState) => {
     noArrow,
     appearance,
     trapFocus,
+    inline,
   } = state;
 
   return (
@@ -36,6 +37,7 @@ export const renderPopover_unstable = (state: PopoverState) => {
         noArrow,
         appearance,
         trapFocus,
+        inline,
       }}
     >
       {state.popoverTrigger}

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -102,6 +102,7 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
     toggleOpen,
     setContextTarget,
     contextTarget,
+    inline: props.inline ?? false,
   };
 };
 

--- a/packages/react-components/react-popover/src/components/PopoverSurface/PopoverSurface.types.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/PopoverSurface.types.ts
@@ -17,7 +17,7 @@ export type PopoverSurfaceSlots = {
  * PopoverSurface State
  */
 export type PopoverSurfaceState = ComponentState<PopoverSurfaceSlots> &
-  Pick<PopoverContextValue, 'mountNode' | 'noArrow' | 'size' | 'appearance' | 'arrowRef'> & {
+  Pick<PopoverContextValue, 'mountNode' | 'noArrow' | 'size' | 'appearance' | 'arrowRef' | 'inline'> & {
     /**
      * CSS class for the arrow element
      */

--- a/packages/react-components/react-popover/src/components/PopoverSurface/renderPopoverSurface.tsx
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/renderPopoverSurface.tsx
@@ -9,12 +9,16 @@ import type { PopoverSurfaceSlots, PopoverSurfaceState } from './PopoverSurface.
 export const renderPopoverSurface_unstable = (state: PopoverSurfaceState) => {
   const { slots, slotProps } = getSlots<PopoverSurfaceSlots>(state);
 
-  return (
-    <Portal mountNode={state.mountNode}>
-      <slots.root {...slotProps.root}>
-        {!state.noArrow && <div ref={state.arrowRef} className={state.arrowClassName} />}
-        {slotProps.root.children}
-      </slots.root>
-    </Portal>
+  const surface = (
+    <slots.root {...slotProps.root}>
+      {!state.noArrow && <div ref={state.arrowRef} className={state.arrowClassName} />}
+      {slotProps.root.children}
+    </slots.root>
   );
+
+  if (state.inline) {
+    return surface;
+  }
+
+  return <Portal mountNode={state.mountNode}>{surface}</Portal>;
 };

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
@@ -26,9 +26,11 @@ export const usePopoverSurface_unstable = (
   const noArrow = usePopoverContext_unstable(context => context.noArrow);
   const appearance = usePopoverContext_unstable(context => context.appearance);
   const trapFocus = usePopoverContext_unstable(context => context.trapFocus);
+  const inline = usePopoverContext_unstable(context => context.inline);
   const { modalAttributes } = useModalAttributes({ trapFocus });
 
   const state: PopoverSurfaceState = {
+    inline,
     appearance,
     noArrow,
     size,

--- a/packages/react-components/react-popover/src/popoverContext.ts
+++ b/packages/react-components/react-popover/src/popoverContext.ts
@@ -12,6 +12,7 @@ export const PopoverContext: Context<PopoverContextValue> = createContext<Popove
   openOnHover: false,
   size: 'medium',
   trapFocus: false,
+  inline: false,
 });
 
 /**
@@ -31,6 +32,7 @@ export type PopoverContextValue = Pick<
   | 'size'
   | 'appearance'
   | 'trapFocus'
+  | 'inline'
 >;
 
 export const usePopoverContext_unstable = <T>(selector: ContextSelector<PopoverContextValue, T>): T =>

--- a/packages/react-components/react-popover/src/stories/PopoverDefault.stories.tsx
+++ b/packages/react-components/react-popover/src/stories/PopoverDefault.stories.tsx
@@ -22,7 +22,7 @@ const ExampleContent = () => {
 };
 
 export const Default = (props: PopoverProps) => (
-  <Popover {...props} inline>
+  <Popover {...props}>
     <PopoverTrigger>
       <Button>Popover trigger</Button>
     </PopoverTrigger>

--- a/packages/react-components/react-popover/src/stories/PopoverDefault.stories.tsx
+++ b/packages/react-components/react-popover/src/stories/PopoverDefault.stories.tsx
@@ -22,7 +22,7 @@ const ExampleContent = () => {
 };
 
 export const Default = (props: PopoverProps) => (
-  <Popover {...props}>
+  <Popover {...props} inline>
     <PopoverTrigger>
       <Button>Popover trigger</Button>
     </PopoverTrigger>


### PR DESCRIPTION
## Current Behavior

There is no way to render a Popover in DOM order

## New Behavior

Setting the `inline` prop will render the Popover in DOM order consistent with what Menu does
