### PR TITLE
normalize the branch chromatic publishes to

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "just-scripts build",
     "build-storybook": "build-storybook -s ./public -o ./dist/storybook --docs",
-    "chromatic": "npx chromatic@6.4.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name build-storybook",
+    "chromatic:branch": "npx chromatic@6.4.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name build-storybook",
+    "chromatic": "npx chromatic@6.4.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name build-storybook --branch-name microsoft:master",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",


### PR DESCRIPTION
Chromatic looks at your origin remote + your current branch to specify the branch name to publish to. Since most people use their fork in origin, this makes it difficult to publish to a consistent branch. 

This PR normalizes the branch used when we run 'chromatic' and allows the old behavior as `yarn chromatic:branch` when you want to publish using your current origin and branch name. 