### PR TITLE
Removing star exports from @fluentui/react-select

### DIFF
--- a/packages/react-components/react-select/src/index.ts
+++ b/packages/react-components/react-select/src/index.ts
@@ -1,6 +1,7 @@
 export {
   Select,
   renderSelect_unstable,
+  // eslint-disable-next-line deprecation/deprecation
   selectClassName,
   selectClassNames,
   useSelectStyles_unstable,

--- a/packages/react-components/react-select/src/index.ts
+++ b/packages/react-components/react-select/src/index.ts
@@ -1,1 +1,9 @@
-export * from './Select';
+export {
+  Select,
+  renderSelect_unstable,
+  selectClassName,
+  selectClassNames,
+  useSelectStyles_unstable,
+  useSelect_unstable,
+} from './Select';
+export type { SelectCommons, SelectProps, SelectSlots, SelectState } from './Select';


### PR DESCRIPTION
## Current Behavior

`react-select` has `export * from ...` in `src/index.ts`.

## New Behavior

`react-select` has explicitly named exports in `src/index.ts`.

## Related Issue(s)

#22099

