### PR TITLE
Removing star exports from @fluentui/react-popover

### DIFF
--- a/change/@fluentui-react-popover-6cc52f6e-7bd8-43e4-8fb6-09c55835caaa.json
+++ b/change/@fluentui-react-popover-6cc52f6e-7bd8-43e4-8fb6-09c55835caaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-popover",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/src/index.ts
+++ b/packages/react-components/react-popover/src/index.ts
@@ -3,6 +3,7 @@ export type { OnOpenChangeData, OpenPopoverEvents, PopoverProps, PopoverSize, Po
 export {
   PopoverSurface,
   arrowHeights,
+  // eslint-disable-next-line deprecation/deprecation
   popoverSurfaceClassName,
   popoverSurfaceClassNames,
   renderPopoverSurface_unstable,

--- a/packages/react-components/react-popover/src/index.ts
+++ b/packages/react-components/react-popover/src/index.ts
@@ -1,4 +1,16 @@
-export * from './Popover';
-export * from './PopoverSurface';
-export * from './popoverContext';
-export * from './PopoverTrigger';
+export { Popover, renderPopover_unstable, usePopover_unstable } from './Popover';
+export type { OnOpenChangeData, OpenPopoverEvents, PopoverProps, PopoverSize, PopoverState } from './Popover';
+export {
+  PopoverSurface,
+  arrowHeights,
+  popoverSurfaceClassName,
+  popoverSurfaceClassNames,
+  renderPopoverSurface_unstable,
+  usePopoverSurfaceStyles_unstable,
+  usePopoverSurface_unstable,
+} from './PopoverSurface';
+export type { PopoverSurfaceProps, PopoverSurfaceSlots, PopoverSurfaceState } from './PopoverSurface';
+export { PopoverContext, usePopoverContext_unstable } from './popoverContext';
+export type { PopoverContextValue } from './popoverContext';
+export { PopoverTrigger, renderPopoverTrigger_unstable, usePopoverTrigger_unstable } from './PopoverTrigger';
+export type { PopoverTriggerChildProps, PopoverTriggerProps, PopoverTriggerState } from './PopoverTrigger';


### PR DESCRIPTION
## Current Behavior

`react-popover` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-popover` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

