### PR TITLE
SpinButton: add aria-valuetext override

### DIFF
--- a/change/@fluentui-react-spinbutton-877bc164-a733-4573-bc88-b5ccba3d20ea.json
+++ b/change/@fluentui-react-spinbutton-877bc164-a733-4573-bc88-b5ccba3d20ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "react-spinbutton: add aria-valuetext override",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
@@ -70,6 +70,17 @@ describe('SpinButton', () => {
     expect(spinButton.getAttribute('aria-valuemax')).toBeNull();
   });
 
+  it('respects `aria-valuetext` when alongside `displayValue`', () => {
+    render(<SpinButton value={1} displayValue="$1.00" aria-valuetext="Custom value text" onChange={jest.fn()} />);
+
+    const spinButton = getSpinButtonInput();
+    expect(spinButton.value).toEqual('$1.00');
+    expect(spinButton.getAttribute('aria-valuenow')).toEqual('1');
+    expect(spinButton.getAttribute('aria-valuetext')).toEqual('Custom value text');
+    expect(spinButton.getAttribute('aria-valuemin')).toBeNull();
+    expect(spinButton.getAttribute('aria-valuemax')).toBeNull();
+  });
+
   it('applies the correct min and max value when both are specified', () => {
     render(<SpinButton value={1} min={0} max={10} onChange={jest.fn()} />);
 

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -275,7 +275,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
   state.input['aria-valuemin'] = min;
   state.input['aria-valuemax'] = max;
   state.input['aria-valuenow'] = currentValue;
-  state.input['aria-valuetext'] = (value !== undefined && displayValue) || undefined;
+  state.input['aria-valuetext'] = state.input['aria-valuetext'] ?? ((value !== undefined && displayValue) || undefined);
   state.input.onChange = useMergedEventCallbacks(state.input.onChange, handleInputChange);
   state.input.onBlur = useMergedEventCallbacks(state.input.onBlur, handleBlur);
   state.input.onKeyDown = useMergedEventCallbacks(state.input.onKeyDown, handleKeyDown);


### PR DESCRIPTION
## Current Behavior

`aria-valuetext` can only be set via the `displayValue` prop.

## New Behavior

`aria-valuetext` can be set via the `displayValue` prop or directly via the `aria-valuetext` prop.

## Related Issue(s)

Fixes #22870
