### PR TITLE
5919001 harsha new

### DIFF
--- a/packages/react-charting/src/components/LineChart/eventAnnotation/LabelLink.tsx
+++ b/packages/react-charting/src/components/LineChart/eventAnnotation/LabelLink.tsx
@@ -67,7 +67,7 @@ export const LabelLink: React.FunctionComponent<ILabelLinkProps> = props => {
 
   return (
     <>
-      <g ref={gRef} onClick={onClick} data-is-focusable={true} style={{ cursor: 'pointer' }}>
+      <g ref={gRef} onClick={onClick} data-is-focusable={false} style={{ cursor: 'pointer' }}>
         <Textbox
           text={text}
           x={props.labelDef.x}

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
@@ -48,7 +48,7 @@ export class VerticalBarChartDynamicExample extends React.Component<IVerticalBar
           data={this.state.dynamicData}
           colors={this.state.colors}
           hideLegend={true}
-          hideTooltip={false}
+          hideTooltip={true}
           yMaxValue={50}
           yAxisTickCount={5}
           height={400}

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
@@ -48,7 +48,7 @@ export class VerticalBarChartDynamicExample extends React.Component<IVerticalBar
           data={this.state.dynamicData}
           colors={this.state.colors}
           hideLegend={true}
-          hideTooltip={true}
+          hideTooltip={false}
           yMaxValue={50}
           yAxisTickCount={5}
           height={400}


### PR DESCRIPTION


## Current Behavior

The screen reader is announcing irrelevant information for 'event3, event 4 and event 5' in a line chart with the events graph. 

## New Behavior

After this fix, the NVDA screen reader is announcing the data in the graph correctly



Fixes #
Removed focus functionality in line chart events graph

