### PR TITLE
Bug 5915906 vertical stacked chart colors of legends is not displayed in high contrast

### DIFF
--- a/change/@fluentui-react-charting-6612157f-b40c-447b-80fa-57671369d12c.json
+++ b/change/@fluentui-react-charting-6612157f-b40c-447b-80fa-57671369d12c.json
@@ -1,0 +1,10 @@
+{
+  "type": "patch",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "@fluentui/react-charting",
+  "email": "ankityadav@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.styles.ts
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.styles.ts
@@ -1,5 +1,5 @@
 import { ICartesianChartStyleProps, ICartesianChartStyles } from './CartesianChart.types';
-import { HighContrastSelectorBlack } from '@fluentui/react/lib/Styling';
+import { HighContrastSelectorBlack, HighContrastSelector } from '@fluentui/react/lib/Styling';
 import { isIE11 } from '@fluentui/react';
 
 const isIE11Var: boolean = isIE11();
@@ -125,6 +125,11 @@ export const getStyles = (props: ICartesianChartStyleProps): ICartesianChartStyl
         color: theme.semanticColors.bodyText,
       },
       !toDrawShape && {
+        selectors: {
+          [HighContrastSelector]: {
+            forcedColorAdjust: 'none',
+          },
+        },
         borderLeft: `4px solid ${lineColor}`,
         paddingLeft: '8px',
       },
@@ -138,6 +143,11 @@ export const getStyles = (props: ICartesianChartStyleProps): ICartesianChartStyl
     calloutlegendText: {
       ...fonts.small,
       lineHeight: '16px',
+      selectors: {
+        [HighContrastSelector]: {
+          color: 'rgb(179, 179, 179)',
+        },
+      },
       color: theme.semanticColors.bodySubtext,
     },
     calloutContentY: [
@@ -145,11 +155,21 @@ export const getStyles = (props: ICartesianChartStyleProps): ICartesianChartStyl
         ...fonts.mediumPlus,
         fontWeight: 'bold',
         lineHeight: '22px',
+        selectors: {
+          [HighContrastSelector]: {
+            color: 'rgb(179, 179, 179)',
+          },
+        },
       },
     ],
     descriptionMessage: [
       theme.fonts.small,
       {
+        selectors: {
+          [HighContrastSelector]: {
+            color: 'rgb(179, 179, 179)',
+          },
+        },
         color: theme.semanticColors.bodyText,
         marginTop: '10px',
         paddingTop: '10px',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ x] Code is up-to-date with the `master` branch
* [ x] Your changes are covered by tests (if possible)
* [ x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
