### PR TITLE
Accessibility: appearance filled contrast fix

### DIFF
--- a/packages/react-components/react-input/src/stories/InputAppearance.stories.tsx
+++ b/packages/react-components/react-input/src/stories/InputAppearance.stories.tsx
@@ -1,37 +1,33 @@
 import * as React from 'react';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@griffel/react';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import { Input } from '../index';
-import { Text } from '@fluentui/react-text';
 
 const useStyles = makeStyles({
   base: {
     display: 'flex',
     flexDirection: 'column',
     maxWidth: '400px',
-    '> div': {
-      display: 'flex',
-      flexDirection: 'column',
-      marginBottom: tokens.spacingVerticalMNudge,
-    },
-    '> div div': {
-      display: 'flex',
-      flexDirection: 'column',
-      ...shorthands.borderRadius(tokens.borderRadiusMedium),
-      ...shorthands.padding(tokens.spacingHorizontalMNudge),
-    },
-    '> div label': {
-      marginBottom: tokens.spacingVerticalXXS,
-      marginLeft: tokens.spacingHorizontalMNudge,
-    },
+  },
+  field: {
+    display: 'grid',
+    gridRowGap: tokens.spacingVerticalXXS,
+    marginTop: tokens.spacingVerticalMNudge,
+    ...shorthands.padding(tokens.spacingHorizontalMNudge),
   },
   filledLighter: {
     backgroundColor: '#8a8a8a',
+    '> label': {
+      color: '#000000',
+    },
   },
   filledDarker: {
     backgroundColor: '#8a8a8a',
+    '> label': {
+      color: '#000000',
+    },
   },
 });
 
@@ -44,40 +40,24 @@ export const Appearance = () => {
 
   return (
     <div className={styles.base}>
-      <div>
+      <div className={styles.field}>
         <Label htmlFor={outlineId}>Outline Input Appearance (default)</Label>
-        <div>
-          <Input appearance="outline" id={outlineId} />
-        </div>
+        <Input appearance="outline" id={outlineId} />
       </div>
 
-      <div>
+      <div className={styles.field}>
         <Label htmlFor={underlineId}>Underline Input Appearance </Label>
-        <div>
-          <Input appearance="underline" id={underlineId} />
-        </div>
+        <Input appearance="underline" id={underlineId} />
       </div>
 
-      <div>
+      <div className={mergeClasses(styles.field, styles.filledLighter)}>
         <Label htmlFor={filledLighterId}>Filled Lighter Input Appearance </Label>
-        <div className={styles.filledLighter}>
-          <Input appearance="filledLighter" id={filledLighterId} />
-        </div>
+        <Input appearance="filledLighter" id={filledLighterId} />
       </div>
 
-      <div>
+      <div className={mergeClasses(styles.field, styles.filledDarker)}>
         <Label htmlFor={filledDarkerId}>Filled Darker Input Appearance </Label>
-        <div className={styles.filledDarker}>
-          <Input appearance="filledDarker" id={filledDarkerId} />
-        </div>
-      </div>
-
-      <div>
-        <Text>
-          The colors adjacent to the input should have a sufficient contrast. Particularly, the color of input with
-          filled darker and lighter styles needs to provide greater than 3 to 1 contrast ratio against the immediate
-          surrounding color to pass accessibility requirements.
-        </Text>
+        <Input appearance="filledDarker" id={filledDarkerId} />
       </div>
     </div>
   );
@@ -86,7 +66,11 @@ export const Appearance = () => {
 Appearance.parameters = {
   docs: {
     description: {
-      story: 'An input can have different appearances.',
+      story:
+        'An input can have different appearances.\n' +
+        `The colors adjacent to the input should have a sufficient contrast. Particularly, the color of input with
+      filled darker and lighter styles needs to provide greater than 3 to 1 contrast ratio against the immediate
+      surrounding color to pass accessibility requirements.`,
     },
   },
 };

--- a/packages/react-components/react-spinbutton/src/stories/SpinButtonAppearance.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButtonAppearance.stories.tsx
@@ -22,13 +22,13 @@ const useStyles = makeStyles({
   filledLighter: {
     backgroundColor: '#8a8a8a',
     '> label': {
-      color: '#ffffff',
+      color: '#000000',
     },
   },
   filledDarker: {
     backgroundColor: '#8a8a8a',
     '> label': {
-      color: '#ffffff',
+      color: '#000000',
     },
   },
 });

--- a/packages/react-components/react-textarea/src/stories/TextareaAppearance.stories.tsx
+++ b/packages/react-components/react-textarea/src/stories/TextareaAppearance.stories.tsx
@@ -23,13 +23,13 @@ const useStyles = makeStyles({
   filledLighter: {
     backgroundColor: '#8a8a8a',
     '> label': {
-      color: '#ffffff',
+      color: '#000000',
     },
   },
   filledDarker: {
     backgroundColor: '#8a8a8a',
     '> label': {
-      color: '#ffffff',
+      color: '#000000',
     },
   },
 });


### PR DESCRIPTION
## Current Behavior

Appearance stories use a white (#ffffff) label against a gray (#8a8a8a) background which only has a 3.45:1 contrast ratio that fails WCAG AA.

## New Behavior

Appearance stories use a black (#000000) label against a gray (#8a8a8a) background which has a 6.08:1 contrast ratio that passes WCAG AA.

## Notes

Used [WebAIM contrast checker](https://webaim.org/resources/contrastchecker/) to get contrast ratios.

