### PR TITLE
ToggleButton: Differentiating hover and checked styles

### DIFF
--- a/change/@fluentui-react-button-ae32d3af-7f8a-478f-ab75-159deab67465.json
+++ b/change/@fluentui-react-button-ae32d3af-7f8a-478f-ab75-159deab67465.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "ToggleButton: Differentiating hover and checked styles.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -1,4 +1,5 @@
 import { iconFilledClassName, iconRegularClassName } from '@fluentui/react-icons';
+import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import { tokens } from '@fluentui/react-theme';
 import { shorthands, mergeClasses, makeStyles } from '@griffel/react';
 import { useButtonStyles_unstable } from '../Button/useButtonStyles';
@@ -43,14 +44,32 @@ export const useCheckedStyles = makeStyles({
   // High contrast styles
   highContrast: {
     '@media (forced-colors: active)': {
+      backgroundColor: 'Highlight',
       ...shorthands.borderColor('Highlight'),
-      color: 'Highlight',
+      color: 'HighlightText',
+      forcedColorAdjust: 'none',
+
+      ':hover': {
+        backgroundColor: 'HighlightText',
+        ...shorthands.borderColor('Highlight'),
+        color: 'Highlight',
+      },
+
+      ':hover:active': {
+        backgroundColor: 'HighlightText',
+        ...shorthands.borderColor('Highlight'),
+        color: 'Highlight',
+      },
 
       ':focus': {
         ...shorthands.borderColor('Highlight'),
       },
     },
   },
+  highContrastFocusStyles: createCustomFocusIndicatorStyle({
+    ...shorthands.border('1px', 'solid', 'HighlightText'),
+    outlineColor: 'Highlight',
+  }),
 
   // Appearance variations
   outline: {


### PR DESCRIPTION
## Current Behavior

`ToggleButton` High Contrast styles are the same for unchecked hover, checked rest and checked hover states.

__Unchecked hover:__
![image](https://user-images.githubusercontent.com/7798177/170151251-78dfc1a1-cf54-4807-bcfc-e924ab4c6a68.png)

__Checked rest:__
![image](https://user-images.githubusercontent.com/7798177/170151282-de680944-27ac-4ee1-b552-0a69211136b4.png)

__Checked hover:__
![image](https://user-images.githubusercontent.com/7798177/170151307-a5f9c74a-5bec-4bdd-a119-43b1bc86bdb4.png)

## New Behavior

`ToggleButton` High Contrast styles are differentiated between unchecked hover, checked rest and checked hover states.

__Unchecked hover:__
![image](https://user-images.githubusercontent.com/7798177/170151349-2810df75-68a8-412d-81db-0077a216499e.png)

__Checked rest:__
![image](https://user-images.githubusercontent.com/7798177/170151382-2eb3b377-c354-4f3a-ad81-67890136f7ea.png)

__Checked hover:__
![image](https://user-images.githubusercontent.com/7798177/170151446-80308fef-e294-4cd9-9e7c-c77ba5e07afe.png)

We have also made sure that the focus style looks correct with the new checked rest styles:

![image](https://user-images.githubusercontent.com/7798177/170151497-87ef0094-a787-4ead-b2b4-04ede1244e7e.png)

## Related Issue(s)

Fixes #23072
