### PR TITLE
react-tabs: Moved to stable RC

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -39,7 +39,7 @@
     "@fluentui/react-spinner": "9.0.0-beta.9",
     "@fluentui/react-spinbutton": "9.0.0-beta.9",
     "@fluentui/react-switch": "9.0.0-rc.9",
-    "@fluentui/react-tabs": "9.0.0-beta.12",
+    "@fluentui/react-tabs": "9.0.0-rc.1",
     "@fluentui/react-text": "9.0.0-rc.8",
     "@fluentui/react-textarea": "9.0.0-alpha.3",
     "@fluentui/react-theme": "9.0.0-rc.7",

--- a/change/@fluentui-react-components-348b6a68-d21e-4f0c-9d42-0f991337ad92.json
+++ b/change/@fluentui-react-components-348b6a68-d21e-4f0c-9d42-0f991337ad92.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Moved react-tabs to stable and rc.1",
+  "packageName": "@fluentui/react-components",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-79150bf6-ae72-4800-be7b-006ecd4d50eb.json
+++ b/change/@fluentui-react-tabs-79150bf6-ae72-4800-be7b-006ecd4d50eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Moved react-tabs to stable and rc.1",
+  "packageName": "@fluentui/react-tabs",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -285,6 +285,7 @@ import { RadioOnChangeData } from '@fluentui/react-radio';
 import { RadioProps } from '@fluentui/react-radio';
 import { RadioSlots } from '@fluentui/react-radio';
 import { RadioState } from '@fluentui/react-radio';
+import { RegisterTabEventHandler } from '@fluentui/react-tabs';
 import { renderAccordion_unstable } from '@fluentui/react-accordion';
 import { renderAccordionHeader_unstable } from '@fluentui/react-accordion';
 import { renderAccordionItem_unstable } from '@fluentui/react-accordion';
@@ -319,6 +320,8 @@ import { renderRadio_unstable } from '@fluentui/react-radio';
 import { renderRadioGroup_unstable } from '@fluentui/react-radio';
 import { renderSlider_unstable } from '@fluentui/react-slider';
 import { renderSplitButton_unstable } from '@fluentui/react-button';
+import { renderTab_unstable } from '@fluentui/react-tabs';
+import { renderTabList_unstable } from '@fluentui/react-tabs';
 import { renderText_unstable } from '@fluentui/react-text';
 import { renderToggleButton_unstable } from '@fluentui/react-button';
 import { renderTooltip_unstable } from '@fluentui/react-tooltip';
@@ -328,6 +331,9 @@ import { resolveShorthand } from '@fluentui/react-utilities';
 import { ResolveShorthandFunction } from '@fluentui/react-utilities';
 import { ResolveShorthandOptions } from '@fluentui/react-utilities';
 import { SelectableHandler } from '@fluentui/react-menu';
+import { SelectTabData } from '@fluentui/react-tabs';
+import { SelectTabEvent } from '@fluentui/react-tabs';
+import { SelectTabEventHandler } from '@fluentui/react-tabs';
 import { setVirtualParent } from '@fluentui/react-portal';
 import { ShadowBrandTokens } from '@fluentui/react-theme';
 import { ShadowTokens } from '@fluentui/react-theme';
@@ -353,6 +359,22 @@ import { StrokeWidthTokens } from '@fluentui/react-theme';
 import { Subheadline } from '@fluentui/react-text';
 import { subheadlineClassName } from '@fluentui/react-text';
 import { subheadlineClassNames } from '@fluentui/react-text';
