### PR TITLE
Fix groupedlist custom checkbox example to not have nested checkboxes

### DIFF
--- a/packages/react-examples/src/react/GroupedList/GroupedList.CustomCheckbox.Example.tsx
+++ b/packages/react-examples/src/react/GroupedList/GroupedList.CustomCheckbox.Example.tsx
@@ -10,7 +10,7 @@ import {
 import { IColumn, IObjectWithKey, DetailsRow } from '@fluentui/react/lib/DetailsList';
 import { FocusZone } from '@fluentui/react/lib/FocusZone';
 import { Selection, SelectionMode, SelectionZone } from '@fluentui/react/lib/Selection';
-import { Toggle } from '@fluentui/react/lib/Toggle';
+import { Icon } from '@fluentui/react/lib/Icon';
 import { useConst } from '@fluentui/react-hooks';
 import { createListItems, createGroups, IExampleItem } from '@fluentui/example-data';
 
@@ -23,9 +23,16 @@ const groupProps: IGroupRenderProps = {
   ),
 };
 
-const onRenderGroupHeaderCheckbox = (props?: IGroupHeaderCheckboxProps) => (
-  <Toggle checked={props ? props.checked : undefined} />
-);
+/* This is rendered within a checkbox, so it must not be interactive itself. */
+const onRenderGroupHeaderCheckbox = (props?: IGroupHeaderCheckboxProps) => {
+  const iconStyles = { root: { fontSize: '36px' } };
+
+  return props?.checked ? (
+    <Icon iconName="ToggleRight" styles={iconStyles} />
+  ) : (
+    <Icon iconName="ToggleLeft" styles={iconStyles} />
+  );
+};
 
 export const GroupedListCustomCheckboxExample: React.FunctionComponent = () => {
   const items: IObjectWithKey[] = useConst(() => createListItems(Math.pow(groupCount, groupDepth + 1)));


### PR DESCRIPTION
Fixes #21644

Previously the GroupedList custom checkbox example nested a `<Toggle>` inside a checkbox, which resulted in nested checkboxes and a11y errors (and hella weird screen reader behavior, in some instances).

This fix swaps out the `<Toggle>` component for a toggle-like icon.