### PR TITLE
fix: enable master screener scoping

### DIFF
--- a/scripts/gulp/tasks/screener.ts
+++ b/scripts/gulp/tasks/screener.ts
@@ -48,7 +48,7 @@ task('screener:runner', cb => {
     affectedPackages = getAffectedPackages(previousMasterCommit);
   }
 
-  if (!affectedPackages.has(docsPackageName) && isPrBuild) {
+  if (!affectedPackages.has(docsPackageName)) {
     handlePromiseExit(cancelScreenerRun(screenerConfig, 'skipped'));
   } else {
     handlePromiseExit(screenerRunner(screenerConfig));

--- a/scripts/tasks/screener.ts
+++ b/scripts/tasks/screener.ts
@@ -32,7 +32,7 @@ export async function screener() {
   }
 
   try {
-    if (!affectedPackages.has(affectedPackageInfo.packageJson.name) && isPrBuild) {
+    if (!affectedPackages.has(affectedPackageInfo.packageJson.name)) {
       await cancelScreenerRun(screenerConfig, 'skipped');
     } else {
       await screenerRunner(screenerConfig);


### PR DESCRIPTION
Removes the condition that scoping should only occur during pr build