### PR TITLE
Card: remove commons type

### DIFF
--- a/change/@fluentui-react-card-c2de5549-5b5a-4da7-8be6-c628273c2b85.json
+++ b/change/@fluentui-react-card-c2de5549-5b5a-4da7-8be6-c628273c2b85.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove commons from Card",
+  "packageName": "@fluentui/react-card",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/etc/react-card.api.md
+++ b/packages/react-components/react-card/etc/react-card.api.md
@@ -20,12 +20,6 @@ export const cardClassName = "fui-Card";
 // @public (undocumented)
 export const cardClassNames: SlotClassNames<CardSlots>;
 
-// @public (undocumented)
-export type CardCommons = {
-    appearance: 'filled' | 'filled-alternative' | 'outline' | 'subtle';
-    focusMode: 'off' | 'no-tab' | 'tab-exit' | 'tab-only';
-};
-
 // @public
 export const CardFooter: ForwardRefComponent<CardFooterProps>;
 
@@ -94,7 +88,10 @@ export type CardPreviewSlots = {
 export type CardPreviewState = ComponentState<CardPreviewSlots>;
 
 // @public
-export type CardProps = ComponentProps<CardSlots> & Partial<CardCommons>;
+export type CardProps = ComponentProps<CardSlots> & {
+    appearance?: 'filled' | 'filled-alternative' | 'outline' | 'subtle';
+    focusMode?: 'off' | 'no-tab' | 'tab-exit' | 'tab-only';
+};
 
 // @public (undocumented)
 export type CardSlots = {
@@ -102,7 +99,7 @@ export type CardSlots = {
 };
 
 // @public
-export type CardState = ComponentState<CardSlots> & CardCommons;
+export type CardState = ComponentState<CardSlots> & Required<Pick<CardProps, 'appearance'>>;
 
 // @public
 export const renderCard_unstable: (state: CardState) => JSX.Element;

--- a/packages/react-components/react-card/src/components/Card/Card.types.ts
+++ b/packages/react-components/react-card/src/components/Card/Card.types.ts
@@ -4,8 +4,11 @@ export type CardSlots = {
   root: Slot<'div'>;
 };
 
-export type CardCommons = {
-  appearance: 'filled' | 'filled-alternative' | 'outline' | 'subtle';
+/**
+ * Card Props
+ */
+export type CardProps = ComponentProps<CardSlots> & {
+  appearance?: 'filled' | 'filled-alternative' | 'outline' | 'subtle';
 
   /**
    * Sets the focus behavior for the card. If `true`, the card will use the `noTab` focus behavior.
@@ -27,15 +30,10 @@ export type CardCommons = {
    *
    * @defaultvalue off
    */
-  focusMode: 'off' | 'no-tab' | 'tab-exit' | 'tab-only';
+  focusMode?: 'off' | 'no-tab' | 'tab-exit' | 'tab-only';
 };
-
-/**
- * Card Props
- */
-export type CardProps = ComponentProps<CardSlots> & Partial<CardCommons>;
 
 /**
  * State used in rendering Card
  */
-export type CardState = ComponentState<CardSlots> & CardCommons;
+export type CardState = ComponentState<CardSlots> & Required<Pick<CardProps, 'appearance'>>;

--- a/packages/react-components/react-card/src/components/Card/useCard.ts
+++ b/packages/react-components/react-card/src/components/Card/useCard.ts
@@ -28,7 +28,6 @@ export const useCard_unstable = (props: CardProps, ref: React.Ref<HTMLElement>):
 
   return {
     appearance,
-    focusMode,
 
     components: { root: 'div' },
     root: getNativeElementProps(props.as || 'div', {

--- a/packages/react-components/react-card/src/index.ts
+++ b/packages/react-components/react-card/src/index.ts
@@ -8,7 +8,7 @@ export {
   useCardStyles_unstable,
   useCard_unstable,
 } from './Card';
-export type { CardCommons, CardProps, CardSlots, CardState } from './Card';
+export type { CardProps, CardSlots, CardState } from './Card';
 export {
   CardFooter,
   cardFooterClassName,


### PR DESCRIPTION
Parent issue: #22862

Removes Commons type for Card, also removes the unused `focusMode` prop from CardState (looks like it was previously included only because it was in Commons)