### PR TITLE
docs(react-link): fix missing dot, create missing files

### DIFF
--- a/change/@fluentui-react-link-2ddae486-b8c1-4c57-9980-5f22d8b7dda7.json
+++ b/change/@fluentui-react-link-2ddae486-b8c1-4c57-9980-5f22d8b7dda7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix missing dot, create missing files",
+  "packageName": "@fluentui/react-link",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-link/src/stories/Link.stories.tsx
+++ b/packages/react-components/react-link/src/stories/Link.stories.tsx
@@ -1,5 +1,8 @@
 import { Link } from '../index';
 
+import descriptionMd from './LinkDescription.md';
+import bestPracticesMd from './LinkBestPractices.md';
+
 export { Default } from './LinkDefault.stories';
 export { Appearance } from './LinkAppearance.stories';
 export { Inline } from './LinkInline.stories';
@@ -20,10 +23,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: [
-          'Links allow users to navigate between different locations',
-          'They can be used as standalone controls or inline with text.',
-        ].join('\n'),
+        component: [descriptionMd, bestPracticesMd].join('\n'),
       },
     },
   },

--- a/packages/react-components/react-link/src/stories/LinkDescription.md
+++ b/packages/react-components/react-link/src/stories/LinkDescription.md
@@ -1,0 +1,1 @@
+Links allow users to navigate between different locations. They can be used as standalone controls or inline with text.


### PR DESCRIPTION
This PR fixes a missing dot in the description:

![image](https://user-images.githubusercontent.com/14183168/170241818-9a97e39b-5dc4-44a2-9900-0eb1c6055292.png)

I also created `.md` files for description & best practices. It should be nice to fill the last one 😉 