### PR TITLE
fix: update mergeClasses() to match implementation in conformance tests

### DIFF
--- a/change/@fluentui-react-conformance-griffel-dbbbeeb9-c536-4c69-8654-8bc9cb180ec9.json
+++ b/change/@fluentui-react-conformance-griffel-dbbbeeb9-c536-4c69-8654-8bc9cb180ec9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: update mock of mergeClasses() to return an empty string",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-conformance-griffel/src/overridesWin.ts
+++ b/packages/react-components/react-conformance-griffel/src/overridesWin.ts
@@ -34,7 +34,7 @@ export const overridesWin: ConformanceTest = (componentInfo, testInfo) => {
     | undefined;
 
   let container: HTMLDivElement | null = null;
-  const mergeClasses = jest.fn();
+  const mergeClasses = jest.fn().mockImplementation(() => '');
 
   jest.mock('@griffel/react', () => {
     const module = jest.requireActual('@griffel/react');
@@ -43,7 +43,7 @@ export const overridesWin: ConformanceTest = (componentInfo, testInfo) => {
   });
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
     jest.resetModules();
 
     container = document.createElement('div');


### PR DESCRIPTION
It affects only conformance tests (`@fluentui/react-conformance-griffel`).

## Current Behavior

`mergeClasses()` implementation is mocked, but it returns `undefined`. Original `mergeClasses()` function always returns a string.

## New Behavior

`mergeClasses()` implementation is mocked and returns the same type as an original function.

## Related Issue(s)

Caused issues in #22933.
