### PR TITLE
SpinButton: remove SpinButtonCommons type

### DIFF
--- a/change/@fluentui-react-spinbutton-e9ad1dc6-db08-4425-a9a3-edbc682aa036.json
+++ b/change/@fluentui-react-spinbutton-e9ad1dc6-db08-4425-a9a3-edbc682aa036.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "react-spinbutton: remove SpinButtonCommons type",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinbutton/etc/react-spinbutton.api.md
+++ b/packages/react-components/react-spinbutton/etc/react-spinbutton.api.md
@@ -27,29 +27,26 @@ export type SpinButtonChangeEvent = React_2.MouseEvent<HTMLButtonElement> | Reac
 export const spinButtonClassNames: SlotClassNames<SpinButtonSlots>;
 
 // @public (undocumented)
-export type SpinButtonCommons = {
-    defaultValue: number;
-    value: number;
-    displayValue: string;
-    min: number;
-    max: number;
-    step: number;
-    stepPage: number;
-    onChange: (event: SpinButtonChangeEvent, data: SpinButtonOnChangeData) => void;
-    precision: number;
-    appearance: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
-    size: 'small' | 'medium';
-    strings?: SpinButtonStrings;
-};
-
-// @public (undocumented)
 export type SpinButtonOnChangeData = {
     value?: number;
     displayValue?: string;
 };
 
 // @public
