### PR TITLE
Bug 5916415 : Adding legend in all other Donut charts other than dynamic

### DIFF
--- a/packages/react-examples/src/react-charting/DonutChart/DonutChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/DonutChart/DonutChart.Basic.Example.tsx
@@ -23,7 +23,7 @@ export class DonutChartBasicExample extends React.Component<IDonutChartProps, {}
         innerRadius={55}
         href={'https://developer.microsoft.com/en-us/'}
         legendsOverflowText={'overflow Items'}
-        hideLegend={true}
+        hideLegend={false}
         height={220}
         width={176}
         valueInsideDonut={39000}

--- a/packages/react-examples/src/react-charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/DonutChart/DonutChart.CustomAccessibility.Example.tsx
@@ -35,7 +35,7 @@ export class DonutChartCustomAccessibilityExample extends React.Component<IDonut
         innerRadius={55}
         href={'https://developer.microsoft.com/en-us/'}
         legendsOverflowText={'overflow Items'}
-        hideLegend={true}
+        hideLegend={false}
         height={220}
         width={176}
         valueInsideDonut={39000}

--- a/packages/react-examples/src/react-charting/DonutChart/DonutChart.CustomCallout.Example.tsx
+++ b/packages/react-examples/src/react-charting/DonutChart/DonutChart.CustomCallout.Example.tsx
@@ -22,7 +22,7 @@ export class DonutChartCustomCalloutExample extends React.Component<IDonutChartP
         innerRadius={55}
         href={'https://developer.microsoft.com/en-us/'}
         legendsOverflowText={'overflow Items'}
-        hideLegend={true}
+        hideLegend={false}
         height={220}
         width={176}
         valueInsideDonut={39000}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
<img width="245" alt="DonutChart1" src="https://user-images.githubusercontent.com/103660888/168591160-a67827c6-7f31-4dc1-bc8d-de73cea8b375.PNG">
<img width="286" alt="DonutChart2" src="https://user-images.githubusercontent.com/103660888/168591247-1a120dec-cf75-4559-a3ba-5036c15b5afd.PNG">
<img width="216" alt="DonutChart3" src="https://user-images.githubusercontent.com/103660888/168591298-60068307-aefb-43fe-97fd-00582ce789bf.PNG">


<!-- This is the behavior we have today -->

## New Behavior

<img width="222" alt="ExpectedBasicDonut" src="https://user-images.githubusercontent.com/103660888/168591416-b74e6460-4c28-43d0-9f23-3d17b6a5236d.PNG">
<img width="248" alt="ExpectedCustomDonut" src="https://user-images.githubusercontent.com/103660888/168591436-d4b107de-f5ea-412f-a7ae-9243520111a1.PNG">
<img width="266" alt="ExpectedCustomAccessDonut" src="https://user-images.githubusercontent.com/103660888/168591502-4087ac45-c058-4cca-9dd8-75f4bd1d5e6f.PNG">

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
