### PR TITLE
Removing TextCommons type in @fluentui/react-text

### DIFF
--- a/change/@fluentui-react-text-2fe193d2-52fa-42b1-b696-c6b562f8ac23.json
+++ b/change/@fluentui-react-text-2fe193d2-52fa-42b1-b696-c6b562f8ac23.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing TextCommons type.",
+  "packageName": "@fluentui/react-text",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-text/etc/react-text.api.md
+++ b/packages/react-components/react-text/etc/react-text.api.md
@@ -81,15 +81,26 @@ export const textClassName = "fui-Text";
 export const textClassNames: SlotClassNames<TextSlots>;
 
 // @public
-export type TextProps = ComponentProps<TextSlots> & Partial<TextCommons>;
-
-// @public
-export type TextSlots = {
-    root: Slot<'span', 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'pre'>;
+export type TextProps = ComponentProps<TextSlots> & {
+    align?: 'start' | 'center' | 'end' | 'justify';
+    block?: boolean;
+    font?: 'base' | 'monospace' | 'numeric';
+    italic?: boolean;
+    size?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
+    strikethrough?: boolean;
+    truncate?: boolean;
+    underline?: boolean;
+    weight?: 'regular' | 'medium' | 'semibold';
+    wrap?: boolean;
 };
 
 // @public
-export type TextState = ComponentState<TextSlots> & TextCommons;
+export type TextSlots = {
+    root: Slot<'span', 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'pre'>;
+};
+
+// @public
+export type TextState = ComponentState<TextSlots> & Required<Pick<TextProps, 'align' | 'block' | 'font' | 'italic' | 'size' | 'strikethrough' | 'truncate' | 'underline' | 'weight' | 'wrap'>>;
 
 // @public
 export const Title1: FunctionComponent<TextWrapperProps>;

--- a/packages/react-components/react-text/etc/react-text.api.md
+++ b/packages/react-components/react-text/etc/react-text.api.md
@@ -82,16 +82,16 @@ export const textClassNames: SlotClassNames<TextSlots>;
 
 // @public
 export type TextProps = ComponentProps<TextSlots> & {
-    align?: 'start' | 'center' | 'end' | 'justify';
-    block?: boolean;
-    font?: 'base' | 'monospace' | 'numeric';
-    italic?: boolean;
-    size?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
-    strikethrough?: boolean;
-    truncate?: boolean;
-    underline?: boolean;
-    weight?: 'regular' | 'medium' | 'semibold';
     wrap?: boolean;
+    truncate?: boolean;
+    block?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+    strikethrough?: boolean;
+    size?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
+    font?: 'base' | 'monospace' | 'numeric';
+    weight?: 'regular' | 'medium' | 'semibold';
+    align?: 'start' | 'center' | 'end' | 'justify';
 };
 
 // @public

--- a/packages/react-components/react-text/src/components/Text/Text.types.ts
+++ b/packages/react-components/react-text/src/components/Text/Text.types.ts
@@ -4,87 +4,91 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
  * Text slots
  */
 export type TextSlots = {
-  root: Slot<'span', 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'pre'>;
-};
-
-type TextCommons = {
-  /**
-   * Wraps the text content on white spaces.
-   *
-   * @defaultValue true
-   */
-  wrap: boolean;
-
-  /**
-   * Truncate overflowing text for block displays.
-   *
-   * @defaultValue false
-   */
-  truncate: boolean;
-
-  /**
-   * Applies a block display for the content.
-   *
-   * @defaultValue false
-   */
-  block: boolean;
-
-  /**
-   * Applies the italic font style to the content.
-   *
-   * @defaultValue false
-   */
-  italic: boolean;
-
-  /**
-   * Applies the underline text decoration to the content.
-   *
-   * @defaultValue false
-   */
-  underline: boolean;
-
-  /**
-   * Applies the strikethrough text decoration to the content.
-   *
-   * @defaultValue false
-   */
-  strikethrough: boolean;
-
-  /**
-   * Applies font size and line height based on the theme tokens.
-   *
-   * @defaultValue 300
-   */
-  size: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
-
-  /**
-   * Applies the font family to the content.
-   *
-   * @defaultValue base
-   */
-  font: 'base' | 'monospace' | 'numeric';
-
-  /**
-   * Applies font weight to the content.
-   *
-   * @defaultValue regular
-   */
-  weight: 'regular' | 'medium' | 'semibold';
-
-  /**
-   * Aligns text based on the parent container.
-   *
-   * @defaultValue start
-   */
-  align: 'start' | 'center' | 'end' | 'justify';
+  root: Slot<'span', 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'pre'>;
 };
 
 /**
  * Text Props
  */
-export type TextProps = ComponentProps<TextSlots> & Partial<TextCommons>;
+export type TextProps = ComponentProps<TextSlots> & {
+  /**
+   * Aligns text based on the parent container.
+   *
+   * @default start
+   */
+  align?: 'start' | 'center' | 'end' | 'justify';
+
+  /**
+   * Applies a block display for the content.
+   *
+   * @default false
+   */
+  block?: boolean;
+
+  /**
+   * Applies the font family to the content.
+   *
+   * @default base
+   */
+  font?: 'base' | 'monospace' | 'numeric';
+
+  /**
+   * Applies the italic font style to the content.
+   *
+   * @default false
+   */
+  italic?: boolean;
+
+  /**
+   * Applies font size and line height based on the theme tokens.
+   *
+   * @default 300
+   */
+  size?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
+
+  /**
+   * Applies the strikethrough text decoration to the content.
+   *
+   * @default false
+   */
+  strikethrough?: boolean;
+
+  /**
+   * Truncate overflowing text for block displays.
+   *
+   * @default false
+   */
+  truncate?: boolean;
+
+  /**
+   * Applies the underline text decoration to the content.
+   *
+   * @default false
+   */
+  underline?: boolean;
+
+  /**
+   * Applies font weight to the content.
+   *
+   * @default regular
+   */
+  weight?: 'regular' | 'medium' | 'semibold';
+
+  /**
+   * Wraps the text content on white spaces.
+   *
+   * @default true
+   */
+  wrap?: boolean;
+};
 
 /**
  * State used in rendering Text
  */
-export type TextState = ComponentState<TextSlots> & TextCommons;
+export type TextState = ComponentState<TextSlots> &
+  Required<
+    Pick<
+      TextProps,
+      'align' | 'block' | 'font' | 'italic' | 'size' | 'strikethrough' | 'truncate' | 'underline' | 'weight' | 'wrap'
+    >
+  >;

--- a/packages/react-components/react-text/src/components/Text/Text.types.ts
+++ b/packages/react-components/react-text/src/components/Text/Text.types.ts
@@ -12,46 +12,11 @@ export type TextSlots = {
  */
 export type TextProps = ComponentProps<TextSlots> & {
   /**
-   * Aligns text based on the parent container.
+   * Wraps the text content on white spaces.
    *
-   * @default start
+   * @default true
    */
-  align?: 'start' | 'center' | 'end' | 'justify';
-
-  /**
-   * Applies a block display for the content.
-   *
-   * @default false
-   */
-  block?: boolean;
-
-  /**
-   * Applies the font family to the content.
-   *
-   * @default base
-   */
-  font?: 'base' | 'monospace' | 'numeric';
-
-  /**
-   * Applies the italic font style to the content.
-   *
-   * @default false
-   */
-  italic?: boolean;
-
-  /**
-   * Applies font size and line height based on the theme tokens.
-   *
-   * @default 300
-   */
-  size?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
-
-  /**
-   * Applies the strikethrough text decoration to the content.
-   *
-   * @default false
-   */
-  strikethrough?: boolean;
+  wrap?: boolean;
 
   /**
    * Truncate overflowing text for block displays.
@@ -61,11 +26,46 @@ export type TextProps = ComponentProps<TextSlots> & {
   truncate?: boolean;
 
   /**
+   * Applies a block display for the content.
+   *
+   * @default false
+   */
+  block?: boolean;
+
+  /**
+   * Applies the italic font style to the content.
+   *
+   * @default false
+   */
+  italic?: boolean;
+
+  /**
    * Applies the underline text decoration to the content.
    *
    * @default false
    */
   underline?: boolean;
+
+  /**
+   * Applies the strikethrough text decoration to the content.
+   *
+   * @default false
+   */
+  strikethrough?: boolean;
+
+  /**
+   * Applies font size and line height based on the theme tokens.
+   *
+   * @default 300
+   */
+  size?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
+
+  /**
+   * Applies the font family to the content.
+   *
+   * @default base
+   */
+  font?: 'base' | 'monospace' | 'numeric';
 
   /**
    * Applies font weight to the content.
@@ -75,11 +75,11 @@ export type TextProps = ComponentProps<TextSlots> & {
   weight?: 'regular' | 'medium' | 'semibold';
 
   /**
-   * Wraps the text content on white spaces.
+   * Aligns text based on the parent container.
    *
-   * @default true
+   * @default start
    */
-  wrap?: boolean;
+  align?: 'start' | 'center' | 'end' | 'justify';
 };
 
 /**

--- a/packages/react-components/react-text/src/components/Text/useText.ts
+++ b/packages/react-components/react-text/src/components/Text/useText.ts
@@ -16,16 +16,16 @@ export const useText_unstable = (props: TextProps, ref: React.Ref<HTMLElement>):
   const as = props.as ?? 'span';
 
   const state: TextState = {
-    wrap: wrap ?? true,
-    truncate: truncate ?? false,
-    block: block ?? false,
-    italic: italic ?? false,
-    underline: underline ?? false,
-    strikethrough: strikethrough ?? false,
-    size: size ?? 300,
-    font: font ?? 'base',
-    weight: weight ?? 'regular',
     align: align ?? 'start',
+    block: block ?? false,
+    font: font ?? 'base',
+    italic: italic ?? false,
+    size: size ?? 300,
+    strikethrough: strikethrough ?? false,
+    truncate: truncate ?? false,
+    underline: underline ?? false,
+    weight: weight ?? 'regular',
+    wrap: wrap ?? true,
 
     components: { root: 'span' },
 


### PR DESCRIPTION
## PR Description

This PR removes the `Commons` type pattern in the types for our `Text` component.

## Related Issue(s)

Fixes part of #22862
