### PR TITLE
Remove additional focus ring from `Input`, `SpinButton`, and `Textarea` when using macOS safari

### DIFF
--- a/change/@fluentui-react-input-28f3decf-aea3-4965-8855-966b465cd73b.json
+++ b/change/@fluentui-react-input-28f3decf-aea3-4965-8855-966b465cd73b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing additional focus ring in native input for macOS safari.",
+  "packageName": "@fluentui/react-input",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-86cf8f69-2ee4-407a-8b1b-ce90f9978be0.json
+++ b/change/@fluentui-react-spinbutton-86cf8f69-2ee4-407a-8b1b-ce90f9978be0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing additional focus ring in native input for macOS safari.",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-17985c27-7371-4178-9cc2-322833f783d9.json
+++ b/change/@fluentui-react-textarea-17985c27-7371-4178-9cc2-322833f783d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removing additional focus ring in native textarea for macOS safari.",
+  "packageName": "@fluentui/react-textarea",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-components/react-input/src/components/Input/useInputStyles.ts
@@ -176,6 +176,8 @@ const useInputElementStyles = makeStyles({
       color: tokens.colorNeutralForeground4,
       opacity: 1, // browser style override
     },
+
+    outlineStyle: 'none',
     ':focus-visible': {
       outlineStyle: 'none', // disable default browser outline
     },

--- a/packages/react-components/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-components/react-input/src/components/Input/useInputStyles.ts
@@ -177,10 +177,7 @@ const useInputElementStyles = makeStyles({
       opacity: 1, // browser style override
     },
 
-    outlineStyle: 'none',
-    ':focus-visible': {
-      outlineStyle: 'none', // disable default browser outline
-    },
+    outlineStyle: 'none', // disable default browser outline
   },
   small: {
     // This is set on root but doesn't inherit

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -152,6 +152,7 @@ const useInputStyles = makeStyles({
     gridColumnEnd: '2',
     gridRowStart: '1',
     gridRowEnd: '3',
+    outlineStyle: 'none',
     ...shorthands.padding(0),
   },
 });

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
@@ -143,10 +143,7 @@ const useTextareaStyles = makeStyles({
       backgroundColor: tokens.colorNeutralBackgroundInverted,
     },
 
-    outlineStyle: 'none',
-    ':focus-visible': {
-      outlineStyle: 'none', // disable default browser outline
-    },
+    outlineStyle: 'none', // disable default browser outline
   },
 
   // The padding style adds both content and regular padding (from design spec), this is because the handle is not

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
@@ -143,6 +143,7 @@ const useTextareaStyles = makeStyles({
       backgroundColor: tokens.colorNeutralBackgroundInverted,
     },
 
+    outlineStyle: 'none',
     ':focus-visible': {
       outlineStyle: 'none', // disable default browser outline
     },


### PR DESCRIPTION


## Current Behavior

Additional focus ring is shown in native input/textarea element when using macOS safari.

## New Behavior

No focus ring is shown in native input/textarea element.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23167
