### PR TITLE
feat(v9): migrate keyboard-keys,priority-overflow,alert,aria,avatar,button,conf-griffel,context-selector to ship rolluped only dts

### DIFF
--- a/change/@fluentui-keyboard-keys-bd228124-f380-4d25-a8dc-9a938739b9a5.json
+++ b/change/@fluentui-keyboard-keys-bd228124-f380-4d25-a8dc-9a938739b9a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/keyboard-keys",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-4c1e0855-adcf-4e30-9fbb-961db1caaba1.json
+++ b/change/@fluentui-react-aria-4c1e0855-adcf-4e30-9fbb-961db1caaba1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-aria",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-5a4b827a-34a5-4cb6-90c2-6a759a0a394e.json
+++ b/change/@fluentui-react-avatar-5a4b827a-34a5-4cb6-90c2-6a759a0a394e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-avatar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-5dd9cade-253d-4b4c-a36f-0d749b04f574.json
+++ b/change/@fluentui-react-button-5dd9cade-253d-4b4c-a36f-0d749b04f574.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-button",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-conformance-griffel-6c6d48e1-fb72-4ddf-aee9-129999c2a25b.json
+++ b/change/@fluentui-react-conformance-griffel-6c6d48e1-fb72-4ddf-aee9-129999c2a25b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-context-selector-39930db1-29aa-4473-bc10-cfd80c90d373.json
+++ b/change/@fluentui-react-context-selector-39930db1-29aa-4473-bc10-cfd80c90d373.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/keyboard-keys/.babelrc.json
+++ b/packages/react-components/keyboard-keys/.babelrc.json
@@ -1,3 +1,4 @@
 {
+  "presets": [],
   "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-components/keyboard-keys/.npmignore
+++ b/packages/react-components/keyboard-keys/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/keyboard-keys/config/api-extractor.json
+++ b/packages/react-components/keyboard-keys/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/keyboard-keys/package.json
+++ b/packages/react-components/keyboard-keys/package.json
@@ -4,7 +4,7 @@
   "description": "Contains a set of keyboard constants for key and keyCode",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/keyboard-keys/tsconfig.lib.json
+++ b/packages/react-components/keyboard-keys/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.stories.ts", "**/*.stories.tsx"],

--- a/packages/react-components/priority-overflow/.babelrc.json
+++ b/packages/react-components/priority-overflow/.babelrc.json
@@ -1,3 +1,4 @@
 {
+  "presets": [],
   "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-components/priority-overflow/.npmignore
+++ b/packages/react-components/priority-overflow/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/priority-overflow/config/api-extractor.json
+++ b/packages/react-components/priority-overflow/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/priority-overflow/jest.config.js
+++ b/packages/react-components/priority-overflow/jest.config.js
@@ -17,5 +17,4 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-components/priority-overflow/package.json
+++ b/packages/react-components/priority-overflow/package.json
@@ -5,7 +5,7 @@
   "description": "Vanilla JS utilities to implement overflow menus",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/priority-overflow/tsconfig.lib.json
+++ b/packages/react-components/priority-overflow/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx"],

--- a/packages/react-components/react-alert/.npmignore
+++ b/packages/react-components/react-alert/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-alert/config/api-extractor.json
+++ b/packages/react-components/react-alert/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-alert/package.json
+++ b/packages/react-components/react-alert/package.json
@@ -5,7 +5,7 @@
   "description": "An alert component to display brief messages",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-alert/tsconfig.lib.json
+++ b/packages/react-components/react-alert/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-aria/.babelrc.json
+++ b/packages/react-components/react-aria/.babelrc.json
@@ -1,3 +1,4 @@
 {
+  "presets": [],
   "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-components/react-aria/.npmignore
+++ b/packages/react-components/react-aria/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-aria/config/api-extractor.json
+++ b/packages/react-components/react-aria/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-aria/package.json
+++ b/packages/react-components/react-aria/package.json
@@ -4,7 +4,7 @@
   "description": "React helper to ensure ARIA",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-aria/tsconfig.lib.json
+++ b/packages/react-components/react-aria/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.stories.ts", "**/*.stories.tsx"],

--- a/packages/react-components/react-avatar/.npmignore
+++ b/packages/react-components/react-avatar/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-avatar/config/api-extractor.json
+++ b/packages/react-components/react-avatar/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-avatar/package.json
+++ b/packages/react-components/react-avatar/package.json
@@ -4,7 +4,7 @@
   "description": "React components for building Microsoft web experiences.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-avatar/tsconfig.lib.json
+++ b/packages/react-components/react-avatar/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-button/.npmignore
+++ b/packages/react-components/react-button/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-button/config/api-extractor.json
+++ b/packages/react-components/react-button/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-button/package.json
+++ b/packages/react-components/react-button/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent UI React Button component.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-button/tsconfig.lib.json
+++ b/packages/react-components/react-button/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-conformance-griffel/.npmignore
+++ b/packages/react-components/react-conformance-griffel/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-conformance-griffel/config/api-extractor.json
+++ b/packages/react-components/react-conformance-griffel/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-conformance-griffel/package.json
+++ b/packages/react-components/react-conformance-griffel/package.json
@@ -3,7 +3,7 @@
   "version": "9.0.0-beta.4",
   "description": "A set of conformance tests for Griffel CSS-in-JS",
   "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"

--- a/packages/react-components/react-conformance-griffel/tsconfig.lib.json
+++ b/packages/react-components/react-conformance-griffel/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["DOM", "ES2019"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment", "jest", "node"],
     "module": "CommonJS"
   },

--- a/packages/react-components/react-context-selector/.babelrc.json
+++ b/packages/react-components/react-context-selector/.babelrc.json
@@ -1,3 +1,4 @@
 {
+  "presets": [],
   "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-components/react-context-selector/.npmignore
+++ b/packages/react-components/react-context-selector/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-context-selector/config/api-extractor.json
+++ b/packages/react-components/react-context-selector/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-context-selector/package.json
+++ b/packages/react-components/react-context-selector/package.json
@@ -4,7 +4,7 @@
   "description": "React useContextSelector hook in userland",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-context-selector/tsconfig.lib.json
+++ b/packages/react-components/react-context-selector/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.stories.ts", "**/*.stories.tsx"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Applied `yarn workspace-generator migrate-converged-pkg` to ship only rolluped type definitions for:
- keyboard-keys,
- priority-overflow,
- alert,
- aria,
- avatar,
- button,
- conformance-griffel,
- context-selector

## Related Issue(s)

Fixes partially https://github.com/microsoft/fluentui/issues/22429
