### PR TITLE
fix(react-spinner): add prefers-reduced-motion to spinner

### DIFF
--- a/change/@fluentui-react-spinner-54d34720-9760-409c-81c7-9dcdd2268545.json
+++ b/change/@fluentui-react-spinner-54d34720-9760-409c-81c7-9dcdd2268545.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add prefers-reduced-motion to spinner",
+  "packageName": "@fluentui/react-spinner",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-spinner/src/components/Spinner/useSpinnerStyles.ts
+++ b/packages/react-components/react-spinner/src/components/Spinner/useSpinnerStyles.ts
@@ -228,6 +228,10 @@ const useTrackStyles = makeStyles({
       strokeLinecap: 'round',
       transform: 'rotate(-90deg)',
       transformOrigin: '50% 50%',
+      '@media screen and (prefers-reduced-motion: reduce)': {
+        animationDuration: '0',
+        animationIterationCount: '0',
+      },
     },
     ['& > svg > circle.fui-Spinner__Track']: {
       stroke: tokens.colorNeutralBackground4,

--- a/packages/react-components/react-spinner/src/components/Spinner/useSpinnerStyles.ts
+++ b/packages/react-components/react-spinner/src/components/Spinner/useSpinnerStyles.ts
@@ -229,8 +229,8 @@ const useTrackStyles = makeStyles({
       transform: 'rotate(-90deg)',
       transformOrigin: '50% 50%',
       '@media screen and (prefers-reduced-motion: reduce)': {
-        animationDuration: '0',
-        animationIterationCount: '0',
+        animationDuration: '0.01ms',
+        animationIterationCount: '1',
       },
     },
     ['& > svg > circle.fui-Spinner__Track']: {


### PR DESCRIPTION
Fixes #23193, adds a single media query.

Verified on Windows, works with the built-in OS animation toggle.