### PR TITLE
Removing TooltipCommons type in @fluentui/react-tooltip

### DIFF
--- a/change/@fluentui-react-tooltip-503f3e06-eca4-40eb-a1e4-23a7e944fce0.json
+++ b/change/@fluentui-react-tooltip-503f3e06-eca4-40eb-a1e4-23a7e944fce0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing TooltipCommons type.",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tooltip/etc/react-tooltip.api.md
+++ b/packages/react-components/react-tooltip/etc/react-tooltip.api.md
@@ -31,10 +31,18 @@ export const tooltipClassName = "fui-Tooltip";
 export const tooltipClassNames: SlotClassNames<TooltipSlots>;
 
 // @public
-export type TooltipProps = ComponentProps<TooltipSlots> & Partial<Omit<TooltipCommons, 'relationship'>> & Pick<TooltipCommons, 'relationship'> & {
+export type TooltipProps = ComponentProps<TooltipSlots> & Pick<PortalProps, 'mountNode'> & {
+    appearance?: 'normal' | 'inverted';
     children?: (React_2.ReactElement & {
         ref?: React_2.Ref<unknown>;
     }) | ((props: TooltipTriggerProps) => React_2.ReactElement | null) | null;
+    hideDelay?: number;
+    onVisibleChange?: (event: React_2.PointerEvent<HTMLElement> | React_2.FocusEvent<HTMLElement> | undefined, data: OnVisibleChangeData) => void;
+    positioning?: PositioningShorthand;
+    relationship: 'label' | 'description' | 'inaccessible';
+    showDelay: number;
+    visible?: boolean;
+    withArrow?: boolean;
 };
 
 // @public
@@ -43,7 +51,7 @@ export type TooltipSlots = {
 };
 
 // @public
-export type TooltipState = ComponentState<TooltipSlots> & TooltipCommons & {
+export type TooltipState = ComponentState<TooltipSlots> & Pick<TooltipProps, 'mountNode' | 'relationship'> & Required<Pick<TooltipProps, 'appearance' | 'hideDelay' | 'positioning' | 'showDelay' | 'visible' | 'withArrow'>> & {
     children?: React_2.ReactElement | null;
     shouldRenderTooltip?: boolean;
     arrowRef?: React_2.Ref<HTMLDivElement>;
@@ -53,7 +61,7 @@ export type TooltipState = ComponentState<TooltipSlots> & TooltipCommons & {
 // @public
 export type TooltipTriggerProps = {
     ref?: React_2.Ref<never>;
-} & Pick<React_2.HTMLAttributes<HTMLElement>, 'onPointerEnter' | 'onPointerLeave' | 'onFocus' | 'onBlur' | 'aria-describedby' | 'aria-labelledby' | 'aria-label'>;
+} & Pick<React_2.HTMLAttributes<HTMLElement>, 'aria-describedby' | 'aria-label' | 'aria-labelledby' | 'onBlur' | 'onFocus' | 'onPointerEnter' | 'onPointerLeave'>;
 
 // @public
 export const useTooltip_unstable: (props: TooltipProps) => TooltipState;

--- a/packages/react-components/react-tooltip/etc/react-tooltip.api.md
+++ b/packages/react-components/react-tooltip/etc/react-tooltip.api.md
@@ -40,7 +40,7 @@ export type TooltipProps = ComponentProps<TooltipSlots> & Pick<PortalProps, 'mou
     onVisibleChange?: (event: React_2.PointerEvent<HTMLElement> | React_2.FocusEvent<HTMLElement> | undefined, data: OnVisibleChangeData) => void;
     positioning?: PositioningShorthand;
     relationship: 'label' | 'description' | 'inaccessible';
-    showDelay: number;
+    showDelay?: number;
     visible?: boolean;
     withArrow?: boolean;
 };

--- a/packages/react-components/react-tooltip/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-components/react-tooltip/src/components/Tooltip/Tooltip.types.ts
@@ -93,7 +93,7 @@ export type TooltipProps = ComponentProps<TooltipSlots> &
      *
      * @default 250
      */
-    showDelay: number;
+    showDelay?: number;
 
     /**
      * Control the tooltip's visibility programatically.

--- a/packages/react-components/react-tooltip/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-components/react-tooltip/src/components/Tooltip/Tooltip.types.ts
@@ -103,7 +103,7 @@ export type TooltipProps = ComponentProps<TooltipSlots> &
      * If not provided, the visibility will be controlled by the tooltip itself, based on hover and focus events on the
      * trigger (child) element.
      *
-     * @default visible
+     * @default false
      */
     visible?: boolean;
 

--- a/packages/react-components/react-tooltip/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-components/react-tooltip/src/components/Tooltip/Tooltip.types.ts
@@ -14,84 +14,13 @@ export type TooltipSlots = {
 };
 
 /**
- * Properties and state for Tooltip
- */
-type TooltipCommons = Pick<PortalProps, 'mountNode'> & {
-  /**
-   * (Required) Specifies whether this tooltip is acting as the description or label of its trigger element.
-   *
-   * * `label` - The tooltip sets the trigger's aria-label or aria-labelledby attribute. This is useful for buttons
-   *    displaying only an icon, for example.
-   * * `description` - The tooltip sets the trigger's aria-description or aria-describedby attribute.
-   * * `inaccessible` - No aria attributes are set on the trigger. This makes the tooltip's content inaccessible to
-   *   screen readers, and should only be used if the tooltip's text is available by some other means.
-   */
-  relationship: 'label' | 'description' | 'inaccessible';
-
-  /**
-   * The tooltip's visual appearance.
-   * * `normal` - Uses the theme's background and text colors.
-   * * `inverted` - Higher contrast variant that uses the theme's inverted colors.
-   *
-   * @defaultvalue normal
-   */
-  appearance?: 'normal' | 'inverted';
-
-  /**
-   * Render an arrow pointing to the target element
-   *
-   * @defaultvalue false
-   */
-  withArrow?: boolean;
-
-  /**
-   * Configure the positioning of the tooltip
-   *
-   * @defaultvalue above
-   */
-  positioning?: PositioningShorthand;
-
-  /**
-   * Control the tooltip's visibility programatically.
-   *
-   * This can be used in conjunction with onVisibleChange to modify the tooltip's show and hide behavior.
-   *
-   * If not provided, the visibility will be controlled by the tooltip itself, based on hover and focus events on the
-   * trigger (child) element.
-   */
-  visible?: boolean;
-
-  /**
-   * Notification when the visibility of the tooltip is changing
-   */
-  onVisibleChange?: (
-    event: React.PointerEvent<HTMLElement> | React.FocusEvent<HTMLElement> | undefined,
-    data: OnVisibleChangeData,
-  ) => void;
-
-  /**
-   * Delay before the tooltip is shown, in milliseconds.
-   *
-   * @defaultvalue 250
-   */
-  showDelay: number;
-
-  /**
-   * Delay before the tooltip is hidden, in milliseconds.
-   *
-   * @defaultvalue 250
-   */
-  hideDelay: number;
-};
-
-/**
  * The properties that are added to the trigger of the Tooltip
  */
 export type TooltipTriggerProps = {
   ref?: React.Ref<never>;
 } & Pick<
   React.HTMLAttributes<HTMLElement>,
-  'onPointerEnter' | 'onPointerLeave' | 'onFocus' | 'onBlur' | 'aria-describedby' | 'aria-labelledby' | 'aria-label'
+  'aria-describedby' | 'aria-label' | 'aria-labelledby' | 'onBlur' | 'onFocus' | 'onPointerEnter' | 'onPointerLeave'
 >;
 
 /**
@@ -105,8 +34,16 @@ export type OnVisibleChangeData = {
  * Properties for Tooltip
  */
 export type TooltipProps = ComponentProps<TooltipSlots> &
-  Partial<Omit<TooltipCommons, 'relationship'>> &
-  Pick<TooltipCommons, 'relationship'> & {
+  Pick<PortalProps, 'mountNode'> & {
+    /**
+     * The tooltip's visual appearance.
+     * * `normal` - Uses the theme's background and text colors.
+     * * `inverted` - Higher contrast variant that uses the theme's inverted colors.
+     *
+     * @default normal
+     */
+    appearance?: 'normal' | 'inverted';
+
     /**
      * The tooltip can have a single JSX child, or a render function that accepts TooltipTriggerProps.
      *
@@ -117,13 +54,73 @@ export type TooltipProps = ComponentProps<TooltipSlots> &
       | (React.ReactElement & { ref?: React.Ref<unknown> })
       | ((props: TooltipTriggerProps) => React.ReactElement | null)
       | null;
+
+    /**
+     * Delay before the tooltip is hidden, in milliseconds.
+     *
+     * @default 250
+     */
+    hideDelay?: number;
+
+    /**
+     * Notification when the visibility of the tooltip is changing
+     */
+    onVisibleChange?: (
+      event: React.PointerEvent<HTMLElement> | React.FocusEvent<HTMLElement> | undefined,
+      data: OnVisibleChangeData,
+    ) => void;
+
+    /**
+     * Configure the positioning of the tooltip
+     *
+     * @default above
+     */
+    positioning?: PositioningShorthand;
+
+    /**
+     * (Required) Specifies whether this tooltip is acting as the description or label of its trigger element.
+     *
+     * * `label` - The tooltip sets the trigger's aria-label or aria-labelledby attribute. This is useful for buttons
+     *    displaying only an icon, for example.
+     * * `description` - The tooltip sets the trigger's aria-description or aria-describedby attribute.
+     * * `inaccessible` - No aria attributes are set on the trigger. This makes the tooltip's content inaccessible to
+     *   screen readers, and should only be used if the tooltip's text is available by some other means.
+     */
+    relationship: 'label' | 'description' | 'inaccessible';
+
+    /**
+     * Delay before the tooltip is shown, in milliseconds.
+     *
+     * @default 250
+     */
+    showDelay: number;
+
+    /**
+     * Control the tooltip's visibility programatically.
+     *
+     * This can be used in conjunction with onVisibleChange to modify the tooltip's show and hide behavior.
+     *
+     * If not provided, the visibility will be controlled by the tooltip itself, based on hover and focus events on the
+     * trigger (child) element.
+     *
+     * @default visible
+     */
+    visible?: boolean;
+
+    /**
+     * Render an arrow pointing to the target element
+     *
+     * @default false
+     */
+    withArrow?: boolean;
   };
 
 /**
  * State used in rendering Tooltip
  */
 export type TooltipState = ComponentState<TooltipSlots> &
-  TooltipCommons & {
+  Pick<TooltipProps, 'mountNode' | 'relationship'> &
+  Required<Pick<TooltipProps, 'appearance' | 'hideDelay' | 'positioning' | 'showDelay' | 'visible' | 'withArrow'>> & {
     children?: React.ReactElement | null;
 
     /**

--- a/packages/react-components/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -31,11 +31,11 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
   const [setDelayTimeout, clearDelayTimeout] = useTimeout();
 
   const {
-    appearance,
+    appearance = 'normal',
     children,
     content,
-    withArrow,
-    positioning,
+    withArrow = false,
+    positioning = 'above',
     onVisibleChange,
     relationship,
     showDelay = 250,


### PR DESCRIPTION
## PR Description

This PR removes the `Commons` type pattern in the types for our `Tooltip` component.

## Related Issue(s)

Fixes part of #22862
