### PR TITLE
Remove Combobox commons types

### DIFF
--- a/packages/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-combobox/etc/react-combobox.api.md
@@ -29,14 +29,20 @@ export type ComboboxOpenChangeData = {
 };
 
 // @public (undocumented)
-export type ComboboxOpenEvents = React_2.MouseEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement> | React_2.FocusEvent<HTMLElement>;
+export type ComboboxOpenEvents = React_2.FocusEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement> | React_2.MouseEvent<HTMLElement>;
 
 // @public
-export type ComboboxProps = ComponentProps<Partial<ComboboxSlots>, 'trigger'> & ComboboxCommons & SelectionProps & {
+export type ComboboxProps = ComponentProps<Partial<ComboboxSlots>, 'trigger'> & SelectionProps & {
+    appearance?: 'filledDarker' | 'filledLighter' | 'outline' | 'underline';
     defaultOpen?: boolean;
     defaultValue?: string;
+    inline?: boolean;
     onOpenChange?: (e: ComboboxOpenEvents, data: ComboboxOpenChangeData) => void;
+    open?: boolean;
+    placeholder?: string;
     positioning?: PositioningShorthand;
+    size?: 'small' | 'medium' | 'large';
+    value?: string;
 };
 
 // @public (undocumented)
@@ -47,7 +53,7 @@ export type ComboboxSlots = {
 };
 
 // @public
-export type ComboboxState = ComponentState<ComboboxSlots> & Required<Pick<ComboboxCommons, 'appearance' | 'open' | 'inline' | 'size'>> & Pick<ComboboxCommons, 'placeholder' | 'value'> & OptionCollectionState & SelectionState & {
+export type ComboboxState = ComponentState<ComboboxSlots> & Required<Pick<ComboboxProps, 'appearance' | 'inline' | 'open' | 'size'>> & Pick<ComboboxProps, 'placeholder' | 'value'> & OptionCollectionState & SelectionState & {
     activeOption?: OptionValue;
     onOptionClick(event: React_2.MouseEvent, option: OptionValue): void;
 };
@@ -59,7 +65,11 @@ export const ComboButton: ForwardRefComponent<ComboButtonProps>;
 export const comboButtonClassNames: SlotClassNames<ComboButtonSlots>;
 
 // @public
-export type ComboButtonProps = Partial<ComponentProps<ComboButtonSlots, 'content'>> & ComboButtonCommons;
+export type ComboButtonProps = Partial<ComponentProps<ComboButtonSlots, 'content'>> & {
+    appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
+    placeholder?: string;
+    value?: string;
+};
 
 // @public (undocumented)
 export type ComboButtonSlots = {
@@ -69,7 +79,7 @@ export type ComboButtonSlots = {
 };
 
 // @public
-export type ComboButtonState = ComponentState<ComboButtonSlots> & ComboButtonCommons & Pick<ComboboxState, 'appearance' | 'size'>;
+export type ComboButtonState = ComponentState<ComboButtonSlots> & Pick<ComboboxState, 'appearance' | 'size'>;
 
 // @public
 export const Listbox: ForwardRefComponent<ListboxProps>;
@@ -122,7 +132,8 @@ export type OptionGroupSlots = {
 export type OptionGroupState = ComponentState<OptionGroupSlots>;
 
 // @public
-export type OptionProps = ComponentProps<Partial<OptionSlots>> & OptionCommons & {
+export type OptionProps = ComponentProps<Partial<OptionSlots>> & {
+    disabled?: boolean;
     value?: string;
 };
 
@@ -133,7 +144,7 @@ export type OptionSlots = {
 };
 
 // @public
-export type OptionState = ComponentState<OptionSlots> & OptionCommons & {
+export type OptionState = ComponentState<OptionSlots> & Pick<OptionProps, 'disabled'> & {
     active: boolean;
     multiselect?: boolean;
     selected: boolean;

--- a/packages/react-combobox/src/components/ComboButton/ComboButton.types.ts
+++ b/packages/react-combobox/src/components/ComboButton/ComboButton.types.ts
@@ -12,7 +12,10 @@ export type ComboButtonSlots = {
   expandIcon: Slot<'span'>;
 };
 
-type ComboButtonCommons = {
+/**
+ * ComboButton Props
+ */
+export type ComboButtonProps = Partial<ComponentProps<ComboButtonSlots, 'content'>> & {
   /**
    * Controls the colors and borders of the combobox.
    * @default 'outline'
@@ -31,13 +34,6 @@ type ComboButtonCommons = {
 };
 
 /**
- * ComboButton Props
- */
-export type ComboButtonProps = Partial<ComponentProps<ComboButtonSlots, 'content'>> & ComboButtonCommons;
-
-/**
  * State used in rendering ComboButton
  */
-export type ComboButtonState = ComponentState<ComboButtonSlots> &
-  ComboButtonCommons &
-  Pick<ComboboxState, 'appearance' | 'size'>;
+export type ComboButtonState = ComponentState<ComboButtonSlots> & Pick<ComboboxState, 'appearance' | 'size'>;

--- a/packages/react-combobox/src/components/Combobox/Combobox.types.ts
+++ b/packages/react-combobox/src/components/Combobox/Combobox.types.ts
@@ -18,49 +18,17 @@ export type ComboboxSlots = {
   trigger: NonNullable<Slot<typeof ComboButton>>;
 };
 
-type ComboboxCommons = {
-  /**
-   * Controls the colors and borders of the combobox.
-   * @default 'outline'
-   */
-  appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
-
-  /**
-   * Render the combobox dropdown inline in the DOM.
-   * This has accessibility benefits, particularly for touch screen readers.
-   */
-  inline?: boolean;
-
-  /**
-   * Sets the open/closed state of the dropdown.
-   * Use together with onOpenChange to fully control the dropdown's visibility
-   */
-  open?: boolean;
-
-  /**
-   * If set, the placeholder will show when no value is selected
-   */
-  placeholder?: string;
-
-  /**
-   * Controls the size of the combobox faceplate
-   * @default 'medium'
-   */
-  size?: 'small' | 'medium' | 'large';
-
-  /**
-   * The value displayed by the Combobox.
-   * Use this with `onSelect` to directly control the displayed value string
-   */
-  value?: string;
-};
-
 /**
  * Combobox Props
  */
 export type ComboboxProps = ComponentProps<Partial<ComboboxSlots>, 'trigger'> &
-  ComboboxCommons &
   SelectionProps & {
+    /**
+     * Controls the colors and borders of the combobox.
+     * @default 'outline'
+     */
+    appearance?: 'filledDarker' | 'filledLighter' | 'outline' | 'underline';
+
     /**
      * The default open state when open is uncontrolled
      */
@@ -72,9 +40,26 @@ export type ComboboxProps = ComponentProps<Partial<ComboboxSlots>, 'trigger'> &
     defaultValue?: string;
 
     /**
+     * Render the combobox dropdown inline in the DOM.
+     * This has accessibility benefits, particularly for touch screen readers.
+     */
+    inline?: boolean;
+
+    /**
      * Callback when the open/closed state of the dropdown changes
      */
     onOpenChange?: (e: ComboboxOpenEvents, data: ComboboxOpenChangeData) => void;
+
+    /**
+     * Sets the open/closed state of the dropdown.
+     * Use together with onOpenChange to fully control the dropdown's visibility
+     */
+    open?: boolean;
+
+    /**
+     * If set, the placeholder will show when no value is selected
+     */
+    placeholder?: string;
 
     /**
      * Configure the positioning of the combobox dropdown
@@ -82,14 +67,26 @@ export type ComboboxProps = ComponentProps<Partial<ComboboxSlots>, 'trigger'> &
      * @defaultvalue below
      */
     positioning?: PositioningShorthand;
+
+    /**
+     * Controls the size of the combobox faceplate
+     * @default 'medium'
+     */
+    size?: 'small' | 'medium' | 'large';
+
+    /**
+     * The value displayed by the Combobox.
+     * Use this with `onSelect` to directly control the displayed value string
+     */
+    value?: string;
   };
 
 /**
  * State used in rendering Combobox
  */
 export type ComboboxState = ComponentState<ComboboxSlots> &
-  Required<Pick<ComboboxCommons, 'appearance' | 'open' | 'inline' | 'size'>> &
-  Pick<ComboboxCommons, 'placeholder' | 'value'> &
+  Required<Pick<ComboboxProps, 'appearance' | 'inline' | 'open' | 'size'>> &
+  Pick<ComboboxProps, 'placeholder' | 'value'> &
   OptionCollectionState &
   SelectionState & {
     /* Option data for the currently highlighted option (not the selected option) */
@@ -112,6 +109,6 @@ export type ComboboxOpenChangeData = {
 
 /* Possible event types for onOpen */
 export type ComboboxOpenEvents =
-  | React.MouseEvent<HTMLElement>
+  | React.FocusEvent<HTMLElement>
   | React.KeyboardEvent<HTMLElement>
-  | React.FocusEvent<HTMLElement>;
+  | React.MouseEvent<HTMLElement>;

--- a/packages/react-combobox/src/components/Option/Option.types.ts
+++ b/packages/react-combobox/src/components/Option/Option.types.ts
@@ -8,31 +8,28 @@ export type OptionSlots = {
   checkIcon: Slot<'span'>;
 };
 
-type OptionCommons = {
+/**
+ * Option Props
+ */
+export type OptionProps = ComponentProps<Partial<OptionSlots>> & {
   /**
    * Sets an option to the `disabled` state.
    * Disabled options cannot be selected, but are still keyboard navigable
    */
   disabled?: boolean;
-};
 
-/**
- * Option Props
- */
-export type OptionProps = ComponentProps<Partial<OptionSlots>> &
-  OptionCommons & {
-    /*
-     * Defines a string value for the option, used for the parent Combobox's value.
-     * Use this if the children are not a string, or you wish the value to differ from the displayed text.
-     */
-    value?: string;
-  };
+  /*
+   * Defines a string value for the option, used for the parent Combobox's value.
+   * Use this if the children are not a string, or you wish the value to differ from the displayed text.
+   */
+  value?: string;
+};
 
 /**
  * State used in rendering Option
  */
 export type OptionState = ComponentState<OptionSlots> &
-  OptionCommons & {
+  Pick<OptionProps, 'disabled'> & {
     /* If true, this is the currently highlighted option */
     active: boolean;
 


### PR DESCRIPTION
Parent issue: #22862

Removes commons types from Combobox, Combobutton, and Option. Also removes unneeded, unused props that were previously added to the State types through Commons, and alphabetizes props.