### PR TITLE
Combobox - Fix useAriaLabelAsText 

### DIFF
--- a/change/@fluentui-react-84189716-76f0-46f9-baa4-5b35f632bd85.json
+++ b/change/@fluentui-react-84189716-76f0-46f9-baa4-5b35f632bd85.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Combobox: Fix issue where the ariaLabel was intended to be used as the preview text but it wasn't showing up",
+  "packageName": "@fluentui/react",
+  "email": "nameraj@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -730,7 +730,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     return currentPendingValue !== null && currentPendingValue !== undefined
       ? currentPendingValue
       : indexWithinBounds(currentOptions, index)
-      ? currentOptions[index].text
+      ? getPreviewText(currentOptions[index])
       : '';
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

**useAriaLabelAsText** indicates that the aria-label should be used as the selected display value. This was broken and this change fixes it.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
