### PR TITLE
move v0 flex stories to migration guide of storybook

### DIFF
--- a/change/@fluentui-react-components-52fe240d-c291-411c-8a8f-02c4d17a7bb2.json
+++ b/change/@fluentui-react-components-52fe240d-c291-411c-8a8f-02c4d17a7bb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "move v0 flex stories to migration guide of storybook",
+  "packageName": "@fluentui/react-components",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/src/Migrations/Flex.Flex.stories.mdx
+++ b/packages/react-components/react-components/src/Migrations/Flex.Flex.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 import { CodeComparison, CodeExample } from './utils.stories';
 
-<Meta title="Migrations/Flex/Flex" />
+<Meta title="Concepts/Upgrading/from v0/Components/Flex/Flex" />
 
 # @fluentui/react-northstar - Flex
 

--- a/packages/react-components/react-components/src/Migrations/Flex.FlexItem.stories.mdx
+++ b/packages/react-components/react-components/src/Migrations/Flex.FlexItem.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 import { CodeComparison, CodeExample } from './utils.stories';
 
-<Meta title="Migrations/Flex/Flex.Item" />
+<Meta title="Concepts/Upgrading/from v0/Components/Flex/Flex Item" />
 
 # @fluentui/react-northstar - Flex.Item
 

--- a/packages/react-components/react-components/src/Migrations/Flex.Overview.stories.mdx
+++ b/packages/react-components/react-components/src/Migrations/Flex.Overview.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs';
 
-<Meta title="Migrations/Flex/Overview" />
+<Meta title="Concepts/Upgrading/from v0/Components/Flex/Overview" />
 
 # Flex
 

--- a/packages/react-components/react-components/src/Migrations/Flex.Stack.stories.mdx
+++ b/packages/react-components/react-components/src/Migrations/Flex.Stack.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 import { CodeComparison, CodeExample } from './utils.stories';
 
-<Meta title="Migrations/Flex/Stack" />
+<Meta title="Concepts/Upgrading/from v0/Components/Flex/Stack" />
 
 # @fluentui/react - Stack
 

--- a/packages/react-components/react-components/src/Migrations/Flex.Stack.stories.mdx
+++ b/packages/react-components/react-components/src/Migrations/Flex.Stack.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 import { CodeComparison, CodeExample } from './utils.stories';
 
-<Meta title="Concepts/Upgrading/from v0/Components/Flex/Stack" />
+<Meta title="Concepts/Upgrading/from v8/Components/Flex/Stack" />
 
 # @fluentui/react - Stack
 

--- a/packages/react-components/react-components/src/Migrations/Flex.StackItem.stories.mdx
+++ b/packages/react-components/react-components/src/Migrations/Flex.StackItem.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 import { CodeComparison, CodeExample } from './utils.stories';
 
-<Meta title="Migrations/Flex/Stack.Item" />
+<Meta title="Concepts/Upgrading/from v0/Components/Flex/Stack item" />
 
 # @fluentui/react - Stack.Item
 

--- a/packages/react-components/react-components/src/Migrations/Flex.StackItem.stories.mdx
+++ b/packages/react-components/react-components/src/Migrations/Flex.StackItem.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 import { CodeComparison, CodeExample } from './utils.stories';
 
-<Meta title="Concepts/Upgrading/from v0/Components/Flex/Stack item" />
+<Meta title="Concepts/Upgrading/from v8/Components/Flex/Stack item" />
 
 # @fluentui/react - Stack.Item
 


### PR DESCRIPTION
moving the original flex migration stories from their own 'migration' heading

![image](https://user-images.githubusercontent.com/1434956/170071752-4688ba64-eb82-4f0d-b9d0-98538cd09554.png)

to upgrading v0 section

![image](https://user-images.githubusercontent.com/1434956/170072085-62dcc01b-d9e3-4688-a7b8-aadadcbe686f.png)
