### PR TITLE
react-link: Improving README and updating spec and migration guide

### DIFF
--- a/change/@fluentui-react-link-db959289-bab9-4e87-a73f-4be1f44892c6.json
+++ b/change/@fluentui-react-link-db959289-bab9-4e87-a73f-4be1f44892c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Improving README and updating spec and migration guide.",
+  "packageName": "@fluentui/react-link",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-link/MIGRATION.md
+++ b/packages/react-components/react-link/MIGRATION.md
@@ -1,9 +1,5 @@
 # Link Migration
 
-## STATUS: WIP 🚧
-
-This Migration guide is a work in progress and is not yet ready for use.
-
 ## Migration from v8
 
 The existing `Link` control supports a very similar set of props to the one being proposed with a few differences that are outlined below:

--- a/packages/react-components/react-link/README.md
+++ b/packages/react-components/react-link/README.md
@@ -2,21 +2,11 @@
 
 **Link components for [Fluent UI](https://dev.microsoft.com/fluentui)**
 
-The Link component references data that a user can follow by clicking or tapping it.
-
-## STATUS: WIP 🚧
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+Links reference data that a user can follow by clicking or tapping it.
 
 ## Usage
 
 To import Link:
-
-```js
-import { Link } from '@fluentui/react-link';
-```
-
-Once the Link component graduates to a production release, the component will be available at:
 
 ```js
 import { Link } from '@fluentui/react-components';
@@ -27,6 +17,23 @@ import { Link } from '@fluentui/react-components';
 ```jsx
 <Link>This is a link</Link>
 <Link href="https://www.bing.com">This is a link</Link>
+<Link href="https://www.bing.com" appearance="subtle">This is a link</Link>
 <Link href="https://www.bing.com" disabled>This is a link</Link>
 <Link href="https://www.bing.com" target="_blank">This is a link</Link>
+<Link as="button" appearance="subtle">This is a link</Link>
 ```
+
+See [Fluent UI Storybook](https://aka.ms/fluentui-storybook) for more detailed usage examples.
+
+Alternatively, run Storybook locally with:
+
+1. `yarn start`
+2. Select `react-link` from the list.
+
+### Specification
+
+See [SPEC.md](./SPEC.md).
+
+### Migration Guide
+
+If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest SpinButton implementation.

--- a/packages/react-components/react-link/SPEC.md
+++ b/packages/react-components/react-link/SPEC.md
@@ -54,72 +54,7 @@ The `Link` can also be custom rendered as something entirely different by replac
 
 ### Props
 
-```ts
-export type LinkProps = ComponentProps &
-  React.AnchorHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement> &
-  Omit<React.ButtonHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement>, 'type'> & {
-    /**
-     * URL the link points to. If not provided, the link renders as a button (unless that behavior is
-     * overridden using `as`).
-     */
-    href?: string;
-
-    /**
-     * Click handler for the link.
-     */
-    onClick?: (event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement | HTMLElement>) => void;
-
-    /**
-     * Relationship to the linked URL (can be a space-separated list).
-     * Most common values are `noreferrer` and/or `noopener`.
-     * This prop is only applied if `href` is set.
-     */
-    rel?: string;
-
-    /**
-     * Where to open the linked URL. Common values are `_blank` (a new tab or window),
-     * `_self` (the current window/context), `_parent`, and `_top`.
-     * This prop is only applied if `href` is set.
-     */
-    target?: string;
-
-    /**
-     * Built-in HTML attribute with different behavior depending on how the link is rendered.
-     * If rendered as `<a>`, hints at the MIME type.
-     * If rendered as `<button>`, override the type of button (`button` is the default).
-     */
-    type?: string;
-
-    /**
-     * A link can appear either with its default style or subtle.
-     * If not specified, the link appears with its default styling.
-     */
-    appearance?: 'subtle';
-
-    /**
-     * Whether the link is disabled.
-     * @default false
-     */
-    disabled?: boolean;
-
-    /**
-     * When set, allows the link to be focusable even when it has been disabled. This is used in scenarios where it is
-     * important to keep a consistent tab order for screen reader and keyboard users.
-     * @default false
-     */
-    disabledFocusable?: boolean;
-
-    /**
-     * If true, changes styling when the link is being used alongside other text content.
-     * @default false
-     */
-    inline?: boolean;
-  };
-```
-
-### Styling Tokens
-
-TBD once we decide on component tokens work.
+See API at [Link.types.ts](./src/components/Link/Link.types.ts).
 
 ## Structure
 
@@ -141,7 +76,7 @@ For `Links` rendering as anything other than `<a>` (the example below uses `<but
 
 ## Migration
 
-See [MIGRATION.md](https://github.com/microsoft/fluentui/blob/master/packages/react-link/MIGRATION.md).
+See [MIGRATION.md](./MIGRATION.md).
 
 ## Behaviors
 


### PR DESCRIPTION
## Current Behavior

README is incomplete and spec and migration guide are outdated when compared to current implementation.

## New Behavior

- README now shows more examples, points to relevant files and does not have a WIP warning anymore.
- Spec is updated to point to `Link.types.ts` instead of copying API interface.
- Migration guide is updated to remove the WIP warning.