### PR TITLE
fix(SplitButton): update flex styles so the inner splitbutton stretches to fill the root

### DIFF
--- a/change/@fluentui-react-0c3014eb-a6a2-4164-9b1c-2415ab57a8dd.json
+++ b/change/@fluentui-react-0c3014eb-a6a2-4164-9b1c-2415ab57a8dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update splitbutton styles so inner buttons stretch to fill root button container",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -638,7 +638,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         aria-roledescription={buttonProps['aria-roledescription']}
         onFocusCapture={this._onSplitContainerFocusCapture}
       >
-        <span style={{ display: 'flex' }}>
+        <span style={{ display: 'flex', width: '100%' }}>
           {this._onRenderContent(tag, buttonProps)}
           {this._onRenderSplitButtonMenuButton(classNames, keytipAttributes)}
           {this._onRenderSplitButtonDivider(classNames)}

--- a/packages/react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -33,11 +33,13 @@ export const getStyles = memoizeFunction(
               borderTopRightRadius: '0',
               borderBottomRightRadius: '0',
               borderRight: 'none',
+              flexGrow: '1',
             },
             '.ms-Button--primary': {
               borderTopRightRadius: '0',
               borderBottomRightRadius: '0',
               border: 'none',
+              flexGrow: '1',
 
               selectors: {
                 [HighContrastSelector]: {


### PR DESCRIPTION
Fixes #21334

Previously, if the root button of `SplitButton` had its width set greater than the default width of its inner content, the inner buttons did not stretch to fit the root width. This PR updates internal splitbutton styles to fix this.

Past behavior:
![screenshot showing regular buttons filling full screen width, and splitbuttons appearing at their default smaller width](https://user-images.githubusercontent.com/3819570/168933099-87bb6052-7c85-43b4-800e-4d1ab66b6745.png)


New behavior:
![screenshot showing splitbuttons filling full page width](https://user-images.githubusercontent.com/3819570/168933077-f0828cfc-0ed1-4c27-9d97-79dda7664058.png)
