### PR TITLE
react-components: Re-exporting AvatarSizes from react-avatar

### DIFF
--- a/change/@fluentui-react-components-0bdd7c90-41f4-40f2-9112-85230911399c.json
+++ b/change/@fluentui-react-components-0bdd7c90-41f4-40f2-9112-85230911399c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Re-exporting AvatarSizes from react-avatar.",
+  "packageName": "@fluentui/react-components",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -50,6 +50,7 @@ import { avatarClassName } from '@fluentui/react-avatar';
 import { avatarClassNames } from '@fluentui/react-avatar';
 import { AvatarNamedColor } from '@fluentui/react-avatar';
 import { AvatarProps } from '@fluentui/react-avatar';
+import { AvatarSizes } from '@fluentui/react-avatar';
 import { AvatarSlots } from '@fluentui/react-avatar';
 import { AvatarState } from '@fluentui/react-avatar';
 import { Badge } from '@fluentui/react-badge';
@@ -614,6 +615,8 @@ export { avatarClassNames }
 export { AvatarNamedColor }
 
 export { AvatarProps }
+
+export { AvatarSizes }
 
 export { AvatarSlots }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -209,7 +209,7 @@ export {
   useAvatar_unstable,
   useAvatarStyles_unstable,
 } from '@fluentui/react-avatar';
-export type { AvatarNamedColor, AvatarProps, AvatarSlots, AvatarState } from '@fluentui/react-avatar';
+export type { AvatarNamedColor, AvatarProps, AvatarSizes, AvatarSlots, AvatarState } from '@fluentui/react-avatar';
 export {
   Badge,
   CounterBadge,


### PR DESCRIPTION
This PR makes the following changes:
* Re-exports AvatarSizes from react-avatar inside react-components.