### PR TITLE
Removing star exports from @fluentui/react-context-selector

### DIFF
--- a/change/@fluentui-react-context-selector-7537040f-fdc5-4767-af02-d8af6be7cfbe.json
+++ b/change/@fluentui-react-context-selector-7537040f-fdc5-4767-af02-d8af6be7cfbe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-context-selector/src/index.ts
+++ b/packages/react-components/react-context-selector/src/index.ts
@@ -1,4 +1,4 @@
 export { createContext } from './createContext';
 export { useContextSelector } from './useContextSelector';
 export { useHasParentContext } from './useHasParentContext';
-export * from './types';
+export type { Context, ContextSelector, ContextValue, ContextValues, ContextVersion } from './types';


### PR DESCRIPTION
## Current Behavior

`react-context-selector` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-context-selector` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

