### PR TITLE
Select: fix icon positioning

### DIFF
--- a/packages/react-components/react-select/src/components/Select/useSelectStyles.ts
+++ b/packages/react-components/react-select/src/components/Select/useSelectStyles.ts
@@ -137,7 +137,7 @@ const useIconStyles = makeStyles({
     color: tokens.colorNeutralStrokeAccessible,
     display: 'block',
     position: 'absolute',
-    right: '0',
+    right: tokens.spacingHorizontalMNudge,
     pointerEvents: 'none',
 
     // the SVG must have display: block for accurate positioning


### PR DESCRIPTION
## Current Behavior

Select's "down" icon is positioned with `right: 0` causing the icon to be displayed right against the edge of Select.

## New Behavior

Select's "down" icon is positioned with `right: tokens.spacingHorizontalMNudge` which is the same token used to pad Select's text.

Griffel automatically transforms this to `left: ...` when Select is used in a right-to-left context.


