### PR TITLE
fix(react-avatar): update Avatar initials to be used as fallback label even without author id

### DIFF
--- a/change/@fluentui-react-avatar-1a0bc871-7b4e-4589-9019-45fb4e8a48f9.json
+++ b/change/@fluentui-react-avatar-1a0bc871-7b4e-4589-9019-45fb4e8a48f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix react-avatar: use initials as a fallback label even when no id is manually defined",
+  "packageName": "@fluentui/react-avatar",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.test.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.test.tsx
@@ -169,12 +169,6 @@ describe('Avatar', () => {
     expect(image.getAttribute('role')).toEqual('presentation');
   });
 
-  it('sets aria-hidden on the initials', () => {
-    render(<Avatar name="First Last" />);
-
-    expect(screen.getByText('FL').getAttribute('aria-hidden')).toBeTruthy();
-  });
-
   it('sets aria-hidden on the icon', () => {
     const iconRef = React.createRef<HTMLSpanElement>();
     render(<Avatar icon={{ ref: iconRef }} />);
@@ -186,6 +180,14 @@ describe('Avatar', () => {
     render(<Avatar initials={{ children: 'FL', id: 'initials-id' }} />);
 
     expect(screen.getByRole('img').getAttribute('aria-labelledby')).toBe('initials-id');
+  });
+
+  it('falls back to string initials for aria-labelledby', () => {
+    render(<Avatar initials="ABC" />);
+
+    const intialsId = screen.getByText('ABC').id;
+
+    expect(screen.getByRole('img').getAttribute('aria-labelledby')).toBe(intialsId);
   });
 
   it('includes badge in aria-labelledby', () => {

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -49,7 +49,6 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
       defaultProps: {
         children: <PersonRegular />,
         'aria-hidden': true,
-        id: baseId + '__initials',
       },
     });
   }

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -36,7 +36,7 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
     required: true,
     defaultProps: {
       children: getInitials(name, dir === 'rtl', { firstInitialOnly: size <= 16 }),
-      'aria-hidden': true,
+      id: baseId + '__initials',
     },
   });
 


### PR DESCRIPTION
The Avatar Size example had `aria-labelledby="undefined"`, caused by a lack of default label for the initials slot.

This PR adds a default `id` prop to the slot, which is then used by `aria-labelledby` when no name is provided. This should work whether the author passes in a string or slotProps with or without an explicit `id`.