### PR TITLE
react-tabs: Moved stories to Components  from Preview Components

### DIFF
--- a/packages/react-components/react-tabs/src/stories/TabList.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList.stories.tsx
@@ -16,7 +16,7 @@ export { WithOverflow } from './TabListWithOverflow.stories';
 export { WithPanels } from './TabListWithPanels.stories';
 
 export default {
-  title: 'Preview Components/TabList',
+  title: 'Components/TabList',
   component: TabList,
   parameters: {
     docs: {


### PR DESCRIPTION
## Change
- Moved the react-tab stories under the Components area

## Issues
Updates #20338