### PR TITLE
fix(tools): properly generate local api extractor config

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -763,7 +763,7 @@ describe('migrate-converged-pkg generator', () => {
         Object {
           "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
           "extends": "./api-extractor.json",
-          "mainEntryPointFilePath": "<projectFolder>/dist/packages/react-components/<unscopedPackageName>/src/index.d.ts",
+          "mainEntryPointFilePath": "<projectFolder>/dist/types/packages/react-components/<unscopedPackageName>/src/index.d.ts",
         }
       `);
       /* eslint-enable @fluentui/max-len */
@@ -808,7 +808,7 @@ describe('migrate-converged-pkg generator', () => {
       expect(pkgJson.scripts).toEqual({
         docs: 'api-extractor run --config=config/api-extractor.local.json --local',
         // eslint-disable-next-line @fluentui/max-len
-        'build:local': `tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../../scripts/typescript/normalize-import --output ./dist/packages/react-components/react-dummy/src && yarn docs`,
+        'build:local': `tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../../scripts/typescript/normalize-import --output ./dist/types/packages/react-components/react-dummy/src && yarn docs`,
         build: 'just-scripts build',
         clean: 'just-scripts clean',
         'code-style': 'just-scripts code-style',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

migration generator contains invalid local:build setup 

## New Behavior

migration generator properly generates `local:build` setup

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes partially https://github.com/microsoft/fluentui/issues/22851
