### PR TITLE
Storybook: Remove z-index from show code button

### DIFF
--- a/.storybook/docs-root.css
+++ b/.storybook/docs-root.css
@@ -67,7 +67,7 @@
     sans-serif;
   font-size: 18px;
   line-height: 24px;
-  margin: 15px 0 0 0 !important;
+  margin: 25px 0 0 0 !important;
   letter-spacing: -0.01em;
   color: #000000;
 }
@@ -76,8 +76,8 @@
 #docs-root [id] > .sbdocs-h3:before {
   content: '';
   display: block;
-  height: 60px;
-  margin: -60px 0 0;
+  height: 40px;
+  margin: -40px 0 0;
 }
 
 #docs-root .sbdocs-li {
@@ -129,6 +129,12 @@
 
 #docs-root .sbdocs-preview > .os-host {
   display: none;
+}
+
+/* Remove z-index from "show code" button container */
+/* https://github.com/microsoft/fluentui/issues/22773 */
+.docs-story > div:nth-child(2) {
+  z-index: auto;
 }
 
 #docs-root .docblock-code-toggle,


### PR DESCRIPTION
fixes #22773

After removing z-index, the jump link pseudo element pushed the H3 up and covered the button (this often effects the code sandbox button as well).

So I reduced the offset of the psuedo element and increase the margin just enough that the H3 height stopped at the bottom of the previous example (color added for visibility)
![image](https://user-images.githubusercontent.com/1434956/166488987-918191aa-95dc-4f21-98b5-01813aa2c7eb.png)

jump links still leave space 

![image](https://user-images.githubusercontent.com/1434956/166489135-49b9522e-fbc1-47aa-9c21-4c33b1b5f0bc.png)
