### PR TITLE
react-tabs: Updated to focus on current selected tab

### DIFF
--- a/change/@fluentui-react-tabs-43ed491b-06ab-4977-abac-6df9f2a7eb88.json
+++ b/change/@fluentui-react-tabs-43ed491b-06ab-4977-abac-6df9f2a7eb88.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updated to focus on current selected tab",
+  "packageName": "@fluentui/react-tabs",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/src/components/TabList/__snapshots__/TabList.test.tsx.snap
+++ b/packages/react-components/react-tabs/src/components/TabList/__snapshots__/TabList.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`TabList renders tabs when disabled 1`] = `
 <div>
   <div
     class="fui-TabList"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
     role="tablist"
   >
     <button
@@ -51,7 +51,7 @@ exports[`TabList renders tabs with default selected tab 1`] = `
 <div>
   <div
     class="fui-TabList"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
     role="tablist"
   >
     <button
@@ -101,7 +101,7 @@ exports[`TabList renders with no tabs 1`] = `
 <div>
   <div
     class="fui-TabList"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
     role="tablist"
   />
 </div>
@@ -111,7 +111,7 @@ exports[`TabList renders with tabs 1`] = `
 <div>
   <div
     class="fui-TabList"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
     role="tablist"
   >
     <button

--- a/packages/react-components/react-tabs/src/components/TabList/useTabList.ts
+++ b/packages/react-components/react-tabs/src/components/TabList/useTabList.ts
@@ -23,7 +23,11 @@ export const useTabList_unstable = (props: TabListProps, ref: React.Ref<HTMLElem
 
   const innerRef = React.useRef<HTMLElement>(null);
 
-  const focusAttributes = useArrowNavigationGroup({ circular: true, axis: vertical ? 'vertical' : 'horizontal' });
+  const focusAttributes = useArrowNavigationGroup({
+    circular: true,
+    axis: vertical ? 'vertical' : 'horizontal',
+    memorizeCurrent: true,
+  });
 
   const [selectedValue, setSelectedValue] = useControllableState({
     state: props.selectedValue,


### PR DESCRIPTION
## Changes
- Updated tabster options to memorizeSelected, this ensures the selected tab is the one that receives focus when the tab list gets keyboard focus.

## Issues

Updates #21594 