### PR TITLE
SpinButton: widen `value` type to include `null`

### DIFF
--- a/change/@fluentui-react-spinbutton-604f015e-1ec4-4a12-9605-e391f23730b4.json
+++ b/change/@fluentui-react-spinbutton-604f015e-1ec4-4a12-9605-e391f23730b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "widen `value` type to include `null`",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinbutton/etc/react-spinbutton.api.md
+++ b/packages/react-components/react-spinbutton/etc/react-spinbutton.api.md
@@ -33,7 +33,7 @@ export type SpinButtonOnChangeData = {
 };
 
 // @public
-export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'input'>, 'onChange' | 'size' | 'value' | 'defaultValue'> & {
+export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'input'>, 'defaultValue' | 'onChange' | 'size' | 'value'> & {
     appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
     defaultValue?: number | null;
     displayValue?: string;

--- a/packages/react-components/react-spinbutton/etc/react-spinbutton.api.md
+++ b/packages/react-components/react-spinbutton/etc/react-spinbutton.api.md
@@ -28,14 +28,14 @@ export const spinButtonClassNames: SlotClassNames<SpinButtonSlots>;
 
 // @public (undocumented)
 export type SpinButtonOnChangeData = {
-    value?: number;
+    value?: number | null;
     displayValue?: string;
 };
 
 // @public
-export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'input'>, 'onChange' | 'size'> & {
+export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'input'>, 'onChange' | 'size' | 'value' | 'defaultValue'> & {
     appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
-    defaultValue?: number;
+    defaultValue?: number | null;
     displayValue?: string;
     max?: number;
     min?: number;
@@ -44,7 +44,7 @@ export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'inp
     size?: 'small' | 'medium';
     step?: number;
     stepPage?: number;
-    value?: number;
+    value?: number | null;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
@@ -276,19 +276,19 @@ describe('SpinButton', () => {
     expect(onChange.mock.calls[1][1]).toEqual({ value: 2, displayValue: undefined });
   });
 
-  it('calls on change when defaultValue is `null` when uncontrolled', () => {
+  it('does not call on change when defaultValue is `null` when uncontrolled', () => {
     const onChange = jest.fn();
     const { getAllByRole } = render(<SpinButton defaultValue={null} onChange={onChange} />);
 
     const [incrementButton, decrementButton] = getAllByRole('button');
     userEvent.click(incrementButton);
 
-    expect(onChange.mock.calls[0][1]).toEqual({ value: null, displayValue: undefined });
+    expect(onChange).not.toHaveBeenCalled();
     expect(getSpinButtonInput().value).toBe('');
 
     userEvent.click(decrementButton);
 
-    expect(onChange.mock.calls[1][1]).toEqual({ value: null, displayValue: undefined });
+    expect(onChange).not.toHaveBeenCalled();
     expect(getSpinButtonInput().value).toBe('');
   });
 
@@ -299,13 +299,13 @@ describe('SpinButton', () => {
     const [incrementButton, decrementButton] = getAllByRole('button');
     userEvent.click(incrementButton);
 
-    expect(onChange.mock.calls[0][1]).toEqual({ value: null, displayValue: undefined });
+    expect(onChange).not.toHaveBeenCalled();
     expect(getSpinButtonInput().value).toBe('');
 
     rerender(<SpinButton value={null} onChange={onChange} />);
     userEvent.click(decrementButton);
 
-    expect(onChange.mock.calls[1][1]).toEqual({ value: null, displayValue: undefined });
+    expect(onChange).not.toHaveBeenCalled();
     expect(getSpinButtonInput().value).toBe('');
   });
 

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
@@ -406,37 +406,69 @@ describe('SpinButton', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('does not call on change when defaultValue is `null` when uncontrolled', () => {
+  it('calls on change when defaultValue is `null` without min when uncontrolled', () => {
     const onChange = jest.fn();
     const { getAllByRole } = render(<SpinButton defaultValue={null} onChange={onChange} />);
 
     const [incrementButton, decrementButton] = getAllByRole('button');
     userEvent.click(incrementButton);
 
-    expect(onChange).not.toHaveBeenCalled();
-    expect(getSpinButtonInput().value).toBe('');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(getSpinButtonInput().value).toBe('1');
 
     userEvent.click(decrementButton);
 
-    expect(onChange).not.toHaveBeenCalled();
-    expect(getSpinButtonInput().value).toBe('');
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(getSpinButtonInput().value).toBe('0');
   });
 
-  it('does not call on change when value is `null` when controlled', () => {
+  it('calls on change when value is `null` without min when controlled', () => {
     const onChange = jest.fn();
-    const { getAllByRole, rerender } = render(<SpinButton value={null} onChange={onChange} />);
+    const { getAllByRole } = render(<SpinButton value={null} onChange={onChange} />);
 
     const [incrementButton, decrementButton] = getAllByRole('button');
     userEvent.click(incrementButton);
 
-    expect(onChange).not.toHaveBeenCalled();
-    expect(getSpinButtonInput().value).toBe('');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][1]).toEqual({ value: 1, displayValue: undefined });
 
-    rerender(<SpinButton value={null} onChange={onChange} />);
     userEvent.click(decrementButton);
 
-    expect(onChange).not.toHaveBeenCalled();
-    expect(getSpinButtonInput().value).toBe('');
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange.mock.calls[1][1]).toEqual({ value: -1, displayValue: undefined });
+  });
+
+  it('calls on change when defaultValue is `null` with min when uncontrolled', () => {
+    const onChange = jest.fn();
+    const { getAllByRole } = render(<SpinButton defaultValue={null} min={5} onChange={onChange} />);
+
+    const [incrementButton, decrementButton] = getAllByRole('button');
+    userEvent.click(incrementButton);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(getSpinButtonInput().value).toBe('6');
+
+    userEvent.click(decrementButton);
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(getSpinButtonInput().value).toBe('5');
+  });
+
+  it('calls on change when value is `null` with min when controlled', () => {
+    const onChange = jest.fn();
+    const { getAllByRole, rerender } = render(<SpinButton value={null} min={5} onChange={onChange} />);
+
+    const [incrementButton, decrementButton] = getAllByRole('button');
+    userEvent.click(incrementButton);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][1]).toEqual({ value: 6, displayValue: undefined });
+
+    rerender(<SpinButton value={null} min={5} onChange={onChange} />);
+    userEvent.click(decrementButton);
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange.mock.calls[1][1]).toEqual({ value: 5, displayValue: undefined });
   });
 
   it('removes the increment and decrement buttons from the tab order', () => {

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
@@ -32,7 +32,10 @@ export type SpinButtonSlots = {
 /**
  * SpinButton Props
  */
-export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'input'>, 'onChange' | 'size'> & {
+export type SpinButtonProps = Omit<
+  ComponentProps<Partial<SpinButtonSlots>, 'input'>,
+  'onChange' | 'size' | 'value' | 'defaultValue'
+> & {
   /**
    * Controls the colors and borders of the input.
    * @default 'outline'
@@ -44,8 +47,10 @@ export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'inp
    *
    * Use this if you intend for the SpinButton to be an uncontrolled component which maintains its
    * own value. For a controlled component, use `value` instead. (Mutually exclusive with `value`.)
+   *
+   * Use `null` to indicate the control has no value.
    */
-  defaultValue?: number;
+  defaultValue?: number | null;
 
   /**
    * String representation of `value`.
@@ -112,9 +117,13 @@ export type SpinButtonProps = Omit<ComponentProps<Partial<SpinButtonSlots>, 'inp
    *
    * Only provide this if the SpinButton is a controlled component where you are maintaining its
    * current state and passing updates based on change events; otherwise, use the `defaultValue`
-   * property. (Mutually exclusive with `defaultValue`.)
+   * property.
+   *
+   * Use `null` to indicate the control has no value.
+   *
+   * Mutually exclusive with `defaultValue`.
    */
-  value?: number;
+  value?: number | null;
 };
 
 /**
@@ -142,7 +151,7 @@ export type SpinButtonChangeEvent =
   | React.KeyboardEvent<HTMLInputElement>;
 
 export type SpinButtonOnChangeData = {
-  value?: number;
+  value?: number | null;
   displayValue?: string;
 };
 

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.types.ts
@@ -34,7 +34,7 @@ export type SpinButtonSlots = {
  */
 export type SpinButtonProps = Omit<
   ComponentProps<Partial<SpinButtonSlots>, 'input'>,
-  'onChange' | 'size' | 'value' | 'defaultValue'
+  'defaultValue' | 'onChange' | 'size' | 'value'
 > & {
   /**
    * Controls the colors and borders of the input.

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -242,6 +242,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
       setSpinState('up');
     } else if (e.key === Keys.Enter) {
       commit(e, currentValue, textValue);
+      internalState.current.previousTextValue = undefined;
       setSpinState('rest');
     } else if (e.key === Keys.Escape) {
       if (internalState.current.previousTextValue) {
@@ -267,6 +268,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
 
     let roundedValue;
     if (valueChanged) {
+      // TODO: What happens when newValueis null?
       roundedValue = precisionRound(newValue!, precision);
       setCurrentValue(roundedValue);
       internalState.current.value = roundedValue;
@@ -275,8 +277,6 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
 
     if (valueChanged || displayValueChanged) {
       onChange?.(e, { value: roundedValue, displayValue: newDisplayValue });
-    } else if (!valueChanged && newValue === null) {
-      onChange?.(e, { value: null });
     }
   };
 

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -47,7 +47,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
   const nativeProps = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'input',
-    excludedPropNames: ['onChange', 'size', 'min', 'max', 'value', 'defaultValue'],
+    excludedPropNames: ['defaultValue', 'max', 'min', 'onChange', 'size', 'value'],
   });
 
   const {

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -284,7 +284,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
   state.input.value = textValue;
   state.input['aria-valuemin'] = min;
   state.input['aria-valuemax'] = max;
-  state.input['aria-valuenow'] = currentValue === null ? undefined : currentValue;
+  state.input['aria-valuenow'] = currentValue ?? undefined;
   state.input['aria-valuetext'] = state.input['aria-valuetext'] ?? ((value !== undefined && displayValue) || undefined);
   state.input.onChange = useMergedEventCallbacks(state.input.onChange, handleInputChange);
   state.input.onBlur = useMergedEventCallbacks(state.input.onBlur, handleBlur);

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -144,14 +144,17 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     if (value === null || currentValue === null) {
       newTextValue = displayValue ?? '';
       internalState.current.value = null;
+      setAtBound('none');
     } else if (value !== undefined) {
       const roundedValue = precisionRound(value, precision);
       newTextValue = displayValue ?? String(roundedValue);
       internalState.current.value = roundedValue;
       setAtBound(getBound(roundedValue, min, max));
     } else {
-      newTextValue = String(precisionRound(currentValue, precision));
-      internalState.current.value = currentValue;
+      const roundedValue = precisionRound(currentValue, precision);
+      newTextValue = String(roundedValue);
+      internalState.current.value = roundedValue;
+      setAtBound(getBound(roundedValue, min, max));
     }
     setTextValue(newTextValue);
   }, [value, displayValue, currentValue, precision, setAtBound, min, max]);
@@ -167,14 +170,15 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
 
   const stepValue = (e: SpinButtonChangeEvent, direction: 'up' | 'down' | 'upPage' | 'downPage') => {
     const val = internalState.current.value;
-
-    if (val === null) {
-      commit(e, null);
-      return;
-    }
-
     const dir = direction === 'up' || direction === 'upPage' ? 1 : -1;
     const stepSize = direction === 'upPage' || direction === 'downPage' ? stepPage : step;
+
+    if (val === null) {
+      const stepStart = min === undefined ? 0 : min;
+      const nullStep = clamp(stepStart + stepSize * dir, min, max);
+      commit(e, nullStep);
+      return;
+    }
 
     let newValue = val + stepSize * dir;
     if (!Number.isNaN(newValue)) {
@@ -268,11 +272,8 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
 
     let roundedValue;
     if (valueChanged) {
-      // TODO: What happens when newValueis null?
       roundedValue = precisionRound(newValue!, precision);
       setCurrentValue(roundedValue);
-      internalState.current.value = roundedValue;
-      setAtBound(getBound(roundedValue, min, max));
     }
 
     if (valueChanged || displayValueChanged) {

--- a/packages/react-components/react-spinbutton/src/stories/SpinButtonControlled.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButtonControlled.stories.tsx
@@ -6,7 +6,7 @@ import { useId } from '@fluentui/react-utilities';
 export const Controlled = () => {
   const id = useId();
 
-  const [spinButtonValue, setSpinButtonValue] = React.useState(10);
+  const [spinButtonValue, setSpinButtonValue] = React.useState<number | null>(10);
 
   const onSpinButtonChange: SpinButtonProps['onChange'] = React.useCallback(
     (_ev, data) => {
@@ -18,7 +18,7 @@ export const Controlled = () => {
         if (!Number.isNaN(newValue)) {
           setSpinButtonValue(newValue);
         } else {
-          console.error(`"${data.displayValue}" is not a valid value.`);
+          console.error(`Cannot parse "${data.displayValue}" as a number.`);
         }
       }
     },

--- a/packages/react-components/react-spinbutton/src/stories/SpinButtonDisplayValue.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButtonDisplayValue.stories.tsx
@@ -20,20 +20,25 @@ export const DisplayValue = () => {
   };
 
   const onSpinButtonChange: SpinButtonProps['onChange'] = (_ev, data) => {
-    if (data.value !== undefined) {
+    if (data.value !== undefined && data.value !== null) {
       setSpinButtonValue(data.value);
       setSpinButtonDisplayValue(formatter(data.value));
-    } else if (data.displayValue) {
+    } else if (data.displayValue !== undefined) {
       const newValue = parser(data.displayValue);
       if (!Number.isNaN(newValue)) {
         setSpinButtonValue(newValue);
         setSpinButtonDisplayValue(formatter(newValue));
+      } else {
+        // Display a "special" value when user types something
+        // that's not parsable as a number.
+        setSpinButtonValue(null);
+        setSpinButtonDisplayValue('(null)');
       }
     }
   };
 
   const id = useId();
-  const [spinButtonValue, setSpinButtonValue] = React.useState(1);
+  const [spinButtonValue, setSpinButtonValue] = React.useState<number | null>(1);
   const [spinButtonDisplayValue, setSpinButtonDisplayValue] = React.useState(formatter(1));
 
   return (


### PR DESCRIPTION
## Current Behavior

`value` and `defaultValue` are typed as the TS `number` type.

## New Behavior

`value` and `defaultValue` have their types widened to `number | null`.

This change is being made based on partner feedback for wanting a reliable way to represent "no value" or "unset value".

`null` was chosen because Typescript can easily ensure users handle the null case as opposed to a value like `NaN`. `null` is also obviously a special case so it's clearer that it should be handled specially. Because `null` is a special, non-`number` value it can more simply be handled internally by SpinButton.

### Alternative Approaches

#### undefined

`undefined` cannot be used as React will interpret `value`/`defaultValue` toggling from a number to `undefined` and back as the component switching from controlled to uncontrolled (which is logged as an error).

<img width="806" alt="React error message about toggling between uncontrolled and controlled component" src="https://user-images.githubusercontent.com/93940821/168698708-97f1351f-42b2-4961-b126-c7098bfaa64a.png">

#### NaN

[NaN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) stands for "not a number" yet it is a number both to Javascript and Typescript:

```ts
console.log(typeof NaN); // "number"
const aNumber: number = NaN; // No TS warnings or errors
```

On the one hand this is convenient as the types for `value` and `defaultValue` could remain simply `number`, however, there are some issues when working with `NaN`:

1. We'd be using `NaN` as a special case yet it's a perfectly valid number and TS will not issue a warning if users don't explicitly handle it. Since it would be part of SpinButton's API it's important that users handle this case. With `number | null` TS will warn users if they don't handle the `null` case.
2. `NaN == NaN` and `NaN === NaN` are both `false` so users must use either the global `isNaN()` function or `Number.isNaN()`. In addition to the friction of not being able to use equality operators on a number value, users now have to make another decision around using `isNaN()` vs `Number.isNaN()` as they have different behavior.

#### Leave the type as `number` and use "special" numbers

Users could choose an "unset" value that is also a number like `-1` but this only works if the "unset" value is outside the [min, max] SpinButton range (and won't work if there is no [min, max] range). Additionally, since SpinButton would have no way of knowing about this special value users would have to implement special handling for scenarios like `value` being set to the "special" number when the user presses the increment button.

## Related Issue(s)

#22673
