### PR TITLE
(fix): Broken storybook test in react-components fixed after accordion move

### DIFF
--- a/change/@fluentui-react-components-7bb589d2-fd19-4663-bea3-71732661b54e.json
+++ b/change/@fluentui-react-components-7bb589d2-fd19-4663-bea3-71732661b54e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "react-components: fix broken storybook test.",
+  "packageName": "@fluentui/react-components",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/.storybook/main.utils.test.js
+++ b/packages/react-components/react-components/.storybook/main.utils.test.js
@@ -6,7 +6,7 @@ describe(`main utils`, () => {
     it(`should generate storybook stories string array of glob based on package.json#dependencies field`, () => {
       const actual = utils.getVnextStories();
       const expected = [
-        expect.stringContaining('../../../react-'),
+        expect.stringContaining('../../react-'),
         expect.stringContaining('/src/**/*.stories.@(ts|tsx|mdx)'),
       ];
 


### PR DESCRIPTION


## Current Behavior

<!-- This is the behavior we have today -->
- Storybook test for `react-components` is broken in `master` branch after `react-accordion` package was moved in #22827:
![image](https://user-images.githubusercontent.com/8649804/169085131-484c96bc-4f60-4856-8457-5c8428586783.png)


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- Test is fixed:

![image](https://user-images.githubusercontent.com/8649804/169085347-c864cb68-a3a3-4daa-a065-12c0693d871e.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
