### PR TITLE
[BREAKING] Remove `status` prop in Spinner

### DIFF
--- a/change/@fluentui-react-spinner-28531f36-212d-4200-8910-88a19de43989.json
+++ b/change/@fluentui-react-spinner-28531f36-212d-4200-8910-88a19de43989.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Remove `status` prop in Spinner",
+  "comment": "BREAKING: Remove `status` prop in Spinner",
   "packageName": "@fluentui/react-spinner",
   "email": "ololubek@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-spinner-28531f36-212d-4200-8910-88a19de43989.json
+++ b/change/@fluentui-react-spinner-28531f36-212d-4200-8910-88a19de43989.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove `status` prop in Spinner",
+  "packageName": "@fluentui/react-spinner",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinner/README.md
+++ b/packages/react-components/react-spinner/README.md
@@ -18,3 +18,12 @@ import { Spinner } from '@fluentui/react-spinner';
 <Spinner label="Loading..." />
 <Spinner size="large" />
 ```
+
+#### Rendering Spinner without the animated circle
+
+You can directly override the Spinner slot to render a Spinner without the animated circle, as shown below
+
+```js
+<Spinner spinner='' appearance="primary" label="Primary Spinner" />
+<Spinner spinner={{style:{visibility: 'hidden'}}} appearance="inverted" label="Inverted Spinner" />
+```

--- a/packages/react-components/react-spinner/Spec.md
+++ b/packages/react-components/react-spinner/Spec.md
@@ -88,8 +88,6 @@ export type SpinnerProps = ComponentProps &
     /* The size prop sets the size of the Spinner
      * @defaultValue "medium"*/
     size?: 'tiny' | 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large' | 'huge',
-    // inactive ? : boolean
-    status?: 'active' | 'inactive',
   };
 ```
 

--- a/packages/react-components/react-spinner/etc/react-spinner.api.md
+++ b/packages/react-components/react-spinner/etc/react-spinner.api.md
@@ -26,7 +26,6 @@ export type SpinnerProps = Omit<ComponentProps<SpinnerSlots>, 'size'> & {
     appearance?: 'primary' | 'inverted';
     labelPosition?: 'above' | 'below' | 'before' | 'after';
     size?: 'tiny' | 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large' | 'huge';
-    status?: 'active' | 'inactive';
 };
 
 // @public (undocumented)
@@ -37,7 +36,7 @@ export type SpinnerSlots = {
 };
 
 // @public
-export type SpinnerState = ComponentState<SpinnerSlots> & Required<Pick<SpinnerProps, 'appearance' | 'labelPosition' | 'size' | 'status'>>;
+export type SpinnerState = ComponentState<SpinnerSlots> & Required<Pick<SpinnerProps, 'appearance' | 'labelPosition' | 'size'>>;
 
 // @public
 export const useSpinner_unstable: (props: SpinnerProps, ref: React_2.Ref<HTMLElement>) => SpinnerState;

--- a/packages/react-components/react-spinner/src/components/Spinner/Spinner.test.tsx
+++ b/packages/react-components/react-spinner/src/components/Spinner/Spinner.test.tsx
@@ -29,4 +29,14 @@ describe('Spinner', () => {
     expect(result.getByText('Loading')).toBeDefined();
     expect(result.queryByRole('progressbar')).toBeDefined();
   });
+
+  it('doesnt render Spinner when slot is overridden', () => {
+    const result = render(<Spinner spinner="" />);
+    expect(result.queryByRole('progressbar')).toBeNull();
+  });
+
+  it('doesnt render Spinner when spinner styles is overridden', () => {
+    const result = render(<Spinner spinner={{ style: { visibility: 'hidden' } }} />);
+    expect(result.queryByRole('progressbar')).toBeNull();
+  });
 });

