### PR TITLE
feat(v9): migrate badge to ship rolluped only dts

### DIFF
--- a/change/@fluentui-react-badge-51877968-a3ea-468a-b353-198c0346e1dc.json
+++ b/change/@fluentui-react-badge-51877968-a3ea-468a-b353-198c0346e1dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "react-badge: ship rolluped only dts.",
+  "packageName": "@fluentui/react-badge",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-badge/.npmignore
+++ b/packages/react-components/react-badge/.npmignore
@@ -7,6 +7,7 @@ e2e/
 etc/
 node_modules/
 src/
+dist/types/
 temp/
 __fixtures__
 __mocks__

--- a/packages/react-components/react-badge/config/api-extractor.json
+++ b/packages/react-components/react-badge/config/api-extractor.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json"
+  "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
 }

--- a/packages/react-components/react-badge/config/api-extractor.local.json
+++ b/packages/react-components/react-badge/config/api-extractor.local.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "extends": "./api-extractor.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/packages/react-components/<unscopedPackageName>/src/index.d.ts"
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/packages/react-components/<unscopedPackageName>/src/index.d.ts"
 }

--- a/packages/react-components/react-badge/package.json
+++ b/packages/react-components/react-badge/package.json
@@ -4,7 +4,7 @@
   "description": "React components for building web experiences",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
@@ -21,7 +21,7 @@
     "start": "yarn storybook",
     "test": "jest --passWithNoTests",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
-    "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../../scripts/typescript/normalize-import --output ./dist/packages/react-components/react-badge/src && yarn docs",
+    "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../../scripts/typescript/normalize-import --output ./dist/types/packages/react-components/react-badge/src && yarn docs",
     "storybook": "node ../../../scripts/storybook/runner",
     "type-check": "tsc -b tsconfig.json"
   },

--- a/packages/react-components/react-badge/tsconfig.lib.json
+++ b/packages/react-components/react-badge/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "lib": ["ES2019", "dom"],
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
+    "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
   "exclude": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Applied `yarn nx workspace-generator migrate-converged-pkg` to ship only rolluped type definitions for:
- react-badge

## Related Issue(s)

Fixes partially https://github.com/microsoft/fluentui/issues/22429
