### PR TITLE
chore(vscode): setup proper file asscociation for codeowners file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -47,7 +47,8 @@
   "eslint.workingDirectories": [{ "mode": "auto" }], // infer working directory based on .eslintrc/package.json location
   "files.associations": {
     "**/package.json.hbs": "json",
-    "**/*.json.hbs": "jsonc"
+    "**/*.json.hbs": "jsonc",
+    "CODEOWNERS": "ini"
   },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Codeowners file is recognized as markdown in vscode which is wrong and might lead to issues

![image](https://user-images.githubusercontent.com/1223799/167818627-a981f2eb-4243-4d8d-aeed-14255f0b6d14.png)


## New Behavior

Codeowners is recognized as proper file type

![image](https://user-images.githubusercontent.com/1223799/167818561-104a03de-787f-474c-a150-a084196cddb5.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/microsoft/fluentui/pull/22909#pullrequestreview-967883338
