### PR TITLE
fix(public-docsite-v9): use image from public folder output

### DIFF
--- a/apps/public-docsite-v9/.storybook/manager-head.html
+++ b/apps/public-docsite-v9/.storybook/manager-head.html
@@ -26,7 +26,7 @@
   content="Fluent UI React Components is a set of UI components and utilities resulting from an effort to converge the set of React based component libraries in production today: @fluentui/react and @fluentui/react-northstar."
 />
 <meta property="og:locale" content="en_US" />
-<meta property="og:image" content="https://react.fluentui.dev/static/media/public/fluentui-wide-banner.webp" />
+<meta property="og:image" content="https://react.fluentui.dev/fluentui-wide-banner.webp" />
 <meta property="og:image:width" content="1207" />
 <meta property="og:image:height" content="705" />
 <meta property="og:image:type" content="image/webp" />


### PR DESCRIPTION
## Current Behavior

Previous implementation tries to use the storybook built assets.

## New Behavior

Meta tags now point to the published public asset folder, which sits on the root.

⚠️ Proper behavior might also not look right due to the complex transparent image we're using, so migrating to another image asset might be required.