### PR TITLE
Fix PlainCard export

### DIFF
--- a/change/@fluentui-react-25c59003-ab69-4806-b14b-555b3a467382.json
+++ b/change/@fluentui-react-25c59003-ab69-4806-b14b-555b3a467382.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Fixing the PlainCard styles export to have the correct path. This never worked before, so I consider it a minor change.",
+  "packageName": "@fluentui/react",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -523,10 +523,10 @@
       "import": "./lib/components/HoverCard/HoverCard.styles.js",
       "require": "./lib-commonjs/components/HoverCard/HoverCard.styles.js"
     },
-    "./lib/components/HoverCard/PlainCard.styles": {
-      "types": "./lib/components/HoverCard/PlainCard.styles.d.ts",
-      "import": "./lib/components/HoverCard/PlainCard.styles.js",
-      "require": "./lib-commonjs/components/HoverCard/PlainCard.styles.js"
+    "./lib/components/HoverCard/PlainCard/PlainCard.styles": {
+      "types": "./lib/components/HoverCard/PlainCard/PlainCard.styles.d.ts",
+      "import": "./lib/components/HoverCard/PlainCard/PlainCard.styles.js",
+      "require": "./lib-commonjs/components/HoverCard/PlainCard/PlainCard.styles.js"
     },
     "./lib/Icon": {
       "types": "./lib/Icon.d.ts",


### PR DESCRIPTION
The export in the `@fluentui/react` package for `PlainCard.styles` is pointing to the wrong path. Either the path changed or this never worked, but it's wrong.

We really need package linting. This could have been caught by just validating that all exports are files that exist in the pre-publish folder content.