### PR TITLE
Removing DividerCommons type in @fluentui/react-divider

### DIFF
--- a/change/@fluentui-react-divider-ca524fc3-b993-4480-9dba-ab97cde6f265.json
+++ b/change/@fluentui-react-divider-ca524fc3-b993-4480-9dba-ab97cde6f265.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing DividerCommons type.",
+  "packageName": "@fluentui/react-divider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-divider/etc/react-divider.api.md
+++ b/packages/react-divider/etc/react-divider.api.md
@@ -21,7 +21,12 @@ export const dividerClassName = "fui-Divider";
 export const dividerClassNames: SlotClassNames<DividerSlots>;
 
 // @public (undocumented)
-export type DividerProps = ComponentProps<Partial<DividerSlots>> & Partial<DividerCommons>;
+export type DividerProps = ComponentProps<Partial<DividerSlots>> & {
+    alignContent?: 'start' | 'center' | 'end';
+    appearance?: 'brand' | 'default' | 'strong' | 'subtle';
+    inset?: boolean;
+    vertical?: boolean;
+};
 
 // @public (undocumented)
 export type DividerSlots = {
@@ -30,7 +35,7 @@ export type DividerSlots = {
 };
 
 // @public (undocumented)
-export type DividerState = ComponentState<DividerSlots> & DividerCommons;
+export type DividerState = ComponentState<DividerSlots> & Required<Pick<DividerProps, 'alignContent' | 'appearance' | 'inset' | 'vertical'>>;
 
 // @public
 export const renderDivider_unstable: (state: DividerState) => JSX.Element;

--- a/packages/react-divider/src/components/Divider/Divider.types.ts
+++ b/packages/react-divider/src/components/Divider/Divider.types.ts
@@ -12,32 +12,36 @@ export type DividerSlots = {
   wrapper: Slot<'div'>;
 };
 
-type DividerCommons = {
+export type DividerProps = ComponentProps<Partial<DividerSlots>> & {
   /**
    * Determines the alignment of the content within the divider.
-   * @defaultvalue 'center'
+   *
+   * @default 'center'
    */
-  alignContent: 'start' | 'center' | 'end';
+  alignContent?: 'start' | 'center' | 'end';
 
   /**
    * A divider can have one of the preset appearances.
    * When not specified, the divider has its default appearance.
+   *
+   * @default 'default'
    */
-  appearance?: 'brand' | 'strong' | 'subtle';
+  appearance?: 'brand' | 'default' | 'strong' | 'subtle';
 
   /**
    * Adds padding to the beginning and end of the divider.
+   *
    * @default false
    */
-  inset: boolean;
+  inset?: boolean;
 
   /**
    * A divider can be horizontal (default) or vertical.
+   *
    * @default false
    */
-  vertical: boolean;
+  vertical?: boolean;
 };
 
-export type DividerProps = ComponentProps<Partial<DividerSlots>> & Partial<DividerCommons>;
-
-export type DividerState = ComponentState<DividerSlots> & DividerCommons;
+export type DividerState = ComponentState<DividerSlots> &
+  Required<Pick<DividerProps, 'alignContent' | 'appearance' | 'inset' | 'vertical'>>;

--- a/packages/react-divider/src/components/Divider/useDivider.ts
+++ b/packages/react-divider/src/components/Divider/useDivider.ts
@@ -8,7 +8,7 @@ import type { DividerProps, DividerState } from './Divider.types';
  * @param ref - User-provided ref to be passed to the Divider component.
  */
 export const useDivider_unstable = (props: DividerProps, ref: React.Ref<HTMLElement>): DividerState => {
-  const { alignContent = 'center', appearance, inset = false, vertical = false, wrapper } = props;
+  const { alignContent = 'center', appearance = 'default', inset = false, vertical = false, wrapper } = props;
   const dividerId = useId('divider-');
 
   return {

--- a/packages/react-divider/src/components/Divider/useDividerStyles.ts
+++ b/packages/react-divider/src/components/Divider/useDividerStyles.ts
@@ -33,20 +33,16 @@ const useBaseStyles = makeStyles({
     lineHeight: tokens.lineHeightBase200,
     textAlign: 'center',
 
-    color: tokens.colorNeutralForeground2,
-
     ':before': {
       boxSizing: 'border-box',
       display: 'flex',
       flexGrow: 1,
-      ...shorthands.borderColor(tokens.colorNeutralStroke2),
     },
 
     ':after': {
       boxSizing: 'border-box',
       display: 'flex',
       flexGrow: 1,
-      ...shorthands.borderColor(tokens.colorNeutralStroke2),
     },
   },
 
@@ -93,6 +89,17 @@ const useBaseStyles = makeStyles({
 
     ':after': {
       ...shorthands.borderColor(tokens.colorBrandStroke1),
+    },
+  },
+  default: {
+    color: tokens.colorNeutralForeground2,
+
+    ':before': {
+      ...shorthands.borderColor(tokens.colorNeutralStroke2),
+    },
+
+    ':after': {
+      ...shorthands.borderColor(tokens.colorNeutralStroke2),
     },
   },
   subtle: {

--- a/packages/react-divider/src/components/Divider/useDividerStyles.ts
+++ b/packages/react-divider/src/components/Divider/useDividerStyles.ts
@@ -103,6 +103,8 @@ const useBaseStyles = makeStyles({
     },
   },
   subtle: {
+    color: tokens.colorNeutralForeground2,
+
     ':before': {
       ...shorthands.borderColor(tokens.colorNeutralStroke3),
     },
@@ -112,6 +114,8 @@ const useBaseStyles = makeStyles({
     },
   },
   strong: {
+    color: tokens.colorNeutralForeground2,
+
     ':before': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1),
     },


### PR DESCRIPTION
## PR Description

This PR removes the `Commons` type pattern in the types for our `Divider` component.

## Related Issue(s)

Fixes part of #22862
