### PR TITLE
Combobox: fix logic for selection and activedescendant

### DIFF
--- a/packages/react-combobox/src/components/Combobox/useCombobox.ts
+++ b/packages/react-combobox/src/components/Combobox/useCombobox.ts
@@ -86,17 +86,29 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
     return selectedOptions[0];
   }, [isFirstMount, multiselect, props.defaultValue, props.value, selectedOptions]);
 
+  // update active option based on change in open state
+  React.useEffect(() => {
+    if (open) {
+      // if there is a selection, start at the most recently selected item
+      if (selectedOptions.length > 0) {
+        const lastSelectedOption = getOptionsMatchingValue(
+          v => v === selectedOptions[selectedOptions.length - 1],
+        ).pop();
+        lastSelectedOption && setActiveOption(lastSelectedOption);
+      }
+      // default to starting at the first option
+      else {
+        setActiveOption(getOptionAtIndex(0));
+      }
+    } else {
+      // reset the active option when closing
+      setActiveOption(undefined);
+    }
+  }, [open]);
+
   const setOpen = (event: ComboboxOpenEvents, newState: boolean) => {
     onOpenChange?.(event, { open: newState });
     setOpenState(newState);
-
-    // reset active option
-    if (newState && selectedOptions.length > 0) {
-      const lastSelectedOption = getOptionsMatchingValue(v => v === selectedOptions[0]).pop();
-      lastSelectedOption && setActiveOption(lastSelectedOption);
-    } else {
-      setActiveOption(undefined);
-    }
   };
 
   const onOptionClick = useEventCallback((event: React.MouseEvent<HTMLElement>, option: OptionValue) => {
@@ -217,7 +229,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
         !multiselect && setOpen(event, false);
       // fallthrough
       case 'Select':
-        activeOption && selectOption(event, activeOption.value);
+        activeOption && !activeOption.disabled && selectOption(event, activeOption.value);
         event.preventDefault();
         break;
       case 'Tab':

--- a/packages/react-combobox/src/components/Combobox/useCombobox.ts
+++ b/packages/react-combobox/src/components/Combobox/useCombobox.ts
@@ -104,6 +104,8 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLBu
       // reset the active option when closing
       setActiveOption(undefined);
     }
+    // this should only be run in response to changes in the open state
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const setOpen = (event: ComboboxOpenEvents, newState: boolean) => {

--- a/packages/react-combobox/src/components/Listbox/useListbox.ts
+++ b/packages/react-combobox/src/components/Listbox/useListbox.ts
@@ -31,7 +31,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
     setActiveOption(getOptionById(option.id));
 
     // handle selection change
-    selectOption(event, option);
+    selectOption(event, option.value);
   };
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
@@ -43,7 +43,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
     switch (action) {
       case 'Select':
       case 'CloseSelect':
-        activeOption && selectOption(event, activeOption);
+        activeOption && selectOption(event, activeOption.value);
         break;
       default:
         newIndex = getIndexFromAction(action, activeIndex, maxIndex);

--- a/packages/react-combobox/src/components/Option/useOption.tsx
+++ b/packages/react-combobox/src/components/Option/useOption.tsx
@@ -67,16 +67,16 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
       return;
     }
 
-    onOptionClick(event, { id, value: optionValue });
+    onOptionClick(event, { id, disabled, value: optionValue });
     props.onClick?.(event);
   };
 
   // register option data with context
   React.useEffect(() => {
     if (id && optionRef.current) {
-      return registerOption({ id, value: optionValue }, optionRef.current);
+      return registerOption({ id, disabled, value: optionValue }, optionRef.current);
     }
-  }, [registerOption, id, optionValue]);
+  }, [registerOption, id, disabled, optionValue]);
 
   return {
     components: {

--- a/packages/react-combobox/src/components/Option/useOption.tsx
+++ b/packages/react-combobox/src/components/Option/useOption.tsx
@@ -41,7 +41,7 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
   const selected = useContextSelector(ListboxContext, ctx => {
     const selectedOptions = ctx.selectedOptions;
 
-    return !!optionValue && !!selectedOptions.find(option => option.value === optionValue);
+    return !!optionValue && !!selectedOptions.find(o => o === optionValue);
   });
 
   // use the id if provided, otherwise use a generated id

--- a/packages/react-combobox/src/utils/OptionCollection.types.ts
+++ b/packages/react-combobox/src/utils/OptionCollection.types.ts
@@ -1,4 +1,7 @@
 export type OptionValue = {
+  /** The disabled state of the option. */
+  disabled?: boolean;
+
   /** The `id` attribute of the option. */
   id: string;
 

--- a/packages/react-combobox/src/utils/OptionCollection.types.ts
+++ b/packages/react-combobox/src/utils/OptionCollection.types.ts
@@ -19,6 +19,9 @@ export type OptionCollectionState = {
   /** Returns the option data by key. */
   getOptionById(id: string): OptionValue | undefined;
 
+  /** Returns an array of options filtered by a value matching function. */
+  getOptionsMatchingValue(matcher: (value: string) => boolean): OptionValue[];
+
   /** The unordered option data. */
   options: OptionValue[];
 

--- a/packages/react-combobox/src/utils/Selection.types.ts
+++ b/packages/react-combobox/src/utils/Selection.types.ts
@@ -1,16 +1,8 @@
 import * as React from 'react';
 
-export type SelectedOption = {
-  /** The `key` prop of the option. */
-  id: string;
-
-  /** The desired display value of the options */
-  value: string;
-};
-
 export type SelectionProps = {
   /* For an uncontrolled component, sets the initial selection */
-  defaultSelectedOptions?: SelectedOption[];
+  defaultSelectedOptions?: string[];
 
   /**
    * Sets the selection type to multiselect.
@@ -27,19 +19,19 @@ export type SelectionProps = {
    * An array of selected option keys.
    * Use this with `onSelect` to directly control the selected option(s)
    */
-  selectedOptions?: SelectedOption[];
+  selectedOptions?: string[];
 };
 
 export type SelectionState = Required<Pick<SelectionProps, 'selectedOptions'>> & Pick<SelectionProps, 'multiselect'>;
 
 /* Values returned by the useSelection hook */
 export type SelectionValue = {
-  selectedOptions: SelectedOption[];
-  selectOption: (event: SelectionEvents, option: SelectedOption) => void;
+  selectedOptions: string[];
+  selectOption: (event: SelectionEvents, optionValue: string) => void;
 };
 
 /* Data for the onSelect callback */
-export type OnSelectData = { option: SelectedOption; selectedOptions: SelectedOption[] };
+export type OnSelectData = { optionValue: string; selectedOptions: string[] };
 
 /* Possible event types for onSelect */
 export type SelectionEvents = React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;

--- a/packages/react-combobox/src/utils/useOptionCollection.ts
+++ b/packages/react-combobox/src/utils/useOptionCollection.ts
@@ -15,12 +15,22 @@ export const useOptionCollection = (): OptionCollectionState => {
       const item = nodes.current.find(node => node.option.id === id);
       return item?.option;
     };
+    const getOptionsMatchingValue = (matcher: (value: string) => boolean) => {
+      console.log('get options matching value, from nodes', nodes.current);
+      return nodes.current
+        .filter(node => {
+          console.log('testing against option value', node.option.value, 'returning', matcher(node.option.value));
+          return matcher(node.option.value);
+        })
+        .map(node => node.option);
+    };
 
     return {
       getCount,
       getOptionAtIndex,
       getIndexOfId,
       getOptionById,
+      getOptionsMatchingValue,
     };
   }, []);
 

--- a/packages/react-combobox/src/utils/useOptionCollection.ts
+++ b/packages/react-combobox/src/utils/useOptionCollection.ts
@@ -16,13 +16,7 @@ export const useOptionCollection = (): OptionCollectionState => {
       return item?.option;
     };
     const getOptionsMatchingValue = (matcher: (value: string) => boolean) => {
-      console.log('get options matching value, from nodes', nodes.current);
-      return nodes.current
-        .filter(node => {
-          console.log('testing against option value', node.option.value, 'returning', matcher(node.option.value));
-          return matcher(node.option.value);
-        })
-        .map(node => node.option);
+      return nodes.current.filter(node => matcher(node.option.value)).map(node => node.option);
     };
 
     return {

--- a/packages/react-combobox/src/utils/useSelection.ts
+++ b/packages/react-combobox/src/utils/useSelection.ts
@@ -1,5 +1,5 @@
 import { useControllableState } from '@fluentui/react-utilities';
-import { SelectedOption, SelectionEvents, SelectionProps, SelectionValue } from './Selection.types';
+import { SelectionEvents, SelectionProps, SelectionValue } from './Selection.types';
 
 export const useSelection = (props: SelectionProps): SelectionValue => {
   const { defaultSelectedOptions, multiselect, onSelect } = props;
@@ -10,24 +10,24 @@ export const useSelection = (props: SelectionProps): SelectionValue => {
     initialState: [],
   });
 
-  const selectOption = (event: SelectionEvents, option: SelectedOption) => {
+  const selectOption = (event: SelectionEvents, optionValue: string) => {
     // for single-select, always return the selected option
-    let newSelection = [option];
+    let newSelection = [optionValue];
 
     // toggle selected state of the option for multiselect
     if (multiselect) {
-      const selectedIndex = selectedOptions.findIndex(o => o.id === option.id);
+      const selectedIndex = selectedOptions.findIndex(o => o === optionValue);
       if (selectedIndex > -1) {
         // deselect option
         newSelection = [...selectedOptions.slice(0, selectedIndex), ...selectedOptions.slice(selectedIndex + 1)];
       } else {
         // select option
-        newSelection = [...selectedOptions, option];
+        newSelection = [...selectedOptions, optionValue];
       }
     }
 
     setSelectedOptions(newSelection);
-    onSelect?.(event, { option, selectedOptions: newSelection });
+    onSelect?.(event, { optionValue, selectedOptions: newSelection });
   };
 
   return { selectedOptions, selectOption };


### PR DESCRIPTION
When switching from `React.Children` to DOM child ordering, the option `id` attribute becoming unstable across renders broke aspects of selecting/unselecting options and calculating the `activedescendant` value on combobox open.

This PR fixes both issues, and adds a `getOptionsMatchingValue` util that will help future filtering by value.