### PR TITLE
doc(react-theme): Add Spacing story

### DIFF
--- a/packages/react-components/react-theme/src/themes/ThemeSpacing.stories.tsx
+++ b/packages/react-components/react-theme/src/themes/ThemeSpacing.stories.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { teamsLightTheme } from '../index';
+import type { HorizontalSpacingTokens, VerticalSpacingTokens } from '../index';
+
+export default {
+  title: 'Theme/Spacing',
+};
+
+const theme = teamsLightTheme;
+
+const SpacingHorizontal = () => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'auto auto 1fr',
+      gap: '10px',
+      alignItems: 'center',
+    }}
+  >
+    {(Object.keys(theme).filter(tokenName =>
+      tokenName.startsWith('spacingHorizontal'),
+    ) as (keyof HorizontalSpacingTokens)[]).map(spacingToken => [
+      <div key={spacingToken}>{spacingToken}</div>,
+      <div key={`${spacingToken}-value`}>{theme[spacingToken]}</div>,
+      <div
+        key={`${spacingToken}-demo`}
+        style={{
+          width: theme[spacingToken],
+          height: '2em',
+          background: '#00CC6A',
+        }}
+      />,
+    ])}
+  </div>
+);
+
+const SpacingVertical = () => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'auto auto 1fr',
+      gap: '10px',
+      alignItems: 'center',
+    }}
+  >
+    {(Object.keys(theme).filter(tokenName =>
+      tokenName.startsWith('spacingVertical'),
+    ) as (keyof VerticalSpacingTokens)[]).map(spacingToken => [
+      <div key={spacingToken}>{spacingToken}</div>,
+      <div key={`${spacingToken}-value`}>{theme[spacingToken]}</div>,
+      <div
+        key={`${spacingToken}-demo`}
+        style={{
+          height: theme[spacingToken],
+          width: '20em',
+          background: '#CC006A',
+        }}
+      />,
+    ])}
+  </div>
+);
+
+export const Spacing = () => (
+  <>
+    <h2>Vertical</h2>
+    <SpacingVertical />
+    <h2>Horizontal</h2>
+    <SpacingHorizontal />
+  </>
+);


### PR DESCRIPTION
Add Spacing story to react-theme storybook:

<img width="643" alt="image" src="https://user-images.githubusercontent.com/9615899/166917687-211267fd-e52c-4b3c-b299-6cd9a691d833.png">

[Storybook preview](https://fluentuipr.z22.web.core.windows.net/pull/22852/public-docsite-v9/storybook/index.html?path=/docs/theme-spacing--spacing)