### PR TITLE
fix(react-avatar): sort out PresenceBadge usage and attributes

### DIFF
--- a/change/@fluentui-react-avatar-84eb3928-ce1b-4f75-b739-5d34a7ed068f.json
+++ b/change/@fluentui-react-avatar-84eb3928-ce1b-4f75-b739-5d34a7ed068f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "PresenceBadge accessibility: fix placement of aria-label, sort out Avatar usage and examples",
+  "packageName": "@fluentui/react-avatar",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-e514e2fd-0699-46c4-ad97-92cb6069877e.json
+++ b/change/@fluentui-react-badge-e514e2fd-0699-46c4-ad97-92cb6069877e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "PresenceBadge accessibility: fix placement of aria-label, sort out Avatar usage and examples",
+  "packageName": "@fluentui/react-badge",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.test.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.test.tsx
@@ -151,7 +151,7 @@ describe('Avatar', () => {
     const rootRef = React.createRef<HTMLSpanElement>();
     render(<Avatar ref={rootRef} image={{ src: 'avatar.png' }} />);
 
-    expect(rootRef.current).toBe(screen.getByRole('img'));
+    expect(rootRef.current?.getAttribute('role')).toBe('img');
   });
 
   it('sets aria-label={name} on the root', () => {
@@ -192,7 +192,7 @@ describe('Avatar', () => {
     const name = 'First Last';
     render(<Avatar id="root-id" name={name} badge={{ status: 'away', id: 'badge-id' }} />);
 
-    expect(screen.getByRole('img').getAttribute('aria-label')).toBe(name);
-    expect(screen.getByRole('img').getAttribute('aria-labelledby')).toBe('root-id badge-id');
+    expect(screen.getAllByRole('img')[0].getAttribute('aria-label')).toBe(name);
+    expect(screen.getAllByRole('img')[0].getAttribute('aria-labelledby')).toBe('root-id badge-id');
   });
 });

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -58,6 +58,8 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
   const image: AvatarState['image'] = resolveShorthand(props.image, {
     defaultProps: {
       alt: '',
+      role: 'presentation',
+      'aria-hidden': true,
       hidden: imageHidden,
     },
   });

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -58,8 +58,6 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
   const image: AvatarState['image'] = resolveShorthand(props.image, {
     defaultProps: {
       alt: '',
-      role: 'presentation',
-      'aria-hidden': true,
       hidden: imageHidden,
     },
   });
@@ -75,8 +73,6 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
   const badge: AvatarState['badge'] = resolveShorthand(props.badge, {
     defaultProps: {
       size: getBadgeSize(size),
-      role: 'presentation',
-      'aria-hidden': true,
       id: baseId + '__badge',
     },
   });

--- a/packages/react-components/react-avatar/src/stories/AvatarBadge.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarBadge.stories.tsx
@@ -3,27 +3,18 @@ import { Avatar } from '../index';
 
 export const Badge = () => (
   <>
-    <Avatar name="Lydia Bauer" badge={{ status: 'available', 'aria-label': 'available' }} />
-    <Avatar name="Amanda Brady" badge={{ status: 'busy', 'aria-label': 'busy' }} />
-    <Avatar name="Henry Brill" badge={{ status: 'out-of-office', 'aria-label': 'out of office' }} />
-    <Avatar name="Robin Counts" badge={{ status: 'away', 'aria-label': 'away' }} />
-    <Avatar name="Tim Deboer" badge={{ status: 'offline', 'aria-label': 'offline' }} />
-    <Avatar name="Cameron Evans" badge={{ status: 'do-not-disturb', 'aria-label': 'do not disturb' }} />
-    <Avatar
-      name="Mona Kane"
-      badge={{ status: 'available', outOfOffice: true, 'aria-label': 'available out of office' }}
-    />
-    <Avatar name="Allan Munger" badge={{ status: 'busy', outOfOffice: true, 'aria-label': 'busy out of office' }} />
-    <Avatar name="Erik Nason" badge={{ status: 'out-of-office', outOfOffice: true, 'aria-label': 'out of office' }} />
-    <Avatar name="Daisy Phillips" badge={{ status: 'away', outOfOffice: true, 'aria-label': 'away out of office' }} />
-    <Avatar
-      name="Kevin Sturgis"
-      badge={{ status: 'offline', outOfOffice: true, 'aria-label': 'offline out of office' }}
-    />
-    <Avatar
-      name="Elliot Woodward"
-      badge={{ status: 'do-not-disturb', outOfOffice: true, 'aria-label': 'do not disturb out of office' }}
-    />
+    <Avatar name="Lydia Bauer" badge={{ status: 'available' }} />
+    <Avatar name="Amanda Brady" badge={{ status: 'busy' }} />
+    <Avatar name="Henry Brill" badge={{ status: 'out-of-office' }} />
+    <Avatar name="Robin Counts" badge={{ status: 'away' }} />
+    <Avatar name="Tim Deboer" badge={{ status: 'offline' }} />
+    <Avatar name="Cameron Evans" badge={{ status: 'do-not-disturb' }} />
+    <Avatar name="Mona Kane" badge={{ status: 'available', outOfOffice: true }} />
+    <Avatar name="Allan Munger" badge={{ status: 'busy', outOfOffice: true }} />
+    <Avatar name="Erik Nason" badge={{ status: 'out-of-office', outOfOffice: true }} />
+    <Avatar name="Daisy Phillips" badge={{ status: 'away', outOfOffice: true }} />
+    <Avatar name="Kevin Sturgis" badge={{ status: 'offline', outOfOffice: true }} />
+    <Avatar name="Elliot Woodward" badge={{ status: 'do-not-disturb', outOfOffice: true }} />
   </>
 );
 

