### PR TITLE
react-file-type-icons: add export of FileTypeIconMap

### DIFF
--- a/change/@fluentui-react-file-type-icons-ce8d68da-748c-4919-93e9-25b4cbdf9752.json
+++ b/change/@fluentui-react-file-type-icons-ce8d68da-748c-4919-93e9-25b4cbdf9752.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added export of FileTypeIconMap",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-file-type-icons/src/index.ts
+++ b/packages/react-file-type-icons/src/index.ts
@@ -4,6 +4,8 @@ export { getFileTypeIconProps } from './getFileTypeIconProps';
 
 export { FileIconType } from './FileIconType';
 
+export { FileTypeIconMap } from './FileTypeIconMap';
+
 export { getFileTypeIconAsHTMLString } from './getFileTypeIconAsHTMLString';
 
 import './version';


### PR DESCRIPTION
## Changes
- Added export from package for FileTypeIconMap

This was previously exported through * exports, and customers deep imported it.  With the change away from * exports this was no longer available.  

## Issues

Fixes #22840