### PR TITLE
feat: add time element on nativeElementMap

### DIFF
--- a/change/@fluentui-react-utilities-84a6b1af-e457-4e58-b948-078b64bc46c7.json
+++ b/change/@fluentui-react-utilities-84a6b1af-e457-4e58-b948-078b64bc46c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add time element on nativeElementMap",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/utils/getNativeElementProps.ts
+++ b/packages/react-components/react-utilities/src/utils/getNativeElementProps.ts
@@ -23,6 +23,7 @@ import {
   imgProperties,
   htmlElementProperties,
   getNativeProps,
+  timeProperties,
 } from './properties';
 
 const nativeElementMap: Record<string, Record<string, number>> = {
@@ -47,6 +48,7 @@ const nativeElementMap: Record<string, Record<string, number>> = {
   form: formProperties,
   iframe: iframeProperties,
   img: imgProperties,
+  time: timeProperties,
 };
 
 /**

--- a/packages/react-components/react-utilities/src/utils/properties.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.ts
@@ -199,6 +199,15 @@ export const anchorProperties = toObjectMap(htmlElementProperties, [
 ]);
 
 /**
+ * An array of TIME tag properties and events.
+ *
+ * @public
+ */
+export const timeProperties = toObjectMap(htmlElementProperties, [
+  'dateTime', // time
+]);
+
+/**
  * An array of BUTTON tag properties and events.
  *
  * @public


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

`getNativeElementProps` doesn't support [<time> element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)

## New Behavior

Adds `<time>` element and it's properties to `getNativeElementProps`
