### PR TITLE
Radio and RadioGroup: Move to Release Candidate

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -33,7 +33,7 @@
     "@fluentui/react-popover": "9.0.0-rc.8",
     "@fluentui/react-positioning": "9.0.0-rc.7",
     "@fluentui/react-provider": "9.0.0-rc.8",
-    "@fluentui/react-radio": "9.0.0-beta.5",
+    "@fluentui/react-radio": "9.0.0-rc.1",
     "@fluentui/react-shared-contexts": "9.0.0-rc.6",
     "@fluentui/react-slider": "9.0.0-beta.13",
     "@fluentui/react-spinner": "9.0.0-beta.8",

--- a/change/@fluentui-react-components-6a2426f9-9054-47fa-98c0-88d7bc0e2992.json
+++ b/change/@fluentui-react-components-6a2426f9-9054-47fa-98c0-88d7bc0e2992.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "react-radio: move to release candidate",
+  "packageName": "@fluentui/react-components",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-de2c632e-259d-43ad-89cf-564df759b82b.json
+++ b/change/@fluentui-react-radio-de2c632e-259d-43ad-89cf-564df759b82b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update README",
+  "packageName": "@fluentui/react-radio",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -261,6 +261,23 @@ import { presenceBadgeClassNames } from '@fluentui/react-badge';
 import { PresenceBadgeProps } from '@fluentui/react-badge';
 import { PresenceBadgeState } from '@fluentui/react-badge';
 import { PresenceBadgeStatus } from '@fluentui/react-badge';
+import { Radio } from '@fluentui/react-radio';
+import { radioClassName } from '@fluentui/react-radio';
+import { radioClassNames } from '@fluentui/react-radio';
+import { RadioGroup } from '@fluentui/react-radio';
+import { radioGroupClassName } from '@fluentui/react-radio';
+import { radioGroupClassNames } from '@fluentui/react-radio';
+import { RadioGroupContext } from '@fluentui/react-radio';
+import { RadioGroupContextValue } from '@fluentui/react-radio';
+import { RadioGroupContextValues } from '@fluentui/react-radio';
+import { RadioGroupOnChangeData } from '@fluentui/react-radio';
+import { RadioGroupProps } from '@fluentui/react-radio';
+import { RadioGroupSlots } from '@fluentui/react-radio';
+import { RadioGroupState } from '@fluentui/react-radio';
+import { RadioOnChangeData } from '@fluentui/react-radio';
+import { RadioProps } from '@fluentui/react-radio';
+import { RadioSlots } from '@fluentui/react-radio';
+import { RadioState } from '@fluentui/react-radio';
 import { renderAccordion_unstable } from '@fluentui/react-accordion';
 import { renderAccordionHeader_unstable } from '@fluentui/react-accordion';
 import { renderAccordionItem_unstable } from '@fluentui/react-accordion';
@@ -290,6 +307,8 @@ import { renderPopover_unstable } from '@fluentui/react-popover';
 import { renderPopoverSurface_unstable } from '@fluentui/react-popover';
 import { renderPopoverTrigger_unstable } from '@fluentui/react-popover';
 import { renderPortal_unstable } from '@fluentui/react-portal';
+import { renderRadio_unstable } from '@fluentui/react-radio';
+import { renderRadioGroup_unstable } from '@fluentui/react-radio';
 import { renderSlider_unstable } from '@fluentui/react-slider';
 import { renderSplitButton_unstable } from '@fluentui/react-button';
 import { renderText_unstable } from '@fluentui/react-text';
@@ -443,6 +462,11 @@ import { usePopoverSurfaceStyles_unstable } from '@fluentui/react-popover';
 import { usePopoverTrigger_unstable } from '@fluentui/react-popover';
 import { usePortal_unstable } from '@fluentui/react-portal';
 import { usePresenceBadge_unstable } from '@fluentui/react-badge';
