### PR TITLE
feat(react-card): add `size` prop

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Card.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Card.stories.tsx
@@ -96,7 +96,20 @@ storiesOf('Card Converged', module)
       includeHighContrast: true,
       includeDarkMode: true,
     },
-  );
+  )
+  .addStory('size', () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <Card size="small">
+        <SampleCardContent />
+      </Card>
+      <Card size="medium">
+        <SampleCardContent />
+      </Card>
+      <Card size="large">
+        <SampleCardContent />
+      </Card>
+    </div>
+  ));
 
 storiesOf('Card Converged', module)
   .addDecorator(story => (

--- a/change/@fluentui-react-card-1c5d944f-4249-4cbd-8a96-9b0753d456ad.json
+++ b/change/@fluentui-react-card-1c5d944f-4249-4cbd-8a96-9b0753d456ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Add `size` property to control card padding and border radius",
+  "packageName": "@fluentui/react-card",
+  "email": "39736248+andrefcdias@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-b30f5c5b-6e1e-4e0a-bf92-4674a1dff190.json
+++ b/change/@fluentui-react-components-b30f5c5b-6e1e-4e0a-bf92-4674a1dff190.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat(react-card): CSS var for `size` prop is now exported",
+  "packageName": "@fluentui/react-components",
+  "email": "39736248+andrefcdias@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/Spec.md
+++ b/packages/react-components/react-card/Spec.md
@@ -105,7 +105,7 @@ Card goes for a more structural and generic approach to a card component and is 
 | Property    | Values                                                                               | Default    | Purpose                                                                          |
 | ----------- | ------------------------------------------------------------------------------------ | ---------- | -------------------------------------------------------------------------------- |
 | orientation | `vertical`, `horizontal`                                                             | `vertical` | Orientation of the card                                                          |
-| size        | `smallest`, `smaller`, `small`, `medium`, `large`                                    | `medium`   | Define the minimum size of the card. Smaller sizes only apply to horizontal card |
+| size        | `small`, `medium`, `large`                                                           | `medium`   | Define the minimum size of the card. Smaller sizes only apply to horizontal card |
 | scale       | `fixed`, `auto-width`, `auto-height`, `auto`, `fluid-width`, `fluid-height`, `fluid` | `auto`     | Manages how the card handles it's scaling depending on the content               |
 | appearance  | `filled`, `filled-alternative`, `outline`, `subtle`                                  | `filled`   | Define the appearance of the card                                                |
 | selectable  | boolean                                                                              | false      | Makes the card selectable by adding a checkbox to the _Actions_ area             |

--- a/packages/react-components/react-card/etc/react-card.api.md
+++ b/packages/react-components/react-card/etc/react-card.api.md
@@ -17,6 +17,11 @@ export const Card: ForwardRefComponent<CardProps>;
 // @public (undocumented)
 export const cardClassNames: SlotClassNames<CardSlots>;
 
+// @public (undocumented)
+export const cardCSSVars: {
+    cardSizeVar: string;
+};
+
 // @public
 export const CardFooter: ForwardRefComponent<CardFooterProps>;
 

--- a/packages/react-components/react-card/etc/react-card.api.md
+++ b/packages/react-components/react-card/etc/react-card.api.md
@@ -79,6 +79,7 @@ export type CardPreviewState = ComponentState<CardPreviewSlots>;
 export type CardProps = ComponentProps<CardSlots> & {
     appearance?: 'filled' | 'filled-alternative' | 'outline' | 'subtle';
     focusMode?: 'off' | 'no-tab' | 'tab-exit' | 'tab-only';
+    size?: 'small' | 'medium' | 'large';
 };
 
 // @public (undocumented)
@@ -87,7 +88,7 @@ export type CardSlots = {
 };
 
 // @public
-export type CardState = ComponentState<CardSlots> & Required<Pick<CardProps, 'appearance'>>;
+export type CardState = ComponentState<CardSlots> & Required<Pick<CardProps, 'appearance' | 'size'>>;
 
 // @public
 export const renderCard_unstable: (state: CardState) => JSX.Element;

--- a/packages/react-components/react-card/src/components/Card/Card.types.ts
+++ b/packages/react-components/react-card/src/components/Card/Card.types.ts
@@ -31,9 +31,11 @@ export type CardProps = ComponentProps<CardSlots> & {
    * @defaultvalue off
    */
   focusMode?: 'off' | 'no-tab' | 'tab-exit' | 'tab-only';
+
+  size?: 'small' | 'medium' | 'large';
 };
 
 /**
  * State used in rendering Card
  */
-export type CardState = ComponentState<CardSlots> & Required<Pick<CardProps, 'appearance'>>;
+export type CardState = ComponentState<CardSlots> & Required<Pick<CardProps, 'appearance' | 'size'>>;

--- a/packages/react-components/react-card/src/components/Card/useCard.ts
+++ b/packages/react-components/react-card/src/components/Card/useCard.ts
@@ -13,7 +13,7 @@ import { useFocusableGroup } from '@fluentui/react-tabster';
  * @param ref - reference to root HTMLElement of Card
  */
 export const useCard_unstable = (props: CardProps, ref: React.Ref<HTMLElement>): CardState => {
-  const { appearance = 'filled', focusMode = 'off' } = props;
+  const { appearance = 'filled', focusMode = 'off', size = 'medium' } = props;
 
   const focusMap = {
     off: undefined,
@@ -30,6 +30,7 @@ export const useCard_unstable = (props: CardProps, ref: React.Ref<HTMLElement>):
 
   return {
     appearance,
+    size,
 
     components: { root: 'div' },
     root: getNativeElementProps(props.as || 'div', {

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.ts
@@ -7,7 +7,9 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 export const cardClassNames: SlotClassNames<CardSlots> = {
   root: 'fui-Card',
 };
-const cardSizeVar = '--fui-Card__size';
+export const cardCSSVars = {
+  cardSizeVar: '--fui-Card--size',
+};
 
 /**
  * Styles for the root slot
@@ -33,28 +35,28 @@ const useStyles = makeStyles({
       ...shorthands.borderWidth(tokens.strokeWidthThin),
     },
 
-    ...shorthands.padding(`var(${cardSizeVar})`),
-    ...shorthands.gap(`var(${cardSizeVar})`),
+    ...shorthands.padding(`var(${cardCSSVars.cardSizeVar})`),
+    ...shorthands.gap(`var(${cardCSSVars.cardSizeVar})`),
 
     [`> .${cardPreviewClassNames.root}`]: {
-      marginLeft: `calc(var(${cardSizeVar}) * -1)`,
-      marginRight: `calc(var(${cardSizeVar}) * -1)`,
+      marginLeft: `calc(var(${cardCSSVars.cardSizeVar}) * -1)`,
+      marginRight: `calc(var(${cardCSSVars.cardSizeVar}) * -1)`,
     },
     [`> :not([aria-hidden="true"]):first-of-type.${cardPreviewClassNames.root}`]: {
-      marginTop: `calc(var(${cardSizeVar}) * -1)`,
+      marginTop: `calc(var(${cardCSSVars.cardSizeVar}) * -1)`,
     },
   },
 
   sizeSmall: {
-    [cardSizeVar]: '8px',
+    [cardCSSVars.cardSizeVar]: '8px',
     ...shorthands.borderRadius(tokens.borderRadiusSmall),
   },
   sizeMedium: {
-    [cardSizeVar]: '12px',
+    [cardCSSVars.cardSizeVar]: '12px',
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
   },
   sizeLarge: {
-    [cardSizeVar]: '16px',
+    [cardCSSVars.cardSizeVar]: '16px',
     ...shorthands.borderRadius(tokens.borderRadiusLarge),
   },
 

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.ts
@@ -7,19 +7,18 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 export const cardClassNames: SlotClassNames<CardSlots> = {
   root: 'fui-Card',
 };
+const cardSizeVar = '--fui-Card__size';
 
 /**
  * Styles for the root slot
  */
 const useStyles = makeStyles({
   root: {
-    display: 'block',
+    display: 'flex',
+    flexDirection: 'column',
     position: 'relative',
     ...shorthands.overflow('hidden'),
     color: tokens.colorNeutralForeground1,
-
-    // TODO: Extract this to separate stiles when tackling the `size` prop
-    ...shorthands.borderRadius(tokens.borderRadiusMedium),
 
     '::after': {
       position: 'absolute',
@@ -32,14 +31,31 @@ const useStyles = makeStyles({
 
       ...shorthands.borderStyle('solid'),
       ...shorthands.borderWidth(tokens.strokeWidthThin),
-      // TODO: Extract this to separate styles when tackling the `size` prop
-      ...shorthands.borderRadius(tokens.borderRadiusMedium),
     },
 
-    [`> *:not(.${cardPreviewClassNames.root})`]: {
-      // TODO: Extract this to separate styles when tackling the `size` prop
-      ...shorthands.margin('12px'),
+    ...shorthands.padding(`var(${cardSizeVar})`),
+    ...shorthands.gap(`var(${cardSizeVar})`),
+
+    [`> .${cardPreviewClassNames.root}`]: {
+      marginLeft: `calc(var(${cardSizeVar}) * -1)`,
+      marginRight: `calc(var(${cardSizeVar}) * -1)`,
     },
+    [`> :not([aria-hidden="true"]):first-of-type.${cardPreviewClassNames.root}`]: {
+      marginTop: `calc(var(${cardSizeVar}) * -1)`,
+    },
+  },
+
+  sizeSmall: {
+    [cardSizeVar]: '8px',
+    ...shorthands.borderRadius(tokens.borderRadiusSmall),
+  },
+  sizeMedium: {
+    [cardSizeVar]: '12px',
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+  },
+  sizeLarge: {
+    [cardSizeVar]: '16px',
+    ...shorthands.borderRadius(tokens.borderRadiusLarge),
   },
 
   interactiveNoOutline: {
@@ -165,6 +181,12 @@ const useStyles = makeStyles({
 export const useCardStyles_unstable = (state: CardState): CardState => {
   const styles = useStyles();
 
+  const sizeMap = {
+    small: styles.sizeSmall,
+    medium: styles.sizeMedium,
+    large: styles.sizeLarge,
+  } as const;
+
   const interactive =
     state.root.onClick ||
     state.root.onMouseUp ||
@@ -177,6 +199,7 @@ export const useCardStyles_unstable = (state: CardState): CardState => {
   state.root.className = mergeClasses(
     cardClassNames.root,
     styles.root,
+    sizeMap[state.size],
     state.appearance === 'filled' && styles.filled,
     state.appearance === 'filled-alternative' && styles.filledAlternative,
     state.appearance === 'outline' && styles.outline,

--- a/packages/react-components/react-card/src/index.ts
+++ b/packages/react-components/react-card/src/index.ts
@@ -1,4 +1,11 @@
-export { Card, cardClassNames, renderCard_unstable, useCardStyles_unstable, useCard_unstable } from './Card';
+export {
+  Card,
+  cardClassNames,
+  cardCSSVars,
+  renderCard_unstable,
+  useCardStyles_unstable,
+  useCard_unstable,
+} from './Card';
 export type { CardProps, CardSlots, CardState } from './Card';
 export {
   CardFooter,

--- a/packages/react-components/react-card/src/stories/Card.stories.tsx
+++ b/packages/react-components/react-card/src/stories/Card.stories.tsx
@@ -4,6 +4,7 @@ import descriptionMd from './CardDescription.md';
 export { Default } from './CardDefault.stories';
 export { Appearance } from './CardAppearance.stories';
 export { FocusMode } from './CardFocusMode.stories';
+export { Size } from './CardSize.stories';
 
 export default {
   title: 'Preview Components/Card',

--- a/packages/react-components/react-card/src/stories/CardFocusMode.stories.tsx
+++ b/packages/react-components/react-card/src/stories/CardFocusMode.stories.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
-
-import { Title3, Text } from '@fluentui/react-text';
-
 import { makeStyles, shorthands } from '@griffel/react';
-import { SampleCard } from './SampleCard.stories';
+import { SampleCard as Card, Title } from './SampleCard.stories';
 
 const useStyles = makeStyles({
   root: {
@@ -19,32 +16,33 @@ export const FocusMode = () => {
   return (
     <div className={styles.root}>
       <div>
-        <Title3 block>'off' (Default)</Title3>
-        <Text block>
-          The contents might still be focusable, but the Card won't manage the focus of its contents or be focusable.
-        </Text>
+        <Title
+          title="'off' (Default)"
+          description="The contents might still be focusable, but the Card won't manage the focus of its contents or be focusable."
+        />
+        <Card />
       </div>
-      <SampleCard />
       <div>
-        <Title3 block>'no-tab'</Title3>
-        <Text block>
-          The Card will be focusable and trap the focus. You can use Tab to navigate between the contents and escaping
-          focus only by pressing the Esc key.
-        </Text>
+        <Title
+          title="'no-tab'"
+          description="The Card will be focusable and trap the focus. You can use Tab to navigate between the contents and escaping focus only by pressing the Esc key."
+        />
+        <Card focusMode="no-tab" />
       </div>
-      <SampleCard focusMode="no-tab" />
       <div>
-        <Title3 block>'tab-exit'</Title3>
-        <Text block>The Card will be focusable and trap the focus, but release it on an Esc or Tab key press.</Text>
+        <Title
+          title="'tab-exit'"
+          description="The Card will be focusable and trap the focus, but release it on an Esc or Tab key press."
+        />
+        <Card focusMode="tab-exit" />
       </div>
-      <SampleCard focusMode="tab-exit" />
       <div>
-        <Title3 block>'tab-only'</Title3>
-        <Text block>
-          The Card will not trap focus but will still be focusable and allow Tab navigation of its contents.
-        </Text>
+        <Title
+          title="'tab-only'"
+          description="The Card will not trap focus but will still be focusable and allow Tab navigation of its contents."
+        />
+        <Card focusMode="tab-only" />
       </div>
-      <SampleCard focusMode="tab-only" />
     </div>
   );
 };

--- a/packages/react-components/react-card/src/stories/CardFocusMode.stories.tsx
+++ b/packages/react-components/react-card/src/stories/CardFocusMode.stories.tsx
@@ -18,14 +18,16 @@ export const FocusMode = () => {
       <div>
         <Title
           title="'off' (Default)"
-          description="The contents might still be focusable, but the Card won't manage the focus of its contents or be focusable."
+          description={`The contents might still be focusable,
+          but the Card won't manage the focus of its contents or be focusable.`}
         />
         <Card />
       </div>
       <div>
         <Title
           title="'no-tab'"
-          description="The Card will be focusable and trap the focus. You can use Tab to navigate between the contents and escaping focus only by pressing the Esc key."
+          description={`The Card will be focusable and trap the focus.
+          You can use Tab to navigate between the contents and escaping focus only by pressing the Esc key.`}
         />
         <Card focusMode="no-tab" />
       </div>
@@ -39,7 +41,8 @@ export const FocusMode = () => {
       <div>
         <Title
           title="'tab-only'"
-          description="The Card will not trap focus but will still be focusable and allow Tab navigation of its contents."
+          description={`The Card will not trap focus
+          but will still be focusable and allow Tab navigation of its contents.`}
         />
         <Card focusMode="tab-only" />
       </div>

--- a/packages/react-components/react-card/src/stories/CardSize.stories.tsx
+++ b/packages/react-components/react-card/src/stories/CardSize.stories.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { makeStyles, shorthands } from '@griffel/react';
+import { SampleCard, Title } from './SampleCard.stories';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    ...shorthands.gap('30px'),
+  },
+});
+
+export const Size = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.root}>
+      <div>
+        <Title title="'small'" />
+        <SampleCard size="small" />
+      </div>
+      <div>
+        <Title title="'medium' (Default)" />
+        <SampleCard />
+      </div>
+      <div>
+        <Title title="'large'" />
+        <SampleCard size="large" />
+      </div>
+    </div>
+  );
+};

--- a/packages/react-components/react-card/src/stories/SampleCard.stories.tsx
+++ b/packages/react-components/react-card/src/stories/SampleCard.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { makeStyles } from '@griffel/react';
 import { Button } from '@fluentui/react-button';
 import { Open16Regular, Share16Regular } from '@fluentui/react-icons';
-import { Body1, Caption1 } from '@fluentui/react-text';
+import { Body1, Caption1, Subtitle1 } from '@fluentui/react-text';
 import { Card, CardHeader, CardFooter, CardPreview } from '../index';
 import type { CardProps } from '../index';
 
@@ -36,3 +37,20 @@ export const SampleCard = (props: CardProps) => (
     </CardFooter>
   </Card>
 );
+
+const useStyles = makeStyles({
+  container: {
+    marginBottom: '16px',
+  },
+});
+
+export const Title = (props: { title: string; description?: string }) => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.container}>
+      <Subtitle1 block>{props.title}</Subtitle1>
+      {props.description && <Body1 block>{props.description}</Body1>}
+    </div>
+  );
+};

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -11,6 +11,7 @@ import { AlertSlots } from '@fluentui/react-alert';
 import { AlertState } from '@fluentui/react-alert';
 import { Card } from '@fluentui/react-card';
 import { cardClassNames } from '@fluentui/react-card';
+import { cardCSSVars } from '@fluentui/react-card';
 import { CardFooter } from '@fluentui/react-card';
 import { cardFooterClassNames } from '@fluentui/react-card';
 import { CardFooterProps } from '@fluentui/react-card';
@@ -88,6 +89,8 @@ export { AlertState }
 export { Card }
 
 export { cardClassNames }
+
+export { cardCSSVars }
 
 export { CardFooter }
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -14,6 +14,7 @@ export {
   CardHeader,
   CardPreview,
   cardClassNames,
+  cardCSSVars,
   cardFooterClassNames,
   cardHeaderClassNames,
   cardPreviewClassNames,


### PR DESCRIPTION
## New Behavior

Added the `size` property which will control:
- Container padding
- Padding in-between children
- Border radius

## Related Issue(s)

#19336
