### PR TITLE
docs(react-badge): fix title in sidebar

### DIFF
--- a/packages/react-components/react-badge/src/stories/PresenceBadge.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/PresenceBadge.stories.tsx
@@ -9,7 +9,7 @@ export { Status } from './PresenceBadgeStatus.stories';
 export { OutOfOffice } from './PresenceBadgeOutOfOffice.stories';
 
 export default {
-  title: 'Components/Presence Badge',
+  title: 'Components/PresenceBadge',
   component: PresenceBadge,
   parameters: {
     docs: {


### PR DESCRIPTION
We don't use spaces for components' names in the sidebar.

### Before

![image](https://user-images.githubusercontent.com/14183168/170237724-dac4c8a6-87bb-4732-a636-393215bc0de8.png)

### After

![image](https://user-images.githubusercontent.com/14183168/170237676-62dce59b-7781-46a9-b845-7230b1ac9e11.png)
