### PR TITLE
feat(v9): migrate checkbox,input,label,link,select to ship rolluped only dts

### DIFF
--- a/change/@fluentui-react-checkbox-65e7ee49-bcf2-42db-9fe8-9a15999b1098.json
+++ b/change/@fluentui-react-checkbox-65e7ee49-bcf2-42db-9fe8-9a15999b1098.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-a16a3406-ea5c-4bcf-b22a-694ce517d2fb.json
+++ b/change/@fluentui-react-input-a16a3406-ea5c-4bcf-b22a-694ce517d2fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-input",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-2e736c10-36a8-439c-900e-8ec9511a2a13.json
+++ b/change/@fluentui-react-label-2e736c10-36a8-439c-900e-8ec9511a2a13.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-label",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-d2e69fee-5358-48b8-98a3-9bc4ab83ecb7.json
+++ b/change/@fluentui-react-link-d2e69fee-5358-48b8-98a3-9bc4ab83ecb7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-link",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-checkbox/.npmignore
+++ b/packages/react-components/react-checkbox/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-checkbox/config/api-extractor.json
+++ b/packages/react-components/react-checkbox/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-checkbox/package.json
+++ b/packages/react-components/react-checkbox/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent UI checkbox component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-checkbox/tsconfig.lib.json
+++ b/packages/react-components/react-checkbox/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-input/.npmignore
+++ b/packages/react-components/react-input/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-input/.storybook/preview.js
+++ b/packages/react-components/react-input/.storybook/preview.js
@@ -4,11 +4,4 @@ import * as rootPreview from '../../../../.storybook/preview';
 export const decorators = [...rootPreview.decorators];
 
 /** @type {typeof rootPreview.parameters} */
-export const parameters = {
-  ...rootPreview.parameters,
-  viewMode: 'story',
-  controls: {
-    disable: false,
-    expanded: false,
-  },
-};
+export const parameters = { ...rootPreview.parameters };

--- a/packages/react-components/react-input/config/api-extractor.json
+++ b/packages/react-components/react-input/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-input/package.json
+++ b/packages/react-components/react-input/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent UI React Input component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-input/tsconfig.lib.json
+++ b/packages/react-components/react-input/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-label/.npmignore
+++ b/packages/react-components/react-label/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-label/config/api-extractor.json
+++ b/packages/react-components/react-label/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-label/package.json
+++ b/packages/react-components/react-label/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent UI React Label component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-label/tsconfig.lib.json
+++ b/packages/react-components/react-label/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-link/.npmignore
+++ b/packages/react-components/react-link/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-link/config/api-extractor.json
+++ b/packages/react-components/react-link/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-link/package.json
+++ b/packages/react-components/react-link/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent UI React Link component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-link/tsconfig.lib.json
+++ b/packages/react-components/react-link/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-select/.npmignore
+++ b/packages/react-components/react-select/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-select/config/api-extractor.json
+++ b/packages/react-components/react-select/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-select/package.json
+++ b/packages/react-components/react-select/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-select/tsconfig.lib.json
+++ b/packages/react-components/react-select/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Applied `yarn workspace-generator migrate-converged-pkg` to ship only rolluped type definitions for:
- react-checkbox
- react-input
- react-label
- react-link
- react-select

## Related Issue(s)

Fixes partially https://github.com/microsoft/fluentui/issues/22429
