### PR TITLE
Details list fix exports

### DIFF
--- a/change/@fluentui-react-86dd4237-8c0f-432e-9d60-dcc86df144ea.json
+++ b/change/@fluentui-react-86dd4237-8c0f-432e-9d60-dcc86df144ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated to add missing exports",
+  "packageName": "@fluentui/react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -912,6 +912,9 @@ export function canAnyMenuItemsCheck(items: IContextualMenuItem[]): boolean;
 export const Check: React_2.FunctionComponent<ICheckProps>;
 
 // @public (undocumented)
+export const CHECK_CELL_WIDTH = 48;
+
+// @public (undocumented)
 export const CheckBase: React_2.FunctionComponent<ICheckProps>;
 
 // @public (undocumented)
@@ -1225,6 +1228,9 @@ export const defaultWeeklyDayPickerStrings: IWeeklyDayPickerStrings;
 export { DelayedRender }
 
 export { Depths }
+
+// @public (undocumented)
+export const DetailsColumn: React_2.FunctionComponent<IDetailsColumnProps>;
 
 // @public
 export class DetailsColumnBase extends React_2.Component<IDetailsColumnProps> {
@@ -1685,6 +1691,12 @@ export function getBackgroundShade(color: IColor, shade: Shade, isInverted?: boo
 // @public (undocumented)
 export function getBoundsFromTargetWindow(target: Element | MouseEvent | Point | Rectangle | null, targetWindow: IWindowWithSegments): IRectangle;
 
+// @public (undocumented)
+export const getCellStyles: (props: {
+    theme: ITheme;
+    cellStyleProps?: ICellStyleProps | undefined;
+}) => IStyle;
+
 export { getChildren }
 
 // @public
@@ -1702,6 +1714,18 @@ export function getContrastRatio(color1: IColor, color2: IColor): number;
 export { getDatePartHashValue }
 
 export { getDateRangeArray }
+
+// @public (undocumented)
+export const getDetailsColumnStyles: (props: IDetailsColumnStyleProps) => IDetailsColumnStyles;
+
+// @public (undocumented)
+export const getDetailsHeaderStyles: (props: IDetailsHeaderStyleProps) => IDetailsHeaderStyles;
+
+// @public (undocumented)
+export const getDetailsListStyles: (props: IDetailsListStyleProps) => IDetailsListStyles;
+
+// @public (undocumented)
+export const getDetailsRowCheckStyles: (props: IDetailsRowCheckStyleProps) => IDetailsRowCheckStyles;
 
 // @public (undocumented)
 export const getDetailsRowStyles: (props: IDetailsRowStyleProps) => IDetailsRowStyles;
@@ -1827,6 +1851,9 @@ export { getScrollbarWidth }
 export function getShade(color: IColor, shade: Shade, isInverted?: boolean): IColor | null;
 
 // @public (undocumented)
+export const getShimmeredDetailsListStyles: (props: IShimmeredDetailsListStyleProps) => IShimmeredDetailsListStyles;
+
+// @public (undocumented)
 export const getSplitButtonClassNames: (styles: IButtonStyles, disabled: boolean, expanded: boolean, checked: boolean, primaryDisabled?: boolean | undefined) => ISplitButtonClassNames;
 
 export { getStartDateOfWeek }
@@ -1919,6 +1946,9 @@ export { hasHorizontalOverflow }
 export { hasOverflow }
 
 export { hasVerticalOverflow }
+
+// @public (undocumented)
+export const HEADER_HEIGHT = 42;
 
 // @public
 export const HEX_REGEX: RegExp;

--- a/packages/react/src/ShimmeredDetailsList.ts
+++ b/packages/react/src/ShimmeredDetailsList.ts
@@ -1,3 +1,4 @@
 export * from './components/DetailsList/ShimmeredDetailsList';
 export * from './components/DetailsList/ShimmeredDetailsList.base';
+export * from './components/DetailsList/ShimmeredDetailsList.styles';
 export * from './components/DetailsList/ShimmeredDetailsList.types';

--- a/packages/react/src/components/DetailsList/DetailsColumn.styles.ts
+++ b/packages/react/src/components/DetailsList/DetailsColumn.styles.ts
@@ -25,7 +25,7 @@ const GlobalClassNames = {
   nearIcon: 'ms-DetailsColumn-nearIcon',
 };
 
-export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles => {
+export const getDetailsColumnStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles => {
   const {
     theme,
     headerClassName,

--- a/packages/react/src/components/DetailsList/DetailsColumn.ts
+++ b/packages/react/src/components/DetailsList/DetailsColumn.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { styled } from '../../Utilities';
 import { DetailsColumnBase } from './DetailsColumn.base';
-import { getStyles } from './DetailsColumn.styles';
+import { getDetailsColumnStyles } from './DetailsColumn.styles';
 import type { IDetailsColumnProps, IDetailsColumnStyleProps, IDetailsColumnStyles } from './DetailsColumn.types';
 
 export const DetailsColumn: React.FunctionComponent<IDetailsColumnProps> = styled<
   IDetailsColumnProps,
   IDetailsColumnStyleProps,
   IDetailsColumnStyles
->(DetailsColumnBase, getStyles, undefined, { scope: 'DetailsColumn' });
+>(DetailsColumnBase, getDetailsColumnStyles, undefined, { scope: 'DetailsColumn' });
 
 export type { IDetailsColumnProps };

--- a/packages/react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -64,7 +64,7 @@ export const getCellStyles = (props: { theme: ITheme; cellStyleProps?: ICellStyl
   ];
 };
 
-export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles => {
+export const getDetailsHeaderStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles => {
   const {
     theme,
     className,

--- a/packages/react/src/components/DetailsList/DetailsHeader.ts
+++ b/packages/react/src/components/DetailsList/DetailsHeader.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { styled } from '../../Utilities';
 import { DetailsHeaderBase } from './DetailsHeader.base';
-import { getStyles } from './DetailsHeader.styles';
+import { getDetailsHeaderStyles } from './DetailsHeader.styles';
 import type {
   IDetailsHeaderProps,
   IDetailsHeaderBaseProps,
@@ -13,6 +13,6 @@ export const DetailsHeader: React.FunctionComponent<IDetailsHeaderBaseProps> = s
   IDetailsHeaderBaseProps,
   IDetailsHeaderStyleProps,
   IDetailsHeaderStyles
->(DetailsHeaderBase, getStyles, undefined, { scope: 'DetailsHeader' });
+>(DetailsHeaderBase, getDetailsHeaderStyles, undefined, { scope: 'DetailsHeader' });
 
 export type { IDetailsHeaderProps, IDetailsHeaderBaseProps };

--- a/packages/react/src/components/DetailsList/DetailsList.styles.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.styles.ts
@@ -11,7 +11,7 @@ const GlobalClassNames = {
   listCell: 'ms-List-cell',
 };
 
-export const getStyles = (props: IDetailsListStyleProps): IDetailsListStyles => {
+export const getDetailsListStyles = (props: IDetailsListStyleProps): IDetailsListStyles => {
   const { theme, className, isHorizontalConstrained, compact, isFixed } = props;
   const { semanticColors } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);

--- a/packages/react/src/components/DetailsList/DetailsList.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.ts
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { styled } from '../../Utilities';
 import { DetailsListBase } from './DetailsList.base';
-import { getStyles } from './DetailsList.styles';
+import { getDetailsListStyles } from './DetailsList.styles';
 import type { IDetailsListProps, IDetailsListStyleProps, IDetailsListStyles } from './DetailsList.types';
 
 export const DetailsList: React.FunctionComponent<IDetailsListProps> = styled<
   IDetailsListProps,
   IDetailsListStyleProps,
   IDetailsListStyles
->(DetailsListBase, getStyles, undefined, {
+>(DetailsListBase, getDetailsListStyles, undefined, {
   scope: 'DetailsList',
 });
 

--- a/packages/react/src/components/DetailsList/DetailsRowCheck.styles.ts
+++ b/packages/react/src/components/DetailsList/DetailsRowCheck.styles.ts
@@ -12,7 +12,7 @@ const GlobalClassNames = {
 
 export const CHECK_CELL_WIDTH = 48;
 
-export const getStyles = (props: IDetailsRowCheckStyleProps): IDetailsRowCheckStyles => {
+export const getDetailsRowCheckStyles = (props: IDetailsRowCheckStyleProps): IDetailsRowCheckStyles => {
   const { theme, className, isHeader, selected, anySelected, canSelect, compact, isVisible } = props;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
   const { rowHeight, compactRowHeight } = DEFAULT_ROW_HEIGHTS;

--- a/packages/react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { css, styled, classNamesFunction, composeRenderFunction, getNativeElementProps } from '../../Utilities';
 import { Check } from '../../Check';
-import { getStyles } from './DetailsRowCheck.styles';
+import { getDetailsRowCheckStyles } from './DetailsRowCheck.styles';
 import { SelectionMode } from '../../Selection';
 import type {
   IDetailsRowCheckProps,
@@ -89,7 +89,7 @@ function _fastDefaultCheckboxRender(checkboxProps: IDetailsCheckboxProps) {
 
 export const DetailsRowCheck = styled<IDetailsRowCheckProps, IDetailsRowCheckStyleProps, IDetailsRowCheckStyles>(
   DetailsRowCheckBase,
-  getStyles,
+  getDetailsRowCheckStyles,
   undefined,
   { scope: 'DetailsRowCheck' },
   true,

--- a/packages/react/src/components/DetailsList/ShimmeredDetailsList.styles.ts
+++ b/packages/react/src/components/DetailsList/ShimmeredDetailsList.styles.ts
@@ -1,6 +1,6 @@
 import type { IShimmeredDetailsListStyleProps, IShimmeredDetailsListStyles } from './ShimmeredDetailsList.types';
 
-export const getStyles = (props: IShimmeredDetailsListStyleProps): IShimmeredDetailsListStyles => {
+export const getShimmeredDetailsListStyles = (props: IShimmeredDetailsListStyleProps): IShimmeredDetailsListStyles => {
   const { theme } = props;
   const { palette } = theme;
 

--- a/packages/react/src/components/DetailsList/ShimmeredDetailsList.ts
+++ b/packages/react/src/components/DetailsList/ShimmeredDetailsList.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { styled } from '../../Utilities';
 import { ShimmeredDetailsListBase } from './ShimmeredDetailsList.base';
-import { getStyles } from './ShimmeredDetailsList.styles';
+import { getShimmeredDetailsListStyles } from './ShimmeredDetailsList.styles';
 import type {
   IShimmeredDetailsListProps,
   IShimmeredDetailsListStyleProps,
@@ -12,4 +12,4 @@ export const ShimmeredDetailsList: React.FunctionComponent<IShimmeredDetailsList
   IShimmeredDetailsListProps,
   IShimmeredDetailsListStyleProps,
   IShimmeredDetailsListStyles
->(ShimmeredDetailsListBase, getStyles, undefined, { scope: 'ShimmeredDetailsList' });
+>(ShimmeredDetailsListBase, getShimmeredDetailsListStyles, undefined, { scope: 'ShimmeredDetailsList' });

--- a/packages/react/src/components/DetailsList/index.ts
+++ b/packages/react/src/components/DetailsList/index.ts
@@ -2,18 +2,25 @@ export * from '../../Selection';
 export * from '../GroupedList/GroupedList.types';
 export * from './DetailsHeader';
 export * from './DetailsHeader.base';
+export * from './DetailsHeader.styles';
 export * from './DetailsHeader.types';
 export * from './DetailsList';
 export * from './DetailsList.base';
+export * from './DetailsList.styles';
 export * from './DetailsList.types';
 export * from './DetailsRow';
 export * from './DetailsRow.base';
 export * from './DetailsRow.types';
 export * from './DetailsRow.styles';
 export * from './DetailsRowCheck';
+export * from './DetailsRowCheck.styles';
 export * from './DetailsRowCheck.types';
 export * from './DetailsRowFields';
 export * from './DetailsRowFields.types';
 export * from './DetailsFooter.types';
+export * from './DetailsColumn';
 export * from './DetailsColumn.base';
+export * from './DetailsColumn.styles';
 export * from './DetailsColumn.types';
+
+// ShimmeredDetailsList is not exported here as it is exported from ../ShimmeredDetailsList.ts


### PR DESCRIPTION
https://github.com/microsoft/fluentui/pull/21508 moved to explicit exports, this removed some exports from v8 components that could previously be deep imported.

## Change
- Updated to explicitly export previously exported for  deep imports
- Because DetailsRow exported styles, exported other styles.  Renamed getStyles to specific names to avoid collisions.  This will allow for custom styled extended components to be authored.

## Issues
Fixes #22989