### PR TITLE
feat(v9): migrate overflow,portal-compat-context,positioning,slider,spinbutton,spinner,sb,sb-addon,tabs,tabster,theme,tooltip,utilities to ship rolluped only dts

### DIFF
--- a/change/@fluentui-react-portal-compat-context-fbe84cb5-31ad-420d-ab7a-0abbd30d29ac.json
+++ b/change/@fluentui-react-portal-compat-context-fbe84cb5-31ad-420d-ab7a-0abbd30d29ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-07ec4122-7030-493a-a478-626501263b47.json
+++ b/change/@fluentui-react-positioning-07ec4122-7030-493a-a478-626501263b47.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-positioning",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-a219f67f-11df-4a32-864d-57129bf36567.json
+++ b/change/@fluentui-react-slider-a219f67f-11df-4a32-864d-57129bf36567.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-slider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-7bd967c8-3ed3-493f-a601-60e3314268c0.json
+++ b/change/@fluentui-react-spinbutton-7bd967c8-3ed3-493f-a601-60e3314268c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-be408d5d-2751-4b8f-a542-f6daa8ed6fd4.json
+++ b/change/@fluentui-react-spinner-be408d5d-2751-4b8f-a542-f6daa8ed6fd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-spinner",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-809f1b63-164c-4251-8982-a9b5478e5497.json
+++ b/change/@fluentui-react-tabs-809f1b63-164c-4251-8982-a9b5478e5497.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-tabs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-f593051e-131c-44e1-a3bf-c3b4856a6f87.json
+++ b/change/@fluentui-react-tabster-f593051e-131c-44e1-a3bf-c3b4856a6f87.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-tabster",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-9df964f0-8037-41e7-b07e-a2c69e01fd45.json
+++ b/change/@fluentui-react-theme-9df964f0-8037-41e7-b07e-a2c69e01fd45.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-7527815f-f9c3-4e67-9e3e-709da41b0a9f.json
+++ b/change/@fluentui-react-tooltip-7527815f-f9c3-4e67-9e3e-709da41b0a9f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-2e5de099-881d-4c37-a269-266cb7ace5d7.json
+++ b/change/@fluentui-react-utilities-2e5de099-881d-4c37-a269-266cb7ace5d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-overflow/.npmignore
+++ b/packages/react-components/react-overflow/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-overflow/.storybook/preview.js
+++ b/packages/react-components/react-overflow/.storybook/preview.js
@@ -4,4 +4,4 @@ import * as rootPreview from '../../../../.storybook/preview';
 export const decorators = [...rootPreview.decorators];
 
 /** @type {typeof rootPreview.parameters} */
-export const parameters = { ...rootPreview.parameters, viewMode: undefined };
+export const parameters = { ...rootPreview.parameters };

--- a/packages/react-components/react-overflow/config/api-extractor.json
+++ b/packages/react-components/react-overflow/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-overflow/package.json
+++ b/packages/react-components/react-overflow/package.json
@@ -5,7 +5,7 @@
   "description": "React bindings for @fluentui/priority-overflow",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-overflow/tsconfig.lib.json
+++ b/packages/react-components/react-overflow/tsconfig.lib.json
@@ -5,16 +5,10 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
-  "exclude": [
-    "./src/common/**",
-    "**/*.spec.ts",
-    "**/*.spec.tsx",
-    "**/*.test.ts",
-    "**/*.test.tsx",
-    "**/*.stories.ts",
-    "**/*.stories.tsx"
-  ],
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.stories.ts", "**/*.stories.tsx"],
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/packages/react-components/react-portal-compat-context/.babelrc.json
+++ b/packages/react-components/react-portal-compat-context/.babelrc.json
@@ -1,3 +1,4 @@
 {
+  "presets": [],
   "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-components/react-portal-compat-context/.npmignore
+++ b/packages/react-components/react-portal-compat-context/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-portal-compat-context/config/api-extractor.json
+++ b/packages/react-components/react-portal-compat-context/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-portal-compat-context/jest.config.js
+++ b/packages/react-components/react-portal-compat-context/jest.config.js
@@ -17,5 +17,4 @@ module.exports = {
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
-  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/packages/react-components/react-portal-compat-context/package.json
+++ b/packages/react-components/react-portal-compat-context/package.json
@@ -4,7 +4,7 @@
   "description": "A package that holds React context for compatibility of React Contexts",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-portal-compat-context/tsconfig.lib.json
+++ b/packages/react-components/react-portal-compat-context/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx"],

--- a/packages/react-components/react-positioning/.npmignore
+++ b/packages/react-components/react-positioning/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-positioning/config/api-extractor.json
+++ b/packages/react-components/react-positioning/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-positioning/package.json
+++ b/packages/react-components/react-positioning/package.json
@@ -4,7 +4,7 @@
   "description": "A react wrapper around Popper.js for Fluent UI",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-positioning/tsconfig.lib.json
+++ b/packages/react-components/react-positioning/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx"],

--- a/packages/react-components/react-slider/.npmignore
+++ b/packages/react-components/react-slider/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-slider/config/api-extractor.json
+++ b/packages/react-components/react-slider/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-slider/package.json
+++ b/packages/react-components/react-slider/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent UI React Slider component.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-slider/src/components/Slider/Slider.stories.tsx
+++ b/packages/react-components/react-slider/src/components/Slider/Slider.stories.tsx
@@ -17,8 +17,6 @@ export default {
   parameters: {
     docs: {
       // The provided typing is wrong, ignore it
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       description: {
         component: [descriptionMd].join('\n'),
       },

--- a/packages/react-components/react-slider/tsconfig.lib.json
+++ b/packages/react-components/react-slider/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-spinbutton/.npmignore
+++ b/packages/react-components/react-spinbutton/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-spinbutton/config/api-extractor.json
+++ b/packages/react-components/react-spinbutton/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-spinbutton/package.json
+++ b/packages/react-components/react-spinbutton/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent UI React SpinButton component.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-spinbutton/tsconfig.lib.json
+++ b/packages/react-components/react-spinbutton/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-spinner/.npmignore
+++ b/packages/react-components/react-spinner/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-spinner/config/api-extractor.json
+++ b/packages/react-components/react-spinner/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-spinner/package.json
+++ b/packages/react-components/react-spinner/package.json
@@ -4,7 +4,7 @@
   "description": "Spinner component for Fluent UI React",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-spinner/tsconfig.lib.json
+++ b/packages/react-components/react-spinner/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-storybook-addon/.babelrc.json
+++ b/packages/react-components/react-storybook-addon/.babelrc.json
@@ -1,3 +1,4 @@
 {
+  "presets": [],
   "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-components/react-storybook-addon/.npmignore
+++ b/packages/react-components/react-storybook-addon/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-storybook-addon/config/api-extractor.json
+++ b/packages/react-components/react-storybook-addon/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-storybook-addon/package.json
+++ b/packages/react-components/react-storybook-addon/package.json
@@ -5,7 +5,7 @@
   "description": "fluentui react storybook addon",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-storybook-addon/tsconfig.lib.json
+++ b/packages/react-components/react-storybook-addon/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.stories.ts", "**/*.stories.tsx"],

