### PR TITLE
Graph texts are not clearly visible in aquatic theme.

### DIFF
--- a/change/@fluentui-react-charting-5b45ec84-abc6-4c15-9c84-87011d733638.json
+++ b/change/@fluentui-react-charting-5b45ec84-abc6-4c15-9c84-87011d733638.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing color contrast issue",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-hannapared@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/LineChart/eventAnnotation/EventAnnotation.tsx
+++ b/packages/react-charting/src/components/LineChart/eventAnnotation/EventAnnotation.tsx
@@ -22,17 +22,11 @@ export const EventsAnnotation: React.FunctionComponent<IEventsAnnotationExtendPr
   const lineDefs: ILineDef[] = props.events.map(e => ({ ...e, x: props.scale(e.date) }));
 
   lineDefs.sort((e1, e2) => +e1.date - +e2.date);
+  const darkThemeMq = window.matchMedia('(prefers-color-scheme: dark)');
+  const fill: string | undefined = darkThemeMq.matches ? 'rgb(255,255,255)' : props.strokeColor;
 
   const lines = uniqBy(lineDefs, x => x.date.toString()).map((x, i) => (
-    <line
-      key={i}
-      x1={x.x}
-      x2={x.x}
-      y1={lineTopY}
-      y2={props.chartYBottom}
-      stroke={props.strokeColor}
-      strokeDasharray="8"
-    />
+    <line key={i} x1={x.x} x2={x.x} y1={lineTopY} y2={props.chartYBottom} stroke={fill} strokeDasharray="8" />
   ));
 
   const labelLinks = calculateLabels(lineDefs, textWidth + textPadding, axisRange[1], axisRange[0]).map((x, i) => (

--- a/packages/react-charting/src/components/LineChart/eventAnnotation/LabelLink.tsx
+++ b/packages/react-charting/src/components/LineChart/eventAnnotation/LabelLink.tsx
@@ -56,13 +56,12 @@ export const LabelLink: React.FunctionComponent<ILabelLinkProps> = props => {
   }
 
   let text: string;
-  let fill: string | undefined;
+  const darkThemeMq = window.matchMedia('(prefers-color-scheme: dark)');
+  const fill: string | undefined = darkThemeMq.matches ? 'rgb(255,255,255)' : props.textColor;
   if (props.labelDef.aggregatedIdx.length === 1) {
     text = props.lineDefs[props.labelDef.aggregatedIdx[0]].event;
-    fill = props.textColor;
   } else {
     text = props.mergedLabel(props.labelDef.aggregatedIdx.length);
-    fill = props.textColor;
   }
 
   return (


### PR DESCRIPTION
## Current Behavior

In The line chart Events Graph Event 3', 'Event4' and 'Event5' texts are not clearly visible in the high contrast aquatic theme.

![image](https://user-images.githubusercontent.com/103020020/169510360-def94b62-d23c-4a1c-a3da-c5dbdb6b5cb8.png)


## New Behavior

After this fix 'Event 3', 'Event4' and 'Event5' texts are clearly visible in high contrast aquatic theme.

![image](https://user-images.githubusercontent.com/103020020/169510711-ac57df40-b7cf-433b-ba5a-a85c0cb3e4af.png)

Fixes #

After this fix Event 3', 'Event4' and 'Event5' texts are clearly visible in high contrast in all the other themes.