### PR TITLE
react-textarea: Move Textarea to release candidate

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV0/Components/Textarea.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV0/Components/Textarea.stories.mdx
@@ -34,8 +34,7 @@ An equivalent `Textarea` in v9 is
 
 ```tsx
 import * as React from 'react';
-import { Label } from '@fluentui/react-components';
-import { Textarea } from '@fluentui/react-components/unstable';
+import { Label, Textarea } from '@fluentui/react-components';
 import { useId } from '@fluentui/react-utilities';
 
 const TextareaV9BasicExample = () => {

--- a/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Textarea.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Upgrade/FromV8/Components/Textarea.stories.mdx
@@ -35,8 +35,7 @@ An equivalent `Textarea` in v9 is
 
 ```tsx
 import * as React from 'react';
-import { Label } from '@fluentui/react-components';
-import { Textarea } from '@fluentui/react-components/unstable';
+import { Label, Textarea } from '@fluentui/react-components';
 import { useId } from '@fluentui/react-utilities';
 
 const TextareaV9BasicExample = () => {

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -41,7 +41,7 @@
     "@fluentui/react-switch": "9.0.0-rc.9",
     "@fluentui/react-tabs": "9.0.0-rc.1",
     "@fluentui/react-text": "9.0.0-rc.8",
-    "@fluentui/react-textarea": "9.0.0-alpha.3",
+    "@fluentui/react-textarea": "9.0.0-rc.1",
     "@fluentui/react-theme": "9.0.0-rc.7",
     "@fluentui/react-tooltip": "9.0.0-rc.9",
     "@fluentui/react-utilities": "9.0.0-rc.8",

--- a/change/@fluentui-react-components-0670ce15-bbdb-4308-ba27-934c4ede2548.json
+++ b/change/@fluentui-react-components-0670ce15-bbdb-4308-ba27-934c4ede2548.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Moving react-textarea from unstable to stable.",
+  "packageName": "@fluentui/react-components",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-006f5a3e-ee5f-4b7e-bd4b-06fd3d4203d5.json
+++ b/change/@fluentui-react-textarea-006f5a3e-ee5f-4b7e-bd4b-06fd3d4203d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Moving react-textarea to RC.",
+  "packageName": "@fluentui/react-textarea",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -331,6 +331,7 @@ import { renderSplitButton_unstable } from '@fluentui/react-button';
 import { renderTab_unstable } from '@fluentui/react-tabs';
 import { renderTabList_unstable } from '@fluentui/react-tabs';
 import { renderText_unstable } from '@fluentui/react-text';
+import { renderTextarea_unstable } from '@fluentui/react-textarea';
 import { renderToggleButton_unstable } from '@fluentui/react-button';
 import { renderTooltip_unstable } from '@fluentui/react-tooltip';
 import { renderToStyleElements } from '@griffel/react';
@@ -387,6 +388,11 @@ import { teamsDarkTheme } from '@fluentui/react-theme';
 import { teamsHighContrastTheme } from '@fluentui/react-theme';
 import { teamsLightTheme } from '@fluentui/react-theme';
 import { Text as Text_2 } from '@fluentui/react-text';
+import { Textarea } from '@fluentui/react-textarea';
+import { textareaClassNames } from '@fluentui/react-textarea';
+import { TextareaProps } from '@fluentui/react-textarea';
+import { TextareaSlots } from '@fluentui/react-textarea';
+import { TextareaState } from '@fluentui/react-textarea';
 import { textClassName } from '@fluentui/react-text';
 import { textClassNames } from '@fluentui/react-text';
 import { TextProps } from '@fluentui/react-text';
@@ -521,6 +527,8 @@ import { useTabList_unstable } from '@fluentui/react-tabs';
 import { useTabListStyles_unstable } from '@fluentui/react-tabs';
 import { useTabStyles_unstable } from '@fluentui/react-tabs';
 import { useText_unstable } from '@fluentui/react-text';
+import { useTextarea_unstable } from '@fluentui/react-textarea';
+import { useTextareaStyles_unstable } from '@fluentui/react-textarea';
 import { useTextStyles_unstable } from '@fluentui/react-text';
 import { useThemeClassName } from '@fluentui/react-shared-contexts';
 import { useToggleButton_unstable } from '@fluentui/react-button';
@@ -1187,6 +1195,8 @@ export { renderTabList_unstable }
 
 export { renderText_unstable }
 
+export { renderTextarea_unstable }
+
 export { renderToggleButton_unstable }
 
 export { renderTooltip_unstable }
@@ -1298,6 +1308,16 @@ export { teamsHighContrastTheme }
 export { teamsLightTheme }
 
 export { Text_2 as Text }
+
+export { Textarea }
+
+export { textareaClassNames }
+
+export { TextareaProps }
+
+export { TextareaSlots }
+
+export { TextareaState }
 
 export { textClassName }
 
@@ -1566,6 +1586,10 @@ export { useTabListStyles_unstable }
 export { useTabStyles_unstable }
 
 export { useText_unstable }
+
+export { useTextarea_unstable }
+
+export { useTextareaStyles_unstable }
 
 export { useTextStyles_unstable }
 

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -43,7 +43,6 @@ import { renderInput_unstable } from '@fluentui/react-input';
 import { renderSpinButton_unstable } from '@fluentui/react-spinbutton';
 import { renderSpinner_unstable } from '@fluentui/react-spinner';
 import { renderSwitch_unstable } from '@fluentui/react-switch';
-import { renderTextarea_unstable } from '@fluentui/react-textarea';
 import { SpinButton } from '@fluentui/react-spinbutton';
 import { SpinButtonBounds } from '@fluentui/react-spinbutton';
 import { SpinButtonChangeEvent } from '@fluentui/react-spinbutton';
@@ -64,11 +63,6 @@ import { SwitchOnChangeData } from '@fluentui/react-switch';
 import { SwitchProps } from '@fluentui/react-switch';
 import { SwitchSlots } from '@fluentui/react-switch';
 import { SwitchState } from '@fluentui/react-switch';
-import { Textarea } from '@fluentui/react-textarea';
-import { textareaClassNames } from '@fluentui/react-textarea';
-import { TextareaProps } from '@fluentui/react-textarea';
-import { TextareaSlots } from '@fluentui/react-textarea';
-import { TextareaState } from '@fluentui/react-textarea';
 import { useCard_unstable } from '@fluentui/react-card';
 import { useCardFooter_unstable } from '@fluentui/react-card';
 import { useCardFooterStyles_unstable } from '@fluentui/react-card';
@@ -85,8 +79,6 @@ import { useSpinner_unstable } from '@fluentui/react-spinner';
 import { useSpinnerStyles_unstable } from '@fluentui/react-spinner';
 import { useSwitch_unstable } from '@fluentui/react-switch';
 import { useSwitchStyles_unstable } from '@fluentui/react-switch';
-import { useTextarea_unstable } from '@fluentui/react-textarea';
-import { useTextareaStyles_unstable } from '@fluentui/react-textarea';
 
 export { Card }
 
@@ -166,8 +158,6 @@ export { renderSpinner_unstable }
 
 export { renderSwitch_unstable }
 
-export { renderTextarea_unstable }
-
 export { SpinButton }
 
 export { SpinButtonBounds }
@@ -208,16 +198,6 @@ export { SwitchSlots }
 
 export { SwitchState }
 
-export { Textarea }
-
-export { textareaClassNames }
-
-export { TextareaProps }
-
-export { TextareaSlots }
-
-export { TextareaState }
-
 export { useCard_unstable }
 
 export { useCardFooter_unstable }
@@ -249,10 +229,6 @@ export { useSpinnerStyles_unstable }
 export { useSwitch_unstable }
 
 export { useSwitchStyles_unstable }
-
-export { useTextarea_unstable }
-
-export { useTextareaStyles_unstable }
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -56,7 +56,7 @@
     "@fluentui/react-switch": "9.0.0-rc.9",
     "@fluentui/react-tabs": "9.0.0-rc.1",
     "@fluentui/react-tabster": "9.0.0-rc.9",
-    "@fluentui/react-textarea": "9.0.0-alpha.3",
+    "@fluentui/react-textarea": "9.0.0-rc.1",
     "@fluentui/react-theme": "9.0.0-rc.7",
     "@fluentui/react-tooltip": "9.0.0-rc.9",
     "@fluentui/react-utilities": "9.0.0-rc.8",

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -602,6 +602,14 @@ export {
 } from '@fluentui/react-text';
 export type { TextProps, TextSlots, TextState } from '@fluentui/react-text';
 export {
+  Textarea,
+  textareaClassNames,
+  renderTextarea_unstable,
+  useTextarea_unstable,
+  useTextareaStyles_unstable,
+} from '@fluentui/react-textarea';
+export type { TextareaProps, TextareaSlots, TextareaState } from '@fluentui/react-textarea';
+export {
   Tooltip,
   renderTooltip_unstable,
   /* eslint-disable-next-line deprecation/deprecation */

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -91,12 +91,3 @@ export {
   useSwitchStyles_unstable,
 } from '@fluentui/react-switch';
 export type { SwitchOnChangeData, SwitchProps, SwitchSlots, SwitchState } from '@fluentui/react-switch';
-
-export {
-  Textarea,
-  textareaClassNames,
-  renderTextarea_unstable,
-  useTextarea_unstable,
-  useTextareaStyles_unstable,
-} from '@fluentui/react-textarea';
-export type { TextareaProps, TextareaSlots, TextareaState } from '@fluentui/react-textarea';

--- a/packages/react-components/react-textarea/README.md
+++ b/packages/react-components/react-textarea/README.md
@@ -16,12 +16,6 @@ To import Textarea:
 import { Textarea } from '@fluentui/react-textarea';
 ```
 
-Once the Textarea component is ready for production use, the component will be available at:
-
-```js
-import { Textarea } from '@fluentui/react-components';
-```
-
 ### Examples
 
 ```js

--- a/packages/react-components/react-textarea/package.json
+++ b/packages/react-components/react-textarea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-textarea",
-  "version": "9.0.0-alpha.3",
+  "version": "9.0.0-rc.1",
   "description": "Fluent UI TextArea component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
This PR makes the following changes:
* Moves Textarea exports from unstable to stable.
* Changes version of react-textarea to rc.