### PR TITLE
docs(react-radio): make Best Practices collapsible

### DIFF
--- a/change/@fluentui-react-radio-5f7a594b-d9a0-498d-b89d-9931a9aa8ce5.json
+++ b/change/@fluentui-react-radio-5f7a594b-d9a0-498d-b89d-9931a9aa8ce5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "make Best Practices collapsible",
+  "packageName": "@fluentui/react-radio",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-radio/src/stories/RadioGroupBestPractices.md
+++ b/packages/react-components/react-radio/src/stories/RadioGroupBestPractices.md
@@ -1,4 +1,7 @@
-## Best practices
+<details>
+<summary>
+ Best Practices
+</summary>
 
 ### Do
 
@@ -21,3 +24,5 @@
 
 - **Include more than 5 options.**
   Use RadioGroup when there are 2-5 options, and you have enough screen space and the options are important enough to be a good use of that screen space. Otherwise, use Dropdown.
+
+</details>


### PR DESCRIPTION
Hides "Best Practices" section under a spoiler as in other components.