### PR TITLE
docs(react-label): remove a notice about unstable

### DIFF
--- a/change/@fluentui-react-label-a2021a5e-4235-448c-838a-b616236c2ff7.json
+++ b/change/@fluentui-react-label-a2021a5e-4235-448c-838a-b616236c2ff7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "remove a notice about unstable",
+  "packageName": "@fluentui/react-label",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-label/src/stories/LabelDescription.md
+++ b/packages/react-components/react-label/src/stories/LabelDescription.md
@@ -1,10 +1,1 @@
 A label provides a name or title for an input.
-
-> **⚠️ Preview components are considered unstable:**
->
-> ```jsx
-> import { Label } from '@fluentui/react-components/unstable';
-> ```
->
-> - Features and APIs may change before final release
-> - Please contact us if you intend to use this in your product


### PR DESCRIPTION
This PR removes the notice as `Label` was promoted to RC in #22865.

![image](https://user-images.githubusercontent.com/14183168/170240292-6f31d985-0fa8-44aa-8239-c8095c33e5b3.png)
