### PR TITLE
Remove flex gap use in checkbox, radio, and switch

### DIFF
--- a/change/@fluentui-react-checkbox-c6da45d9-3093-456a-ad57-0c6b821b7fef.json
+++ b/change/@fluentui-react-checkbox-c6da45d9-3093-456a-ad57-0c6b821b7fef.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Refactor styles to remove usage of flex gap, for browser compatibility",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-5c8282ed-50c7-4ce4-bc53-e1abfb7e2630.json
+++ b/change/@fluentui-react-radio-5c8282ed-50c7-4ce4-bc53-e1abfb7e2630.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Refactor styles to remove usage of flex gap, for browser compatibility",
+  "packageName": "@fluentui/react-radio",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-c0e19c79-161f-4be3-8f91-c67e3254610e.json
+++ b/change/@fluentui-react-switch-c0e19c79-161f-4be3-8f91-c67e3254610e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Refactor styles to remove usage of flex gap, for browser compatibility",
+  "packageName": "@fluentui/react-switch",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -27,7 +27,6 @@ const useRootStyles = makeStyles({
   base: {
     position: 'relative',
     display: 'inline-flex',
-    columnGap: spacingHorizontalM,
     ...shorthands.padding(spacingHorizontalS),
     ...createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
   },
@@ -196,13 +195,22 @@ const useLabelStyles = makeStyles({
     color: 'inherit',
   },
 
+  before: {
+    marginRight: spacingHorizontalM,
+  },
+  after: {
+    marginLeft: spacingHorizontalM,
+  },
+
   // Use a (negative) margin to account for the difference between the indicator's height and the label's line height.
   // This prevents the label from expanding the height of the Checkbox, but preserves line height if the label wraps.
   medium: {
-    ...shorthands.margin(`calc((${indicatorSizeMedium} - ${tokens.lineHeightBase300}) / 2)`, 0),
+    marginTop: `calc((${indicatorSizeMedium} - ${tokens.lineHeightBase300}) / 2)`,
+    marginBottom: `calc((${indicatorSizeMedium} - ${tokens.lineHeightBase300}) / 2)`,
   },
   large: {
-    ...shorthands.margin(`calc((${indicatorSizeLarge} - ${tokens.lineHeightBase300}) / 2)`, 0),
+    marginTop: `calc((${indicatorSizeLarge} - ${tokens.lineHeightBase300}) / 2)`,
+    marginBottom: `calc((${indicatorSizeLarge} - ${tokens.lineHeightBase300}) / 2)`,
   },
 });
 
@@ -233,6 +241,7 @@ export const useCheckboxStyles_unstable = (state: CheckboxState): CheckboxState 
       checkboxClassNames.label,
       labelStyles.base,
       labelStyles[state.size],
+      labelStyles[state.labelPosition],
       state.label.className,
     );
   }

--- a/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
+++ b/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
@@ -29,14 +29,12 @@ const useRootStyles = makeStyles({
   base: {
     display: 'inline-flex',
     position: 'relative',
-    columnGap: spacingHorizontalM,
     ...shorthands.padding(spacingHorizontalS),
   },
 
   vertical: {
     flexDirection: 'column',
     alignItems: 'center',
-    rowGap: spacingHorizontalM,
   },
 
   focusIndicator: createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
@@ -158,7 +156,11 @@ const useLabelStyles = makeStyles({
     ...shorthands.margin(`calc((${indicatorSize} - ${tokens.lineHeightBase300}) / 2)`, 0),
   },
 
+  after: {
+    marginLeft: spacingHorizontalM,
+  },
   below: {
+    marginTop: spacingHorizontalM,
     textAlign: 'center',
   },
 });
@@ -187,7 +189,7 @@ export const useRadioStyles_unstable = (state: RadioState) => {
     state.label.className = mergeClasses(
       radioClassNames.label,
       labelStyles.base,
-      state.labelPosition === 'below' && labelStyles.below,
+      labelStyles[state.labelPosition],
       state.label.className,
     );
   }

--- a/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
+++ b/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
@@ -150,15 +150,17 @@ const useLabelStyles = makeStyles({
   base: {
     alignSelf: 'center',
     userSelect: 'none',
-
-    // Use a (negative) margin to account for the difference between the indicator's height and the label's line height.
-    // This prevents the label from expanding the height of the Radio, but preserves line height if the label wraps.
-    ...shorthands.margin(`calc((${indicatorSize} - ${tokens.lineHeightBase300}) / 2)`, 0),
   },
 
   after: {
     marginLeft: spacingHorizontalM,
+
+    // Use a (negative) margin to account for the difference between the indicator's height and the label's line height.
+    // This prevents the label from expanding the height of the Radio, but preserves line height if the label wraps.
+    marginTop: `calc((${indicatorSize} - ${tokens.lineHeightBase300}) / 2)`,
+    marginBottom: `calc((${indicatorSize} - ${tokens.lineHeightBase300}) / 2)`,
   },
+
   below: {
     marginTop: spacingHorizontalM,
     textAlign: 'center',

--- a/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -30,7 +30,6 @@ const trackWidth = 40;
 const useRootStyles = makeStyles({
   base: {
     boxSizing: 'border-box',
-    columnGap: `${spacingM}px`,
     display: 'inline-flex',
     ...shorthands.padding(`${spacingS}px`),
     position: 'relative',
@@ -42,16 +41,13 @@ const useRootStyles = makeStyles({
   above: {
     flexDirection: 'column',
     paddingTop: `${spacingXS}px`,
-    rowGap: `${spacingXS}px`,
   },
   after: {
     alignItems: 'flex-start',
-    columnGap: `${spacingM}px`,
     flexDirection: 'row',
   },
   before: {
     alignItems: 'flex-start',
-    columnGap: `${spacingM}px`,
     flexDirection: 'row',
   },
 });
@@ -199,6 +195,16 @@ const useLabelStyles = makeStyles({
   base: {
     userSelect: 'none',
   },
+
+  above: {
+    marginBottom: `${spacingXS}px`,
+  },
+  after: {
+    marginLeft: `${spacingM}px`,
+  },
+  before: {
+    marginRight: `${spacingM}px`,
+  },
 });
 
 /**
@@ -229,7 +235,12 @@ export const useSwitchStyles_unstable = (state: SwitchState): SwitchState => {
   );
 
   if (state.label) {
-    state.label.className = mergeClasses(switchClassNames.label, labelStyles.base, state.label.className);
+    state.label.className = mergeClasses(
+      switchClassNames.label,
+      labelStyles.base,
+      labelStyles[labelPosition],
+      state.label.className,
+    );
   }
 
   return state;


### PR DESCRIPTION
## Current Behavior

The styles of the checkbox, radio, and switch controls include the flex 'gap' property, which is not compatible with some older browsers.

## New Behavior

Replace the flex gap property with a margin on the label.

## Related Issue(s)

* #22704
