### PR TITLE
Removing star exports from @fluentui/react-positioning

### DIFF
--- a/change/@fluentui-react-positioning-1c708a83-6c21-43a5-a086-d7efcede45ee.json
+++ b/change/@fluentui-react-positioning-1c708a83-6c21-43a5-a086-d7efcede45ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-positioning",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/index.ts
+++ b/packages/react-components/react-positioning/src/index.ts
@@ -1,6 +1,21 @@
-export * from './createVirtualElementFromClick';
-export * from './createArrowStyles';
-export * from './usePopper';
-export * from './usePopperMouseTarget';
+export { createVirtualElementFromClick } from './createVirtualElementFromClick';
+export { createArrowHeightStyles, createArrowStyles } from './createArrowStyles';
+export type { CreateArrowStylesOptions } from './createArrowStyles';
+export { usePopper } from './usePopper';
+export { usePopperMouseTarget } from './usePopperMouseTarget';
 export { resolvePositioningShorthand, mergeArrowOffset } from './utils/index';
-export * from './types';
+export type {
+  Alignment,
+  AutoSize,
+  Boundary,
+  Offset,
+  OffsetFunction,
+  OffsetFunctionParam,
+  PopperOptions,
+  PopperRefHandle,
+  PopperVirtualElement,
+  Position,
+  PositioningProps,
+  PositioningShorthand,
+  PositioningShorthandValue,
+} from './types';


### PR DESCRIPTION
## Current Behavior

`react-positioning` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-positioning` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

