### PR TITLE
Re-exporting GriffelStyle in @fluentui/react-components

### DIFF
--- a/change/@fluentui-react-components-7c6772c6-71f1-4dd4-bbd1-a1429d1e491c.json
+++ b/change/@fluentui-react-components-7c6772c6-71f1-4dd4-bbd1-a1429d1e491c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Re-exporting GriffelStyle.",
+  "packageName": "@fluentui/react-components",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -123,6 +123,7 @@ import { getNativeElementProps } from '@fluentui/react-utilities';
 import { getNativeProps } from '@fluentui/react-utilities';
 import { getPartitionedNativeProps } from '@fluentui/react-utilities';
 import { getSlots } from '@fluentui/react-utilities';
+import { GriffelStyle } from '@griffel/react';
 import { Headline } from '@fluentui/react-text';
 import { headlineClassName } from '@fluentui/react-text';
 import { headlineClassNames } from '@fluentui/react-text';
@@ -723,6 +724,8 @@ export { getNativeProps }
 export { getPartitionedNativeProps }
 
 export { getSlots }
+
+export { GriffelStyle }
 
 export { Headline }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -9,6 +9,7 @@ export {
   renderToStyleElements,
   shorthands,
 } from '@griffel/react';
+export type { GriffelStyle } from '@griffel/react';
 export {
   FluentProvider,
   /* eslint-disable-next-line deprecation/deprecation */


### PR DESCRIPTION
## Current Behavior

`GriffelStyle` is exported from `@griffel/react` but not from `@fluentui/react-components`, meaning that people wanting to type objects to spread in `makeStyles` calls have to take a dependency on `@griffel/react`.

## New Behavior

`GriffelStyle` is re-exported in `@fluentui/react-components`, meaning that people wanting to type objects to spread in `makeStyles` calls don't have to take a dependency on `@griffel/react`.