### PR TITLE
Removing FluentProviderCommons type in @fluentui/react-provider

### DIFF
--- a/change/@fluentui-react-provider-1a934471-371e-40d3-a414-9888ed5f7606.json
+++ b/change/@fluentui-react-provider-1a934471-371e-40d3-a414-9888ed5f7606.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing FluentProviderCommons type.",
+  "packageName": "@fluentui/react-provider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-provider/etc/react-provider.api.md
+++ b/packages/react-components/react-provider/etc/react-provider.api.md
@@ -4,21 +4,25 @@
 
 ```ts
 
-import type { ComponentProps } from '@fluentui/react-utilities';
+import { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { PartialTheme } from '@fluentui/react-theme';
 import type { ProviderContextValue } from '@fluentui/react-shared-contexts';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import { SlotClassNames } from '@fluentui/react-utilities';
-import type { Theme } from '@fluentui/react-theme';
+import { Theme } from '@fluentui/react-theme';
 import type { ThemeClassNameContextValue } from '@fluentui/react-shared-contexts';
 import type { TooltipContextType } from '@fluentui/react-shared-contexts';
 import { useFluent } from '@fluentui/react-shared-contexts';
 import { useTheme } from '@fluentui/react-shared-contexts';
 
 // @public (undocumented)
-export const FluentProvider: React_2.ForwardRefExoticComponent<FluentProviderProps & React_2.RefAttributes<HTMLElement>>;
+export const FluentProvider: React_2.ForwardRefExoticComponent<Omit<ComponentProps<FluentProviderSlots, "root">, "dir"> & {
+    dir?: "ltr" | "rtl" | undefined;
+    targetDocument: Document | undefined;
+    theme?: Partial<Theme> | undefined;
+} & React_2.RefAttributes<HTMLElement>>;
 
 // @public @deprecated (undocumented)
 export const fluentProviderClassName = "fui-FluentProvider";
@@ -27,22 +31,19 @@ export const fluentProviderClassName = "fui-FluentProvider";
 export const fluentProviderClassNames: SlotClassNames<FluentProviderSlots>;
 
 // @public (undocumented)
-export interface FluentProviderContextValues extends Pick<FluentProviderState, 'theme'> {
-    // (undocumented)
+export type FluentProviderContextValues = Pick<FluentProviderState, 'theme'> & {
     provider: ProviderContextValue;
-    // (undocumented)
-    textDirection: 'ltr' | 'rtl';
-    // (undocumented)
     themeClassName: ThemeClassNameContextValue;
-    // (undocumented)
+    textDirection: 'ltr' | 'rtl';
     tooltip: TooltipContextType;
-}
+};
 
 // @public (undocumented)
-export interface FluentProviderProps extends Omit<ComponentProps<FluentProviderSlots>, 'dir'>, Partial<FluentProviderCommons> {
-    // (undocumented)
+export type FluentProviderProps = Omit<ComponentProps<FluentProviderSlots>, 'dir'> & {
+    dir?: 'ltr' | 'rtl';
+    targetDocument: Document | undefined;
     theme?: PartialTheme;
-}
+};
 
 // @public (undocumented)
 export type FluentProviderSlots = {
@@ -50,12 +51,10 @@ export type FluentProviderSlots = {
 };
 
 // @public (undocumented)
-export interface FluentProviderState extends ComponentState<FluentProviderSlots>, FluentProviderCommons {
-    // (undocumented)
+export type FluentProviderState = ComponentState<FluentProviderSlots> & Required<Pick<FluentProviderProps, 'dir' | 'targetDocument'>> & {
     theme: Theme | Partial<Theme> | undefined;
-    // (undocumented)
     themeClassName: string;
-}
+};
 
 // @public
 export const renderFluentProvider_unstable: (state: FluentProviderState, contextValues: FluentProviderContextValues) => JSX.Element;

--- a/packages/react-components/react-provider/etc/react-provider.api.md
+++ b/packages/react-components/react-provider/etc/react-provider.api.md
@@ -20,7 +20,7 @@ import { useTheme } from '@fluentui/react-shared-contexts';
 // @public (undocumented)
 export const FluentProvider: React_2.ForwardRefExoticComponent<Omit<ComponentProps<FluentProviderSlots, "root">, "dir"> & {
     dir?: "ltr" | "rtl" | undefined;
-    targetDocument: Document | undefined;
+    targetDocument?: Document | undefined;
     theme?: Partial<Theme> | undefined;
 } & React_2.RefAttributes<HTMLElement>>;
 
@@ -41,7 +41,7 @@ export type FluentProviderContextValues = Pick<FluentProviderState, 'theme'> & {
 // @public (undocumented)
 export type FluentProviderProps = Omit<ComponentProps<FluentProviderSlots>, 'dir'> & {
     dir?: 'ltr' | 'rtl';
-    targetDocument: Document | undefined;
+    targetDocument?: Document;
     theme?: PartialTheme;
 };
 
@@ -51,7 +51,7 @@ export type FluentProviderSlots = {
 };
 
 // @public (undocumented)
-export type FluentProviderState = ComponentState<FluentProviderSlots> & Required<Pick<FluentProviderProps, 'dir' | 'targetDocument'>> & {
+export type FluentProviderState = ComponentState<FluentProviderSlots> & Pick<FluentProviderProps, 'targetDocument'> & Required<Pick<FluentProviderProps, 'dir'>> & {
     theme: Theme | Partial<Theme> | undefined;
     themeClassName: string;
 };

--- a/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.types.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.types.ts
@@ -10,28 +10,25 @@ export type FluentProviderSlots = {
   root: Slot<'div'>;
 };
 
-interface FluentProviderCommons {
+export type FluentProviderProps = Omit<ComponentProps<FluentProviderSlots>, 'dir'> & {
   /** Sets the direction of text & generated styles. */
-  dir: 'ltr' | 'rtl';
+  dir?: 'ltr' | 'rtl';
 
   /** Provides the document, can be undefined during SSR render. */
   targetDocument: Document | undefined;
-}
 
-export interface FluentProviderProps
-  extends Omit<ComponentProps<FluentProviderSlots>, 'dir'>,
-    Partial<FluentProviderCommons> {
   theme?: PartialTheme;
-}
+};
 
-export interface FluentProviderState extends ComponentState<FluentProviderSlots>, FluentProviderCommons {
-  theme: Theme | Partial<Theme> | undefined;
-  themeClassName: string;
-}
+export type FluentProviderState = ComponentState<FluentProviderSlots> &
+  Required<Pick<FluentProviderProps, 'dir' | 'targetDocument'>> & {
+    theme: Theme | Partial<Theme> | undefined;
+    themeClassName: string;
+  };
 
-export interface FluentProviderContextValues extends Pick<FluentProviderState, 'theme'> {
+export type FluentProviderContextValues = Pick<FluentProviderState, 'theme'> & {
   provider: ProviderContextValue;
   themeClassName: ThemeClassNameContextValue;
   textDirection: 'ltr' | 'rtl';
   tooltip: TooltipContextType;
-}
+};

--- a/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.types.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.types.ts
@@ -15,13 +15,14 @@ export type FluentProviderProps = Omit<ComponentProps<FluentProviderSlots>, 'dir
   dir?: 'ltr' | 'rtl';
 
   /** Provides the document, can be undefined during SSR render. */
-  targetDocument: Document | undefined;
+  targetDocument?: Document;
 
   theme?: PartialTheme;
 };
 
 export type FluentProviderState = ComponentState<FluentProviderSlots> &
-  Required<Pick<FluentProviderProps, 'dir' | 'targetDocument'>> & {
+  Pick<FluentProviderProps, 'targetDocument'> &
+  Required<Pick<FluentProviderProps, 'dir'>> & {
     theme: Theme | Partial<Theme> | undefined;
     themeClassName: string;
   };


### PR DESCRIPTION
## PR Description

This PR removes the `Commons` type pattern in the types for our `FluentProvider` component.

## Related Issue(s)

Fixes part of #22862
