### PR TITLE
fix(Pill): selectable by keyboard

### DIFF
--- a/packages/fluentui/accessibility/src/behaviors/Pill/pillBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Pill/pillBehavior.ts
@@ -6,8 +6,8 @@ export const pillBehavior: Accessibility<PillBehaviorProps> = p => ({
   attributes: {
     root: {
       role: p.actionable ? 'button' : 'none',
-      tabIndex: p.actionable ? 0 : -1,
-      [IS_FOCUSABLE_ATTRIBUTE]: p.actionable || p.role === 'option',
+      tabIndex: p.actionable || p.selectable ? 0 : -1,
+      [IS_FOCUSABLE_ATTRIBUTE]: p.actionable || p.selectable || p.role === 'option',
       ...(p.selectable && {
         'aria-selected': p.selected,
       }),
@@ -19,6 +19,8 @@ export const pillBehavior: Accessibility<PillBehaviorProps> = p => ({
         performDismiss: {
           keyCombinations: [{ keyCode: keyboardKey.Delete }, { keyCode: keyboardKey.Backspace }],
         },
+      }),
+      ...(p.selectable && {
         performClick: {
           keyCombinations: [{ keyCode: keyboardKey.Enter }, { keyCode: SpacebarKey }],
         },

--- a/packages/fluentui/react-northstar/src/components/Pill/Pill.tsx
+++ b/packages/fluentui/react-northstar/src/components/Pill/Pill.tsx
@@ -212,7 +212,7 @@ export const Pill = (React.forwardRef<HTMLSpanElement, PillProps>((props, ref) =
       {...getA11yProps('root', {
         className: classes.root,
         ref,
-        ...(actionable && { onClick: handleClick }),
+        ...((actionable || selectable) && { onClick: handleClick }),
         ...unhandledProps,
       })}
     >
@@ -255,6 +255,7 @@ export const Pill = (React.forwardRef<HTMLSpanElement, PillProps>((props, ref) =
 
 Pill.defaultProps = {
   as: 'span' as const,
+  accessibility: pillBehavior,
 };
 
 Pill.propTypes = {


### PR DESCRIPTION
## Current Behavior

Selecting `Pill` by keyboard isn't working

## New Behavior

Selecting `Pill` is now working by keyboard and mouse
