### PR TITLE
(fix) create-package script now works when creating a converged node package

### DIFF
--- a/scripts/create-package/plopfile.ts
+++ b/scripts/create-package/plopfile.ts
@@ -17,7 +17,7 @@ const v8ReferencePackages = {
 };
 const convergedReferencePackages = {
   react: ['react-provider'],
-  node: ['babel-make-styles'],
+  node: ['react-components/react-utilities'],
 };
 
 interface Answers {


### PR DESCRIPTION


## Current Behavior

<!-- This is the behavior we have today -->
- When creating a `converged` `node` package with the `yarn create-package` script, the console errors out since the referenced package (`babel-make-styles`) has long been removed from the monorepo by #21482.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- the referenced package when creating a `converged` `node` package is now `react-utilities`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Partially Fixes #22960
