### PR TITLE
feat: add react toolbar stories

### DIFF
--- a/packages/react-components/react-toolbar/src/stories/Toolbar.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar.stories.tsx
@@ -5,6 +5,7 @@ import bestPracticesMd from './ToolbarBestPractices.md';
 
 export { Default } from './ToolbarDefault.stories';
 export { Small } from './ToolbarSmall.stories';
+export { WithTooltip } from './ToolbarWithTooltip.stories';
 
 export default {
   title: 'Components/Toolbar',

--- a/packages/react-components/react-toolbar/src/stories/Toolbar.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar.stories.tsx
@@ -6,6 +6,8 @@ import bestPracticesMd from './ToolbarBestPractices.md';
 export { Default } from './ToolbarDefault.stories';
 export { Small } from './ToolbarSmall.stories';
 export { WithTooltip } from './ToolbarWithTooltip.stories';
+export { WithPopover } from './ToolbarWithPopover.stories';
+export { Subtle } from './ToolbarSubtle.stories';
 
 export default {
   title: 'Components/Toolbar',

--- a/packages/react-components/react-toolbar/src/stories/ToolbarBestPractices.md
+++ b/packages/react-components/react-toolbar/src/stories/ToolbarBestPractices.md
@@ -2,4 +2,8 @@
 
 ### Do
 
-### Don't
+- Use toolbar as a grouping element only if the group contains 3 or more controls. Refer to ['toolbar aria practices'](https://www.w3.org/TR/wai-aria-practices-1.2/#toolbar) for details.
+- Label each toolbar when the application contains more than one toolbar (using `aria-label` or `aria-labelledby` props). Refer to [toolbar(role)](https://www.w3.org/WAI/PF/aria/roles#toolbar) for details.
+- Use `active` prop on a ToolbarMenuItem if you want to have an active icon indicator displayed next to it.
+- If `Toolbar` contains menu, the menu closes after clicking on one of the menu items. To prevent losing focus, move it manually in the `onClick` handler.
+- If `Toolbar` contains multiple radio groups in the menu, consider using role="group" and `aria-label` for radio group shorthands

--- a/packages/react-components/react-toolbar/src/stories/ToolbarSubtle.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/ToolbarSubtle.stories.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { Toolbar, ToolbarProps } from '../index';
+import { ToolbarButton } from '../ToolbarButton';
+import { ToolbarDivider } from '../ToolbarDivider';
+import { ToolbarToggleButton } from '../ToolbarToggleButton';
+
+export const Subtle = (props: Partial<ToolbarProps>) => (
+  <Toolbar {...props}>
+    <ToolbarButton appearance="subtle">Click me</ToolbarButton>
+    <ToolbarButton appearance="subtle">Click me</ToolbarButton>
+    <ToolbarButton appearance="subtle">Click me</ToolbarButton>
+    <ToolbarDivider />
+    <ToolbarToggleButton appearance="subtle">Click me to Toggle</ToolbarToggleButton>
+  </Toolbar>
+);

--- a/packages/react-components/react-toolbar/src/stories/ToolbarWithPopover.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/ToolbarWithPopover.stories.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { Toolbar, ToolbarProps } from '../index';
+import { ToolbarButton } from '../ToolbarButton';
+import { ToolbarDivider } from '../ToolbarDivider';
+import { ToolbarToggleButton } from '../ToolbarToggleButton';
+import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
+import { CalendarMonthRegular } from '@fluentui/react-icons';
+
+export const WithPopover = (props: Partial<ToolbarProps>) => (
+  <Toolbar {...props} size="small">
+    <Popover>
+      <PopoverTrigger>
+        <ToolbarButton>Click here</ToolbarButton>
+      </PopoverTrigger>
+      <PopoverSurface>
+        <div>Popover content</div>
+      </PopoverSurface>
+    </Popover>
+    <ToolbarDivider />
+    <Popover>
+      <PopoverTrigger>
+        <ToolbarToggleButton icon={<CalendarMonthRegular />} />
+      </PopoverTrigger>
+      <PopoverSurface>
+        <div>Popover content</div>
+      </PopoverSurface>
+    </Popover>
+    <ToolbarDivider />
+  </Toolbar>
+);

--- a/packages/react-components/react-toolbar/src/stories/ToolbarWithPopover.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/ToolbarWithPopover.stories.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Toolbar, ToolbarProps } from '../index';
 import { ToolbarButton } from '../ToolbarButton';
 import { ToolbarDivider } from '../ToolbarDivider';
-import { ToolbarToggleButton } from '../ToolbarToggleButton';
 import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
 import { CalendarMonthRegular } from '@fluentui/react-icons';
 
@@ -19,7 +18,7 @@ export const WithPopover = (props: Partial<ToolbarProps>) => (
     <ToolbarDivider />
     <Popover>
       <PopoverTrigger>
-        <ToolbarToggleButton icon={<CalendarMonthRegular />} />
+        <ToolbarButton icon={<CalendarMonthRegular />} />
       </PopoverTrigger>
       <PopoverSurface>
         <div>Popover content</div>

--- a/packages/react-components/react-toolbar/src/stories/ToolbarWithPopover.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/ToolbarWithPopover.stories.tsx
@@ -24,6 +24,5 @@ export const WithPopover = (props: Partial<ToolbarProps>) => (
         <div>Popover content</div>
       </PopoverSurface>
     </Popover>
-    <ToolbarDivider />
   </Toolbar>
 );

--- a/packages/react-components/react-toolbar/src/stories/ToolbarWithTooltip.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/ToolbarWithTooltip.stories.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { Toolbar, ToolbarProps } from '../index';
+import { ToolbarButton } from '../ToolbarButton';
+import { ToolbarDivider } from '../ToolbarDivider';
+import { ToolbarToggleButton } from '../ToolbarToggleButton';
+import { Tooltip } from '@fluentui/react-tooltip';
+import { CalendarMonthRegular } from '@fluentui/react-icons';
+
+export const WithTooltip = (props: Partial<ToolbarProps>) => (
+  <Toolbar {...props} size="small">
+    <Tooltip content="No Icon On this one" relationship="label" withArrow>
+      <ToolbarButton>Hover me</ToolbarButton>
+    </Tooltip>
+    <ToolbarDivider />
+    <Tooltip content="With calendar icon" relationship="label" withArrow>
+      <ToolbarButton icon={<CalendarMonthRegular />} />
+    </Tooltip>
+    <ToolbarButton>Click me</ToolbarButton>
+    <ToolbarToggleButton>Click me to Toggle</ToolbarToggleButton>
+    <ToolbarDivider />
+  </Toolbar>
+);

--- a/packages/react-components/react-toolbar/src/stories/ToolbarWithTooltip.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/ToolbarWithTooltip.stories.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Toolbar, ToolbarProps } from '../index';
 import { ToolbarButton } from '../ToolbarButton';
 import { ToolbarDivider } from '../ToolbarDivider';
-import { ToolbarToggleButton } from '../ToolbarToggleButton';
 import { Tooltip } from '@fluentui/react-tooltip';
 import { CalendarMonthRegular } from '@fluentui/react-icons';
 
@@ -16,7 +15,7 @@ export const WithTooltip = (props: Partial<ToolbarProps>) => (
       <ToolbarButton icon={<CalendarMonthRegular />} />
     </Tooltip>
     <ToolbarButton>Click me</ToolbarButton>
-    <ToolbarToggleButton>Click me to Toggle</ToolbarToggleButton>
+    <ToolbarButton>Hover me</ToolbarButton>
     <ToolbarDivider />
   </Toolbar>
 );


### PR DESCRIPTION
# Overview

Adds few `react-toolbar` stories, showing using `ToolbarButton` as icon only, combination with `Tooltip` and `Popover` and subtle variation. 