### PR TITLE
react-tabs: Removed flexgap from useTabStyles

### DIFF
--- a/change/@fluentui-react-tabs-35cfa4bc-b5ec-4b83-af69-63f5410eda03.json
+++ b/change/@fluentui-react-tabs-35cfa4bc-b5ec-4b83-af69-63f5410eda03.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removed flexgap from useTabStyles",
+  "packageName": "@fluentui/react-tabs",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/src/components/Tab/useTabStyles.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTabStyles.ts
@@ -26,9 +26,11 @@ const useRootStyles = makeStyles({
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
     ...shorthands.borderWidth(0),
     cursor: 'pointer',
-    display: 'flex',
-    flexDirection: 'row',
+    display: 'grid',
     flexShrink: 0,
+    gridAutoFlow: 'column',
+    gridTemplateColumns: 'auto',
+    gridTemplateRows: 'auto',
     fontFamily: tokens.fontFamilyBase,
     lineHeight: tokens.lineHeightBase300,
     outlineStyle: 'none',
@@ -36,16 +38,19 @@ const useRootStyles = makeStyles({
     ...shorthands.overflow('hidden'),
     textTransform: 'none',
   },
+  horizontal: {
+    justifyContent: 'center',
+  },
+  vertical: {
+    justifyContent: 'flex-start',
+  },
   mediumHorizontal: {
     columnGap: tokens.spacingHorizontalSNudge,
-    justifyContent: 'center',
     ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalMNudge),
   },
   mediumVertical: {
     // horizontal spacing is deliberate. This is the gap between icon and content.
     columnGap: tokens.spacingHorizontalSNudge,
-    justifyContent: 'flex-start',
-    minWidth: '120px',
     ...shorthands.padding(tokens.spacingVerticalSNudge, tokens.spacingHorizontalMNudge),
   },
   smallHorizontal: {
@@ -357,6 +362,7 @@ export const useTabStyles_unstable = (state: TabState): TabState => {
   state.root.className = mergeClasses(
     tabClassNames.root,
     rootStyles.base,
+    vertical ? rootStyles.vertical : rootStyles.horizontal,
     size !== 'small' && (vertical ? rootStyles.mediumVertical : rootStyles.mediumHorizontal),
     size === 'small' && (vertical ? rootStyles.smallVertical : rootStyles.smallHorizontal),
     focusStyles.base,

--- a/packages/react-components/react-tabs/src/components/Tab/useTabStyles.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTabStyles.ts
@@ -42,7 +42,7 @@ const useRootStyles = makeStyles({
     justifyContent: 'center',
   },
   vertical: {
-    justifyContent: 'flex-start',
+    justifyContent: 'start',
   },
   mediumHorizontal: {
     columnGap: tokens.spacingHorizontalSNudge,


### PR DESCRIPTION
## Changes
- Updated Tab component to use grid
- Removed the min-width of 120px from medium vertical (no longer specified in figma)
- Collapsed horiztontal/vertical styles to ensure correct content alignment.

## Issues

Updates #22704