### PR TITLE
Removing SelectCommons type in @fluentui/react-select

### DIFF
--- a/packages/react-components/react-select/etc/react-select.api.md
+++ b/packages/react-components/react-select/etc/react-select.api.md
@@ -24,14 +24,11 @@ export const selectClassName = "fui-Select";
 export const selectClassNames: SlotClassNames<SelectSlots>;
 
 // @public (undocumented)
-export interface SelectCommons {
+export type SelectProps = Omit<ComponentProps<Partial<SelectSlots>, 'select'>, 'size'> & {
     appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
     inline?: boolean;
     size?: 'small' | 'medium' | 'large';
-}
-
-// @public (undocumented)
-export type SelectProps = Omit<ComponentProps<Partial<SelectSlots>, 'select'>, 'size'> & SelectCommons;
+};
 
 // @public (undocumented)
 export type SelectSlots = {
@@ -41,7 +38,7 @@ export type SelectSlots = {
 };
 
 // @public (undocumented)
-export type SelectState = ComponentState<SelectSlots> & Required<SelectCommons>;
+export type SelectState = ComponentState<SelectSlots> & Required<Pick<SelectProps, 'appearance' | 'inline' | 'size'>>;
 
 // @public
 export const useSelect_unstable: (props: SelectProps, ref: React_2.Ref<HTMLSelectElement>) => SelectState;

--- a/packages/react-components/react-select/src/components/Select/Select.types.ts
+++ b/packages/react-components/react-select/src/components/Select/Select.types.ts
@@ -15,27 +15,28 @@ export type SelectSlots = {
   icon: Slot<'span'>;
 };
 
-export interface SelectCommons {
+export type SelectProps = Omit<ComponentProps<Partial<SelectSlots>, 'select'>, 'size'> & {
   /**
-   * Matches the Input sizes
-   * @default 'medium'
+   * Controls the colors and borders of the Select.
+   *
+   * @default 'outline'
    */
-  size?: 'small' | 'medium' | 'large';
+  appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
 
   /**
    * If true, the Select will have an inline `display`, allowing it to be inline with other content.
    * By default, Select has block layout.
+   *
    * @default false
    */
   inline?: boolean;
 
   /**
-   * Controls the colors and borders of the Select.
-   * @default 'outline'
+   * Matches the Input sizes
+   *
+   * @default 'medium'
    */
-  appearance?: 'outline' | 'underline' | 'filledDarker' | 'filledLighter';
-}
+  size?: 'small' | 'medium' | 'large';
+};
 
-export type SelectProps = Omit<ComponentProps<Partial<SelectSlots>, 'select'>, 'size'> & SelectCommons;
-
-export type SelectState = ComponentState<SelectSlots> & Required<SelectCommons>;
+export type SelectState = ComponentState<SelectSlots> & Required<Pick<SelectProps, 'appearance' | 'inline' | 'size'>>;

--- a/packages/react-components/react-select/src/index.ts
+++ b/packages/react-components/react-select/src/index.ts
@@ -7,4 +7,4 @@ export {
   useSelectStyles_unstable,
   useSelect_unstable,
 } from './Select';
-export type { SelectCommons, SelectProps, SelectSlots, SelectState } from './Select';
+export type { SelectProps, SelectSlots, SelectState } from './Select';


### PR DESCRIPTION
## PR Description

This PR removes the `Commons` type pattern in the types for our `Select` component.

## Related Issue(s)

Fixes part of #22862