+import { useRadio_unstable } from '@fluentui/react-radio';
+import { useRadioGroup_unstable } from '@fluentui/react-radio';
+import { useRadioGroupContextValues } from '@fluentui/react-radio';
+import { useRadioGroupStyles_unstable } from '@fluentui/react-radio';
+import { useRadioStyles_unstable } from '@fluentui/react-radio';
 import { useSlider_unstable } from '@fluentui/react-slider';
 import { useSliderState_unstable } from '@fluentui/react-slider';
 import { useSliderStyles_unstable } from '@fluentui/react-slider';
@@ -976,6 +1000,40 @@ export { PresenceBadgeState }
 
 export { PresenceBadgeStatus }
 
+export { Radio }
+
+export { radioClassName }
+
+export { radioClassNames }
+
+export { RadioGroup }
+
+export { radioGroupClassName }
+
+export { radioGroupClassNames }
+
+export { RadioGroupContext }
+
+export { RadioGroupContextValue }
+
+export { RadioGroupContextValues }
+
+export { RadioGroupOnChangeData }
+
+export { RadioGroupProps }
+
+export { RadioGroupSlots }
+
+export { RadioGroupState }
+
+export { RadioOnChangeData }
+
+export { RadioProps }
+
+export { RadioSlots }
+
+export { RadioState }
+
 export { renderAccordion_unstable }
 
 export { renderAccordionHeader_unstable }
@@ -1033,6 +1091,10 @@ export { renderPopoverSurface_unstable }
 export { renderPopoverTrigger_unstable }
 
 export { renderPortal_unstable }
+
+export { renderRadio_unstable }
+
+export { renderRadioGroup_unstable }
 
 export { renderSlider_unstable }
 
@@ -1339,6 +1401,16 @@ export { usePopoverTrigger_unstable }
 export { usePortal_unstable }
 
 export { usePresenceBadge_unstable }
+
+export { useRadio_unstable }
+
+export { useRadioGroup_unstable }
+
+export { useRadioGroupContextValues }
+
+export { useRadioGroupStyles_unstable }
+
+export { useRadioStyles_unstable }
 
 export { useSlider_unstable }
 

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -48,19 +48,6 @@ import { labelClassNames } from '@fluentui/react-label';
 import { LabelProps } from '@fluentui/react-label';
 import { LabelSlots } from '@fluentui/react-label';
 import { LabelState } from '@fluentui/react-label';
-import { Radio } from '@fluentui/react-radio';
-import { radioClassName } from '@fluentui/react-radio';
-import { radioClassNames } from '@fluentui/react-radio';
-import { RadioGroup } from '@fluentui/react-radio';
-import { radioGroupClassName } from '@fluentui/react-radio';
-import { radioGroupClassNames } from '@fluentui/react-radio';
-import { RadioGroupOnChangeData } from '@fluentui/react-radio';
-import { RadioGroupProps } from '@fluentui/react-radio';
-import { RadioGroupSlots } from '@fluentui/react-radio';
-import { RadioGroupState } from '@fluentui/react-radio';
-import { RadioProps } from '@fluentui/react-radio';
-import { RadioSlots } from '@fluentui/react-radio';
-import { RadioState } from '@fluentui/react-radio';
 import { RegisterTabEventHandler } from '@fluentui/react-tabs';
 import { renderCard_unstable } from '@fluentui/react-card';
 import { renderCardFooter_unstable } from '@fluentui/react-card';
@@ -69,8 +56,6 @@ import { renderCardPreview_unstable } from '@fluentui/react-card';
 import { renderCheckbox_unstable } from '@fluentui/react-checkbox';
 import { renderInput_unstable } from '@fluentui/react-input';
 import { renderLabel_unstable } from '@fluentui/react-label';
-import { renderRadio_unstable } from '@fluentui/react-radio';
-import { renderRadioGroup_unstable } from '@fluentui/react-radio';
 import { renderSpinButton_unstable } from '@fluentui/react-spinbutton';
 import { renderSpinner_unstable } from '@fluentui/react-spinner';
 import { renderSwitch_unstable } from '@fluentui/react-switch';
@@ -136,10 +121,6 @@ import { useInput_unstable } from '@fluentui/react-input';
 import { useInputStyles_unstable } from '@fluentui/react-input';
 import { useLabel_unstable } from '@fluentui/react-label';
 import { useLabelStyles_unstable } from '@fluentui/react-label';
