### PR TITLE
chore(tools): enable unused vars lint rule and fix violations

### DIFF
--- a/tools/.eslintrc.json
+++ b/tools/.eslintrc.json
@@ -2,6 +2,7 @@
   "extends": ["plugin:@fluentui/eslint-plugin/node"],
   "root": true,
   "rules": {
-    "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../"] }]
+    "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../"] }],
+    "@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }]
   }
 }

--- a/tools/generators/generate-change-files.ts
+++ b/tools/generators/generate-change-files.ts
@@ -1,4 +1,4 @@
-import { Tree, logger, joinPathFragments } from '@nrwl/devkit';
+import { Tree, logger } from '@nrwl/devkit';
 import * as path from 'path';
 import * as childProcess from 'child_process';
 import * as chalk from 'chalk';

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -12,7 +12,6 @@ import {
   writeJson,
   updateProjectConfiguration,
   serializeJson,
-  generateFiles,
 } from '@nrwl/devkit';
 import * as path from 'path';
 import * as os from 'os';
@@ -100,7 +99,7 @@ function runBatchMigration(tree: Tree, userLog: UserLog, projectNames?: string[]
   });
 }
 
-function runMigrationOnProject(tree: Tree, schema: AssertedSchema, userLog: UserLog) {
+function runMigrationOnProject(tree: Tree, schema: AssertedSchema, _userLog: UserLog) {
   const options = normalizeOptions(tree, schema);
 
   if (options.owner) {
@@ -566,10 +565,6 @@ function updateApiExtractorForLocalBuilds(tree: Tree, options: NormalizedSchema)
 }
 
 function setupStorybook(tree: Tree, options: NormalizedSchema) {
-  function transformRelativePath(_path: string) {
-    return joinPathFragments('..', _path);
-  }
-
   const sbAction = shouldSetupStorybook(tree, options);
 
   const template = {

--- a/tools/generators/print-stats.spec.ts
+++ b/tools/generators/print-stats.spec.ts
@@ -1,4 +1,4 @@
-import { addProjectConfiguration, getProjects, logger, stripIndents, Tree } from '@nrwl/devkit';
+import { addProjectConfiguration, getProjects, logger, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import * as chalk from 'chalk';
 import { disableChalk, formatMockedCalls } from '../utils-testing';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

`tools/` dont use TypeScript style rules which defeat the purpose of disabling compilation because style violations, thus we are not notified about unused identifiers in our code

## New Behavior

`no-unused-vars` is enabled

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