-export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'input'>, 'onChange' | 'size'> & Partial<SpinButtonCommons>;
+export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'input'>, 'onChange' | 'size'> & {
+    defaultValue?: number;
+    value?: number;
+    displayValue?: string;
+    min?: number;
+    max?: number;
+    step?: number;
+    stepPage?: number;
+    onChange?: (event: SpinButtonChangeEvent, data: SpinButtonOnChangeData) => void;
+    precision?: number;
+    appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
+    size?: 'small' | 'medium';
+    strings?: SpinButtonStrings;
+};
 
 // @public (undocumented)
 export type SpinButtonSlots = {
@@ -63,7 +60,7 @@ export type SpinButtonSlots = {
 export type SpinButtonSpinState = 'rest' | 'up' | 'down';
 
 // @public
-export type SpinButtonState = ComponentState<SpinButtonSlots> & Partial<SpinButtonCommons> & Pick<SpinButtonCommons, 'appearance' | 'size'> & {
+export type SpinButtonState = ComponentState<SpinButtonSlots> & Partial<Exclude<SpinButtonProps, keyof SpinButtonSlots>> & Required<Pick<SpinButtonProps, 'appearance' | 'size'>> & {
     spinState: SpinButtonSpinState;
     atBound: SpinButtonBounds;
 };

--- a/packages/react-components/react-spinbutton/etc/react-spinbutton.api.md
+++ b/packages/react-components/react-spinbutton/etc/react-spinbutton.api.md
@@ -34,18 +34,18 @@ export type SpinButtonOnChangeData = {
 
 // @public
 export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'input'>, 'onChange' | 'size'> & {
+    appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
     defaultValue?: number;
-    value?: number;
     displayValue?: string;
-    min?: number;
     max?: number;
-    step?: number;
-    stepPage?: number;
+    min?: number;
     onChange?: (event: SpinButtonChangeEvent, data: SpinButtonOnChangeData) => void;
     precision?: number;
-    appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
     size?: 'small' | 'medium';
+    step?: number;
+    stepPage?: number;
     strings?: SpinButtonStrings;
+    value?: number;
 };
 
 // @public (undocumented)
@@ -60,7 +60,7 @@ export type SpinButtonSlots = {
 export type SpinButtonSpinState = 'rest' | 'up' | 'down';
 
 // @public
-export type SpinButtonState = ComponentState<SpinButtonSlots> & Partial<Exclude<SpinButtonProps, keyof SpinButtonSlots>> & Required<Pick<SpinButtonProps, 'appearance' | 'size'>> & {
+export type SpinButtonState = ComponentState<SpinButtonSlots> & Required<Pick<SpinButtonProps, 'appearance' | 'size'>> & {
     spinState: SpinButtonSpinState;
     atBound: SpinButtonBounds;
 };

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
@@ -29,14 +29,17 @@ export type SpinButtonSlots = {
   decrementButton: NonNullable<Slot<'button'>>;
 };
 
-export type SpinButtonCommons = {
+/**
+ * SpinButton Props
+ */
+export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'input'>, 'onChange' | 'size'> & {
   /**
    * Initial value of the control (assumed to be valid). Updates to this prop will not be respected.
    *
    * Use this if you intend for the SpinButton to be an uncontrolled component which maintains its
    * own value. For a controlled component, use `value` instead. (Mutually exclusive with `value`.)
    */
-  defaultValue: number;
+  defaultValue?: number;
 
   /**
    * Current value of the control (assumed to be valid).
@@ -45,7 +48,7 @@ export type SpinButtonCommons = {
    * current state and passing updates based on change events; otherwise, use the `defaultValue`
    * property. (Mutually exclusive with `defaultValue`.)
    */
-  value: number;
+  value?: number;
 
   /**
    * String representation of `value`.
@@ -57,17 +60,17 @@ export type SpinButtonCommons = {
    * current state and passing updates based on change events. When SpinButton is used as an
    * uncontrolled component this prop is ignored.
    */
-  displayValue: string;
+  displayValue?: string;
 
   /**
    * Min value of the control. If not provided, the control has no minimum value.
    */
-  min: number;
+  min?: number;
 
   /**
    * Max value of the control. If not provided, the control has no maximum value.
    */
-  max: number;
+  max?: number;
 
   /**
    * Difference between two adjacent values of the control.
@@ -75,14 +78,14 @@ export type SpinButtonCommons = {
    * The precision calculated this way will always be greater than or equal 0.
    * @default 1
    */
-  step: number;
+  step?: number;
 
   /**
    * Large difference between two values. This should be greater than `step` and is used
    * when users hit the Page Up or Page Down keys.
    * @default 1
    */
-  stepPage: number;
+  stepPage?: number;
 
   /**
    * Callback for when the committed value changes.
@@ -91,7 +94,7 @@ export type SpinButtonCommons = {
    * - User *commits* edits to the input text by focusing away (blurring) or pressing enter.
    *   Note that this is NOT called for every key press while the user is editing.
    */
-  onChange: (event: SpinButtonChangeEvent, data: SpinButtonOnChangeData) => void;
+  onChange?: (event: SpinButtonChangeEvent, data: SpinButtonOnChangeData) => void;
 
   /**
    * How many decimal places the value should be rounded to.
@@ -99,19 +102,19 @@ export type SpinButtonCommons = {
    * The default is calculated based on the precision of `step`: i.e. if step = 1, precision = 0.
    * step = 0.0089, precision = 4. step = 300, precision = 2. step = 23.00, precision = 2.
    */
-  precision: number;
+  precision?: number;
 
   /**
    * Controls the colors and borders of the input.
    * @default 'outline'
    */
-  appearance: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
+  appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
 
   /**
    * Size of the input.
    * @default 'medium'
    */
-  size: 'small' | 'medium';
+  size?: 'small' | 'medium';
 
   /**
    * Strings for localizing text in the control.
@@ -120,17 +123,11 @@ export type SpinButtonCommons = {
 };
 
 /**
- * SpinButton Props
- */
-export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'input'>, 'onChange' | 'size'> &
-  Partial<SpinButtonCommons>;
-
-/**
  * State used in rendering SpinButton
  */
 export type SpinButtonState = ComponentState<SpinButtonSlots> &
-  Partial<SpinButtonCommons> &
-  Pick<SpinButtonCommons, 'appearance' | 'size'> & {
+  Partial<Exclude<SpinButtonProps, keyof SpinButtonSlots>> &
+  Required<Pick<SpinButtonProps, 'appearance' | 'size'>> & {
     /**
      * State used to track which direction, if any, SpinButton is currently spinning.
      * @default 'rest'

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
@@ -34,21 +34,18 @@ export type SpinButtonSlots = {
  */
 export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'input'>, 'onChange' | 'size'> & {
   /**
+   * Controls the colors and borders of the input.
+   * @default 'outline'
+   */
+  appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
+
+  /**
    * Initial value of the control (assumed to be valid). Updates to this prop will not be respected.
    *
    * Use this if you intend for the SpinButton to be an uncontrolled component which maintains its
    * own value. For a controlled component, use `value` instead. (Mutually exclusive with `value`.)
    */
   defaultValue?: number;
-
-  /**
-   * Current value of the control (assumed to be valid).
-   *
-   * Only provide this if the SpinButton is a controlled component where you are maintaining its
-   * current state and passing updates based on change events; otherwise, use the `defaultValue`
-   * property. (Mutually exclusive with `defaultValue`.)
-   */
-  value?: number;
 
   /**
    * String representation of `value`.
@@ -63,29 +60,14 @@ export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'inp
   displayValue?: string;
 
   /**
-   * Min value of the control. If not provided, the control has no minimum value.
-   */
-  min?: number;
-
-  /**
    * Max value of the control. If not provided, the control has no maximum value.
    */
   max?: number;
 
   /**
-   * Difference between two adjacent values of the control.
-   * This value is used to calculate the precision of the input if no `precision` is given.
-   * The precision calculated this way will always be greater than or equal 0.
-   * @default 1
+   * Min value of the control. If not provided, the control has no minimum value.
    */
-  step?: number;
-
-  /**
-   * Large difference between two values. This should be greater than `step` and is used
-   * when users hit the Page Up or Page Down keys.
-   * @default 1
-   */
-  stepPage?: number;
+  min?: number;
 
   /**
    * Callback for when the committed value changes.
@@ -105,28 +87,45 @@ export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'inp
   precision?: number;
 
   /**
-   * Controls the colors and borders of the input.
-   * @default 'outline'
-   */
-  appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
-
-  /**
    * Size of the input.
    * @default 'medium'
    */
   size?: 'small' | 'medium';
 
   /**
+   * Difference between two adjacent values of the control.
+   * This value is used to calculate the precision of the input if no `precision` is given.
+   * The precision calculated this way will always be greater than or equal 0.
+   * @default 1
+   */
+  step?: number;
+
+  /**
+   * Large difference between two values. This should be greater than `step` and is used
+   * when users hit the Page Up or Page Down keys.
+   * @default 1
+   */
+  stepPage?: number;
+
+  /**
    * Strings for localizing text in the control.
    */
   strings?: SpinButtonStrings;
+
+  /**
+   * Current value of the control (assumed to be valid).
+   *
+   * Only provide this if the SpinButton is a controlled component where you are maintaining its
+   * current state and passing updates based on change events; otherwise, use the `defaultValue`
+   * property. (Mutually exclusive with `defaultValue`.)
+   */
+  value?: number;
 };
 
 /**
  * State used in rendering SpinButton
  */
 export type SpinButtonState = ComponentState<SpinButtonSlots> &
-  Partial<Exclude<SpinButtonProps, keyof SpinButtonSlots>> &
   Required<Pick<SpinButtonProps, 'appearance' | 'size'>> & {
     /**
      * State used to track which direction, if any, SpinButton is currently spinning.

--- a/packages/react-components/react-spinbutton/src/index.ts
+++ b/packages/react-components/react-spinbutton/src/index.ts
@@ -8,7 +8,6 @@ export {
 export type {
   SpinButtonOnChangeData,
   SpinButtonChangeEvent,
-  SpinButtonCommons,
   SpinButtonProps,
   SpinButtonSlots,
   SpinButtonState,


### PR DESCRIPTION
## Current Behavior

`SpinButton` exports a `SpinButtonCommons` type.

## New Behavior

`SpinButtonCommons` is removed per: #20964

## Related Issue(s)

#22862
