### PR TITLE
Focuszone: update to treat arrow keys in textarea the same as arrow keys in input

### DIFF
--- a/change/@fluentui-react-focus-e173e41b-2ecf-4753-be67-84890ed731ea.json
+++ b/change/@fluentui-react-focus-e173e41b-2ecf-4753-be67-84890ed731ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "FocusZone: allow arrow keys to move within textareas, similar to text inputs",
+  "packageName": "@fluentui/react-focus",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-focus/etc/react-focus.api.md
+++ b/packages/react-focus/etc/react-focus.api.md
@@ -96,7 +96,7 @@ export interface IFocusZoneProps extends React_2.HTMLAttributes<HTMLElement> {
     shouldEnterInnerZone?: (ev: React_2.KeyboardEvent<HTMLElement>) => boolean;
     shouldFocusInnerElementWhenReceivedFocus?: boolean;
     shouldFocusOnMount?: boolean;
-    shouldInputLoseFocusOnArrowKey?: (inputElement: HTMLInputElement) => boolean;
+    shouldInputLoseFocusOnArrowKey?: (inputElement: HTMLInputElement | HTMLTextAreaElement) => boolean;
     shouldRaiseClicks?: boolean;
     shouldRaiseClicksOnEnter?: boolean;
     shouldRaiseClicksOnSpace?: boolean;

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -104,7 +104,7 @@ const _allInstances: {
 } = {};
 const _outerZones: Set<FocusZone> = new Set();
 
-const ALLOWED_INPUT_TYPES = ['text', 'number', 'password', 'email', 'tel', 'url', 'search'];
+const ALLOWED_INPUT_TYPES = ['text', 'number', 'password', 'email', 'tel', 'url', 'search', 'textarea'];
 
 const ALLOW_VIRTUAL_ELEMENTS = false;
 
@@ -1360,7 +1360,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     return false;
   }
 
-  private _shouldInputLoseFocus(element: HTMLInputElement, isForward?: boolean): boolean {
+  private _shouldInputLoseFocus(element: HTMLInputElement | HTMLTextAreaElement, isForward?: boolean): boolean {
     // If a tab was used, we want to focus on the next element.
     if (
       !this._processingTabKey &&

--- a/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
@@ -216,11 +216,11 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement> {
   shouldRaiseClicksOnSpace?: boolean;
 
   /**
-   * A callback method to determine if the input element should lose focus on arrow keys
-   *  @param inputElement - The input element which is to loose focus.
+   * A callback method to determine if an input or textarea element should lose focus on arrow keys
+   *  @param inputElement - The input or textarea element which is to loose focus.
    *  @returns True if input element should loose focus or false otherwise.
    */
-  shouldInputLoseFocusOnArrowKey?: (inputElement: HTMLInputElement) => boolean;
+  shouldInputLoseFocusOnArrowKey?: (inputElement: HTMLInputElement | HTMLTextAreaElement) => boolean;
 
   /**
    * Determines whether to disable the paging support for Page Up and Page Down keyboard scenarios.

--- a/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
@@ -217,7 +217,7 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement> {
 
   /**
    * A callback method to determine if an input or textarea element should lose focus on arrow keys
-   *  @param inputElement - The input or textarea element which is to loose focus.
+   *  @param inputElement - The input or textarea element which is to lose focus.
    *  @returns True if input element should loose focus or false otherwise.
    */
   shouldInputLoseFocusOnArrowKey?: (inputElement: HTMLInputElement | HTMLTextAreaElement) => boolean;


### PR DESCRIPTION
Resolves #20301

Interestingly, `<textarea>` has a `type` attribute that always returns the string `"textarea"`, so all that was needed was to add that to `ALLOWED_INPUT_TYPES`.

I also updated the typings for the internal functions and `props.shouldInputLoseFocusOnArrowKey` to accurately reflect the possible element types. Textarea was already returning true in `_isElementInput`, so this better reflects the current behavior.