### PR TITLE
fix: MenuDivider should be visible in Windows high contrast mode

### DIFF
--- a/packages/react-components/react-menu/src/components/MenuDivider/useMenuDividerStyles.ts
+++ b/packages/react-components/react-menu/src/components/MenuDivider/useMenuDividerStyles.ts
@@ -9,10 +9,10 @@ export const menuDividerClassNames: SlotClassNames<MenuDividerSlots> = {
 
 const useStyles = makeStyles({
   root: {
-    height: '1px',
     ...shorthands.margin('4px', '-5px', '4px', '-5px'),
     width: 'auto',
-    backgroundColor: tokens.colorNeutralStroke2,
+    backgroundColor: 'transparent',
+    ...shorthands.border('0.5px', 'solid', tokens.colorNeutralStroke2),
   },
 });
 


### PR DESCRIPTION
Replaces the background color based divider with a border based divider
which will render on high contrast mode without an extra media query

## Current Behavior

![image](https://user-images.githubusercontent.com/20744592/170260605-2d5b5cb3-47e3-4a00-80db-f70cd0986c4d.png)

## New Behavior

![image](https://user-images.githubusercontent.com/20744592/170260522-0e9747bb-f6a2-47c9-8126-03f0727ee3ae.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
