### PR TITLE
docs(react-divider): use colors instead of direct colors in the story

### DIFF
--- a/packages/react-components/react-divider/src/stories/DividerCustomStyles.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/DividerCustomStyles.stories.tsx
@@ -21,7 +21,6 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
-    backgroundColor: 'white',
     minHeight: '192px',
   },
   customWidth: {
@@ -36,10 +35,10 @@ const useStyles = makeStyles({
   },
   customLineColor: {
     ':before': {
-      ...shorthands.borderColor('#FF00FF'),
+      ...shorthands.borderColor(tokens.colorPaletteRedBorder2),
     },
     ':after': {
-      ...shorthands.borderColor('#FF00FF'),
+      ...shorthands.borderColor(tokens.colorPaletteRedBorder2),
     },
   },
   customLineStyle: {
@@ -71,7 +70,9 @@ export const CustomStyles = () => {
         <Divider className={styles.customFont}>Custom font (14px bold)</Divider>
       </div>
       <div className={styles.example}>
-        <Divider className={styles.customLineColor}>Custom line color (#FF00FF)</Divider>
+        <Divider className={styles.customLineColor}>
+          Custom line color (<code>tokens.colorPaletteRedBorder2</code>)
+        </Divider>
       </div>
       <div className={styles.example}>
         <Divider className={styles.customLineStyle}>Custom line style (2px dashed)</Divider>


### PR DESCRIPTION
This PR removes the usage of direct colors and replaces them with tokens to show right patterns.

### Before

#### Light

![image](https://user-images.githubusercontent.com/14183168/170248173-dc3be861-20f3-4837-8526-627ef58e3a9b.png)

#### Dark

![image](https://user-images.githubusercontent.com/14183168/170248145-ac333e34-707d-4767-bdb2-65a0fc6a21ae.png)


#### HC

![image](https://user-images.githubusercontent.com/14183168/170248090-5ac4b8c7-3440-4171-9920-ed9b3959e267.png)


### After

#### Light

![image](https://user-images.githubusercontent.com/14183168/170247903-f5213ad5-a41b-4f7d-9ff4-6e8f5bf939b1.png)

#### Dark

![image](https://user-images.githubusercontent.com/14183168/170247933-02e27d72-604e-4461-8bde-b4e68e374df6.png)

#### HC

![image](https://user-images.githubusercontent.com/14183168/170248006-05e36549-859c-42b4-b39a-303a8632bd61.png)
