### PR TITLE
Aligning vertical bar labels with the bars. Preventing zero valued arcs show up in pie chart

### DIFF
--- a/change/@fluentui-react-charting-93ba5b08-f672-4745-8d41-ca6e26b9db7c.json
+++ b/change/@fluentui-react-charting-93ba5b08-f672-4745-8d41-ca6e26b9db7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Test change",
+  "packageName": "@fluentui/react-charting",
+  "email": "atishay.jain@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-93ba5b08-f672-4745-8d41-ca6e26b9db7c.json
+++ b/change/@fluentui-react-charting-93ba5b08-f672-4745-8d41-ca6e26b9db7c.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Test change",
+  "comment": "Align vertical bar chart labels with the bar. Fixing empty pies showing in donut chart",
   "packageName": "@fluentui/react-charting",
   "email": "atishay.jain@microsoft.com",
   "dependentChangeType": "none"

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -98,7 +98,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
 
     const legendBars = this._createLegends(data!, palette);
     const outerRadius = Math.min(this.state._width!, this.state._height!) / 2;
-    const chartData = data && data.chartData;
+    const chartData = data && data.chartData?.filter((d: IChartDataPoint) => d.data! > 0);
     const valueInsideDonut = this._valueInsideDonut(this.props.valueInsideDonut!, chartData!);
     return (
       <div

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -76,7 +76,7 @@ const _getPointPath = (x: number, y: number, w: number, index: number): string =
      Z`,
     //pyramid
     `M${x} ${y - 0.5774 * w}
-     L${x + w / 2} ${y + 0.2886 * w}
+     L${x + w / 2} ${y + 0.28826 * w}
      L${x - w / 2} ${y + 0.2886 * w} Z`,
     //hexagon
     `M${x - 0.5 * w} ${y - 0.866 * w}

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -76,7 +76,7 @@ const _getPointPath = (x: number, y: number, w: number, index: number): string =
      Z`,
     //pyramid
     `M${x} ${y - 0.5774 * w}
-     L${x + w / 2} ${y + 0.28826 * w}
+     L${x + w / 2} ${y + 0.2886 * w}
      L${x - w / 2} ${y + 0.2886 * w} Z`,
     //hexagon
     `M${x - 0.5 * w} ${y - 0.866 * w}

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { max as d3Max } from 'd3-array';
 import { line as d3Line } from 'd3-shape';
 import { select as d3Select } from 'd3-selection';
-import { scaleLinear as d3ScaleLinear, ScaleLinear as D3ScaleLinear } from 'd3-scale';
+import { scaleLinear as d3ScaleLinear, ScaleLinear as D3ScaleLinear, scaleBand as d3ScaleBand } from 'd3-scale';
 import { classNamesFunction, getId, getRTL } from '@fluentui/react/lib/Utilities';
 import { IProcessedStyleSet, IPalette } from '@fluentui/react/lib/Styling';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';
@@ -455,13 +455,11 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
         .range([0, containerHeight - this.margins.bottom! - this.margins.top!]);
       return { xBarScale, yBarScale };
     } else {
-      const endpointDistance = 0.5 * ((containerWidth - this.margins.right!) / this._points.length);
-      const xBarScale = d3ScaleLinear()
-        .domain(this._isRtl ? [this._points.length - 1, 0] : [0, this._points.length - 1])
-        .range([
-          this.margins.left! + endpointDistance - 0.5 * this._barWidth,
-          containerWidth - this.margins.right! - endpointDistance - 0.5 * this._barWidth,
-        ]);
+      const xBarScale = d3ScaleBand()
+        .domain(this._xAxisLabels)
+        .range([this.margins.left!, containerWidth - this.margins.right!])
+        .padding(this.props.xAxisPadding || 0.1);
+
       const yBarScale = d3ScaleLinear()
         .domain([0, this._yMax])
         .range([0, containerHeight - this.margins.bottom! - this.margins.top!]);
@@ -546,7 +544,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
       return (
         <rect
           key={point.x}
-          x={xBarScale(index)}
+          x={xBarScale(point.x)}
           y={containerHeight - this.margins.bottom! - yBarScale(point.y)}
           width={this._barWidth}
           height={barHeight}
@@ -563,6 +561,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           data-is-focusable={!this.props.hideTooltip}
           onFocus={this._onBarFocus.bind(this, point, index, colorScale(point.y))}
           fill={point.color ? point.color : colorScale(point.y)}
+          transform={`translate(${0.5 * (xBarScale.bandwidth() - this._barWidth)}, 0)`}
         />
       );
     });

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.types.ts
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.types.ts
@@ -62,6 +62,11 @@ export interface IVerticalBarChartProps extends ICartesianChartProps {
    * The prop used to define the culture to localized the numbers
    */
   culture?: string;
+
+  /**
+   * it's padding between bar's or lines in the graph
+   */
+  xAxisPadding?: number;
 }
 
 export interface IVerticalBarChartStyleProps extends ICartesianChartStyleProps {

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -282,15 +282,15 @@ export class VerticalStackedBarChartBase extends React.Component<
         shouldHighlight = selectedLegendTitle === item; // item is legend name;
       }
       for (let i = 1; i < lineObject[item].length; i++) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const x1 = isNumeric
           ? xScale(lineObject[item][i - 1].xItem.xAxisPoint as number)
