### PR TITLE
0 graphic" value is read by the screen reader for all the values in vertical bar chart dynamic graph

### DIFF
--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
@@ -48,7 +48,7 @@ export class VerticalBarChartDynamicExample extends React.Component<IVerticalBar
           data={this.state.dynamicData}
           colors={this.state.colors}
           hideLegend={true}
-          hideTooltip={true}
+          hideTooltip={false}
           yMaxValue={50}
           yAxisTickCount={5}
           height={400}

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
@@ -54,6 +54,7 @@ export class VerticalBarChartDynamicExample extends React.Component<IVerticalBar
           height={400}
           width={650}
         />
+
         <DefaultButton text="Change data" onClick={this._changeData} />
         <DefaultButton text="Change colors" onClick={this._changeColors} />
       </div>


### PR DESCRIPTION


## Current Behavior

The screen reader is reading "zero graphic" for all the values in the vertical bar chart dynamic graph.

## New Behavior
After the fix, the issue is resolved in NVDA and Google chrome screen reader extension the issue is only reproducing in the narrator 


Fixes #
Earlier tooltip was hidden in the vertical bar chart dynamic graph, after this fix the data is being announced in NVDA and chrome screenreaders.