### PR TITLE
chore: re-enable Dialog e2e

### DIFF
--- a/packages/fluentui/e2e/cypress.json
+++ b/packages/fluentui/e2e/cypress.json
@@ -1,5 +1,4 @@
 {
-  "ignoreTestFiles": "*?ialog*.spec.ts",
   "video": false,
   "screenshotOnRunFailure": false,
   "integrationFolder": "./tests",

--- a/packages/fluentui/e2e/tests/dialogInDialogWithDropdown.spec.ts
+++ b/packages/fluentui/e2e/tests/dialogInDialogWithDropdown.spec.ts
@@ -44,7 +44,7 @@ describe('Dialog in Dialog', () => {
     cy.clickOn(innerTrigger);
 
     cy.clickOn(dropdownIndicator);
-    cy.visible(dropdownList);
+    cy.exist(dropdownList);
     // TODO this test was failling on timeout. Cypress was probably too fast and components weren't ready.
     cy.wait(50);
     cy.waitForSelectorAndPressKey(dropdownList, '{esc}');

--- a/packages/fluentui/e2e/tests/dialogWithDropdown.spec.ts
+++ b/packages/fluentui/e2e/tests/dialogWithDropdown.spec.ts
@@ -36,7 +36,7 @@ describe('Dialog with dropdown', () => {
     cy.clickOn(dialogTrigger);
     cy.clickOn(dropdownIndicator);
 
-    cy.visible(dropdownList);
+    cy.exist(dropdownList);
     cy.waitForSelectorAndPressKey(dropdownList, '{esc}');
     cy.visible(dropdownSelector);
   });
@@ -45,7 +45,7 @@ describe('Dialog with dropdown', () => {
     cy.clickOn(dialogTrigger);
     cy.clickOn(dropdownIndicator);
 
-    cy.visible(dropdownList);
+    cy.exist(dropdownList);
     cy.waitForSelectorAndPressKey(dropdownList, '{esc}');
     cy.visible(dropdownSelector);
 

--- a/packages/fluentui/react-northstar/src/components/Dialog/Dialog.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dialog/Dialog.tsx
@@ -258,10 +258,24 @@ export const Dialog = (React.forwardRef<HTMLDivElement, DialogProps>((props, ref
     },
   });
 
+  // when press left click on Dialog content and hold, and mouse up on Dialog overlay, Dialog should keep open
+  const isMouseDownInsideContent = React.useRef(false);
+  const registerMouseDownOnDialogContent = (e: React.MouseEvent) => {
+    if (e.button === 0) {
+      isMouseDownInsideContent.current = true;
+    }
+    if (unhandledProps.onMouseDown) {
+      _.invoke(unhandledProps, 'onMouseDown', e);
+    }
+  };
+
   const handleOverlayClick = (e: MouseEvent) => {
     // Dialog has different conditions to close than Popup, so we don't need to iterate across all
     // refs
-    const isInsideContentClick = doesNodeContainClick(contentRef.current, e, context.target);
+    const isInsideContentClick =
+      isMouseDownInsideContent.current || doesNodeContainClick(contentRef.current, e, context.target);
+    isMouseDownInsideContent.current = false;
+
     const isInsideOverlayClick = doesNodeContainClick(overlayRef.current, e, context.target);
 
     const shouldClose = !isInsideContentClick && isInsideOverlayClick;
@@ -318,6 +332,7 @@ export const Dialog = (React.forwardRef<HTMLDivElement, DialogProps>((props, ref
           className: classes.root,
           ref,
           ...unhandledProps,
+          onMouseDown: registerMouseDownOnDialogContent,
         })}
       >
         {Header.create(header, {

--- a/packages/fluentui/react-northstar/src/components/Dialog/Dialog.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dialog/Dialog.tsx
@@ -258,24 +258,10 @@ export const Dialog = (React.forwardRef<HTMLDivElement, DialogProps>((props, ref
     },
   });
 
-  // when press left click on Dialog content and hold, and mouse up on Dialog overlay, Dialog should keep open
-  const isMouseDownInsideContent = React.useRef(false);
-  const registerMouseDownOnDialogContent = (e: React.MouseEvent) => {
-    if (e.button === 0) {
-      isMouseDownInsideContent.current = true;
-    }
-    if (unhandledProps.onMouseDown) {
-      _.invoke(unhandledProps, 'onMouseDown', e);
-    }
-  };
-
   const handleOverlayClick = (e: MouseEvent) => {
     // Dialog has different conditions to close than Popup, so we don't need to iterate across all
     // refs
-    const isInsideContentClick =
-      isMouseDownInsideContent.current || doesNodeContainClick(contentRef.current, e, context.target);
-    isMouseDownInsideContent.current = false;
-
+    const isInsideContentClick = doesNodeContainClick(contentRef.current, e, context.target);
     const isInsideOverlayClick = doesNodeContainClick(overlayRef.current, e, context.target);
 
     const shouldClose = !isInsideContentClick && isInsideOverlayClick;
@@ -332,7 +318,6 @@ export const Dialog = (React.forwardRef<HTMLDivElement, DialogProps>((props, ref
           className: classes.root,
           ref,
           ...unhandledProps,
-          onMouseDown: registerMouseDownOnDialogContent,
         })}
       >
         {Header.create(header, {


### PR DESCRIPTION
Re-enables Dialog cypress test. 
It's disabled previously by #17483 due to flakyness. #22544 introduced cypress retry, so this PR re-enables the tests.

A small change was made to test as it was failing: Dialog dropdown list is considered not 'visible' by cypress because it was partially covered in the test. But the tests are for keyboarding, so it only needs to verify dropdown list exist. 