### PR TITLE
docs: remove "codesandbox-dependency" comment

### DIFF
--- a/packages/react-components/react-card/src/stories/CardDefault.stories.tsx
+++ b/packages/react-components/react-card/src/stories/CardDefault.stories.tsx
@@ -4,7 +4,7 @@ import { Body1, Caption1 } from '@fluentui/react-text';
 
 import { Button } from '@fluentui/react-button';
 import { ArrowReplyRegular, ShareRegular } from '@fluentui/react-icons';
-import { Card, CardFooter, CardHeader, CardPreview } from '../index'; // codesandbox-dependency: @fluentui/react-card ^9.0.0-beta
+import { Card, CardFooter, CardHeader, CardPreview } from '../index';
 import { ASSET_URL } from './SampleCard.stories';
 
 const avatarElviaURL = ASSET_URL + '/assets/avatar_elvia.svg';

--- a/packages/react-components/react-label/src/stories/LabelDefault.stories.tsx
+++ b/packages/react-components/react-label/src/stories/LabelDefault.stories.tsx
@@ -1,4 +1,4 @@
 import * as React from 'react';
-import { Label, LabelProps } from '../index'; // codesandbox-dependency: @fluentui/react-label ^9.0.0-beta
+import { Label, LabelProps } from '../index';
 
 export const Default = (props: LabelProps) => <Label {...props}>This is a label</Label>;

--- a/packages/react-components/react-label/src/stories/LabelDisabled.stories.tsx
+++ b/packages/react-components/react-label/src/stories/LabelDisabled.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Label } from '../index'; // codesandbox-dependency: @fluentui/react-label ^9.0.0-beta
+import { Label } from '../index';
 
 export const Disabled = () => (
   <Label disabled required>

--- a/packages/react-components/react-label/src/stories/LabelRequired.stories.tsx
+++ b/packages/react-components/react-label/src/stories/LabelRequired.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Label } from '../index'; // codesandbox-dependency: @fluentui/react-label ^9.0.0-beta
+import { Label } from '../index';
 
 export const Required = () => (
   <>

--- a/packages/react-components/react-label/src/stories/LabelSize.stories.tsx
+++ b/packages/react-components/react-label/src/stories/LabelSize.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Label } from '../index'; // codesandbox-dependency: @fluentui/react-label ^9.0.0-beta
+import { Label } from '../index';
 
 export const Size = () => {
   return (

--- a/packages/react-components/react-label/src/stories/LabelStrong.stories.tsx
+++ b/packages/react-components/react-label/src/stories/LabelStrong.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Label } from '../index'; // codesandbox-dependency: @fluentui/react-label ^9.0.0-beta
+import { Label } from '../index';
 
 export const Strong = () => <Label strong>Strong label</Label>;
 


### PR DESCRIPTION
This PR removes "codesandbox-dependency" comments as they don't rely work and just create noise in code.