### PR TITLE
react-label: Adding upgrade guidance for Label and fixing minor typos in stories

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV0/Components/Label.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV0/Components/Label.stories.mdx
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/addon-docs';
 
 Fluent UI Northstar (v0) provides the `Label` control to allow users to classify content. Fluent UI v9 also provides a `Label`, but has a simpler API.
 
-The main difference with v0's and v9's `Label` is that v9 doesn't provide an image and icon prop. v9 also accepts a custome required indicator that can be a string or jsx element.
+The main difference with v0's and v9's `Label` is that v9 doesn't provide an image and icon prop. v9 also accepts a custom required indicator that can be a string or jsx element.
 
 ## Examples
 
@@ -44,7 +44,7 @@ This table maps `Label` v0 props to the `Label` v9 equivalent.
 | `as`            | n/a         |                                                |
 | `circular`      | n/a         |                                                |
 | `className`     | `className` |                                                |
-| `color`         | `className` | use `className` to customize color.            |
+| `color`         | `className` | use `className` to customize color             |
 | `content`       | `children`  | v9 uses React `children` instead of data props |
 | `design`        | n/a         |                                                |
 | `fluid`         | n/a         |                                                |

--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV0/Components/Label.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV0/Components/Label.stories.mdx
@@ -4,9 +4,9 @@ import { Meta } from '@storybook/addon-docs';
 
 # Label Upgrade
 
-Fluent UI Northstar (v0) provides the `Label` control to allow users to classify content. Fluent UI v9 also provides a `Label`, but has a simpler API.
+Fluent UI Northstar (v0) provides the `Label` control to allow users to classify content. Fluent UI v9 also provides a `Label`, but has a different API.
 
-The main difference with v0's and v9's `Label` is that v9 doesn't provide an image and icon prop. v9 also accepts a custom required indicator that can be a string or jsx element.
+The main difference with v0's and v9's `Label` is that v9 doesn't provide an image and icon prop. v9 also accepts a custom required indicator that can be a string or JSX element.
 
 ## Examples
 

--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV0/Components/Label.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV0/Components/Label.stories.mdx
@@ -1,0 +1,58 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Concepts/Upgrading/from v0/Components/Label Upgrade" />
+
+# Label Upgrade
+
+Fluent UI Northstar (v0) provides the `Label` control to allow users to classify content. Fluent UI v9 also provides a `Label`, but has a simpler API.
+
+The main difference with v0's and v9's `Label` is that v9 doesn't provide an image and icon prop. v9 also accepts a custome required indicator that can be a string or jsx element.
+
+## Examples
+
+### Basic Upgrade
+
+Basic usage of `Label` v0
+
+```tsx
+import * as React from 'react';
+import { Label } from '@fluentui/react-northstar';
+
+const LabelV0BasicExample = () => {
+  return <Label content="You have 23 emails" />;
+};
+```
+
+An equivalent `Label` in v9 is
+
+```tsx
+import * as React from 'react';
+import { Label } from '@fluentui/react-components/unstable';
+
+const LabelV9BasicExample = () => {
+  return <Label>You have 23 emails</Label>;
+};
+```
+
+## Prop Mapping
+
+This table maps `Label` v0 props to the `Label` v9 equivalent.
+
+| v0              | v9          | Notes                                          |
+| --------------- | ----------- | ---------------------------------------------- |
+| `accessibility` | n/a         |                                                |
+| `as`            | n/a         |                                                |
+| `circular`      | n/a         |                                                |
+| `className`     | `className` |                                                |
+| `color`         | `className` | use `className` to customize color.            |
+| `content`       | `children`  | v9 uses React `children` instead of data props |
+| `design`        | n/a         |                                                |
+| `fluid`         | n/a         |                                                |
+| `icon`          | n/a         |                                                |
+| `iconPosition`  | n/a         |                                                |
+| `image`         | n/a         |                                                |
+| `imagePosition` | n/a         |                                                |
+| `key`           | `key`       | v9 uses the intrinsic React prop               |
+| `ref`           | `ref`       |                                                |
+| `styles`        | `className` |                                                |
+| `variables`     | n/a         | Use `FluentProvider` to customize themes       |

--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Label.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Label.stories.mdx
@@ -1,0 +1,64 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Concepts/Upgrading/from v8/Components/Label Upgrade" />
+
+# Label Upgrade
+
+Fluent UI v8 provides the `Label` control that gives a name or title to a control or group of controls. Fluent UI v9 also provides a `Label` with a slightly different API.
+
+The main difference with v8's and v9's `Label` is that v9 allows the user to use a custom indicator.
+
+## Examples
+
+### Basic Upgrade
+
+Basic usage of `Label` v8
+
+```tsx
+import * as React from 'react';
+import { Label } from '@fluentui/react/lib/Label';
+import { useId } from '@fluentui/react-hooks';
+
+export const LabelBasicExample = () => {
+  const inputId = useId('anInput');
+
+  return (
+    <>
+      <Label htmlFor={inputId}>A Label for an input</Label>
+      <input id={inputId} type="text" />
+    </>
+  );
+};
+```
+
+An equivalent `Label` in v9 is
+
+```tsx
+import * as React from 'react';
+import { Label } from '@fluentui/react-components/unstable';
+import { useId } from '@fluentui/react-utilities';
+
+const LabelV9BasicExample = () => {
+  const inputId = useId('anInput');
+
+  return (
+    <>
+      <Label htmlFor={inputId}>A Label for an input</Label>
+      <input id={inputId} type="text" />
+    </>
+  );
+};
+```
+
+## Prop Mapping
+
+This table maps `Label` v8 props to the `Label` v9 equivalent.
+
+| v8             | v9          | Notes                                    |
+| -------------- | ----------- | ---------------------------------------- |
+| `as`           | n/a         |                                          |
+| `componentRef` | `ref`       |                                          |
+| `disabled`     | `disabled`  |                                          |
+| `required`     | `required`  |                                          |
+| `styles`       | `className` |                                          |
+| `theme`        | n/a         | use `FluentProvider` to customize themes |

--- a/packages/react-components/react-label/src/stories/LabelSize.stories.tsx
+++ b/packages/react-components/react-label/src/stories/LabelSize.stories.tsx
@@ -14,7 +14,7 @@ export const Size = () => {
 Size.parameters = {
   docs: {
     description: {
-      story: 'A Label supports `small`, `medium`, and `large` size.',
+      story: 'A Label supports `small`, `medium`, and `large` sizes.',
     },
   },
 };

--- a/packages/react-components/react-label/src/stories/LabelStrong.stories.tsx
+++ b/packages/react-components/react-label/src/stories/LabelStrong.stories.tsx
@@ -6,7 +6,7 @@ export const Strong = () => <Label strong>Strong label</Label>;
 Strong.parameters = {
   docs: {
     description: {
-      story: 'A Label a semibold/strong fontweight.',
+      story: 'A Label with a strong font weight.',
     },
   },
 };


### PR DESCRIPTION
## PR Details

This PR adds the following:
- Upgrade guides from v8->v9 and v0->v9.
- Fixes minor typos in label stories.