### PR TITLE
Radio: Refactor styles to remove usage of flex gap

### DIFF
--- a/change/@fluentui-react-radio-e5e0980d-9cfa-4712-bbb1-a90cc32359e1.json
+++ b/change/@fluentui-react-radio-e5e0980d-9cfa-4712-bbb1-a90cc32359e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Refactor styles to remove usage of flex gap",
+  "packageName": "@fluentui/react-radio",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
+++ b/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
@@ -29,14 +29,12 @@ const useRootStyles = makeStyles({
   base: {
     display: 'inline-flex',
     position: 'relative',
-    columnGap: spacingHorizontalM,
     ...shorthands.padding(spacingHorizontalS),
   },
 
   vertical: {
     flexDirection: 'column',
     alignItems: 'center',
-    rowGap: spacingHorizontalM,
   },
 
   focusIndicator: createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
@@ -152,13 +150,19 @@ const useLabelStyles = makeStyles({
   base: {
     alignSelf: 'center',
     userSelect: 'none',
+  },
+
+  after: {
+    marginLeft: spacingHorizontalM,
 
     // Use a (negative) margin to account for the difference between the indicator's height and the label's line height.
     // This prevents the label from expanding the height of the Radio, but preserves line height if the label wraps.
-    ...shorthands.margin(`calc((${indicatorSize} - ${tokens.lineHeightBase300}) / 2)`, 0),
+    marginTop: `calc((${indicatorSize} - ${tokens.lineHeightBase300}) / 2)`,
+    marginBottom: `calc((${indicatorSize} - ${tokens.lineHeightBase300}) / 2)`,
   },
 
   below: {
+    marginTop: spacingHorizontalM,
     textAlign: 'center',
   },
 });
@@ -187,7 +191,7 @@ export const useRadioStyles_unstable = (state: RadioState) => {
     state.label.className = mergeClasses(
       radioClassNames.label,
       labelStyles.base,
-      state.labelPosition === 'below' && labelStyles.below,
+      labelStyles[state.labelPosition],
       state.label.className,
     );
   }


### PR DESCRIPTION
## Current Behavior

The styles include the flex 'gap' property, which is not compatible with some older browsers.

## New Behavior

Replace the flex gap property with a margin on the label.

## Related Issue(s)

* #22704
