### PR TITLE
new high contrast styles for slider steps

### DIFF
--- a/change/@fluentui-react-slider-07687c06-fb88-4671-a9ab-25b5a821ae42.json
+++ b/change/@fluentui-react-slider-07687c06-fb88-4671-a9ab-25b5a821ae42.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "new high contrast styles for slider steps",
+  "packageName": "@fluentui/react-slider",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-slider/src/components/Slider/useSliderStyles.ts
+++ b/packages/react-components/react-slider/src/components/Slider/useSliderStyles.ts
@@ -146,7 +146,17 @@ const useRailStyles = makeStyles({
         ${tokens.colorNeutralBackground1} calc(var(${railStepsPercentVar}) - 1px),
         ${tokens.colorNeutralBackground1} var(${railStepsPercentVar})
       )`,
+      '@media (forced-colors: active)': {
+        backgroundImage: `repeating-linear-gradient(
+          var(${railDirectionVar}),
+          #0000 0%,
+          #0000 calc(var(${railStepsPercentVar}) - 1px),
+          HighlightText calc(var(${railStepsPercentVar}) - 1px),
+          HighlightText var(${railStepsPercentVar})
+        )`,
+      },
     },
+    // force steps to use HighlightText for high contrast mode
   },
 
   horizontal: {


### PR DESCRIPTION
fixes #23149

Add specific high contrast styles for slider steps to ensure that they are visible.

before
![image](https://user-images.githubusercontent.com/1434956/170320949-ffeb7092-3201-4538-94cf-ab8986a731f3.png)


after

![image](https://user-images.githubusercontent.com/1434956/170320985-e8d96166-73a8-48bd-869d-39ec1074a16e.png)
