### PR TITLE
Switch: Moving component out of unstable

### DIFF
--- a/change/@fluentui-react-components-e2f0fda9-b4ae-4ca7-a7b7-82c2bd8a34e5.json
+++ b/change/@fluentui-react-components-e2f0fda9-b4ae-4ca7-a7b7-82c2bd8a34e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Switch: Moving component out of unstable.",
+  "packageName": "@fluentui/react-components",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -330,6 +330,7 @@ import { renderRadioGroup_unstable } from '@fluentui/react-radio';
 import { renderSlider_unstable } from '@fluentui/react-slider';
 import { renderSpinner_unstable } from '@fluentui/react-spinner';
 import { renderSplitButton_unstable } from '@fluentui/react-button';
+import { renderSwitch_unstable } from '@fluentui/react-switch';
 import { renderTab_unstable } from '@fluentui/react-tabs';
 import { renderTabList_unstable } from '@fluentui/react-tabs';
 import { renderText_unstable } from '@fluentui/react-text';
@@ -375,6 +376,12 @@ import { StrokeWidthTokens } from '@fluentui/react-theme';
 import { Subheadline } from '@fluentui/react-text';
 import { subheadlineClassName } from '@fluentui/react-text';
 import { subheadlineClassNames } from '@fluentui/react-text';
+import { Switch } from '@fluentui/react-switch';
+import { switchClassNames } from '@fluentui/react-switch';
+import { SwitchOnChangeData } from '@fluentui/react-switch';
+import { SwitchProps } from '@fluentui/react-switch';
+import { SwitchSlots } from '@fluentui/react-switch';
+import { SwitchState } from '@fluentui/react-switch';
 import { Tab } from '@fluentui/react-tabs';
 import { tabClassName } from '@fluentui/react-tabs';
 import { tabClassNames } from '@fluentui/react-tabs';
@@ -531,6 +538,8 @@ import { useSpinnerStyles_unstable } from '@fluentui/react-spinner';
 import { useSplitButton_unstable } from '@fluentui/react-button';
 import { useSplitButtonStyles_unstable } from '@fluentui/react-button';
 import { useSSRContext } from '@fluentui/react-utilities';
+import { useSwitch_unstable } from '@fluentui/react-switch';
+import { useSwitchStyles_unstable } from '@fluentui/react-switch';
 import { useTab_unstable } from '@fluentui/react-tabs';
 import { useTabList_unstable } from '@fluentui/react-tabs';
 import { useTabListStyles_unstable } from '@fluentui/react-tabs';
@@ -1202,6 +1211,8 @@ export { renderSpinner_unstable }
 
 export { renderSplitButton_unstable }
 
+export { renderSwitch_unstable }
+
 export { renderTab_unstable }
 
 export { renderTabList_unstable }
@@ -1291,6 +1302,18 @@ export { Subheadline }
 export { subheadlineClassName }
 
 export { subheadlineClassNames }
+
+export { Switch }
+
+export { switchClassNames }
+
+export { SwitchOnChangeData }
+
+export { SwitchProps }
+
+export { SwitchSlots }
+
+export { SwitchState }
 
 export { Tab }
 
@@ -1603,6 +1626,10 @@ export { useSplitButton_unstable }
 export { useSplitButtonStyles_unstable }
 
 export { useSSRContext }
+
+export { useSwitch_unstable }
+
+export { useSwitchStyles_unstable }
 
 export { useTab_unstable }
 

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -41,7 +41,6 @@ import { renderCardHeader_unstable } from '@fluentui/react-card';
 import { renderCardPreview_unstable } from '@fluentui/react-card';
 import { renderInput_unstable } from '@fluentui/react-input';
 import { renderSpinButton_unstable } from '@fluentui/react-spinbutton';
-import { renderSwitch_unstable } from '@fluentui/react-switch';
 import { SpinButton } from '@fluentui/react-spinbutton';
 import { SpinButtonBounds } from '@fluentui/react-spinbutton';
 import { SpinButtonChangeEvent } from '@fluentui/react-spinbutton';
