### PR TITLE
Fix: Update appearance stories to use tokens

### DIFF
--- a/packages/react-components/react-combobox/src/stories/ComboboxAppearance.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/ComboboxAppearance.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { makeStyles, shorthands } from '@griffel/react';
 import { useId } from '@fluentui/react-utilities';
 import { Combobox, ComboboxProps, Option } from '../index';
+import { tokens } from '@fluentui/react-theme';
 
 const useStyles = makeStyles({
   root: {
@@ -13,14 +14,23 @@ const useStyles = makeStyles({
       display: 'flex',
       flexDirection: 'column',
       ...shorthands.gap('5px'),
-      ...shorthands.borderRadius('10px'),
       // need padding to see the background color for filled variants
       ...shorthands.padding('5px', '20px', '10px'),
     },
   },
   // filledLighter and filledDarker appearances depend on particular background colors
-  filledLighter: { backgroundColor: '#8a8a8a' },
-  filledDarker: { backgroundColor: '#8a8a8a' },
+  filledLighter: {
+    backgroundColor: tokens.colorPaletteDarkBlueForeground1,
+    '> label': {
+      color: tokens.colorNeutralForegroundInverted,
+    },
+  },
+  filledDarker: {
+    backgroundColor: tokens.colorPaletteDarkBlueForeground1,
+    '> label': {
+      color: tokens.colorNeutralForegroundInverted,
+    },
+  },
 });
 
 export const Appearance = (props: Partial<ComboboxProps>) => {

--- a/packages/react-components/react-input/src/stories/InputAppearance.stories.tsx
+++ b/packages/react-components/react-input/src/stories/InputAppearance.stories.tsx
@@ -18,15 +18,15 @@ const useStyles = makeStyles({
     ...shorthands.padding(tokens.spacingHorizontalMNudge),
   },
   filledLighter: {
-    backgroundColor: '#8a8a8a',
+    backgroundColor: tokens.colorPaletteDarkBlueForeground1,
     '> label': {
-      color: '#000000',
+      color: tokens.colorNeutralForegroundInverted,
     },
   },
   filledDarker: {
-    backgroundColor: '#8a8a8a',
+    backgroundColor: tokens.colorPaletteDarkBlueForeground1,
     '> label': {
-      color: '#000000',
+      color: tokens.colorNeutralForegroundInverted,
     },
   },
 });

--- a/packages/react-components/react-select/src/stories/SelectAppearance.stories.tsx
+++ b/packages/react-components/react-select/src/stories/SelectAppearance.stories.tsx
@@ -19,15 +19,15 @@ const useStyles = makeStyles({
   },
 
   filledLighter: {
-    backgroundColor: '#8a8a8a',
+    backgroundColor: tokens.colorPaletteDarkBlueForeground1,
     '> label': {
-      color: '#000000',
+      color: tokens.colorNeutralForegroundInverted,
     },
   },
   filledDarker: {
-    backgroundColor: '#8a8a8a',
+    backgroundColor: tokens.colorPaletteDarkBlueForeground1,
     '> label': {
-      color: '#000000',
+      color: tokens.colorNeutralForegroundInverted,
     },
   },
 });

--- a/packages/react-components/react-spinbutton/src/stories/SpinButtonAppearance.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButtonAppearance.stories.tsx
@@ -20,15 +20,15 @@ const useStyles = makeStyles({
   },
 
   filledLighter: {
-    backgroundColor: '#8a8a8a',
+    backgroundColor: tokens.colorPaletteDarkBlueForeground1,
     '> label': {
-      color: '#000000',
+      color: tokens.colorNeutralForegroundInverted,
     },
   },
   filledDarker: {
-    backgroundColor: '#8a8a8a',
+    backgroundColor: tokens.colorPaletteDarkBlueForeground1,
     '> label': {
-      color: '#000000',
+      color: tokens.colorNeutralForegroundInverted,
     },
   },
 });


### PR DESCRIPTION
## Current Behavior

Appearance stories for ComboBox, Input, Select and SpinButton have adequate contrast with the background for the filledDarker and filledLighter appearances but do not use tokens for colors.

## New Behavior

All relevant stories use tokens for colors.

The previous colors used were in the color palette but not exported as directly usable tokens. This color change has been reviewed with design.

Textarea is updated in #23190