### PR TITLE
Removing star exports from @fluentui/react-portal

### DIFF
--- a/change/@fluentui-react-portal-eb79eb2d-3fec-4001-b4a7-145f781fbaa7.json
+++ b/change/@fluentui-react-portal-eb79eb2d-3fec-4001-b4a7-145f781fbaa7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-portal",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-portal/src/index.ts
+++ b/packages/react-components/react-portal/src/index.ts
@@ -1,2 +1,3 @@
-export * from './components/Portal/index';
+export { Portal, renderPortal_unstable, usePortal_unstable } from './components/Portal/index';
+export type { PortalProps, PortalState } from './components/Portal/index';
 export { elementContains, setVirtualParent } from './virtualParent/index';


### PR DESCRIPTION
## Current Behavior

`react-portal` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-portal` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