--- a/packages/react-components/react-spinner/src/components/Spinner/Spinner.test.tsx
+++ b/packages/react-components/react-spinner/src/components/Spinner/Spinner.test.tsx
@@ -21,17 +21,12 @@ describe('Spinner', () => {
 
   it('has role progressbar', () => {
     const result = render(<Spinner label="Default Spinner" />);
-    expect(result.queryByRole('progessbar')).toBeDefined();
+    expect(result.queryByRole('progressbar')).toBeDefined();
   });
 
   it('renders Spinner with a label', () => {
     const result = render(<Spinner label="Loading" />);
     expect(result.getByText('Loading')).toBeDefined();
-    expect(result.queryByRole('progessbar')).toBeDefined();
-  });
-
-  it('doesnt render svg when status is inactive', () => {
-    const result = render(<Spinner status="inactive" />);
-    expect(result.queryByRole('progessbar')).toBeNull();
+    expect(result.queryByRole('progressbar')).toBeDefined();
   });
 });

--- a/packages/react-components/react-spinner/src/components/Spinner/Spinner.types.ts
+++ b/packages/react-components/react-spinner/src/components/Spinner/Spinner.types.ts
@@ -41,16 +41,10 @@ export type SpinnerProps = Omit<ComponentProps<SpinnerSlots>, 'size'> & {
    * @default 'medium'
    */
   size?: 'tiny' | 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large' | 'huge';
-
-  /**
-   * The status of the Spinner.
-   * @default 'active'
-   */
-  status?: 'active' | 'inactive';
 };
 
 /**
  * State used in rendering Spinner
  */
 export type SpinnerState = ComponentState<SpinnerSlots> &
-  Required<Pick<SpinnerProps, 'appearance' | 'labelPosition' | 'size' | 'status'>>;
+  Required<Pick<SpinnerProps, 'appearance' | 'labelPosition' | 'size'>>;

--- a/packages/react-components/react-spinner/src/components/Spinner/renderSpinner.tsx
+++ b/packages/react-components/react-spinner/src/components/Spinner/renderSpinner.tsx
@@ -7,11 +7,11 @@ import type { SpinnerState, SpinnerSlots } from './Spinner.types';
  */
 export const renderSpinner_unstable = (state: SpinnerState) => {
   const { slots, slotProps } = getSlots<SpinnerSlots>(state);
-  const { labelPosition, status } = state;
+  const { labelPosition } = state;
   return (
     <slots.root {...slotProps.root}>
       {slots.label && (labelPosition === 'above' || labelPosition === 'before') && <slots.label {...slotProps.label} />}
-      {slots.spinner && status === 'active' && <slots.spinner {...slotProps.spinner} />}
+      {slots.spinner && <slots.spinner {...slotProps.spinner} />}
       {slots.label && (labelPosition === 'below' || labelPosition === 'after') && <slots.label {...slotProps.label} />}
     </slots.root>
   );

--- a/packages/react-components/react-spinner/src/components/Spinner/useSpinner.tsx
+++ b/packages/react-components/react-spinner/src/components/Spinner/useSpinner.tsx
@@ -15,7 +15,7 @@ import { DefaultSvg } from './DefaultSvg';
  */
 export const useSpinner_unstable = (props: SpinnerProps, ref: React.Ref<HTMLElement>): SpinnerState => {
   // Props
-  const { appearance = 'primary', labelPosition = 'after', size = 'medium', status = 'active' } = props;
+  const { appearance = 'primary', labelPosition = 'after', size = 'medium' } = props;
   const baseId = useId('spinner');
 
   const { tabIndex, ...rest } = props;
@@ -44,7 +44,6 @@ export const useSpinner_unstable = (props: SpinnerProps, ref: React.Ref<HTMLElem
     appearance,
     labelPosition,
     size,
-    status,
     components: {
       root: 'div',
       spinner: 'span',


### PR DESCRIPTION
This PR is to remove the `status` prop from `Spinner` and add documentation about changing the active state of `Spinner` in documentation

Fixes #23184