### PR TITLE
fix: Replace controlled menu story checkbox with v9 checkbox

### DIFF
--- a/packages/react-components/react-menu/src/stories/MenuControllingOpenAndClose.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/MenuControllingOpenAndClose.stories.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuProps } from '../index';
 
 import { Button } from '@fluentui/react-button';
+import { Checkbox } from '@fluentui/react-checkbox';
 
 export const ControllingOpenAndClose = () => {
   const [open, setOpen] = React.useState(false);
@@ -16,10 +17,9 @@ export const ControllingOpenAndClose = () => {
 
   return (
     <div>
-      <label style={{ display: 'flex', gap: '10px', alignItems: 'center', marginBottom: '10px' }}>
-        open
-        <input type="checkbox" name="state" value="open" checked={open} onChange={onChange} />
-      </label>
+      <div>
+        <Checkbox label="Open" checked={open} onChange={onChange} />
+      </div>
 
       <Menu open={open} onOpenChange={onOpenChange}>
         <MenuTrigger>


### PR DESCRIPTION
Currently the story uses a native html `input` as checkbox. Replaces that with the v9 checkbox to get full supported interactions

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23164
