### PR TITLE
react-label: Removing commons from Label

### DIFF
--- a/change/@fluentui-react-label-345f3781-60ef-404d-bdaa-5fc22c842c21.json
+++ b/change/@fluentui-react-label-345f3781-60ef-404d-bdaa-5fc22c842c21.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing commons type from Label.",
+  "packageName": "@fluentui/react-label",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-label/etc/react-label.api.md
+++ b/packages/react-components/react-label/etc/react-label.api.md
@@ -22,8 +22,8 @@ export const labelClassNames: SlotClassNames<LabelSlots>;
 
 // @public
 export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> & {
-    required?: boolean | Slot<'span'>;
     disabled?: boolean;
+    required?: boolean | Slot<'span'>;
     size?: 'small' | 'medium' | 'large';
     strong?: boolean;
 };

--- a/packages/react-components/react-label/etc/react-label.api.md
+++ b/packages/react-components/react-label/etc/react-label.api.md
@@ -21,8 +21,11 @@ export const labelClassName = "fui-Label";
 export const labelClassNames: SlotClassNames<LabelSlots>;
 
 // @public
-export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> & Partial<LabelCommons> & {
+export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> & {
     required?: boolean | Slot<'span'>;
+    disabled: boolean;
+    size: 'small' | 'medium' | 'large';
+    strong: boolean;
 };
 
 // @public (undocumented)
@@ -32,7 +35,7 @@ export type LabelSlots = {
 };
 
 // @public
-export type LabelState = ComponentState<LabelSlots> & LabelCommons;
+export type LabelState = ComponentState<LabelSlots> & Pick<LabelProps, 'disabled' | 'size' | 'strong'>;
 
 // @public
 export const renderLabel_unstable: (state: LabelState) => JSX.Element;

--- a/packages/react-components/react-label/etc/react-label.api.md
+++ b/packages/react-components/react-label/etc/react-label.api.md
@@ -23,9 +23,9 @@ export const labelClassNames: SlotClassNames<LabelSlots>;
 // @public
 export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> & {
     required?: boolean | Slot<'span'>;
-    disabled: boolean;
-    size: 'small' | 'medium' | 'large';
-    strong: boolean;
+    disabled?: boolean;
+    size?: 'small' | 'medium' | 'large';
+    strong?: boolean;
 };
 
 // @public (undocumented)
@@ -35,7 +35,7 @@ export type LabelSlots = {
 };
 
 // @public
-export type LabelState = ComponentState<LabelSlots> & Pick<LabelProps, 'disabled' | 'size' | 'strong'>;
+export type LabelState = ComponentState<LabelSlots> & Required<Pick<LabelProps, 'disabled' | 'size' | 'strong'>>;
 
 // @public
 export const renderLabel_unstable: (state: LabelState) => JSX.Element;

--- a/packages/react-components/react-label/src/components/Label/Label.types.ts
+++ b/packages/react-components/react-label/src/components/Label/Label.types.ts
@@ -1,6 +1,16 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
-type LabelCommons = {
+/**
+ * Label Props
+ */
+export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> & {
+  /**
+   * Displays an indicator that the label is for a required field. The required prop can be set to true to display
+   * an asterisk (*). Or it can be set to a string or jsx content to display a different indicator.
+   * @default false
+   */
+  required?: boolean | Slot<'span'>;
+
   /**
    * Renders the label as disabled
    * @default false
@@ -28,17 +38,4 @@ export type LabelSlots = {
 /**
  * State used in rendering Label
  */
-export type LabelState = ComponentState<LabelSlots> & LabelCommons;
-
-/**
- * Label Props
- */
-export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> &
-  Partial<LabelCommons> & {
-    /**
-     * Displays an indicator that the label is for a required field. The required prop can be set to true to display
-     * an asterisk (*). Or it can be set to a string or jsx content to display a different indicator.
-     * @default false
-     */
-    required?: boolean | Slot<'span'>;
-  };
+export type LabelState = ComponentState<LabelSlots> & Pick<LabelProps, 'disabled' | 'size' | 'strong'>;

--- a/packages/react-components/react-label/src/components/Label/Label.types.ts
+++ b/packages/react-components/react-label/src/components/Label/Label.types.ts
@@ -15,19 +15,19 @@ export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> & {
    * Renders the label as disabled
    * @default false
    */
-  disabled: boolean;
+  disabled?: boolean;
 
   /**
    * A label supports different sizes.
    * @default 'medium'
    */
-  size: 'small' | 'medium' | 'large';
+  size?: 'small' | 'medium' | 'large';
 
   /**
    * A label supports semibold/strong fontweight.
    * @default false
    */
-  strong: boolean;
+  strong?: boolean;
 };
 
 export type LabelSlots = {
@@ -38,4 +38,4 @@ export type LabelSlots = {
 /**
  * State used in rendering Label
  */
-export type LabelState = ComponentState<LabelSlots> & Pick<LabelProps, 'disabled' | 'size' | 'strong'>;
+export type LabelState = ComponentState<LabelSlots> & Required<Pick<LabelProps, 'disabled' | 'size' | 'strong'>>;

--- a/packages/react-components/react-label/src/components/Label/Label.types.ts
+++ b/packages/react-components/react-label/src/components/Label/Label.types.ts
@@ -5,17 +5,17 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
  */
 export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> & {
   /**
+   * Renders the label as disabled
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
    * Displays an indicator that the label is for a required field. The required prop can be set to true to display
    * an asterisk (*). Or it can be set to a string or jsx content to display a different indicator.
    * @default false
    */
   required?: boolean | Slot<'span'>;
-
-  /**
-   * Renders the label as disabled
-   * @default false
-   */
-  disabled?: boolean;
 
   /**
    * A label supports different sizes.


### PR DESCRIPTION
This PR adds the new changes:
* Removing Commons type from Label. 