### PR TITLE
fix(eslint-plugin): move ban-context to react config from base

### DIFF
--- a/change/@fluentui-eslint-plugin-2c3414b0-7f2f-4207-ab2c-4f64f742f5f1.json
+++ b/change/@fluentui-eslint-plugin-2c3414b0-7f2f-4207-ab2c-4f64f742f5f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(eslint-plugin): move ban-context to react config from base",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/src/configs/base.js
+++ b/packages/eslint-plugin/src/configs/base.js
@@ -1,14 +1,8 @@
 // @ts-check
 
 const path = require('path');
-const configHelpers = require('../utils/configHelpers');
 
 const { getNamingConventionRule } = require('../utils/configHelpers');
-
-/** @type {import("eslint").Linter.RulesRecord} */
-const typeAwareRules = {
-  '@fluentui/ban-context-export': ['error', { exclude: ['**/react-shared-contexts/**'] }],
-};
 
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
@@ -21,8 +15,6 @@ module.exports = {
     ...getNamingConventionRule(),
   },
   overrides: [
-    // Enable rules requiring type info only for appropriate files/circumstances
-    ...configHelpers.getTypeInfoRuleOverrides(typeAwareRules),
     {
       files: '**/src/index.{ts,tsx,js}',
       rules: {

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -12,8 +12,8 @@ const typeAwareRules = {
 module.exports = {
   extends: [path.join(__dirname, 'base'), path.join(__dirname, 'react-config')],
   rules: {},
-  overrides: {
+  overrides: [
     // Enable rules requiring type info only for appropriate files/circumstances
     ...configHelpers.getTypeInfoRuleOverrides(typeAwareRules),
-  },
+  ],
 };

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -1,9 +1,19 @@
 // @ts-check
 
 const path = require('path');
+const configHelpers = require('../utils/configHelpers');
+
+/** @type {import("eslint").Linter.RulesRecord} */
+const typeAwareRules = {
+  '@fluentui/ban-context-export': ['error', { exclude: ['**/react-shared-contexts/**'] }],
+};
 
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   extends: [path.join(__dirname, 'base'), path.join(__dirname, 'react-config')],
   rules: {},
+  overrides: {
+    // Enable rules requiring type info only for appropriate files/circumstances
+    ...configHelpers.getTypeInfoRuleOverrides(typeAwareRules),
+  },
 };

--- a/packages/eslint-plugin/src/rules/ban-context-export/index.js
+++ b/packages/eslint-plugin/src/rules/ban-context-export/index.js
@@ -1,7 +1,9 @@
 // @ts-check
-const { ESLintUtils, AST_NODE_TYPES } = require('@typescript-eslint/experimental-utils');
-const createRule = require('../../utils/createRule');
+const { AST_NODE_TYPES } = require('@typescript-eslint/experimental-utils');
 const minimatch = require('minimatch');
+
+const createRule = require('../../utils/createRule');
+const { getTypeServices } = require('../../utils/type-services');
 
 /** @typedef { import('@typescript-eslint/experimental-utils').TSESTree.VariableDeclarator } VariableDeclarator*/
 /** @typedef { import('@typescript-eslint/experimental-utils').TSESTree.ExportSpecifier} ExportSpecifier */
@@ -11,12 +13,9 @@ const minimatch = require('minimatch');
  * }} Options
  */
 
-/** @type {Options} */
-const defaultOptions = {};
-
 module.exports = createRule({
   name: 'ban-context-export',
-  defaultOptions: [],
+  defaultOptions: /** @type {ReadonlyArray<Options>} */ ([{}]),
   meta: {
     schema: [
       {
@@ -45,11 +44,7 @@ module.exports = createRule({
     },
   },
   create(context) {
-    const rawOptions = /** @type {Options[]} */ (context.options);
-    const { exclude = [] } = rawOptions.length ? rawOptions[0] : defaultOptions;
-    const { program, esTreeNodeToTSNodeMap } = ESLintUtils.getParserServices(context);
-    /** @type {import("typescript").TypeChecker | undefined} */
-    let typeChecker;
+    const [{ exclude = /** @type string[]*/ ([]) } = {}] = context.options;
 
     /**
      * @param { ExportSpecifier | VariableDeclarator } node
@@ -66,61 +61,72 @@ module.exports = createRule({
         return;
       }
 
-      if (!typeChecker) {
-        typeChecker = program.getTypeChecker();
-      }
+      const { getType } = getTypeServices(context);
 
-      const tsNode = esTreeNodeToTSNodeMap.get(node);
-      const typeNode = typeChecker.getTypeAtLocation(tsNode);
+      const type = getType(node);
 
-      // @fluentui/react-context-selector
-      if (typeNode.aliasSymbol?.name === 'Context' && typeNode.aliasSymbol.declarations?.length) {
-        const firstDeclaration = typeNode.aliasSymbol.declarations[0];
-        const fileName = firstDeclaration.parent.getSourceFile().fileName;
-        if (fileName.includes('react-context-selector')) {
-          context.report({
-            node,
-            messageId: 'contextSelector',
-            data: {
-              exportName,
-              filename: context.getFilename(),
-            },
-          });
+      /**
+       *
+       * @param {{
+          typeProperty: Extract<keyof import('typescript').Type, 'symbol' | 'aliasSymbol'>
+          messageId: Parameters<typeof context.report>[0]['messageId']
+          fileNameCheck:(fileName:string)=>boolean;
+        }} options
+       */
+      function reportViolation(options) {
+        const typeSymbol = type[options.typeProperty];
+
+        if (!typeSymbol) {
+          return;
+        }
+
+        if (typeSymbol.name === 'Context' && typeSymbol.declarations?.length) {
+          const firstDeclaration = typeSymbol.declarations[0];
+          const fileName = firstDeclaration.parent.getSourceFile().fileName;
+
+          if (options.fileNameCheck(fileName)) {
+            context.report({
+              node,
+              messageId: options.messageId,
+              data: {
+                exportName,
+                filename: context.getFilename(),
+              },
+            });
+          }
         }
       }
 
-      // Native react
-      if (typeNode.symbol?.name === 'Context' && typeNode.symbol.declarations?.length) {
-        const firstDeclaration = typeNode.symbol.declarations[0];
-        const fileName = firstDeclaration.parent.getSourceFile().fileName;
-        if (/\/node_modules\/@types\/react\//.test(fileName)) {
-          context.report({
-            node,
-            messageId: 'nativeContext',
-            data: {
-              exportName,
-              filename: context.getFilename(),
-            },
-          });
-        }
-      }
+      reportViolation({
+        typeProperty: 'aliasSymbol',
+        messageId: 'contextSelector',
+        fileNameCheck: fileName => fileName.includes('react-context-selector'),
+      });
+
+      const nativeContextFileNamePathRegexp = /\/node_modules\/@types\/react\//;
+      reportViolation({
+        typeProperty: 'symbol',
+        messageId: 'nativeContext',
+        fileNameCheck: fileName => nativeContextFileNamePathRegexp.test(fileName),
+      });
     }
 
     return {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       ExportNamedDeclaration(exportNamedDeclaration) {
         if (exportNamedDeclaration.declaration?.type === AST_NODE_TYPES.VariableDeclaration) {
-          /** @type { import('@typescript-eslint/experimental-utils').TSESTree.VariableDeclaration } */
           const variableDeclaration = exportNamedDeclaration.declaration;
           variableDeclaration.declarations.forEach(declaration => {
-            let identifierName = 'unknown';
             if (declaration.id.type === AST_NODE_TYPES.Identifier) {
-              /** @type { import('@typescript-eslint/experimental-utils').TSESTree.Identifier } */
               const identifier = declaration.id;
-              identifierName = identifier.name;
+              const identifierName = identifier.name;
+
+              checkContextType(declaration, identifierName);
+
+              return;
             }
 
-            checkContextType(declaration, identifierName);
+            checkContextType(declaration, 'unknown');
           });
         }
       },

--- a/packages/eslint-plugin/src/rules/ban-context-export/index.js
+++ b/packages/eslint-plugin/src/rules/ban-context-export/index.js
@@ -67,11 +67,14 @@ module.exports = createRule({
 
       /**
        *
-       * `symbol` - standard typescript type kind / type Hello = string
-       * `aliasSymbol` - typescript type kind created via type alias / type HelloAlias = Hello
+       * `symbol` - type defined via `interface` / export interface User { name: string }
+       * `aliasSymbol` - type defined via `type` / export type User = { name: string }
        *
-       * Types from imported aliases are resolved in different way, thus one needs to use `aliasSymbol`,
-       *  to get proper type (in our case it's the case of `react-context-selector` )
+       * In our case:
+       * - `React.createContext` from `@types/react` return type is `interface Context` we use `symbol`
+       * - `createContext` from `@fluentui/react-context-selector` return type is `type Context` we use `aliasSymbol`
+       *
+       * @see https://github.com/microsoft/TypeScript/issues/46921#issuecomment-985048637
        * @typedef {Extract<keyof import('typescript').Type, 'symbol' | 'aliasSymbol'>} TypeProperty
        */
 

--- a/packages/eslint-plugin/src/rules/ban-context-export/index.js
+++ b/packages/eslint-plugin/src/rules/ban-context-export/index.js
@@ -67,8 +67,18 @@ module.exports = createRule({
 
       /**
        *
+       * `symbol` - standard typescript type kind / type Hello = string
+       * `aliasSymbol` - typescript type kind created via type alias / type HelloAlias = Hello
+       *
+       * Types from imported aliases are resolved in different way, thus one needs to use `aliasSymbol`,
+       *  to get proper type (in our case it's the case of `react-context-selector` )
+       * @typedef {Extract<keyof import('typescript').Type, 'symbol' | 'aliasSymbol'>} TypeProperty
+       */
+
+      /**
+       *
        * @param {{
-          typeProperty: Extract<keyof import('typescript').Type, 'symbol' | 'aliasSymbol'>
+          typeProperty: TypeProperty
           messageId: Parameters<typeof context.report>[0]['messageId']
           fileNameCheck:(fileName:string)=>boolean;
         }} options

--- a/packages/eslint-plugin/src/rules/ban-context-export/index.test.js
+++ b/packages/eslint-plugin/src/rules/ban-context-export/index.test.js
@@ -38,8 +38,6 @@ ruleTester.run('ban-context-export', rule, {
       filename: 'src/index.ts',
     },
     {
-      // No way to type generics with jsdoc
-      // @ts-ignore
       options: [{ exclude: ['**/special-path/**/*'] }],
       parserOptions: getParserOptions('exclude'),
       code: `
@@ -86,8 +84,6 @@ ruleTester.run('ban-context-export', rule, {
     },
     {
       errors: [{ messageId: 'nativeContext' }],
-      // No way to type generics with jsdoc
-      // @ts-ignore
       options: [{ exclude: ['**/wrong-path/**/*'] }],
       parserOptions: getParserOptions('exclude'),
       code: `

--- a/packages/eslint-plugin/src/utils/type-services.js
+++ b/packages/eslint-plugin/src/utils/type-services.js
@@ -1,0 +1,30 @@
+/* eslint-disable @fluentui/max-len */
+const { ESLintUtils } = require('@typescript-eslint/experimental-utils');
+
+/**
+ * @template {string} TMessageIds
+ * @template {unknown[]} TOptions
+ * @param {import('@typescript-eslint/experimental-utils').TSESLint.RuleContext<TMessageIds, Readonly<TOptions>>} context
+ * @returns
+ */
+function getTypeServices(context) {
+  const { esTreeNodeToTSNodeMap, program } = ESLintUtils.getParserServices(context);
+  const typeChecker = program.getTypeChecker();
+
+  /**
+   *
+   * @param {import('@typescript-eslint/experimental-utils').TSESTree.Node} node
+   * @returns
+   */
+  function getType(node) {
+    const tsNode = esTreeNodeToTSNodeMap.get(node);
+    return tsNode && typeChecker.getTypeAtLocation(tsNode);
+  }
+
+  return {
+    getType,
+    typeChecker,
+  };
+}
+
+exports.getTypeServices = getTypeServices;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

ban-context-export is part of base, thus is applied on node.js apps which is out of scope

## New Behavior

- ban-context is applied only on web related packages in v9
- some additional refactoring to encapsulate type information acquisition within custom rules etc

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Follows #23141 