+import { Tab } from '@fluentui/react-tabs';
+import { tabClassName } from '@fluentui/react-tabs';
+import { tabClassNames } from '@fluentui/react-tabs';
+import { TabList } from '@fluentui/react-tabs';
+import { tabListClassName } from '@fluentui/react-tabs';
+import { tabListClassNames } from '@fluentui/react-tabs';
+import { TabListContextValue } from '@fluentui/react-tabs';
+import { TabListContextValues } from '@fluentui/react-tabs';
+import { TabListProps } from '@fluentui/react-tabs';
+import { TabListSlots } from '@fluentui/react-tabs';
+import { TabListState } from '@fluentui/react-tabs';
+import { TabProps } from '@fluentui/react-tabs';
+import { TabRegisterData } from '@fluentui/react-tabs';
+import { TabSlots } from '@fluentui/react-tabs';
+import { TabState } from '@fluentui/react-tabs';
+import { TabValue } from '@fluentui/react-tabs';
 import { teamsDarkTheme } from '@fluentui/react-theme';
 import { teamsHighContrastTheme } from '@fluentui/react-theme';
 import { teamsLightTheme } from '@fluentui/react-theme';
@@ -484,6 +506,10 @@ import { useSliderStyles_unstable } from '@fluentui/react-slider';
 import { useSplitButton_unstable } from '@fluentui/react-button';
 import { useSplitButtonStyles_unstable } from '@fluentui/react-button';
 import { useSSRContext } from '@fluentui/react-utilities';
+import { useTab_unstable } from '@fluentui/react-tabs';
+import { useTabList_unstable } from '@fluentui/react-tabs';
+import { useTabListStyles_unstable } from '@fluentui/react-tabs';
+import { useTabStyles_unstable } from '@fluentui/react-tabs';
 import { useText_unstable } from '@fluentui/react-text';
 import { useTextStyles_unstable } from '@fluentui/react-text';
 import { useThemeClassName } from '@fluentui/react-shared-contexts';
@@ -1059,6 +1085,8 @@ export { RadioSlots }
 
 export { RadioState }
 
+export { RegisterTabEventHandler }
+
 export { renderAccordion_unstable }
 
 export { renderAccordionHeader_unstable }
@@ -1127,6 +1155,10 @@ export { renderSlider_unstable }
 
 export { renderSplitButton_unstable }
 
+export { renderTab_unstable }
+
+export { renderTabList_unstable }
+
 export { renderText_unstable }
 
 export { renderToggleButton_unstable }
@@ -1144,6 +1176,12 @@ export { ResolveShorthandFunction }
 export { ResolveShorthandOptions }
 
 export { SelectableHandler }
+
+export { SelectTabData }
+
+export { SelectTabEvent }
+
+export { SelectTabEventHandler }
 
 export { setVirtualParent }
 
@@ -1194,6 +1232,38 @@ export { Subheadline }
 export { subheadlineClassName }
 
 export { subheadlineClassNames }
+
+export { Tab }
+
+export { tabClassName }
+
+export { tabClassNames }
+
+export { TabList }
+
+export { tabListClassName }
+
+export { tabListClassNames }
+
+export { TabListContextValue }
+
+export { TabListContextValues }
+
+export { TabListProps }
+
+export { TabListSlots }
+
+export { TabListState }
+
+export { TabProps }
+
+export { TabRegisterData }
+
+export { TabSlots }
+
+export { TabState }
+
+export { TabValue }
 
 export { teamsDarkTheme }
 
@@ -1456,6 +1526,14 @@ export { useSplitButton_unstable }
 export { useSplitButtonStyles_unstable }
 
 export { useSSRContext }
+
+export { useTab_unstable }
+
+export { useTabList_unstable }
+
+export { useTabListStyles_unstable }
+
+export { useTabStyles_unstable }
 
 export { useText_unstable }
 

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -42,7 +42,6 @@ import { InputOnChangeData } from '@fluentui/react-input';
 import { InputProps } from '@fluentui/react-input';
 import { InputSlots } from '@fluentui/react-input';
 import { InputState } from '@fluentui/react-input';
-import { RegisterTabEventHandler } from '@fluentui/react-tabs';
 import { renderCard_unstable } from '@fluentui/react-card';
 import { renderCardFooter_unstable } from '@fluentui/react-card';
 import { renderCardHeader_unstable } from '@fluentui/react-card';
