### PR TITLE
Update window to use iconBaseUrl to prevent collision

### DIFF
--- a/change/@fluentui-font-icons-mdl2-329545c1-bd7e-4a32-aa67-bc0f624b16a0.json
+++ b/change/@fluentui-font-icons-mdl2-329545c1-bd7e-4a32-aa67-bc0f624b16a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update window to use iconBaseUrl to prevent collision",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-font-icons-mdl2-329545c1-bd7e-4a32-aa67-bc0f624b16a0.json
+++ b/change/@fluentui-font-icons-mdl2-329545c1-bd7e-4a32-aa67-bc0f624b16a0.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Update window to use iconBaseUrl to prevent collision",
   "packageName": "@fluentui/font-icons-mdl2",
   "email": "ololubek@microsoft.com",

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -23,6 +23,10 @@ import { registerIconAliases } from './iconAliases';
 import { getWindow } from '@fluentui/utilities';
 const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
 
+/*
+ * The Window variable has the iconBaseUrl prop in order to allow for users to redirect icon font downloads to a new URL.
+ * The config can be burned on the page to ensure there are no race conditions which might load resources on script load.
+ */
 declare global {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   interface Window {

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -27,7 +27,7 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   interface Window {
     FabricConfig?: {
-      fontBaseUrl?: string;
+      iconBaseUrl?: string;
     };
   }
 }
@@ -35,7 +35,7 @@ declare global {
 const win = getWindow();
 
 export function initializeIcons(
-  baseUrl: string = win?.FabricConfig?.fontBaseUrl ?? DEFAULT_BASE_URL,
+  baseUrl: string = win?.FabricConfig?.iconBaseUrl ?? DEFAULT_BASE_URL,
   options?: IIconOptions,
 ): void {
   [

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -39,6 +39,7 @@ declare global {
 const win = getWindow();
 
 export function initializeIcons(
+  // eslint-disable-next-line deprecation/deprecation
   baseUrl: string = win?.FabricConfig?.iconBaseUrl || win?.FabricConfig?.fontBaseUrl || DEFAULT_BASE_URL,
   options?: IIconOptions,
 ): void {

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -28,7 +28,7 @@ declare global {
   interface Window {
     FabricConfig?: {
       /**
-       * @deprecated
+       * @deprecated - Use iconBaseUrl instead.
        */
       fontBaseUrl?: string;
       iconBaseUrl?: string;

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -27,6 +27,10 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   interface Window {
     FabricConfig?: {
+      /**
+       * @deprecated
+       */
+      fontBaseUrl?: string;
       iconBaseUrl?: string;
     };
   }
@@ -35,7 +39,7 @@ declare global {
 const win = getWindow();
 
 export function initializeIcons(
-  baseUrl: string = win?.FabricConfig?.iconBaseUrl ?? DEFAULT_BASE_URL,
+  baseUrl: string = win?.FabricConfig?.iconBaseUrl || win?.FabricConfig?.fontBaseUrl || DEFAULT_BASE_URL,
   options?: IIconOptions,
 ): void {
   [

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -30,11 +30,26 @@ const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_2
 declare global {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   interface Window {
+  /**
+   * The FabricConfig options can be burned on the page prior to script load to provide
+   * alternative defaults at script load time. This helps avoid race conditions by calling
+   * `initializeIcons` too late, or in cases where you can't control the `initializeIcons` call,
+   * such as using the pre-created Fluent bundle.
+   */
     FabricConfig?: {
       /**
-       * @deprecated - Use iconBaseUrl instead.
+       * Controls the base url of the font files. This is useful for scenarios where the fonts
+       * are stored on a private CDN other than the default SharePoint CDN.
        */
       fontBaseUrl?: string;
+
+      /**
+       * Controls the base url of the icon font files. This is useful for scenarios where the icons
+       * are stored on a private CDN other than the default SharePoint CDN. Note that in prior
+       * iterations, `fontBaseUrl` was used to control both font and icon base urls. While you can
+       * still use `fontBaseUrl` to provide a single base url for both, the `iconBaseUrl` will be
+       * used first if available.
+       */
       iconBaseUrl?: string;
     };
   }

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -24,18 +24,19 @@ import { getWindow } from '@fluentui/utilities';
 const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
 
 /*
- * The Window variable has the iconBaseUrl prop in order to allow for users to redirect icon font downloads to a new URL.
- * The config can be burned on the page to ensure there are no race conditions which might load resources on script load.
+ * The Window variable has the iconBaseUrl prop in order to allow for users to redirect icon font downloads to a new
+ * URL. The config can be burned on the page to ensure there are no race conditions which might load resources on
+ * script load.
  */
 declare global {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   interface Window {
-  /**
-   * The FabricConfig options can be burned on the page prior to script load to provide
-   * alternative defaults at script load time. This helps avoid race conditions by calling
-   * `initializeIcons` too late, or in cases where you can't control the `initializeIcons` call,
-   * such as using the pre-created Fluent bundle.
-   */
+    /**
+     * The FabricConfig options can be burned on the page prior to script load to provide
+     * alternative defaults at script load time. This helps avoid race conditions by calling
+     * `initializeIcons` too late, or in cases where you can't control the `initializeIcons` call,
+     * such as using the pre-created Fluent bundle.
+     */
     FabricConfig?: {
       /**
        * Controls the base url of the font files. This is useful for scenarios where the fonts

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -59,7 +59,6 @@ declare global {
 const win = getWindow();
 
 export function initializeIcons(
-  // eslint-disable-next-line deprecation/deprecation
   baseUrl: string = win?.FabricConfig?.iconBaseUrl || win?.FabricConfig?.fontBaseUrl || DEFAULT_BASE_URL,
   options?: IIconOptions,
 ): void {


### PR DESCRIPTION
This PR updates #22411, which originally used `fontBaseUrl` to use `iconBaseUrl` to avoid a collision of the `fontBaseUrl` window variable between Icon fonts and Text fonts 