### PR TITLE
Removing PopoverCommons type in @fluentui/react-popover

### DIFF
--- a/change/@fluentui-react-popover-553765b9-3f08-4494-9ffa-a7a039c73d13.json
+++ b/change/@fluentui-react-popover-553765b9-3f08-4494-9ffa-a7a039c73d13.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing PopoverCommons type.",
+  "packageName": "@fluentui/react-popover",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/etc/react-popover.api.md
+++ b/packages/react-components/react-popover/etc/react-popover.api.md
@@ -29,7 +29,7 @@ export type OnOpenChangeData = {
 };
 
 // @public
-export type OpenPopoverEvents = MouseEvent | TouchEvent | React_2.MouseEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement> | React_2.FocusEvent<HTMLElement>;
+export type OpenPopoverEvents = MouseEvent | TouchEvent | React_2.FocusEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement> | React_2.MouseEvent<HTMLElement>;
 
 // @public
 export const Popover: React_2.FC<PopoverProps>;
@@ -41,25 +41,38 @@ export const PopoverContext: Context<PopoverContextValue>;
 export type PopoverContextValue = Pick<PopoverState, 'toggleOpen' | 'setOpen' | 'triggerRef' | 'contentRef' | 'openOnHover' | 'openOnContext' | 'mountNode' | 'noArrow' | 'arrowRef' | 'size' | 'appearance' | 'trapFocus' | 'inline'>;
 
 // @public
-export type PopoverProps = Partial<PopoverCommons> & {
+export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
+    appearance?: 'brand' | 'inverted';
     children: [JSX.Element, JSX.Element] | JSX.Element;
+    closeOnScroll?: boolean;
+    defaultOpen?: boolean;
+    inline?: boolean;
+    mouseLeaveDelay?: number;
+    noArrow?: boolean;
+    onOpenChange?: (e: OpenPopoverEvents, data: OnOpenChangeData) => void;
+    open?: boolean;
+    openOnContext?: boolean;
+    openOnHover?: boolean;
+    positioning?: PositioningShorthand;
+    size?: PopoverSize;
+    trapFocus?: boolean;
 };
 
 // @public
 export type PopoverSize = 'small' | 'medium' | 'large';
 
 // @public
