### PR TITLE
Switch: Adding label to Default story so that it is accessible

### DIFF
--- a/packages/react-switch/src/stories/SwitchDefault.stories.tsx
+++ b/packages/react-switch/src/stories/SwitchDefault.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Switch } from '../index';
 import type { SwitchProps } from '../index';
 
-export const Default = (props: SwitchProps) => <Switch {...props} />;
+export const Default = (props: SwitchProps) => <Switch label="This is a switch" {...props} />;
 
 Default.argTypes = {
   checked: {


### PR DESCRIPTION
## Current Behavior

The default `Switch` story lacks a label which makes the story not accessible.

## New Behavior

This PR adds a label to the default `Switch` story to make it accessible.

## Related Issue(s)


Fixes #22816
