### PR TITLE
Fixed bug where className changes in List props does not cause a rerender

### DIFF
--- a/change/@fluentui-react-585cf689-44c1-4b45-9155-4ac53e9339be.json
+++ b/change/@fluentui-react-585cf689-44c1-4b45-9155-4ac53e9339be.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed bug where className changes in List props does not cause a rerender",
+  "packageName": "@fluentui/react",
+  "email": "odhanson@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/List/List.test.tsx
+++ b/packages/react/src/components/List/List.test.tsx
@@ -172,13 +172,17 @@ describe('List', () => {
     });
 
     it("sets optional className to List's root", done => {
-      const wrapper = mount(<List items={mockData(100)} />);
+      const data = mockData(100);
 
-      wrapper.setProps({ items: mockData(100), className: 'foo', onPagesUpdated: (pages: IPage[]) => done() });
+      const wrapper = mount(<List items={data} />);
+
+      wrapper.setProps({ items: data, className: 'foo' });
 
       const listRoot = wrapper.find(List);
 
       expect(listRoot.getDOMNode().className).toContain('foo');
+
+      done();
     });
 
     it('renders the return value of optional onRenderCell prop per row', done => {

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -403,6 +403,10 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
       return true;
     }
 
+    if (newProps.className !== this.props.className) {
+      return true;
+    }
+
     if (newProps.items === this.props.items && oldPages!.length === newPages!.length) {
       for (let i = 0; i < oldPages!.length; i++) {
         const oldPage = oldPages![i];


### PR DESCRIPTION



## Current Behavior

List component doesn't update when className property changes.

## New Behavior

List component updates when className property changes.

## Related Issue(s)

Fixes #23125 
