### PR TITLE
Experiment: Test screener scoping for v0

### DIFF
--- a/packages/fluentui/react-northstar/src/index.ts
+++ b/packages/fluentui/react-northstar/src/index.ts
@@ -1,3 +1,5 @@
+// Testing screener scoping
+
 export * from '@fluentui/accessibility';
 export * from '@fluentui/react-component-ref';
 export * from '@fluentui/react-bindings';


### PR DESCRIPTION
Adds a comment so that Lage will include v0 into the affected tree