### PR TITLE
react-radio: update context usage

### DIFF
--- a/change/@fluentui-react-radio-28f564dd-9c08-42ff-bda1-827bf93e7d58.json
+++ b/change/@fluentui-react-radio-28f564dd-9c08-42ff-bda1-827bf93e7d58.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "react-radio: update context usage",
+  "packageName": "@fluentui/react-radio",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-radio/etc/react-radio.api.md
+++ b/packages/react-radio/etc/react-radio.api.md
@@ -6,6 +6,7 @@
 
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
+import type { Context } from '@fluentui/react-context-selector';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { Label } from '@fluentui/react-label';
 import * as React_2 from 'react';
@@ -31,10 +32,15 @@ export const radioGroupClassName = "fui-RadioGroup";
 export const radioGroupClassNames: SlotClassNames<RadioGroupSlots>;
 
 // @public
-export const RadioGroupContext: React_2.Context<RadioGroupContextValue>;
+export const RadioGroupContext: Context<RadioGroupContextValue>;
 
 // @public (undocumented)
-export type RadioGroupContextValue = Pick<RadioGroupProps, 'name' | 'layout' | 'value' | 'defaultValue' | 'disabled'>;
+export type RadioGroupContextValue = Pick<RadioGroupProps, 'name' | 'value' | 'defaultValue' | 'disabled' | 'layout'>;
+
+// @public (undocumented)
+export type RadioGroupContextValues = {
+    radioGroup: RadioGroupContextValue;
+};
 
 // @public
 export type RadioGroupOnChangeData = {
@@ -57,9 +63,7 @@ export type RadioGroupSlots = {
 };
 
 // @public
-export type RadioGroupState = ComponentState<RadioGroupSlots> & Required<Pick<RadioGroupProps, 'layout'>> & {
-    context: RadioGroupContextValue;
-};
+export type RadioGroupState = ComponentState<RadioGroupSlots> & Required<Pick<RadioGroupProps, 'layout'>> & Partial<Exclude<RadioGroupProps, 'onChange' | 'layout'>>;
 
 // @public
 export type RadioOnChangeData = {
@@ -89,7 +93,7 @@ export type RadioState = ComponentState<RadioSlots> & Required<Pick<RadioProps, 
 export const renderRadio_unstable: (state: RadioState) => JSX.Element;
 
 // @public
-export const renderRadioGroup_unstable: (state: RadioGroupState) => JSX.Element;
+export const renderRadioGroup_unstable: (state: RadioGroupState, contextValues: RadioGroupContextValues) => JSX.Element;
 
 // @public
 export const useRadio_unstable: (props: RadioProps, ref: React_2.Ref<HTMLInputElement>) => RadioState;

--- a/packages/react-radio/package.json
+++ b/packages/react-radio/package.json
@@ -31,6 +31,7 @@
     "@fluentui/react-conformance-griffel": "9.0.0-beta.4"
   },
   "dependencies": {
+    "@fluentui/react-context-selector": "9.0.0-rc.6",
     "@fluentui/react-icons": "^2.0.166-rc.3",
     "@fluentui/react-label": "9.0.0-beta.10",
     "@fluentui/react-tabster": "9.0.0-rc.7",

--- a/packages/react-radio/src/components/Radio/useRadio.tsx
+++ b/packages/react-radio/src/components/Radio/useRadio.tsx
@@ -3,6 +3,7 @@ import { CircleFilled } from '@fluentui/react-icons';
 import { Label } from '@fluentui/react-label';
 import { getPartitionedNativeProps, resolveShorthand, useId, useMergedEventCallbacks } from '@fluentui/react-utilities';
 import { RadioGroupContext } from '../../contexts/RadioGroupContext';
+import { useContextSelector } from '@fluentui/react-context-selector';
 import type { RadioProps, RadioState } from './Radio.types';
 
 /**
@@ -15,14 +16,18 @@ import type { RadioProps, RadioState } from './Radio.types';
  * @param ref - reference to `<input>` element of Radio
  */
 export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLInputElement>): RadioState => {
-  const group = React.useContext(RadioGroupContext);
+  const nameGroup = useContextSelector(RadioGroupContext, ctx => ctx.name);
+  const value = useContextSelector(RadioGroupContext, ctx => ctx.value);
+  const defaultValue = useContextSelector(RadioGroupContext, ctx => ctx.defaultValue);
+  const disabledGroup = useContextSelector(RadioGroupContext, ctx => ctx.disabled);
+  const layout = useContextSelector(RadioGroupContext, ctx => ctx.layout);
 
   const {
-    name = group.name,
-    checked = group.value !== undefined ? group.value === props.value : undefined,
-    defaultChecked = group.defaultValue !== undefined ? group.defaultValue === props.value : undefined,
-    labelPosition = group.layout === 'horizontalStacked' ? 'below' : 'after',
-    disabled = group.disabled,
+    name = nameGroup,
+    checked = value !== undefined ? value === props.value : undefined,
+    defaultChecked = defaultValue !== undefined ? defaultValue === props.value : undefined,
+    labelPosition = layout === 'horizontalStacked' ? 'below' : 'after',
+    disabled = disabledGroup,
     onChange,
   } = props;
 

--- a/packages/react-radio/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react-radio/src/components/RadioGroup/RadioGroup.tsx
@@ -4,15 +4,17 @@ import { RadioGroupProps } from './RadioGroup.types';
 import { renderRadioGroup_unstable } from './renderRadioGroup';
 import { useRadioGroup_unstable } from './useRadioGroup';
 import { useRadioGroupStyles_unstable } from './useRadioGroupStyles';
+import { useRadioGroupContextValues } from '../../contexts/useRadioGroupContextValues';
 
 /**
  * A RadioGroup component presents a set of options where only one option can be selected.
  */
 export const RadioGroup: ForwardRefComponent<RadioGroupProps> = React.forwardRef((props, ref) => {
   const state = useRadioGroup_unstable(props, ref);
+  const contextValues = useRadioGroupContextValues(state);
 
   useRadioGroupStyles_unstable(state);
-  return renderRadioGroup_unstable(state);
+  return renderRadioGroup_unstable(state, contextValues);
 });
 
 RadioGroup.displayName = 'RadioGroup';

--- a/packages/react-radio/src/components/RadioGroup/RadioGroup.types.ts
+++ b/packages/react-radio/src/components/RadioGroup/RadioGroup.types.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import { RadioGroupContextValue } from '../../contexts/RadioGroupContext';
 
 export type RadioGroupSlots = {
   /**
@@ -39,7 +38,7 @@ export type RadioGroupProps = Omit<ComponentProps<Partial<RadioGroupSlots>>, 'on
   /**
    * How the radio items are laid out in the group.
    *
-   * @defaultvalue vertical
+   * @default vertical
    */
   layout?: 'vertical' | 'horizontal' | 'horizontalStacked';
 
@@ -63,6 +62,11 @@ export type RadioGroupOnChangeData = {
  * State used in rendering RadioGroup
  */
 export type RadioGroupState = ComponentState<RadioGroupSlots> &
-  Required<Pick<RadioGroupProps, 'layout'>> & {
-    context: RadioGroupContextValue;
-  };
+  Required<Pick<RadioGroupProps, 'layout'>> &
+  Partial<Exclude<RadioGroupProps, 'onChange' | 'layout'>>;
+
+export type RadioGroupContextValue = Pick<RadioGroupProps, 'name' | 'value' | 'defaultValue' | 'disabled' | 'layout'>;
+
+export type RadioGroupContextValues = {
+  radioGroup: RadioGroupContextValue;
+};

--- a/packages/react-radio/src/components/RadioGroup/renderRadioGroup.tsx
+++ b/packages/react-radio/src/components/RadioGroup/renderRadioGroup.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
 import { RadioGroupContext } from '../../contexts/RadioGroupContext';
-import { RadioGroupSlots, RadioGroupState } from './RadioGroup.types';
+import { RadioGroupContextValues, RadioGroupSlots, RadioGroupState } from './RadioGroup.types';
 
 /**
  * Render the final JSX of RadioGroup
  */
-export const renderRadioGroup_unstable = (state: RadioGroupState) => {
+export const renderRadioGroup_unstable = (state: RadioGroupState, contextValues: RadioGroupContextValues) => {
   const { slots, slotProps } = getSlots<RadioGroupSlots>(state);
 
   return (
-    <RadioGroupContext.Provider value={state.context}>
+    <RadioGroupContext.Provider value={contextValues.radioGroup}>
       <slots.root {...slotProps.root} />
     </RadioGroupContext.Provider>
   );

--- a/packages/react-radio/src/components/RadioGroup/useRadioGroup.ts
+++ b/packages/react-radio/src/components/RadioGroup/useRadioGroup.ts
@@ -18,16 +18,10 @@ export const useRadioGroup_unstable = (props: RadioGroupProps, ref: React.Ref<HT
 
   return {
     layout,
-    context: React.useMemo(
-      () => ({
-        name,
-        value,
-        defaultValue,
-        disabled,
-        layout,
-      }),
-      [name, layout, value, defaultValue, disabled],
-    ),
+    name,
+    value,
+    defaultValue,
+    disabled,
     components: {
       root: 'div',
     },

--- a/packages/react-radio/src/contexts/RadioGroupContext.ts
+++ b/packages/react-radio/src/contexts/RadioGroupContext.ts
@@ -1,9 +1,8 @@
-import * as React from 'react';
-import { RadioGroupProps } from '../RadioGroup';
-
-export type RadioGroupContextValue = Pick<RadioGroupProps, 'name' | 'layout' | 'value' | 'defaultValue' | 'disabled'>;
+import { createContext } from '@fluentui/react-context-selector';
+import type { Context } from '@fluentui/react-context-selector';
+import type { RadioGroupContextValue } from '../RadioGroup';
 
 /**
  * RadioGroupContext is provided by RadioGroup, and is consumed by Radio to determine default values of some props.
  */
-export const RadioGroupContext = React.createContext<RadioGroupContextValue>({});
+export const RadioGroupContext: Context<RadioGroupContextValue> = createContext({});

--- a/packages/react-radio/src/contexts/useRadioGroupContextValues.ts
+++ b/packages/react-radio/src/contexts/useRadioGroupContextValues.ts
@@ -1,0 +1,15 @@
+import type { RadioGroupContextValue, RadioGroupContextValues, RadioGroupState } from '../RadioGroup';
+
+export const useRadioGroupContextValues = (state: RadioGroupState): RadioGroupContextValues => {
+  const { name, value, defaultValue, disabled, layout } = state;
+
+  const radioGroup: RadioGroupContextValue = {
+    name,
+    value,
+    defaultValue,
+    disabled,
+    layout,
+  };
+
+  return { radioGroup };
+};

--- a/packages/react-radio/src/index.ts
+++ b/packages/react-radio/src/index.ts
@@ -8,12 +8,12 @@ export {
   useRadioGroup_unstable,
 } from './RadioGroup';
 export type {
+  RadioGroupContextValue,
+  RadioGroupContextValues,
   RadioGroupOnChangeData,
   RadioGroupProps,
   RadioGroupSlots,
   RadioGroupState,
-  RadioGroupContextValue,
-  RadioGroupContextValues,
 } from './RadioGroup';
 export {
   Radio,

--- a/packages/react-radio/src/index.ts
+++ b/packages/react-radio/src/index.ts
@@ -7,7 +7,14 @@ export {
   useRadioGroupStyles_unstable,
   useRadioGroup_unstable,
 } from './RadioGroup';
-export type { RadioGroupOnChangeData, RadioGroupProps, RadioGroupSlots, RadioGroupState } from './RadioGroup';
+export type {
+  RadioGroupOnChangeData,
+  RadioGroupProps,
+  RadioGroupSlots,
+  RadioGroupState,
+  RadioGroupContextValue,
+  RadioGroupContextValues,
+} from './RadioGroup';
 export {
   Radio,
   /* eslint-disable-next-line deprecation/deprecation */
@@ -19,4 +26,3 @@ export {
 } from './Radio';
 export type { RadioProps, RadioSlots, RadioState, RadioOnChangeData } from './Radio';
 export { RadioGroupContext } from './contexts/RadioGroupContext';
-export type { RadioGroupContextValue } from './contexts/RadioGroupContext';


### PR DESCRIPTION
## Current Behavior

`RadioGroup` passes context to its render function via state.

## New Behavior

Context is removed from `RadioGroup` state and passed into its render function as a separate object.

### Prior Art

- [Tablist](https://github.com/microsoft/fluentui/blob/master/packages/react-components/react-tabs/src/components/TabList/TabList.tsx#L17)

## Related Issue(s)

Fixes #22100
