### PR TITLE
react-label: Move package to release candidate

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV0/Components/Label.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV0/Components/Label.stories.mdx
@@ -27,7 +27,7 @@ An equivalent `Label` in v9 is
 
 ```tsx
 import * as React from 'react';
-import { Label } from '@fluentui/react-components/unstable';
+import { Label } from '@fluentui/react-components';
 
 const LabelV9BasicExample = () => {
   return <Label>You have 23 emails</Label>;

--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Label.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Label.stories.mdx
@@ -35,7 +35,7 @@ An equivalent `Label` in v9 is
 
 ```tsx
 import * as React from 'react';
-import { Label } from '@fluentui/react-components/unstable';
+import { Label } from '@fluentui/react-components';
 import { useId } from '@fluentui/react-utilities';
 
 const LabelV9BasicExample = () => {

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -27,7 +27,7 @@
     "@fluentui/react-icons": "^2.0.166-rc.3",
     "@fluentui/react-image": "9.0.0-rc.8",
     "@fluentui/react-input": "9.0.0-beta.9",
-    "@fluentui/react-label": "9.0.0-beta.12",
+    "@fluentui/react-label": "9.0.0-rc.1",
     "@fluentui/react-link": "9.0.0-rc.9",
     "@fluentui/react-menu": "9.0.0-rc.9",
     "@fluentui/react-popover": "9.0.0-rc.9",

--- a/change/@fluentui-react-checkbox-fc3b783d-b10c-43cf-b03a-6646856ec6a8.json
+++ b/change/@fluentui-react-checkbox-fc3b783d-b10c-43cf-b03a-6646856ec6a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "updated react-label package version",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-components-5740471f-c897-45c5-a64a-d3c159f0651d.json
+++ b/change/@fluentui-react-components-5740471f-c897-45c5-a64a-d3c159f0651d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Move react-label to release candidate",
+  "packageName": "@fluentui/react-components",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-10008ff1-dd56-4728-a953-ae3ed4da40d6.json
+++ b/change/@fluentui-react-label-10008ff1-dd56-4728-a953-ae3ed4da40d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update README and package version",
+  "packageName": "@fluentui/react-label",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-f645af04-971d-4f32-aa33-83f684cc3557.json
+++ b/change/@fluentui-react-radio-f645af04-971d-4f32-aa33-83f684cc3557.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "updated react-label package version",
+  "packageName": "@fluentui/react-radio",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-2dc9ec82-9aea-40d6-8117-aa740ffc062d.json
+++ b/change/@fluentui-react-slider-2dc9ec82-9aea-40d6-8117-aa740ffc062d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "updated react-label package version",
+  "packageName": "@fluentui/react-slider",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-6601fbc3-bf10-4d98-a2af-7f06fb10b893.json
+++ b/change/@fluentui-react-spinbutton-6601fbc3-bf10-4d98-a2af-7f06fb10b893.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "updated react-label package version",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-9ad99e50-109a-4750-a33d-b5c4714ea1bc.json
+++ b/change/@fluentui-react-spinner-9ad99e50-109a-4750-a33d-b5c4714ea1bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "updated react-label package version",
+  "packageName": "@fluentui/react-spinner",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-6c7f04e3-673b-4984-b43f-af3109bb5052.json
+++ b/change/@fluentui-react-switch-6c7f04e3-673b-4984-b43f-af3109bb5052.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "updated react-label package version",
+  "packageName": "@fluentui/react-switch",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-checkbox/package.json
+++ b/packages/react-components/react-checkbox/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluentui/react-icons": "^2.0.166-rc.3",
-    "@fluentui/react-label": "9.0.0-beta.12",
+    "@fluentui/react-label": "9.0.0-rc.1",
     "@fluentui/react-tabster": "9.0.0-rc.9",
     "@fluentui/react-theme": "9.0.0-rc.7",
     "@fluentui/react-utilities": "9.0.0-rc.8",

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -134,6 +134,12 @@ import { imageClassNames } from '@fluentui/react-image';
 import { ImageProps } from '@fluentui/react-image';
 import { ImageSlots } from '@fluentui/react-image';
 import { ImageState } from '@fluentui/react-image';
+import { Label } from '@fluentui/react-label';
+import { labelClassName } from '@fluentui/react-label';
+import { labelClassNames } from '@fluentui/react-label';
+import { LabelProps } from '@fluentui/react-label';
+import { LabelSlots } from '@fluentui/react-label';
+import { LabelState } from '@fluentui/react-label';
 import { LargeTitle } from '@fluentui/react-text';
 import { largeTitleClassName } from '@fluentui/react-text';
 import { largeTitleClassNames } from '@fluentui/react-text';
@@ -291,6 +297,7 @@ import { renderDivider_unstable } from '@fluentui/react-divider';
 import { RendererProvider } from '@griffel/react';
 import { renderFluentProvider_unstable } from '@fluentui/react-provider';
 import { renderImage_unstable } from '@fluentui/react-image';
+import { renderLabel_unstable } from '@fluentui/react-label';
 import { renderLink_unstable } from '@fluentui/react-link';
 import { renderMenu_unstable } from '@fluentui/react-menu';
 import { renderMenuButton_unstable } from '@fluentui/react-button';
@@ -422,6 +429,8 @@ import { useImage_unstable } from '@fluentui/react-image';
 import { useImageStyles_unstable } from '@fluentui/react-image';
 import { useIsSSR } from '@fluentui/react-utilities';
 import { useKeyboardNavAttribute } from '@fluentui/react-tabster';
+import { useLabel_unstable } from '@fluentui/react-label';
+import { useLabelStyles_unstable } from '@fluentui/react-label';
 import { useLink_unstable } from '@fluentui/react-link';
 import { useLinkState_unstable } from '@fluentui/react-link';
 import { useLinkStyles_unstable } from '@fluentui/react-link';
@@ -748,6 +757,18 @@ export { ImageSlots }
 
 export { ImageState }
 
+export { Label }
+
+export { labelClassName }
+
+export { labelClassNames }
+
+export { LabelProps }
+
+export { LabelSlots }
+
+export { LabelState }
+
 export { LargeTitle }
 
 export { largeTitleClassName }
@@ -1062,6 +1083,8 @@ export { renderFluentProvider_unstable }
 
 export { renderImage_unstable }
 
+export { renderLabel_unstable }
+
 export { renderLink_unstable }
 
 export { renderMenu_unstable }
@@ -1323,6 +1346,10 @@ export { useImageStyles_unstable }
 export { useIsSSR }
 
 export { useKeyboardNavAttribute }
+
+export { useLabel_unstable }
+
+export { useLabelStyles_unstable }
 
 export { useLink_unstable }
 

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -42,12 +42,6 @@ import { InputOnChangeData } from '@fluentui/react-input';
 import { InputProps } from '@fluentui/react-input';
 import { InputSlots } from '@fluentui/react-input';
 import { InputState } from '@fluentui/react-input';
-import { Label } from '@fluentui/react-label';
-import { labelClassName } from '@fluentui/react-label';
-import { labelClassNames } from '@fluentui/react-label';
-import { LabelProps } from '@fluentui/react-label';
-import { LabelSlots } from '@fluentui/react-label';
-import { LabelState } from '@fluentui/react-label';
 import { RegisterTabEventHandler } from '@fluentui/react-tabs';
 import { renderCard_unstable } from '@fluentui/react-card';
 import { renderCardFooter_unstable } from '@fluentui/react-card';
@@ -55,7 +49,6 @@ import { renderCardHeader_unstable } from '@fluentui/react-card';
 import { renderCardPreview_unstable } from '@fluentui/react-card';
 import { renderCheckbox_unstable } from '@fluentui/react-checkbox';
 import { renderInput_unstable } from '@fluentui/react-input';
-import { renderLabel_unstable } from '@fluentui/react-label';
 import { renderSpinButton_unstable } from '@fluentui/react-spinbutton';
 import { renderSpinner_unstable } from '@fluentui/react-spinner';
 import { renderSwitch_unstable } from '@fluentui/react-switch';
@@ -119,8 +112,6 @@ import { useCheckbox_unstable } from '@fluentui/react-checkbox';
 import { useCheckboxStyles_unstable } from '@fluentui/react-checkbox';
 import { useInput_unstable } from '@fluentui/react-input';
 import { useInputStyles_unstable } from '@fluentui/react-input';
-import { useLabel_unstable } from '@fluentui/react-label';
-import { useLabelStyles_unstable } from '@fluentui/react-label';
 import { useSpinButton_unstable } from '@fluentui/react-spinbutton';
 import { useSpinButtonStyles_unstable } from '@fluentui/react-spinbutton';
 import { useSpinner_unstable } from '@fluentui/react-spinner';
@@ -210,18 +201,6 @@ export { InputSlots }
 
 export { InputState }
 
-export { Label }
-
-export { labelClassName }
-
-export { labelClassNames }
-
-export { LabelProps }
-
-export { LabelSlots }
-
-export { LabelState }
-
 export { RegisterTabEventHandler }
 
 export { renderCard_unstable }
@@ -235,8 +214,6 @@ export { renderCardPreview_unstable }
 export { renderCheckbox_unstable }
 
 export { renderInput_unstable }
-
-export { renderLabel_unstable }
 
 export { renderSpinButton_unstable }
 
@@ -363,10 +340,6 @@ export { useCheckboxStyles_unstable }
 export { useInput_unstable }
 
 export { useInputStyles_unstable }
-
-export { useLabel_unstable }
-
-export { useLabelStyles_unstable }
 
 export { useSpinButton_unstable }
 

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -40,7 +40,7 @@
     "@fluentui/react-divider": "9.0.0-rc.8",
     "@fluentui/react-image": "9.0.0-rc.8",
     "@fluentui/react-input": "9.0.0-beta.9",
-    "@fluentui/react-label": "9.0.0-beta.12",
+    "@fluentui/react-label": "9.0.0-rc.1",
     "@fluentui/react-link": "9.0.0-rc.9",
     "@fluentui/react-menu": "9.0.0-rc.9",
     "@fluentui/react-popover": "9.0.0-rc.9",

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -315,6 +315,16 @@ export {
 } from '@fluentui/react-image';
 export type { ImageProps, ImageSlots, ImageState } from '@fluentui/react-image';
 export {
+  Label,
+  /* eslint-disable-next-line deprecation/deprecation */
+  labelClassName,
+  labelClassNames,
+  renderLabel_unstable,
+  useLabel_unstable,
+  useLabelStyles_unstable,
+} from '@fluentui/react-label';
+export type { LabelProps, LabelSlots, LabelState } from '@fluentui/react-label';
+export {
   Link,
   /* eslint-disable-next-line deprecation/deprecation */
   linkClassName,

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -68,17 +68,6 @@ export {
 export type { InputOnChangeData, InputProps, InputSlots, InputState } from '@fluentui/react-input';
 
 export {
-  Label,
-  /* eslint-disable-next-line deprecation/deprecation */
-  labelClassName,
-  labelClassNames,
-  renderLabel_unstable,
-  useLabel_unstable,
-  useLabelStyles_unstable,
-} from '@fluentui/react-label';
-export type { LabelProps, LabelSlots, LabelState } from '@fluentui/react-label';
-
-export {
   SpinButton,
   renderSpinButton_unstable,
   spinButtonClassNames,

--- a/packages/react-components/react-label/README.md
+++ b/packages/react-components/react-label/README.md
@@ -4,13 +4,15 @@
 
 These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
 
+Labels provide a name or title to a component or group of components, e.g., text fields, checkboxes, radio buttons, and dropdown menus.
+
 ## Usage
 
-To use the `Label` component import it from `@fluentui/react-label` and use it as shown below.
+To use the `Label` component import it from ` and use it as shown below.
 
 ```tsx
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
+import { Label } from '@fluentui/react-components';
 import { useId } from '@fluentui/react-utilities';
 
 export const labelExample = () => {
@@ -26,3 +28,14 @@ export const labelExample = () => {
   );
 };
 ```
+
+See [Fluent UI Storybook](https://aka.ms/fluentui-storybook) for more detailed usage examples.
+
+Alternatively, run Storybook locally with:
+
+1. `yarn start`
+2. Select `react-label` from the list.
+
+### Specification
+
+See [Spec.md](./Spec.md).

--- a/packages/react-components/react-label/package.json
+++ b/packages/react-components/react-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-label",
-  "version": "9.0.0-beta.12",
+  "version": "9.0.0-rc.1",
   "description": "Fluent UI React Label component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/react-components/react-label/src/stories/Label.stories.tsx
+++ b/packages/react-components/react-label/src/stories/Label.stories.tsx
@@ -10,7 +10,7 @@ export { Disabled } from './LabelDisabled.stories';
 export { Required } from './LabelRequired.stories';
 
 const meta: Meta = {
-  title: 'Preview Components/Label',
+  title: 'Components/Label',
   component: Label,
   parameters: {
     docs: {

--- a/packages/react-components/react-radio/package.json
+++ b/packages/react-components/react-radio/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluentui/react-context-selector": "9.0.0-rc.8",
     "@fluentui/react-icons": "^2.0.166-rc.3",
-    "@fluentui/react-label": "9.0.0-beta.12",
+    "@fluentui/react-label": "9.0.0-rc.1",
     "@fluentui/react-tabster": "9.0.0-rc.9",
     "@fluentui/react-theme": "9.0.0-rc.7",
     "@fluentui/react-utilities": "9.0.0-rc.8",

--- a/packages/react-components/react-slider/package.json
+++ b/packages/react-components/react-slider/package.json
@@ -29,7 +29,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.5",
-    "@fluentui/react-label": "9.0.0-beta.12",
+    "@fluentui/react-label": "9.0.0-rc.1",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/react-components/react-spinbutton/package.json
+++ b/packages/react-components/react-spinbutton/package.json
@@ -29,7 +29,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.5",
-    "@fluentui/react-label": "9.0.0-beta.12",
+    "@fluentui/react-label": "9.0.0-rc.1",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/react-components/react-spinner/package.json
+++ b/packages/react-components/react-spinner/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluentui/react-theme": "9.0.0-rc.7",
-    "@fluentui/react-label": "9.0.0-beta.12",
+    "@fluentui/react-label": "9.0.0-rc.1",
     "@fluentui/react-utilities": "9.0.0-rc.8",
     "@griffel/react": "1.0.3",
     "tslib": "^2.1.0"

--- a/packages/react-components/react-switch/package.json
+++ b/packages/react-components/react-switch/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluentui/react-icons": "^2.0.166-rc.3",
-    "@fluentui/react-label": "9.0.0-beta.12",
+    "@fluentui/react-label": "9.0.0-rc.1",
     "@fluentui/react-tabster": "9.0.0-rc.9",
     "@fluentui/react-theme": "9.0.0-rc.7",
     "@fluentui/react-utilities": "9.0.0-rc.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,6 +1686,16 @@
   resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.166-rc.3.tgz#6a66d104a4809ca9da1982f895bc24abb624e342"
   integrity sha512-mhTti5DcCvG/UxRD+/P5Qjdo/QDOE57eRcRBVooOpfO2N1Q+9sE44NYczOeOHpV2AufNqomX0QYf5iPYZ1lEtg==
 
+"@fluentui/react-label@9.0.0-beta.12":
+  version "9.0.0-beta.12"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-label/-/react-label-9.0.0-beta.12.tgz#1b839792f4d593e7837bb87618c9a6891d744200"
+  integrity sha512-9rwT83XRG25aJZcJZdYzSJbGBwlQk5ix+/kyRz4gd32wI+KrHprxhv7CBmyql6yEuMBGGRnCOG2PO46RRCneoA==
+  dependencies:
+    "@fluentui/react-theme" "9.0.0-rc.7"
+    "@fluentui/react-utilities" "9.0.0-rc.8"
+    "@griffel/react" "1.0.3"
+    tslib "^2.1.0"
+
 "@griffel/babel-preset@1.2.0", "@griffel/babel-preset@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@griffel/babel-preset/-/babel-preset-1.2.0.tgz#c1a7c9bc4a45d3bed561fb6bad1bcefbc3c01bff"
@@ -27010,7 +27020,7 @@ y18n@^3.2.1:
   integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
 
 y18n@^4.0.0:
-  version "4.0.1"
+  version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -27010,7 +27010,7 @@ y18n@^3.2.1:
   integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
 
 y18n@^4.0.0:
-  version "4.0.0"
+  version "4.0.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,16 +1686,6 @@
   resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.166-rc.3.tgz#6a66d104a4809ca9da1982f895bc24abb624e342"
   integrity sha512-mhTti5DcCvG/UxRD+/P5Qjdo/QDOE57eRcRBVooOpfO2N1Q+9sE44NYczOeOHpV2AufNqomX0QYf5iPYZ1lEtg==
 
-"@fluentui/react-label@9.0.0-beta.12":
-  version "9.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-label/-/react-label-9.0.0-beta.12.tgz#1b839792f4d593e7837bb87618c9a6891d744200"
-  integrity sha512-9rwT83XRG25aJZcJZdYzSJbGBwlQk5ix+/kyRz4gd32wI+KrHprxhv7CBmyql6yEuMBGGRnCOG2PO46RRCneoA==
-  dependencies:
-    "@fluentui/react-theme" "9.0.0-rc.7"
-    "@fluentui/react-utilities" "9.0.0-rc.8"
-    "@griffel/react" "1.0.3"
-    tslib "^2.1.0"
-
 "@griffel/babel-preset@1.2.0", "@griffel/babel-preset@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@griffel/babel-preset/-/babel-preset-1.2.0.tgz#c1a7c9bc4a45d3bed561fb6bad1bcefbc3c01bff"


### PR DESCRIPTION
## Current Behavior

`Label` is exported in `@fluentui/react-components/unstable`.

## New Behavior

1. `Label` imports now use `@fluentui/react-components` instead of `@fluentui/react-components/unstable`.
2. `react-label` package is now `rc` instead of `beta`.
3. Updates packages to new `react-label` version.

## Related Issue(s)

Fixes #22777
