### PR TITLE
Removing star exports from @fluentui/react-shared-contexts

### DIFF
--- a/change/@fluentui-react-shared-contexts-f4ca11af-26f3-4154-aaaf-80a1429661ac.json
+++ b/change/@fluentui-react-shared-contexts-f4ca11af-26f3-4154-aaaf-80a1429661ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-shared-contexts/src/index.ts
+++ b/packages/react-shared-contexts/src/index.ts
@@ -1,5 +1,9 @@
-export * from './MenuContext';
-export * from './ThemeContext';
-export * from './ThemeClassNameContext';
-export * from './TooltipContext';
-export * from './ProviderContext';
+export { MenuContext, useMenuContext } from './MenuContext';
+export type { MinimalMenuProps } from './MenuContext';
+export { ThemeContext, useTheme } from './ThemeContext';
+export { ThemeClassNameContext, useThemeClassName } from './ThemeClassNameContext';
+export type { ThemeClassNameContextValue } from './ThemeClassNameContext';
+export { TooltipContext } from './TooltipContext';
+export type { TooltipContextType } from './TooltipContext';
+export { ProviderContext, useFluent } from './ProviderContext';
+export type { ProviderContextValue } from './ProviderContext';


### PR DESCRIPTION
## Current Behavior

`react-shared-contexts` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-shared-contexts` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

