### PR TITLE
react-select: update contrast in appearance stories

### DIFF
--- a/packages/react-components/react-select/src/stories/Select.stories.tsx
+++ b/packages/react-components/react-select/src/stories/Select.stories.tsx
@@ -1,6 +1,8 @@
 import { Select } from '../Select';
 import selectDescription from '../SelectDescription.md';
 
+import bestPracticesMd from './SelectBestPractices.md';
+
 export { Default } from './SelectDefault.stories';
 export { Appearance } from './SelectAppearance.stories';
 export { Controlled } from './SelectControlled.stories';
@@ -15,7 +17,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: [selectDescription].join('\n'),
+        component: [selectDescription, bestPracticesMd].join('\n'),
       },
     },
   },

--- a/packages/react-components/react-select/src/stories/SelectAppearance.stories.tsx
+++ b/packages/react-components/react-select/src/stories/SelectAppearance.stories.tsx
@@ -21,13 +21,13 @@ const useStyles = makeStyles({
   filledLighter: {
     backgroundColor: '#8a8a8a',
     '> label': {
-      color: '#ffffff',
+      color: '#000000',
     },
   },
   filledDarker: {
     backgroundColor: '#8a8a8a',
     '> label': {
-      color: '#ffffff',
+      color: '#000000',
     },
   },
 });

--- a/packages/react-components/react-select/src/stories/SelectAppearance.stories.tsx
+++ b/packages/react-components/react-select/src/stories/SelectAppearance.stories.tsx
@@ -1,40 +1,79 @@
 import * as React from 'react';
 import { Select } from '../index';
 import { useId } from '@fluentui/react-utilities';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { tokens } from '@fluentui/react-theme';
+
+const useStyles = makeStyles({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    maxWidth: '500px',
+  },
+
+  field: {
+    display: 'grid',
+    gridRowGap: tokens.spacingVerticalXXS,
+    marginTop: tokens.spacingVerticalMNudge,
+    ...shorthands.padding(tokens.spacingVerticalMNudge, tokens.spacingHorizontalMNudge),
+  },
+
+  filledLighter: {
+    backgroundColor: '#8a8a8a',
+    '> label': {
+      color: '#ffffff',
+    },
+  },
+  filledDarker: {
+    backgroundColor: '#8a8a8a',
+    '> label': {
+      color: '#ffffff',
+    },
+  },
+});
 
 export const Appearance = () => {
+  const styles = useStyles();
   const selectId = useId();
 
   return (
-    <>
-      <label htmlFor={`${selectId}-outline`}>Outline</label>
-      <Select id={`${selectId}-outline`} appearance="outline">
-        <option>Red</option>
-        <option>Green</option>
-        <option>Blue</option>
-      </Select>
+    <div className={styles.base}>
+      <div className={styles.field}>
+        <label htmlFor={`${selectId}-outline`}>Outline</label>
+        <Select id={`${selectId}-outline`} appearance="outline">
+          <option>Red</option>
+          <option>Green</option>
+          <option>Blue</option>
+        </Select>
+      </div>
 
-      <label htmlFor={`${selectId}-underline`}>Underline</label>
-      <Select id={`${selectId}-underline`} appearance="underline">
-        <option>Red</option>
-        <option>Green</option>
-        <option>Blue</option>
-      </Select>
+      <div className={styles.field}>
+        <label htmlFor={`${selectId}-underline`}>Underline</label>
+        <Select id={`${selectId}-underline`} appearance="underline">
+          <option>Red</option>
+          <option>Green</option>
+          <option>Blue</option>
+        </Select>
+      </div>
 
-      <label htmlFor={`${selectId}-filledDarker`}>Filled Darker</label>
-      <Select id={`${selectId}-filledDarker`} appearance="filledDarker">
-        <option>Red</option>
-        <option>Green</option>
-        <option>Blue</option>
-      </Select>
+      <div className={mergeClasses(styles.field, styles.filledLighter)}>
+        <label htmlFor={`${selectId}-filledLighter`}>Filled Lighter</label>
+        <Select id={`${selectId}-filledLighter`} appearance="filledLighter">
+          <option>Red</option>
+          <option>Green</option>
+          <option>Blue</option>
+        </Select>
+      </div>
 
-      <label htmlFor={`${selectId}-filledLighter`}>Filled Lighter</label>
-      <Select id={`${selectId}-filledLighter`} appearance="filledLighter">
-        <option>Red</option>
-        <option>Green</option>
-        <option>Blue</option>
-      </Select>
-    </>
+      <div className={mergeClasses(styles.field, styles.filledDarker)}>
+        <label htmlFor={`${selectId}-filledDarker`}>Filled Darker</label>
+        <Select id={`${selectId}-filledDarker`} appearance="filledDarker">
+          <option>Red</option>
+          <option>Green</option>
+          <option>Blue</option>
+        </Select>
+      </div>
+    </div>
   );
 };
 
@@ -42,11 +81,10 @@ Appearance.parameters = {
   docs: {
     description: {
       story:
-        'A Select can have the following `appearance` variants:\n' +
-        '- `outline` (default): has a border around all four sides.\n' +
-        '- `underline`: only has a bottom border.\n' +
-        '- `filledDarker`: no border, only a subtle background color difference against a white page.\n' +
-        '- `filledLighter`: no border, and a white background.\n',
+        `Select can have different appearances.\n` +
+        `The colors adjacent to the input should have a sufficient contrast. Particularly, the color of input with
+    filled darker and lighter styles needs to provide greater than 3 to 1 contrast ratio against the immediate
+    surrounding color to pass accessibility requirements.`,
     },
   },
 };

--- a/packages/react-components/react-select/src/stories/SelectBestPractices.md
+++ b/packages/react-components/react-select/src/stories/SelectBestPractices.md
@@ -1,0 +1,9 @@
+## Best practices
+
+### Do
+
+- **Consider using `Select` with underline or outline appearances.** When the contrast ratio against the immediate surrounding color is less than 3:1, consider using underline or outline styles which has a bottom border stroke. But please ensure the color of bottom border stroke has a sufficient contrast which is greater than 3 to 1 against the immediate surrounding.
+
+### Don't
+
+- **Don’t place `Select` on a surface which doesn’t have a sufficient contrast.** The colors adjacent to the input should have a sufficient contrast. Particularly, the color of input with filled darker and lighter styles needs to provide greater than 3 to 1 contrast ratio against the immediate surrounding color to pass accessibility requirements.


### PR DESCRIPTION
## Current Behavior

Select appearance stories for filledLighter and filledDarker are not against a sufficiently contrasting background.

## New Behavior

- Select appearance stories for filledLighter and filledDarker are against a sufficiently contrasting background.
- Adds a best practices MD file with do's and don'ts for contrast
- Adds contrast guidance to the appearance story description

## Related Issue(s)

#22967