### PR TITLE
fix(react-spinner): fix Firefox rendering by adding px units to r

### DIFF
--- a/change/@fluentui-react-spinner-1c220f3c-62cf-44a3-93e6-86a9e5a48933.json
+++ b/change/@fluentui-react-spinner-1c220f3c-62cf-44a3-93e6-86a9e5a48933.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix Spinner on Firefox: add px units to r values",
+  "packageName": "@fluentui/react-spinner",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-spinner/src/components/Spinner/useSpinnerStyles.ts
+++ b/packages/react-components/react-spinner/src/components/Spinner/useSpinnerStyles.ts
@@ -14,13 +14,13 @@ export const spinnerClassNames: SlotClassNames<SpinnerSlots> = {
  * Radii for the Spinner circles
  */
 const rValues = {
-  tiny: '9',
-  extraSmall: '11',
-  small: '13',
-  medium: '14.5',
-  large: '16.5',
-  extraLarge: '18.5',
-  huge: '20',
+  tiny: '9px',
+  extraSmall: '11px',
+  small: '13px',
+  medium: '14.5px',
+  large: '16.5px',
+  extraLarge: '18.5px',
+  huge: '20px',
 };
 
 /*


### PR DESCRIPTION
Previously the spinner did not visually render at all on Firefox, since the `<circle>` SVG elements were missing an `r` definition. It turns out Griffel does not output the style for `r` on Firefox specifically if the units are left off (issue logged: https://github.com/microsoft/griffel/issues/119).

I verified that the spinner now renders on both Chromium and Firefox with this change (and non-0 `r` generally should have units in any case, since it's specified as `length | percentage`)