### PR TITLE
Removing ToggleButtonCommons type in @fluentui/react-button

### DIFF
--- a/change/@fluentui-react-button-fc2226f9-0a2b-4a6d-8fc1-af544f362a71.json
+++ b/change/@fluentui-react-button-fc2226f9-0a2b-4a6d-8fc1-af544f362a71.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing ToggleButtonCommons type in @fluentui/react-button.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/etc/react-button.api.md
+++ b/packages/react-components/react-button/etc/react-button.api.md
@@ -132,7 +132,7 @@ export const toggleButtonClassNames: SlotClassNames<ButtonSlots>;
 // @public (undocumented)
 export type ToggleButtonProps = ButtonProps & {
     defaultChecked?: boolean;
-    checked: boolean;
+    checked?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-button/etc/react-button.api.md
+++ b/packages/react-components/react-button/etc/react-button.api.md
@@ -130,12 +130,13 @@ export const toggleButtonClassName: string;
 export const toggleButtonClassNames: SlotClassNames<ButtonSlots>;
 
 // @public (undocumented)
-export type ToggleButtonProps = ButtonProps & Partial<ToggleButtonCommons> & {
+export type ToggleButtonProps = ButtonProps & {
     defaultChecked?: boolean;
+    checked: boolean;
 };
 
 // @public (undocumented)
-export type ToggleButtonState = ButtonState & ToggleButtonCommons;
+export type ToggleButtonState = ButtonState & Required<Pick<ToggleButtonProps, 'checked'>>;
 
 // @public
 export const useButton_unstable: (props: ButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ButtonState;

--- a/packages/react-components/react-button/src/components/ToggleButton/ToggleButton.types.ts
+++ b/packages/react-components/react-button/src/components/ToggleButton/ToggleButton.types.ts
@@ -1,23 +1,22 @@
 import type { ButtonProps, ButtonState } from '../Button/Button.types';
 
-type ToggleButtonCommons = {
+export type ToggleButtonProps = ButtonProps & {
+  /**
+   * Defines whether the `ToggleButton` is initially in a checked state or not when rendered.
+   *
+   * @default false
+   */
+  defaultChecked?: boolean;
+
   /**
    * Defines the controlled checked state of the `ToggleButton`.
    * If passed, `ToggleButton` ignores the `defaultChecked` property.
    * This should only be used if the checked state is to be controlled at a higher level and there is a plan to pass the
    * correct value based on handling `onClick` events and re-rendering.
+   *
    * @default false
    */
   checked: boolean;
 };
 
-export type ToggleButtonProps = ButtonProps &
-  Partial<ToggleButtonCommons> & {
-    /**
-     * Defines whether the `ToggleButton` is initially in a checked state or not when rendered.
-     * @default false
-     */
-    defaultChecked?: boolean;
-  };
-
-export type ToggleButtonState = ButtonState & ToggleButtonCommons;
+export type ToggleButtonState = ButtonState & Required<Pick<ToggleButtonProps, 'checked'>>;

--- a/packages/react-components/react-button/src/components/ToggleButton/ToggleButton.types.ts
+++ b/packages/react-components/react-button/src/components/ToggleButton/ToggleButton.types.ts
@@ -16,7 +16,7 @@ export type ToggleButtonProps = ButtonProps & {
    *
    * @default false
    */
-  checked: boolean;
+  checked?: boolean;
 };
 
 export type ToggleButtonState = ButtonState & Required<Pick<ToggleButtonProps, 'checked'>>;


### PR DESCRIPTION
## PR Description

This PR removes the `ToggleButtonCommons` type pattern in the types for our `ToggleButton` component.

## Related Issue(s)

Fixes part of #22862
