### PR TITLE
v8 combobox: Updated to scroll to pending selected element

### DIFF
--- a/change/@fluentui-react-e95e14ca-cf22-42d4-9362-4a569382502e.json
+++ b/change/@fluentui-react-e95e14ca-cf22-42d4-9362-4a569382502e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated to scroll to pending selected element",
+  "packageName": "@fluentui/react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -224,8 +224,8 @@ function findFirstDescendant(element: HTMLElement, match: (element: HTMLElement)
   // For loop is used because forEach cannot be stopped.
   for (let index = 0; index < children.length; index++) {
     const child = children[index];
-    if (match(children[index])) {
-      return children[index];
+    if (match(child)) {
+      return child;
     }
     const candidate = findFirstDescendant(child, match);
     if (candidate) {

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -40,6 +40,7 @@ import type {
 } from './ComboBox.types';
 import type { IButtonStyles } from '../../Button';
 import type { ICalloutProps } from '../../Callout';
+import { getChildren } from '@fluentui/utilities';
 
 export interface IComboBoxState {
   /** The open state */
@@ -209,6 +210,29 @@ interface IComboBoxInternalProps extends Omit<IComboBoxProps, 'ref'> {
     setCurrentOptions: React.Dispatch<React.SetStateAction<IComboBoxOption[]>>;
     setSuggestedDisplayValue: React.Dispatch<React.SetStateAction<string | undefined>>;
   };
+}
+
+/**
+ * Depth-first search to find the first descendant element where the match function returns true.
+ * @param element - element to start searching at
+ * @param match - the function that determines if the element is a match
+ * @returns the matched element or null no match was found
+ */
+function findFirstDescendant(element: HTMLElement, match: (element: HTMLElement) => boolean): HTMLElement | null {
+  const children = getChildren(element);
+
+  // For loop is used because forEach cannot be stopped.
+  for (let index = 0; index < children.length; index++) {
+    const child = children[index];
+    if (match(children[index])) {
+      return children[index];
+    }
+    const candidate = findFirstDescendant(child, match);
+    if (candidate) {
+      return candidate;
+    }
+  }
+  return null;
 }
 
 @customizable('ComboBox', ['theme', 'styles'], true)
@@ -1668,18 +1692,31 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
   private _scrollIntoView(): void {
     const { onScrollToItem, scrollSelectedToTop } = this.props;
 
-    const currentPendingSelectedInded = this._getPendingSelectedIndex(true);
+    const currentPendingSelectedIndex = this._getPendingSelectedIndex(true);
 
     if (onScrollToItem) {
       // Use the custom scroll handler
-      onScrollToItem(currentPendingSelectedInded >= 0 ? currentPendingSelectedInded : this._getFirstSelectedIndex());
-    } else if (this._selectedElement.current && this._selectedElement.current.offsetParent) {
+      onScrollToItem(currentPendingSelectedIndex >= 0 ? currentPendingSelectedIndex : this._getFirstSelectedIndex());
+      return;
+    }
+
+    let scrollToElement: HTMLElement | null = this._selectedElement.current as HTMLElement;
+
+    // in multi-select there are multiple selected elements, so we use the pending select index
+    // to locate the option to scroll to.
+    if (this.props.multiSelect && this._comboBoxMenu.current) {
+      scrollToElement = findFirstDescendant(this._comboBoxMenu.current, (element: HTMLElement) => {
+        return element.dataset?.index === currentPendingSelectedIndex.toString();
+      });
+    }
+
+    if (scrollToElement && scrollToElement.offsetParent) {
       let alignToTop = true;
 
       // We are using refs, scroll the ref into view
       if (this._comboBoxMenu.current && this._comboBoxMenu.current.offsetParent) {
         const scrollableParent = this._comboBoxMenu.current.offsetParent;
-        const selectedElement = this._selectedElement.current.offsetParent;
+        const selectedElement = scrollToElement.offsetParent;
 
         const { offsetHeight, offsetTop } = selectedElement as HTMLElement;
         const { offsetHeight: parentOffsetHeight, scrollTop } = scrollableParent as HTMLElement;
@@ -1697,7 +1734,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
       // if _comboboxMenu doesn't exist, fall back to scrollIntoView
       else {
-        this._selectedElement.current.offsetParent.scrollIntoView(alignToTop);
+        scrollToElement.offsetParent.scrollIntoView(alignToTop);
       }
     }
   }


### PR DESCRIPTION
## Customer Issue
[Usable - Customer Insights - Segments>New quick segment]: List items present under "Value" combo box are not getting scrolled using keyboard.
https://powerbi.visualstudio.com/Customer360/_workitems/edit/782446

A multi-select combo box with several item does not scroll when keyboard is used.

CodePen for repro: https://codepen.io/mraveesha/pen/JjpYqLw

## Cause of issue
- The scrollToItem function uses the selected element reference
- Combobox in multi-select does not have a single selected element reference
- There is a pending selected index, but no reference for the pending element

## Changes
- Added a function to find a descendant child based on a predicate.  Necessary to find options with a data-index matching the pending selected index.
- Updated scrollToItem method to find the element for scrolling when in multi-select mode

