### PR TITLE
Removing star exports from @fluentui/react-menu

### DIFF
--- a/change/@fluentui-react-menu-394468ee-99e0-459a-a148-34743656d75b.json
+++ b/change/@fluentui-react-menu-394468ee-99e0-459a-a148-34743656d75b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-menu",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/index.ts
+++ b/packages/react-components/react-menu/src/index.ts
@@ -1,18 +1,106 @@
-export * from './contexts/menuContext';
-export * from './contexts/menuTriggerContext';
-export * from './contexts/menuGroupContext';
-export * from './contexts/menuListContext';
+export { MenuContext, MenuProvider, useMenuContext_unstable } from './contexts/menuContext';
+export type { MenuContextValue } from './contexts/menuContext';
+export { MenuTriggerContextProvider, useMenuTriggerContext_unstable } from './contexts/menuTriggerContext';
+export { MenuGroupContextProvider, useMenuGroupContext_unstable } from './contexts/menuGroupContext';
+export type { MenuGroupContextValue } from './contexts/menuGroupContext';
+export { MenuListContext, MenuListProvider, useMenuListContext_unstable } from './contexts/menuListContext';
+export type { MenuListContextValue } from './contexts/menuListContext';
 
-export * from './Menu';
-export * from './MenuDivider';
-export * from './MenuGroup';
-export * from './MenuGroupHeader';
-export * from './MenuItem';
-export * from './MenuItemCheckbox';
-export * from './MenuItemRadio';
-export * from './MenuList';
-export * from './MenuPopover';
-export * from './MenuSplitGroup';
-export * from './MenuTrigger';
+export { Menu, renderMenu_unstable, useMenuContextValues_unstable, useMenu_unstable } from './Menu';
+export type { MenuContextValues, MenuOpenChangeData, MenuOpenEvents, MenuProps, MenuSlots, MenuState } from './Menu';
+export {
+  MenuDivider,
+  menuDividerClassName,
+  menuDividerClassNames,
+  renderMenuDivider_unstable,
+  useMenuDividerStyles_unstable,
+  useMenuDivider_unstable,
+} from './MenuDivider';
+export type { MenuDividerProps, MenuDividerSlots, MenuDividerState } from './MenuDivider';
+export {
+  MenuGroup,
+  menuGroupClassName,
+  menuGroupClassNames,
+  renderMenuGroup_unstable,
+  useMenuGroupContextValues_unstable,
+  useMenuGroupStyles_unstable,
+  useMenuGroup_unstable,
+} from './MenuGroup';
+export type { MenuGroupContextValues, MenuGroupProps, MenuGroupSlots, MenuGroupState } from './MenuGroup';
+export {
+  MenuGroupHeader,
+  menuGroupHeaderClassName,
+  menuGroupHeaderClassNames,
+  renderMenuGroupHeader_unstable,
+  useMenuGroupHeaderStyles_unstable,
+  useMenuGroupHeader_unstable,
+} from './MenuGroupHeader';
+export type { MenuGroupHeaderProps, MenuGroupHeaderSlots, MenuGroupHeaderState } from './MenuGroupHeader';
+export {
+  MenuItem,
+  menuItemClassName,
+  menuItemClassNames,
+  renderMenuItem_unstable,
+  useMenuItemStyles_unstable,
+  useMenuItem_unstable,
+} from './MenuItem';
+export type { MenuItemProps, MenuItemSlots, MenuItemState } from './MenuItem';
+export {
+  MenuItemCheckbox,
+  menuItemCheckboxClassName,
+  menuItemCheckboxClassNames,
+  renderMenuItemCheckbox_unstable,
+  useMenuItemCheckboxStyles_unstable,
+  useMenuItemCheckbox_unstable,
+} from './MenuItemCheckbox';
+export type { MenuItemCheckboxProps, MenuItemCheckboxState } from './MenuItemCheckbox';
+export {
+  MenuItemRadio,
+  menuItemRadioClassName,
+  menuItemRadioClassNames,
+  renderMenuItemRadio_unstable,
+  useMenuItemRadioStyles_unstable,
+  useMenuItemRadio_unstable,
+} from './MenuItemRadio';
+export type { MenuItemRadioProps, MenuItemRadioState } from './MenuItemRadio';
+export {
+  MenuList,
+  menuListClassName,
+  menuListClassNames,
+  renderMenuList_unstable,
+  useMenuListContextValues_unstable,
+  useMenuListStyles_unstable,
+  useMenuList_unstable,
+} from './MenuList';
+export type {
+  MenuCheckedValueChangeData,
+  MenuCheckedValueChangeEvent,
+  MenuListContextValues,
+  MenuListProps,
+  MenuListSlots,
+  MenuListState,
+  UninitializedMenuListState,
+} from './MenuList';
+export {
+  MenuPopover,
+  menuPopoverClassName,
+  menuPopoverClassNames,
+  renderMenuPopover_unstable,
+  useMenuPopoverStyles_unstable,
+  useMenuPopover_unstable,
+} from './MenuPopover';
+export type { MenuPopoverProps, MenuPopoverSlots, MenuPopoverState } from './MenuPopover';
+export {
+  MenuSplitGroup,
+  menuSplitGroupClassName,
+  menuSplitGroupClassNames,
+  renderMenuSplitGroup_unstable,
+  useMenuSplitGroupStyles_unstable,
+  useMenuSplitGroup_unstable,
+} from './MenuSplitGroup';
+export type { MenuSplitGroupProps, MenuSplitGroupSlots, MenuSplitGroupState } from './MenuSplitGroup';
+export { MenuTrigger, renderMenuTrigger_unstable, useMenuTrigger_unstable } from './MenuTrigger';
+export type { MenuTriggerChildProps, MenuTriggerProps, MenuTriggerState } from './MenuTrigger';
 
