### PR TITLE
Checkbox: Refactor styles to remove usage of flex gap

### DIFF
--- a/change/@fluentui-react-checkbox-45dc4e8d-6372-49fa-a2c2-5824ecb0e30e.json
+++ b/change/@fluentui-react-checkbox-45dc4e8d-6372-49fa-a2c2-5824ecb0e30e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Refactor styles to remove usage of flex gap",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -27,7 +27,6 @@ const useRootStyles = makeStyles({
   base: {
     position: 'relative',
     display: 'inline-flex',
-    columnGap: spacingHorizontalM,
     ...shorthands.padding(spacingHorizontalS),
     ...createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
   },
@@ -196,13 +195,22 @@ const useLabelStyles = makeStyles({
     color: 'inherit',
   },
 
+  before: {
+    marginRight: spacingHorizontalM,
+  },
+  after: {
+    marginLeft: spacingHorizontalM,
+  },
+
   // Use a (negative) margin to account for the difference between the indicator's height and the label's line height.
   // This prevents the label from expanding the height of the Checkbox, but preserves line height if the label wraps.
   medium: {
-    ...shorthands.margin(`calc((${indicatorSizeMedium} - ${tokens.lineHeightBase300}) / 2)`, 0),
+    marginTop: `calc((${indicatorSizeMedium} - ${tokens.lineHeightBase300}) / 2)`,
+    marginBottom: `calc((${indicatorSizeMedium} - ${tokens.lineHeightBase300}) / 2)`,
   },
   large: {
-    ...shorthands.margin(`calc((${indicatorSizeLarge} - ${tokens.lineHeightBase300}) / 2)`, 0),
+    marginTop: `calc((${indicatorSizeLarge} - ${tokens.lineHeightBase300}) / 2)`,
+    marginBottom: `calc((${indicatorSizeLarge} - ${tokens.lineHeightBase300}) / 2)`,
   },
 });
 
@@ -233,6 +241,7 @@ export const useCheckboxStyles_unstable = (state: CheckboxState): CheckboxState 
       checkboxClassNames.label,
       labelStyles.base,
       labelStyles[state.size],
+      labelStyles[state.labelPosition],
       state.label.className,
     );
   }


### PR DESCRIPTION
## Current Behavior

The styles include the flex 'gap' property, which is not compatible with some older browsers.

## New Behavior

Replace the flex gap property with a margin on the label.

## Related Issue(s)

* #22704