@@ -52,12 +51,7 @@ import { renderInput_unstable } from '@fluentui/react-input';
 import { renderSpinButton_unstable } from '@fluentui/react-spinbutton';
 import { renderSpinner_unstable } from '@fluentui/react-spinner';
 import { renderSwitch_unstable } from '@fluentui/react-switch';
-import { renderTab_unstable } from '@fluentui/react-tabs';
-import { renderTabList_unstable } from '@fluentui/react-tabs';
 import { renderTextarea_unstable } from '@fluentui/react-textarea';
-import { SelectTabData } from '@fluentui/react-tabs';
-import { SelectTabEvent } from '@fluentui/react-tabs';
-import { SelectTabEventHandler } from '@fluentui/react-tabs';
 import { SpinButton } from '@fluentui/react-spinbutton';
 import { SpinButtonBounds } from '@fluentui/react-spinbutton';
 import { SpinButtonChangeEvent } from '@fluentui/react-spinbutton';
@@ -79,22 +73,6 @@ import { SwitchOnChangeData } from '@fluentui/react-switch';
 import { SwitchProps } from '@fluentui/react-switch';
 import { SwitchSlots } from '@fluentui/react-switch';
 import { SwitchState } from '@fluentui/react-switch';
-import { Tab } from '@fluentui/react-tabs';
-import { tabClassName } from '@fluentui/react-tabs';
-import { tabClassNames } from '@fluentui/react-tabs';
-import { TabList } from '@fluentui/react-tabs';
-import { tabListClassName } from '@fluentui/react-tabs';
-import { tabListClassNames } from '@fluentui/react-tabs';
-import { TabListContextValue } from '@fluentui/react-tabs';
-import { TabListContextValues } from '@fluentui/react-tabs';
-import { TabListProps } from '@fluentui/react-tabs';
-import { TabListSlots } from '@fluentui/react-tabs';
-import { TabListState } from '@fluentui/react-tabs';
-import { TabProps } from '@fluentui/react-tabs';
-import { TabRegisterData } from '@fluentui/react-tabs';
-import { TabSlots } from '@fluentui/react-tabs';
-import { TabState } from '@fluentui/react-tabs';
-import { TabValue } from '@fluentui/react-tabs';
 import { Textarea } from '@fluentui/react-textarea';
 import { textareaClassNames } from '@fluentui/react-textarea';
 import { TextareaProps } from '@fluentui/react-textarea';
@@ -118,10 +96,6 @@ import { useSpinner_unstable } from '@fluentui/react-spinner';
 import { useSpinnerStyles_unstable } from '@fluentui/react-spinner';
 import { useSwitch_unstable } from '@fluentui/react-switch';
 import { useSwitchStyles_unstable } from '@fluentui/react-switch';
-import { useTab_unstable } from '@fluentui/react-tabs';
-import { useTabList_unstable } from '@fluentui/react-tabs';
-import { useTabListStyles_unstable } from '@fluentui/react-tabs';
-import { useTabStyles_unstable } from '@fluentui/react-tabs';
 import { useTextarea_unstable } from '@fluentui/react-textarea';
 import { useTextareaStyles_unstable } from '@fluentui/react-textarea';
 
@@ -201,8 +175,6 @@ export { InputSlots }
 
 export { InputState }
 
-export { RegisterTabEventHandler }
-
 export { renderCard_unstable }
 
 export { renderCardFooter_unstable }
@@ -221,17 +193,7 @@ export { renderSpinner_unstable }
 
 export { renderSwitch_unstable }
 
-export { renderTab_unstable }
-
-export { renderTabList_unstable }
-
 export { renderTextarea_unstable }
-
-export { SelectTabData }
-
-export { SelectTabEvent }
-
-export { SelectTabEventHandler }
 
 export { SpinButton }
 
@@ -274,38 +236,6 @@ export { SwitchProps }
 export { SwitchSlots }
 
 export { SwitchState }
