### PR TITLE
typo fix: changing groupp to group

### DIFF
--- a/packages/react-components/react-card/src/components/Card/useCard.ts
+++ b/packages/react-components/react-card/src/components/Card/useCard.ts
@@ -22,11 +22,11 @@ export const useCard_unstable = (props: CardProps, ref: React.Ref<HTMLElement>):
     'tab-only': 'unlimited',
   } as const;
 
-  const groupperAttrs = useFocusableGroup({
+  const grouperAttrs = useFocusableGroup({
     tabBehavior: focusMap[focusMode],
   });
 
-  const focusAttrs = focusMode !== 'off' ? { tabIndex: 0, ...groupperAttrs } : null;
+  const focusAttrs = focusMode !== 'off' ? { tabIndex: 0, ...grouperAttrs } : null;
 
   return {
     appearance,

--- a/packages/react-components/react-menu/src/stories/Menu.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu.stories.tsx
@@ -9,7 +9,7 @@ export { AligningWithIcons } from './MenuAligningWithIcons.stories';
 export { AligningWithSelectableItems } from './MenuAligningWithSelectableItems.stories';
 export { SecondaryContentForMenuItems } from './MenuSecondaryContentForMenuItems.stories';
 export { ControllingOpenAndClose } from './MenuControllingOpenAndClose.stories';
-export { GrouppingItems } from './MenuGrouppingItems.stories';
+export { GroupingItems } from './MenuGroupingItems.stories';
 export { VisualDividerOnly } from './MenuVisualDividerOnly.stories';
 export { CheckboxItems } from './MenuCheckboxItems.stories';
 export { RadioItems } from './MenuRadioItems.stories';

--- a/packages/react-components/react-menu/src/stories/MenuGroupingItems.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/MenuGroupingItems.stories.tsx
@@ -16,7 +16,7 @@ const CutIcon = bundleIcon(CutFilled, CutRegular);
 const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);
 const EditIcon = bundleIcon(EditFilled, EditRegular);
 
-export const GrouppingItems = () => (
+export const GroupingItems = () => (
   <Menu>
     <MenuTrigger>
       <Button>Toggle menu</Button>
@@ -42,7 +42,7 @@ export const GrouppingItems = () => (
   </Menu>
 );
 
-GrouppingItems.parameters = {
+GroupingItems.parameters = {
   docs: {
     description: {
       story: [

--- a/packages/react-components/react-menu/src/stories/MenuVisualDividerOnly.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/MenuVisualDividerOnly.stories.tsx
@@ -42,7 +42,7 @@ VisualDividerOnly.parameters = {
     description: {
       story: [
         'If a divider is needed only for visual aesthetics, the `MenuDivider` component can be used separately.',
-        'When items should be logically groupped, use the `MenuGroup` and `MenuGroupHeader` components',
+        'When items should be logically grouped, use the `MenuGroup` and `MenuGroupHeader` components',
         'for correct accessible markup.',
       ].join('\n'),
     },

--- a/packages/react-components/react-tabster/src/hooks/useFocusableGroup.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusableGroup.ts
@@ -1,4 +1,4 @@
-import { Types, getGroupper } from 'tabster';
+import { Types, getGrouper } from 'tabster';
 import { useTabsterAttributes } from './useTabsterAttributes';
 import { useTabster } from './useTabster';
 
@@ -10,18 +10,18 @@ export interface UseFocusableGroupOptions {
 }
 
 /**
- * A hook that returns the necessary tabster attributes to support groupping.
+ * A hook that returns the necessary tabster attributes to support grouping.
  * @param options - Options to configure keyboard navigation
  */
 export const useFocusableGroup = (options?: UseFocusableGroupOptions): Types.TabsterDOMAttribute => {
   const tabster = useTabster();
 
   if (tabster) {
-    getGroupper(tabster);
+    getGrouper(tabster);
   }
 
   return useTabsterAttributes({
-    groupper: {
+    grouper: {
       tabbability: getTabbability(options?.tabBehavior),
     },
   });
@@ -29,14 +29,14 @@ export const useFocusableGroup = (options?: UseFocusableGroupOptions): Types.Tab
 
 const getTabbability = (
   tabBehavior?: UseFocusableGroupOptions['tabBehavior'],
-): Types.GroupperTabbability | undefined => {
+): Types.GrouperTabbability | undefined => {
   switch (tabBehavior) {
     case 'unlimited':
-      return Types.GroupperTabbabilities.Unlimited;
+      return Types.GrouperTabbabilities.Unlimited;
     case 'limited':
-      return Types.GroupperTabbabilities.Limited;
+      return Types.GrouperTabbabilities.Limited;
     case 'limited-trap-focus':
-      return Types.GroupperTabbabilities.LimitedTrapFocus;
+      return Types.GrouperTabbabilities.LimitedTrapFocus;
     default:
       return undefined;
   }

--- a/rfcs/react-components/components/moving-from-focus-zone-to-tabster.md
+++ b/rfcs/react-components/components/moving-from-focus-zone-to-tabster.md
@@ -124,7 +124,7 @@ The bundle size of each of the different modules of the library are listed in th
 
 `Tabster's` Core API provides the following functionalities:
 
-- Groupper - handling groups of focusable elements.
+- Grouper - handling groups of focusable elements.
 - Mover - hanling moving between (groups of) focusable elements.
 - Focusable - utilities to find and verify focusable elements.
 - Focused element state - observes the currently focused element.
@@ -209,11 +209,11 @@ Below, we present a comparison between the functionality available in `FocusZone
   - _What is missing in `Tabster`?:_ And abstraction similar to `useArrowNavigationGroup` would be nice to have. Even then, there is no equivalent currently for `inputOnly` tabbing.
 - `shouldEnterInnerZone?: (ev: React.KeyboardEvent<HTMLElement>) => boolean`
   - _Description:_ Callback function that will be executed on keypresses to determine if the user intends to navigate into the inner (nested) zone. Returning true will ask the first inner zone to set focus.
-  - _Partial equivalent in `Tabster`:_ The "groupper" part of `Tabster` groups focusables and can handle nesting.
+  - _Partial equivalent in `Tabster`:_ The "grouper" part of `Tabster` groups focusables and can handle nesting.
   - _What is missing in `Tabster`?:_ We need to be very clear about how we support nested focusables to determine what kind of API is needed here.
 - `shouldFocusInnerElementWhenReceivedFocus?: boolean`
   - _Description:_ If true and `FocusZone's` root element (container) receives focus, the focus will land either on the `defaultTabbableElement` (if set) or on the first tabbable element of this `FocusZone`. Commonly used in the case of nested `FocusZones` where the nested `FocusZone's` container is a focusable element.
-  - _Partial equivalent in `Tabster`:_ The "groupper" part of `Tabster` groups focusables and can handle nesting.
+  - _Partial equivalent in `Tabster`:_ The "grouper" part of `Tabster` groups focusables and can handle nesting.
   - _What is missing in `Tabster`?:_ We need to be very clear about how we support nested focusables to determine what kind of API is needed here.
 
 ### What is covered in `FocusZone` that is not covered by `Tabster`


### PR DESCRIPTION
Changing all instances of "groupp" to "group"

Still requires a change on tabster's end (https://github.com/microsoft/tabster/issues/151#issue-1248477095) so I'm leaving this as a draft until we hear back from them.