### PR TITLE
fix(Pivot): aria-selected not allowed on menuitems

### DIFF
--- a/change/@fluentui-react-1b195929-6f94-41d0-9f13-4403c965df3a.json
+++ b/change/@fluentui-react-1b195929-6f94-41d0-9f13-4403c965df3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix Pivot a11y issue: aria-selected not allowed on menuitems",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -130,9 +130,21 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
       contentString += link.itemCount ? ' (' + link.itemCount + ')' : '';
       // Adding space supplementary for icon
       contentString += link.itemIcon ? ' xx' : '';
+
+      const itemSemantics =
+        link.role && link.role !== 'tab'
+          ? {
+              role: link.role,
+            }
+          : {
+              role: 'tab',
+              'aria-selected': isSelected,
+            };
+
       return (
         <CommandButton
           {...headerButtonProps}
+          {...itemSemantics}
           id={tabId}
           key={itemKey}
           className={css(className, isSelected && classNames.linkIsSelected)}
@@ -141,8 +153,6 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
           // eslint-disable-next-line react/jsx-no-bind
           onKeyDown={(ev: React.KeyboardEvent<HTMLElement>) => onKeyDown(itemKey!, ev)}
           aria-label={link.ariaLabel}
-          role={link.role || 'tab'}
-          aria-selected={isSelected}
           name={link.headerText}
           keytipProps={link.keytipProps}
           data-content={contentString}


### PR DESCRIPTION
Related to #20662

A previous fix to Pivot turned the overflow popup into a semantic menu, which fixed one bug but created another -- `aria-selected` is allowed on tabs but not menuitems. This PR removes the `aria-selected` semantics if the item is rendered inside the overflow menu.

This should be fine as far as accessible semantics go, since the menu items themselves should never be selected and shouldn't need selection semantics. Once an overflowed item is chosen from the menu, it becomes part of the actual tablist.