### PR TITLE
Removing ToolbarCommons type in @fluentui/react-toolbar

### DIFF
--- a/packages/react-components/react-toolbar/etc/react-toolbar.api.md
+++ b/packages/react-components/react-toolbar/etc/react-toolbar.api.md
@@ -51,11 +51,6 @@ export type ToolbarButtonState = ComponentState<Partial<ButtonSlots>> & ButtonSt
 export const toolbarClassNames: SlotClassNames<ToolbarSlots>;
 
 // @public (undocumented)
-export type ToolbarCommons = {
-    size?: 'small' | 'medium';
-};
-
-// @public (undocumented)
 export type ToolbarContextValue = {
     size: ToolbarProps['size'];
 };
@@ -75,7 +70,9 @@ export type ToolbarDividerProps = ComponentProps<Partial<DividerSlots>>;
 export type ToolbarDividerState = ComponentState<Partial<DividerSlots>> & DividerState;
 
 // @public
-export type ToolbarProps = ComponentProps<ToolbarSlots> & ToolbarCommons;
+export type ToolbarProps = ComponentProps<ToolbarSlots> & {
+    size?: 'small' | 'medium';
+};
 
 // @public
 export const ToolbarRadio: ForwardRefComponent<ToolbarRadioProps>;
@@ -105,7 +102,7 @@ export type ToolbarSlots = {
 };
 
 // @public
-export type ToolbarState = ComponentState<ToolbarSlots> & ToolbarCommons;
+export type ToolbarState = ComponentState<ToolbarSlots> & Required<Pick<ToolbarProps, 'size'>>;
 
 // @public
 export const ToolbarToggleButton: ForwardRefComponent<ToolbarToggleButtonProps>;

--- a/packages/react-components/react-toolbar/src/components/Toolbar/Toolbar.types.ts
+++ b/packages/react-components/react-toolbar/src/components/Toolbar/Toolbar.types.ts
@@ -4,23 +4,22 @@ export type ToolbarSlots = {
   root: Slot<'div'>;
 };
 
-export type ToolbarCommons = {
+/**
+ * Toolbar Props
+ */
+export type ToolbarProps = ComponentProps<ToolbarSlots> & {
   /**
    * Toolbar can have small or medium size
+   *
    * @default medium
    */
   size?: 'small' | 'medium';
 };
 
 /**
- * Toolbar Props
- */
-export type ToolbarProps = ComponentProps<ToolbarSlots> & ToolbarCommons;
-
-/**
  * State used in rendering Toolbar
  */
-export type ToolbarState = ComponentState<ToolbarSlots> & ToolbarCommons;
+export type ToolbarState = ComponentState<ToolbarSlots> & Required<Pick<ToolbarProps, 'size'>>;
 
 export type ToolbarContextValue = {
   size: ToolbarProps['size'];

--- a/packages/react-components/react-toolbar/src/components/Toolbar/useToolbar.ts
+++ b/packages/react-components/react-toolbar/src/components/Toolbar/useToolbar.ts
@@ -18,7 +18,11 @@ export const useToolbar_unstable = (props: ToolbarProps, ref: React.Ref<HTMLElem
     axis: 'horizontal',
   });
 
+  const { size = 'medium' } = props;
+
   return {
+    size,
+
     // TODO add appropriate props/defaults
     components: {
       // TODO add each slot's element type or component

--- a/packages/react-components/react-toolbar/src/index.ts
+++ b/packages/react-components/react-toolbar/src/index.ts
@@ -5,19 +5,19 @@ export {
   useToolbarStyles_unstable,
   useToolbar_unstable,
 } from './Toolbar';
-export type {
-  ToolbarCommons,
-  ToolbarContextValue,
-  ToolbarContextValues,
-  ToolbarProps,
-  ToolbarSlots,
-  ToolbarState,
-} from './Toolbar';
+export type { ToolbarContextValue, ToolbarContextValues, ToolbarProps, ToolbarSlots, ToolbarState } from './Toolbar';
 export { ToolbarButton } from './ToolbarButton';
 export type { ToolbarButtonProps, ToolbarButtonState } from './ToolbarButton';
 export { ToolbarDivider, useToolbarDividerStyles_unstable } from './ToolbarDivider';
 export type { ToolbarDividerProps, ToolbarDividerState } from './ToolbarDivider';
 export { ToolbarToggleButton } from './ToolbarToggleButton';
 export type { ToolbarToggleButtonProps, ToolbarToggleButtonState } from './ToolbarToggleButton';
-export * from './ToolbarRadio';
-export * from './ToolbarRadioGroup';
+export { ToolbarRadio } from './ToolbarRadio';
+export type { ToolbarRadioProps, ToolbarRadioState } from './ToolbarRadio';
+export { ToolbarRadioGroup } from './ToolbarRadioGroup';
+export type {
+  RadioGroupContextValue,
+  RadioGroupContextValues,
+  ToolbarRadioGroupProps,
+  ToolbarRadioGroupState,
+} from './ToolbarRadioGroup';


### PR DESCRIPTION
## PR Description

This PR removes the `Commons` type pattern in the types for our `Toolbar` component.

## Related Issue(s)

Fixes part of #22862
