### PR TITLE
[BREAKING] react-label: Rename strong prop to weight to align with Text

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Label.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Label.stories.tsx
@@ -27,7 +27,7 @@ storiesOf('Label Converged', module)
     includeHighContrast: true,
     includeDarkMode: true,
   })
-  .addStory('Strong', () => <Label strong>I'm a strong label</Label>)
+  .addStory('Weight', () => <Label weight="semibold">I'm a semibold label</Label>)
   .addStory('Small', () => <Label size="small">I'm a small label</Label>)
   .addStory('Large', () => <Label size="large">I'm a large label</Label>)
   .addStory('CustomRequired', () => <Label required="**">I'm a label with custom required text</Label>, {

--- a/apps/vr-tests-react-components/src/stories/Label.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Label.stories.tsx
@@ -27,7 +27,7 @@ storiesOf('Label Converged', module)
     includeHighContrast: true,
     includeDarkMode: true,
   })
-  .addStory('Weight', () => <Label weight="semibold">I'm a semibold label</Label>)
+  .addStory('Semibold', () => <Label weight="semibold">I'm a semibold label</Label>)
   .addStory('Small', () => <Label size="small">I'm a small label</Label>)
   .addStory('Large', () => <Label size="large">I'm a large label</Label>)
   .addStory('CustomRequired', () => <Label required="**">I'm a label with custom required text</Label>, {

--- a/change/@fluentui-react-label-202fb7e6-5017-4358-bb13-905f5150f2a3.json
+++ b/change/@fluentui-react-label-202fb7e6-5017-4358-bb13-905f5150f2a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Renaming strong prop to weight to align with Text.",
+  "packageName": "@fluentui/react-label",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-label/etc/react-label.api.md
+++ b/packages/react-components/react-label/etc/react-label.api.md
@@ -22,7 +22,7 @@ export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> & {
     disabled?: boolean;
     required?: boolean | Slot<'span'>;
     size?: 'small' | 'medium' | 'large';
-    strong?: boolean;
+    weight?: 'regular' | 'semibold';
 };
 
 // @public (undocumented)
@@ -32,7 +32,7 @@ export type LabelSlots = {
 };
 
 // @public
-export type LabelState = ComponentState<LabelSlots> & Required<Pick<LabelProps, 'disabled' | 'size' | 'strong'>>;
+export type LabelState = ComponentState<LabelSlots> & Required<Pick<LabelProps, 'disabled' | 'size' | 'weight'>>;
 
 // @public
 export const renderLabel_unstable: (state: LabelState) => JSX.Element;

--- a/packages/react-components/react-label/src/components/Label/Label.types.ts
+++ b/packages/react-components/react-label/src/components/Label/Label.types.ts
@@ -24,10 +24,10 @@ export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> & {
   size?: 'small' | 'medium' | 'large';
 
   /**
-   * A label supports semibold/strong fontweight.
-   * @default false
+   * A label supports regular and semibold fontweight.
+   * @default regular
    */
-  strong?: boolean;
+  weight?: 'regular' | 'semibold';
 };
 
 export type LabelSlots = {
@@ -38,4 +38,4 @@ export type LabelSlots = {
 /**
  * State used in rendering Label
  */
-export type LabelState = ComponentState<LabelSlots> & Required<Pick<LabelProps, 'disabled' | 'size' | 'strong'>>;
+export type LabelState = ComponentState<LabelSlots> & Required<Pick<LabelProps, 'disabled' | 'size' | 'weight'>>;

--- a/packages/react-components/react-label/src/components/Label/useLabel.tsx
+++ b/packages/react-components/react-label/src/components/Label/useLabel.tsx
@@ -13,13 +13,13 @@ import { resolveShorthand } from '@fluentui/react-utilities';
  * @param ref - reference to root HTMLElement of Label
  */
 export const useLabel_unstable = (props: LabelProps, ref: React.Ref<HTMLElement>): LabelState => {
-  const { disabled = false, required = false, strong = false, size = 'medium' } = props;
+  const { disabled = false, required = false, weight = 'regular', size = 'medium' } = props;
   return {
     disabled,
     required: resolveShorthand(required === true ? '*' : required || undefined, {
       defaultProps: { 'aria-hidden': 'true' },
     }),
-    strong,
+    weight,
     size,
     components: { root: 'label', required: 'span' },
     root: getNativeElementProps('label', { ref, ...props }),

--- a/packages/react-components/react-label/src/components/Label/useLabelStyles.ts
+++ b/packages/react-components/react-label/src/components/Label/useLabelStyles.ts
@@ -46,7 +46,7 @@ const useStyles = makeStyles({
     fontWeight: tokens.fontWeightSemibold,
   },
 
-  strong: {
+  semibold: {
     fontWeight: tokens.fontWeightSemibold,
   },
 });
@@ -61,7 +61,7 @@ export const useLabelStyles_unstable = (state: LabelState): LabelState => {
     styles.root,
     state.disabled && styles.disabled,
     styles[state.size],
-    state.strong && styles.strong,
+    state.weight === 'semibold' && styles.semibold,
     state.root.className,
   );
 

--- a/packages/react-components/react-label/src/stories/Label.stories.tsx
+++ b/packages/react-components/react-label/src/stories/Label.stories.tsx
@@ -5,7 +5,7 @@ import { Label } from '../index';
 import descriptionMd from './LabelDescription.md';
 export { Default } from './LabelDefault.stories';
 export { Size } from './LabelSize.stories';
-export { Strong } from './LabelStrong.stories';
+export { Weight } from './LabelWeight.stories';
 export { Disabled } from './LabelDisabled.stories';
 export { Required } from './LabelRequired.stories';
 

--- a/packages/react-components/react-label/src/stories/LabelWeight.stories.tsx
+++ b/packages/react-components/react-label/src/stories/LabelWeight.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Label } from '../index'; // codesandbox-dependency: @fluentui/react-label ^9.0.0-beta
 
-export const Strong = () => <Label strong>Strong label</Label>;
+export const Weight = () => <Label weight="semibold">Strong label</Label>;
 
-Strong.parameters = {
+Weight.parameters = {
   docs: {
     description: {
-      story: 'A Label with a strong font weight.',
+      story: 'A Label with a semibold font weight.',
     },
   },
 };


### PR DESCRIPTION
## Current Behavior

`Label` uses the `strong` prop to render a semibold state.

## New Behavior

`Label` uses the `weight` prop to render a semibold state.

## Related Issue(s)


Fixes #23222
