### PR TITLE
Radio: Add `required` prop to `RadioGroup`

### DIFF
--- a/change/@fluentui-react-radio-a22e2729-5ad0-485c-b919-8e7284539d2d.json
+++ b/change/@fluentui-react-radio-a22e2729-5ad0-485c-b919-8e7284539d2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "react-radio: add required prop to RadioGroup",
+  "packageName": "@fluentui/react-radio",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-radio/etc/react-radio.api.md
+++ b/packages/react-radio/etc/react-radio.api.md
@@ -35,7 +35,7 @@ export const radioGroupClassNames: SlotClassNames<RadioGroupSlots>;
 export const RadioGroupContext: Context<RadioGroupContextValue>;
 
 // @public (undocumented)
-export type RadioGroupContextValue = Pick<RadioGroupProps, 'name' | 'value' | 'defaultValue' | 'disabled' | 'layout'>;
+export type RadioGroupContextValue = Pick<RadioGroupProps, 'name' | 'value' | 'defaultValue' | 'disabled' | 'layout' | 'required'>;
 
 // @public (undocumented)
 export type RadioGroupContextValues = {
@@ -55,6 +55,7 @@ export type RadioGroupProps = Omit<ComponentProps<Partial<RadioGroupSlots>>, 'on
     onChange?: (ev: React_2.FormEvent<HTMLDivElement>, data: RadioGroupOnChangeData) => void;
     layout?: 'vertical' | 'horizontal' | 'horizontalStacked';
     disabled?: boolean;
+    required?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-radio/src/components/Radio/useRadio.tsx
+++ b/packages/react-radio/src/components/Radio/useRadio.tsx
@@ -21,6 +21,7 @@ export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLInputEle
   const defaultValue = useContextSelector(RadioGroupContext, ctx => ctx.defaultValue);
   const disabledGroup = useContextSelector(RadioGroupContext, ctx => ctx.disabled);
   const layout = useContextSelector(RadioGroupContext, ctx => ctx.layout);
+  const requiredGroup = useContextSelector(RadioGroupContext, ctx => ctx.required);
 
   const {
     name = nameGroup,
@@ -28,6 +29,7 @@ export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLInputEle
     defaultChecked = defaultValue !== undefined ? defaultValue === props.value : undefined,
     labelPosition = layout === 'horizontalStacked' ? 'below' : 'after',
     disabled = disabledGroup,
+    required = requiredGroup,
     onChange,
   } = props;
 
@@ -52,6 +54,7 @@ export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLInputEle
       checked,
       defaultChecked,
       disabled,
+      required,
       ...nativeProps.primary,
     },
   });

--- a/packages/react-radio/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/packages/react-radio/src/components/RadioGroup/RadioGroup.test.tsx
@@ -72,6 +72,20 @@ describe('RadioGroup', () => {
     expect(items[2].disabled).toBe(true);
   });
 
