### PR TITLE
Removing Common types from all button components

### DIFF
--- a/change/@fluentui-react-button-cd9b6fd2-8ae2-4a79-846d-b8a159c280b6.json
+++ b/change/@fluentui-react-button-cd9b6fd2-8ae2-4a79-846d-b8a159c280b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing Common types from all button components.",
+  "packageName": "@fluentui/react-button",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/etc/react-button.api.md
+++ b/packages/react-components/react-button/etc/react-button.api.md
@@ -22,7 +22,15 @@ export const buttonClassName: string;
 export const buttonClassNames: SlotClassNames<ButtonSlots>;
 
 // @public (undocumented)
-export type ButtonProps = ComponentProps<ButtonSlots> & Partial<ButtonCommons>;
+export type ButtonProps = ComponentProps<ButtonSlots> & {
+    appearance?: 'secondary' | 'primary' | 'outline' | 'subtle' | 'transparent';
+    block?: boolean;
+    disabledFocusable?: boolean;
+    disabled?: boolean;
+    iconPosition?: 'before' | 'after';
+    shape?: 'rounded' | 'circular' | 'square';
+    size?: 'small' | 'medium' | 'large';
+};
 
 // @public (undocumented)
 export type ButtonSlots = {
@@ -31,7 +39,7 @@ export type ButtonSlots = {
 };
 
 // @public (undocumented)
-export type ButtonState = ComponentState<ButtonSlots> & ButtonCommons & {
+export type ButtonState = ComponentState<ButtonSlots> & Required<Pick<ButtonProps, 'appearance' | 'block' | 'disabledFocusable' | 'disabled' | 'iconPosition' | 'shape' | 'size'>> & {
     iconOnly: boolean;
 };
 
@@ -45,7 +53,7 @@ export const compoundButtonClassName: string;
 export const compoundButtonClassNames: SlotClassNames<CompoundButtonSlots>;
 
 // @public (undocumented)
-export type CompoundButtonProps = ComponentProps<Partial<CompoundButtonSlots>> & Partial<ButtonCommons>;
+export type CompoundButtonProps = ComponentProps<Partial<CompoundButtonSlots>> & Pick<ButtonProps, 'appearance' | 'block' | 'disabledFocusable' | 'disabled' | 'iconPosition' | 'shape' | 'size'>;
 
 // @public (undocumented)
 export type CompoundButtonSlots = ButtonSlots & {
@@ -66,7 +74,7 @@ export const menuButtonClassName: string;
 export const menuButtonClassNames: SlotClassNames<MenuButtonSlots>;
 
 // @public (undocumented)
-export type MenuButtonProps = ComponentProps<MenuButtonSlots> & Partial<Omit<ButtonCommons, 'iconPosition'>>;
+export type MenuButtonProps = ComponentProps<MenuButtonSlots> & Pick<ButtonProps, 'appearance' | 'block' | 'disabledFocusable' | 'disabled' | 'shape' | 'size'>;
 
 // @public (undocumented)
 export type MenuButtonSlots = ButtonSlots & {

--- a/packages/react-components/react-button/src/components/Button/Button.types.ts
+++ b/packages/react-components/react-button/src/components/Button/Button.types.ts
@@ -13,15 +13,18 @@ export type ButtonSlots = {
   icon?: Slot<'span'>;
 };
 
-export type ButtonCommons = {
+export type ButtonProps = ComponentProps<ButtonSlots> & {
   /**
    * A button can have its content and borders styled for greater emphasis or to be subtle.
+   * - 'secondary' (default): Gives emphasis to the button in such a way that it indicates a secondary action.
    * - 'primary': Emphasizes the button as a primary action.
    * - 'outline': Removes background styling.
    * - 'subtle': Minimizes emphasis to blend into the background until hovered or focused.
    * - 'transparent': Removes background and border styling.
+   *
+   * @default 'secondary'
    */
-  appearance?: 'primary' | 'outline' | 'subtle' | 'transparent';
+  appearance?: 'secondary' | 'primary' | 'outline' | 'subtle' | 'transparent';
 
   /**
    * A button can fill the width of its container.
@@ -29,47 +32,53 @@ export type ButtonCommons = {
    *
    * @deprecated - Use style overrides instead.
    */
-  block: boolean;
+  block?: boolean;
 
   /**
    * When set, allows the button to be focusable even when it has been disabled. This is used in scenarios where it
    * is important to keep a consistent tab order for screen reader and keyboard users. The primary example of this
    * pattern is when the disabled button is in a menu or a commandbar and is seldom used for standalone buttons.
+   *
    * @default false
    */
-  disabledFocusable: boolean;
+  disabledFocusable?: boolean;
 
   /**
    * A button can show that it cannot be interacted with.
+   *
    * @default false
    */
-  disabled: boolean;
+  disabled?: boolean;
 
   /**
    * A button can format its icon to appear before or after its content.
+   *
    * @default 'before'
    */
   iconPosition?: 'before' | 'after';
 
   /**
    * A button can be rounded, circular, or square.
+   *
    * @default 'rounded'
    */
-  shape: 'rounded' | 'circular' | 'square';
+  shape?: 'rounded' | 'circular' | 'square';
 
   /**
    * A button supports different sizes.
+   *
    * @default 'medium'
    */
-  size: 'small' | 'medium' | 'large';
+  size?: 'small' | 'medium' | 'large';
 };
 
-export type ButtonProps = ComponentProps<ButtonSlots> & Partial<ButtonCommons>;
-
 export type ButtonState = ComponentState<ButtonSlots> &
-  ButtonCommons & {
+  Required<
+    Pick<ButtonProps, 'appearance' | 'block' | 'disabledFocusable' | 'disabled' | 'iconPosition' | 'shape' | 'size'>
+  > & {
     /**
      * A button can contain only an icon.
+     *
      * @default false
      */
     iconOnly: boolean;

--- a/packages/react-components/react-button/src/components/Button/useButton.ts
+++ b/packages/react-components/react-button/src/components/Button/useButton.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useARIAButton } from '@fluentui/react-aria';
-import type { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import type { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import type { ButtonProps, ButtonState } from './Button.types';
 
 /**
@@ -14,7 +14,7 @@ export const useButton_unstable = (
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ButtonState => {
   const {
-    appearance,
+    appearance = 'secondary',
     as,
     // eslint-disable-next-line deprecation/deprecation
     block = false,

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
@@ -122,6 +122,9 @@ const useRootStyles = makeStyles({
       color: tokens.colorNeutralForegroundOnBrand,
     },
   },
+  secondary: {
+    /* The secondary styles are exactly the same as the base styles. */
+  },
   subtle: {
     backgroundColor: tokens.colorSubtleBackground,
     ...shorthands.borderColor('transparent'),
@@ -294,6 +297,9 @@ const useRootDisabledStyles = makeStyles({
     ':hover:active': {
       ...shorthands.borderColor('transparent'),
     },
+  },
+  secondary: {
+    /* The secondary styles are exactly the same as the base styles. */
   },
   subtle: {
     backgroundColor: 'transparent',

--- a/packages/react-components/react-button/src/components/CompoundButton/CompoundButton.types.ts
+++ b/packages/react-components/react-button/src/components/CompoundButton/CompoundButton.types.ts
@@ -1,5 +1,5 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import type { ButtonCommons, ButtonSlots, ButtonState } from '../Button/Button.types';
+import type { ButtonProps, ButtonSlots, ButtonState } from '../Button/Button.types';
 
 export type CompoundButtonSlots = ButtonSlots & {
   /**
@@ -13,7 +13,8 @@ export type CompoundButtonSlots = ButtonSlots & {
   contentContainer: NonNullable<Slot<'span'>>;
 };
 
-export type CompoundButtonProps = ComponentProps<Partial<CompoundButtonSlots>> & Partial<ButtonCommons>;
+export type CompoundButtonProps = ComponentProps<Partial<CompoundButtonSlots>> &
+  Pick<ButtonProps, 'appearance' | 'block' | 'disabledFocusable' | 'disabled' | 'iconPosition' | 'shape' | 'size'>;
 
 export type CompoundButtonState = ComponentState<CompoundButtonSlots> &
   Omit<ButtonState, keyof ButtonSlots | 'components'>;

--- a/packages/react-components/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
@@ -1,5 +1,5 @@
-import { shorthands, mergeClasses, makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
+import { shorthands, mergeClasses, makeStyles } from '@griffel/react';
 import { useButtonStyles_unstable } from '../Button/useButtonStyles';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { CompoundButtonSlots, CompoundButtonState } from './CompoundButton.types';
@@ -77,6 +77,9 @@ const useRootStyles = makeStyles({
         color: tokens.colorNeutralForegroundOnBrand,
       },
     },
+  },
+  secondary: {
+    /* The secondary styles are exactly the same as the base styles. */
   },
   subtle: {
     [`& .${compoundButtonClassNames.secondaryContent}`]: {

--- a/packages/react-components/react-button/src/components/MenuButton/MenuButton.types.ts
+++ b/packages/react-components/react-button/src/components/MenuButton/MenuButton.types.ts
@@ -1,5 +1,5 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import type { ButtonCommons, ButtonSlots, ButtonState } from '../Button/Button.types';
+import type { ButtonProps, ButtonSlots, ButtonState } from '../Button/Button.types';
 
 export type MenuButtonSlots = ButtonSlots & {
   /**
@@ -8,7 +8,8 @@ export type MenuButtonSlots = ButtonSlots & {
   menuIcon?: Slot<'span'>;
 };
 
-export type MenuButtonProps = ComponentProps<MenuButtonSlots> & Partial<Omit<ButtonCommons, 'iconPosition'>>;
+export type MenuButtonProps = ComponentProps<MenuButtonSlots> &
+  Pick<ButtonProps, 'appearance' | 'block' | 'disabledFocusable' | 'disabled' | 'shape' | 'size'>;
 
 export type MenuButtonState = ComponentState<MenuButtonSlots> &
   Omit<ButtonState, keyof ButtonSlots | 'components' | 'iconPosition'>;

--- a/packages/react-components/react-button/src/components/MenuButton/useMenuButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/MenuButton/useMenuButtonStyles.ts
@@ -1,5 +1,4 @@
 import { mergeClasses, makeStyles } from '@griffel/react';
-import { ButtonState } from '../Button/Button.types';
 import { useButtonStyles_unstable } from '../Button/useButtonStyles';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { MenuButtonSlots, MenuButtonState } from './MenuButton.types';
@@ -51,7 +50,7 @@ export const useMenuButtonStyles_unstable = (state: MenuButtonState): MenuButton
     );
   }
 
-  useButtonStyles_unstable(state as ButtonState);
+  useButtonStyles_unstable({ ...state, iconPosition: 'before' });
 
   return state;
 };

--- a/packages/react-components/react-button/src/components/SplitButton/useSplitButton.ts
+++ b/packages/react-components/react-button/src/components/SplitButton/useSplitButton.ts
@@ -14,7 +14,7 @@ export const useSplitButton_unstable = (
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): SplitButtonState => {
   const {
-    appearance,
+    appearance = 'secondary',
     // eslint-disable-next-line deprecation/deprecation
     block = false,
     children,

--- a/packages/react-components/react-button/src/components/SplitButton/useSplitButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/SplitButton/useSplitButtonStyles.ts
@@ -74,6 +74,9 @@ const useRootStyles = makeStyles({
       },
     },
   },
+  secondary: {
+    /* The secondary styles are exactly the same as the base styles. */
+  },
   subtle: {
     [`& .${splitButtonClassNames.primaryActionButton}`]: {
       borderRightColor: tokens.colorNeutralStroke1Hover,

--- a/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -86,6 +86,9 @@ export const useCheckedStyles = makeStyles({
       color: tokens.colorNeutralForegroundOnBrand,
     },
   },
+  secondary: {
+    /* The secondary styles are exactly the same as the base styles. */
+  },
   subtle: {
     backgroundColor: tokens.colorSubtleBackgroundSelected,
     ...shorthands.borderColor('transparent'),
@@ -156,6 +159,9 @@ export const useDisabledStyles = makeStyles({
     ':hover:active': {
       ...shorthands.borderColor('transparent'),
     },
+  },
+  secondary: {
+    /* The secondary styles are exactly the same as the base styles. */
   },
   subtle: {
     backgroundColor: 'transparent',


### PR DESCRIPTION
## PR Description

This PR removes the `Commons` type pattern in the types for all our `Button` components.

## Related Issue(s)

Fixes part of #22862
