### PR TITLE
Badge: remove commons type

### DIFF
--- a/change/@fluentui-react-badge-b0df5892-a8d0-40c4-9f88-195a256a2af2.json
+++ b/change/@fluentui-react-badge-b0df5892-a8d0-40c4-9f88-195a256a2af2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove commons types from badges",
+  "packageName": "@fluentui/react-badge",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-badge/etc/react-badge.api.md
+++ b/packages/react-badge/etc/react-badge.api.md
@@ -48,18 +48,18 @@ export const counterBadgeClassName = "fui-CounterBadge";
 export const counterBadgeClassNames: SlotClassNames<BadgeSlots>;
 
 // @public (undocumented)
-export type CounterBadgeProps = Omit<BadgeProps, 'appearance' | 'shape' | 'color'> & {
-    appearance: 'filled' | 'ghost';
-    color: Extract<BadgeProps['color'], 'brand' | 'danger' | 'important' | 'informative'>;
-    count: number;
-    dot: boolean;
-    overflowCount: number;
-    shape: 'circular' | 'rounded';
-    showZero: boolean;
+export type CounterBadgeProps = Omit<BadgeProps, 'appearance' | 'color' | 'shape'> & {
+    appearance?: 'filled' | 'ghost';
+    color?: Extract<BadgeProps['color'], 'brand' | 'danger' | 'important' | 'informative'>;
+    count?: number;
+    dot?: boolean;
+    overflowCount?: number;
+    shape?: 'circular' | 'rounded';
+    showZero?: boolean;
 };
 
 // @public (undocumented)
-export type CounterBadgeState = Omit<BadgeState, 'appearance' | 'shape' | 'color'> & Required<Pick<CounterBadgeProps, 'appearance' | 'color' | 'count' | 'dot' | 'shape' | 'showZero'>>;
+export type CounterBadgeState = Omit<BadgeState, 'appearance' | 'color' | 'shape'> & Required<Pick<CounterBadgeProps, 'appearance' | 'color' | 'count' | 'dot' | 'shape' | 'showZero'>>;
 
 // @public
 export const PresenceBadge: ForwardRefComponent<PresenceBadgeProps>;

--- a/packages/react-badge/etc/react-badge.api.md
+++ b/packages/react-badge/etc/react-badge.api.md
@@ -21,7 +21,13 @@ export const badgeClassName = "fui-Badge";
 export const badgeClassNames: SlotClassNames<BadgeSlots>;
 
 // @public (undocumented)
-export type BadgeProps = Omit<ComponentProps<BadgeSlots>, 'color'> & Partial<BadgeCommons>;
+export type BadgeProps = Omit<ComponentProps<BadgeSlots>, 'color'> & {
+    appearance?: 'filled' | 'ghost' | 'outline' | 'tint';
+    color?: 'brand' | 'danger' | 'important' | 'informative' | 'severe' | 'subtle' | 'success' | 'warning';
+    iconPosition?: 'before' | 'after';
+    shape?: 'circular' | 'rounded' | 'square';
+    size?: 'tiny' | 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large';
+};
 
 // @public (undocumented)
 export type BadgeSlots = {
@@ -30,7 +36,7 @@ export type BadgeSlots = {
 };
 
 // @public (undocumented)
-export type BadgeState = ComponentState<BadgeSlots> & BadgeCommons;
+export type BadgeState = ComponentState<BadgeSlots> & Required<Pick<BadgeProps, 'appearance' | 'color' | 'iconPosition' | 'shape' | 'size'>>;
 
 // @public
 export const CounterBadge: ForwardRefComponent<CounterBadgeProps>;
@@ -42,10 +48,18 @@ export const counterBadgeClassName = "fui-CounterBadge";
 export const counterBadgeClassNames: SlotClassNames<BadgeSlots>;
 
 // @public (undocumented)
-export type CounterBadgeProps = Omit<BadgeProps, 'appearance' | 'shape' | 'color'> & Partial<CounterBadgeCommons>;
+export type CounterBadgeProps = Omit<BadgeProps, 'appearance' | 'shape' | 'color'> & {
+    appearance: 'filled' | 'ghost';
+    color: Extract<BadgeProps['color'], 'brand' | 'danger' | 'important' | 'informative'>;
+    count: number;
+    dot: boolean;
+    overflowCount: number;
+    shape: 'circular' | 'rounded';
+    showZero: boolean;
+};
 
 // @public (undocumented)
-export type CounterBadgeState = Omit<BadgeState, 'appearance' | 'shape' | 'color'> & CounterBadgeCommons;
+export type CounterBadgeState = Omit<BadgeState, 'appearance' | 'shape' | 'color'> & Required<Pick<CounterBadgeProps, 'appearance' | 'color' | 'count' | 'dot' | 'shape' | 'showZero'>>;
 
 // @public
 export const PresenceBadge: ForwardRefComponent<PresenceBadgeProps>;
@@ -57,10 +71,13 @@ export const presenceBadgeClassName = "fui-PresenceBadge";
 export const presenceBadgeClassNames: SlotClassNames<BadgeSlots>;
 
 // @public (undocumented)
-export type PresenceBadgeProps = Omit<ComponentProps<Pick<BadgeSlots, 'root'>>, 'color'> & Partial<Pick<PresenceBadgeCommons, 'status' | 'outOfOffice' | 'size'>>;
+export type PresenceBadgeProps = Omit<ComponentProps<Pick<BadgeSlots, 'root'>>, 'color'> & Pick<BadgeProps, 'size'> & {
+    status?: PresenceBadgeStatus;
+    outOfOffice?: boolean;
+};
 
 // @public (undocumented)
-export type PresenceBadgeState = PresenceBadgeCommons & ComponentState<BadgeSlots>;
+export type PresenceBadgeState = ComponentState<BadgeSlots> & BadgeState & Required<Pick<PresenceBadgeProps, 'status' | 'outOfOffice'>>;
 
 // @public (undocumented)
 export type PresenceBadgeStatus = 'busy' | 'outOfOffice' | 'away' | 'available' | 'offline' | 'doNotDisturb' | 'unknown';

--- a/packages/react-badge/src/components/Badge/Badge.types.ts
+++ b/packages/react-badge/src/components/Badge/Badge.types.ts
@@ -5,39 +5,39 @@ export type BadgeSlots = {
   icon?: Slot<'span'>;
 };
 
-export type BadgeCommons = {
+// react has a non-standard `color` attribute in its types
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a4ab0fa432320e70da9e51c8ae2e47377f65804b/types/react/index.d.ts#L1868
+export type BadgeProps = Omit<ComponentProps<BadgeSlots>, 'color'> & {
   /**
    * A Badge can be filled, outline, ghost, inverted
    * @defaultvalue filled
    */
-  appearance: 'filled' | 'ghost' | 'outline' | 'tint';
+  appearance?: 'filled' | 'ghost' | 'outline' | 'tint';
 
   /**
    * A Badge can be one of preset colors
    * @defaultvalue brand
    */
-  color: 'brand' | 'danger' | 'important' | 'informative' | 'severe' | 'subtle' | 'success' | 'warning';
+  color?: 'brand' | 'danger' | 'important' | 'informative' | 'severe' | 'subtle' | 'success' | 'warning';
 
   /**
    * A Badge can position the icon before or after the content.
    * @defaultvalue before
    */
-  iconPosition: 'before' | 'after';
+  iconPosition?: 'before' | 'after';
 
   /**
    * A Badge can be square, circular or rounded.
    * @defaultvalue circular
    */
-  shape: 'circular' | 'rounded' | 'square';
+  shape?: 'circular' | 'rounded' | 'square';
 
   /**
    * A Badge can be on of several preset sizes.
    * @defaultvalue medium
    */
-  size: 'tiny' | 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large';
+  size?: 'tiny' | 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large';
 };
 
-// react has a non-standard `color` attribute in its types
-// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a4ab0fa432320e70da9e51c8ae2e47377f65804b/types/react/index.d.ts#L1868
-export type BadgeProps = Omit<ComponentProps<BadgeSlots>, 'color'> & Partial<BadgeCommons>;
-export type BadgeState = ComponentState<BadgeSlots> & BadgeCommons;
+export type BadgeState = ComponentState<BadgeSlots> &
+  Required<Pick<BadgeProps, 'appearance' | 'color' | 'iconPosition' | 'shape' | 'size'>>;

--- a/packages/react-badge/src/components/CounterBadge/CounterBadge.types.ts
+++ b/packages/react-badge/src/components/CounterBadge/CounterBadge.types.ts
@@ -1,48 +1,51 @@
 import type { BadgeProps, BadgeState } from '../Badge/index';
 
-export type CounterBadgeProps = Omit<BadgeProps, 'appearance' | 'shape' | 'color'> & {
+export type CounterBadgeProps = Omit<BadgeProps, 'appearance' | 'color' | 'shape'> & {
   /**
-   * A Badge can be filled, ghost
+   * A Badge can have different appearances that emphasize certain parts of it:
+   *  - filled: The default appearance if one is not specified.
+   *    The badge background is filled with color with a contrasting foreground text to match.
+   *  - ghost: The badge background is transparent, with the foreground text taking color to emphasize it.
    * @default filled
    */
-  appearance: 'filled' | 'ghost';
+  appearance?: 'filled' | 'ghost';
 
   /**
    * Semantic colors for a counter badge
    * @default brand
    */
-  color: Extract<BadgeProps['color'], 'brand' | 'danger' | 'important' | 'informative'>;
+  color?: Extract<BadgeProps['color'], 'brand' | 'danger' | 'important' | 'informative'>;
 
   /**
    * Value displayed by the Badge
    * @default 0
    */
-  count: number;
+  count?: number;
 
   /**
    * If a dot should be displayed without the count
    * @default false
    */
-  dot: boolean;
+  dot?: boolean;
 
   /**
    * Max number to be displayed
    * @default 99
    */
-  overflowCount: number;
+  overflowCount?: number;
 
   /**
    * A Badge can be circular or rounded
    * @default circular
    */
-  shape: 'circular' | 'rounded';
+  shape?: 'circular' | 'rounded';
 
   /**
    * If the badge should be shown when count is 0
    * @default false
    */
-  showZero: boolean;
+  showZero?: boolean;
 };
 
-export type CounterBadgeState = Omit<BadgeState, 'appearance' | 'shape' | 'color'> &
+export type CounterBadgeState = Omit<BadgeState, 'appearance' | 'color' | 'shape'> &
   Required<Pick<CounterBadgeProps, 'appearance' | 'color' | 'count' | 'dot' | 'shape' | 'showZero'>>;

--- a/packages/react-badge/src/components/CounterBadge/CounterBadge.types.ts
+++ b/packages/react-badge/src/components/CounterBadge/CounterBadge.types.ts
@@ -1,36 +1,6 @@
 import type { BadgeProps, BadgeState } from '../Badge/index';
 
-type CounterBadgeCommons = {
-  /**
-   * Max number to be displayed
-   * @default 99
-   */
-  overflowCount: number;
-
-  /**
-   * Value displayed by the Badge
-   * @default 0
-   */
-  count: number;
-
-  /**
-   * If the badge should be shown when count is 0
-   * @default false
-   */
-  showZero: boolean;
-
-  /**
-   * If a dot should be displayed without the count
-   * @default false
-   */
-  dot: boolean;
-
-  /**
-   * A Badge can be circular or rounded
-   * @default circular
-   */
-  shape: 'circular' | 'rounded';
-
+export type CounterBadgeProps = Omit<BadgeProps, 'appearance' | 'shape' | 'color'> & {
   /**
    * A Badge can be filled, ghost
    * @default filled
@@ -42,8 +12,37 @@ type CounterBadgeCommons = {
    * @default brand
    */
   color: Extract<BadgeProps['color'], 'brand' | 'danger' | 'important' | 'informative'>;
+
+  /**
+   * Value displayed by the Badge
+   * @default 0
+   */
+  count: number;
+
+  /**
+   * If a dot should be displayed without the count
+   * @default false
+   */
+  dot: boolean;
+
+  /**
+   * Max number to be displayed
+   * @default 99
+   */
+  overflowCount: number;
+
+  /**
+   * A Badge can be circular or rounded
+   * @default circular
+   */
+  shape: 'circular' | 'rounded';
+
+  /**
+   * If the badge should be shown when count is 0
+   * @default false
+   */
+  showZero: boolean;
 };
 
-export type CounterBadgeProps = Omit<BadgeProps, 'appearance' | 'shape' | 'color'> & Partial<CounterBadgeCommons>;
-
-export type CounterBadgeState = Omit<BadgeState, 'appearance' | 'shape' | 'color'> & CounterBadgeCommons;
+export type CounterBadgeState = Omit<BadgeState, 'appearance' | 'shape' | 'color'> &
+  Required<Pick<CounterBadgeProps, 'appearance' | 'color' | 'count' | 'dot' | 'shape' | 'showZero'>>;

--- a/packages/react-badge/src/components/CounterBadge/useCounterBadge.ts
+++ b/packages/react-badge/src/components/CounterBadge/useCounterBadge.ts
@@ -20,13 +20,12 @@ export const useCounterBadge_unstable = (props: CounterBadgeProps, ref: React.Re
     shape,
     appearance,
     showZero,
-    overflowCount,
     count,
     dot,
   };
 
   if (!state.dot && !state.root.children) {
-    state.root.children = state.count > state.overflowCount ? `${state.overflowCount}+` : `${state.count}`;
+    state.root.children = state.count > overflowCount ? `${overflowCount}+` : `${state.count}`;
   }
 
   return state;

--- a/packages/react-badge/src/components/PresenceBadge/PresenceBadge.types.ts
+++ b/packages/react-badge/src/components/PresenceBadge/PresenceBadge.types.ts
@@ -1,5 +1,5 @@
 import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
-import type { BadgeCommons, BadgeSlots } from '../Badge/Badge.types';
+import type { BadgeProps, BadgeState, BadgeSlots } from '../Badge/Badge.types';
 
 export type PresenceBadgeStatus =
   | 'busy'
@@ -10,21 +10,21 @@ export type PresenceBadgeStatus =
   | 'doNotDisturb'
   | 'unknown';
 
-type PresenceBadgeCommons = {
-  /**
-   * Represents several status
-   * @default available
-   */
-  status: PresenceBadgeStatus;
-  /**
-   * Modifies the display to indicate that the user is out of office.
-   * This can be combined with any status to display an out-of-office version of that status
-   * @default false
-   */
-  outOfOffice: boolean;
-} & BadgeCommons;
-
 export type PresenceBadgeProps = Omit<ComponentProps<Pick<BadgeSlots, 'root'>>, 'color'> &
-  Partial<Pick<PresenceBadgeCommons, 'status' | 'outOfOffice' | 'size'>>;
+  Pick<BadgeProps, 'size'> & {
+    /**
+     * Represents several status
+     * @default available
+     */
+    status?: PresenceBadgeStatus;
+    /**
+     * Modifies the display to indicate that the user is out of office.
+     * This can be combined with any status to display an out-of-office version of that status
+     * @default false
+     */
+    outOfOffice?: boolean;
+  };
 
-export type PresenceBadgeState = PresenceBadgeCommons & ComponentState<BadgeSlots>;
+export type PresenceBadgeState = ComponentState<BadgeSlots> &
+  BadgeState &
+  Required<Pick<PresenceBadgeProps, 'status' | 'outOfOffice'>>;

--- a/packages/react-badge/src/components/PresenceBadge/PresenceBadge.types.ts
+++ b/packages/react-badge/src/components/PresenceBadge/PresenceBadge.types.ts
@@ -17,6 +17,7 @@ export type PresenceBadgeProps = Omit<ComponentProps<Pick<BadgeSlots, 'root'>>, 
      * @default available
      */
     status?: PresenceBadgeStatus;
+
     /**
      * Modifies the display to indicate that the user is out of office.
      * This can be combined with any status to display an out-of-office version of that status


### PR DESCRIPTION
Parent issue: #22862

Removes the commons type from all components in react-badge