### PR TITLE
(chore) Cleanup getVnextStories function now that all v9 packages have been moved to common folder

### DIFF
--- a/apps/public-docsite-v9/.storybook/main.utils.js
+++ b/apps/public-docsite-v9/.storybook/main.utils.js
@@ -19,17 +19,10 @@ function getVnextStories() {
 
   return Object.keys({ ...dependencies, '@fluentui/react-components': '' })
     .filter(pkgName => pkgName.startsWith('@fluentui/'))
-    .map(pkgName => {
-      const name = pkgName.replace('@fluentui/', '');
-      const storiesGlob = '/src/**/*.stories.@(ts|tsx|mdx)';
-
-      //TODO: simplify once all v9 packages have been moved to the new react-components subfolder.
-      if (fs.existsSync(`../../packages/${name}/package.json`)) {
-        return `../../../packages/${name}${storiesGlob}`;
-      } else {
-        return `../../../packages/react-components/${name}${storiesGlob}`;
-      }
-    });
+    .map(
+      pkgName =>
+        '../../../packages/react-components/' + pkgName.replace('@fluentui/', '') + '/src/**/*.stories.@(ts|tsx|mdx)',
+    );
 }
 
 exports.getVnextStories = getVnextStories;

--- a/apps/public-docsite-v9/.storybook/main.utils.js
+++ b/apps/public-docsite-v9/.storybook/main.utils.js
@@ -19,10 +19,12 @@ function getVnextStories() {
 
   return Object.keys({ ...dependencies, '@fluentui/react-components': '' })
     .filter(pkgName => pkgName.startsWith('@fluentui/'))
-    .map(
-      pkgName =>
-        '../../../packages/react-components/' + pkgName.replace('@fluentui/', '') + '/src/**/*.stories.@(ts|tsx|mdx)',
-    );
+    .map(pkgName => {
+      const name = pkgName.replace('@fluentui/', '');
+      const storiesGlob = '/src/**/*.stories.@(ts|tsx|mdx)';
+
+      return `../../../packages/react-components/${name}${storiesGlob}`;
+    });
 }
 
 exports.getVnextStories = getVnextStories;

--- a/change/@fluentui-react-components-bceca457-a419-4d28-9017-f25641f217a4.json
+++ b/change/@fluentui-react-components-bceca457-a419-4d28-9017-f25641f217a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "react-components: simplify getVnextStories util function.",
+  "packageName": "@fluentui/react-components",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/.storybook/main.utils.js
+++ b/packages/react-components/react-components/.storybook/main.utils.js
@@ -14,7 +14,12 @@ function getVnextStories() {
 
   return Object.keys(dependencies)
     .filter(pkgName => pkgName.startsWith('@fluentui/'))
-    .map(pkgName => '../../' + pkgName.replace('@fluentui/', '') + '/src/**/*.stories.@(ts|tsx|mdx)');
+    .map(pkgName => {
+      const name = pkgName.replace('@fluentui/', '');
+      const storiesGlob = '/src/**/*.stories.@(ts|tsx|mdx)';
+
+      return `../../${name}${storiesGlob}`;
+    });
 }
 
 exports.getVnextStories = getVnextStories;

--- a/packages/react-components/react-components/.storybook/main.utils.js
+++ b/packages/react-components/react-components/.storybook/main.utils.js
@@ -14,18 +14,7 @@ function getVnextStories() {
 
   return Object.keys(dependencies)
     .filter(pkgName => pkgName.startsWith('@fluentui/'))
-    .map(pkgName => {
-      const name = pkgName.replace('@fluentui/', '');
-      const storiesGlob = '/src/**/*.stories.@(ts|tsx|mdx)';
-      const pkgUnmigratedPath = `../../${name}`;
-      const pkgMigratedPath = `../${name}`;
-      //TODO: simplify once all v9 packages have been moved to the new react-components subfolder.
-      if (fs.existsSync(pkgUnmigratedPath + '/package.json')) {
-        return `../${pkgUnmigratedPath}${storiesGlob}`;
-      } else {
-        return `../${pkgMigratedPath}${storiesGlob}`;
-      }
-    });
+    .map(pkgName => '../../' + pkgName.replace('@fluentui/', '') + '/src/**/*.stories.@(ts|tsx|mdx)');
 }
 
 exports.getVnextStories = getVnextStories;


### PR DESCRIPTION
## Changes
- Follow-up to TODO items to simplify `getVnextStories` util function now that all v9 packages have been moved to common folder.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Part of #22427
