### PR TITLE
Combobox: child trigger/listbox pattern

### DIFF
--- a/packages/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-combobox/etc/react-combobox.api.md
@@ -7,6 +7,9 @@
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import type { InputProps } from '@fluentui/react-input';
+import type { InputSlots } from '@fluentui/react-input';
+import type { InputState } from '@fluentui/react-input';
 import type { PositioningShorthand } from '@fluentui/react-positioning';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
@@ -22,6 +25,23 @@ export const comboboxClassNames: SlotClassNames<ComboboxSlots>;
 export type ComboboxContextValues = {
     combobox: ComboboxContextValue;
 };
+
+// @public
+export const ComboboxInput: ForwardRefComponent<ComboboxInputProps>;
+
+// @public (undocumented)
+export const comboboxInputClassNames: SlotClassNames<ComboboxInputSlots>;
+
+// @public
+export type ComboboxInputProps = Partial<ComponentProps<ComboboxInputSlots>> & Omit<InputProps, 'contentBefore' | 'contentAfter'>;
+
+// @public (undocumented)
+export type ComboboxInputSlots = Pick<InputSlots, 'root' | 'input'> & {
+    expandIcon: Slot<'span'>;
+};
+
+// @public
+export type ComboboxInputState = ComponentState<ComboboxInputSlots> & Omit<InputState, 'components' | 'contentBefore' | 'contentAfter'>;
 
 // @public
 export type ComboboxOpenChangeData = {
@@ -83,7 +103,7 @@ export type ComboButtonSlots = {
 };
 
 // @public
-export type ComboButtonState = ComponentState<ComboButtonSlots> & ComboButtonCommons & Required<Pick<ComboButtonProps, 'appearance' | 'size'>> & Pick<ComboButtonProps, 'placeholder'>;
+export type ComboButtonState = ComponentState<ComboButtonSlots> & Required<Pick<ComboButtonProps, 'appearance' | 'size'>> & Pick<ComboButtonProps, 'placeholder'>;
 
 // @public
 export const Listbox: ForwardRefComponent<ListboxProps>;
@@ -163,6 +183,9 @@ export type OptionState = ComponentState<OptionSlots> & OptionCommons & {
 export const renderCombobox_unstable: (state: ComboboxState, contextValues: ComboboxContextValues) => JSX.Element;
 
 // @public
+export const renderComboboxInput_unstable: (state: ComboboxInputState) => JSX.Element;
+
+// @public
 export const renderComboButton_unstable: (state: ComboButtonState) => JSX.Element;
 
 // @public
@@ -176,6 +199,12 @@ export const renderOptionGroup_unstable: (state: OptionGroupState) => JSX.Elemen
 
 // @public
 export const useCombobox_unstable: (props: ComboboxProps, ref: React_2.Ref<HTMLDivElement>) => ComboboxState;
+
+// @public
+export const useComboboxInput_unstable: (props: ComboboxInputProps, ref: React_2.Ref<HTMLInputElement>) => ComboboxInputState;
+
+// @public
+export const useComboboxInputStyles_unstable: (state: ComboboxInputState) => ComboboxInputState;
 
 // @public
 export const useComboboxStyles_unstable: (state: ComboboxState) => ComboboxState;

--- a/packages/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-combobox/etc/react-combobox.api.md
@@ -32,25 +32,34 @@ export type ComboboxOpenChangeData = {
 export type ComboboxOpenEvents = React_2.MouseEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement> | React_2.FocusEvent<HTMLElement>;
 
 // @public
-export type ComboboxProps = ComponentProps<Partial<ComboboxSlots>, 'trigger'> & ComboboxCommons & SelectionProps & {
+export type ComboboxProps = ComponentProps<Partial<ComboboxSlots>> & SelectionProps & {
     defaultOpen?: boolean;
     defaultValue?: string;
+    inline?: boolean;
     onOpenChange?: (e: ComboboxOpenEvents, data: ComboboxOpenChangeData) => void;
+    open?: boolean;
     positioning?: PositioningShorthand;
+    value?: string;
 };
 
 // @public (undocumented)
 export type ComboboxSlots = {
     root: NonNullable<Slot<'div'>>;
-    listbox: NonNullable<Slot<typeof Listbox>>;
-    trigger: NonNullable<Slot<typeof ComboButton>>;
 };
 
 // @public
-export type ComboboxState = ComponentState<ComboboxSlots> & Required<Pick<ComboboxCommons, 'appearance' | 'open' | 'inline' | 'size'>> & Pick<ComboboxCommons, 'placeholder' | 'value'> & OptionCollectionState & SelectionState & {
+export type ComboboxState = ComponentState<ComboboxSlots> & Required<Pick<ComboboxProps, 'open' | 'inline'>> & Pick<ComboboxProps, 'value'> & OptionCollectionState & SelectionState & {
     activeOption?: OptionValue;
     idBase: string;
+    listbox: React_2.ReactNode;
+    popperContainerRef: React_2.MutableRefObject<HTMLDivElement>;
+    triggerRef: React_2.RefObject<HTMLButtonElement>;
+    onListboxClick(): void;
+    onListboxMouseDown(): void;
     onOptionClick(event: React_2.MouseEvent, option: OptionValue): void;
+    onTriggerBlur(event: React_2.FocusEvent<HTMLButtonElement>): void;
+    onTriggerClick(event: React_2.MouseEvent<HTMLButtonElement>): void;
+    onTriggerKeyDown(event: React_2.KeyboardEvent<HTMLButtonElement>): void;
 };
 
 // @public
@@ -60,7 +69,11 @@ export const ComboButton: ForwardRefComponent<ComboButtonProps>;
 export const comboButtonClassNames: SlotClassNames<ComboButtonSlots>;
 
 // @public
-export type ComboButtonProps = Partial<ComponentProps<ComboButtonSlots, 'content'>> & ComboButtonCommons;
+export type ComboButtonProps = Partial<ComponentProps<ComboButtonSlots, 'content'>> & {
+    appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
+    placeholder?: string;
+    size?: 'small' | 'medium' | 'large';
+};
 
 // @public (undocumented)
 export type ComboButtonSlots = {
@@ -70,7 +83,7 @@ export type ComboButtonSlots = {
 };
 
 // @public
-export type ComboButtonState = ComponentState<ComboButtonSlots> & ComboButtonCommons & Pick<ComboboxState, 'appearance' | 'size'>;
+export type ComboButtonState = ComponentState<ComboButtonSlots> & ComboButtonCommons & Required<Pick<ComboButtonProps, 'appearance' | 'size'>> & Pick<ComboButtonProps, 'placeholder'>;
 
 // @public
 export const Listbox: ForwardRefComponent<ListboxProps>;
@@ -162,7 +175,7 @@ export const renderOption_unstable: (state: OptionState) => JSX.Element;
 export const renderOptionGroup_unstable: (state: OptionGroupState) => JSX.Element;
 
 // @public
-export const useCombobox_unstable: (props: ComboboxProps, ref: React_2.Ref<HTMLButtonElement>) => ComboboxState;
+export const useCombobox_unstable: (props: ComboboxProps, ref: React_2.Ref<HTMLDivElement>) => ComboboxState;
 
 // @public
 export const useComboboxStyles_unstable: (state: ComboboxState) => ComboboxState;

--- a/packages/react-combobox/package.json
+++ b/packages/react-combobox/package.json
@@ -36,6 +36,7 @@
     "@fluentui/keyboard-keys": "9.0.0-rc.4",
     "@fluentui/react-context-selector": "9.0.0-rc.6",
     "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-input": "^9.0.0-beta.7",
     "@fluentui/react-portal": "9.0.0-rc.7",
     "@fluentui/react-positioning": "9.0.0-rc.6",
     "@fluentui/react-theme": "9.0.0-rc.5",

--- a/packages/react-combobox/src/ComboboxInput.ts
+++ b/packages/react-combobox/src/ComboboxInput.ts
@@ -1,0 +1,1 @@
+export * from './components/ComboboxInput/index';

--- a/packages/react-combobox/src/components/ComboButton/ComboButton.types.ts
+++ b/packages/react-combobox/src/components/ComboButton/ComboButton.types.ts
@@ -1,5 +1,4 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import type { ComboboxState } from '../Combobox/Combobox.types';
 
 export type ComboButtonSlots = {
   /* The wrapper slot */
@@ -12,7 +11,12 @@ export type ComboButtonSlots = {
   expandIcon: Slot<'span'>;
 };
 
-type ComboButtonCommons = {
+type ComboButtonCommons = {};
+
+/**
+ * ComboButton Props
+ */
+export type ComboButtonProps = Partial<ComponentProps<ComboButtonSlots, 'content'>> & {
   /**
    * Controls the colors and borders of the combobox.
    * @default 'outline'
@@ -25,19 +29,16 @@ type ComboButtonCommons = {
   placeholder?: string;
 
   /**
-   * Sets the displayed value of the ComboButton
+   * Controls the size of the combobox faceplate
+   * @default 'medium'
    */
-  value?: string;
+  size?: 'small' | 'medium' | 'large';
 };
-
-/**
- * ComboButton Props
- */
-export type ComboButtonProps = Partial<ComponentProps<ComboButtonSlots, 'content'>> & ComboButtonCommons;
 
 /**
  * State used in rendering ComboButton
  */
 export type ComboButtonState = ComponentState<ComboButtonSlots> &
   ComboButtonCommons &
-  Pick<ComboboxState, 'appearance' | 'size'>;
+  Required<Pick<ComboButtonProps, 'appearance' | 'size'>> &
+  Pick<ComboButtonProps, 'placeholder'>;

--- a/packages/react-combobox/src/components/ComboButton/ComboButton.types.ts
+++ b/packages/react-combobox/src/components/ComboButton/ComboButton.types.ts
@@ -11,8 +11,6 @@ export type ComboButtonSlots = {
   expandIcon: Slot<'span'>;
 };
 
-type ComboButtonCommons = {};
-
 /**
  * ComboButton Props
  */
@@ -39,6 +37,5 @@ export type ComboButtonProps = Partial<ComponentProps<ComboButtonSlots, 'content
  * State used in rendering ComboButton
  */
 export type ComboButtonState = ComponentState<ComboButtonSlots> &
-  ComboButtonCommons &
   Required<Pick<ComboButtonProps, 'appearance' | 'size'>> &
   Pick<ComboButtonProps, 'placeholder'>;

--- a/packages/react-combobox/src/components/ComboButton/__snapshots__/ComboButton.test.tsx.snap
+++ b/packages/react-combobox/src/components/ComboButton/__snapshots__/ComboButton.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`ComboButton renders a default state 1`] = `
     class="fui-ComboButton"
   >
     <button
+      aria-expanded="false"
       class="fui-ComboButton__content"
       role="combobox"
       type="button"

--- a/packages/react-combobox/src/components/ComboButton/useComboButton.tsx
+++ b/packages/react-combobox/src/components/ComboButton/useComboButton.tsx
@@ -26,7 +26,7 @@ export const useComboButton_unstable = (
   const contextOnBlur = useContextSelector(ComboboxContext, ctx => ctx.onTriggerBlur);
   const contextOnClick = useContextSelector(ComboboxContext, ctx => ctx.onTriggerClick);
   const contextOnKeyDown = useContextSelector(ComboboxContext, ctx => ctx.onTriggerKeyDown);
-  const contextRef = useContextSelector(ComboboxContext, ctx => ctx.triggerRef);
+  const contextRef = useContextSelector(ComboboxContext, ctx => ctx.triggerRef as React.RefObject<HTMLButtonElement>);
 
   const nativeProps = getPartitionedNativeProps({
     props,

--- a/packages/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -7,7 +7,6 @@ describe('Combobox', () => {
   isConformant({
     Component: Combobox,
     displayName: 'Combobox',
-    primarySlot: 'trigger',
     // don't test deprecated className export on new components
     disabledTests: ['component-has-static-classname-exported'],
     testOptions: {

--- a/packages/react-combobox/src/components/Combobox/Combobox.types.ts
+++ b/packages/react-combobox/src/components/Combobox/Combobox.types.ts
@@ -77,7 +77,7 @@ export type ComboboxState = ComponentState<ComboboxSlots> &
     popperContainerRef: React.MutableRefObject<HTMLDivElement>;
 
     /* Ref to be used by the trigger */
-    triggerRef: React.RefObject<HTMLButtonElement>;
+    triggerRef: React.RefObject<HTMLButtonElement | HTMLInputElement>;
 
     /* Callback when a the listbox is clicked, for internal use */
     onListboxClick(): void;
@@ -89,13 +89,13 @@ export type ComboboxState = ComponentState<ComboboxSlots> &
     onOptionClick(event: React.MouseEvent, option: OptionValue): void;
 
     /* Callback when the trigger is blurred, for internal use */
-    onTriggerBlur(event: React.FocusEvent<HTMLButtonElement>): void;
+    onTriggerBlur(event: React.FocusEvent<HTMLButtonElement | HTMLInputElement>): void;
 
     /* Callback when the trigger is clicked, for internal use */
-    onTriggerClick(event: React.MouseEvent<HTMLButtonElement>): void;
+    onTriggerClick(event: React.MouseEvent<HTMLButtonElement | HTMLInputElement>): void;
 
     /* Callback for the trigger keydown event, for internal use */
-    onTriggerKeyDown(event: React.KeyboardEvent<HTMLButtonElement>): void;
+    onTriggerKeyDown(event: React.KeyboardEvent<HTMLButtonElement | HTMLInputElement>): void;
   };
 
 export type ComboboxContextValues = {

--- a/packages/react-combobox/src/components/Combobox/Combobox.types.ts
+++ b/packages/react-combobox/src/components/Combobox/Combobox.types.ts
@@ -4,62 +4,16 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 import type { OptionValue, OptionCollectionState } from '../../utils/OptionCollection.types';
 import { SelectionProps, SelectionState } from '../../utils/Selection.types';
 import type { ComboboxContextValue } from '../../contexts/ComboboxContext';
-import { Listbox } from '../Listbox/Listbox';
-import { ComboButton } from '../ComboButton/ComboButton';
 
 export type ComboboxSlots = {
   /* The root combobox slot */
   root: NonNullable<Slot<'div'>>;
-
-  /* The dropdown listbox slot */
-  listbox: NonNullable<Slot<typeof Listbox>>;
-
-  /* The primary slot, the element with role="combobox" */
-  trigger: NonNullable<Slot<typeof ComboButton>>;
-};
-
-type ComboboxCommons = {
-  /**
-   * Controls the colors and borders of the combobox.
-   * @default 'outline'
-   */
-  appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
-
-  /**
-   * Render the combobox dropdown inline in the DOM.
-   * This has accessibility benefits, particularly for touch screen readers.
-   */
-  inline?: boolean;
-
-  /**
-   * Sets the open/closed state of the dropdown.
-   * Use together with onOpenChange to fully control the dropdown's visibility
-   */
-  open?: boolean;
-
-  /**
-   * If set, the placeholder will show when no value is selected
-   */
-  placeholder?: string;
-
-  /**
-   * Controls the size of the combobox faceplate
-   * @default 'medium'
-   */
-  size?: 'small' | 'medium' | 'large';
-
-  /**
-   * The value displayed by the Combobox.
-   * Use this with `onSelect` to directly control the displayed value string
-   */
-  value?: string;
 };
 
 /**
  * Combobox Props
  */
-export type ComboboxProps = ComponentProps<Partial<ComboboxSlots>, 'trigger'> &
-  ComboboxCommons &
+export type ComboboxProps = ComponentProps<Partial<ComboboxSlots>> &
   SelectionProps & {
     /**
      * The default open state when open is uncontrolled
@@ -72,9 +26,21 @@ export type ComboboxProps = ComponentProps<Partial<ComboboxSlots>, 'trigger'> &
     defaultValue?: string;
 
     /**
+     * Render the combobox dropdown inline in the DOM.
+     * This has accessibility benefits, particularly for touch screen readers.
+     */
+    inline?: boolean;
+
+    /**
      * Callback when the open/closed state of the dropdown changes
      */
     onOpenChange?: (e: ComboboxOpenEvents, data: ComboboxOpenChangeData) => void;
+
+    /**
+     * Sets the open/closed state of the dropdown.
+     * Use together with onOpenChange to fully control the dropdown's visibility
+     */
+    open?: boolean;
 
     /**
      * Configure the positioning of the combobox dropdown
@@ -82,14 +48,20 @@ export type ComboboxProps = ComponentProps<Partial<ComboboxSlots>, 'trigger'> &
      * @defaultvalue below
      */
     positioning?: PositioningShorthand;
+
+    /**
+     * The value displayed by the Combobox.
+     * Use this with `onSelect` to directly control the displayed value string
+     */
+    value?: string;
   };
 
 /**
  * State used in rendering Combobox
  */
 export type ComboboxState = ComponentState<ComboboxSlots> &
-  Required<Pick<ComboboxCommons, 'appearance' | 'open' | 'inline' | 'size'>> &
-  Pick<ComboboxCommons, 'placeholder' | 'value'> &
+  Required<Pick<ComboboxProps, 'open' | 'inline'>> &
+  Pick<ComboboxProps, 'value'> &
   OptionCollectionState &
   SelectionState & {
     /* Option data for the currently highlighted option (not the selected option) */
@@ -98,8 +70,32 @@ export type ComboboxState = ComponentState<ComboboxSlots> &
     /* Unique id string that can be used as a base for default option ids */
     idBase: string;
 
+    /* The listbox child node */
+    listbox: React.ReactNode;
+
+    /* Ref to be used by the popup listbox */
+    popperContainerRef: React.MutableRefObject<HTMLDivElement>;
+
+    /* Ref to be used by the trigger */
+    triggerRef: React.RefObject<HTMLButtonElement>;
+
+    /* Callback when a the listbox is clicked, for internal use */
+    onListboxClick(): void;
+
+    /* Callback for the listbox mousedown event, for internal use */
+    onListboxMouseDown(): void;
+
     /* Callback when an option is clicked, for internal use */
     onOptionClick(event: React.MouseEvent, option: OptionValue): void;
+
+    /* Callback when the trigger is blurred, for internal use */
+    onTriggerBlur(event: React.FocusEvent<HTMLButtonElement>): void;
+
+    /* Callback when the trigger is clicked, for internal use */
+    onTriggerClick(event: React.MouseEvent<HTMLButtonElement>): void;
+
+    /* Callback for the trigger keydown event, for internal use */
+    onTriggerKeyDown(event: React.KeyboardEvent<HTMLButtonElement>): void;
   };
 
 export type ComboboxContextValues = {

--- a/packages/react-combobox/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react-combobox/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -4,35 +4,6 @@ exports[`Combobox renders a default state 1`] = `
 <div>
   <div
     class="fui-Combobox"
-  >
-    <div
-      class="fui-ComboButton fui-Combobox__trigger"
-    >
-      <button
-        aria-expanded="false"
-        class="fui-ComboButton__content"
-        role="combobox"
-        type="button"
-      >
-        <span
-          class="fui-ComboButton__expandIcon"
-        >
-          <svg
-            aria-hidden="true"
-            class=""
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 01-.78 0L4.15 8.35a.5.5 0 11.7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0z"
-            />
-          </svg>
-        </span>
-      </button>
-    </div>
-  </div>
+  />
 </div>
 `;

--- a/packages/react-combobox/src/components/Combobox/renderCombobox.tsx
+++ b/packages/react-combobox/src/components/Combobox/renderCombobox.tsx
@@ -10,13 +10,12 @@ import { ComboboxContext } from '../../contexts/ComboboxContext';
 export const renderCombobox_unstable = (state: ComboboxState, contextValues: ComboboxContextValues) => {
   const { slots, slotProps } = getSlots<ComboboxSlots>(state);
 
-  const listbox = <slots.listbox {...slotProps.listbox}>{slotProps.root.children}</slots.listbox>;
-  const popup = state.inline ? listbox : <Portal>{listbox}</Portal>;
+  const popup = state.inline ? state.listbox : <Portal>{state.listbox}</Portal>;
 
   return (
     <slots.root {...slotProps.root}>
       <ComboboxContext.Provider value={contextValues.combobox}>
-        <slots.trigger {...slotProps.trigger} />
+        {state.root.children}
         {state.open ? popup : null}
       </ComboboxContext.Provider>
     </slots.root>

--- a/packages/react-combobox/src/components/Combobox/useComboboxStyles.ts
+++ b/packages/react-combobox/src/components/Combobox/useComboboxStyles.ts
@@ -4,8 +4,6 @@ import type { ComboboxSlots, ComboboxState } from './Combobox.types';
 
 export const comboboxClassNames: SlotClassNames<ComboboxSlots> = {
   root: 'fui-Combobox',
-  listbox: 'fui-Combobox__listbox',
-  trigger: 'fui-Combobox__trigger',
 };
 
 /**
@@ -13,8 +11,6 @@ export const comboboxClassNames: SlotClassNames<ComboboxSlots> = {
  */
 const useStyles = makeStyles({
   root: {},
-  listbox: {},
-  trigger: {},
 });
 
 /**
@@ -23,8 +19,6 @@ const useStyles = makeStyles({
 export const useComboboxStyles_unstable = (state: ComboboxState): ComboboxState => {
   const styles = useStyles();
   state.root.className = mergeClasses(comboboxClassNames.root, styles.root, state.root.className);
-  state.listbox.className = mergeClasses(comboboxClassNames.listbox, styles.listbox, state.listbox.className);
-  state.trigger.className = mergeClasses(comboboxClassNames.trigger, styles.trigger, state.trigger.className);
 
   return state;
 };

--- a/packages/react-combobox/src/components/ComboboxInput/ComboboxInput.test.tsx
+++ b/packages/react-combobox/src/components/ComboboxInput/ComboboxInput.test.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { ComboboxInput } from './ComboboxInput';
+import { isConformant } from '../../common/isConformant';
+
+describe('ComboboxInput', () => {
+  isConformant({
+    Component: ComboboxInput,
+    displayName: 'ComboboxInput',
+    primarySlot: 'input',
+    // don't test deprecated className export on new components
+    disabledTests: ['component-has-static-classname-exported'],
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<ComboboxInput />);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-combobox/src/components/ComboboxInput/ComboboxInput.tsx
+++ b/packages/react-combobox/src/components/ComboboxInput/ComboboxInput.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useComboboxInput_unstable } from './useComboboxInput';
+import { renderComboboxInput_unstable } from './renderComboboxInput';
+import { useComboboxInputStyles_unstable } from './useComboboxInputStyles';
+import type { ComboboxInputProps } from './ComboboxInput.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * ComboboxInput component - TODO: add more docs
+ */
+export const ComboboxInput: ForwardRefComponent<ComboboxInputProps> = React.forwardRef((props, ref) => {
+  const state = useComboboxInput_unstable(props, ref);
+
+  useComboboxInputStyles_unstable(state);
+  return renderComboboxInput_unstable(state);
+});
+
+ComboboxInput.displayName = 'ComboboxInput';

--- a/packages/react-combobox/src/components/ComboboxInput/ComboboxInput.types.ts
+++ b/packages/react-combobox/src/components/ComboboxInput/ComboboxInput.types.ts
@@ -1,0 +1,19 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { InputProps, InputSlots, InputState } from '@fluentui/react-input';
+
+export type ComboboxInputSlots = Pick<InputSlots, 'root' | 'input'> & {
+  /* The dropdown arrow icon */
+  expandIcon: Slot<'span'>;
+};
+
+/**
+ * ComboboxInput Props
+ */
+export type ComboboxInputProps = Partial<ComponentProps<ComboboxInputSlots>> &
+  Omit<InputProps, 'contentBefore' | 'contentAfter'>;
+
+/**
+ * State used in rendering ComboboxInput
+ */
+export type ComboboxInputState = ComponentState<ComboboxInputSlots> &
+  Omit<InputState, 'components' | 'contentBefore' | 'contentAfter'>;

--- a/packages/react-combobox/src/components/ComboboxInput/index.ts
+++ b/packages/react-combobox/src/components/ComboboxInput/index.ts
@@ -1,0 +1,5 @@
+export * from './ComboboxInput';
+export * from './ComboboxInput.types';
+export * from './renderComboboxInput';
+export * from './useComboboxInput';
+export * from './useComboboxInputStyles';

--- a/packages/react-combobox/src/components/ComboboxInput/renderComboboxInput.tsx
+++ b/packages/react-combobox/src/components/ComboboxInput/renderComboboxInput.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { ComboboxInputState, ComboboxInputSlots } from './ComboboxInput.types';
+
+/**
+ * Render the final JSX of ComboboxInput
+ */
+export const renderComboboxInput_unstable = (state: ComboboxInputState) => {
+  const { slots, slotProps } = getSlots<ComboboxInputSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return (
+    <slots.root {...slotProps.root}>
+      <slots.input {...slotProps.input} />
+      <slots.expandIcon {...slotProps.expandIcon} />
+    </slots.root>
+  );
+};

--- a/packages/react-combobox/src/components/ComboboxInput/useComboboxInput.tsx
+++ b/packages/react-combobox/src/components/ComboboxInput/useComboboxInput.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { useContextSelector } from '@fluentui/react-context-selector';
+import { ChevronDownRegular as ChevronDownIcon } from '@fluentui/react-icons';
+import { useInput_unstable } from '@fluentui/react-input';
+import { resolveShorthand, useMergedRefs } from '@fluentui/react-utilities';
+import { ComboboxContext } from '../../contexts/ComboboxContext';
+import type { ComboboxInputProps, ComboboxInputState } from './ComboboxInput.types';
+
+/**
+ * Create the state required to render ComboboxInput.
+ *
+ * The returned state can be modified with hooks such as useComboboxInputStyles_unstable,
+ * before being passed to renderComboboxInput_unstable.
+ *
+ * @param props - props from this instance of ComboboxInput
+ * @param ref - reference to root HTMLElement of ComboboxInput
+ */
+export const useComboboxInput_unstable = (
+  props: ComboboxInputProps,
+  ref: React.Ref<HTMLInputElement>,
+): ComboboxInputState => {
+  // pull initial state from Input hook
+  const inputState = useInput_unstable(props, ref);
+
+  // combobox context values
+  const activeOption = useContextSelector(ComboboxContext, ctx => ctx.activeOption);
+  const open = useContextSelector(ComboboxContext, ctx => ctx.open);
+  const value = useContextSelector(ComboboxContext, ctx => ctx.value);
+  const contextOnBlur = useContextSelector(ComboboxContext, ctx => ctx.onTriggerBlur);
+  const contextOnClick = useContextSelector(ComboboxContext, ctx => ctx.onTriggerClick);
+  const contextOnKeyDown = useContextSelector(ComboboxContext, ctx => ctx.onTriggerKeyDown);
+  const contextRef = useContextSelector(ComboboxContext, ctx => ctx.triggerRef as React.RefObject<HTMLInputElement>);
+
+  const state: ComboboxInputState = {
+    ...inputState,
+    components: {
+      root: inputState.components.root,
+      input: inputState.components.input,
+      expandIcon: 'span',
+    },
+    expandIcon: resolveShorthand(props.expandIcon, {
+      required: true,
+      defaultProps: {
+        children: <ChevronDownIcon />,
+      },
+    }),
+    input: {
+      ...inputState.input,
+      ref: useMergedRefs(contextRef, inputState.input.ref || ref),
+      'aria-activedescendant': open ? activeOption?.id : undefined,
+      'aria-expanded': open,
+      role: inputState.input.role || 'combobox',
+      value: inputState.input.value || value,
+    },
+  };
+
+  state.input.onBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    contextOnBlur(event);
+    inputState.input.onBlur?.(event);
+  };
+
+  state.input.onClick = (event: React.MouseEvent<HTMLInputElement>) => {
+    contextOnClick(event);
+    inputState.input.onClick?.(event);
+  };
+
+  state.input.onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    contextOnKeyDown(event);
+    inputState.input.onKeyDown?.(event);
+  };
+
+  return state;
+};

--- a/packages/react-combobox/src/components/ComboboxInput/useComboboxInputStyles.ts
+++ b/packages/react-combobox/src/components/ComboboxInput/useComboboxInputStyles.ts
@@ -1,0 +1,60 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import { useInputStyles_unstable } from '@fluentui/react-input';
+import { tokens } from '@fluentui/react-theme';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import { iconSizes } from '../../utils/internalTokens';
+import type { ComboboxInputSlots, ComboboxInputState } from './ComboboxInput.types';
+
+export const comboboxInputClassNames: SlotClassNames<ComboboxInputSlots> = {
+  root: 'fui-ComboboxInput',
+  input: 'fui-ComboboxInput__input',
+  expandIcon: 'fui-ComboboxInput__expandIcon',
+};
+
+const useIconStyles = makeStyles({
+  icon: {
+    boxSizing: 'border-box',
+    color: tokens.colorNeutralStrokeAccessible,
+    display: 'block',
+    flexGrow: 0,
+    flexShrink: 0,
+    fontSize: tokens.fontSizeBase500,
+
+    // the SVG must have display: block for accurate positioning
+    // otherwise an extra inline space is inserted after the svg element
+    '& svg': {
+      display: 'block',
+    },
+  },
+
+  // icon size variants
+  small: {
+    fontSize: iconSizes.small,
+  },
+  medium: {
+    fontSize: iconSizes.medium,
+  },
+  large: {
+    fontSize: iconSizes.large,
+  },
+});
+
+/**
+ * Apply styling to the ComboboxInput slots based on the state
+ */
+export const useComboboxInputStyles_unstable = (state: ComboboxInputState): ComboboxInputState => {
+  const styledState = useInputStyles_unstable(state);
+
+  const iconStyles = useIconStyles();
+
+  if (state.expandIcon) {
+    styledState.expandIcon.className = mergeClasses(
+      comboboxInputClassNames.expandIcon,
+      iconStyles.icon,
+      iconStyles[state.size],
+      state.expandIcon.className,
+    );
+  }
+
+  return styledState;
+};

--- a/packages/react-combobox/src/contexts/ComboboxContext.ts
+++ b/packages/react-combobox/src/contexts/ComboboxContext.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createContext } from '@fluentui/react-context-selector';
 import { ComboboxState } from '../components/Combobox/Combobox.types';
 
@@ -6,20 +7,49 @@ import { ComboboxState } from '../components/Combobox/Combobox.types';
  */
 export type ComboboxContextValue = Pick<
   ComboboxState,
-  'activeOption' | 'appearance' | 'idBase' | 'onOptionClick' | 'open' | 'registerOption' | 'selectedOptions' | 'size'
+  | 'activeOption'
+  | 'idBase'
+  | 'onListboxClick'
+  | 'onListboxMouseDown'
+  | 'onOptionClick'
+  | 'onTriggerBlur'
+  | 'onTriggerClick'
+  | 'onTriggerKeyDown'
+  | 'open'
+  | 'popperContainerRef'
+  | 'registerOption'
+  | 'selectedOptions'
+  | 'triggerRef'
+  | 'value'
 >;
 
 export const ComboboxContext = createContext<ComboboxContextValue>({
   activeOption: undefined,
-  appearance: 'outline',
   idBase: '',
+  onListboxClick() {
+    // noop
+  },
+  onListboxMouseDown() {
+    // noop
+  },
   onOptionClick() {
     // noop
   },
+  onTriggerBlur() {
+    // noop
+  },
+  onTriggerClick() {
+    // noop
+  },
+  onTriggerKeyDown() {
+    // noop
+  },
   open: false,
+  popperContainerRef: ({ current: null } as unknown) as React.MutableRefObject<HTMLDivElement>,
   selectedOptions: [],
   registerOption() {
     // noop
   },
-  size: 'medium',
+  triggerRef: ({ current: null } as unknown) as React.RefObject<HTMLButtonElement>,
+  value: undefined,
 });

--- a/packages/react-combobox/src/contexts/useComboboxContextValues.ts
+++ b/packages/react-combobox/src/contexts/useComboboxContextValues.ts
@@ -1,17 +1,38 @@
 import { ComboboxContextValues, ComboboxState } from '../components/Combobox/Combobox.types';
 
 export function useComboboxContextValues(state: ComboboxState): ComboboxContextValues {
-  const { activeOption, appearance, idBase, onOptionClick, open, registerOption, selectedOptions, size } = state;
+  const {
+    activeOption,
+    idBase,
+    onListboxClick,
+    onListboxMouseDown,
+    onOptionClick,
+    onTriggerBlur,
+    onTriggerClick,
+    onTriggerKeyDown,
+    open,
+    popperContainerRef,
+    registerOption,
+    selectedOptions,
+    triggerRef,
+    value,
+  } = state;
 
   const combobox = {
     activeOption,
-    appearance,
     idBase,
     open,
+    onListboxClick,
+    onListboxMouseDown,
     onOptionClick,
+    onTriggerBlur,
+    onTriggerClick,
+    onTriggerKeyDown,
+    popperContainerRef,
     registerOption,
     selectedOptions,
-    size,
+    triggerRef,
+    value,
   };
 
   return { combobox };

--- a/packages/react-combobox/src/index.ts
+++ b/packages/react-combobox/src/index.ts
@@ -5,3 +5,4 @@ export * from './Option';
 export * from './Combobox';
 export * from './ComboButton';
 export * from './OptionGroup';
+export * from './ComboboxInput';

--- a/packages/react-combobox/src/stories/Combobox.stories.tsx
+++ b/packages/react-combobox/src/stories/Combobox.stories.tsx
@@ -5,6 +5,7 @@ import descriptionMd from './ComboboxDescription.md';
 import bestPracticesMd from './ComboboxBestPractices.md';
 
 export { Default } from './ComboboxDefault.stories';
+export { Editable } from './ComboboxEditable.stories';
 export { Multiselect } from './ComboboxMultiselect.stories';
 
 export default {

--- a/packages/react-combobox/src/stories/ComboboxDefault.stories.tsx
+++ b/packages/react-combobox/src/stories/ComboboxDefault.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useId } from '@fluentui/react-utilities';
-import { Combobox, ComboboxProps, Option } from '../index';
+import { ComboButton, Combobox, ComboboxProps, Listbox, Option } from '../index';
 
 export const Default = (props: Partial<ComboboxProps>) => {
   const comboId = useId('combo-default');
@@ -8,12 +8,15 @@ export const Default = (props: Partial<ComboboxProps>) => {
   return (
     <>
       <label id={comboId}>Best pet</label>
-      <Combobox aria-labelledby={comboId} placeholder="Select an animal" {...props}>
-        {options.map(option => (
-          <Option key={option} disabled={option === 'Ferret'}>
-            {option}
-          </Option>
-        ))}
+      <Combobox aria-labelledby={comboId} {...props}>
+        <ComboButton placeholder="Select an animal" />
+        <Listbox>
+          {options.map(option => (
+            <Option key={option} disabled={option === 'Ferret'}>
+              {option}
+            </Option>
+          ))}
+        </Listbox>
       </Combobox>
     </>
   );

--- a/packages/react-combobox/src/stories/ComboboxEditable.stories.tsx
+++ b/packages/react-combobox/src/stories/ComboboxEditable.stories.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { useId } from '@fluentui/react-utilities';
+import { Combobox, ComboboxInput, ComboboxProps, Listbox, Option } from '../index';
+
+export const Editable = (props: Partial<ComboboxProps>) => {
+  const comboId = useId('combo-default');
+  const options = ['Cat', 'Dog', 'Ferret', 'Fish', 'Hamster', 'Snake'];
+  return (
+    <>
+      <label id={comboId}>Best pet</label>
+      <Combobox aria-labelledby={comboId} {...props}>
+        <ComboboxInput placeholder="Select an animal" />
+        <Listbox>
+          {options.map(option => (
+            <Option key={option} disabled={option === 'Ferret'}>
+              {option}
+            </Option>
+          ))}
+        </Listbox>
+      </Combobox>
+    </>
+  );
+};

--- a/packages/react-combobox/src/stories/ComboboxMultiselect.stories.tsx
+++ b/packages/react-combobox/src/stories/ComboboxMultiselect.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useId } from '@fluentui/react-utilities';
-import { Combobox, ComboboxProps, Option } from '../index';
+import { ComboButton, Combobox, ComboboxProps, Listbox, Option } from '../index';
 
 export const Multiselect = (props: Partial<ComboboxProps>) => {
   const comboId = useId('combo-multi');
@@ -8,12 +8,15 @@ export const Multiselect = (props: Partial<ComboboxProps>) => {
   return (
     <>
       <label id={comboId}>Best pet</label>
-      <Combobox aria-labelledby={comboId} multiselect={true} placeholder="Select an animal" {...props}>
-        {options.map(option => (
-          <Option key={option} disabled={option === 'Ferret'}>
-            {option}
-          </Option>
-        ))}
+      <Combobox aria-labelledby={comboId} multiselect={true} {...props}>
+        <ComboButton placeholder="Select an animal" />
+        <Listbox>
+          {options.map(option => (
+            <Option key={option} disabled={option === 'Ferret'}>
+              {option}
+            </Option>
+          ))}
+        </Listbox>
       </Combobox>
     </>
   );

--- a/workspace.json
+++ b/workspace.json
@@ -317,7 +317,8 @@
       "root": "packages/react-combobox",
       "projectType": "library",
       "sourceRoot": "packages/react-combobox/src",
-      "tags": ["vNext", "platform:web"]
+      "tags": ["vNext", "platform:web"],
+      "implicitDependencies": []
     },
     "@fluentui/react-component-event-listener": {
       "root": "packages/fluentui/react-component-event-listener",


### PR DESCRIPTION
Draft! One of two options, together with #22906

Important note: this PR is for discussion only. If we go this route, I'll break up the changes into multiple smaller PRs for detailed review.

This shows a variation of Combobox that is authored with children rather than slots for the trigger and listbox. Editable vs. non-editable comboboxes are done by swapping out the child trigger:
```tsx
<Combobox {...props} value='Ferret'>
     <ComboButton appearance="outline" placeholder="Select an animal" />
     <Listbox>
       {options.map(option => (
         <Option key={option} disabled={option === 'Ferret'}>
           {option}
         </Option>
       ))}
     </Listbox>
</Combobox>
```
vs.
```tsx
<Combobox {...props} value='Ferret'>
     <ComboboxInput appearance="outline" placeholder="Select an animal" />
     <Listbox>
       {options.map(option => (
         <Option key={option} disabled={option === 'Ferret'}>
           {option}
         </Option>
       ))}
     </Listbox>
</Combobox>
```

There are some known type failures in ComboboxInput that will be ironed out if this option is chosen.

____

The alternative (from before this PR) would be to author editable vs. non-editable like this:

```tsx
<Combobox {...props} appearance="outline" value='Ferret'>
     {options.map(option => (
         <Option key={option} disabled={option === 'Ferret'}>
           {option}
         </Option>
       ))}
</Combobox>
```

vs.

```tsx
<Dropdown {...props} appearance="outline" value='Ferret'>
     {options.map(option => (
         <Option key={option} disabled={option === 'Ferret'}>
           {option}
         </Option>
       ))}
</Dropdown>
```
