### PR TITLE
Removing DialogCommons type in @fluentui/react-dialog

### DIFF
--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -21,7 +21,7 @@ export const dialogClassName = "fui-Dialog";
 export const dialogClassNames: SlotClassNames<DialogSlots>;
 
 // @public
-export type DialogProps = ComponentProps<DialogSlots> & DialogCommons;
+export type DialogProps = ComponentProps<DialogSlots>;
 
 // @public (undocumented)
 export type DialogSlots = {
@@ -29,7 +29,7 @@ export type DialogSlots = {
 };
 
 // @public
-export type DialogState = ComponentState<DialogSlots> & DialogCommons;
+export type DialogState = ComponentState<DialogSlots> & Required<Pick<DialogProps, never>>;
 
 // @public
 export const renderDialog_unstable: (state: DialogState) => JSX.Element;

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -29,7 +29,7 @@ export type DialogSlots = {
 };
 
 // @public
-export type DialogState = ComponentState<DialogSlots> & Required<DialogProps>;
+export type DialogState = ComponentState<DialogSlots>;
 
 // @public
 export const renderDialog_unstable: (state: DialogState) => JSX.Element;

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -29,7 +29,7 @@ export type DialogSlots = {
 };
 
 // @public
-export type DialogState = ComponentState<DialogSlots> & Required<Pick<DialogProps, never>>;
+export type DialogState = ComponentState<DialogSlots> & Required<DialogProps>;
 
 // @public
 export const renderDialog_unstable: (state: DialogState) => JSX.Element;

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
@@ -4,16 +4,13 @@ export type DialogSlots = {
   root: Slot<'div'>;
 };
 
-type DialogCommons = {
-  // TODO Add things shared between props and state here
-};
-
 /**
  * Dialog Props
  */
-export type DialogProps = ComponentProps<DialogSlots> & DialogCommons;
+export type DialogProps = ComponentProps<DialogSlots>;
 
 /**
  * State used in rendering Dialog
  */
-export type DialogState = ComponentState<DialogSlots> & DialogCommons;
+// TODO: Replace never below with union of props to pick from DialogProps above.
+export type DialogState = ComponentState<DialogSlots> & Required<Pick<DialogProps, never>>;

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
@@ -12,5 +12,6 @@ export type DialogProps = ComponentProps<DialogSlots>;
 /**
  * State used in rendering Dialog
  */
-// TODO: Replace never below with union of props to pick from DialogProps above.
-export type DialogState = ComponentState<DialogSlots> & Required<Pick<DialogProps, never>>;
+// TODO: Add union of props to pick from DialogProps once they're implemented.
+// i.e. Required<Pick<DialogProps, 'property1' | 'property2'>>;
+export type DialogState = ComponentState<DialogSlots> & Required<DialogProps>>;

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
@@ -14,4 +14,4 @@ export type DialogProps = ComponentProps<DialogSlots>;
  */
 // TODO: Add union of props to pick from DialogProps once they're implemented.
 // i.e. Required<Pick<DialogProps, 'property1' | 'property2'>>;
-export type DialogState = ComponentState<DialogSlots> & Required<DialogProps>>;
+export type DialogState = ComponentState<DialogSlots>;


### PR DESCRIPTION
## PR Description

This PR removes the `Commons` type pattern in the types for our `Dialog` component.

## Related Issue(s)

Fixes part of #22862
