### PR TITLE
useControllableValue: add error message if controlled/uncontrolled usage is changed

### DIFF
--- a/change/@fluentui-react-hooks-1f4767f7-73f7-441f-9af3-d8d5b5af44e5.json
+++ b/change/@fluentui-react-hooks-1f4767f7-73f7-441f-9af3-d8d5b5af44e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "useControllableValue should allow a controlled value to be set after the first call",
+  "packageName": "@fluentui/react-hooks",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-hooks-8201fcfc-9fce-44a3-8a81-53848d527c05.json
+++ b/change/@fluentui-react-hooks-8201fcfc-9fce-44a3-8a81-53848d527c05.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "useControllableValue should allow a controlled value to be set after the first call",
+  "comment": "update ControllableValue to log an error when controlledValue changes between defined and undefined",
   "packageName": "@fluentui/react-hooks",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-hooks/src/useControllableValue.test.tsx
+++ b/packages/react-hooks/src/useControllableValue.test.tsx
@@ -4,6 +4,10 @@ import { useControllableValue } from './useControllableValue';
 import { validateHookValueNotChanged } from './testUtilities';
 
 describe('useControllableValue', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('respects controlled value', () => {
     let resultValue: boolean | undefined;
     const TestComponent: React.FunctionComponent<{ value?: boolean; defaultValue?: boolean }> = ({
@@ -72,7 +76,6 @@ describe('useControllableValue', () => {
 
     wrapper.setProps({ value: 'A' });
     expect(spy).toHaveBeenCalledTimes(1);
-    jest.clearAllMocks();
   });
 
   it('logs an error when a value switches controlled to uncontrolled', () => {
@@ -89,7 +92,6 @@ describe('useControllableValue', () => {
 
     wrapper.setProps({ value: undefined });
     expect(spy).toHaveBeenCalledTimes(1);
-    jest.clearAllMocks();
   });
 
   validateHookValueNotChanged('returns the same setter callback', () => {

--- a/packages/react-hooks/src/useControllableValue.test.tsx
+++ b/packages/react-hooks/src/useControllableValue.test.tsx
@@ -58,6 +58,23 @@ describe('useControllableValue', () => {
     expect(resultValue!).toBe(true);
   });
 
+  it('updates from uncontrolled to controlled when controlledValue is set', () => {
+    let resultValue: string | undefined;
+    const TestComponent: React.FunctionComponent<{ value?: string; defaultValue?: string }> = ({
+      value,
+      defaultValue,
+    }) => {
+      [resultValue] = useControllableValue(value, defaultValue);
+      return <div />;
+    };
+
+    const wrapper = mount(<TestComponent value={undefined} />);
+    expect(resultValue!).toBeUndefined();
+
+    wrapper.setProps({ value: 'A' });
+    expect(resultValue!).toBe('A');
+  });
+
   validateHookValueNotChanged('returns the same setter callback', () => {
     const [, setValue] = useControllableValue('hello', 'world');
     return [setValue];

--- a/packages/react-hooks/src/useControllableValue.test.tsx
+++ b/packages/react-hooks/src/useControllableValue.test.tsx
@@ -58,21 +58,38 @@ describe('useControllableValue', () => {
     expect(resultValue!).toBe(true);
   });
 
-  it('updates from uncontrolled to controlled when controlledValue is set', () => {
-    let resultValue: string | undefined;
+  it('logs an error when a value switches uncontrolled to controlled', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
     const TestComponent: React.FunctionComponent<{ value?: string; defaultValue?: string }> = ({
       value,
       defaultValue,
     }) => {
-      [resultValue] = useControllableValue(value, defaultValue);
+      useControllableValue(value, defaultValue);
       return <div />;
     };
 
     const wrapper = mount(<TestComponent value={undefined} />);
-    expect(resultValue!).toBeUndefined();
 
     wrapper.setProps({ value: 'A' });
-    expect(resultValue!).toBe('A');
+    expect(spy).toHaveBeenCalledTimes(1);
+    jest.clearAllMocks();
+  });
+
+  it('logs an error when a value switches controlled to uncontrolled', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
+    const TestComponent: React.FunctionComponent<{ value?: string; defaultValue?: string }> = ({
+      value,
+      defaultValue,
+    }) => {
+      useControllableValue(value, defaultValue);
+      return <div />;
+    };
+
+    const wrapper = mount(<TestComponent value={'A'} />);
+
+    wrapper.setProps({ value: undefined });
+    expect(spy).toHaveBeenCalledTimes(1);
+    jest.clearAllMocks();
   });
 
   validateHookValueNotChanged('returns the same setter callback', () => {

--- a/packages/react-hooks/src/useControllableValue.ts
+++ b/packages/react-hooks/src/useControllableValue.ts
@@ -43,14 +43,16 @@ export function useControllableValue<
   onChange?: ChangeCallback<TElement, TValue, TEvent>,
 ) {
   const [value, setValue] = React.useState<TValue | undefined>(defaultUncontrolledValue);
-  const isControlled = useConst<boolean>(controlledValue !== undefined);
+  const isControlled = controlledValue !== undefined;
   const currentValue = isControlled ? controlledValue : value;
 
-  // Duplicate the current value and onChange in refs so they're accessible from
+  // Duplicate the controlled state, current value, and onChange in refs so they're accessible from
   // setValueOrCallOnChange without creating a new callback every time
+  const isControlledRef = React.useRef(isControlled);
   const valueRef = React.useRef(currentValue);
   const onChangeRef = React.useRef(onChange);
   React.useEffect(() => {
+    isControlledRef.current = isControlled;
     valueRef.current = currentValue;
     onChangeRef.current = onChange;
   });
@@ -66,7 +68,7 @@ export function useControllableValue<
       onChangeRef.current(ev!, newValue);
     }
 
-    if (!isControlled) {
+    if (!isControlledRef.current) {
       setValue(newValue);
     }
   });

--- a/packages/react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.test.tsx
@@ -219,7 +219,9 @@ describe('Checkbox', () => {
     expect(checkbox!.indeterminate).toEqual(false);
     expect(checkboxInput.indeterminate).toEqual(false);
 
-    checkboxComponent.rerender(<Checkbox title="indeterminate-title" checked={true} componentRef={checkboxRef} />);
+    checkboxComponent.rerender(
+      <Checkbox title="indeterminate-title" indeterminate={false} checked={true} componentRef={checkboxRef} />,
+    );
 
     expect(checkbox!.indeterminate).toEqual(false);
     expect(checkboxInput.indeterminate).toEqual(false);

--- a/packages/react/src/components/SwatchColorPicker/SwatchColorPicker.test.tsx
+++ b/packages/react/src/components/SwatchColorPicker/SwatchColorPicker.test.tsx
@@ -28,6 +28,10 @@ describe('SwatchColorPicker', () => {
     resetIds();
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders SwatchColorPicker correctly', () => {
     const component = create(<SwatchColorPicker colorCells={DEFAULT_OPTIONS} columnCount={4} />);
     const tree = component.toJSON();
@@ -146,8 +150,8 @@ describe('SwatchColorPicker', () => {
     expect(tableElements.at(0).prop('aria-checked')).toEqual(true);
     expect(tableElements.at(1).prop('aria-checked')).toEqual(false);
 
-    // Update the props to set selected to undefined
-    wrapper.setProps({ selectedId: undefined });
+    // Update the props to set selected to an empty string
+    wrapper.setProps({ selectedId: '' });
 
     tableElements = findNodes(wrapper, '.ms-Button');
     expect(tableElements.length).toEqual(2);
@@ -158,6 +162,9 @@ describe('SwatchColorPicker', () => {
   });
 
   it('Cannot clear the selectedID if uncontrolled', () => {
+    // handle console error for uncontrolled > controlled change
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
     const props: ISwatchColorPickerProps = {
       colorCells: DEFAULT_OPTIONS,
       columnCount: 4,


### PR DESCRIPTION
Fixes #20039

Currently `useControllableValue` has a `useConst` for tracking whether the value is controlled, so if the controlled value is undefined on first render, it will never be respected. This change updates `isControlled` to always reflect whether `controlledValue` is passed.