### PR TITLE
Removing Commons type from component creation template

### DIFF
--- a/scripts/create-component/plop-templates/src/components/{{componentName}}/{{componentName}}.types.ts.hbs
+++ b/scripts/create-component/plop-templates/src/components/{{componentName}}/{{componentName}}.types.ts.hbs
@@ -4,16 +4,13 @@ export type {{componentName}}Slots = {
   root: Slot<'div'>;
 };
 
-type {{componentName}}Commons = {
-  // TODO Add things shared between props and state here
-};
-
 /**
  * {{componentName}} Props
  */
-export type {{componentName}}Props = ComponentProps<{{componentName}}Slots> & {{componentName}}Commons;
+export type {{componentName}}Props = ComponentProps<{{componentName}}Slots> & {};
 
 /**
  * State used in rendering {{componentName}}
  */
-export type {{componentName}}State = ComponentState<{{componentName}}Slots> & {{componentName}}Commons;
+ // TODO: Replace never below with union of props to pick from {{componentName}}Props above.
+export type {{componentName}}State = ComponentState<{{componentName}}Slots> & Required<Pick<{{componentName}}Props, never>>;

--- a/scripts/create-component/plop-templates/src/components/{{componentName}}/{{componentName}}.types.ts.hbs
+++ b/scripts/create-component/plop-templates/src/components/{{componentName}}/{{componentName}}.types.ts.hbs
@@ -13,6 +13,6 @@ export type {{componentName}}Props = ComponentProps<{{componentName}}Slots> & {}
  * State used in rendering {{componentName}}
  */
 export type {{componentName}}State = ComponentState<{{componentName}}Slots>;
-// TODO: Uncomment following section and provide union of props to pick from {{componentName}}Props.
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from {{componentName}}Props.
 // & Required<Pick<{{componentName}}Props, 'propName'>>
 ;

--- a/scripts/create-component/plop-templates/src/components/{{componentName}}/{{componentName}}.types.ts.hbs
+++ b/scripts/create-component/plop-templates/src/components/{{componentName}}/{{componentName}}.types.ts.hbs
@@ -12,5 +12,7 @@ export type {{componentName}}Props = ComponentProps<{{componentName}}Slots> & {}
 /**
  * State used in rendering {{componentName}}
  */
- // TODO: Replace never below with union of props to pick from {{componentName}}Props above.
-export type {{componentName}}State = ComponentState<{{componentName}}Slots> & Required<Pick<{{componentName}}Props, never>>;
+export type {{componentName}}State = ComponentState<{{componentName}}Slots>;
+// TODO: Uncomment following section and provide union of props to pick from {{componentName}}Props.
+// & Required<Pick<{{componentName}}Props, 'propName'>>
+;


### PR DESCRIPTION
## PR Description

This PR removes the `Commons` type pattern from the template used when creating a component using our `create-component` script.

## Related Issue(s)

Fixes part of #22862
