### PR TITLE
React: Remove deprecated React.props

### DIFF
--- a/change/@fluentui-react-783fd50b-a4fd-4855-a5a4-24aa5f752db0.json
+++ b/change/@fluentui-react-783fd50b-a4fd-4855-a5a4-24aa5f752db0.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Remove deprecated React.props",
+  "comment": "chore: Removing deprecated React.props and replacing it with mirrored type.",
   "packageName": "@fluentui/react",
   "email": "manhducdkcb@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-783fd50b-a4fd-4855-a5a4-24aa5f752db0.json
+++ b/change/@fluentui-react-783fd50b-a4fd-4855-a5a4-24aa5f752db0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove deprecated React.props",
+  "packageName": "@fluentui/react",
+  "email": "manhducdkcb@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2072,8 +2072,10 @@ export { IAnimationStyles }
 
 export { IAnimationVariables }
 
+// Warning: (ae-forgotten-export) The symbol "IReactProps" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export interface IAnnouncedProps extends React_2.Props<AnnouncedBase>, React_2.HTMLAttributes<HTMLDivElement> {
+export interface IAnnouncedProps extends IReactProps<AnnouncedBase>, React_2.HTMLAttributes<HTMLDivElement> {
     'aria-live'?: 'off' | 'polite' | 'assertive';
     as?: React_2.ElementType;
     message?: string;
@@ -2241,7 +2243,7 @@ export interface IBasePicker<T> {
 }
 
 // @public
-export interface IBasePickerProps<T> extends React_2.Props<any> {
+export interface IBasePickerProps<T> extends IReactProps<any> {
     ['aria-label']?: string;
     className?: string;
     componentRef?: IRefObject<IBasePicker<T>>;
@@ -4913,7 +4915,7 @@ export interface IDialogFooter {
 }
 
 // @public (undocumented)
-export interface IDialogFooterProps extends React_2.Props<DialogFooterBase> {
+export interface IDialogFooterProps extends IReactProps<DialogFooterBase> {
     className?: string;
     componentRef?: IRefObject<IDialogFooter>;
     styles?: IStyleFunctionOrObject<IDialogFooterStyleProps, IDialogFooterStyles>;
@@ -5110,7 +5112,7 @@ export interface IDocumentCardDetails {
 // Warning: (ae-forgotten-export) The symbol "DocumentCardDetailsBase" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export interface IDocumentCardDetailsProps extends React_2.Props<DocumentCardDetailsBase> {
+export interface IDocumentCardDetailsProps extends IReactProps<DocumentCardDetailsBase> {
     className?: string;
     componentRef?: IRefObject<IDocumentCardDetails>;
     styles?: IStyleFunctionOrObject<IDocumentCardDetailsStyleProps, IDocumentCardDetailsStyles>;
@@ -5303,7 +5305,7 @@ export interface IDocumentCardStatus {
 // Warning: (ae-forgotten-export) The symbol "DocumentCardStatusBase" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export interface IDocumentCardStatusProps extends React_2.Props<DocumentCardStatusBase> {
+export interface IDocumentCardStatusProps extends IReactProps<DocumentCardStatusBase> {
     className?: string;
     componentRef?: IRefObject<IDocumentCardStatus>;
     status: string;
@@ -8641,7 +8643,7 @@ export interface IStackTokens {
 }
 
 // @public (undocumented)
-export interface IStickyProps extends React_2.Props<Sticky> {
+export interface IStickyProps extends IReactProps<Sticky> {
     componentRef?: IRefObject<IStickyProps>;
     isScrollSynced?: boolean;
     stickyBackgroundColor?: string;
@@ -8787,7 +8789,7 @@ export interface ISuggestionsItemStyles {
 }
 
 // @public
-export interface ISuggestionsProps<T> extends React_2.Props<any> {
+export interface ISuggestionsProps<T> extends IReactProps<any> {
     className?: string;
     componentRef?: IRefObject<ISuggestions<T>>;
     createGenericItem?: () => void;

--- a/packages/react/src/common/React.types.ts
+++ b/packages/react/src/common/React.types.ts
@@ -1,0 +1,8 @@
+import * as React from 'react';
+
+// Mirror of the removed interface React.Props<T> since React 18
+export interface IReactProps<T> {
+  children?: React.ReactNode | undefined;
+  key?: React.Key | undefined;
+  ref?: React.LegacyRef<T> | undefined;
+}

--- a/packages/react/src/components/Announced/Announced.types.ts
+++ b/packages/react/src/components/Announced/Announced.types.ts
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { AnnouncedBase } from './Announced.base';
 import type { IStyle } from '../../Styling';
 import type { IStyleFunctionOrObject } from '../../Utilities';
+import type { IReactProps } from '../../common/React.types';
 
 /**
  * {@docCategory Announced}
  */
-// eslint-disable-next-line deprecation/deprecation
-export interface IAnnouncedProps extends React.Props<AnnouncedBase>, React.HTMLAttributes<HTMLDivElement> {
+export interface IAnnouncedProps extends IReactProps<AnnouncedBase>, React.HTMLAttributes<HTMLDivElement> {
   /**
    * The status message the screen reader should announce.
    */

--- a/packages/react/src/components/Dialog/DialogFooter.types.ts
+++ b/packages/react/src/components/Dialog/DialogFooter.types.ts
@@ -1,7 +1,7 @@
-import * as React from 'react';
 import { DialogFooterBase } from './DialogFooter.base';
 import type { IStyle, ITheme } from '../../Styling';
 import type { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import type { IReactProps } from '../../common/React.types';
 
 /**
  * {@docCategory Dialog}
@@ -11,8 +11,7 @@ export interface IDialogFooter {}
 /**
  * {@docCategory Dialog}
  */
-// eslint-disable-next-line deprecation/deprecation
-export interface IDialogFooterProps extends React.Props<DialogFooterBase> {
+export interface IDialogFooterProps extends IReactProps<DialogFooterBase> {
   /**
    * Gets the component ref.
    */

--- a/packages/react/src/components/DocumentCard/DocumentCardDetails.types.ts
+++ b/packages/react/src/components/DocumentCard/DocumentCardDetails.types.ts
@@ -1,7 +1,7 @@
-import * as React from 'react';
 import { DocumentCardDetailsBase } from './DocumentCardDetails.base';
 import type { IStyle, ITheme } from '../../Styling';
 import type { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import type { IReactProps } from '../../common/React.types';
 
 /**
  * {@docCategory DocumentCard}
@@ -11,8 +11,7 @@ export interface IDocumentCardDetails {}
 /**
  * {@docCategory DocumentCard}
  */
-// eslint-disable-next-line deprecation/deprecation
-export interface IDocumentCardDetailsProps extends React.Props<DocumentCardDetailsBase> {
+export interface IDocumentCardDetailsProps extends IReactProps<DocumentCardDetailsBase> {
   /**
    * Gets the component ref.
    */

--- a/packages/react/src/components/DocumentCard/DocumentCardStatus.types.ts
+++ b/packages/react/src/components/DocumentCard/DocumentCardStatus.types.ts
@@ -1,7 +1,7 @@
-import * as React from 'react';
 import { DocumentCardStatusBase } from './DocumentCardStatus.base';
 import type { IStyle, ITheme } from '../../Styling';
 import type { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import type { IReactProps } from '../../common/React.types';
 
 /**
  * {@docCategory DocumentCard}
@@ -11,8 +11,7 @@ export interface IDocumentCardStatus {}
 /**
  * {@docCategory DocumentCard}
  */
-// eslint-disable-next-line deprecation/deprecation
-export interface IDocumentCardStatusProps extends React.Props<DocumentCardStatusBase> {
+export interface IDocumentCardStatusProps extends IReactProps<DocumentCardStatusBase> {
   /**
    * Gets the component ref.
    */

--- a/packages/react/src/components/ScrollablePane/ScrollablePane.types.ts
+++ b/packages/react/src/components/ScrollablePane/ScrollablePane.types.ts
@@ -18,7 +18,7 @@ export interface IScrollablePane {
  * {@docCategory ScrollablePane}
  */
 export interface IScrollablePaneProps extends React.HTMLAttributes<HTMLElement | ScrollablePaneBase> {
-  // export interface IScrollablePaneProps extends React.Props<ScrollablePaneBase> {
+  // export interface IScrollablePaneProps extends IReactProps<ScrollablePaneBase> {
   /**
    * Optional callback to access the IScrollablePane interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react/src/components/Sticky/Sticky.types.ts
+++ b/packages/react/src/components/Sticky/Sticky.types.ts
@@ -1,9 +1,8 @@
-import * as React from 'react';
 import { Sticky } from './Sticky';
 import type { IRefObject } from '../../Utilities';
+import type { IReactProps } from '../../common/React.types';
 
-// eslint-disable-next-line deprecation/deprecation
-export interface IStickyProps extends React.Props<Sticky> {
+export interface IStickyProps extends IReactProps<Sticky> {
   /**
    * Gets ref to component interface.
    */

--- a/packages/react/src/components/pickers/BasePicker.types.ts
+++ b/packages/react/src/components/pickers/BasePicker.types.ts
@@ -6,6 +6,7 @@ import type { ISuggestionModel, ISuggestionsProps } from './Suggestions/Suggesti
 import type { ICalloutProps } from '../../Callout';
 import type { ITheme, IStyle } from '../../Styling';
 import type { ISuggestionItemProps } from '../pickers/Suggestions/SuggestionsItem.types';
+import type { IReactProps } from '../../common/React.types';
 import { IIconProps } from '../Icon/Icon.types';
 
 /**
@@ -37,8 +38,7 @@ export interface IBasePicker<T> {
  * displaying persona's then type T could either be of Persona or IPersona props
  * {@docCategory Pickers}
  */
-// eslint-disable-next-line deprecation/deprecation
-export interface IBasePickerProps<T> extends React.Props<any> {
+export interface IBasePickerProps<T> extends IReactProps<any> {
   /**
    * Optional callback to access the IBasePicker interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -6,6 +6,7 @@ import type { IPersonaProps } from '../../Persona/Persona.types';
 import type { IStyle, ITheme } from '../../../Styling';
 import type { ISpinnerStyleProps } from '../../Spinner/Spinner.types';
 import type { ISuggestionItemProps } from './SuggestionsItem.types';
+import type { IReactProps } from '../../../common/React.types';
 import { IIconProps } from '../../Icon/Icon.types';
 /**
  * Suggestions component.
@@ -39,8 +40,7 @@ export interface ISuggestions<T> {
  * Type T is the type of the items that are displayed.
  * {@docCategory Pickers}
  */
-// eslint-disable-next-line deprecation/deprecation
-export interface ISuggestionsProps<T> extends React.Props<any> {
+export interface ISuggestionsProps<T> extends IReactProps<any> {
   /**
    * Optional callback to access the ISuggestions interface. Use this instead of ref for accessing
    * the public methods and properties of the component.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

`React.Props` was used to allow clients to pass ref and key to createElement, which is no longer necessary. ClassAttributes<T> is recommended to pass ref.

React18 typing introduces a breaking change that removes this deprecation completely.

## New Behavior

FluentUI doesn't use the deprecated type.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #22423 
