### PR TITLE
Theme Designer: starting to build out styles for layout

### DIFF
--- a/packages/react-components/theme-designer/src/ThemeDesigner.tsx
+++ b/packages/react-components/theme-designer/src/ThemeDesigner.tsx
@@ -1,19 +1,45 @@
 import * as React from 'react';
+import { makeStyles } from '@griffel/react';
 import type { ThemeDesignerProps } from './ThemeDesigner.types';
 
 import { Nav } from './components/Nav/Nav';
 import { Sidebar } from './components/Sidebar/Sidebar';
 import { Content } from './components/Content/Content';
 
+const useStyles = makeStyles({
+  root: {
+    display: 'grid',
+    gridTemplateColumns: '300px auto',
+    gridTemplateRows: '40px auto',
+  },
+  nav: {
+    gridColumnStart: 1,
+    gridColumnEnd: 3,
+  },
+  sidebar: {
+    gridRowStart: 2,
+    gridRowEnd: 3,
+    gridColumnStart: 1,
+    gridColumnEnd: 2,
+  },
+  content: {
+    gridRowStart: 2,
+    gridRowEnd: 3,
+    gridColumnStart: 2,
+    gridColumnEnd: 3,
+  },
+});
+
 /**
  * ThemeDesigner component - TODO: add more docs
  */
 export const ThemeDesigner: React.FC<ThemeDesignerProps> = props => {
+  const styles = useStyles();
   return (
-    <>
-      <Nav />
-      <Sidebar />
-      <Content />
-    </>
+    <div className={styles.root}>
+      <Nav className={styles.nav} />
+      <Sidebar className={styles.sidebar} />
+      <Content className={styles.content} />
+    </div>
   );
 };

--- a/packages/react-components/theme-designer/src/components/Component/Component.stories.tsx
+++ b/packages/react-components/theme-designer/src/components/Component/Component.stories.tsx
@@ -1,3 +1,0 @@
-import { Component } from './Component';
-export default { component: Component };
-export const Default = {};

--- a/packages/react-components/theme-designer/src/components/Component/Component.tsx
+++ b/packages/react-components/theme-designer/src/components/Component/Component.tsx
@@ -1,7 +1,0 @@
-import * as React from 'react';
-
-export interface ComponentProps {}
-
-export const Component: React.FC<ComponentProps> = props => {
-  return <div>New Component</div>;
-};

--- a/packages/react-components/theme-designer/src/components/Content/Content.tsx
+++ b/packages/react-components/theme-designer/src/components/Content/Content.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import { makeStyles, mergeClasses } from '@griffel/react';
 
 export interface ContentProps {
-  className?: String;
+  className: string;
 }
 
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
 export const Content: React.FC<ContentProps> = props => {
-  return <div>Content</div>;
+  const styles = useStyles();
+  return <div className={mergeClasses(styles.root, props.className)}>Content</div>;
 };

--- a/packages/react-components/theme-designer/src/components/Content/Content.tsx
+++ b/packages/react-components/theme-designer/src/components/Content/Content.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { makeStyles, mergeClasses } from '@griffel/react';
 
 export interface ContentProps {
-  className: string;
+  className?: string;
 }
 
 const useStyles = makeStyles({

--- a/packages/react-components/theme-designer/src/components/Nav/Nav.tsx
+++ b/packages/react-components/theme-designer/src/components/Nav/Nav.tsx
@@ -1,9 +1,22 @@
 import * as React from 'react';
+import { makeStyles, mergeClasses } from '@griffel/react';
 
 export interface NavProps {
-  className?: String;
+  className: string;
 }
 
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'left',
+    borderBottomWidth: '1px',
+    borderBottomColor: '#D1D1D1',
+    borderBottomStyle: 'solid',
+  },
+});
+
 export const Nav: React.FC<NavProps> = props => {
-  return <div>Nav</div>;
+  const styles = useStyles();
+  return <div className={mergeClasses(styles.root, props.className)}>Nav</div>;
 };

--- a/packages/react-components/theme-designer/src/components/Nav/Nav.tsx
+++ b/packages/react-components/theme-designer/src/components/Nav/Nav.tsx
@@ -10,9 +10,7 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'left',
-    borderBottomWidth: '1px',
-    borderBottomColor: '#D1D1D1',
-    borderBottomStyle: 'solid',
+   ...shorthands.borderBottom('1px', 'solid', '#D1D1D1')
   },
 });
 

--- a/packages/react-components/theme-designer/src/components/Nav/Nav.tsx
+++ b/packages/react-components/theme-designer/src/components/Nav/Nav.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 
 export interface NavProps {
-  className: string;
+  className?: string;
 }
 
 const useStyles = makeStyles({

--- a/packages/react-components/theme-designer/src/components/Nav/Nav.tsx
+++ b/packages/react-components/theme-designer/src/components/Nav/Nav.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, mergeClasses } from '@griffel/react';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 
 export interface NavProps {
   className: string;
@@ -10,7 +10,7 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'left',
-   ...shorthands.borderBottom('1px', 'solid', '#D1D1D1')
+    ...shorthands.borderBottom('1px', 'solid', '#D1D1D1'),
   },
 });
 

--- a/packages/react-components/theme-designer/src/components/Sidebar/Sidebar.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, mergeClasses } from '@griffel/react';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 
 export interface SidebarProps {
   className: string;
@@ -10,9 +10,7 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    borderRightWidth: '1px',
-    borderRightColor: '#D1D1D1',
-    borderRightStyle: 'solid',
+    ...shorthands.borderRight('1px', 'solid', '#D1D1D1'),
   },
 });
 

--- a/packages/react-components/theme-designer/src/components/Sidebar/Sidebar.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/Sidebar.tsx
@@ -1,9 +1,22 @@
 import * as React from 'react';
+import { makeStyles, mergeClasses } from '@griffel/react';
 
 export interface SidebarProps {
-  className?: String;
+  className: string;
 }
 
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRightWidth: '1px',
+    borderRightColor: '#D1D1D1',
+    borderRightStyle: 'solid',
+  },
+});
+
 export const Sidebar: React.FC<SidebarProps> = props => {
-  return <div>Sidebar</div>;
+  const styles = useStyles();
+  return <div className={mergeClasses(styles.root, props.className)}>Sidebar</div>;
 };

--- a/packages/react-components/theme-designer/src/components/Sidebar/Sidebar.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/Sidebar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 
 export interface SidebarProps {
-  className: string;
+  className?: string;
 }
 
 const useStyles = makeStyles({


### PR DESCRIPTION
Adding styles to the preexisting layout of the theme designer such that it now has a designated area for the navbar, sidebar, and content.

<img width="525" alt="image" src="https://user-images.githubusercontent.com/31319479/170107424-e44729d8-03c0-422c-92ac-e7d394cdef0e.png">