### PR TITLE
react-spinbutton: remove flex-gap from stories

### DIFF
--- a/packages/react-components/react-spinbutton/src/stories/SpinButton.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButton.stories.tsx
@@ -25,15 +25,6 @@ const meta: Meta = {
       },
     },
   },
-  decorators: [
-    (Story, context) => {
-      return (
-        <div>
-          <Story />
-        </div>
-      );
-    },
-  ],
 };
 
 export default meta;

--- a/packages/react-components/react-spinbutton/src/stories/SpinButton.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButton.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Meta } from '@storybook/react';
 import { SpinButton } from '../index';
 

--- a/packages/react-components/react-spinbutton/src/stories/SpinButton.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButton.stories.tsx
@@ -15,22 +15,6 @@ export { Appearance } from './SpinButtonAppearance.stories';
 export { RTL } from './SpinButtonRTL.stories';
 export { Disabled } from './SpinButtonDisabled.stories';
 
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
-
-const useDecoratorStyles = makeStyles({
-  base: {
-    display: 'flex',
-    flexDirection: 'column',
-    backgroundColor: 'transparent',
-    rowGap: '2px',
-  },
-
-  docsViewMode: {
-    maxWidth: '500px',
-    ...shorthands.padding('24px'),
-  },
-});
-
 const meta: Meta = {
   title: 'Preview Components/SpinButton',
   component: SpinButton,
@@ -43,12 +27,8 @@ const meta: Meta = {
   },
   decorators: [
     (Story, context) => {
-      const decoratorStyles = useDecoratorStyles();
-
-      const className = mergeClasses(decoratorStyles.base, context.viewMode === 'docs' && decoratorStyles.docsViewMode);
-
       return (
-        <div className={className}>
+        <div>
           <Story />
         </div>
       );

--- a/packages/react-components/react-spinbutton/src/stories/SpinButtonBounds.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButtonBounds.stories.tsx
@@ -2,8 +2,23 @@ import * as React from 'react';
 import { SpinButton, SpinButtonProps } from '../index';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
+import { tokens } from '@fluentui/react-theme';
+import { makeStyles } from '@griffel/react';
+
+const useLayoutStyles = makeStyles({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    maxWidth: '500px',
+
+    '> label': {
+      marginBottom: tokens.spacingVerticalXXS,
+    },
+  },
+});
 
 export const Bounds = () => {
+  const layoutStyles = useLayoutStyles();
   const id = useId();
 
   const [spinButtonValue, setSpinButtonValue] = React.useState(10);
@@ -26,11 +41,11 @@ export const Bounds = () => {
   );
 
   return (
-    <>
+    <div className={layoutStyles.base}>
       <Label htmlFor={id}>Bounded SpinButton</Label>
       <SpinButton value={spinButtonValue} min={0} max={20} onChange={onSpinButtonChange} id={id} />
       <p>min: 0, max: 20</p>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-spinbutton/src/stories/SpinButtonControlled.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButtonControlled.stories.tsx
@@ -2,8 +2,23 @@ import * as React from 'react';
 import { SpinButton, SpinButtonProps } from '../index';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
+import { tokens } from '@fluentui/react-theme';
+import { makeStyles } from '@griffel/react';
+
+const useLayoutStyles = makeStyles({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    maxWidth: '500px',
+
+    '> label': {
+      marginBottom: tokens.spacingVerticalXXS,
+    },
+  },
+});
 
 export const Controlled = () => {
+  const layoutStyles = useLayoutStyles();
   const id = useId();
 
   const [spinButtonValue, setSpinButtonValue] = React.useState<number | null>(10);
@@ -26,10 +41,10 @@ export const Controlled = () => {
   );
 
   return (
-    <>
+    <div className={layoutStyles.base}>
       <Label htmlFor={id}>Controlled SpinButton</Label>
       <SpinButton value={spinButtonValue} onChange={onSpinButtonChange} id={id} />
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-spinbutton/src/stories/SpinButtonDisabled.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButtonDisabled.stories.tsx
@@ -2,15 +2,30 @@ import * as React from 'react';
 import { SpinButton } from '../index';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
+import { tokens } from '@fluentui/react-theme';
+import { makeStyles } from '@griffel/react';
+
+const useLayoutStyles = makeStyles({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    maxWidth: '500px',
+
+    '> label': {
+      marginBottom: tokens.spacingVerticalXXS,
+    },
+  },
+});
 
 export const Disabled = () => {
+  const layoutStyles = useLayoutStyles();
   const id = useId();
 
   return (
-    <>
+    <div className={layoutStyles.base}>
       <Label htmlFor={id}>Disabled</Label>
       <SpinButton disabled id={id} />
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-spinbutton/src/stories/SpinButtonDisplayValue.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButtonDisplayValue.stories.tsx
@@ -2,6 +2,20 @@ import * as React from 'react';
 import { SpinButton, SpinButtonProps } from '../index';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
+import { tokens } from '@fluentui/react-theme';
+import { makeStyles } from '@griffel/react';
+
+const useLayoutStyles = makeStyles({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    maxWidth: '500px',
+
+    '> label': {
+      marginBottom: tokens.spacingVerticalXXS,
+    },
+  },
+});
 
 type FormatterFn = (value: number) => string;
 type ParserFn = (formattedValue: string) => number;
@@ -37,15 +51,16 @@ export const DisplayValue = () => {
     }
   };
 
+  const layoutStyles = useLayoutStyles();
   const id = useId();
   const [spinButtonValue, setSpinButtonValue] = React.useState<number | null>(1);
   const [spinButtonDisplayValue, setSpinButtonDisplayValue] = React.useState(formatter(1));
 
   return (
-    <>
+    <div className={layoutStyles.base}>
       <Label htmlFor={id}>Display Value</Label>
       <SpinButton value={spinButtonValue} displayValue={spinButtonDisplayValue} onChange={onSpinButtonChange} id={id} />
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-spinbutton/src/stories/SpinButtonRTL.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButtonRTL.stories.tsx
@@ -3,22 +3,27 @@ import { SpinButton } from '../index';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
 import { FluentProvider } from '@fluentui/react-provider';
+import { tokens } from '@fluentui/react-theme';
 import { makeStyles } from '@griffel/react';
 
-const useLayout = makeStyles({
-  root: {
+const useLayoutStyles = makeStyles({
+  base: {
     display: 'flex',
     flexDirection: 'column',
-    rowGap: '2px',
+    maxWidth: '500px',
+
+    '> label': {
+      marginBottom: tokens.spacingVerticalXXS,
+    },
   },
 });
 
 export const RTL = () => {
-  const layoutStyles = useLayout();
+  const layoutStyles = useLayoutStyles();
   const id = useId();
 
   return (
-    <FluentProvider dir="rtl" className={layoutStyles.root}>
+    <FluentProvider dir="rtl" className={layoutStyles.base}>
       <Label htmlFor={id}>Right-to-Left Layout</Label>
       <SpinButton id={id} />
     </FluentProvider>

--- a/packages/react-components/react-spinbutton/src/stories/SpinButtonSize.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButtonSize.stories.tsx
@@ -2,31 +2,47 @@ import * as React from 'react';
 import { SpinButton } from '../index';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
+import { tokens } from '@fluentui/react-theme';
 import { makeStyles } from '@griffel/react';
 
-const useLayout = makeStyles({
-  root: {
+const useLayoutStyles = makeStyles({
+  base: {
     display: 'flex',
     flexDirection: 'column',
+    maxWidth: '500px',
 
-    [`> * + label`]: {
-      marginTop: '10px',
+    '> div': {
+      display: 'flex',
+      flexDirection: 'column',
+      marginTop: tokens.spacingHorizontalMNudge,
+    },
+
+    '> div:first-child': {
+      marginTop: '0px',
+    },
+
+    '> div label': {
+      marginBottom: tokens.spacingVerticalXXS,
     },
   },
 });
 
 export const Size = () => {
-  const layoutStyles = useLayout();
+  const layoutStyles = useLayoutStyles();
   const smallId = useId('small-id');
   const mediumId = useId('medium-id');
 
   return (
-    <div className={layoutStyles.root}>
-      <Label htmlFor={smallId}>Small</Label>
-      <SpinButton size="small" id={smallId} />
+    <div className={layoutStyles.base}>
+      <div>
+        <Label htmlFor={smallId}>Small</Label>
+        <SpinButton size="small" id={smallId} />
+      </div>
 
-      <Label htmlFor={mediumId}>Medium (default)</Label>
-      <SpinButton id={mediumId} />
+      <div>
+        <Label htmlFor={mediumId}>Medium (default)</Label>
+        <SpinButton id={mediumId} />
+      </div>
     </div>
   );
 };

--- a/packages/react-components/react-spinbutton/src/stories/SpinButtonStep.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButtonStep.stories.tsx
@@ -2,8 +2,23 @@ import * as React from 'react';
 import { SpinButton, SpinButtonProps } from '../index';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
+import { tokens } from '@fluentui/react-theme';
+import { makeStyles } from '@griffel/react';
+
+const useLayoutStyles = makeStyles({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    maxWidth: '500px',
+
+    '> label': {
+      marginBottom: tokens.spacingVerticalXXS,
+    },
+  },
+});
 
 export const Step = () => {
+  const layoutStyles = useLayoutStyles();
   const id = useId();
   const [spinButtonValue, setSpinButtonValue] = React.useState(10);
 
@@ -22,10 +37,10 @@ export const Step = () => {
   );
 
   return (
-    <>
+    <div className={layoutStyles.base}>
       <Label htmlFor={id}>Step Size</Label>
       <SpinButton value={spinButtonValue} step={2} stepPage={20} onChange={onSpinButtonChange} id={id} />
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-spinbutton/src/stories/SpinButtonUncontrolled.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButtonUncontrolled.stories.tsx
@@ -2,15 +2,30 @@ import * as React from 'react';
 import { SpinButton } from '../index';
 import { Label } from '@fluentui/react-label';
 import { useId } from '@fluentui/react-utilities';
+import { tokens } from '@fluentui/react-theme';
+import { makeStyles } from '@griffel/react';
+
+const useLayoutStyles = makeStyles({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    maxWidth: '500px',
+
+    '> label': {
+      marginBottom: tokens.spacingVerticalXXS,
+    },
+  },
+});
 
 export const Uncontrolled = () => {
+  const layoutStyles = useLayoutStyles();
   const id = useId();
 
   return (
-    <>
+    <div className={layoutStyles.base}>
       <Label htmlFor={id}>Uncontrolled SpinButton</Label>
       <SpinButton defaultValue={10} id={id} />
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Current Behavior

SpinButton stories use CSS `flex-gap` and have shared styles preventing easy copy-paste of examples.

## New Behavior

- Removes all instances of flex-gap from SpinButton stories
- Refactors story styles so all styles necessary for a story are included with it. Previously, the root story had global styles. This change makes it easier to look at the code to see what's happening and copy-paste as needed.

## Related Issue(s)

#22704
