### PR TITLE
Accordion: remove commons type

### DIFF
--- a/change/@fluentui-react-accordion-cb404d3d-936e-4aa5-803f-ea179b52acee.json
+++ b/change/@fluentui-react-accordion-cb404d3d-936e-4aa5-803f-ea179b52acee.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "remove commons types from accordion, remove unused state props",
+  "packageName": "@fluentui/react-accordion",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-accordion/etc/react-accordion.api.md
@@ -98,8 +98,8 @@ export const AccordionItemContext: React_2.Context<AccordionItemContextValue>;
 // @public (undocumented)
 export type AccordionItemContextValue = {
     disabled: boolean;
-    open: boolean;
     onHeaderClick(ev: React_2.MouseEvent | React_2.KeyboardEvent): void;
+    open: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-accordion/etc/react-accordion.api.md
@@ -96,8 +96,7 @@ export const accordionItemClassNames: SlotClassNames<AccordionItemSlots>;
 export const AccordionItemContext: React_2.Context<AccordionItemContextValue>;
 
 // @public (undocumented)
-export type AccordionItemContextValue = {
-    disabled: boolean;
+export type AccordionItemContextValue = Required<Pick<AccordionItemProps, 'disabled'>> & {
     onHeaderClick(ev: React_2.MouseEvent | React_2.KeyboardEvent): void;
     open: boolean;
 };

--- a/packages/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-accordion/etc/react-accordion.api.md
@@ -26,7 +26,7 @@ export const accordionClassNames: SlotClassNames<AccordionSlots>;
 export const AccordionContext: Context<AccordionContextValue>;
 
 // @public (undocumented)
-export type AccordionContextValue = Omit<AccordionCommons, 'multiple'> & {
+export type AccordionContextValue = Required<Pick<AccordionProps, 'collapsible'>> & Pick<AccordionProps, 'navigation'> & {
     openItems: AccordionItemValue[];
     requestToggle: (event: AccordionToggleEvent, data: AccordionToggleData) => void;
 };
@@ -46,11 +46,9 @@ export const accordionHeaderClassName = "fui-AccordionHeader";
 export const accordionHeaderClassNames: SlotClassNames<AccordionHeaderSlots>;
 
 // @public (undocumented)
-export type AccordionHeaderContextValue = {
+export type AccordionHeaderContextValue = Required<Pick<AccordionHeaderProps, 'expandIconPosition' | 'size'>> & {
     disabled: boolean;
     open: boolean;
-    expandIconPosition: AccordionHeaderExpandIconPosition;
-    size: AccordionHeaderSize;
 };
 
 // @public (undocumented)
@@ -62,7 +60,11 @@ export type AccordionHeaderContextValues = {
 export type AccordionHeaderExpandIconPosition = 'start' | 'end';
 
 // @public (undocumented)
-export type AccordionHeaderProps = ComponentProps<Partial<AccordionHeaderSlots>> & Partial<AccordionHeaderCommons>;
+export type AccordionHeaderProps = ComponentProps<Partial<AccordionHeaderSlots>> & {
+    expandIconPosition?: AccordionHeaderExpandIconPosition;
+    inline?: boolean;
+    size?: AccordionHeaderSize;
+};
 
 // @public (undocumented)
 export type AccordionHeaderSize = 'small' | 'medium' | 'large' | 'extra-large';
@@ -76,7 +78,7 @@ export type AccordionHeaderSlots = {
 };
 
 // @public (undocumented)
-export type AccordionHeaderState = ComponentState<AccordionHeaderSlots> & AccordionHeaderCommons & AccordionHeaderContextValue;
+export type AccordionHeaderState = ComponentState<AccordionHeaderSlots> & Required<Pick<AccordionHeaderProps, 'inline'>> & AccordionHeaderContextValue;
 
 // @public (undocumented)
 export type AccordionIndex = number | number[];
@@ -94,7 +96,8 @@ export const accordionItemClassNames: SlotClassNames<AccordionItemSlots>;
 export const AccordionItemContext: React_2.Context<AccordionItemContextValue>;
 
 // @public (undocumented)
-export type AccordionItemContextValue = Omit<AccordionItemCommons, 'value'> & {
+export type AccordionItemContextValue = {
+    disabled: boolean;
     open: boolean;
     onHeaderClick(ev: React_2.MouseEvent | React_2.KeyboardEvent): void;
 };
@@ -105,7 +108,10 @@ export type AccordionItemContextValues = {
 };
 
 // @public (undocumented)
-export type AccordionItemProps = ComponentProps<AccordionItemSlots> & Partial<AccordionItemCommons> & Pick<AccordionItemCommons, 'value'>;
+export type AccordionItemProps = ComponentProps<AccordionItemSlots> & {
+    disabled?: boolean;
+    value: AccordionItemValue;
+};
 
 // @public (undocumented)
 export type AccordionItemSlots = {
@@ -113,7 +119,7 @@ export type AccordionItemSlots = {
 };
 
 // @public (undocumented)
-export type AccordionItemState = ComponentState<AccordionItemSlots> & AccordionItemCommons & AccordionItemContextValue;
+export type AccordionItemState = ComponentState<AccordionItemSlots> & AccordionItemContextValue;
 
 // @public (undocumented)
 export type AccordionItemValue = unknown;
@@ -141,10 +147,13 @@ export type AccordionPanelState = ComponentState<AccordionPanelSlots> & {
 };
 
 // @public (undocumented)
-export type AccordionProps = ComponentProps<AccordionSlots> & Partial<AccordionCommons> & {
-    openItems?: AccordionItemValue | AccordionItemValue[];
+export type AccordionProps = ComponentProps<AccordionSlots> & {
     defaultOpenItems?: AccordionItemValue | AccordionItemValue[];
+    collapsible?: boolean;
+    multiple?: boolean;
+    navigation?: 'linear' | 'circular';
     onToggle?: AccordionToggleEventHandler;
+    openItems?: AccordionItemValue | AccordionItemValue[];
 };
 
 // @public (undocumented)
@@ -153,7 +162,7 @@ export type AccordionSlots = {
 };
 
 // @public (undocumented)
-export type AccordionState = ComponentState<AccordionSlots> & AccordionCommons & AccordionContextValue;
+export type AccordionState = ComponentState<AccordionSlots> & AccordionContextValue;
 
 // @public (undocumented)
 export type AccordionToggleData = {

--- a/packages/react-accordion/src/components/Accordion/Accordion.types.ts
+++ b/packages/react-accordion/src/components/Accordion/Accordion.types.ts
@@ -8,33 +8,18 @@ export type AccordionToggleEvent<E = HTMLElement> = React.MouseEvent<E> | React.
 
 export type AccordionToggleEventHandler = (event: AccordionToggleEvent, data: AccordionToggleData) => void;
 
-type AccordionCommons = {
-  /**
-   * Indicates if keyboard navigation is available and gives two options,
-   * linear or circular navigation
-   */
-  navigation?: 'linear' | 'circular';
-  /**
-   * Indicates if Accordion support multiple Panels opened at the same time
-   */
-  multiple: boolean;
-  /**
-   * Indicates if Accordion support multiple Panels closed at the same time
-   */
-  collapsible: boolean;
-};
-
-export type AccordionContextValue = Omit<AccordionCommons, 'multiple'> & {
-  /**
-   * The list of opened panels by index
-   */
-  openItems: AccordionItemValue[];
-  /**
-   * Callback used by AccordionItem to request a change on it's own opened state
-   * Should be used to toggle AccordionItem
-   */
-  requestToggle: (event: AccordionToggleEvent, data: AccordionToggleData) => void;
-};
+export type AccordionContextValue = Required<Pick<AccordionProps, 'collapsible'>> &
+  Pick<AccordionProps, 'navigation'> & {
+    /**
+     * The list of opened panels by index
+     */
+    openItems: AccordionItemValue[];
+    /**
+     * Callback used by AccordionItem to request a change on it's own opened state
+     * Should be used to toggle AccordionItem
+     */
+    requestToggle: (event: AccordionToggleEvent, data: AccordionToggleData) => void;
+  };
 
 export type AccordionContextValues = {
   accordion: AccordionContextValue;
@@ -48,17 +33,34 @@ export type AccordionToggleData = {
   value: AccordionItemValue;
 };
 
-export type AccordionProps = ComponentProps<AccordionSlots> &
-  Partial<AccordionCommons> & {
-    /**
-     * Controls the state of the panel
-     */
-    openItems?: AccordionItemValue | AccordionItemValue[];
-    /**
-     * Default value for the uncontrolled state of the panel
-     */
-    defaultOpenItems?: AccordionItemValue | AccordionItemValue[];
-    onToggle?: AccordionToggleEventHandler;
-  };
+export type AccordionProps = ComponentProps<AccordionSlots> & {
+  /**
+   * Default value for the uncontrolled state of the panel
+   */
+  defaultOpenItems?: AccordionItemValue | AccordionItemValue[];
 
-export type AccordionState = ComponentState<AccordionSlots> & AccordionCommons & AccordionContextValue;
+  /**
+   * Indicates if Accordion support multiple Panels closed at the same time
+   */
+  collapsible?: boolean;
+
+  /**
+   * Indicates if Accordion support multiple Panels opened at the same time
+   */
+  multiple?: boolean;
+
+  /**
+   * Indicates if keyboard navigation is available and gives two options,
+   * linear or circular navigation
+   */
+  navigation?: 'linear' | 'circular';
+
+  onToggle?: AccordionToggleEventHandler;
+
+  /**
+   * Controls the state of the panel
+   */
+  openItems?: AccordionItemValue | AccordionItemValue[];
+};
+
+export type AccordionState = ComponentState<AccordionSlots> & AccordionContextValue;

--- a/packages/react-accordion/src/components/Accordion/useAccordion.ts
+++ b/packages/react-accordion/src/components/Accordion/useAccordion.ts
@@ -31,16 +31,10 @@ export const useAccordion_unstable = (props: AccordionProps, ref: React.Ref<HTML
 
   const requestToggle = useEventCallback((event: AccordionToggleEvent, data: AccordionToggleData) => {
     onToggle?.(event, data);
-    setOpenItems(previousOpenItems =>
-      updateOpenItems(data.value, previousOpenItems, {
-        collapsible,
-        multiple,
-      }),
-    );
+    setOpenItems(previousOpenItems => updateOpenItems(data.value, previousOpenItems, multiple, collapsible));
   });
 
   return {
-    multiple,
     collapsible,
     navigation,
     openItems,
@@ -76,12 +70,14 @@ function initializeUncontrolledOpenItems({
  * Updates the list of open indexes based on an index that changes
  * @param value - the index that will change
  * @param previousOpenItems - list of current open indexes
- * @param param2 - {multiple, collapsible}
+ * @param multiple - if Accordion support multiple Panels opened at the same time
+ * @param collapsible - if Accordion support multiple Panels closed at the same time
  */
 function updateOpenItems(
   value: AccordionItemValue,
   previousOpenItems: AccordionItemValue[],
-  { multiple, collapsible }: Pick<AccordionState, 'multiple' | 'collapsible'>,
+  multiple: boolean,
+  collapsible: boolean,
 ) {
   if (multiple) {
     if (previousOpenItems.includes(value)) {

--- a/packages/react-accordion/src/components/AccordionHeader/AccordionHeader.types.ts
+++ b/packages/react-accordion/src/components/AccordionHeader/AccordionHeader.types.ts
@@ -4,11 +4,9 @@ import type { ARIAButtonSlotProps } from '@fluentui/react-aria';
 export type AccordionHeaderSize = 'small' | 'medium' | 'large' | 'extra-large';
 export type AccordionHeaderExpandIconPosition = 'start' | 'end';
 
-export type AccordionHeaderContextValue = {
+export type AccordionHeaderContextValue = Required<Pick<AccordionHeaderProps, 'expandIconPosition' | 'size'>> & {
   disabled: boolean;
   open: boolean;
-  expandIconPosition: AccordionHeaderExpandIconPosition;
-  size: AccordionHeaderSize;
 };
 
 export type AccordionHeaderContextValues = {
@@ -34,23 +32,23 @@ export type AccordionHeaderSlots = {
   icon?: Slot<'div'>;
 };
 
-type AccordionHeaderCommons = {
-  /**
-   * Size of spacing in the heading
-   */
-  size: AccordionHeaderSize;
+export type AccordionHeaderProps = ComponentProps<Partial<AccordionHeaderSlots>> & {
   /**
    * The position of the expand  icon slot in heading
    */
-  expandIconPosition: AccordionHeaderExpandIconPosition;
+  expandIconPosition?: AccordionHeaderExpandIconPosition;
+
   /**
    * Indicates if the AccordionHeader should be rendered inline
    */
-  inline: boolean;
+  inline?: boolean;
+
+  /**
+   * Size of spacing in the heading
+   */
+  size?: AccordionHeaderSize;
 };
 
-export type AccordionHeaderProps = ComponentProps<Partial<AccordionHeaderSlots>> & Partial<AccordionHeaderCommons>;
-
 export type AccordionHeaderState = ComponentState<AccordionHeaderSlots> &
-  AccordionHeaderCommons &
+  Required<Pick<AccordionHeaderProps, 'inline'>> &
   AccordionHeaderContextValue;

--- a/packages/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
+++ b/packages/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
-export type AccordionItemContextValue = {
-  disabled: boolean;
+export type AccordionItemContextValue = Required<Pick<AccordionItemProps, 'disabled'>> & {
   onHeaderClick(ev: React.MouseEvent | React.KeyboardEvent): void;
   open: boolean;
 };

--- a/packages/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
+++ b/packages/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
-export type AccordionItemContextValue = Omit<AccordionItemCommons, 'value'> & {
+export type AccordionItemContextValue = {
+  disabled: boolean;
   open: boolean;
   onHeaderClick(ev: React.MouseEvent | React.KeyboardEvent): void;
 };
@@ -14,21 +15,17 @@ export type AccordionItemSlots = {
   root: Slot<'div'>;
 };
 
-type AccordionItemCommons = {
+export type AccordionItemProps = ComponentProps<AccordionItemSlots> & {
   /**
    * Disables opening/closing of panel
    */
-  disabled: boolean;
+  disabled?: boolean;
   /**
    * required value that identifies this item inside an Accordion component
    */
   value: AccordionItemValue;
 };
 
-export type AccordionItemProps = ComponentProps<AccordionItemSlots> &
-  Partial<AccordionItemCommons> &
-  Pick<AccordionItemCommons, 'value'>;
-
 export type AccordionItemValue = unknown;
 
-export type AccordionItemState = ComponentState<AccordionItemSlots> & AccordionItemCommons & AccordionItemContextValue;
+export type AccordionItemState = ComponentState<AccordionItemSlots> & AccordionItemContextValue;

--- a/packages/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
+++ b/packages/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
@@ -3,8 +3,8 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 
 export type AccordionItemContextValue = {
   disabled: boolean;
-  open: boolean;
   onHeaderClick(ev: React.MouseEvent | React.KeyboardEvent): void;
+  open: boolean;
 };
 
 export type AccordionItemContextValues = {

--- a/packages/react-accordion/src/components/AccordionItem/useAccordionItem.ts
+++ b/packages/react-accordion/src/components/AccordionItem/useAccordionItem.ts
@@ -25,7 +25,6 @@ export const useAccordionItem_unstable = (
 
   return {
     open,
-    value,
     disabled,
     onHeaderClick: onAccordionHeaderClick,
     components: {


### PR DESCRIPTION
Parent issue: #22862

While removing Commons, I noticed a couple places there was a prop on state that wasn't used, so I removed those. I also alphabetized type props.