### PR TITLE
Hotell/build/migrate v9 to rolluped dts p6

### DIFF
--- a/change/@fluentui-react-portal-compat-ba5c1278-c702-44c4-b9cf-a8cc5316716c.json
+++ b/change/@fluentui-react-portal-compat-ba5c1278-c702-44c4-b9cf-a8cc5316716c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-130f47b9-944a-4335-95fd-676a2520ea84.json
+++ b/change/@fluentui-react-radio-130f47b9-944a-4335-95fd-676a2520ea84.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-radio",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-7c334e7e-2377-471c-8edf-5fb09b4d4ae1.json
+++ b/change/@fluentui-react-switch-7c334e7e-2377-471c-8edf-5fb09b4d4ae1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-switch",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-514fb246-4c11-447a-b1c6-b69a0237fcf0.json
+++ b/change/@fluentui-react-textarea-514fb246-4c11-447a-b1c6-b69a0237fcf0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ship rolluped only dts",
+  "packageName": "@fluentui/react-textarea",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-portal-compat/.babelrc.json
+++ b/packages/react-components/react-portal-compat/.babelrc.json
@@ -1,3 +1,4 @@
 {
+  "presets": [],
   "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/packages/react-components/react-portal-compat/.npmignore
+++ b/packages/react-components/react-portal-compat/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-portal-compat/config/api-extractor.json
+++ b/packages/react-components/react-portal-compat/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-portal-compat/package.json
+++ b/packages/react-components/react-portal-compat/package.json
@@ -4,7 +4,7 @@
   "description": "A package that contains compatibility layer for React Portals",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-portal-compat/tsconfig.lib.json
+++ b/packages/react-components/react-portal-compat/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx"],

--- a/packages/react-components/react-radio/.npmignore
+++ b/packages/react-components/react-radio/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-radio/config/api-extractor.json
+++ b/packages/react-components/react-radio/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-radio/package.json
+++ b/packages/react-components/react-radio/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent UI Radio component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-radio/tsconfig.lib.json
+++ b/packages/react-components/react-radio/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-switch/.npmignore
+++ b/packages/react-components/react-switch/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-switch/config/api-extractor.json
+++ b/packages/react-components/react-switch/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-switch/package.json
+++ b/packages/react-components/react-switch/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent UI React Switch component.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-switch/tsconfig.lib.json
+++ b/packages/react-components/react-switch/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [

--- a/packages/react-components/react-textarea/.npmignore
+++ b/packages/react-components/react-textarea/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-textarea/config/api-extractor.json
+++ b/packages/react-components/react-textarea/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-textarea/package.json
+++ b/packages/react-components/react-textarea/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent UI TextArea component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/react-components/react-textarea/tsconfig.lib.json
+++ b/packages/react-components/react-textarea/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Applied `yarn workspace-generator migrate-converged-pkg` to ship only rolluped type definitions for:
- react-checkbox
- react-input
- react-label
- react-link
- react-select

## Related Issue(s)

Fixes partially https://github.com/microsoft/fluentui/issues/22429
