### PR TITLE
Fix create-package script referencing moved react-provider package

### DIFF
--- a/scripts/create-package/plopfile.ts
+++ b/scripts/create-package/plopfile.ts
@@ -16,7 +16,7 @@ const v8ReferencePackages = {
   node: ['codemods'],
 };
 const convergedReferencePackages = {
-  react: ['react-provider'],
+  react: ['react-components/react-provider'],
   node: ['babel-make-styles'],
 };
 


### PR DESCRIPTION
## Current Behavior

`yarn create-package` fails because it's looking for the react-provider package, which was moved in the source tree.

```
ENOENT: no such file or directory, open 'D:\repos\fluentui-b\packages\react-provider\package.json'
```

Full log:
```
> yarn create-package
yarn run v1.23.34
$ plop --plopfile ./scripts/create-package/plopfile.ts --dest . --require ./scripts/ts-node-register
? Package name (do NOT include @fluentui prefix): react-field
? Package target: react
? Package description: React components for building web experie
nces
? Provide team that owns this package @microsoft/cxe-red
? Is this a converged package? Yes
√  +! 2 files added
 -> \packages\react-components\react-field\.npmignore
 -> \packages\react-components\react-field\LICENSE
√  +! 12 files added
 -> \packages\react-components\react-field\.babelrc.json        
 -> \packages\react-components\react-field\.eslintrc.json       
 -> \packages\react-components\react-field\jest.config.js       
 -> \packages\react-components\react-field\just.config.ts       
 -> \packages\react-components\react-field\package.json
 -> \packages\react-components\react-field\README.md
 -> \packages\react-components\react-field\Spec.md
 -> \packages\react-components\react-field\tsconfig.json        
 -> \packages\react-components\react-field\config\api-extractor.json
 -> \packages\react-components\react-field\config\tests.js      
 -> \packages\react-components\react-field\etc\react-field.api.md
 -> \packages\react-components\react-field\src\index.ts
×  +- D:\repos\fluentui-b\packages\react-provider\package.json: ENOENT: no such file or directory, open 'D:\repos\fluentui-b\packages\react-provider\package.json'
×  +- packages/react-components/react-field/tsconfig.json Aborted due to previous action failure
×  -> Aborted due to previous action failure
×  -> Aborted due to previous action failure
×  -> Aborted due to previous action failure
```

## New Behavior

Update reference to moved package.

## Related Issue(s)

* Fixes part of #22960
  * That bug also covers a failure in creating a node package, which is not fixed in this PR
