### PR TITLE
fix: Context menu should close when its trigger is clicked

### DIFF
--- a/change/@fluentui-react-menu-885fe8d5-9fab-4126-b211-93d4f5d6d2f8.json
+++ b/change/@fluentui-react-menu-885fe8d5-9fab-4126-b211-93d4f5d6d2f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Context menu closes when its trigger is left clicked",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/e2e/Menu.e2e.tsx
+++ b/packages/react-components/react-menu/e2e/Menu.e2e.tsx
@@ -791,3 +791,37 @@ describe(`Nested Menus`, () => {
     });
   });
 });
+
+describe('Context menu', () => {
+  const ContextMenuExample = () => (
+    <Menu openOnContext>
+      <MenuTrigger>
+        <button>trigger</button>
+      </MenuTrigger>
+      <MenuPopover>
+        <MenuList>
+          <MenuItem>Item</MenuItem>
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+
+  it('should open on right click ', () => {
+    mount(<ContextMenuExample />);
+
+    cy.get(menuTriggerSelector).rightclick().get(menuSelector).should('exist');
+  });
+
+  it('should close when the trigger is clicked', () => {
+    mount(<ContextMenuExample />);
+
+    cy.get(menuTriggerSelector)
+      .rightclick()
+      .get(menuSelector)
+      .should('exist')
+      .get(menuTriggerSelector)
+      .click()
+      .get(menuSelector)
+      .should('not.exist');
+  });
+});

--- a/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
@@ -109,7 +109,10 @@ const useMenuSelectableState = (
 };
 
 const useMenuOpenState = (
-  state: Pick<MenuState, 'isSubmenu' | 'menuPopoverRef' | 'onOpenChange' | 'setContextTarget' | 'triggerRef'> &
+  state: Pick<
+    MenuState,
+    'isSubmenu' | 'menuPopoverRef' | 'onOpenChange' | 'setContextTarget' | 'triggerRef' | 'openOnContext'
+  > &
     Pick<MenuProps, 'open' | 'defaultOpen'>,
 ) => {
   const { targetDocument } = useFluent();
@@ -177,7 +180,9 @@ const useMenuOpenState = (
     contains: elementContains,
     disabled: !open,
     element: targetDocument,
-    refs: [state.menuPopoverRef, state.triggerRef],
+    refs: [state.menuPopoverRef, !state.openOnContext && state.triggerRef].filter(
+      Boolean,
+    ) as React.MutableRefObject<HTMLElement>[],
     callback: e => setOpen(e, { open: false }),
   });
   useOnMenuMouseEnter({

--- a/packages/react-components/react-menu/src/stories/MenuDefault.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/MenuDefault.stories.tsx
@@ -5,7 +5,7 @@ import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuProps } from '.
 import { Button } from '@fluentui/react-button';
 
 export const Default = (props: Partial<MenuProps>) => (
-  <Menu {...props}>
+  <Menu {...props} openOnContext>
     <MenuTrigger>
       <Button>Toggle menu</Button>
     </MenuTrigger>

--- a/packages/react-components/react-menu/src/stories/MenuDefault.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/MenuDefault.stories.tsx
@@ -5,7 +5,7 @@ import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuProps } from '.
 import { Button } from '@fluentui/react-button';
 
 export const Default = (props: Partial<MenuProps>) => (
-  <Menu {...props} openOnContext>
+  <Menu {...props}>
     <MenuTrigger>
       <Button>Toggle menu</Button>
     </MenuTrigger>


### PR DESCRIPTION
## Current Behavior

Context menu cannot be dismissed when its trigger is clicked

## New Behavior

Context menu is dismissed when its trigger is clicked

## Related Issue(s)

Fixes #23081
