### PR TITLE
ci: add node.js engines restrictions/source of truth

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,5 +2,5 @@
   "buildCommand": "build:codesandbox",
   "packages": ["packages/react", "packages/react-components/react-components"],
   "sandboxes": ["x5u3t", "spnyu"],
-  "node": "12"
+  "node": "14"
 }

--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -2,8 +2,8 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '14.x'
-      checkLatest: true
+      versionSpec: '14.18.1'
+      checkLatest: false
     displayName: 'Install Node.js'
 
   - script: |

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"
   },
+  "engines": {
+    "node": "^14.18.1 || ^16.0.0"
+  },
   "scripts": {
     "build": "lage build --verbose",
     "build:codesandbox": "yarn build --to @fluentui/react --to @fluentui/react-components --min",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- our wiki says that we support node 14 and node 16 but there are no tooling restrictions
- our CI is using 14.x
- contributors can use any version, thus run into unexpected issues
- after adding griffel lint user on node lower than 14.7 wont be able to install dependencies locally
  - https://github.com/microsoft/fluentui/pull/22961/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deR5966 

## New Behavior

- we cover our wiki  node support 14 by tooling
- our ci is using explicitly 14.8.1 which is last supported version to make everything work
- we setup `"engines"` in our package.json to enforce contributors to use node versions that are LTS and latest maintenance mode (14.8.1)

### NOTE 💡: 
- what about NodeJS v18 (Current) support - ATM we use dependencies that don't support Node 18 (eslint-plugin-jsdoc), thus installing deps would throw an error. 
  - ![using node v18 dependency error during installation](https://user-images.githubusercontent.com/1223799/168820428-e4b58db7-60c6-45f3-9b94-42255f976031.png)
  -  until we migrate to latest this just follows prescription of our dependencies
- if you're using unsupported version of Node that don't fall into our supported version range, you'll need to update Node.js accordingly on your machine, otherwise you won't be able to contribute. Thanks for understanding 🙌.


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/microsoft/fluentui/issues/23031
