### PR TITLE
remove chromatic banner on public site

### DIFF
--- a/apps/public-docsite-v9/public/shell.css
+++ b/apps/public-docsite-v9/public/shell.css
@@ -62,3 +62,8 @@
   top: 0 !important;
   height: 100% !important;
 }
+
+/* Remove 'Published on Chromatic' banner */
+#back-to-chromatic {
+  display: none !important;
+}


### PR DESCRIPTION
removing chromatic banner 

![image](https://user-images.githubusercontent.com/1434956/170059612-85262f88-33d9-4b9b-bbca-103b836417d2.png)


1) its distracting
2) we don't want to drive any traffic back to our chromatic instance