### PR TITLE
react-input: write readme

### DIFF
--- a/change/@fluentui-react-input-4ba8cfdb-9f07-45c5-8c1d-ed672b804ed5.json
+++ b/change/@fluentui-react-input-4ba8cfdb-9f07-45c5-8c1d-ed672b804ed5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "write readme",
+  "packageName": "@fluentui/react-input",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-input/README.md
+++ b/packages/react-components/react-input/README.md
@@ -17,8 +17,8 @@ import { Input } from '@fluentui/react-input';
 #### Examples
 
 ```jsx
-<Input defaultValue="Hello, World!"/>
-<Input value={value} onChange={onInputChange}/>
+<Input defaultValue="Hello, World!" />
+<Input value={value} onChange={onInputChange} />
 ```
 
 See [Fluent UI Storybook](https://aka.ms/fluentui-storybook) for more detailed usage examples.

--- a/packages/react-components/react-input/README.md
+++ b/packages/react-components/react-input/README.md
@@ -3,3 +3,35 @@
 **React Input components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
 
 These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+
+Inputs give people a way to enter and edit text.
+
+### Usage
+
+Import Input:
+
+```js
+import { Input } from '@fluentui/react-input';
+```
+
+#### Examples
+
+```jsx
+<Input defaultValue="Hello, World!"/>
+<Input value={value} onChange={onInputChange}/>
+```
+
+See [Fluent UI Storybook](https://aka.ms/fluentui-storybook) for more detailed usage examples.
+
+Alternatively, run Storybook locally with:
+
+1. `yarn start`
+2. Select `react-input` from the list.
+
+### Specification
+
+See [Spec.md](./Spec.md)
+
+### Upgrade Guide
+
+If you're upgrading to Fluent UI v9 see the upgrade guide in [Storybook](https://aka.ms/fluentui-storybook) under Concepts > Upgrading.


### PR DESCRIPTION
## Current Behavior

`react-input`'s README was incomplete.

## New Behavior

`react-input`'s README now:

1. Provides a short summary of what the component is for
2. Shows sow to import the component
3. Show basic usage 
4. Provides links to relevant documentation

