### PR TITLE
feat: Export react-overflow utilities as unstable

### DIFF
--- a/apps/public-docsite-v9/.storybook/main.utils.js
+++ b/apps/public-docsite-v9/.storybook/main.utils.js
@@ -6,6 +6,9 @@
 const fs = require('fs');
 const path = require('path');
 
+// Dependencies to exclude stories loading
+const excludedDependencies = ['@fluentui/react-overflow'];
+
 function getVnextStories() {
   /** @type {Record<string,unknown>} */
   const packageJson = JSON.parse(
@@ -18,7 +21,7 @@ function getVnextStories() {
   const dependencies = /** @type {Record<string,string>} */ (packageJson.dependencies);
 
   return Object.keys({ ...dependencies, '@fluentui/react-components': '' })
-    .filter(pkgName => pkgName.startsWith('@fluentui/'))
+    .filter(pkgName => pkgName.startsWith('@fluentui/') && !excludedDependencies.includes(pkgName))
     .map(pkgName => {
       const name = pkgName.replace('@fluentui/', '');
       const storiesGlob = '/src/**/*.stories.@(ts|tsx|mdx)';

--- a/change/@fluentui-react-components-8ecebe2c-3d74-499f-8aca-ca4ed8c45f1b.json
+++ b/change/@fluentui-react-components-8ecebe2c-3d74-499f-8aca-ca4ed8c45f1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Export react-overflow utilities as unstable",
+  "packageName": "@fluentui/react-components",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/.storybook/main.utils.js
+++ b/packages/react-components/react-components/.storybook/main.utils.js
@@ -6,6 +6,9 @@
 const fs = require('fs');
 const path = require('path');
 
+// Dependencies to exclude stories loading
+const excludedDependencies = ['@fluentui/react-overflow'];
+
 function getVnextStories() {
   /** @type {Record<string,unknown>} */
   const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, `../package.json`), 'utf-8'));
@@ -13,7 +16,7 @@ function getVnextStories() {
   const dependencies = /** @type {Record<string,string>} */ (packageJson.dependencies);
 
   return Object.keys(dependencies)
-    .filter(pkgName => pkgName.startsWith('@fluentui/'))
+    .filter(pkgName => pkgName.startsWith('@fluentui/') && !excludedDependencies.includes(pkgName))
     .map(pkgName => {
       const name = pkgName.replace('@fluentui/', '');
       const storiesGlob = '/src/**/*.stories.@(ts|tsx|mdx)';

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -29,6 +29,13 @@ import { CardPreviewState } from '@fluentui/react-card';
 import { CardProps } from '@fluentui/react-card';
 import { CardSlots } from '@fluentui/react-card';
 import { CardState } from '@fluentui/react-card';
+import { DATA_OVERFLOW_ITEM } from '@fluentui/react-overflow';
+import { DATA_OVERFLOW_MENU } from '@fluentui/react-overflow';
+import { DATA_OVERFLOWING } from '@fluentui/react-overflow';
+import { Overflow } from '@fluentui/react-overflow';
+import { OverflowItem } from '@fluentui/react-overflow';
+import { OverflowItemProps } from '@fluentui/react-overflow';
+import { OverflowProps } from '@fluentui/react-overflow';
 import { renderAlert_unstable } from '@fluentui/react-alert';
 import { renderCard_unstable } from '@fluentui/react-card';
 import { renderCardFooter_unstable } from '@fluentui/react-card';
@@ -60,6 +67,9 @@ import { useCardHeaderStyles_unstable } from '@fluentui/react-card';
 import { useCardPreview_unstable } from '@fluentui/react-card';
 import { useCardPreviewStyles_unstable } from '@fluentui/react-card';
 import { useCardStyles_unstable } from '@fluentui/react-card';
+import { useIsOverflowGroupVisible } from '@fluentui/react-overflow';
+import { useIsOverflowItemVisible } from '@fluentui/react-overflow';
+import { useOverflowMenu } from '@fluentui/react-overflow';
 import { useSelect_unstable } from '@fluentui/react-select';
 import { useSelectStyles_unstable } from '@fluentui/react-select';
 import { useSpinButton_unstable } from '@fluentui/react-spinbutton';
@@ -114,6 +124,20 @@ export { CardProps }
 export { CardSlots }
 
 export { CardState }
+
+export { DATA_OVERFLOW_ITEM }
+
+export { DATA_OVERFLOW_MENU }
+
+export { DATA_OVERFLOWING }
+
+export { Overflow }
+
+export { OverflowItem }
+
+export { OverflowItemProps }
+
+export { OverflowProps }
 
 export { renderAlert_unstable }
 
@@ -176,6 +200,12 @@ export { useCardPreview_unstable }
 export { useCardPreviewStyles_unstable }
 
 export { useCardStyles_unstable }
+
+export { useIsOverflowGroupVisible }
+
+export { useIsOverflowItemVisible }
+
+export { useOverflowMenu }
 
 export { useSelect_unstable }
 

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -45,6 +45,7 @@
     "@fluentui/react-label": "9.0.0-rc.3",
     "@fluentui/react-link": "9.0.0-rc.11",
     "@fluentui/react-menu": "9.0.0-rc.11",
+    "@fluentui/react-overflow": "9.0.0-beta.2",
     "@fluentui/react-popover": "9.0.0-rc.11",
     "@fluentui/react-positioning": "9.0.0-rc.10",
     "@fluentui/react-portal": "9.0.0-rc.11",

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -69,3 +69,16 @@ export type {
   SpinButtonSpinState,
   SpinButtonBounds,
 } from '@fluentui/react-spinbutton';
+
+export {
+  Overflow,
+  OverflowItem,
+  useIsOverflowGroupVisible,
+  useIsOverflowItemVisible,
+  useOverflowMenu,
+  DATA_OVERFLOWING,
+  DATA_OVERFLOW_MENU,
+  DATA_OVERFLOW_ITEM,
+} from '@fluentui/react-overflow';
+
+export type { OverflowProps, OverflowItemProps } from '@fluentui/react-overflow';


### PR DESCRIPTION
## Current Behavior

`react-overflow` is not exported from `react-components`

## New Behavior

`react-overflow` is exported from `react-components/unstable`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23179
