### PR TITLE
Feat: add sortable icon & aria-label on DetailsList column

### DIFF
--- a/change/@fluentui-react-d3e09d56-0762-43c9-8c50-ab7284729cc6.json
+++ b/change/@fluentui-react-d3e09d56-0762-43c9-8c50-ab7284729cc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "allow for showing a sortable icon on an unsorted but sortable column in a DetailsList",
+  "packageName": "@fluentui/react",
+  "email": "paruther@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-d3e09d56-0762-43c9-8c50-ab7284729cc6.json
+++ b/change/@fluentui-react-d3e09d56-0762-43c9-8c50-ab7284729cc6.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "allow for showing a sortable icon on an unsorted but sortable column in a DetailsList",
+  "comment": "allow for showing a sortable icon and sortable aria-label on an unsorted but sortable column in a DetailsList",
   "packageName": "@fluentui/react",
   "email": "paruther@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
@@ -78,6 +78,13 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
     thumbnailColumn.ariaLabel = 'Thumbnail';
     thumbnailColumn.onColumnClick = undefined;
 
+    //indicate that all columns except thumbnail column can be sorted
+    columns.forEach((_column: IColumn, index: number) => {
+      if (columns[index].name) {
+        columns[index].isSortable = true;
+      }
+    });
+
     return columns;
   }
 

--- a/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
@@ -79,9 +79,9 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
     thumbnailColumn.onColumnClick = undefined;
 
     //indicate that all columns except thumbnail column can be sorted
