### PR TITLE
Switch: Fixing disabled styles in high contrast mode

### DIFF
--- a/change/@fluentui-react-switch-6e25e7c6-b270-4622-bd00-745aab81504f.json
+++ b/change/@fluentui-react-switch-6e25e7c6-b270-4622-bd00-745aab81504f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Switch: Fixing disabled styles in high contrast mode.",
+  "packageName": "@fluentui/react-switch",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -178,6 +178,21 @@ const useInputStyles = makeStyles({
       },
     },
   },
+
+  highContrast: {
+    '@media (forced-colors: active)': {
+      ':disabled': {
+        [`& ~ .${switchClassNames.indicator}`]: {
+          color: 'GrayText',
+          ...shorthands.borderColor('GrayText'),
+        },
+
+        [`& ~ .${switchClassNames.label}`]: {
+          color: 'GrayText',
+        },
+      },
+    },
+  },
 });
 
 const useLabelStyles = makeStyles({
@@ -206,7 +221,12 @@ export const useSwitchStyles_unstable = (state: SwitchState): SwitchState => {
 
   state.indicator.className = mergeClasses(switchClassNames.indicator, indicatorStyles.base, state.indicator.className);
 
-  state.input.className = mergeClasses(switchClassNames.input, inputStyles.base, state.input.className);
+  state.input.className = mergeClasses(
+    switchClassNames.input,
+    inputStyles.base,
+    inputStyles.highContrast,
+    state.input.className,
+  );
 
   if (state.label) {
     state.label.className = mergeClasses(switchClassNames.label, labelStyles.base, state.label.className);


### PR DESCRIPTION
## Current Behavior

Disabled `Switches` are indistinguishable from enabled ones in High Contrast mode:

![image](https://user-images.githubusercontent.com/7798177/166587411-01497fb3-5965-4811-9f20-4f47801e240e.png)

## New Behavior

Disabled `Switches` are styled using `GrayText` so they are immediately distinguishable from enabled ones in High Contrast mode:

![image](https://user-images.githubusercontent.com/7798177/166604478-3c403a97-9699-4429-a7f9-70eb2788eda3.png)

## Related Issue(s)

Fixes #22815
