### PR TITLE
v9: Add Select to Preview Components

### DIFF
--- a/change/@fluentui-react-components-863d4794-3dd2-4e12-868e-2162affc2c4f.json
+++ b/change/@fluentui-react-components-863d4794-3dd2-4e12-868e-2162affc2c4f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add Select to Preview Components",
+  "packageName": "@fluentui/react-components",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-93492b0a-799b-4692-898e-a1cc3c689a34.json
+++ b/change/@fluentui-react-select-93492b0a-799b-4692-898e-a1cc3c689a34.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add Select to Preview Components",
+  "packageName": "@fluentui/react-select",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -28,7 +28,13 @@ import { renderCard_unstable } from '@fluentui/react-card';
 import { renderCardFooter_unstable } from '@fluentui/react-card';
 import { renderCardHeader_unstable } from '@fluentui/react-card';
 import { renderCardPreview_unstable } from '@fluentui/react-card';
+import { renderSelect_unstable } from '@fluentui/react-select';
 import { renderSpinButton_unstable } from '@fluentui/react-spinbutton';
+import { Select } from '@fluentui/react-select';
+import { selectClassNames } from '@fluentui/react-select';
+import { SelectProps } from '@fluentui/react-select';
+import { SelectSlots } from '@fluentui/react-select';
+import { SelectState } from '@fluentui/react-select';
 import { SpinButton } from '@fluentui/react-spinbutton';
 import { SpinButtonBounds } from '@fluentui/react-spinbutton';
 import { SpinButtonChangeEvent } from '@fluentui/react-spinbutton';
@@ -46,6 +52,8 @@ import { useCardHeaderStyles_unstable } from '@fluentui/react-card';
 import { useCardPreview_unstable } from '@fluentui/react-card';
 import { useCardPreviewStyles_unstable } from '@fluentui/react-card';
 import { useCardStyles_unstable } from '@fluentui/react-card';
+import { useSelect_unstable } from '@fluentui/react-select';
+import { useSelectStyles_unstable } from '@fluentui/react-select';
 import { useSpinButton_unstable } from '@fluentui/react-spinbutton';
 import { useSpinButtonStyles_unstable } from '@fluentui/react-spinbutton';
 
@@ -97,7 +105,19 @@ export { renderCardHeader_unstable }
 
 export { renderCardPreview_unstable }
 
+export { renderSelect_unstable }
+
 export { renderSpinButton_unstable }
+
+export { Select }
+
+export { selectClassNames }
+
+export { SelectProps }
+
+export { SelectSlots }
+
+export { SelectState }
 
 export { SpinButton }
 
@@ -132,6 +152,10 @@ export { useCardPreview_unstable }
 export { useCardPreviewStyles_unstable }
 
 export { useCardStyles_unstable }
+
+export { useSelect_unstable }
+
+export { useSelectStyles_unstable }
 
 export { useSpinButton_unstable }
 

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -49,6 +49,7 @@
     "@fluentui/react-portal": "9.0.0-rc.11",
     "@fluentui/react-provider": "9.0.0-rc.11",
     "@fluentui/react-radio": "9.0.0-rc.4",
+    "@fluentui/react-select": "9.0.0-beta.0",
     "@fluentui/react-shared-contexts": "9.0.0-rc.9",
     "@fluentui/react-slider": "9.0.0-beta.16",
     "@fluentui/react-spinbutton": "9.0.0-beta.11",

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -38,6 +38,15 @@ export type {
 } from '@fluentui/react-card';
 
 export {
+  Select,
+  renderSelect_unstable,
+  selectClassNames,
+  useSelectStyles_unstable,
+  useSelect_unstable,
+} from '@fluentui/react-select';
+export type { SelectProps, SelectSlots, SelectState } from '@fluentui/react-select';
+
+export {
   SpinButton,
   renderSpinButton_unstable,
   spinButtonClassNames,

--- a/packages/react-components/react-select/package.json
+++ b/packages/react-components/react-select/package.json
@@ -2,7 +2,6 @@
   "name": "@fluentui/react-select",
   "version": "9.0.0-beta.0",
   "description": "Fluent UI React Select component",
-  "private": true,
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "dist/index.d.ts",
@@ -51,5 +50,12 @@
       "minor",
       "patch"
     ]
+  },
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js",
+      "require": "./lib-commonjs/index.js"
+    }
   }
 }

--- a/packages/react-components/react-select/src/stories/Select.stories.tsx
+++ b/packages/react-components/react-select/src/stories/Select.stories.tsx
@@ -12,7 +12,7 @@ export { Inline } from './SelectInline.stories';
 export { Size } from './SelectSize.stories';
 
 export default {
-  title: 'Components/Select',
+  title: 'Preview Components/Select',
   component: Select,
   parameters: {
     docs: {


### PR DESCRIPTION
Exports the `react-select` package from `react-components` as an unstable preview component