--- a/packages/react-components/react-storybook/.babelrc.json
+++ b/packages/react-components/react-storybook/.babelrc.json
@@ -1,3 +1,4 @@
 {
+  "presets": [],
   "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-components/react-storybook/.npmignore
+++ b/packages/react-components/react-storybook/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-storybook/config/api-extractor.json
+++ b/packages/react-components/react-storybook/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-storybook/package.json
+++ b/packages/react-components/react-storybook/package.json
@@ -5,7 +5,7 @@
   "description": "Storybook addons and utils for @fluentui/react-components",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-storybook/tsconfig.lib.json
+++ b/packages/react-components/react-storybook/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.stories.ts", "**/*.stories.tsx"],

--- a/packages/react-components/react-tabs/.npmignore
+++ b/packages/react-components/react-tabs/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-tabs/config/api-extractor.json
+++ b/packages/react-components/react-tabs/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-tabs/package.json
+++ b/packages/react-components/react-tabs/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent UI React tabs components",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-tabs/tsconfig.lib.json
+++ b/packages/react-components/react-tabs/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-tabster/.npmignore
+++ b/packages/react-components/react-tabster/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-tabster/config/api-extractor.json
+++ b/packages/react-components/react-tabster/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-tabster/e2e/tsconfig.json
+++ b/packages/react-components/react-tabster/e2e/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": false,
     "types": ["node", "cypress", "cypress-storybook/cypress", "cypress-real-events"],
     "lib": ["ES2019", "dom"]
   },

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -4,7 +4,7 @@
   "description": "Utilities for focus management and facade for tabster",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-tabster/tsconfig.lib.json
+++ b/packages/react-components/react-tabster/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.stories.ts", "**/*.stories.tsx"],

--- a/packages/react-components/react-theme/.babelrc.json
+++ b/packages/react-components/react-theme/.babelrc.json
@@ -1,3 +1,4 @@
 {
+  "presets": [],
   "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-components/react-theme/.npmignore
+++ b/packages/react-components/react-theme/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-theme/config/api-extractor.json
+++ b/packages/react-components/react-theme/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-theme/package.json
+++ b/packages/react-components/react-theme/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent UI themes",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-theme/tsconfig.lib.json
+++ b/packages/react-components/react-theme/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.stories.ts", "**/*.stories.tsx"],

--- a/packages/react-components/react-tooltip/.npmignore
+++ b/packages/react-components/react-tooltip/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-tooltip/config/api-extractor.json
+++ b/packages/react-components/react-tooltip/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-tooltip/package.json
+++ b/packages/react-components/react-tooltip/package.json
@@ -4,7 +4,7 @@
   "description": "React components for building web experiences",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-tooltip/tsconfig.lib.json
+++ b/packages/react-components/react-tooltip/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-utilities/.babelrc.json
+++ b/packages/react-components/react-utilities/.babelrc.json
@@ -1,3 +1,4 @@
 {
+  "presets": [],
   "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-components/react-utilities/.npmignore
+++ b/packages/react-components/react-utilities/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-utilities/config/api-extractor.json
+++ b/packages/react-components/react-utilities/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-utilities/package.json
+++ b/packages/react-components/react-utilities/package.json
@@ -4,7 +4,7 @@
   "description": "A set of general React-specific utilities.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
@@ -21,7 +21,6 @@
     "test": "jest --passWithNoTests",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../../scripts/typescript/normalize-import --output ./dist/packages/react-components/react-utilities/src && yarn docs",
-    "start": "yarn storybook",
     "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {

--- a/packages/react-components/react-utilities/tsconfig.lib.json
+++ b/packages/react-components/react-utilities/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.stories.ts", "**/*.stories.tsx"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Applied `yarn nx workspace-generator migrate-converged-pkg` to ship only rolluped type definitions for:
- overflow,
- portal-compat-context,
- positioning,
- slider,
- spinbutton,
- spinner,
- storybook,
- storybook-addon,
- tabs,
- tabster,
- theme,
- tooltip,
- utilities

## Related Issue(s)

Fixes partially https://github.com/microsoft/fluentui/issues/22429