--- a/packages/react-components/react-avatar/src/stories/AvatarDefault.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarDefault.stories.tsx
@@ -2,7 +2,7 @@ import { ArgTypes } from '@storybook/api';
 import * as React from 'react';
 import { Avatar, AvatarProps } from '../index';
 
-export const Default = (props: Partial<AvatarProps>) => <Avatar {...props} />;
+export const Default = (props: Partial<AvatarProps>) => <Avatar aria-label="Guest" {...props} />;
 
 const argTypes: ArgTypes = {
   initials: {

--- a/packages/react-components/react-badge/src/components/PresenceBadge/__snapshots__/PresenceBadge.test.tsx.snap
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/__snapshots__/PresenceBadge.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`PresenceBadge renders a default state 1`] = `
 <div
+  aria-label="available"
   className="fui-PresenceBadge"
+  role="img"
 >
   <span
     className="fui-PresenceBadge__icon"

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
@@ -54,16 +54,17 @@ export const usePresenceBadge_unstable = (
   props: PresenceBadgeProps,
   ref: React.Ref<HTMLElement>,
 ): PresenceBadgeState => {
+  const statusText = DEFAULT_STRINGS[props.status ?? 'available'];
+  const oofText = props.outOfOffice && props.status !== 'out-of-office' ? ` ${DEFAULT_STRINGS['out-of-office']}` : '';
   const state: PresenceBadgeState = {
     ...useBadge_unstable(
       {
         size: 'medium',
+        'aria-label': statusText + oofText,
+        role: 'img',
         ...props,
         icon: resolveShorthand(props.icon, {
           required: true,
-          defaultProps: {
-            'aria-label': props.status && DEFAULT_STRINGS[props.status],
-          },
         }),
       },
       ref,


### PR DESCRIPTION
I started to fix the Avatar Status stories by removing the explicit `aria-label`, and then realized a few other things needed to be sorted out as well. In addition to removing the `aria-label` from the stories, the primary purpose of the changes here are to future-proof our naming approach for Avatar/Badge:

- The PresenceBadge element with `aria-label` is now the root, so that if outside components pass it an `id` to use with `aria-labelledby` or `aria-describedby` (such as Avatar), then the id-referenced element is the same one as has `aria-label`. The reason this matters is pretty complex, but essentially I'm worried that a child generic element with `aria-label` may not be reliably used in the accName calculation.
- The PresenceBadge element that gets `aria-label` is no longer hidden or made presentational by Avatar, since doing so risks the name not being exposed reliably.
- We now have nested images, but that seems like the lowest-risk option. I also can't think of any practical drawbacks of doing this, either with current AT or even in theory.

Note: this is worth revisiting in the future, depending on how the spec discussion and implementation support shakes out for naming and describing by reference when the reference is hidden, or within something hidden. Changing this shouldn't be a breaking issue in the future.