+  it('applies required to every radio item', () => {
+    const { getAllByRole } = render(
+      <RadioGroup required>
+        <Radio />
+        <Radio />
+        <Radio />
+      </RadioGroup>,
+    );
+    const items = getAllByRole('radio') as HTMLInputElement[];
+    expect(items[0].required).toBe(true);
+    expect(items[1].required).toBe(true);
+    expect(items[2].required).toBe(true);
+  });
+
   it('has no radio item selected by default', () => {
     const { getByDisplayValue } = render(
       <RadioGroup>

--- a/packages/react-radio/src/components/RadioGroup/RadioGroup.types.ts
+++ b/packages/react-radio/src/components/RadioGroup/RadioGroup.types.ts
@@ -46,6 +46,11 @@ export type RadioGroupProps = Omit<ComponentProps<Partial<RadioGroupSlots>>, 'on
    * Disable all Radio items in this group.
    */
   disabled?: boolean;
+
+  /**
+   * Require all Radio items in this group.
+   */
+  required?: boolean;
 };
 
 /**
@@ -65,7 +70,10 @@ export type RadioGroupState = ComponentState<RadioGroupSlots> &
   Required<Pick<RadioGroupProps, 'layout'>> &
   Partial<Exclude<RadioGroupProps, 'onChange' | 'layout'>>;
 
-export type RadioGroupContextValue = Pick<RadioGroupProps, 'name' | 'value' | 'defaultValue' | 'disabled' | 'layout'>;
+export type RadioGroupContextValue = Pick<
+  RadioGroupProps,
+  'name' | 'value' | 'defaultValue' | 'disabled' | 'layout' | 'required'
+>;
 
 export type RadioGroupContextValues = {
   radioGroup: RadioGroupContextValue;

--- a/packages/react-radio/src/components/RadioGroup/useRadioGroup.ts
+++ b/packages/react-radio/src/components/RadioGroup/useRadioGroup.ts
@@ -14,7 +14,7 @@ import { RadioGroupProps, RadioGroupState } from './RadioGroup.types';
 export const useRadioGroup_unstable = (props: RadioGroupProps, ref: React.Ref<HTMLDivElement>): RadioGroupState => {
   const generatedName = useId('radiogroup-');
 
-  const { name = generatedName, value, defaultValue, disabled, layout = 'vertical', onChange } = props;
+  const { name = generatedName, value, defaultValue, disabled, layout = 'vertical', onChange, required } = props;
 
   return {
     layout,
@@ -22,6 +22,7 @@ export const useRadioGroup_unstable = (props: RadioGroupProps, ref: React.Ref<HT
     value,
     defaultValue,
     disabled,
+    required,
     components: {
       root: 'div',
     },

--- a/packages/react-radio/src/contexts/useRadioGroupContextValues.ts
+++ b/packages/react-radio/src/contexts/useRadioGroupContextValues.ts
@@ -1,7 +1,7 @@
 import type { RadioGroupContextValue, RadioGroupContextValues, RadioGroupState } from '../RadioGroup';
 
 export const useRadioGroupContextValues = (state: RadioGroupState): RadioGroupContextValues => {
-  const { name, value, defaultValue, disabled, layout } = state;
+  const { name, value, defaultValue, disabled, layout, required } = state;
 
   const radioGroup: RadioGroupContextValue = {
     name,
@@ -9,6 +9,7 @@ export const useRadioGroupContextValues = (state: RadioGroupState): RadioGroupCo
     defaultValue,
     disabled,
     layout,
+    required,
   };
 
   return { radioGroup };

--- a/packages/react-radio/src/stories/RadioGroupRequired.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroupRequired.stories.tsx
@@ -10,11 +10,11 @@ export const Required = () => {
       <Label id={labelId} required>
         Favorite Fruit
       </Label>
-      <RadioGroup aria-labelledby={labelId}>
-        <Radio value="apple" label="Apple" required />
-        <Radio value="pear" label="Pear" required />
-        <Radio value="banana" label="Banana" required />
-        <Radio value="orange" label="Orange" required />
+      <RadioGroup aria-labelledby={labelId} required>
+        <Radio value="apple" label="Apple" />
+        <Radio value="pear" label="Pear" />
+        <Radio value="banana" label="Banana" />
+        <Radio value="orange" label="Orange" />
       </RadioGroup>
     </div>
   );
@@ -22,7 +22,7 @@ export const Required = () => {
 Required.parameters = {
   docs: {
     description: {
-      story: 'Use the `required` prop on every `Radio` child of a `RadioGroup` to make the group as required.',
+      story: 'Use the `required` prop on `RadioGroup` to make all child `Radio`s required.',
     },
   },
 };


### PR DESCRIPTION
## Current Behavior

`RadioGroup` lacks a `required` prop so each individual child `Radio` must set its `required` prop to make a group required.

## New Behavior

`RadioGroup` has a `required` prop that is passed down to all child `Radio`s via context.

## Related Issue(s)

Fixes #22766
