### PR TITLE
docs(react-tabster): adds stories for focus indicator documentation

### DIFF
--- a/change/@fluentui-react-components-1a69c62b-6d1a-41e1-8088-ad70c2eb8ce2.json
+++ b/change/@fluentui-react-components-1a69c62b-6d1a-41e1-8088-ad70c2eb8ce2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Adds stories for focus indicator documentation",
+  "packageName": "@fluentui/react-components",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-1cf49a3e-7aaa-4a4f-a0e7-42bacc9d2774.json
+++ b/change/@fluentui-react-tabster-1cf49a3e-7aaa-4a4f-a0e7-42bacc9d2774.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Adds stories for focus indicator documentation",
+  "packageName": "@fluentui/react-tabster",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/src/Concepts/Accessibility/AccessibleComponents.stories.mdx
+++ b/packages/react-components/react-components/src/Concepts/Accessibility/AccessibleComponents.stories.mdx
@@ -25,7 +25,7 @@ Fluent UI components fulfill following requirements:
 - **Focus handling** when the component is able to move the focus in a predictable way - mostly when opening menus, popups or dialogs (autofocus) or dismissing them using Esc. Focus trap for Dialog and popups
 - **Sufficient color contrast**
 - Light, Dark and High Contrast **themes**
-- Displaying **focus indicator** when keyboard is used to interact with them
+- Displaying [**focus indicator**](?path=/docs/concepts-developer-accessibility-focus-indicator--page) when keyboard is used to interact with them
 - **Tested** against visual inconsistencies/bugs on a zoom up to 400%
 
 Fluent UI components use [tabster](https://github.com/microsoft/tabster) for focus handling functionality, so that they can be easily integrated with application-level tabster functionality such as delooser and cross-iframe focusing.

--- a/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
+++ b/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
@@ -49,7 +49,7 @@ For example, [Link](?path=/docs/components-link--default) component is using `cr
 
 ```tsx
 import { makeStyles } from '@griffel/react';
-import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
+import { createCustomFocusIndicatorStyle } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   focusIndicator: createCustomFocusIndicatorStyle({

--- a/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
+++ b/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
@@ -16,7 +16,12 @@ Instantiates [keyborg](https://github.com/microsoft/keyborg) and add attribute t
 
 ### Styling focus indicators
 
-Both methods are used internally to declare focus indication based on the attribute provided by `useKeyboardNavAttribute`, by default a component on Fluent UI uses `createFocusOutlineStyle` to create a focus indicator with [outline style](https://developer.mozilla.org/en-US/docs/Web/CSS/outline), but in some cases an outline is not the desired style, on those cases `createCustomFocusIndicatorStyle` can be used to add a cusom style with the same mechanisms.
+The default focus indicator used in Fluent UI is an outline. However, in some cases more specific focus indicators are necessary depending on the use case and component design. In order to accommodate these requirements, Fluent UI exports two different utilities to style focus indicators:
+
+1. `createFocusOutlineStyle`
+2. `createCustomFocusIndicatorStyle`
+
+Both of the helper functions are powered using the method described above.
 
 #### createFocusOutlineStyle
 

--- a/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
+++ b/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
@@ -14,7 +14,7 @@ Fluent UI `@fluentui/react-tabster` package defines `useKeyboardNavAttribute`, `
 Instantiates [keyborg](https://github.com/microsoft/keyborg) and add attribute to ensure focus indicator synced to keyborg logic.
 
 
-### createCustomFocusIndicatorStyle and createFocusOutlineStyle
+### Styling focus indicators
 
 Both methods are used internally to declare focus indication based on the attribute provided by `useKeyboardNavAttribute`, by default a component on Fluent UI uses `createFocusOutlineStyle` to create a focus indicator with [outline style](https://developer.mozilla.org/en-US/docs/Web/CSS/outline), but in some cases an outline is not the desired style, on those cases `createCustomFocusIndicatorStyle` can be used to add a cusom style with the same mechanisms.
 

--- a/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
+++ b/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
@@ -41,6 +41,11 @@ const useStyles = makeStyles({
 
 #### createCustomFocusIndicatorStyle
 
+> ⚠️ A bad focus indicator can have serious accessibility consequences and can render
+> your experience unusable by certain user. Please ensure before creating a custom focus
+> indicator that you have gotten the necessary feedback from designers and accessibility
+> experts.
+
 For example, [Link](?path=/docs/components-link--default) component uses `createCustomFocusIndicatorStyle` to add a double underlined focus indication style
 
 <Canvas>

--- a/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
+++ b/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
@@ -1,0 +1,57 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
+import { ScenariosListLink } from '../../AccessibilityScenarios/utils';
+
+<Meta title="Concepts/Developer/Accessibility/Focus indicator" />
+
+## Focus indicator
+
+Fluent UI components use [tabster](https://github.com/microsoft/tabster) for focus handling functionality, so that they can be easily integrated with application-level tabster functionality such as delooser and cross-iframe focusing.
+
+Fluent UI `@fluentui/react-tabster` package defines `useKeyboardNavAttribute`, `createCustomFocusIndicatorStyle` and `createFocusOutlineStyle` to integrate tabster keyboard navigation mechanism seemlesly within Fluent UI.
+
+### useKeyboardNavAttribute
+
+Instantiates [keyborg](https://github.com/microsoft/keyborg) and add attribute to ensure focus indicator synced to keyborg logic.
+
+`useKeyboardNavAttribute` is being used internally by Fluent UI providers and portals to ensure that top level elements will have attributes to indicate focus, in a similar way to what `:focus-visible` does, ensuring Fluent UI components are aware when focus is required.
+
+### createCustomFocusIndicatorStyle and createFocusOutlineStyle
+
+Both methods are used internally to declare focus indication based on the attribute provided by `useKeyboardNavAttribute`, by default a component on Fluent UI uses `createFocusOutlineStyle` to create a focus indicator with [outline style](https://developer.mozilla.org/en-US/docs/Web/CSS/outline), but in some cases an outline is not the desired style, on those cases `createCustomFocusIndicatorStyle` can be used to add a cusom style with the same mechanisms.
+
+#### createFocusOutlineStyle
+
+For example, [AccordionHeader](?path=/docs/components-accordion--default) component is using `createFocusOutlineStyle` to a the default outline style when focus is detected
+
+<Canvas>
+  <Story id="components-accordion--default" />
+</Canvas>
+
+```tsx
+import { makeStyles } from '@griffel/react';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
+
+const useStyles = makeStyles({
+  focusIndicator: createFocusOutlineStyle(),
+```
+
+#### createCustomFocusIndicatorStyle
+
+For example, [Link](?path=/docs/components-link--default) component is using `createCustomFocusIndicatorStyle` to add a double underlined focus indication style
+
+<Canvas>
+  <Story id="components-link--default" />
+</Canvas>
+
+```tsx
+import { makeStyles } from '@griffel/react';
+import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
+
+const useStyles = makeStyles({
+  focusIndicator: createCustomFocusIndicatorStyle({
+    borderBottomColor: 'transparent',
+    textDecorationColor: tokens.colorStrokeFocus2,
+    textDecorationLine: 'underline',
+    textDecorationStyle: 'double',
+  }),
+```

--- a/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
+++ b/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
@@ -33,7 +33,7 @@ For example, the [AccordionHeader](?path=/docs/components-accordion--default) co
 
 ```tsx
 import { makeStyles } from '@griffel/react';
-import { createFocusOutlineStyle } from '@fluentui/react-tabster';
+import { createFocusOutlineStyle } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   focusIndicator: createFocusOutlineStyle(),

--- a/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
+++ b/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
@@ -25,7 +25,7 @@ Both of the helper functions are powered using the method described above.
 
 #### createFocusOutlineStyle
 
-For example, [AccordionHeader](?path=/docs/components-accordion--default) component is using `createFocusOutlineStyle` to a the default outline style when focus is detected
+For example, the [AccordionHeader](?path=/docs/components-accordion--default) component uses `createFocusOutlineStyle` to style the default outline style when focus is detected
 
 <Canvas>
   <Story id="components-accordion--default" />

--- a/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
+++ b/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
@@ -41,7 +41,7 @@ const useStyles = makeStyles({
 
 #### createCustomFocusIndicatorStyle
 
-For example, [Link](?path=/docs/components-link--default) component is using `createCustomFocusIndicatorStyle` to add a double underlined focus indication style
+For example, [Link](?path=/docs/components-link--default) component uses `createCustomFocusIndicatorStyle` to add a double underlined focus indication style
 
 <Canvas>
   <Story id="components-link--default" />

--- a/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
+++ b/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
@@ -13,7 +13,6 @@ Fluent UI `@fluentui/react-tabster` package defines `useKeyboardNavAttribute`, `
 
 Instantiates [keyborg](https://github.com/microsoft/keyborg) and add attribute to ensure focus indicator synced to keyborg logic.
 
-`useKeyboardNavAttribute` is being used internally by Fluent UI providers and portals to ensure that top level elements will have attributes to indicate focus, in a similar way to what `:focus-visible` does, ensuring Fluent UI components are aware when focus is required.
 
 ### createCustomFocusIndicatorStyle and createFocusOutlineStyle
 

--- a/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
+++ b/packages/react-components/react-components/src/Concepts/Accessibility/FocusIndicator.stories.mdx
@@ -32,7 +32,7 @@ For example, the [AccordionHeader](?path=/docs/components-accordion--default) co
 </Canvas>
 
 ```tsx
-import { makeStyles } from '@griffel/react';
+import { makeStyles } from '@fluentui/react-components';
 import { createFocusOutlineStyle } from '@fluentui/react-components';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-tabster/src/hooks/useKeyboardNavAttribute.ts
+++ b/packages/react-components/react-tabster/src/hooks/useKeyboardNavAttribute.ts
@@ -6,7 +6,9 @@ import type { KeyborgCallback } from 'keyborg/dist/Keyborg';
 import type { RefObject } from 'react';
 
 /**
- * instantiates keyborg and add attribute to ensure focus indicator synced to keyborg logic
+ * Instantiates [keyborg](https://github.com/microsoft/keyborg) and adds `data-keyboard-nav`
+ * attribute to a referenced element to ensure keyboard navigation awareness
+ * synced to keyborg logic without having to cause a re-render on react tree.
  */
 export function useKeyboardNavAttribute<E extends HTMLElement>() {
   const { targetDocument } = useFluent();

--- a/packages/react-components/react-tabster/src/stories/FocusIndicator.stories.mdx
+++ b/packages/react-components/react-tabster/src/stories/FocusIndicator.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
-import { ScenariosListLink } from '../../AccessibilityScenarios/utils';
 
 <Meta title="Concepts/Developer/Accessibility/Focus indicator" />
 
@@ -11,8 +10,25 @@ Fluent UI `@fluentui/react-tabster` package defines `useKeyboardNavAttribute`, `
 
 ### useKeyboardNavAttribute
 
-Instantiates [keyborg](https://github.com/microsoft/keyborg) and add attribute to ensure focus indicator synced to keyborg logic.
+Instantiates [keyborg](https://github.com/microsoft/keyborg) and adds `data-keyboard-nav` attribute to a referenced element to ensure keyboard navigation awareness synced to keyborg logic without having to cause a re-render on react tree.
 
+```tsx
+function Root() {
+  const ref = useKeyboardNavAttribute();
+  return <div ref={ref}>{children}</div>;
+}
+```
+
+```html
+<!-- data-keyboard-nav is present when navigating with keyboard -->
+<div data-keyboard-nav="">
+  <!-- ... -->
+</div>
+<!-- data-keyboard-nav is not present when navigating with mouse -->
+<div>
+  <!-- ... -->
+</div>
+```
 
 ### Styling focus indicators
 
@@ -25,7 +41,7 @@ Both of the helper functions are powered using the method described above.
 
 #### createFocusOutlineStyle
 
-For example, the [AccordionHeader](?path=/docs/components-accordion--default) component uses `createFocusOutlineStyle` to style the default outline style when focus is detected
+The [AccordionHeader](?path=/docs/components-accordion--default) component uses `createFocusOutlineStyle` to style the default outline style when focus is detected
 
 <Canvas>
   <Story id="components-accordion--default" />
@@ -36,7 +52,20 @@ import { makeStyles } from '@fluentui/react-components';
 import { createFocusOutlineStyle } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
-  focusIndicator: createFocusOutlineStyle(),
+  focusIndicator: createFocusOutlineStyle({
+    // selector to be used to decide focus presence: 'focus-within' | 'focus'
+    selector: 'focus-within',
+    // custom style to be applied with the outline style
+    style: {
+      outlineOffset: { top: '6px', bottom: '6px', left: '4px', right: '4px' },
+    },
+  }),
+});
+
+function Component() {
+  const styles = useStyles();
+  return <div className={styles.focusIndicator} />;
+}
 ```
 
 #### createCustomFocusIndicatorStyle
@@ -46,7 +75,7 @@ const useStyles = makeStyles({
 > indicator that you have gotten the necessary feedback from designers and accessibility
 > experts.
 
-For example, [Link](?path=/docs/components-link--default) component uses `createCustomFocusIndicatorStyle` to add a double underlined focus indication style
+The [Link](?path=/docs/components-link--default) component uses `createCustomFocusIndicatorStyle` to add a double underlined focus indication style
 
 <Canvas>
   <Story id="components-link--default" />
@@ -63,4 +92,10 @@ const useStyles = makeStyles({
     textDecorationLine: 'underline',
     textDecorationStyle: 'double',
   }),
+});
+
+function Link() {
+  const styles = useStyles();
+  return <a className={styles.focusIndicator} />;
+}
 ```


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

There is no documentation available on how to use focus indication methods provided by `@fluentui/react-tabster`

## New Behavior

Provides documentation under `Accessibility` about how to use and why we have a focus indication mechanism in FluentUI
