### PR TITLE
RFC: Browser Support Minbar for v9

### DIFF
--- a/rfcs/shared/build-system/06-browser-support-for-v9.md
+++ b/rfcs/shared/build-system/06-browser-support-for-v9.md
@@ -16,9 +16,9 @@ As it stands, Fluent v9 does not currently adhere to a specific browser support 
 
 The proposed browser support matrix will be loosely based off the [Resize Observer](https://caniuse.com/mdn-api_resizeobserver) support matrix . This decision was driven by the current usage of the `ResizeObserver` in Fluent v9 as well as the current business goals of our partner teams. Along with that, being able to maintain our current ES2019 target and eventually move to ES2020 without the need to transpile down was also a factor. As it stands, the lack of adequate polyfill capabilities for CSS features in tandem with the goals of our partners is the biggest detriment to the support matrix not being higher.
 
-| Edge | Firefox | Chrome | Safari | Opera | Internet Explorer |
-| ---- | ------- | ------ | ------ | ----- | ----------------- |
-| >=80 | >=74    | >=80   | >=14   | >=67  | Not Supported     |
+| Edge | Firefox | Chrome | Safari | Opera | Safari on IOS | Chrome for Android | Samsung | Internet Explorer |
+| ---- | ------- | ------ | ------ | ----- | ------------- | ------------------ | ------- | ----------------- |
+| >=80 | >=74    | >=80   | >=14   | >=67  | >=14          | >=101              | >=16    | Not Supported     |
 
 This browser support matrix will be available through all relevant public docsite and/or wikis for maximum visibility.
 
@@ -52,7 +52,7 @@ With an eye towards being a modern library, Fluent will follow a yearly audit pr
 
 ### Cons
 
-- Incompatible CSS features (`flex gap`) are already present in the library and will need to be removed and refactored.
+- Incompatible CSS features (`flex gap` & `:focus-visible`) are already present in the library and will need to be removed and refactored.
 
 ## Open Issues
 

--- a/rfcs/shared/build-system/06-browser-support-for-v9.md
+++ b/rfcs/shared/build-system/06-browser-support-for-v9.md
@@ -14,11 +14,13 @@ As it stands, Fluent v9 does not currently adhere to a specific browser support 
 
 ### Browser Support Matrix
 
-The proposed browser support matrix will be loosely based off the [Resize Observer](https://caniuse.com/mdn-api_resizeobserver) support matrix. This decision was driven by the current usage of the `ResizeObserver` in Fluent v9 as well as the current business goals of our partner teams. Along with that, being able to maintain our current ES2019 target and eventually move to ES2020 without the need to transpile down was also a factor. As it stands, the lack of adequate polyfill capabilities for CSS features in tandem with the goals of our partners is the biggest detriment to the support matrix not being higher.
+The proposed browser support matrix will be loosely based off the [Resize Observer](https://caniuse.com/mdn-api_resizeobserver) support matrix . This decision was driven by the current usage of the `ResizeObserver` in Fluent v9 as well as the current business goals of our partner teams. Along with that, being able to maintain our current ES2019 target and eventually move to ES2020 without the need to transpile down was also a factor. As it stands, the lack of adequate polyfill capabilities for CSS features in tandem with the goals of our partners is the biggest detriment to the support matrix not being higher.
 
 | Edge | Firefox | Chrome | Safari | Opera | Internet Explorer |
 | ---- | ------- | ------ | ------ | ----- | ----------------- |
 | >=80 | >=74    | >=80   | >=14   | >=67  | Not Supported     |
+
+This browser support matrix will be available through all relevant public docsite and/or wikis for maximum visibility.
 
 ### ECMAScript Syntax & Expectations
 
@@ -32,10 +34,13 @@ Fluent developers are expected to adhere to the proposed browser matrix thus any
 
 With a defined browser matrix, the Fluent team will now have better guidance on what CSS features can and cannot be used. Using polyfills is not a real option in this case because the current ecosystem around CSS polyfills results in egregious amounts of code that increase bundle size while also degrading performance. This puts the responsibility squarely on the Fluent team to ensure that no unsupported CSS features are introduced to the library.
 
+### Browser Support Going Forward
+
+With an eye towards being a modern library, Fluent will follow a yearly audit process to evaluate and update the current browser support matrix to keep pace with the ever evolving ecosystem of the web. This will allow the team to utilize modern tools and improve overall engineering efficiency while also providing consumers with performance and bundlesize improvements. Due to the nature of how Safari browser updates are tied to MacOS versions, Safari will be the browser that ultimately holds the library back from fully adopting modern browser versions across the board. Because of this, the proposed timeframe for when these audits occur should be whenever a Safari major release occurs. These tend to happen annually during the month of September so Fluent can target an annual audit around that time.
+
 ## Out of Scope
 
 - The specifics on how to prevent the addition of ES syntax, browser APIs or CSS features that don't conform to this matrix.
-- Strategy on moving browser support forward for future releases of v10, v11, and so on.
 
 ## Pros and Cons
 

--- a/rfcs/shared/build-system/06-browser-support-for-v9.md
+++ b/rfcs/shared/build-system/06-browser-support-for-v9.md
@@ -1,0 +1,68 @@
+# RFC: Browser Support for Fluent v9
+
+Contributors: Fluent UI React Build team, @TristanWatanabe
+
+## Summary
+
+---
+
+Fluent v9 is currently lacking a defined browser support matrix so this RFC proposes a set of major browser versions compatible with the library to act as the source of truth. As mentioned below, Fluent developers are expected to conform to these browsers and ensure no incompatible syntax, browser APIs or CSS features are introduced to the library. Consumers who require older browser support that aren't covered in this matrix are responsible for performing downlevel transpilations and/or using polyfills themselves.
+
+## Problem Statement
+
+---
+
+As it stands, Fluent v9 does not currently adhere to a specific browser support matrix. This makes it difficult for partner teams and general consumers of the library to know how using the library will impact their own product. There's also a lack of guidance for the internal team in terms of the syntax, browser APIs and CSS features that they can/can't use.
+
+## Detailed Design or Proposal
+
+---
+
+### **Browser Support Matrix**
+
+The proposed browser support matrix will be loosely based off the [Resize Observer](https://caniuse.com/mdn-api_resizeobserver) support matrix. This decision was driven by the current usage of the `ResizeObserver` in Fluent v9 as well as the current business goals of our partner teams. Along with that, being able to maintain our current ES2019 target and eventually move to ES2020 without the need to transpile down was also a factor. As it stands, the lack of adequate polyfill capabilities for CSS features in tandem with the goals of our partners is the biggest detriment to the support matrix not being higher.
+
+| Edge | Firefox | Chrome | Safari | Opera | Internet Explorer |
+| ---- | ------- | ------ | ------ | ----- | ----------------- |
+| >=80 | >=74    | >=80   | >=14   | >=67  | Not Supported     |
+
+### **ECMAScript Syntax & Expectations**
+
+Fluent v9 currently targets ES2019 thus the browser matrix above ensures that no features need to be transpiled down; that way, consumers on modern browsers get the added benefit of reduced bundle size that the latest ECMAScript (ES) standards provide. The proposed browser matrix also keeps the option of moving to ES2020 open since all ES2020 features are already supported by these browsers. This means that Fluent v9's target will firmly be ES2019/2020 so consumers who require older browser environments are responsible for transpiling down and/or polyfilling themselves. Utilizing standard polyfill libraries such as `core-js` should alleviate some of the consumer pain of having to support new ES features on old browsers.
+
+### **Browser APIs & Expectations**
+
+Fluent developers are expected to adhere to the proposed browser matrix thus any usage of browser APIs that aren't compatible should be avoided. For consumers who require the use of older browsers that don't support certain browser features like `ResizeObserver`, they are expected to handle the issue themselves whether through the implementation of their own polyfills or the use of a third-party one.
+
+### **CSS Features & Expectations**
+
+With a defined browser matrix, the Fluent team will now have better guidance on what CSS features can and cannot be used. Using polyfills is not a real option in this case because the current ecosystem around CSS polyfills results in egregious amounts of code that increase bundle size while also degrading performance. This puts the responsibility squarely on the Fluent team to ensure that no unsupported CSS features are introduced to the library.
+
+## Out of Scope
+
+---
+
+- The specifics on how to prevent the addition of ES syntax, browser APIs or CSS features that don't conform to this matrix.
+- Strategy on moving browser support forward for future releases of v10, v11, and so on.
+
+## Pros and Cons
+
+---
+
+### **Pros**
+
+- A source of truth for Fluent team and consumers to refer to for browser support.
+- Able to ship modern ES2019 code with the option of going to ES2020 without downleveling.
+- Less maintanance by putting onus of older/unsupported browsers to consumers.
+
+### **Cons**
+
+- Incompatible CSS features (`flex gap`) are already present in the library and will need to be refactored.
+
+## Open Issues
+
+---
+
+- [#22704](https://github.com/microsoft/fluentui/issues/22704)
+- [#22273](https://github.com/microsoft/fluentui/issues/22273)
+- [#19550](https://github.com/microsoft/fluentui/issues/19550)

--- a/rfcs/shared/build-system/06-browser-support-for-v9.md
+++ b/rfcs/shared/build-system/06-browser-support-for-v9.md
@@ -47,11 +47,9 @@ With a defined browser matrix, the Fluent team will now have better guidance on 
 
 ### Cons
 
-- Incompatible CSS features (`flex gap`) are already present in the library and will need to be refactored.
+- Incompatible CSS features (`flex gap`) are already present in the library and will need to be removed and refactored.
 
 ## Open Issues
-
----
 
 - [#22704](https://github.com/microsoft/fluentui/issues/22704)
 - [#22273](https://github.com/microsoft/fluentui/issues/22273)

--- a/rfcs/shared/build-system/06-browser-support-for-v9.md
+++ b/rfcs/shared/build-system/06-browser-support-for-v9.md
@@ -4,21 +4,15 @@ Contributors: Fluent UI React Build team, @TristanWatanabe
 
 ## Summary
 
----
-
 Fluent v9 is currently lacking a defined browser support matrix so this RFC proposes a set of major browser versions compatible with the library to act as the source of truth. As mentioned below, Fluent developers are expected to conform to these browsers and ensure no incompatible syntax, browser APIs or CSS features are introduced to the library. Consumers who require older browser support that aren't covered in this matrix are responsible for performing downlevel transpilations and/or using polyfills themselves.
 
 ## Problem Statement
-
----
 
 As it stands, Fluent v9 does not currently adhere to a specific browser support matrix. This makes it difficult for partner teams and general consumers of the library to know how using the library will impact their own product. There's also a lack of guidance for the internal team in terms of the syntax, browser APIs and CSS features that they can/can't use.
 
 ## Detailed Design or Proposal
 
----
-
-### **Browser Support Matrix**
+### Browser Support Matrix
 
 The proposed browser support matrix will be loosely based off the [Resize Observer](https://caniuse.com/mdn-api_resizeobserver) support matrix. This decision was driven by the current usage of the `ResizeObserver` in Fluent v9 as well as the current business goals of our partner teams. Along with that, being able to maintain our current ES2019 target and eventually move to ES2020 without the need to transpile down was also a factor. As it stands, the lack of adequate polyfill capabilities for CSS features in tandem with the goals of our partners is the biggest detriment to the support matrix not being higher.
 
@@ -26,36 +20,32 @@ The proposed browser support matrix will be loosely based off the [Resize Observ
 | ---- | ------- | ------ | ------ | ----- | ----------------- |
 | >=80 | >=74    | >=80   | >=14   | >=67  | Not Supported     |
 
-### **ECMAScript Syntax & Expectations**
+### ECMAScript Syntax & Expectations
 
 Fluent v9 currently targets ES2019 thus the browser matrix above ensures that no features need to be transpiled down; that way, consumers on modern browsers get the added benefit of reduced bundle size that the latest ECMAScript (ES) standards provide. The proposed browser matrix also keeps the option of moving to ES2020 open since all ES2020 features are already supported by these browsers. This means that Fluent v9's target will firmly be ES2019/2020 so consumers who require older browser environments are responsible for transpiling down and/or polyfilling themselves. Utilizing standard polyfill libraries such as `core-js` should alleviate some of the consumer pain of having to support new ES features on old browsers.
 
-### **Browser APIs & Expectations**
+### Browser APIs & Expectations
 
 Fluent developers are expected to adhere to the proposed browser matrix thus any usage of browser APIs that aren't compatible should be avoided. For consumers who require the use of older browsers that don't support certain browser features like `ResizeObserver`, they are expected to handle the issue themselves whether through the implementation of their own polyfills or the use of a third-party one.
 
-### **CSS Features & Expectations**
+### CSS Features & Expectations
 
 With a defined browser matrix, the Fluent team will now have better guidance on what CSS features can and cannot be used. Using polyfills is not a real option in this case because the current ecosystem around CSS polyfills results in egregious amounts of code that increase bundle size while also degrading performance. This puts the responsibility squarely on the Fluent team to ensure that no unsupported CSS features are introduced to the library.
 
 ## Out of Scope
-
----
 
 - The specifics on how to prevent the addition of ES syntax, browser APIs or CSS features that don't conform to this matrix.
 - Strategy on moving browser support forward for future releases of v10, v11, and so on.
 
 ## Pros and Cons
 
----
-
-### **Pros**
+### Pros
 
 - A source of truth for Fluent team and consumers to refer to for browser support.
 - Able to ship modern ES2019 code with the option of going to ES2020 without downleveling.
 - Less maintanance by putting onus of older/unsupported browsers to consumers.
 
-### **Cons**
+### Cons
 
 - Incompatible CSS features (`flex gap`) are already present in the library and will need to be refactored.
 

--- a/rfcs/shared/build-system/06-browser-support-for-v9.md
+++ b/rfcs/shared/build-system/06-browser-support-for-v9.md
@@ -14,7 +14,7 @@ As it stands, Fluent v9 does not currently adhere to a specific browser support 
 
 ### Browser Support Matrix
 
-The proposed browser support matrix will be loosely based off the [Resize Observer](https://caniuse.com/mdn-api_resizeobserver) support matrix . This decision was driven by the current usage of the `ResizeObserver` in Fluent v9 as well as the current business goals of our partner teams. Along with that, being able to maintain our current ES2019 target and eventually move to ES2020 without the need to transpile down was also a factor. As it stands, the lack of adequate polyfill capabilities for CSS features in tandem with the goals of our partners is the biggest detriment to the support matrix not being higher.
+The proposed browser support matrix will be based off the [Flex Gap](https://caniuse.com/flexbox-gap) support matrix. This decision was driven by the current usage of `flex gap` in Fluent v9 and it's the feature that requires the highest browser matrix support within the library. Along with that, being able to maintain our current ES2019 target and eventually move to ES2020 without the need to transpile down was also a factor.
 
 **Desktop Browsers:**
 
@@ -46,6 +46,8 @@ With a defined browser matrix, the Fluent team will now have better guidance on 
 
 With an eye towards being a modern library, Fluent will follow a yearly audit process to evaluate and update the current browser support matrix to keep pace with the ever evolving ecosystem of the web. This will allow the team to utilize modern tools and improve overall engineering efficiency while also providing consumers with performance and bundlesize improvements. The proposed yearly audit gives Fluent a reasonable timeframe to evaluate, decide and give notice if browser matrix changes are to be made.
 
+**Note**: As of now, the browser matrix is set to adhere to `flex gap`'s supported browsers but that may change in the future once ongoing conversations with partner teams regarding their own support matrices are resolved. If the conclusion results in Fluent having to lower the browser support matrix (such as dropping Edge/Chrome from 84 to 80), then the Fluent team will ensure that any features currently being used that isn't compatible with the updated matrix are removed and refactored.
+
 ## Out of Scope
 
 - The specifics on how to prevent the addition of ES syntax, browser APIs or CSS features that don't conform to this matrix.
@@ -60,7 +62,7 @@ With an eye towards being a modern library, Fluent will follow a yearly audit pr
 
 ### Cons
 
-- Incompatible CSS features (`flex gap` & `:focus-visible`) are already present in the library and will need to be removed and refactored.
+- Incompatible CSS features (`:focus-visible`) are already present in the library and will need to be removed and refactored.
 
 ## Open Issues
 

--- a/rfcs/shared/build-system/06-browser-support-for-v9.md
+++ b/rfcs/shared/build-system/06-browser-support-for-v9.md
@@ -20,7 +20,7 @@ The proposed browser support matrix will be loosely based off the [Resize Observ
 
 | Edge | Firefox | Chrome | Safari | Opera | Internet Explorer |
 | ---- | ------- | ------ | ------ | ----- | ----------------- |
-| >=80 | >=74    | >=80   | >=14   | >=67  | Not Supported     |
+| >=80 | >=75    | >=80   | >=14   | >=67  | Not Supported     |
 
 **Mobile Browsers:**
 

--- a/rfcs/shared/build-system/06-browser-support-for-v9.md
+++ b/rfcs/shared/build-system/06-browser-support-for-v9.md
@@ -4,7 +4,7 @@ Contributors: Fluent UI React Build team, @TristanWatanabe
 
 ## Summary
 
-Fluent v9 is currently lacking a defined browser support matrix so this RFC proposes a set of major browser versions compatible with the library to act as the source of truth. As mentioned below, Fluent developers are expected to conform to these browsers and ensure no incompatible syntax, browser APIs or CSS features are introduced to the library. Consumers who require older browser support that aren't covered in this matrix are responsible for performing downlevel transpilations and/or using polyfills themselves.
+Fluent v9 is currently lacking a defined browser support matrix so this RFC proposes a set of major browser versions compatible with the library to act as the source of truth. As mentioned below, Fluent developers are expected to conform to these browsers and ensure no incompatible syntax, browser APIs or CSS features are introduced to the library. Also, Fluent will not be providing polyfills for features that we expect our browser matrix to already support (i.e. ResizeObserver, ES2019 features, etc.) so consumers who need to support older browsers are expected to handle that case themselves.
 
 ## Problem Statement
 
@@ -32,7 +32,7 @@ This browser support matrix will be available through all relevant public docsit
 
 ### ECMAScript Syntax & Expectations
 
-Fluent v9 currently targets ES2019 thus the browser matrix above ensures that no features need to be transpiled down; that way, consumers on modern browsers get the added benefit of reduced bundle size that the latest ECMAScript (ES) standards provide. The proposed browser matrix also keeps the option of moving to ES2020 open since all ES2020 features are already supported by these browsers. This means that Fluent v9's target will firmly be ES2019/2020 so consumers who require older browser environments are responsible for transpiling down and/or polyfilling themselves. Utilizing standard polyfill libraries such as `core-js` should alleviate some of the consumer pain of having to support new ES features on old browsers.
+Fluent v9 currently makes use of ES2019 syntax thus the browser matrix above ensures that no features need to be transpiled down; that way, consumers on modern browsers get the added benefit of reduced bundle size that the latest ECMAScript (ES) standards provide. The proposed browser matrix also keeps the option of moving to ES2020 open since all ES2020 features are already supported by these browsers. This means that consumers who need to support older browsers (such as those that only support up to ES6) are responsible for transpiling down and/or polyfilling themselves. Utilizing standard polyfill libraries such as `core-js` should alleviate some of the consumer pain of having to support new ES features on old browsers.
 
 ### Browser APIs & Expectations
 

--- a/rfcs/shared/build-system/06-browser-support-for-v9.md
+++ b/rfcs/shared/build-system/06-browser-support-for-v9.md
@@ -16,9 +16,17 @@ As it stands, Fluent v9 does not currently adhere to a specific browser support 
 
 The proposed browser support matrix will be loosely based off the [Resize Observer](https://caniuse.com/mdn-api_resizeobserver) support matrix . This decision was driven by the current usage of the `ResizeObserver` in Fluent v9 as well as the current business goals of our partner teams. Along with that, being able to maintain our current ES2019 target and eventually move to ES2020 without the need to transpile down was also a factor. As it stands, the lack of adequate polyfill capabilities for CSS features in tandem with the goals of our partners is the biggest detriment to the support matrix not being higher.
 
-| Edge | Firefox | Chrome | Safari | Opera | Safari on IOS | Chrome for Android | Samsung | Internet Explorer |
-| ---- | ------- | ------ | ------ | ----- | ------------- | ------------------ | ------- | ----------------- |
-| >=80 | >=74    | >=80   | >=14   | >=67  | >=14          | >=101              | >=16    | Not Supported     |
+**Desktop Browsers:**
+
+| Edge | Firefox | Chrome | Safari | Opera | Internet Explorer |
+| ---- | ------- | ------ | ------ | ----- | ----------------- |
+| >=80 | >=74    | >=80   | >=14   | >=67  | Not Supported     |
+
+**Mobile Browsers:**
+
+| Safari on IOS | Chrome for Android | Samsung |
+| ------------- | ------------------ | ------- |
+| >=14          | >=80               | >=16    |
 
 This browser support matrix will be available through all relevant public docsite and/or wikis for maximum visibility.
 

--- a/rfcs/shared/build-system/06-browser-support-for-v9.md
+++ b/rfcs/shared/build-system/06-browser-support-for-v9.md
@@ -20,13 +20,13 @@ The proposed browser support matrix will be loosely based off the [Resize Observ
 
 | Edge | Firefox | Chrome | Safari | Opera | Internet Explorer |
 | ---- | ------- | ------ | ------ | ----- | ----------------- |
-| >=80 | >=75    | >=80   | >=14   | >=67  | Not Supported     |
+| >=84 | >=75    | >=84   | >=14.1 | >=73  | Not Supported     |
 
 **Mobile Browsers:**
 
 | Safari on IOS | Chrome for Android | Samsung |
 | ------------- | ------------------ | ------- |
-| >=14          | >=80               | >=16    |
+| >=14.5        | >=84               | >=16    |
 
 This browser support matrix will be available through all relevant public docsite and/or wikis for maximum visibility.
 

--- a/rfcs/shared/build-system/06-browser-support-for-v9.md
+++ b/rfcs/shared/build-system/06-browser-support-for-v9.md
@@ -44,7 +44,7 @@ With a defined browser matrix, the Fluent team will now have better guidance on 
 
 ### Browser Support Going Forward
 
-With an eye towards being a modern library, Fluent will follow a yearly audit process to evaluate and update the current browser support matrix to keep pace with the ever evolving ecosystem of the web. This will allow the team to utilize modern tools and improve overall engineering efficiency while also providing consumers with performance and bundlesize improvements. Due to the nature of how Safari browser updates are tied to MacOS versions, Safari will be the browser that ultimately holds the library back from fully adopting modern browser versions across the board. Because of this, the proposed timeframe for when these audits occur should be whenever a Safari major release occurs. These tend to happen annually during the month of September so Fluent can target an annual audit around that time.
+With an eye towards being a modern library, Fluent will follow a yearly audit process to evaluate and update the current browser support matrix to keep pace with the ever evolving ecosystem of the web. This will allow the team to utilize modern tools and improve overall engineering efficiency while also providing consumers with performance and bundlesize improvements. The proposed yearly audit gives Fluent a reasonable timeframe to evaluate, decide and give notice if browser matrix changes are to be made.
 
 ## Out of Scope
 


### PR DESCRIPTION
This RFC proposes a browser minbar support matrix for v9 to conform to. To get breakdown that led to this matrix, please read this [document](https://microsoft.sharepoint-df.com/teams/FluentUIInternal/_layouts/15/Doc.aspx?sourcedoc=%7B66e5f1ff-23d0-49ab-9a7d-acf3b47344f3%7D&action=edit&wd=target(Build%20system.one%7C13440648-7e78-4299-bc71-661d59756ff2%2FV9%20Browser%20Minbar%20Conclusion%7Cfe9116b5-693e-4559-aaf2-27ca7725abd2%2F)&share=IgH_8eVm0COrSZp9rPO0c0TzAZ1rnQYDmLb_8iCSF8BicSQ).

[Preview👀](https://github.com/microsoft/fluentui/pull/22889/files?short_path=6386842#diff-638684245ec063dc55bc05729c53b47175161565a02cdf30fb334a8a59fbf863)

Current global browser coverage of proposed browser matrix: **88%**
- https://browserslist.dev/?q=Y2hyb21lID49IDg0LCBmaXJlZm94ID49IDc1LCBlZGdlID49IDg0LCBzYWZhcmkgPj0gMTQuMSwgb3BlcmEgPj0gNzMsIGlvc19zYWYgPj0gMTQuNSwgQ2hyb21lQW5kcm9pZCA%2BPSA4NCwgc2Ftc3VuZyA%2BPTE2


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22273
