### PR TITLE
Fix docs page layout and reduce size of button on small screens

### DIFF
--- a/.storybook/docs-root.css
+++ b/.storybook/docs-root.css
@@ -156,6 +156,16 @@
   border-radius: 5px 5px 0px 0px !important;
 }
 
+/* Reduce font size of CodeSandbox and Show Code button when zoomed or small window width*/
+/* https://github.com/microsoft/fluentui/issues/22764 */
+
+@media screen and (max-width: 380px) {
+  #docs-root .docblock-code-toggle,
+  .docs-story > a:last-child {
+    font-size: 10px !important;
+  }
+}
+
 /* Make storybook-addon-export-to-codesandbox button match Figma design */
 .docs-story > a:last-child {
   right: 105px !important;

--- a/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
@@ -32,6 +32,8 @@ const useStyles = makeStyles({
     },
   },
   container: {
+    // without a width, this div grows wider than its parent
+    width: '200px',
     flexGrow: 1,
   },
 });


### PR DESCRIPTION
Fixes #22764

![image](https://user-images.githubusercontent.com/1434956/166576868-a5c5c41d-9844-4972-9b0d-54e9a91422ea.png)


After https://github.com/microsoft/fluentui-storybook-addons/pull/16 is merged we can go back through the CSS file and use the classname rather than the longer compound selector

Work tracked in https://github.com/microsoft/fluentui/issues/22884
