### PR TITLE
fix(tools): remove obsolete e2e support.js setup from migration gener…

### DIFF
--- a/tools/generators/migrate-converged-pkg/__snapshots__/index.spec.ts.snap
+++ b/tools/generators/migrate-converged-pkg/__snapshots__/index.spec.ts.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`migrate-converged-pkg generator e2e config should setup e2e if present 1`] = `
-"// workaround for https://github.com/cypress-io/cypress/issues/8599
-import '@fluentui/scripts/cypress/support';
-"
-`;
-
 exports[`migrate-converged-pkg generator jest config updates should setup new local jest config which extends from root  1`] = `
 "const { createConfig } = require('@fluentui/scripts/jest/jest-resources');
 const path = require('path');

--- a/tools/generators/migrate-converged-pkg/files/e2e/support.js__tmpl__
+++ b/tools/generators/migrate-converged-pkg/files/e2e/support.js__tmpl__
@@ -1,2 +1,0 @@
-// workaround for https://github.com/cypress-io/cypress/issues/8599
-import '@fluentui/scripts/cypress/support';

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -672,7 +672,6 @@ describe('migrate-converged-pkg generator', () => {
       const projectConfig = readProjectConfiguration(tree, config.projectName);
       const paths = {
         e2eRoot: `${projectConfig.root}/e2e`,
-        e2eSupport: `${projectConfig.root}/e2e/support.js`,
         packageJson: `${projectConfig.root}/package.json`,
         tsconfig: {
           main: `${projectConfig.root}/tsconfig.json`,
@@ -734,12 +733,6 @@ describe('migrate-converged-pkg generator', () => {
         include: ['**/*.ts', '**/*.tsx'],
       });
       expect(mainTsConfig.references).toEqual(expect.arrayContaining([{ path: './e2e/tsconfig.json' }]));
-
-      // support.js
-      const supportFile = tree.read(paths.e2eSupport)?.toString('utf-8');
-
-      // Why not inline snapshot? -> this is needed to stop TS parsing static imports and evaluating them in nx dep graph tree as true dependency - https://github.com/nrwl/nx/issues/8938
-      expect(supportFile).toMatchSnapshot();
 
       // package.json updates
       const packageJson: PackageJson = readJson(tree, paths.packageJson);

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -723,9 +723,6 @@ function setupE2E(tree: Tree, options: NormalizedSchema) {
 
   writeJson<TsConfig>(tree, options.paths.e2e.tsconfig, templates.e2e.tsconfig);
 
-  // this is needed to stop TS parsing static imports and evaluating them in nx dep graph tree as true dependency - https://github.com/nrwl/nx/issues/8938
-  generateFiles(tree, joinPathFragments(__dirname, 'files', 'e2e'), options.paths.e2e.rootFolder, { tmpl: '' });
-
   updateJson(tree, options.paths.tsconfig.main, (json: TsConfig) => {
     json.references?.push({
       path: `./${path.basename(options.paths.e2e.rootFolder)}/${path.basename(options.paths.e2e.tsconfig)}`,


### PR DESCRIPTION
…ator

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

migration generator setups `support.js` for cypress e2e which is no longer necessary

## New Behavior

no `support.js` is being setup

## Related Issue(s)