-    columns.forEach((_column: IColumn, index: number) => {
-      if (columns[index].name) {
-        columns[index].isSortable = true;
+    columns.forEach((column: IColumn) => {
+      if (column.name) {
+        column.showSortIconWhenUnsorted = true;
       }
     });
 

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3640,6 +3640,7 @@ export interface IColumn {
     isPadded?: boolean;
     isResizable?: boolean;
     isRowHeader?: boolean;
+    isSortable?: boolean;
     isSorted?: boolean;
     isSortedDescending?: boolean;
     key: string;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3640,7 +3640,6 @@ export interface IColumn {
     isPadded?: boolean;
     isResizable?: boolean;
     isRowHeader?: boolean;
-    isSortable?: boolean;
     isSorted?: boolean;
     isSortedDescending?: boolean;
     key: string;
@@ -3656,6 +3655,7 @@ export interface IColumn {
     onRenderField?: IRenderFunction<IDetailsColumnFieldProps>;
     onRenderFilterIcon?: IRenderFunction<IDetailsColumnFilterIconProps>;
     onRenderHeader?: IRenderFunction<IDetailsColumnProps>;
+    showSortIconWhenUnsorted?: boolean;
     sortableAriaLabel?: string;
     sortAscendingAriaLabel?: string;
     sortDescendingAriaLabel?: string;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3656,6 +3656,7 @@ export interface IColumn {
     onRenderField?: IRenderFunction<IDetailsColumnFieldProps>;
     onRenderFilterIcon?: IRenderFunction<IDetailsColumnFilterIconProps>;
     onRenderHeader?: IRenderFunction<IDetailsColumnProps>;
+    sortableAriaLabel?: string;
     sortAscendingAriaLabel?: string;
     sortDescendingAriaLabel?: string;
     styles?: IStyleFunctionOrObject<IDetailsColumnStyleProps, IDetailsColumnStyles>;

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -292,7 +292,8 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
       column.filterAriaLabel ||
       column.sortAscendingAriaLabel ||
       column.sortDescendingAriaLabel ||
-      column.groupAriaLabel
+      column.groupAriaLabel ||
+      column.sortableAriaLabel
     );
   }
 

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -165,10 +165,10 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
 
                   {column.isFiltered && <IconComponent className={classNames.nearIcon} iconName="Filter" />}
 
-                  {column.isSorted && (
+                  {(column.isSorted || column.isSortable) && (
                     <IconComponent
                       className={classNames.sortIcon}
-                      iconName={column.isSortedDescending ? 'SortDown' : 'SortUp'}
+                      iconName={column.isSorted ? (column.isSortedDescending ? 'SortDown' : 'SortUp') : 'Sort'}
                     />
                   )}
 

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -165,7 +165,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
 
                   {column.isFiltered && <IconComponent className={classNames.nearIcon} iconName="Filter" />}
 
-                  {(column.isSorted || column.isSortable) && (
+                  {(column.isSorted || column.showSortIconWhenUnsorted) && (
                     <IconComponent
                       className={classNames.sortIcon}
                       iconName={column.isSorted ? (column.isSortedDescending ? 'SortDown' : 'SortUp') : 'Sort'}
@@ -309,8 +309,12 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
         hidden
       >
         {(column.isFiltered && column.filterAriaLabel) || null}
-        {(column.isSorted &&
-          (column.isSortedDescending ? column.sortDescendingAriaLabel : column.sortAscendingAriaLabel)) ||
+        {((column.isSorted || column.showSortIconWhenUnsorted) &&
+          (column.isSorted
+            ? column.isSortedDescending
+              ? column.sortDescendingAriaLabel
+              : column.sortAscendingAriaLabel
+            : column.sortableAriaLabel)) ||
           null}
         {(column.isGrouped && column.groupAriaLabel) || null}
       </label>

--- a/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -262,7 +262,7 @@ describe('DetailsColumn', () => {
   });
 
   it('renders a sortable icon on an unsorted column is isSortable is set to true', () => {
-    const column: IColumn = { ...baseColumn, isSortable: true, sortableAriaLabel: 'Foo' };
+    const column: IColumn = { ...baseColumn, showSortIconWhenUnsorted: true, sortableAriaLabel: 'Foo' };
 
     const columns = [column];
     let component: any;

--- a/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -4,6 +4,7 @@ import { ColumnActionsMode } from './DetailsList.types';
 import { mount } from 'enzyme';
 import { DetailsList } from './DetailsList';
 import { TooltipHost } from '../../Tooltip';
+import * as renderer from 'react-test-renderer';
 import type { IColumn, IDetailsHeaderProps } from './DetailsList.types';
 import type { IRenderFunction } from '../../Utilities';
 import type { ITooltipHostProps } from '../../Tooltip';
@@ -258,5 +259,26 @@ describe('DetailsColumn', () => {
     const columnHeaderTitle = columnHeader.find('.ms-DetailsHeader-cellTitle');
 
     expect(columnHeaderTitle.getDOMNode().getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('renders a sortable icon on an unsorted column is isSortable is set to true', () => {
+    const column: IColumn = { ...baseColumn, isSortable: true, sortableAriaLabel: 'Foo' };
+
+    const columns = [column];
+    let component: any;
+
+    component = renderer.create(
+      <DetailsList
+        items={[]}
+        setKey={'key1'}
+        initialFocusedIndex={0}
+        skipViewportMeasures={true}
+        columns={columns}
+        componentRef={ref => (component = ref)}
+        onShouldVirtualize={() => false}
+      />,
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
   });
 });

--- a/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -261,7 +261,7 @@ describe('DetailsColumn', () => {
     expect(columnHeaderTitle.getDOMNode().getAttribute('aria-expanded')).toBe('true');
   });
 
-  it('renders a sortable icon on an unsorted column is isSortable is set to true', () => {
+  it('renders a sortable icon on an unsorted column when showSortIconWhenUnsorted is set to true', () => {
     const column: IColumn = { ...baseColumn, showSortIconWhenUnsorted: true, sortableAriaLabel: 'Foo' };
 
     const columns = [column];

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -516,6 +516,12 @@ export interface IColumn {
    */
   sortDescendingAriaLabel?: string;
 
+  /**
+   * Accessible label for indicating that the list could be sorted by this column but isn't currently
+   * This will be read after the main column header label.
+   */
+  sortableAriaLabel?: string;
+
   /** Accessible label for the status of this column when grouped. */
   groupAriaLabel?: string;
 

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -433,6 +433,9 @@ export interface IColumn {
   /** If true, allow the column to be collapsed when rendered in justified layout. */
   isCollapsible?: boolean;
 
+  /** If true, column header will render a icon indicating column is sortable while unsorted */
+  isSortable?: boolean;
+
   /** Determines if the column is currently sorted. Renders a sort arrow in the column header. */
   isSorted?: boolean;
 

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -433,8 +433,8 @@ export interface IColumn {
   /** If true, allow the column to be collapsed when rendered in justified layout. */
   isCollapsible?: boolean;
 
-  /** If true, column header will render a icon indicating column is sortable while unsorted */
-  isSortable?: boolean;
+  /** If true, column header will render an icon indicating column is sortable while unsorted */
+  showSortIconWhenUnsorted?: boolean;
 
   /** Determines if the column is currently sorted. Renders a sort arrow in the column header. */
   isSorted?: boolean;

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -517,7 +517,7 @@ export interface IColumn {
   sortDescendingAriaLabel?: string;
 
   /**
-   * Accessible label for indicating that the list could be sorted by this column but isn't currently
+   * Accessible label for indicating that the list could be sorted by this column but isn't currently.
    * This will be read after the main column header label.
    */
   sortableAriaLabel?: string;

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsColumn.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsColumn.test.tsx.snap
@@ -1,0 +1,570 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DetailsColumn renders a sortable icon on an unsorted column is isSortable is set to true 1`] = `
+<div
+  className="ms-Viewport"
+  style={
+    Object {
+      "minHeight": 1,
+      "minWidth": 1,
+    }
+  }
+>
+  <div
+    className=
+        ms-DetailsList
+        is-horizontalConstrained
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          -webkit-overflow-scrolling: touch;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          overflow-x: auto;
+          overflow-y: visible;
+          position: relative;
+        }
+        & .ms-List-cell {
+          min-height: 38px;
+          word-break: break-word;
+        }
+    data-automationid="DetailsList"
+    data-is-scrollable="false"
+  >
+    <div
+      aria-colcount={2}
+      aria-readonly="true"
+      aria-rowcount={1}
+      role="grid"
+    >
+      <div
+        className="ms-DetailsList-headerWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className=
+              ms-FocusZone
+              ms-DetailsHeader
+              &:focus {
+                outline: none;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background: #ffffff;
+                border-bottom: 1px solid #edebe9;
+                box-sizing: content-box;
+                cursor: default;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                height: 42px;
+                line-height: 42px;
+                min-width: 100%;
+                padding-bottom: 1px;
+                padding-top: 16px;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                white-space: nowrap;
+              }
+              &:hover .ms-DetailsHeader-check {
+                opacity: 1;
+              }
+              & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
+                display: block;
+              }
+          data-automationid="DetailsHeader"
+          data-focuszone-id="FocusZone44"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          onMouseMove={[Function]}
+          role="row"
+        >
+          <div
+            aria-labelledby="header43-checkTooltip"
+            className=
+                ms-DetailsHeader-cell
+                ms-DetailsHeader-cellIsCheck
+                {
+                  align-items: center;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-flex;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  outline: transparent;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+            onClick={[Function]}
+            role="columnheader"
+          >
+            <span
+              className="ms-DetailsHeader-checkTooltip"
+            >
+              <div
+                aria-checked={false}
+                className=
+                    ms-DetailsRow-check
+                    ms-DetailsHeader-check
+                    ms-DetailsRow-check--isHeader
+                    ms-Check-checkHost
+                    {
+                      height: 42px;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      opacity: 1;
+                    }
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      align-items: center;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      box-sizing: border-box;
+                      cursor: default;
+                      display: flex;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 12px;
+                      font-weight: 400;
+                      height: 42px;
+                      justify-content: center;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      opacity: 0;
+                      outline: transparent;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      vertical-align: top;
+                      width: 48px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-automationid="DetailsRowCheck"
+                data-is-focusable={true}
+                data-selection-toggle={true}
+                id="header43-check"
+                role="checkbox"
+                tabIndex={-1}
+              >
+                <div
+                  className=
+                      ms-Check
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 18px;
+                        line-height: 1;
+                        position: relative;
+                        user-select: none;
+                        vertical-align: top;
+                        width: 18px;
+                      }
+                      &:before {
+                        background: #ffffff;
+                        border-radius: 50%;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        opacity: 1;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                      }
+                      .ms-Check-checkHost:hover & {
+                        opacity: 1;
+                      }
+                      .ms-Check-checkHost:focus & {
+                        opacity: 1;
+                      }
+                      &:hover {
+                        opacity: 1;
+                      }
+                      &:focus {
+                        opacity: 1;
+                      }
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-circle
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          align-items: center;
+                          color: #605e5c;
+                          display: inline-flex;
+                          font-size: 18px;
+                          height: 18px;
+                          justify-content: center;
+                          left: 0px;
+                          position: absolute;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          color: WindowText;
+                        }
+                    data-icon-name="CircleRing"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Check-check
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          align-items: center;
+                          color: #605e5c;
+                          display: inline-flex;
+                          font-size: 16px;
+                          height: 18px;
+                          justify-content: center;
+                          left: .5px;
+                          opacity: 0;
+                          position: absolute;
+                          text-align: center;
+                          top: -1px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        &:hover {
+                          opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active), (forced-colors: active){& {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
+                        }
+                    data-icon-name="StatusCircleCheckmark"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                </div>
+              </div>
+            </span>
+          </div>
+          <div
+            aria-sort="none"
+            className=
+                ms-DetailsHeader-cell
+                is-actionable
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: inherit;
+                  margin-bottom: 0;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: left;
+                  text-overflow: ellipsis;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #f3f2f1;
+                  color: #323130;
+                }
+                &:active {
+                  background: #edebe9;
+                }
+                &:hover i[data-icon-name="GripperBarVertical"] {
+                  display: block;
+                }
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="1"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 40,
+              }
+            }
+          >
+            <span
+              className=
+
+                  {
+                    bottom: 0px;
+                    display: block;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+            >
+              <span
+                aria-describedby="header43-1-tooltip"
+                aria-labelledby="header43-1-name"
+                className=
+                    ms-DetailsHeader-cellTitle
+                    {
+                      align-items: stretch;
+                      box-sizing: border-box;
+                      display: flex;
+                      flex-direction: row;
+                      justify-content: flex-start;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 12px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                data-is-focusable="true"
+                id="header43-1"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                role="button"
+              >
+                <span
+                  className=
+                      ms-DetailsHeader-cellName
+                      {
+                        flex: 0 1 auto;
+                        font-size: 14px;
+                        font-weight: 600;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      }
+                  id="header43-1-name"
+                >
+                  Foo
+                </span>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Icon
+                      {
+                        display: inline-block;
+                      }
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: "FabricMDL2Icons";
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      {
+                        color: #605e5c;
+                        opacity: 1;
+                        padding-left: 4px;
+                        position: relative;
+                        top: 1px;
+                      }
+                  data-icon-name="Sort"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </span>
+          </div>
+          <label
+            className=
+
+                {
+                  border: 0px;
+                  height: 1px;
+                  margin-bottom: -1px;
+                  margin-left: -1px;
+                  margin-right: -1px;
+                  margin-top: -1px;
+                  overflow: hidden;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: absolute;
+                  white-space: nowrap;
+                  width: 1px;
+                }
+            hidden={true}
+            id="header43-1-tooltip"
+          />
+        </div>
+      </div>
+      <div
+        className="ms-DetailsList-contentWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone45"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+          >
+            <div
+              className="ms-List"
+            >
+              <div
+                className="ms-List-surface"
+                role="presentation"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsColumn.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsColumn.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DetailsColumn renders a sortable icon on an unsorted column is isSortable is set to true 1`] = `
+exports[`DetailsColumn renders a sortable icon on an unsorted column when showSortIconWhenUnsorted is set to true 1`] = `
 <div
   className="ms-Viewport"
   style={
@@ -516,7 +516,9 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column is isSortab
                 }
             hidden={true}
             id="header43-1-tooltip"
-          />
+          >
+            Foo
+          </label>
         </div>
       </div>
       <div


### PR DESCRIPTION
## Current Behavior

A column that could be sorted (e.g., has an onColumnClick function that sets the isSorted/isSortedDescending properties on the column) does not provide any indicator that it is sortable. 

## New Behavior

A column that could be sorted can (backwards compatible, so not set by default) be made to show a sort icon (up + down arrow) and have an aria-label indicating the column could be sorted.

## Related Issue(s)

Fixes #21767