-          : (xBarScale as any)(lineObject[item][i - 1].xItem.xAxisPoint as string) + this._additionalSpace;
+          : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (xBarScale as any)(lineObject[item][i - 1].xItem.xAxisPoint as string) + this._additionalSpace;
         const y1 = yScale(lineObject[item][i - 1].y);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const x2 = isNumeric
           ? xScale(lineObject[item][i].xItem.xAxisPoint as number)
-          : (xBarScale as any)(lineObject[item][i].xItem.xAxisPoint as string) + this._additionalSpace;
+          : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (xBarScale as any)(lineObject[item][i].xItem.xAxisPoint as string) + this._additionalSpace;
         const y2 = yScale(lineObject[item][i].y);
         lines.push(
           <line
@@ -317,11 +317,11 @@ export class VerticalStackedBarChartBase extends React.Component<
         dots.push(
           <circle
             key={`${index}-${subIndex}-dot`}
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cx={
               isNumeric
                 ? xScale(circlePoint.xItem.xAxisPoint as number)
-                : (xBarScale as any)(circlePoint.xItem.xAxisPoint as string) + this._additionalSpace
+                : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  (xBarScale as any)(circlePoint.xItem.xAxisPoint as string) + this._additionalSpace
             }
             cy={yScale(circlePoint.y)}
             onMouseOver={

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -274,7 +274,7 @@ export class VerticalStackedBarChartBase extends React.Component<
     const lineObject: LineObject = this._getFormattedLineData(this.props.data);
     const lines: React.ReactNode[] = [];
     const dots: React.ReactNode[] = [];
-    const xScaleBandwidthTranslate = isNumeric ? 0 : xBarScale.bandwidth() / 2;
+    const xScaleBandwidthTranslate = isNumeric ? 0 : (xBarScale as any).bandwidth() / 2;
     Object.keys(lineObject).forEach((item: string, index: number) => {
       let shouldHighlight = true;
       if (isLegendHovered || isLegendSelected) {
@@ -283,11 +283,11 @@ export class VerticalStackedBarChartBase extends React.Component<
       for (let i = 1; i < lineObject[item].length; i++) {
         const x1 = isNumeric
           ? xScale(lineObject[item][i - 1].xItem.xAxisPoint as number)
-          : xBarScale(lineObject[item][i - 1].xItem.xAxisPoint as string) + this._additionalSpace;
+          : (xBarScale as any)(lineObject[item][i - 1].xItem.xAxisPoint as string) + this._additionalSpace;
         const y1 = yScale(lineObject[item][i - 1].y);
         const x2 = isNumeric
           ? xScale(lineObject[item][i].xItem.xAxisPoint as number)
-          : xBarScale(lineObject[item][i].xItem.xAxisPoint as string) + this._additionalSpace;
+          : (xBarScale as any)(lineObject[item][i].xItem.xAxisPoint as string) + this._additionalSpace;
         const y2 = yScale(lineObject[item][i].y);
         lines.push(
           <line
@@ -317,7 +317,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             cx={
               isNumeric
                 ? xScale(circlePoint.xItem.xAxisPoint as number)
-                : xBarScale(circlePoint.xItem.xAxisPoint as string) + this._additionalSpace
+                : (xBarScale as any)(circlePoint.xItem.xAxisPoint as string) + this._additionalSpace
             }
             cy={yScale(circlePoint.y)}
             onMouseOver={

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -274,6 +274,7 @@ export class VerticalStackedBarChartBase extends React.Component<
     const lineObject: LineObject = this._getFormattedLineData(this.props.data);
     const lines: React.ReactNode[] = [];
     const dots: React.ReactNode[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const xScaleBandwidthTranslate = isNumeric ? 0 : (xBarScale as any).bandwidth() / 2;
     Object.keys(lineObject).forEach((item: string, index: number) => {
       let shouldHighlight = true;
@@ -281,10 +282,12 @@ export class VerticalStackedBarChartBase extends React.Component<
         shouldHighlight = selectedLegendTitle === item; // item is legend name;
       }
       for (let i = 1; i < lineObject[item].length; i++) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const x1 = isNumeric
           ? xScale(lineObject[item][i - 1].xItem.xAxisPoint as number)
           : (xBarScale as any)(lineObject[item][i - 1].xItem.xAxisPoint as string) + this._additionalSpace;
         const y1 = yScale(lineObject[item][i - 1].y);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const x2 = isNumeric
           ? xScale(lineObject[item][i].xItem.xAxisPoint as number)
           : (xBarScale as any)(lineObject[item][i].xItem.xAxisPoint as string) + this._additionalSpace;
@@ -314,6 +317,7 @@ export class VerticalStackedBarChartBase extends React.Component<
         dots.push(
           <circle
             key={`${index}-${subIndex}-dot`}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cx={
               isNumeric
                 ? xScale(circlePoint.xItem.xAxisPoint as number)
@@ -753,7 +757,7 @@ export class VerticalStackedBarChartBase extends React.Component<
               `}
               fill={color}
               ref={e => (ref.refElement = e)}
-              transform={`translate(${xScaleBandwidthTranslate}, 0)`} // todo do we need this property if there is no translation // test vertical stacked bar chart for RTL.
+              transform={`translate(${xScaleBandwidthTranslate}, 0)`}
               {...rectFocusProps}
             />
           );

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { max as d3Max } from 'd3-array';
 import { Axis as D3Axis } from 'd3-axis';
 import { select as d3Select } from 'd3-selection';
-import { scaleLinear as d3ScaleLinear, ScaleLinear as D3ScaleLinear } from 'd3-scale';
+import { scaleLinear as d3ScaleLinear, ScaleLinear as D3ScaleLinear, scaleBand as d3ScaleBand } from 'd3-scale';
 import { classNamesFunction, getId, getRTL, warnDeprecations, memoizeFunction } from '@fluentui/react/lib/Utilities';
 import { IPalette } from '@fluentui/react/lib/Styling';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';
@@ -274,6 +274,7 @@ export class VerticalStackedBarChartBase extends React.Component<
     const lineObject: LineObject = this._getFormattedLineData(this.props.data);
     const lines: React.ReactNode[] = [];
     const dots: React.ReactNode[] = [];
+    const xScaleBandwidthTranslate = isNumeric ? 0 : xBarScale.bandwidth() / 2;
     Object.keys(lineObject).forEach((item: string, index: number) => {
       let shouldHighlight = true;
       if (isLegendHovered || isLegendSelected) {
@@ -282,11 +283,11 @@ export class VerticalStackedBarChartBase extends React.Component<
       for (let i = 1; i < lineObject[item].length; i++) {
         const x1 = isNumeric
           ? xScale(lineObject[item][i - 1].xItem.xAxisPoint as number)
-          : xBarScale(lineObject[item][i - 1].index) + this._additionalSpace;
+          : xBarScale(lineObject[item][i - 1].xItem.xAxisPoint as string) + this._additionalSpace;
         const y1 = yScale(lineObject[item][i - 1].y);
         const x2 = isNumeric
           ? xScale(lineObject[item][i].xItem.xAxisPoint as number)
-          : xBarScale(lineObject[item][i].index) + this._additionalSpace;
+          : xBarScale(lineObject[item][i].xItem.xAxisPoint as string) + this._additionalSpace;
         const y2 = yScale(lineObject[item][i].y);
         lines.push(
           <line
@@ -298,6 +299,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             opacity={shouldHighlight ? 1 : 0.1}
             strokeWidth={3}
             stroke={lineObject[item][i].color}
+            transform={`translate(${xScaleBandwidthTranslate}, 0)`}
             {...(isLegendSelected &&
               selectedLegendTitle === item && {
                 onMouseOver: this._lineHover.bind(this, lineObject[item][i - 1]),
@@ -315,7 +317,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             cx={
               isNumeric
                 ? xScale(circlePoint.xItem.xAxisPoint as number)
-                : xBarScale(circlePoint.index) + this._additionalSpace
+                : xBarScale(circlePoint.xItem.xAxisPoint as string) + this._additionalSpace
             }
             cy={yScale(circlePoint.y)}
             onMouseOver={
@@ -332,6 +334,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             fill={this.props.theme!.palette.white}
             strokeWidth={3}
             visibility={this._getCircleVisibilityAndRadius(circlePoint.xItem.xAxisPoint, circlePoint.legend).visibility}
+            transform={`translate(${xScaleBandwidthTranslate}, 0)`}
           />,
         );
       });
@@ -683,7 +686,9 @@ export class VerticalStackedBarChartBase extends React.Component<
     const bars = this._points.map((singleChartData: IVerticalStackedChartProps, indexNumber: number) => {
       let yPoint = containerHeight - this.margins.bottom!;
       const xPoint = xBarScale(
-        this._xAxisType === XAxisTypes.NumericAxis ? (singleChartData.xAxisPoint as number) : indexNumber,
+        this._xAxisType === XAxisTypes.NumericAxis
+          ? (singleChartData.xAxisPoint as number)
+          : (singleChartData.xAxisPoint as string),
       );
 
       // Removing datapoints with zero data
@@ -729,6 +734,8 @@ export class VerticalStackedBarChartBase extends React.Component<
         }
         yPoint = yPoint - barHeight - (index ? gapHeight : 0);
 
+        const xScaleBandwidthTranslate = this._xAxisType === XAxisTypes.NumericAxis ? 0 : xBarScale.bandwidth() / 2;
+
         // If set, apply the corner radius to the top of the final bar
         if (barCornerRadius && barHeight > barCornerRadius && index === barsToDisplay.length - 1) {
           return (
@@ -746,6 +753,7 @@ export class VerticalStackedBarChartBase extends React.Component<
               `}
               fill={color}
               ref={e => (ref.refElement = e)}
+              transform={`translate(${xScaleBandwidthTranslate}, 0)`} // todo do we need this property if there is no translation // test vertical stacked bar chart for RTL.
               {...rectFocusProps}
             />
           );
@@ -765,6 +773,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             ref={e => (ref.refElement = e)}
             {...rectFocusProps}
             role="text"
+            transform={`translate(${xScaleBandwidthTranslate}, 0)`}
           />
         );
       });
@@ -833,13 +842,14 @@ export class VerticalStackedBarChartBase extends React.Component<
 
       return { xBarScale, yBarScale };
     } else {
-      const endpointDistance = 0.5 * ((containerWidth - this.margins.right!) / this._dataset.length);
-      const xBarScale = d3ScaleLinear()
-        .domain(this._isRtl ? [this._dataset.length - 1, 0] : [0, this._dataset.length - 1])
+      const xBarScale = d3ScaleBand()
+        .domain(this._xAxisLabels)
         .range([
-          this.margins.left! + endpointDistance - this._additionalSpace,
-          containerWidth - this.margins.right! - endpointDistance - this._additionalSpace,
-        ]);
+          this.margins.left! - this._additionalSpace,
+          containerWidth - this.margins.right! - this._additionalSpace,
+        ])
+        .padding(this.props.xAxisPadding || 0.1);
+
       return { xBarScale, yBarScale };
     }
   };

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
@@ -101,6 +101,11 @@ export interface IVerticalStackedBarChartProps extends ICartesianChartProps {
    * The prop used to define the culture to localized the numbers
    */
   culture?: string;
+
+  /**
+   * it's padding between bar's or lines in the graph
+   */
+  xAxisPadding?: number;
 }
 
 export interface IVerticalStackedBarChartStyleProps extends ICartesianChartStyleProps {}

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChartPage.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChartPage.tsx
@@ -51,6 +51,7 @@ export class VerticalBarChartPage extends React.Component<IComponentDemoPageProp
           <PropertiesTableSet
             sources={[
               require<string>('!raw-loader?esModule=false!@fluentui/react-charting/src/components/VerticalBarChart/VerticalBarChart.types.ts'),
+              require<string>('!raw-loader?esModule=false!@fluentui/react-charting/src/components/CommonComponents/CartesianChart.types.ts'),
             ]}
           />
         }

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChartPage.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChartPage.tsx
@@ -64,6 +64,17 @@ export class VerticalBarChartPage extends React.Component<IComponentDemoPageProp
               along the vertical axis.
             </p>
             <p>The bar widths are proportional to the number of bars and space available within the charting area.</p>
+            <br />
+            <h3>Implementation details</h3>
+            <p>
+              The current vertical bar charts implementation is in the cartesian coordinate system. The cartesian
+              coordinate system is represented by Cartesian Chart which serves as the base class for vertical bar charts
+            </p>
+          </div>
+        }
+        bestPractices={
+          <div>
+            <p>Coming soon.</p>
           </div>
         }
       />


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently labels in vertical bar chart are not correctly aligned with the bars.
In donut charts, a zero valued datapoint can show up.

## New Behavior

Both of the above issues are fixed.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

Switched from linear scale to d3 band scale which is the correct scale to be used for vertical bar charts.
For donut chart, added a filter condition to remove datapoints having 0 or less to be shown in the pie chart.