### PR TITLE
fix: remove deprecated branches to fix styles caching in Avatar

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### BREAKING CHANGES
 - Change default Divider color in light and dark theme @yuanboxue-amber ([#22665](https://github.com/microsoft/fluentui/pull/22665))
+- Do not pass deprecated `.styles` to slots in `Avatar` @layershifter ([#23034](https://github.com/microsoft/fluentui/pull/23034))
 
 ### Features
 - Adding the `MicPulse` and `MicPulseOff` icons @sfilipi ([#22944](https://github.com/microsoft/fluentui/pull/22944))

--- a/packages/fluentui/docs/src/examples/components/Avatar/Visual/AvatarStatusOverrideExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Avatar/Visual/AvatarStatusOverrideExample.shorthand.tsx
@@ -5,8 +5,8 @@ const AvatarExampleShorthand = () => (
   <Provider
     theme={{
       componentStyles: {
-        Avatar: {
-          status: ({ variables: v }) => ({ ...(v.isFoo && { backgroundColor: 'red' }) }),
+        AvatarStatus: {
+          root: ({ variables: v }) => ({ ...(v.isFoo && { backgroundColor: 'red' }) }),
         },
       },
     }}
@@ -21,8 +21,8 @@ const AvatarExampleShorthand = () => (
       status={{
         icon: <AcceptIcon />,
         title: 'Available',
+        variables: { isFoo: true },
       }}
-      variables={{ isFoo: true }}
     />
   </Provider>
 );

--- a/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
@@ -82,7 +82,7 @@ export const Avatar = (React.forwardRef<HTMLDivElement, AvatarProps>((props, ref
     debugName: Avatar.displayName,
     rtl: context.rtl,
   });
-  const { classes, styles: resolvedStyles } = useStyles(Avatar.displayName, {
+  const { classes } = useStyles(Avatar.displayName, {
     className: avatarClassName,
     mapPropsToStyles: () => ({ size, square }),
     mapPropsToInlineStyles: () => ({
@@ -103,8 +103,6 @@ export const Avatar = (React.forwardRef<HTMLDivElement, AvatarProps>((props, ref
         avatar: !square,
         title: name,
         size,
-        // remove in upcoming breaking change
-        styles: resolvedStyles.image,
       }),
   });
 
@@ -112,7 +110,6 @@ export const Avatar = (React.forwardRef<HTMLDivElement, AvatarProps>((props, ref
     defaultProps: () =>
       getA11Props('icon', {
         title: name,
-        styles: resolvedStyles.icon,
         size,
         square,
       }),
@@ -126,7 +123,6 @@ export const Avatar = (React.forwardRef<HTMLDivElement, AvatarProps>((props, ref
         title: name,
         size,
         square,
-        styles: resolvedStyles.label,
       }),
   });
 
@@ -140,8 +136,6 @@ export const Avatar = (React.forwardRef<HTMLDivElement, AvatarProps>((props, ref
         defaultProps: () =>
           getA11Props('status', {
             size,
-            // remove in upcoming breaking change
-            styles: resolvedStyles.status,
           }),
         overrideProps: (predefinedProps: AvatarStatusProps) => ({
           variables: mergeVariablesOverrides(variables, predefinedProps.variables),


### PR DESCRIPTION
# BREAKING CHANGES

`Avatar` components will not longer pass via `styles` down to components. We left it for compat reasons, but it breaks styles caching.

For full context and migration plan please check #16428, #16417, #16409, #16382.

### Before

![image](https://user-images.githubusercontent.com/14183168/168825705-e3f8820c-e596-408f-a1f8-6161b136b2b4.png)


### After

![image](https://user-images.githubusercontent.com/14183168/168819400-e32eecb6-068a-43ef-8919-9f000fd67469.png)


