### PR TITLE
[Line Charts]: Not able to access all groups available in graph using keyboard.

### DIFF
--- a/change/@fluentui-react-charting-c92dee22-0e93-42e9-8548-0df5ead10380.json
+++ b/change/@fluentui-react-charting-c92dee22-0e93-42e9-8548-0df5ead10380.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Not able to access all groups available in graph using keyboard.",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-hannapared@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -559,7 +559,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
             id={circleId}
             key={circleId}
             d={path}
-            data-is-focusable={i === 0 ? true : false}
+            data-is-focusable={true}
             onMouseOver={this._handleHover.bind(
               this,
               x1,
@@ -608,7 +608,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
               id={lastCircleId}
               key={lastCircleId}
               d={path}
-              data-is-focusable={i === 0 ? true : false}
+              data-is-focusable={true}
               onMouseOver={this._handleHover.bind(
                 this,
                 x2,


### PR DESCRIPTION


## Current Behavior

 Not able to access all groups available in the graph using the keyboard.

## New Behavior

After this fix using the keyboard tab key arrow keys, we are able to navigate the graph as expected.



Fixes #
After this fix using the keyboard tab key arrow keys, we are able to navigate the graph as expected.