### PR TITLE
feat: add meta tags

### DIFF
--- a/apps/public-docsite-v9/.storybook/manager-head.html
+++ b/apps/public-docsite-v9/.storybook/manager-head.html
@@ -10,6 +10,31 @@
 />
 <link href="/shell.css" rel="stylesheet" />
 
+<!-- Primary meta tags -->
+<meta name="title" content="Fluent UI React" />
+<meta
+  name="description"
+  content="Fluent UI React Components is a set of UI components and utilities resulting from an effort to converge the set of React based component libraries in production today: @fluentui/react and @fluentui/react-northstar."
+/>
+
+<!-- Open Graph -->
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://react.fluentui.dev/" />
+<meta property="og:title" content="Fluent UI React" />
+<meta
+  property="og:description"
+  content="Fluent UI React Components is a set of UI components and utilities resulting from an effort to converge the set of React based component libraries in production today: @fluentui/react and @fluentui/react-northstar."
+/>
+<meta property="og:locale" content="en_US" />
+<meta property="og:image" content="https://react.fluentui.dev/static/media/public/fluentui-wide-banner.webp" />
+<meta property="og:image:width" content="1207" />
+<meta property="og:image:height" content="705" />
+<meta property="og:image:type" content="image/webp" />
+<meta property="og:image:alt" content="Fluent UI React v9 banner" />
+
+<!-- Twitter -->
+<meta property="twitter:card" content="summary_large_image" />
+
 <!--
   Override the default styles used in the Storybook svg icons for the left tree panel.
 


### PR DESCRIPTION
## Current Behavior

No meta tags = bad SEO & no sharing embed / less user engagement

## New Behavior

Added base, Open Graph and Twitter meta tags.
This is preliminary work to improve SEO and user engagement, the content in itself is up for discussion as we might want to use more appropriate content.
Twitter tags don't need to be duplicated (see [Twitter documentation](https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started#opengraph)) but I can add them for verbosity if prefered.