### PR TITLE
Removing LinkCommons type in @fluentui/react-link

### DIFF
--- a/change/@fluentui-react-link-dbe9a9a3-2bd7-4293-ab9c-f2e04bc8b1ab.json
+++ b/change/@fluentui-react-link-dbe9a9a3-2bd7-4293-ab9c-f2e04bc8b1ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing LinkCommon type.",
+  "packageName": "@fluentui/react-link",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-link/etc/react-link.api.md
+++ b/packages/react-components/react-link/etc/react-link.api.md
@@ -21,7 +21,12 @@ export const linkClassName = "fui-Link";
 export const linkClassNames: SlotClassNames<LinkSlots>;
 
 // @public (undocumented)
-export type LinkProps = ComponentProps<LinkSlots> & LinkCommons;
+export type LinkProps = ComponentProps<LinkSlots> & {
+    appearance?: 'default' | 'subtle';
+    disabled?: boolean;
+    disabledFocusable?: boolean;
+    inline?: boolean;
+};
 
 // @public (undocumented)
 export type LinkSlots = {
@@ -29,7 +34,7 @@ export type LinkSlots = {
 };
 
 // @public (undocumented)
-export type LinkState = ComponentState<LinkSlots> & LinkCommons;
+export type LinkState = ComponentState<LinkSlots> & Required<Pick<LinkProps, 'appearance' | 'disabled' | 'disabledFocusable' | 'inline'>>;
 
 // @public
 export const renderLink_unstable: (state: LinkState) => JSX.Element;

--- a/packages/react-components/react-link/src/components/Link/Link.types.ts
+++ b/packages/react-components/react-link/src/components/Link/Link.types.ts
@@ -7,12 +7,13 @@ export type LinkSlots = {
   root: Slot<'a', 'button'>;
 };
 
-type LinkCommons = {
+export type LinkProps = ComponentProps<LinkSlots> & {
   /**
    * A link can appear either with its default style or subtle.
    * If not specified, the link appears with its default styling.
+   * @default 'default'
    */
-  appearance?: 'subtle';
+  appearance?: 'default' | 'subtle';
 
   /**
    * Whether the link is disabled.
@@ -34,6 +35,5 @@ type LinkCommons = {
   inline?: boolean;
 };
 
-export type LinkProps = ComponentProps<LinkSlots> & LinkCommons;
-
-export type LinkState = ComponentState<LinkSlots> & LinkCommons;
+export type LinkState = ComponentState<LinkSlots> &
+  Required<Pick<LinkProps, 'appearance' | 'disabled' | 'disabledFocusable' | 'inline'>>;

--- a/packages/react-components/react-link/src/components/Link/useLink.ts
+++ b/packages/react-components/react-link/src/components/Link/useLink.ts
@@ -12,7 +12,7 @@ export const useLink_unstable = (
   props: LinkProps,
   ref: React.Ref<HTMLAnchorElement | HTMLButtonElement>,
 ): LinkState => {
-  const { appearance, disabled, disabledFocusable, inline } = props;
+  const { appearance = 'default', disabled = false, disabledFocusable = false, inline = false } = props;
   const as = props.as || (props.href ? 'a' : 'button');
 
   const state: LinkState = {

--- a/packages/react-components/react-link/src/components/Link/useLinkState.ts
+++ b/packages/react-components/react-link/src/components/Link/useLinkState.ts
@@ -45,7 +45,7 @@ export const useLinkState_unstable = (state: LinkState): LinkState => {
   };
 
   // Set the aria-disabled and disabled props correctly.
-  state.root['aria-disabled'] = disabled || disabledFocusable;
+  state.root['aria-disabled'] = disabled || disabledFocusable || undefined;
   if (state.root.as === 'button') {
     state.root.disabled = disabled && !disabledFocusable;
   }

--- a/packages/react-components/react-link/src/components/Link/useLinkState.ts
+++ b/packages/react-components/react-link/src/components/Link/useLinkState.ts
@@ -45,6 +45,7 @@ export const useLinkState_unstable = (state: LinkState): LinkState => {
   };
 
   // Set the aria-disabled and disabled props correctly.
+  state.disabled = disabled || disabledFocusable;
   state.root['aria-disabled'] = disabled || disabledFocusable || undefined;
   if (state.root.as === 'button') {
     state.root.disabled = disabled && !disabledFocusable;

--- a/packages/react-components/react-link/src/components/Link/useLinkStyles.ts
+++ b/packages/react-components/react-link/src/components/Link/useLinkStyles.ts
@@ -99,15 +99,17 @@ const useStyles = makeStyles({
 
 export const useLinkStyles_unstable = (state: LinkState): LinkState => {
   const styles = useStyles();
+  const { appearance, inline, root } = state;
+
   state.root.className = mergeClasses(
     linkClassNames.root,
     styles.root,
     styles.focusIndicator,
-    state.root.as === 'a' && state.root.href && styles.href,
-    state.appearance === 'subtle' && styles.subtle,
-    state.inline && styles.inline,
-    state.appearance === 'subtle' && state.inline && styles.inlineSubtle,
-    state.root['aria-disabled'] && styles.disabled,
+    root.as === 'a' && root.href && styles.href,
+    appearance === 'subtle' && styles.subtle,
+    inline && styles.inline,
+    appearance === 'subtle' && inline && styles.inlineSubtle,
+    root['aria-disabled'] && styles.disabled,
     state.root.className,
   );
 

--- a/packages/react-components/react-link/src/components/Link/useLinkStyles.ts
+++ b/packages/react-components/react-link/src/components/Link/useLinkStyles.ts
@@ -99,7 +99,7 @@ const useStyles = makeStyles({
 
 export const useLinkStyles_unstable = (state: LinkState): LinkState => {
   const styles = useStyles();
-  const { appearance, inline, root } = state;
+  const { appearance, disabled, inline, root } = state;
 
   state.root.className = mergeClasses(
     linkClassNames.root,
@@ -109,7 +109,7 @@ export const useLinkStyles_unstable = (state: LinkState): LinkState => {
     appearance === 'subtle' && styles.subtle,
     inline && styles.inline,
     appearance === 'subtle' && inline && styles.inlineSubtle,
-    root['aria-disabled'] && styles.disabled,
+    disabled && styles.disabled,
     state.root.className,
   );
 

--- a/packages/react-components/react-link/src/stories/LinkInline.stories.tsx
+++ b/packages/react-components/react-link/src/stories/LinkInline.stories.tsx
@@ -3,10 +3,10 @@ import { Link } from '../index';
 
 export const Inline = () => (
   <div>
-    This is an
+    This is an{' '}
     <Link href="https://www.bing.com" inline>
       inline link
-    </Link>
+    </Link>{' '}
     used alongside other text
   </div>
 );


### PR DESCRIPTION
## PR Description

This PR removes the `Commons` type pattern in the types for our `Link` component.

## Related Issue(s)

Fixes part of #22862
