### PR TITLE
Image: Updating useImageStyles to use styles[state] pattern for props of string union types

### DIFF
--- a/change/@fluentui-react-image-f9c64c07-9b02-450f-969a-e2b9f3baa9b1.json
+++ b/change/@fluentui-react-image-f9c64c07-9b02-450f-969a-e2b9f3baa9b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Image: Updating useImageStyles to use styles[state] pattern for props of string union types.",
+  "packageName": "@fluentui/react-image",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-image/src/components/Image/useImageStyles.ts
+++ b/packages/react-components/react-image/src/components/Image/useImageStyles.ts
@@ -12,51 +12,68 @@ export const imageClassNames: SlotClassNames<ImageSlots> = {
 };
 
 const useStyles = makeStyles({
-  root: {
+  // Base styles
+  base: {
     ...shorthands.borderColor(tokens.colorNeutralStroke1),
     ...shorthands.borderRadius(tokens.borderRadiusNone),
 
     boxSizing: 'border-box',
     display: 'inline-block',
   },
-  rootBordered: {
+
+  // Bordered styles
+  bordered: {
     ...shorthands.borderStyle('solid'),
     ...shorthands.borderWidth(tokens.strokeWidthThin),
   },
-  rootCircular: {
+
+  // Shape variations
+  circular: {
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
   },
-  rootRounded: {
+  rounded: {
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
   },
-  rootShadow: {
+  square: {
+    /* The square styles are exactly the same as the base styles. */
+  },
+
+  // Shadow styles
+  shadow: {
     boxShadow: tokens.shadow4,
   },
-  rootFitNone: {
-    objectFit: 'none',
-    objectPosition: 'left top',
-    height: '100%',
-    width: '100%',
-  },
-  rootFitCenter: {
+
+  // Fit variations
+  center: {
     objectFit: 'none',
     objectPosition: 'center',
     height: '100%',
     width: '100%',
   },
-  rootFitCover: {
-    objectFit: 'cover',
-    objectPosition: 'center',
-    height: '100%',
-    width: '100%',
-  },
-  rootFitContain: {
+  contain: {
     objectFit: 'contain',
     objectPosition: 'center',
     height: '100%',
     width: '100%',
   },
-  rootBlock: {
+  default: {
+    /* The default styles are exactly the same as the base styles. */
+  },
+  cover: {
+    objectFit: 'cover',
+    objectPosition: 'center',
+    height: '100%',
+    width: '100%',
+  },
+  none: {
+    objectFit: 'none',
+    objectPosition: 'left top',
+    height: '100%',
+    width: '100%',
+  },
+
+  // Block styles
+  block: {
     width: '100%',
   },
 });
@@ -65,16 +82,12 @@ export const useImageStyles_unstable = (state: ImageState) => {
   const styles = useStyles();
   state.root.className = mergeClasses(
     imageClassNames.root,
-    styles.root,
-    state.bordered && styles.rootBordered,
-    state.shape === 'circular' && styles.rootCircular,
-    state.shape === 'rounded' && styles.rootRounded,
-    state.shadow && styles.rootShadow,
-    state.fit === 'none' && styles.rootFitNone,
-    state.fit === 'center' && styles.rootFitCenter,
-    state.fit === 'cover' && styles.rootFitCover,
-    state.fit === 'contain' && styles.rootFitContain,
-    state.block && styles.rootBlock,
+    styles.base,
+    state.block && styles.block,
+    state.bordered && styles.bordered,
+    state.shadow && styles.shadow,
+    styles[state.fit],
+    styles[state.shape],
     state.root.className,
   );
 };


### PR DESCRIPTION
## Current Behavior

`useImageStyles` does not use the `styles[state]` pattern for props of string union types (i.e. `'string1' | 'string2' | 'string3'`) found in other components.

## New Behavior

`useImageStyles` uses the `styles[state]` pattern for props of string union types (i.e. `'string1' | 'string2' | 'string3'`) found in other components. This improves bundle size and readability.
