### PR TITLE
Removing star exports from @fluentui/react-theme

### DIFF
--- a/change/@fluentui-react-theme-8b4f6828-3b50-4af4-bb43-73b2ce6b3090.json
+++ b/change/@fluentui-react-theme-8b4f6828-3b50-4af4-bb43-73b2ce6b3090.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing star exports.",
+  "packageName": "@fluentui/react-theme",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-theme/src/index.ts
+++ b/packages/react-components/react-theme/src/index.ts
@@ -1,5 +1,12 @@
-export * from './themes/index';
-export * from './utils/index';
+export {
+  teamsDarkTheme,
+  teamsHighContrastTheme,
+  teamsLightTheme,
+  webDarkTheme,
+  webHighContrastTheme,
+  webLightTheme,
+} from './themes/index';
+export { createDarkTheme, createHighContrastTheme, createLightTheme, createTeamsDarkTheme } from './utils/index';
 
 export { themeToTokensObject } from './themeToTokensObject';
 export { tokens } from './tokens';


### PR DESCRIPTION
## Current Behavior

`react-theme` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-theme` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

