### PR TITLE
Avatar: remove commons types

### DIFF
--- a/change/@fluentui-react-avatar-2c5f12fa-f3d8-4d4d-ad02-eeb76cbbd25d.json
+++ b/change/@fluentui-react-avatar-2c5f12fa-f3d8-4d4d-ad02-eeb76cbbd25d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "remove commons type from avatar and avatargroup",
+  "packageName": "@fluentui/react-avatar",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -31,7 +31,13 @@ export const AvatarGroup: ForwardRefComponent<AvatarGroupProps>;
 export const avatarGroupClassNames: SlotClassNames<AvatarGroupSlots>;
 
 // @public
-export type AvatarGroupProps = ComponentProps<AvatarGroupSlots> & Partial<AvatarGroupCommons>;
+export type AvatarGroupProps = ComponentProps<AvatarGroupSlots> & {
+    layout?: 'spread' | 'stack' | 'pie';
+    maxAvatars?: number;
+    overflowIndicator?: 'number-overflowed' | 'icon';
+    size?: AvatarSizes;
+    strings?: AvatarGroupStrings;
+};
 
 // @public (undocumented)
 export type AvatarGroupSlots = {
@@ -41,7 +47,7 @@ export type AvatarGroupSlots = {
 };
 
 // @public
-export type AvatarGroupState = ComponentState<AvatarGroupSlots> & AvatarGroupCommons & {
+export type AvatarGroupState = ComponentState<AvatarGroupSlots> & {
     tooltipContent: TooltipProps['content'];
 };
 
@@ -49,7 +55,15 @@ export type AvatarGroupState = ComponentState<AvatarGroupSlots> & AvatarGroupCom
 export type AvatarNamedColor = 'darkRed' | 'cranberry' | 'red' | 'pumpkin' | 'peach' | 'marigold' | 'gold' | 'brass' | 'brown' | 'forest' | 'seafoam' | 'darkGreen' | 'lightTeal' | 'teal' | 'steel' | 'blue' | 'royalBlue' | 'cornflower' | 'navy' | 'lavender' | 'purple' | 'grape' | 'lilac' | 'pink' | 'magenta' | 'plum' | 'beige' | 'mink' | 'platinum' | 'anchor';
 
 // @public
-export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & Partial<AvatarCommons>;
+export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & {
+    active?: 'active' | 'inactive' | 'unset';
+    activeAppearance?: 'ring' | 'shadow' | 'ring-shadow';
+    color?: 'neutral' | 'brand' | 'colorful' | AvatarNamedColor;
+    idForColor?: string | undefined;
+    name?: string;
+    shape?: 'circular' | 'square';
+    size?: AvatarSizes;
+};
 
 // @public
 export type AvatarSizes = 20 | 24 | 28 | 32 | 36 | 40 | 48 | 56 | 64 | 72 | 96 | 120 | 128;
@@ -64,8 +78,8 @@ export type AvatarSlots = {
 };
 
 // @public
-export type AvatarState = ComponentState<AvatarSlots> & AvatarCommons & {
-    color: Exclude<AvatarCommons['color'], 'colorful'>;
+export type AvatarState = ComponentState<AvatarSlots> & Required<Pick<AvatarProps, 'active' | 'activeAppearance' | 'shape' | 'size'>> & {
+    color: 'neutral' | 'brand' | AvatarNamedColor;
 };
 
 // @public

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -79,7 +79,7 @@ export type AvatarSlots = {
 
 // @public
 export type AvatarState = ComponentState<AvatarSlots> & Required<Pick<AvatarProps, 'active' | 'activeAppearance' | 'shape' | 'size'>> & {
-    color: 'neutral' | 'brand' | AvatarNamedColor;
+    color: NonNullable<Exclude<AvatarProps['color'], 'colorful'>>;
 };
 
 // @public

--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -24,7 +24,7 @@ export type AvatarSlots = {
   /**
    * Icon to be displayed when the avatar doesn't have an image or initials.
    *
-   * @defaultvalue `PersonRegular` (the default icon's size depends on the Avatar's size)
+   * @default `PersonRegular` (the default icon's size depends on the Avatar's size)
    */
   icon?: Slot<'span'>;
 
@@ -84,14 +84,14 @@ export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & {
    * * inactive: the avatar will be reduced in size and partially transparent
    * * unset: normal display
    *
-   * @defaultvalue unset
+   * @default unset
    */
   active?: 'active' | 'inactive' | 'unset';
 
   /**
    * The appearance when `active="active"`
    *
-   * @defaultvalue ring
+   * @default ring
    */
   activeAppearance?: 'ring' | 'shadow' | 'ring-shadow';
 
@@ -102,7 +102,7 @@ export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & {
    * * colorful: picks a color from a set of pre-defined colors, based on a hash of the name (or idForColor if provided)
    * * [AvatarNamedColor]: a specific color from the theme
    *
-   * @defaultvalue neutral
+   * @default neutral
    */
   color?: 'neutral' | 'brand' | 'colorful' | AvatarNamedColor;
 
@@ -122,7 +122,7 @@ export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & {
 
   /**
    * The avatar can have a circular or square shape.
-   * @defaultvalue circular
+   * @default circular
    */
   shape?: 'circular' | 'square';
 
@@ -138,7 +138,7 @@ export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & {
    * For example, to set the avatar to 45px in size:
    * `<Avatar size={40} style={{ width: '45px', height: '45px' }} />`
    *
-   * @defaultvalue 32
+   * @default 32
    */
   size?: AvatarSizes;
 };
@@ -151,5 +151,5 @@ export type AvatarState = ComponentState<AvatarSlots> &
     /**
      * The Avatar's color, it matches props.color but with `'colorful'` resolved to a named color
      */
-    color: 'neutral' | 'brand' | AvatarNamedColor;
+    color: NonNullable<Exclude<AvatarProps['color'], 'colorful'>>;
   };

--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -34,72 +34,6 @@ export type AvatarSlots = {
   badge?: Slot<typeof PresenceBadge>;
 };
 
-type AvatarCommons = {
-  /**
-   * The name of the person or entity represented by this Avatar. This should always be provided if it is available.
-   *
-   * The name will be used to determine the initials displayed when there is no icon, as well as provided to
-   * accessibility tools.
-   */
-  name?: string;
-
-  /**
-   * Size of the avatar in pixels.
-   *
-   * Size is restricted to a limited set of supported values recommended for most uses (see `AvatarSizeValue`) and
-   * based on design guidelines for the Avatar control.
-   *
-   * If a non-supported size is neeeded, set `size` to the next-smaller supported size, and set `width` and `height`
-   * to override the rendered size.
-   *
-   * For example, to set the avatar to 45px in size:
-   * `<Avatar size={40} style={{ width: '45px', height: '45px' }} />`
-   *
-   * @defaultvalue 32
-   */
-  size: AvatarSizes;
-
-  /**
-   * The avatar can have a circular or square shape.
-   * @defaultvalue circular
-   */
-  shape: 'circular' | 'square';
-
-  /**
-   * Optional activity indicator
-   * * active: the avatar will be decorated according to activeAppearance
-   * * inactive: the avatar will be reduced in size and partially transparent
-   * * unset: normal display
-   *
-   * @defaultvalue unset
-   */
-  active: 'active' | 'inactive' | 'unset';
-
-  /**
-   * The appearance when `active="active"`
-   *
-   * @defaultvalue ring
-   */
-  activeAppearance: 'ring' | 'shadow' | 'ring-shadow';
-
-  /**
-   * The color when displaying either an icon or initials.
-   * * neutral (default): gray
-   * * brand: color from the brand palette
-   * * colorful: picks a color from a set of pre-defined colors, based on a hash of the name (or idForColor if provided)
-   * * [AvatarNamedColor]: a specific color from the theme
-   *
-   * @defaultvalue neutral
-   */
-  color: 'neutral' | 'brand' | 'colorful' | AvatarNamedColor;
-
-  /**
-   * Specify a string to be used instead of the name, to determine which color to use when color="colorful".
-   * Use this when a name is not available, but there is another unique identifier that can be used instead.
-   */
-  idForColor: string | undefined;
-};
-
 /**
  * A specific named color for the Avatar
  */
@@ -143,15 +77,79 @@ export type AvatarSizes = 20 | 24 | 28 | 32 | 36 | 40 | 48 | 56 | 64 | 72 | 96 |
 /**
  * Properties for Avatar
  */
-export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & Partial<AvatarCommons>;
+export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & {
+  /**
+   * Optional activity indicator
+   * * active: the avatar will be decorated according to activeAppearance
+   * * inactive: the avatar will be reduced in size and partially transparent
+   * * unset: normal display
+   *
+   * @defaultvalue unset
+   */
+  active?: 'active' | 'inactive' | 'unset';
+
+  /**
+   * The appearance when `active="active"`
+   *
+   * @defaultvalue ring
+   */
+  activeAppearance?: 'ring' | 'shadow' | 'ring-shadow';
+
+  /**
+   * The color when displaying either an icon or initials.
+   * * neutral (default): gray
+   * * brand: color from the brand palette
+   * * colorful: picks a color from a set of pre-defined colors, based on a hash of the name (or idForColor if provided)
+   * * [AvatarNamedColor]: a specific color from the theme
+   *
+   * @defaultvalue neutral
+   */
+  color?: 'neutral' | 'brand' | 'colorful' | AvatarNamedColor;
+
+  /**
+   * Specify a string to be used instead of the name, to determine which color to use when color="colorful".
+   * Use this when a name is not available, but there is another unique identifier that can be used instead.
+   */
+  idForColor?: string | undefined;
+
+  /**
+   * The name of the person or entity represented by this Avatar. This should always be provided if it is available.
+   *
+   * The name will be used to determine the initials displayed when there is no icon, as well as provided to
+   * accessibility tools.
+   */
+  name?: string;
+
+  /**
+   * The avatar can have a circular or square shape.
+   * @defaultvalue circular
+   */
+  shape?: 'circular' | 'square';
+
+  /**
+   * Size of the avatar in pixels.
+   *
+   * Size is restricted to a limited set of supported values recommended for most uses (see `AvatarSizeValue`) and
+   * based on design guidelines for the Avatar control.
+   *
+   * If a non-supported size is neeeded, set `size` to the next-smaller supported size, and set `width` and `height`
+   * to override the rendered size.
+   *
+   * For example, to set the avatar to 45px in size:
+   * `<Avatar size={40} style={{ width: '45px', height: '45px' }} />`
+   *
+   * @defaultvalue 32
+   */
+  size?: AvatarSizes;
+};
 
 /**
  * State used in rendering Avatar
  */
 export type AvatarState = ComponentState<AvatarSlots> &
-  AvatarCommons & {
+  Required<Pick<AvatarProps, 'active' | 'activeAppearance' | 'shape' | 'size'>> & {
     /**
-     * The Avatar's color, with `'colorful'` resolved to a named color
+     * The Avatar's color, it matches props.color but with `'colorful'` resolved to a named color
      */
-    color: Exclude<AvatarCommons['color'], 'colorful'>;
+    color: 'neutral' | 'brand' | AvatarNamedColor;
   };

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -98,12 +98,10 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
 
   return {
     size,
-    name,
     shape,
     active,
     activeAppearance,
     color,
-    idForColor,
 
     components: {
       root: 'span',

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/AvatarGroup.types.ts
@@ -18,31 +18,34 @@ export type AvatarGroupSlots = {
   popoverSurface?: Slot<typeof PopoverSurface>;
 };
 
-type AvatarGroupCommons = {
+/**
+ * AvatarGroup Props
+ */
+export type AvatarGroupProps = ComponentProps<AvatarGroupSlots> & {
   /**
    * Layout the Avatars should be displayed as.
    * @default spread
    */
-  layout: 'spread' | 'stack' | 'pie';
+  layout?: 'spread' | 'stack' | 'pie';
 
   /**
    * Maximum number of Avatars to be displayed before overflowing.
    * NOTE: if pie layout is used, `maxAvatars` will be ignored.
    * @default 5
    */
-  maxAvatars: number;
-
-  /**
-   * Size of the avatars.
-   * @default 32
-   */
-  size: AvatarSizes;
+  maxAvatars?: number;
 
   /**
    * Whether the overflow indicator should render an icon instead of the number of overflowed avatars.
    * @default false
    */
-  overflowIndicator: 'number-overflowed' | 'icon';
+  overflowIndicator?: 'number-overflowed' | 'icon';
+
+  /**
+   * Size of the avatars.
+   * @default 32
+   */
+  size?: AvatarSizes;
 
   /**
    * Strings for localizing text in the tooltip.
@@ -51,17 +54,11 @@ type AvatarGroupCommons = {
 };
 
 /**
- * AvatarGroup Props
- */
-export type AvatarGroupProps = ComponentProps<AvatarGroupSlots> & Partial<AvatarGroupCommons>;
-
-/**
  * State used in rendering AvatarGroup
  */
-export type AvatarGroupState = ComponentState<AvatarGroupSlots> &
-  AvatarGroupCommons & {
-    tooltipContent: TooltipProps['content'];
-  };
+export type AvatarGroupState = ComponentState<AvatarGroupSlots> & {
+  tooltipContent: TooltipProps['content'];
+};
 
 export type AvatarGroupStrings = {
   /**

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.ts
@@ -15,21 +15,9 @@ import { avatarGroupDefaultStrings } from './AvatarGroup.strings';
  * @param ref - reference to root HTMLElement of AvatarGroup
  */
 export const useAvatarGroup_unstable = (props: AvatarGroupProps, ref: React.Ref<HTMLElement>): AvatarGroupState => {
-  const {
-    overflowIndicator = 'number-overflowed',
-    layout = 'spread',
-    children,
-    maxAvatars = 5,
-    size = 32,
-    strings = avatarGroupDefaultStrings,
-  } = props;
+  const { children, strings = avatarGroupDefaultStrings } = props;
 
   return {
-    maxAvatars,
-    layout,
-    size,
-    strings: strings,
-    overflowIndicator,
     // TODO: Replace with actual logic.
     tooltipContent: strings.tooltipContent.replace('{numOverflowedAvatars}', String(10)),
     components: {


### PR DESCRIPTION
Parent issue: #22862

Removes Commons type from both Avatar and AvatarGroup, and removes unused props from state.

Note: AvatarGroup will likely implement a context at some point, and then the AvatarGroupContext type would likely pick from props, and those values would be re-added to state. I've still removed them from state for now, since they're not currently used.