### PR TITLE
docs(react-badge): remove .args usage in CounterBadge stories

### DIFF
--- a/packages/react-components/react-badge/src/stories/CounterBadgeAppearance.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/CounterBadgeAppearance.stories.tsx
@@ -1,18 +1,14 @@
 import * as React from 'react';
 
-import { CounterBadge, CounterBadgeProps } from '../index';
+import { CounterBadge } from '../index';
 
-export const Appearance = (args: CounterBadgeProps) => {
+export const Appearance = () => {
   return (
     <>
-      <CounterBadge {...args} appearance="filled" />
-      <CounterBadge {...args} appearance="ghost" />
+      <CounterBadge count={5} appearance="filled" />
+      <CounterBadge count={5} appearance="ghost" />
     </>
   );
-};
-
-Appearance.args = {
-  count: 5,
 };
 
 Appearance.parameters = {

--- a/packages/react-components/react-badge/src/stories/CounterBadgeColor.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/CounterBadgeColor.stories.tsx
@@ -1,20 +1,16 @@
 import * as React from 'react';
 
-import { CounterBadge, CounterBadgeProps } from '../index';
+import { CounterBadge } from '../index';
 
-export const Color = (args: CounterBadgeProps) => {
+export const Color = () => {
   return (
     <>
-      <CounterBadge appearance="filled" color="brand" {...args} />
-      <CounterBadge appearance="filled" color="danger" {...args} />
-      <CounterBadge appearance="filled" color="important" {...args} />
-      <CounterBadge appearance="filled" color="informative" {...args} />
+      <CounterBadge appearance="filled" color="brand" count={5} />
+      <CounterBadge appearance="filled" color="danger" count={5} />
+      <CounterBadge appearance="filled" color="important" count={5} />
+      <CounterBadge appearance="filled" color="informative" count={5} />
     </>
   );
-};
-
-Color.args = {
-  count: 5,
 };
 
 Color.parameters = {

--- a/packages/react-components/react-badge/src/stories/CounterBadgeDefault.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/CounterBadgeDefault.stories.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { CounterBadge, CounterBadgeProps } from '../index';
 
 export const Default = (args: CounterBadgeProps) => <CounterBadge {...args} />;
+
 Default.args = {
   count: 5,
 };

--- a/packages/react-components/react-badge/src/stories/CounterBadgeDot.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/CounterBadgeDot.stories.tsx
@@ -1,13 +1,8 @@
 import * as React from 'react';
 
-import { CounterBadge, CounterBadgeProps } from '../index';
+import { CounterBadge } from '../index';
 
-export const Dot = (args: CounterBadgeProps) => <CounterBadge {...args} />;
-
-Dot.args = {
-  count: 0,
-  dot: true,
-};
+export const Dot = () => <CounterBadge count={0} dot />;
 
 Dot.parameters = {
   docs: {

--- a/packages/react-components/react-badge/src/stories/CounterBadgeShapes.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/CounterBadgeShapes.stories.tsx
@@ -1,18 +1,14 @@
 import * as React from 'react';
 
-import { CounterBadge, CounterBadgeProps } from '../index';
+import { CounterBadge } from '../index';
 
-export const Shapes = (args: CounterBadgeProps) => {
+export const Shapes = () => {
   return (
     <>
-      <CounterBadge {...args} shape="circular" />
-      <CounterBadge {...args} shape="rounded" />
+      <CounterBadge count={5} shape="circular" />
+      <CounterBadge count={5} shape="rounded" />
     </>
   );
-};
-
-Shapes.args = {
-  count: 5,
 };
 
 Shapes.parameters = {

--- a/packages/react-components/react-badge/src/stories/CounterBadgeSizes.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/CounterBadgeSizes.stories.tsx
@@ -1,22 +1,18 @@
 import * as React from 'react';
 
-import { CounterBadge, CounterBadgeProps } from '../index';
+import { CounterBadge } from '../index';
 
-export const Sizes = (args: CounterBadgeProps) => {
+export const Sizes = () => {
   return (
     <>
-      <CounterBadge {...args} size="tiny" />
-      <CounterBadge {...args} size="extra-small" />
-      <CounterBadge {...args} size="small" />
-      <CounterBadge {...args} size="medium" />
-      <CounterBadge {...args} size="large" />
-      <CounterBadge {...args} size="extra-large" />
+      <CounterBadge count={5} size="tiny" />
+      <CounterBadge count={5} size="extra-small" />
+      <CounterBadge count={5} size="small" />
+      <CounterBadge count={5} size="medium" />
+      <CounterBadge count={5} size="large" />
+      <CounterBadge count={5} size="extra-large" />
     </>
   );
-};
-
-Sizes.args = {
-  count: 5,
 };
 
 Sizes.parameters = {


### PR DESCRIPTION
This PR removes `.args` usage from stories as they are not support by our CodeSandbox export. This causes a bad issue as after the export there is nothing:

![image](https://user-images.githubusercontent.com/14183168/170249421-8d030920-21c5-455d-9698-28e2f5eca5c3.png)

For example, https://codesandbox.io/s/vcgu1o?file=/example.tsx