### PR TITLE
react-tabster: Remove usage of :focus-visible to conform to browser matrix

### DIFF
--- a/change/@fluentui-react-tabster-a9d2f52c-1973-4333-8f19-c4566036b6d4.json
+++ b/change/@fluentui-react-tabster-a9d2f52c-1973-4333-8f19-c4566036b6d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove usage of focus-visible pseudo-class to conform to browser support matrix.",
+  "packageName": "@fluentui/react-tabster",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
+++ b/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
@@ -16,7 +16,7 @@ export const createCustomFocusIndicatorStyle = (
   style: GriffelStyle,
   { selector = defaultOptions.selector }: CreateCustomFocusIndicatorStyleOptions = defaultOptions,
 ): GriffelStyle => ({
-  ':focus-visible': {
+  ':focus': {
     outlineStyle: 'none',
   },
   [`${KEYBOARD_NAV_SELECTOR} :${selector}`]: style,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- `createCustomFocusIndicatorStyle ` uses `:focus-visible` to remove default browser focus outline but that pseudo-class would not be supported by our browser matrix. 

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- Use `:focus` pseudo-class instead to achieve same result of removing focus outline. 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Partially fixes #23020