-export * from './selectable/index';
+export { useCheckmarkStyles_unstable } from './selectable/index';
+export type { MenuItemSelectableProps, MenuItemSelectableState, SelectableHandler } from './selectable/index';

--- a/packages/react-components/react-menu/src/index.ts
+++ b/packages/react-components/react-menu/src/index.ts
@@ -10,6 +10,7 @@ export { Menu, renderMenu_unstable, useMenuContextValues_unstable, useMenu_unsta
 export type { MenuContextValues, MenuOpenChangeData, MenuOpenEvents, MenuProps, MenuSlots, MenuState } from './Menu';
 export {
   MenuDivider,
+  // eslint-disable-next-line deprecation/deprecation
   menuDividerClassName,
   menuDividerClassNames,
   renderMenuDivider_unstable,
@@ -19,6 +20,7 @@ export {
 export type { MenuDividerProps, MenuDividerSlots, MenuDividerState } from './MenuDivider';
 export {
   MenuGroup,
+  // eslint-disable-next-line deprecation/deprecation
   menuGroupClassName,
   menuGroupClassNames,
   renderMenuGroup_unstable,
@@ -29,6 +31,7 @@ export {
 export type { MenuGroupContextValues, MenuGroupProps, MenuGroupSlots, MenuGroupState } from './MenuGroup';
 export {
   MenuGroupHeader,
+  // eslint-disable-next-line deprecation/deprecation
   menuGroupHeaderClassName,
   menuGroupHeaderClassNames,
   renderMenuGroupHeader_unstable,
@@ -38,6 +41,7 @@ export {
 export type { MenuGroupHeaderProps, MenuGroupHeaderSlots, MenuGroupHeaderState } from './MenuGroupHeader';
 export {
   MenuItem,
+  // eslint-disable-next-line deprecation/deprecation
   menuItemClassName,
   menuItemClassNames,
   renderMenuItem_unstable,
@@ -47,6 +51,7 @@ export {
 export type { MenuItemProps, MenuItemSlots, MenuItemState } from './MenuItem';
 export {
   MenuItemCheckbox,
+  // eslint-disable-next-line deprecation/deprecation
   menuItemCheckboxClassName,
   menuItemCheckboxClassNames,
   renderMenuItemCheckbox_unstable,
@@ -56,6 +61,7 @@ export {
 export type { MenuItemCheckboxProps, MenuItemCheckboxState } from './MenuItemCheckbox';
 export {
   MenuItemRadio,
+  // eslint-disable-next-line deprecation/deprecation
   menuItemRadioClassName,
   menuItemRadioClassNames,
   renderMenuItemRadio_unstable,
@@ -65,6 +71,7 @@ export {
 export type { MenuItemRadioProps, MenuItemRadioState } from './MenuItemRadio';
 export {
   MenuList,
+  // eslint-disable-next-line deprecation/deprecation
   menuListClassName,
   menuListClassNames,
   renderMenuList_unstable,
@@ -83,6 +90,7 @@ export type {
 } from './MenuList';
 export {
   MenuPopover,
+  // eslint-disable-next-line deprecation/deprecation
   menuPopoverClassName,
   menuPopoverClassNames,
   renderMenuPopover_unstable,
@@ -92,6 +100,7 @@ export {
 export type { MenuPopoverProps, MenuPopoverSlots, MenuPopoverState } from './MenuPopover';
 export {
   MenuSplitGroup,
+  // eslint-disable-next-line deprecation/deprecation
   menuSplitGroupClassName,
   menuSplitGroupClassNames,
   renderMenuSplitGroup_unstable,


### PR DESCRIPTION
## Current Behavior

`react-menu` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-menu` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

