### PR TITLE
Removing ImageCommons type in @fluentui/react-image

### DIFF
--- a/packages/react-components/react-image/etc/react-image.api.md
+++ b/packages/react-components/react-image/etc/react-image.api.md
@@ -22,7 +22,13 @@ export const imageClassName = "fui-Image";
 export const imageClassNames: SlotClassNames<ImageSlots>;
 
 // @public (undocumented)
-export type ImageProps = ComponentProps<ImageSlots> & Partial<ImageCommons>;
+export type ImageProps = ComponentProps<ImageSlots> & {
+    block?: boolean;
+    bordered?: boolean;
+    fit?: 'none' | 'center' | 'contain' | 'cover';
+    shadow?: boolean;
+    shape?: 'square' | 'circular' | 'rounded';
+};
 
 // @public (undocumented)
 export type ImageSlots = {
@@ -30,7 +36,7 @@ export type ImageSlots = {
 };
 
 // @public (undocumented)
-export type ImageState = ComponentState<ImageSlots> & ImageCommons;
+export type ImageState = ComponentState<ImageSlots> & Required<Pick<ImageProps, 'block' | 'bordered' | 'fit' | 'shadow' | 'shape'>>;
 
 // @public
 export const renderImage_unstable: (state: ImageState) => JSX.Element;

--- a/packages/react-components/react-image/src/components/Image/Image.types.ts
+++ b/packages/react-components/react-image/src/components/Image/Image.types.ts
@@ -4,34 +4,42 @@ export type ImageSlots = {
   root: Slot<'img'>;
 };
 
-type ImageCommons = {
+export type ImageProps = ComponentProps<ImageSlots> & {
   /**
-   * An image can appear with rectangular border.
+   * An image can take up the width of its container.
+   *
+   * @default false
+   */
+  block?: boolean;
+
+  /**
+   * An image can appear with a rectangular border.
+   *
+   * @default false
    */
   bordered?: boolean;
 
   /**
    * An image can set how it should be resized to fit its container.
+   *
+   * @default 'none'
    */
   fit?: 'none' | 'center' | 'contain' | 'cover';
 
   /**
-   * An image can take up the width of its container.
+   * An image can appear elevated with shadow.
+   *
+   * @default false
    */
-  block?: boolean;
+  shadow?: boolean;
 
   /**
    * An image can appear square, circular, or rounded.
-   * @defaultvalue square
+   *
+   * @default 'square'
    */
   shape?: 'square' | 'circular' | 'rounded';
-
-  /**
-   * An image can appear elevated with shadow.
-   */
-  shadow?: boolean;
 };
 
-export type ImageProps = ComponentProps<ImageSlots> & Partial<ImageCommons>;
-
-export type ImageState = ComponentState<ImageSlots> & ImageCommons;
+export type ImageState = ComponentState<ImageSlots> &
+  Required<Pick<ImageProps, 'block' | 'bordered' | 'fit' | 'shadow' | 'shape'>>;

--- a/packages/react-components/react-image/src/components/Image/useImage.ts
+++ b/packages/react-components/react-image/src/components/Image/useImage.ts
@@ -6,7 +6,7 @@ import type { ImageProps, ImageState } from './Image.types';
  * Given user props, returns state and render function for an Image.
  */
 export const useImage_unstable = (props: ImageProps, ref: React.Ref<HTMLImageElement>): ImageState => {
-  const { bordered, fit, block, shape = 'square', shadow } = props;
+  const { bordered = false, fit = 'none', block = false, shape = 'square', shadow = false } = props;
 
   const state: ImageState = {
     bordered,

--- a/packages/react-components/react-image/src/components/Image/useImageStyles.ts
+++ b/packages/react-components/react-image/src/components/Image/useImageStyles.ts
@@ -12,51 +12,63 @@ export const imageClassNames: SlotClassNames<ImageSlots> = {
 };
 
 const useStyles = makeStyles({
-  root: {
+  base: {
     ...shorthands.borderColor(tokens.colorNeutralStroke1),
-    ...shorthands.borderRadius(tokens.borderRadiusNone),
 
     boxSizing: 'border-box',
     display: 'inline-block',
   },
-  rootBordered: {
+
+  // Bordered styles
+  bordered: {
     ...shorthands.borderStyle('solid'),
     ...shorthands.borderWidth(tokens.strokeWidthThin),
   },
-  rootCircular: {
+
+  // Shape styles
+  circular: {
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
   },
-  rootRounded: {
+  rounded: {
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
   },
-  rootShadow: {
+  square: {
+    ...shorthands.borderRadius(tokens.borderRadiusNone),
+  },
+
+  // Shadow styles
+  shadow: {
     boxShadow: tokens.shadow4,
   },
-  rootFitNone: {
+
+  // Fit styles
+  none: {
     objectFit: 'none',
     objectPosition: 'left top',
     height: '100%',
     width: '100%',
   },
-  rootFitCenter: {
+  center: {
     objectFit: 'none',
     objectPosition: 'center',
     height: '100%',
     width: '100%',
   },
-  rootFitCover: {
+  cover: {
     objectFit: 'cover',
     objectPosition: 'center',
     height: '100%',
     width: '100%',
   },
-  rootFitContain: {
+  contain: {
     objectFit: 'contain',
     objectPosition: 'center',
     height: '100%',
     width: '100%',
   },
-  rootBlock: {
+
+  // Block styles
+  block: {
     width: '100%',
   },
 });
@@ -65,16 +77,12 @@ export const useImageStyles_unstable = (state: ImageState) => {
   const styles = useStyles();
   state.root.className = mergeClasses(
     imageClassNames.root,
-    styles.root,
-    state.bordered && styles.rootBordered,
-    state.shape === 'circular' && styles.rootCircular,
-    state.shape === 'rounded' && styles.rootRounded,
-    state.shadow && styles.rootShadow,
-    state.fit === 'none' && styles.rootFitNone,
-    state.fit === 'center' && styles.rootFitCenter,
-    state.fit === 'cover' && styles.rootFitCover,
-    state.fit === 'contain' && styles.rootFitContain,
-    state.block && styles.rootBlock,
+    styles.base,
+    styles[state.fit],
+    styles[state.shape],
+    state.block && styles.block,
+    state.bordered && styles.bordered,
+    state.shadow && styles.shadow,
     state.root.className,
   );
 };


### PR DESCRIPTION
## PR Description

This PR removes the `Commons` type pattern in the types for our `Image` component.

## Related Issue(s)

Fixes part of #22862