-
-export { Tab }
-
-export { tabClassName }
-
-export { tabClassNames }
-
-export { TabList }
-
-export { tabListClassName }
-
-export { tabListClassNames }
-
-export { TabListContextValue }
-
-export { TabListContextValues }
-
-export { TabListProps }
-
-export { TabListSlots }
-
-export { TabListState }
-
-export { TabProps }
-
-export { TabRegisterData }
-
-export { TabSlots }
-
-export { TabState }
-
-export { TabValue }
 
 export { Textarea }
 
@@ -352,14 +282,6 @@ export { useSpinnerStyles_unstable }
 export { useSwitch_unstable }
 
 export { useSwitchStyles_unstable }
-
-export { useTab_unstable }
-
-export { useTabList_unstable }
-
-export { useTabListStyles_unstable }
-
-export { useTabStyles_unstable }
 
 export { useTextarea_unstable }
 

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -54,7 +54,7 @@
     "@fluentui/react-spinbutton": "9.0.0-beta.9",
     "@fluentui/react-spinner": "9.0.0-beta.9",
     "@fluentui/react-switch": "9.0.0-rc.9",
-    "@fluentui/react-tabs": "9.0.0-beta.12",
+    "@fluentui/react-tabs": "9.0.0-rc.1",
     "@fluentui/react-tabster": "9.0.0-rc.9",
     "@fluentui/react-textarea": "9.0.0-alpha.3",
     "@fluentui/react-theme": "9.0.0-rc.7",

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -516,6 +516,36 @@ export {
 } from '@fluentui/react-slider';
 export type { SliderProps, SliderSlots, SliderOnChangeData, SliderState } from '@fluentui/react-slider';
 export {
+  renderTab_unstable,
+  Tab,
+  tabClassName,
+  tabClassNames,
+  useTabStyles_unstable,
+  useTab_unstable,
+  renderTabList_unstable,
+  TabList,
+  tabListClassName,
+  tabListClassNames,
+  useTabListStyles_unstable,
+  useTabList_unstable,
+} from '@fluentui/react-tabs';
+export type {
+  TabProps,
+  TabSlots,
+  TabState,
+  TabValue,
+  TabRegisterData,
+  RegisterTabEventHandler,
+  SelectTabData,
+  SelectTabEvent,
+  SelectTabEventHandler,
+  TabListContextValue,
+  TabListContextValues,
+  TabListProps,
+  TabListSlots,
+  TabListState,
+} from '@fluentui/react-tabs';
+export {
   Body,
   Caption,
   Display,

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -112,35 +112,3 @@ export {
   useTextareaStyles_unstable,
 } from '@fluentui/react-textarea';
 export type { TextareaProps, TextareaSlots, TextareaState } from '@fluentui/react-textarea';
-
-export type {
-  TabProps,
-  TabSlots,
-  TabState,
-  TabValue,
-  TabRegisterData,
-  RegisterTabEventHandler,
-  SelectTabData,
-  SelectTabEvent,
-  SelectTabEventHandler,
-  TabListContextValue,
-  TabListContextValues,
-  TabListProps,
-  TabListSlots,
-  TabListState,
-} from '@fluentui/react-tabs';
-
-export {
-  renderTab_unstable,
-  Tab,
-  tabClassName,
-  tabClassNames,
-  useTabStyles_unstable,
-  useTab_unstable,
-  renderTabList_unstable,
-  TabList,
-  tabListClassName,
-  tabListClassNames,
-  useTabListStyles_unstable,
-  useTabList_unstable,
-} from '@fluentui/react-tabs';

--- a/packages/react-components/react-tabs/package.json
+++ b/packages/react-components/react-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-tabs",
-  "version": "9.0.0-beta.12",
+  "version": "9.0.0-rc.1",
   "description": "Fluent UI React tabs components",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
react-tabs is ready for stable and RC status:
- No breaking changes expected
- Supports tab panel and overflow scenarios
- Verified figma and implementation match
- a11y review mostly complete (Windows, Mac, colors, keyboard, screen readers pass)

## Changes
- Updated version of react-tabs to 9.0.0-rc.1
- Moved exports from unstable to index