### PR TITLE
react-select: fix disabled border color, and HCM styles

### DIFF
--- a/change/@fluentui-react-select-2b040bfc-4f00-4690-a56f-cb7a66ac9aa9.json
+++ b/change/@fluentui-react-select-2b040bfc-4f00-4690-a56f-cb7a66ac9aa9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update disabled select style",
+  "packageName": "@fluentui/react-select",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-select/src/components/Select/useSelectStyles.ts
+++ b/packages/react-components/react-select/src/components/Select/useSelectStyles.ts
@@ -91,8 +91,12 @@ const useSelectStyles = makeStyles({
   },
   disabled: {
     backgroundColor: tokens.colorTransparentBackground,
+    ...shorthands.border('1px', 'solid', tokens.colorNeutralStrokeDisabled),
     color: tokens.colorNeutralForegroundDisabled,
     cursor: 'not-allowed',
+    '@media (forced-colors: active)': {
+      ...shorthands.borderColor('GrayText'),
+    },
   },
   small: {
     height: fieldHeights.small,
@@ -142,6 +146,12 @@ const useIconStyles = makeStyles({
       display: 'block',
     },
   },
+  disabled: {
+    color: tokens.colorNeutralForegroundDisabled,
+    '@media (forced-colors: active)': {
+      color: 'GrayText',
+    },
+  },
   small: {
     fontSize: iconSizes.small,
     height: iconSizes.small,
@@ -188,7 +198,13 @@ export const useSelectStyles_unstable = (state: SelectState): SelectState => {
   );
 
   if (state.icon) {
-    state.icon.className = mergeClasses(selectClassNames.icon, iconStyles.icon, iconStyles[size], state.icon.className);
+    state.icon.className = mergeClasses(
+      selectClassNames.icon,
+      iconStyles.icon,
+      disabled && iconStyles.disabled,
+      iconStyles[size],
+      state.icon.className,
+    );
   }
 
   return state;


### PR DESCRIPTION
Adds the disabled border color to Select, to match the Input spec. Also adds that color to the down arrow icon, as well as adding HCM colors.