### PR TITLE
fix: create-component finds package path based on pacakge name

### DIFF
--- a/scripts/create-component/create-component.ts
+++ b/scripts/create-component/create-component.ts
@@ -24,6 +24,13 @@ const convergedComponentPackages = Object.entries(getAllPackageInfo())
   )
   .map(([packageName]) => packageName);
 
+const packagePathsByPackageName = Object.entries(getAllPackageInfo())
+  .map(([packageName, packageInfo]) => [packageName, packageInfo.packagePath])
+  .reduce((obj, [packageName, packagePath]) => {
+    obj[packageName] = packagePath;
+    return obj;
+  }, {});
+
 const root = findGitRoot();
 
 interface Answers {
@@ -71,7 +78,7 @@ module.exports = (plop: NodePlopAPI) => {
       const globOptions: AddManyActionConfig['globOptions'] = { dot: true };
 
       const packageName = answers.packageNpmName.replace('@fluentui/', '');
-      const packagePath = path.join(root, 'packages', packageName);
+      const packagePath = packagePathsByPackageName[answers.packageNpmName] ?? path.join(root, 'packages', packageName);
       const componentPath = path.join(packagePath, 'src/components', answers.componentName);
       const componentNames = names(answers.componentName);
       const data: Data = {


### PR DESCRIPTION
Updates the create-component script to find package path based on the
package name instead of hard coding the path
