### PR TITLE
react-checkbox: Removing commons from Checkbox

### DIFF
--- a/change/@fluentui-react-checkbox-70a251eb-7216-43ee-8c4c-20d3d63cdb50.json
+++ b/change/@fluentui-react-checkbox-70a251eb-7216-43ee-8c4c-20d3d63cdb50.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing commons from checkbox.",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-checkbox/etc/react-checkbox.api.md
+++ b/packages/react-components/react-checkbox/etc/react-checkbox.api.md
@@ -28,10 +28,14 @@ export interface CheckboxOnChangeData {
 }
 
 // @public
-export type CheckboxProps = Omit<ComponentProps<Partial<CheckboxSlots>, 'input'>, 'size' | 'checked' | 'defaultChecked' | 'onChange'> & Partial<CheckboxCommons> & {
+export type CheckboxProps = Omit<ComponentProps<Partial<CheckboxSlots>, 'input'>, 'size' | 'checked' | 'defaultChecked' | 'onChange'> & {
+    checked?: 'mixed' | boolean;
     children?: never;
-    onChange?: (ev: React_2.ChangeEvent<HTMLInputElement>, data: CheckboxOnChangeData) => void;
     defaultChecked?: 'mixed' | boolean;
+    labelPosition?: 'before' | 'after';
+    onChange?: (ev: React_2.ChangeEvent<HTMLInputElement>, data: CheckboxOnChangeData) => void;
+    shape?: 'square' | 'circular';
+    size?: 'medium' | 'large';
 };
 
 // @public (undocumented)
@@ -43,7 +47,7 @@ export type CheckboxSlots = {
 };
 
 // @public
-export type CheckboxState = ComponentState<CheckboxSlots> & CheckboxCommons;
+export type CheckboxState = ComponentState<CheckboxSlots> & Required<Pick<CheckboxProps, 'checked' | 'labelPosition' | 'shape' | 'size'>>;
 
 // @public (undocumented)
 export const renderCheckbox_unstable: (state: CheckboxState) => JSX.Element;

--- a/packages/react-components/react-checkbox/etc/react-checkbox.api.md
+++ b/packages/react-components/react-checkbox/etc/react-checkbox.api.md
@@ -28,7 +28,7 @@ export interface CheckboxOnChangeData {
 }
 
 // @public
-export type CheckboxProps = Omit<ComponentProps<Partial<CheckboxSlots>, 'input'>, 'size' | 'checked' | 'defaultChecked' | 'onChange'> & {
+export type CheckboxProps = Omit<ComponentProps<Partial<CheckboxSlots>, 'input'>, 'checked' | 'defaultChecked' | 'onChange' | 'size'> & {
     checked?: 'mixed' | boolean;
     children?: never;
     defaultChecked?: 'mixed' | boolean;

--- a/packages/react-components/react-checkbox/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/Checkbox.types.ts
@@ -35,7 +35,7 @@ export type CheckboxSlots = {
  */
 export type CheckboxProps = Omit<
   ComponentProps<Partial<CheckboxSlots>, 'input'>,
-  'size' | 'checked' | 'defaultChecked' | 'onChange'
+  'checked' | 'defaultChecked' | 'onChange' | 'size'
 > & {
   /**
    * The controlled value for the checkbox.

--- a/packages/react-components/react-checkbox/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/Checkbox.types.ts
@@ -2,6 +2,34 @@ import * as React from 'react';
 import { Label } from '@fluentui/react-label';
 import { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
+export type CheckboxSlots = {
+  /**
+   * The root element of the Checkbox.
+   *
+   * The root slot receives the `className` and `style` specified directly on the `<Checkbox>`.
+   * All other native props will be applied to the primary slot: `input`
+   */
+  root: NonNullable<Slot<'span'>>;
+
+  /**
+   * The Checkbox's label.
+   */
+  label?: Slot<typeof Label>;
+
+  /**
+   * Hidden input that handles the checkbox's functionality.
+   *
+   * This is the PRIMARY slot: all native properties specified directly on `<Checkbox>` will be applied to this slot,
+   * except `className` and `style`, which remain on the root slot.
+   */
+  input: NonNullable<Slot<'input'>>;
+
+  /**
+   * The checkbox, with the checkmark icon as its child when checked.
+   */
+  indicator: Slot<'div'>;
+};
+
 /**
  * Checkbox Props
  */
@@ -62,34 +90,6 @@ export type CheckboxProps = Omit<
 export interface CheckboxOnChangeData {
   checked: 'mixed' | boolean;
 }
-
-export type CheckboxSlots = {
-  /**
-   * The root element of the Checkbox.
-   *
-   * The root slot receives the `className` and `style` specified directly on the `<Checkbox>`.
-   * All other native props will be applied to the primary slot: `input`
-   */
-  root: NonNullable<Slot<'span'>>;
-
-  /**
-   * The Checkbox's label.
-   */
-  label?: Slot<typeof Label>;
-
-  /**
-   * Hidden input that handles the checkbox's functionality.
-   *
-   * This is the PRIMARY slot: all native properties specified directly on `<Checkbox>` will be applied to this slot,
-   * except `className` and `style`, which remain on the root slot.
-   */
-  input: NonNullable<Slot<'input'>>;
-
-  /**
-   * The checkbox, with the checkmark icon as its child when checked.
-   */
-  indicator: Slot<'div'>;
-};
 
 /**
  * State used in rendering Checkbox

--- a/packages/react-components/react-checkbox/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/Checkbox.types.ts
@@ -2,38 +2,59 @@ import * as React from 'react';
 import { Label } from '@fluentui/react-label';
 import { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
-interface CheckboxCommons {
+/**
+ * Checkbox Props
+ */
+export type CheckboxProps = Omit<
+  ComponentProps<Partial<CheckboxSlots>, 'input'>,
+  'size' | 'checked' | 'defaultChecked' | 'onChange'
+> & {
+  /**
+   * The controlled value for the checkbox.
+   *
+   * @default false
+   */
+  checked?: 'mixed' | boolean;
+
+  /**
+   * Checkboxes don't support children. To add a label, use the `label` prop.
+   */
+  children?: never;
+
+  /**
+   * Whether the checkbox should be rendered as checked by default.
+   */
+  defaultChecked?: 'mixed' | boolean;
+
+  /**
+   * The position of the label relative to the checkbox indicator.
+   *
+   * @default after
+   */
+  labelPosition?: 'before' | 'after';
+
+  /**
+   * Callback to be called when the checked state value changes.
+   */
+  onChange?: (ev: React.ChangeEvent<HTMLInputElement>, data: CheckboxOnChangeData) => void;
+
   /**
    * The shape of the checkbox indicator.
    *
    * The `circular` variant is only recommended to be used in a tasks-style UI (checklist),
    * since it otherwise could be confused for a `RadioItem`.
    *
-   * @defaultvalue square
+   * @default square
    */
-  shape: 'square' | 'circular';
-
-  /**
-   * The controlled value for the checkbox.
-   *
-   * @defaultvalue false
-   */
-  checked: 'mixed' | boolean;
+  shape?: 'square' | 'circular';
 
   /**
    * The size of the checkbox indicator.
    *
-   * @defaultvalue medium
+   * @default medium
    */
-  size: 'medium' | 'large';
-
-  /**
-   * The position of the label relative to the checkbox indicator.
-   *
-   * @defaultvalue after
-   */
-  labelPosition: 'before' | 'after';
-}
+  size?: 'medium' | 'large';
+};
 
 /**
  * Data for the onChange event for checkbox.
@@ -71,30 +92,7 @@ export type CheckboxSlots = {
 };
 
 /**
- * Checkbox Props
- */
-export type CheckboxProps = Omit<
-  ComponentProps<Partial<CheckboxSlots>, 'input'>,
-  'size' | 'checked' | 'defaultChecked' | 'onChange'
-> &
-  Partial<CheckboxCommons> & {
-    /**
-     * Checkboxes don't support children. To add a label, use the `label` prop.
-     */
-    children?: never;
-
-    /**
-     * Callback to be called when the checked state value changes.
-     */
-    onChange?: (ev: React.ChangeEvent<HTMLInputElement>, data: CheckboxOnChangeData) => void;
-
-    /**
-     * Whether the checkbox should be rendered as checked by default.
-     */
-    defaultChecked?: 'mixed' | boolean;
-  };
-
-/**
  * State used in rendering Checkbox
  */
-export type CheckboxState = ComponentState<CheckboxSlots> & CheckboxCommons;
+export type CheckboxState = ComponentState<CheckboxSlots> &
+  Required<Pick<CheckboxProps, 'checked' | 'labelPosition' | 'shape' | 'size'>>;


### PR DESCRIPTION
This PR adds the following changes:
* Removes commons type from Checkbox.
* Changes `defaultvalue` to `default` in Checkbox types.

## Related issues

#22862 