### PR TITLE
Switch: Refactor styles to remove usage of flex gap

### DIFF
--- a/change/@fluentui-react-switch-41e97da5-1bde-44dc-9a12-9f2e3f818133.json
+++ b/change/@fluentui-react-switch-41e97da5-1bde-44dc-9a12-9f2e3f818133.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Refactor styles to remove usage of flex gap",
+  "packageName": "@fluentui/react-switch",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -30,29 +30,17 @@ const trackWidth = 40;
 const useRootStyles = makeStyles({
   base: {
     boxSizing: 'border-box',
-    columnGap: `${spacingM}px`,
     display: 'inline-flex',
+    alignItems: 'flex-start',
     ...shorthands.padding(`${spacingS}px`),
     position: 'relative',
 
     ...createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
   },
 
-  // Label position variations
-  above: {
+  vertical: {
     flexDirection: 'column',
     paddingTop: `${spacingXS}px`,
-    rowGap: `${spacingXS}px`,
-  },
-  after: {
-    alignItems: 'flex-start',
-    columnGap: `${spacingM}px`,
-    flexDirection: 'row',
-  },
-  before: {
-    alignItems: 'flex-start',
-    columnGap: `${spacingM}px`,
-    flexDirection: 'row',
   },
 });
 
@@ -199,6 +187,16 @@ const useLabelStyles = makeStyles({
   base: {
     userSelect: 'none',
   },
+
+  above: {
+    marginBottom: `${spacingXS}px`,
+  },
+  after: {
+    marginLeft: `${spacingM}px`,
+  },
+  before: {
+    marginRight: `${spacingM}px`,
+  },
 });
 
 /**
@@ -215,7 +213,7 @@ export const useSwitchStyles_unstable = (state: SwitchState): SwitchState => {
   state.root.className = mergeClasses(
     switchClassNames.root,
     rootStyles.base,
-    rootStyles[labelPosition],
+    labelPosition === 'above' && rootStyles.vertical,
     state.root.className,
   );
 
@@ -229,7 +227,12 @@ export const useSwitchStyles_unstable = (state: SwitchState): SwitchState => {
   );
 
   if (state.label) {
-    state.label.className = mergeClasses(switchClassNames.label, labelStyles.base, state.label.className);
+    state.label.className = mergeClasses(
+      switchClassNames.label,
+      labelStyles.base,
+      labelStyles[labelPosition],
+      state.label.className,
+    );
   }
 
   return state;

--- a/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -29,9 +29,9 @@ const trackWidth = 40;
 
 const useRootStyles = makeStyles({
   base: {
+    alignItems: 'flex-start',
     boxSizing: 'border-box',
     display: 'inline-flex',
-    alignItems: 'flex-start',
     ...shorthands.padding(`${spacingS}px`),
     position: 'relative',
 


### PR DESCRIPTION
## Current Behavior

The styles include the flex 'gap' property, which is not compatible with some older browsers.

## New Behavior

Replace the flex gap property with a margin on the label.

## Related Issue(s)

* #22704