-export type PopoverState = PopoverCommons & Pick<PopoverProps, 'children'> & {
+export type PopoverState = Pick<PopoverProps, 'appearance' | 'mountNode' | 'noArrow' | 'onOpenChange' | 'openOnContext' | 'openOnHover' | 'trapFocus'> & Required<Pick<PopoverProps, 'inline' | 'open'>> & Pick<PopoverProps, 'children'> & {
+    arrowRef: React_2.MutableRefObject<HTMLDivElement | null>;
+    contentRef: React_2.MutableRefObject<HTMLElement | null>;
+    contextTarget: PopperVirtualElement | undefined;
+    popoverSurface: React_2.ReactElement | undefined;
+    popoverTrigger: React_2.ReactElement | undefined;
+    setContextTarget: ReturnType<typeof usePopperMouseTarget>[1];
     setOpen: (e: OpenPopoverEvents, open: boolean) => void;
+    size: NonNullable<PopoverProps['size']>;
     toggleOpen: (e: OpenPopoverEvents) => void;
     triggerRef: React_2.MutableRefObject<HTMLElement | null>;
-    contentRef: React_2.MutableRefObject<HTMLElement | null>;
-    arrowRef: React_2.MutableRefObject<HTMLDivElement | null>;
-    contextTarget: PopperVirtualElement | undefined;
-    setContextTarget: ReturnType<typeof usePopperMouseTarget>[1];
-    size: NonNullable<PopoverProps['size']>;
-    popoverTrigger: React_2.ReactElement | undefined;
-    popoverSurface: React_2.ReactElement | undefined;
 };
 
 // @public
@@ -80,7 +93,7 @@ export type PopoverSurfaceSlots = {
 };
 
 // @public
-export type PopoverSurfaceState = ComponentState<PopoverSurfaceSlots> & Pick<PopoverContextValue, 'mountNode' | 'noArrow' | 'size' | 'appearance' | 'arrowRef' | 'inline'> & {
+export type PopoverSurfaceState = ComponentState<PopoverSurfaceSlots> & Pick<PopoverContextValue, 'appearance' | 'arrowRef' | 'inline' | 'mountNode' | 'noArrow' | 'size'> & {
     arrowClassName?: string;
 };
 
@@ -90,7 +103,7 @@ export const PopoverTrigger: React_2.FC<PopoverTriggerProps> & FluentTriggerComp
 // @public (undocumented)
 export type PopoverTriggerChildProps = {
     ref?: React_2.Ref<never>;
-} & Pick<React_2.HTMLAttributes<HTMLElement>, 'aria-haspopup' | 'onClick' | 'onMouseEnter' | 'onKeyDown' | 'onMouseLeave' | 'onContextMenu'>;
+} & Pick<React_2.HTMLAttributes<HTMLElement>, 'aria-haspopup' | 'onClick' | 'onContextMenu' | 'onKeyDown' | 'onMouseEnter' | 'onMouseLeave'>;
 
 // @public
 export type PopoverTriggerProps = {

--- a/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
@@ -1,55 +1,16 @@
 import * as React from 'react';
-import type { PopperVirtualElement, PositioningShorthand, usePopperMouseTarget } from '@fluentui/react-positioning';
 import type { PortalProps } from '@fluentui/react-portal';
+import type { PopperVirtualElement, PositioningShorthand, usePopperMouseTarget } from '@fluentui/react-positioning';
 
 /**
  * Determines popover padding and arrow size
  */
 export type PopoverSize = 'small' | 'medium' | 'large';
 
-type PopoverCommons = Pick<PortalProps, 'mountNode'> & {
-  /**
-   * Popovers are rendered out of DOM order on `document.body` by default, use this to render the popover in DOM order
-   */
-  inline: boolean;
-
-  /**
-   * Controls the opening of the Popover
-   */
-  open: boolean;
-  /**
-   * Used to set the initial open state of the Popover in uncontrolled mode
-   */
-  defaultOpen?: boolean;
-  /**
-   * Call back when the component requests to change value
-   * The `open` value is used as a hint when directly controlling the component
-   */
-  onOpenChange?: (e: OpenPopoverEvents, data: OnOpenChangeData) => void;
-  /**
-   * Flag to open the Popover by hovering the trigger
-   */
-  openOnHover?: boolean;
-
-  /**
-   * Sets the delay for closing popover on mouse leave
-   */
-  mouseLeaveDelay?: number;
-
-  /**
-   * Flag to open the Popover as a context menu. Disables all other interactions
-   */
-  openOnContext?: boolean;
-  /**
-   * Do not display the arrow
-   */
-  noArrow?: boolean;
-  /**
-   * Determines popover padding and arrow size
-   * @default medium
-   */
-  size?: PopoverSize;
-
+/**
+ * Popover Props
+ */
+export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
   /**
    * A popover can appear styled with brand or inverted.
    * When not specified, the default style is used.
@@ -57,9 +18,68 @@ type PopoverCommons = Pick<PortalProps, 'mountNode'> & {
   appearance?: 'brand' | 'inverted';
 
   /**
-   * Should trap focus
+   * Can contain two children including {@link PopoverTrigger} and {@link PopoverSurface}.
+   * Alternatively can only contain {@link PopoverSurface} if using a custom `target`.
    */
-  trapFocus?: boolean;
+  children: [JSX.Element, JSX.Element] | JSX.Element;
+
+  /**
+   * Close when scroll outside of it
+   *
+   * @default false
+   */
+  closeOnScroll?: boolean;
+
+  /**
+   * Used to set the initial open state of the Popover in uncontrolled mode
+   *
+   * @default false
+   */
+  defaultOpen?: boolean;
+
+  /**
+   * Popovers are rendered out of DOM order on `document.body` by default, use this to render the popover in DOM order
+   *
+   * @default false
+   */
+  inline?: boolean;
+
+  /**
+   * Sets the delay for closing popover on mouse leave
+   */
+  mouseLeaveDelay?: number;
+
+  /**
+   * Do not display the arrow
+   */
+  noArrow?: boolean;
+
+  /**
+   * Call back when the component requests to change value
+   * The `open` value is used as a hint when directly controlling the component
+   */
+  onOpenChange?: (e: OpenPopoverEvents, data: OnOpenChangeData) => void;
+
+  /**
+   * Controls the opening of the Popover
+   *
+   * @default false
+   */
+  open?: boolean;
+
+  /**
+   * Flag to open the Popover as a context menu. Disables all other interactions
+   *
+   * @default false
+   */
+  openOnContext?: boolean;
+
+  /**
+   * Flag to open the Popover by hovering the trigger
+   *
+   * @default false
+   */
+  openOnHover?: boolean;
 
   /**
    * Configures the position of the Popover
@@ -67,61 +87,69 @@ type PopoverCommons = Pick<PortalProps, 'mountNode'> & {
   positioning?: PositioningShorthand;
 
   /**
-   * Close when scroll outside of it
+   * Determines popover padding and arrow size
+   *
+   * @default medium
    */
-  closeOnScroll?: boolean;
-};
+  size?: PopoverSize;
 
-/**
- * Popover Props
- */
-export type PopoverProps = Partial<PopoverCommons> & {
   /**
-   * Can contain two children including {@link PopoverTrigger} and {@link PopoverSurface}.
-   * Alternatively can only contain {@link PopoverSurface} if using a custom `target`.
+   * Should trap focus
+   *
+   * @default false
    */
-  children: [JSX.Element, JSX.Element] | JSX.Element;
+  trapFocus?: boolean;
 };
 
 /**
  * Popover State
  */
-export type PopoverState = PopoverCommons &
+export type PopoverState = Pick<
+  PopoverProps,
+  'appearance' | 'mountNode' | 'noArrow' | 'onOpenChange' | 'openOnContext' | 'openOnHover' | 'trapFocus'
+> &
+  Required<Pick<PopoverProps, 'inline' | 'open'>> &
   Pick<PopoverProps, 'children'> & {
-    /**
-     * Callback to open/close the Popover
-     */
-    setOpen: (e: OpenPopoverEvents, open: boolean) => void;
-    /**
-     * Callback to toggle the open state of the Popover
-     */
-    toggleOpen: (e: OpenPopoverEvents) => void;
-    /**
-     * Ref of the PopoverTrigger
-     */
-    triggerRef: React.MutableRefObject<HTMLElement | null>;
-    /**
-     * Ref of the PopoverSurface
-     */
-    contentRef: React.MutableRefObject<HTMLElement | null>;
     /**
      * Ref of the pointing arrow
      */
     arrowRef: React.MutableRefObject<HTMLDivElement | null>;
+
+    /**
+     * Ref of the PopoverSurface
+     */
+    contentRef: React.MutableRefObject<HTMLElement | null>;
+
     /**
      * Anchors the popper to the mouse click for context events
      */
     contextTarget: PopperVirtualElement | undefined;
+
+    popoverSurface: React.ReactElement | undefined;
+
+    popoverTrigger: React.ReactElement | undefined;
+
     /**
      * A callback to set the target of the popper to the mouse click for context events
      */
     setContextTarget: ReturnType<typeof usePopperMouseTarget>[1];
 
+    /**
+     * Callback to open/close the Popover
+     */
+    setOpen: (e: OpenPopoverEvents, open: boolean) => void;
+
     size: NonNullable<PopoverProps['size']>;
 
-    popoverTrigger: React.ReactElement | undefined;
+    /**
+     * Callback to toggle the open state of the Popover
+     */
+    toggleOpen: (e: OpenPopoverEvents) => void;
 
-    popoverSurface: React.ReactElement | undefined;
+    /**
+     * Ref of the PopoverTrigger
+     */
+    triggerRef: React.MutableRefObject<HTMLElement | null>;
   };
 
 /**
@@ -135,6 +163,6 @@ export type OnOpenChangeData = { open: boolean };
 export type OpenPopoverEvents =
   | MouseEvent
   | TouchEvent
-  | React.MouseEvent<HTMLElement>
+  | React.FocusEvent<HTMLElement>
   | React.KeyboardEvent<HTMLElement>
-  | React.FocusEvent<HTMLElement>;
+  | React.MouseEvent<HTMLElement>;

--- a/packages/react-components/react-popover/src/components/Popover/renderPopover.tsx
+++ b/packages/react-components/react-popover/src/components/Popover/renderPopover.tsx
@@ -7,37 +7,37 @@ import type { PopoverState } from './Popover.types';
  */
 export const renderPopover_unstable = (state: PopoverState) => {
   const {
-    setOpen,
-    toggleOpen,
-    triggerRef,
+    appearance,
+    arrowRef,
     contentRef,
+    inline,
+    mountNode,
+    noArrow,
     openOnContext,
     openOnHover,
-    mountNode,
-    arrowRef,
+    setOpen,
     size,
-    noArrow,
-    appearance,
+    toggleOpen,
     trapFocus,
-    inline,
+    triggerRef,
   } = state;
 
   return (
     <PopoverContext.Provider
       value={{
+        appearance,
+        arrowRef,
+        contentRef,
+        inline,
+        mountNode,
+        noArrow,
+        openOnContext,
+        openOnHover,
         setOpen,
         toggleOpen,
         triggerRef,
-        contentRef,
-        openOnHover,
-        openOnContext,
-        mountNode,
-        arrowRef,
         size,
-        noArrow,
-        appearance,
         trapFocus,
-        inline,
       }}
     >
       {state.popoverTrigger}

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -1,19 +1,19 @@
 import * as React from 'react';
+import { elementContains } from '@fluentui/react-portal';
+import {
+  mergeArrowOffset,
+  resolvePositioningShorthand,
+  usePopper,
+  usePopperMouseTarget,
+} from '@fluentui/react-positioning';
+import { useFluent } from '@fluentui/react-shared-contexts';
+import { useFocusFinders } from '@fluentui/react-tabster';
 import {
   useControllableState,
   useEventCallback,
   useOnClickOutside,
   useOnScrollOutside,
 } from '@fluentui/react-utilities';
-import { useFluent } from '@fluentui/react-shared-contexts';
-import {
-  usePopper,
-  resolvePositioningShorthand,
-  mergeArrowOffset,
-  usePopperMouseTarget,
-} from '@fluentui/react-positioning';
-import { elementContains } from '@fluentui/react-portal';
-import { useFocusFinders } from '@fluentui/react-tabster';
 import { arrowHeights } from '../PopoverSurface/index';
 import type { OpenPopoverEvents, PopoverProps, PopoverState } from './Popover.types';
 

--- a/packages/react-components/react-popover/src/components/PopoverSurface/PopoverSurface.types.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/PopoverSurface.types.ts
@@ -17,7 +17,7 @@ export type PopoverSurfaceSlots = {
  * PopoverSurface State
  */
 export type PopoverSurfaceState = ComponentState<PopoverSurfaceSlots> &
-  Pick<PopoverContextValue, 'mountNode' | 'noArrow' | 'size' | 'appearance' | 'arrowRef' | 'inline'> & {
+  Pick<PopoverContextValue, 'appearance' | 'arrowRef' | 'inline' | 'mountNode' | 'noArrow' | 'size'> & {
     /**
      * CSS class for the arrow element
      */

--- a/packages/react-components/react-popover/src/components/PopoverTrigger/PopoverTrigger.types.ts
+++ b/packages/react-components/react-popover/src/components/PopoverTrigger/PopoverTrigger.types.ts
@@ -20,5 +20,5 @@ export type PopoverTriggerChildProps = {
   ref?: React.Ref<never>;
 } & Pick<
   React.HTMLAttributes<HTMLElement>,
-  'aria-haspopup' | 'onClick' | 'onMouseEnter' | 'onKeyDown' | 'onMouseLeave' | 'onContextMenu'
+  'aria-haspopup' | 'onClick' | 'onContextMenu' | 'onKeyDown' | 'onMouseEnter' | 'onMouseLeave'
 >;


### PR DESCRIPTION
## PR Description

This PR removes the `Commons` type pattern in the types for our `Popover` component.

## Related Issue(s)

Fixes part of #22862
