### PR TITLE
Removing star exports from @fluentui/react-aria

### DIFF
--- a/change/@fluentui-react-aria-0f6b0cd4-dab6-46e2-b058-e2dba0b37f18.json
+++ b/change/@fluentui-react-aria-0f6b0cd4-dab6-46e2-b058-e2dba0b37f18.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-aria",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/src/index.ts
+++ b/packages/react-components/react-aria/src/index.ts
@@ -1,2 +1,3 @@
-export * from './hooks/index';
-export * from './utils/index';
+export { useARIAButton } from './hooks/index';
+export type { ARIAButtonSlotProps } from './hooks/index';
+export { mergeARIADisabled } from './utils/index';


### PR DESCRIPTION
## Current Behavior

`react-aria` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-aria` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

