### PR TITLE
react-divider: flip inset and appearance story descriptions

### DIFF
--- a/packages/react-components/react-divider/src/stories/DividerAppearance.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/DividerAppearance.stories.tsx
@@ -42,7 +42,9 @@ export const Appearance = () => {
 Appearance.parameters = {
   docs: {
     description: {
-      story: 'A divider can have its line inset from the edges of its container.',
+      story:
+        'A divider can have a `brand`, `subtle`, or `strong` appearance.' +
+        ' When not specified, it has its default experience.',
     },
   },
 };

--- a/packages/react-components/react-divider/src/stories/DividerInset.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/DividerInset.stories.tsx
@@ -44,9 +44,7 @@ export const Inset = () => {
 Inset.parameters = {
   docs: {
     description: {
-      story:
-        'A divider can have a `brand`, `subtle`, or `strong` appearance.' +
-        ' When not specified, it has its default experience.',
+      story: 'A divider can have its line inset from the edges of its container.',
     },
   },
 };


### PR DESCRIPTION
## Changes
- The `appearance` and `inset` storybook descriptions are currently flipped. This PR fixes that so both stories have the correct descriptions.