-import { useRadio_unstable } from '@fluentui/react-radio';
-import { useRadioGroup_unstable } from '@fluentui/react-radio';
-import { useRadioGroupStyles_unstable } from '@fluentui/react-radio';
-import { useRadioStyles_unstable } from '@fluentui/react-radio';
 import { useSpinButton_unstable } from '@fluentui/react-spinbutton';
 import { useSpinButtonStyles_unstable } from '@fluentui/react-spinbutton';
 import { useSpinner_unstable } from '@fluentui/react-spinner';
@@ -241,32 +222,6 @@ export { LabelSlots }
 
 export { LabelState }
 
-export { Radio }
-
-export { radioClassName }
-
-export { radioClassNames }
-
-export { RadioGroup }
-
-export { radioGroupClassName }
-
-export { radioGroupClassNames }
-
-export { RadioGroupOnChangeData }
-
-export { RadioGroupProps }
-
-export { RadioGroupSlots }
-
-export { RadioGroupState }
-
-export { RadioProps }
-
-export { RadioSlots }
-
-export { RadioState }
-
 export { RegisterTabEventHandler }
 
 export { renderCard_unstable }
@@ -282,10 +237,6 @@ export { renderCheckbox_unstable }
 export { renderInput_unstable }
 
 export { renderLabel_unstable }
-
-export { renderRadio_unstable }
-
-export { renderRadioGroup_unstable }
 
 export { renderSpinButton_unstable }
 
@@ -416,14 +367,6 @@ export { useInputStyles_unstable }
 export { useLabel_unstable }
 
 export { useLabelStyles_unstable }
-
-export { useRadio_unstable }
-
-export { useRadioGroup_unstable }
-
-export { useRadioGroupStyles_unstable }
-
-export { useRadioStyles_unstable }
 
 export { useSpinButton_unstable }
 

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -47,7 +47,7 @@
     "@fluentui/react-positioning": "9.0.0-rc.7",
     "@fluentui/react-portal": "9.0.0-rc.8",
     "@fluentui/react-provider": "9.0.0-rc.8",
