### PR TITLE
SpinButton: update stepper clamping behavior

### DIFF
--- a/change/@fluentui-react-spinbutton-d39a9441-b65d-4309-b07e-02e8a6516464.json
+++ b/change/@fluentui-react-spinbutton-d39a9441-b65d-4309-b07e-02e8a6516464.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update stepper clamping behavior",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
@@ -152,6 +152,7 @@ describe('SpinButton', () => {
     const onChange = jest.fn();
     const { getAllByRole } = render(<SpinButton defaultValue={100} min={0} max={10} onChange={onChange} />);
 
+    expect(getSpinButtonInput().value).toEqual('100');
     const [incrementButton] = getAllByRole('button');
 
     userEvent.click(incrementButton);
@@ -163,6 +164,7 @@ describe('SpinButton', () => {
     const onChange = jest.fn();
     const { getAllByRole, rerender } = render(<SpinButton value={100} min={0} max={10} onChange={onChange} />);
 
+    expect(getSpinButtonInput().value).toEqual('100');
     const [incrementButton, decrementButton] = getAllByRole('button');
 
     userEvent.click(incrementButton);

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
@@ -148,34 +148,30 @@ describe('SpinButton', () => {
     expect(getSpinButtonInput().value).toEqual('100');
   });
 
-  it('does not clamp the value when outside the bounds when uncontrolled', () => {
+  it('clamps the value when outside the bounds when uncontrolled', () => {
     const onChange = jest.fn();
     const { getAllByRole } = render(<SpinButton defaultValue={100} min={0} max={10} onChange={onChange} />);
 
-    const [incrementButton, decrementButton] = getAllByRole('button');
+    const [incrementButton] = getAllByRole('button');
 
     userEvent.click(incrementButton);
-    expect(onChange.mock.calls[0][1]).toEqual({ value: 101, displayValue: undefined });
-    expect(getSpinButtonInput().value).toEqual('101');
-
-    userEvent.click(decrementButton);
-    expect(onChange.mock.calls[1][1]).toEqual({ value: 100, displayValue: undefined });
-    expect(getSpinButtonInput().value).toEqual('100');
+    expect(onChange.mock.calls[0][1]).toEqual({ value: 10, displayValue: undefined });
+    expect(getSpinButtonInput().value).toEqual('10');
   });
 
-  it('does not clamp the value when outside the bounds when controlled', () => {
+  it('clamps the value when outside the bounds when controlled', () => {
     const onChange = jest.fn();
     const { getAllByRole, rerender } = render(<SpinButton value={100} min={0} max={10} onChange={onChange} />);
 
     const [incrementButton, decrementButton] = getAllByRole('button');
 
     userEvent.click(incrementButton);
-    expect(onChange.mock.calls[0][1]).toEqual({ value: 101, displayValue: undefined });
+    expect(onChange.mock.calls[0][1]).toEqual({ value: 10, displayValue: undefined });
 
-    rerender(<SpinButton value={101} min={0} max={10} onChange={onChange} />);
+    rerender(<SpinButton value={-1} min={0} max={10} onChange={onChange} />);
 
     userEvent.click(decrementButton);
-    expect(onChange.mock.calls[1][1]).toEqual({ value: 100, displayValue: undefined });
+    expect(onChange.mock.calls[1][1]).toEqual({ value: 0, displayValue: undefined });
   });
 
   it('does not update the value when `defaultValue` changes', () => {

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -14,7 +14,7 @@ import {
   SpinButtonChangeEvent,
   SpinButtonBounds,
 } from './SpinButton.types';
-import { calculatePrecision, precisionRound, getBound, clampWhenInRange } from '../../utils/index';
+import { calculatePrecision, precisionRound, getBound, clamp } from '../../utils/index';
 import { ChevronUp16Regular, ChevronDown16Regular } from '@fluentui/react-icons';
 
 type InternalState = {
@@ -169,7 +169,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
 
     let newValue = val + stepSize * dir;
     if (!Number.isNaN(newValue)) {
-      newValue = clampWhenInRange(val, newValue, min, max);
+      newValue = clamp(newValue, min, max);
     }
 
     commit(e, newValue);

--- a/packages/react-components/react-spinbutton/src/utils/clamp.test.ts
+++ b/packages/react-components/react-spinbutton/src/utils/clamp.test.ts
@@ -1,36 +1,49 @@
-import { clampWhenInRange } from './clamp';
+import { clamp } from './clamp';
 
 describe('SpinButton Clamp Util', () => {
-  describe('clampWhenInRange', () => {
-    it('should clamp the new value', () => {
-      expect(clampWhenInRange(5, 0, 1, 10)).toBe(1);
-      expect(clampWhenInRange(5, 11, 1, 10)).toBe(10);
-      expect(clampWhenInRange(1, 0, 1, 10)).toBe(1);
-      expect(clampWhenInRange(10, 11, 1, 10)).toBe(10);
-
-      expect(clampWhenInRange(5, 0, 1, undefined)).toBe(1);
-      expect(clampWhenInRange(5, 11, undefined, 10)).toBe(10);
-      expect(clampWhenInRange(1, 0, 1, undefined)).toBe(1);
-      expect(clampWhenInRange(10, 11, undefined, 10)).toBe(10);
-
-      expect(clampWhenInRange(5, 4, 5, 5)).toBe(5);
-      expect(clampWhenInRange(5, 6, 5, 5)).toBe(5);
-      expect(clampWhenInRange(4, 5, 5, 5)).toBe(5);
-      expect(clampWhenInRange(6, 5, 5, 5)).toBe(5);
+  describe('clamp', () => {
+    let spy: jest.SpyInstance;
+    beforeEach(() => {
+      /**
+       * clamp() logs errors when:
+       * 1) not in production mode
+       * 2) min > max
+       * Mocking it to suppress the error messages during test
+       */
+      spy = jest.spyOn(console, 'error').mockImplementation();
     });
 
-    it('should not clamp the new value', () => {
-      expect(clampWhenInRange(0, -1, 1, 10)).toBe(-1);
-      expect(clampWhenInRange(11, 12, 1, 10)).toBe(12);
+    afterEach(() => {
+      spy.mockRestore();
+    });
 
-      expect(clampWhenInRange(0, 1, undefined, undefined)).toBe(1);
-      expect(clampWhenInRange(0, -1, undefined, 10)).toBe(-1);
-      expect(clampWhenInRange(11, 12, 1, undefined)).toBe(12);
+    it('should clamp when both min and max are defined', () => {
+      expect(clamp(0, 1, 10)).toBe(1);
+      expect(clamp(11, 1, 10)).toBe(10);
+    });
 
-      expect(clampWhenInRange(4, 3, 5, 5)).toBe(3);
-      expect(clampWhenInRange(6, 7, 5, 5)).toBe(7);
+    it('should clamp when only min is defined', () => {
+      expect(clamp(0, 1, undefined)).toBe(1);
+      expect(clamp(10, 1, undefined)).toBe(10);
+    });
 
-      expect(clampWhenInRange(4, 5, 10, 7)).toBe(5);
+    it('should clamp when only max is defined', () => {
+      expect(clamp(11, undefined, 10)).toBe(10);
+      expect(clamp(1, undefined, 10)).toBe(1);
+    });
+
+    it('should clamp when min and max are the same', () => {
+      expect(clamp(4, 5, 5)).toBe(5);
+      expect(clamp(6, 5, 5)).toBe(5);
+      expect(clamp(5, 5, 5)).toBe(5);
+    });
+
+    it('should not clamp when min is greater than max', () => {
+      expect(clamp(5, 10, 7)).toBe(5);
+    });
+
+    it('should not clamp when min and max are undefined', () => {
+      expect(clamp(1, undefined, undefined)).toBe(1);
     });
   });
 });

--- a/packages/react-components/react-spinbutton/src/utils/clamp.ts
+++ b/packages/react-components/react-spinbutton/src/utils/clamp.ts
@@ -1,12 +1,6 @@
-export const clampWhenInRange = (oldValue: number, newValue: number, min?: number, max?: number): number => {
-  // When oldValue is in the range of [min, max] clamp newValue.
-  // Don't clamp values outside this range so users get a
-  // more natural behavior. For example, if the range is [5, 15]
-  // and the user types 1 into the input we don't want to clamp
-  // the value when they next press the increment button because
-  // clamping would snap the value to 5 rather than increment to 2.
-  let nextValue = newValue;
-  if (min !== undefined && oldValue >= min) {
+export const clamp = (value: number, min?: number, max?: number): number => {
+  let nextValue = value;
+  if (min !== undefined) {
     if (max !== undefined && min > max) {
       const error = new Error();
       if (process.env.NODE_ENV !== 'production') {
@@ -15,18 +9,18 @@ export const clampWhenInRange = (oldValue: number, newValue: number, min?: numbe
           [
             `"min" value "${min}" is greater than "max" value "${max}".`,
             '"min" must be less than or equal to "max".',
-            `Returning value "${newValue}".`,
+            `Returning value "${value}".`,
             error.stack,
           ].join(),
         );
       }
-      return newValue;
+      return value;
     }
 
     nextValue = Math.max(min, nextValue);
   }
 
-  if (max !== undefined && oldValue <= max) {
+  if (max !== undefined) {
     nextValue = Math.min(max, nextValue);
   }
 


### PR DESCRIPTION
## Current Behavior

SpinButton allows users to type in values outside of the [min, max] range (out of bounds values) and it still allows this after this change.

After typing an out of bounds value and then using the steppers to increment/decrement the value, SpinButton allows this
value to be stepped as if it were in bounds and _not_ clamp it to the [min, max] range.

## New Behavior

This change updates this behavior such that out of bounds values are clamped to the [min, max] range. 

Values that are less than min are clamped to min when the increment or decrement steppers or hotkeys are used. 

Values that are greater than max are clamped to max when the increment or decrement steppers or hotkeys are used.