@@ -51,12 +50,6 @@ import { SpinButtonProps } from '@fluentui/react-spinbutton';
 import { SpinButtonSlots } from '@fluentui/react-spinbutton';
 import { SpinButtonSpinState } from '@fluentui/react-spinbutton';
 import { SpinButtonState } from '@fluentui/react-spinbutton';
-import { Switch } from '@fluentui/react-switch';
-import { switchClassNames } from '@fluentui/react-switch';
-import { SwitchOnChangeData } from '@fluentui/react-switch';
-import { SwitchProps } from '@fluentui/react-switch';
-import { SwitchSlots } from '@fluentui/react-switch';
-import { SwitchState } from '@fluentui/react-switch';
 import { useCard_unstable } from '@fluentui/react-card';
 import { useCardFooter_unstable } from '@fluentui/react-card';
 import { useCardFooterStyles_unstable } from '@fluentui/react-card';
@@ -69,8 +62,6 @@ import { useInput_unstable } from '@fluentui/react-input';
 import { useInputStyles_unstable } from '@fluentui/react-input';
 import { useSpinButton_unstable } from '@fluentui/react-spinbutton';
 import { useSpinButtonStyles_unstable } from '@fluentui/react-spinbutton';
-import { useSwitch_unstable } from '@fluentui/react-switch';
-import { useSwitchStyles_unstable } from '@fluentui/react-switch';
 
 export { Card }
 
@@ -146,8 +137,6 @@ export { renderInput_unstable }
 
 export { renderSpinButton_unstable }
 
-export { renderSwitch_unstable }
-
 export { SpinButton }
 
 export { SpinButtonBounds }
@@ -165,18 +154,6 @@ export { SpinButtonSlots }
 export { SpinButtonSpinState }
 
 export { SpinButtonState }
-
-export { Switch }
-
-export { switchClassNames }
-
-export { SwitchOnChangeData }
-
-export { SwitchProps }
-
-export { SwitchSlots }
-
-export { SwitchState }
 
 export { useCard_unstable }
 
@@ -201,10 +178,6 @@ export { useInputStyles_unstable }
 export { useSpinButton_unstable }
 
 export { useSpinButtonStyles_unstable }
-
-export { useSwitch_unstable }
-
-export { useSwitchStyles_unstable }
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -534,6 +534,14 @@ export {
 } from '@fluentui/react-spinner';
 export type { SpinnerProps, SpinnerSlots, SpinnerState } from '@fluentui/react-spinner';
 export {
+  Switch,
+  switchClassNames,
+  renderSwitch_unstable,
+  useSwitch_unstable,
+  useSwitchStyles_unstable,
+} from '@fluentui/react-switch';
+export type { SwitchOnChangeData, SwitchProps, SwitchSlots, SwitchState } from '@fluentui/react-switch';
+export {
   renderTab_unstable,
   Tab,
   tabClassName,

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -73,12 +73,3 @@ export type {
   SpinButtonSpinState,
   SpinButtonBounds,
 } from '@fluentui/react-spinbutton';
-
-export {
-  Switch,
-  switchClassNames,
-  renderSwitch_unstable,
-  useSwitch_unstable,
-  useSwitchStyles_unstable,
-} from '@fluentui/react-switch';
-export type { SwitchOnChangeData, SwitchProps, SwitchSlots, SwitchState } from '@fluentui/react-switch';

--- a/packages/react-components/react-switch/src/stories/Switch.stories.tsx
+++ b/packages/react-components/react-switch/src/stories/Switch.stories.tsx
@@ -12,7 +12,7 @@ export { Required } from './SwitchRequired.stories';
 export { Themed } from './SwitchThemed.stories';
 
 export default {
-  title: 'Preview Components/Switch',
+  title: 'Components/Switch',
   component: Switch,
   parameters: {
     docs: {


### PR DESCRIPTION
## Current Behavior

`Switch` component is re-exported in `@fluentui/react-components/lib/unstable`.

## New Behavior

`Switch` component is re-exported in `@fluentui/react-components.`

## Related Issue(s)

Fixes #22818