-    "@fluentui/react-radio": "9.0.0-beta.5",
+    "@fluentui/react-radio": "9.0.0-rc.1",
     "@fluentui/react-shared-contexts": "9.0.0-rc.6",
     "@fluentui/react-slider": "9.0.0-beta.13",
     "@fluentui/react-spinbutton": "9.0.0-beta.8",

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -27,6 +27,36 @@ export type {
   FluentProviderState,
 } from '@fluentui/react-provider';
 export {
+  Radio,
+  /* eslint-disable-next-line deprecation/deprecation */
+  radioClassName,
+  radioClassNames,
+  RadioGroup,
+  /* eslint-disable-next-line deprecation/deprecation */
+  radioGroupClassName,
+  radioGroupClassNames,
+  RadioGroupContext,
+  renderRadio_unstable,
+  renderRadioGroup_unstable,
+  useRadio_unstable,
+  useRadioGroupContextValues,
+  useRadioGroup_unstable,
+  useRadioGroupStyles_unstable,
+  useRadioStyles_unstable,
+} from '@fluentui/react-radio';
+export type {
+  RadioGroupContextValue,
+  RadioGroupContextValues,
+  RadioGroupOnChangeData,
+  RadioGroupProps,
+  RadioGroupSlots,
+  RadioGroupState,
+  RadioOnChangeData,
+  RadioProps,
+  RadioSlots,
+  RadioState,
+} from '@fluentui/react-radio';
+export {
   createCustomFocusIndicatorStyle,
   createFocusOutlineStyle,
   useArrowNavigationGroup,

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -79,32 +79,6 @@ export {
 export type { LabelProps, LabelSlots, LabelState } from '@fluentui/react-label';
 
 export {
-  Radio,
-  /* eslint-disable-next-line deprecation/deprecation */
-  radioClassName,
-  radioClassNames,
-  RadioGroup,
-  /* eslint-disable-next-line deprecation/deprecation */
-  radioGroupClassName,
-  radioGroupClassNames,
-  renderRadio_unstable,
-  renderRadioGroup_unstable,
-  useRadio_unstable,
-  useRadioGroup_unstable,
-  useRadioGroupStyles_unstable,
-  useRadioStyles_unstable,
-} from '@fluentui/react-radio';
-export type {
-  RadioGroupOnChangeData,
-  RadioGroupProps,
-  RadioGroupSlots,
-  RadioGroupState,
-  RadioProps,
-  RadioSlots,
-  RadioState,
-} from '@fluentui/react-radio';
-
-export {
   SpinButton,
   renderSpinButton_unstable,
   spinButtonClassNames,

--- a/packages/react-radio/README.md
+++ b/packages/react-radio/README.md
@@ -11,6 +11,10 @@ A Radio allows a user to select a single value from two or more options. All Rad
 Import `Radio` and `RadioGroup`:
 
 ```js
+// From @fluentui/react-components
+import { Radio, RadioGroup } from '@fluentui/react-components';
+
+// Directly from @fluentui/react-radio
 import { Radio, RadioGroup } from '@fluentui/react-radio';
 ```
 

--- a/packages/react-radio/etc/react-radio.api.md
+++ b/packages/react-radio/etc/react-radio.api.md
@@ -102,6 +102,9 @@ export const useRadio_unstable: (props: RadioProps, ref: React_2.Ref<HTMLInputEl
 // @public
 export const useRadioGroup_unstable: (props: RadioGroupProps, ref: React_2.Ref<HTMLDivElement>) => RadioGroupState;
 
+// @public (undocumented)
+export const useRadioGroupContextValues: (state: RadioGroupState) => RadioGroupContextValues;
+
 // @public
 export const useRadioGroupStyles_unstable: (state: RadioGroupState) => void;
 

--- a/packages/react-radio/package.json
+++ b/packages/react-radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-radio",
-  "version": "9.0.0-beta.5",
+  "version": "9.0.0-rc.1",
   "description": "Fluent UI Radio component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/react-radio/src/contexts/index.ts
+++ b/packages/react-radio/src/contexts/index.ts
@@ -1,0 +1,2 @@
+export * from './RadioGroupContext';
+export * from './useRadioGroupContextValues';

--- a/packages/react-radio/src/index.ts
+++ b/packages/react-radio/src/index.ts
@@ -25,4 +25,4 @@ export {
   useRadio_unstable,
 } from './Radio';
 export type { RadioProps, RadioSlots, RadioState, RadioOnChangeData } from './Radio';
-export { RadioGroupContext } from './contexts/RadioGroupContext';
+export { RadioGroupContext, useRadioGroupContextValues } from './contexts';

--- a/packages/react-radio/src/index.ts
+++ b/packages/react-radio/src/index.ts
@@ -25,4 +25,4 @@ export {
   useRadio_unstable,
 } from './Radio';
 export type { RadioProps, RadioSlots, RadioState, RadioOnChangeData } from './Radio';
-export { RadioGroupContext, useRadioGroupContextValues } from './contexts';
+export { RadioGroupContext, useRadioGroupContextValues } from './contexts/index';

--- a/packages/react-radio/src/stories/RadioGroup.stories.tsx
+++ b/packages/react-radio/src/stories/RadioGroup.stories.tsx
@@ -14,7 +14,7 @@ export { DisabledItem } from './RadioGroupDisabledItem.stories';
 export { LabelSubtext } from './RadioGroupLabelSubtext.stories';
 
 export default {
-  title: 'Preview Components/RadioGroup',
+  title: 'Components/RadioGroup',
   component: RadioGroup,
   parameters: {
     docs: {


### PR DESCRIPTION
## Current Behavior

`Radio` and `RadioGroup` are exported from `@fluentui/react-components/unstable`

## New Behavior

1. `Radio` and `RadioGroup` are exported from `@fluentui/react-components` and not from /unstable
2. Story location for RadioGroup is updated in Storybook
3. Radio README.md demonstrates how to import controls from `@fluentui/react-components` 

## Related Issue(s)

Fixes #22680
