### PR TITLE
Theme designer: FluentUI v9 scaffold content examples

### DIFF
--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -32,7 +32,7 @@
     "@griffel/react": "1.0.5",
     "tslib": "^2.1.0",
     "@fluentui/react-components": "^9.0.0-rc.12",
-    "@fluentui/react-icons": "1.1.170"
+    "@fluentui/react-icons": "^2.0.166-rc.3"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <18.0.0",

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -30,7 +30,9 @@
     "@fluentui/react-theme": "9.0.0-rc.9",
     "@fluentui/react-utilities": "9.0.0-rc.9",
     "@griffel/react": "1.0.5",
-    "tslib": "^2.1.0"
+    "tslib": "^2.1.0",
+    "@fluentui/react-components": "^9.0.0-rc.12",
+    "@fluentui/react-icons": "^9.0.0-rc.12"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <18.0.0",

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -32,7 +32,7 @@
     "@griffel/react": "1.0.5",
     "tslib": "^2.1.0",
     "@fluentui/react-components": "^9.0.0-rc.12",
-    "@fluentui/react-icons": "^9.0.0-rc.12"
+    "@fluentui/react-icons": "1.1.170"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <18.0.0",

--- a/packages/react-components/theme-designer/src/components/Content/Content.tsx
+++ b/packages/react-components/theme-designer/src/components/Content/Content.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { makeStyles, mergeClasses } from '@griffel/react';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { Demo } from '../Demo/Demo';
 
 export interface ContentProps {
   className?: string;
@@ -8,12 +9,18 @@ export interface ContentProps {
 const useStyles = makeStyles({
   root: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'left',
     justifyContent: 'center',
+    flexDirection: 'column',
+    ...shorthands.padding('40px', '10%', '0px', '10%'),
   },
 });
 
 export const Content: React.FC<ContentProps> = props => {
   const styles = useStyles();
-  return <div className={mergeClasses(styles.root, props.className)}>Content</div>;
+  return (
+    <div className={mergeClasses(styles.root, props.className)}>
+      <Demo />
+    </div>
+  );
 };

--- a/packages/react-components/theme-designer/src/components/Demo/Demo.stories.tsx
+++ b/packages/react-components/theme-designer/src/components/Demo/Demo.stories.tsx
@@ -1,0 +1,3 @@
+import { Demo } from './Demo';
+export default { component: Demo };
+export const Default = {};

--- a/packages/react-components/theme-designer/src/components/Demo/Demo.tsx
+++ b/packages/react-components/theme-designer/src/components/Demo/Demo.tsx
@@ -10,7 +10,7 @@ import {
   Tab,
   Input,
   Button,
-  Label,
+  Caption1,
   Menu,
   MenuTrigger,
   MenuList,
@@ -205,7 +205,7 @@ export const Demo: React.FC<ContentProps> = props => {
   const styles = useStyles();
   return (
     <FluentProvider theme={teamsLightTheme}>
-      <Label>Examples</Label>
+      <Caption1>Examples</Caption1>
       <div className={mergeClasses(styles.root, props.className)}>
         <Column1 />
         <Column2 />

--- a/packages/react-components/theme-designer/src/components/Demo/Demo.tsx
+++ b/packages/react-components/theme-designer/src/components/Demo/Demo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { makeStyles, mergeClasses } from '@griffel/react';
 import {
   FluentProvider,
   teamsLightTheme,
@@ -13,8 +13,15 @@ import {
   Menu,
   MenuTrigger,
   MenuList,
+  MenuButton,
   MenuItemCheckbox,
   MenuPopover,
+  Slider,
+  Badge,
+  Switch,
+  Radio,
+  RadioGroup,
+  Checkbox,
 } from '@fluentui/react-components';
 import {
   SearchRegular,
@@ -25,6 +32,11 @@ import {
   ClipboardPasteFilled,
   EditRegular,
   EditFilled,
+  ChevronRightRegular,
+  MeetNowRegular,
+  MeetNowFilled,
+  CalendarLtrFilled,
+  CalendarLtrRegular,
 } from '@fluentui/react-icons';
 
 export interface ContentProps {
@@ -34,17 +46,47 @@ export interface ContentProps {
 const useStyles = makeStyles({
   root: {
     display: 'grid',
+    alignItems: 'flex-start',
     justifyContent: 'center',
     gridTemplateColumns: '30% 30% 30%',
     gridTemplateRows: 'auto',
     gridColumnGap: '5%',
   },
-  col: {
+  col2: {
+    display: 'grid',
+    gridTemplateRows: 'auto auto auto',
+    gridRowGap: '10%',
+    justifyContent: 'center',
     alignItems: 'center',
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'flex-start',
-    rowGap: '20px',
+  },
+  col3: {
+    display: 'grid',
+    gridTemplateColumns: 'auto auto',
+    gridTemplateRows: 'auto auto auto auto',
+    gridRowGap: '5%',
+    gridColumnGap: '5%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  slider: {
+    gridColumnStart: 1,
+    gridColumnEnd: 3,
+    width: '100%',
+  },
+  icons: {
+    display: 'grid',
+    gridTemplateColumns: 'auto auto',
+    gridTemplateRows: 'auto auto',
+    gridRowGap: '20%',
+    gridColumnGap: '20%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  twoRow: {
+    display: 'grid',
+    gridTemplateRows: 'auto auto',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 
@@ -53,6 +95,8 @@ export const Demo: React.FC<ContentProps> = props => {
   const CutIcon = bundleIcon(CutFilled, CutRegular);
   const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);
   const EditIcon = bundleIcon(EditFilled, EditRegular);
+  const MeetNowIcon = bundleIcon(MeetNowFilled, MeetNowRegular);
+  const CalendarLtrIcon = bundleIcon(CalendarLtrFilled, CalendarLtrRegular);
   return (
     <FluentProvider theme={teamsLightTheme}>
       <Label>Examples</Label>
@@ -66,7 +110,7 @@ export const Demo: React.FC<ContentProps> = props => {
             format.
           </Body1>
         </div>
-        <div className={styles.col}>
+        <div className={styles.col2}>
           <TabList defaultSelectedValue="tab1">
             <Tab value="tab1">Home</Tab>
             <Tab value="tab2">Pages</Tab>
@@ -78,7 +122,7 @@ export const Demo: React.FC<ContentProps> = props => {
           />
           <Menu>
             <MenuTrigger>
-              <Button>Select</Button>
+              <MenuButton>Select </MenuButton>
             </MenuTrigger>
             <MenuPopover>
               <MenuList>
@@ -95,7 +139,37 @@ export const Demo: React.FC<ContentProps> = props => {
             </MenuPopover>
           </Menu>
         </div>
-        <div>col3</div>
+        <div className={styles.col3}>
+          <div>
+            <Button appearance="primary">Sign Up</Button>
+          </div>
+          <div>
+            <Button appearance="transparent" icon={<ChevronRightRegular />} iconPosition="after">
+              Learn More
+            </Button>
+          </div>
+          <Slider className={styles.slider} defaultValue={20} />
+          <div className={styles.icons}>
+            <Badge size="medium" appearance="filled" icon={<CalendarLtrIcon />} />
+            <Badge size="medium" appearance="ghost" icon={<CalendarLtrIcon />} />
+            <Badge size="medium" appearance="outline" icon={<MeetNowIcon />} />
+            <Badge size="medium" appearance="tint" icon={<MeetNowIcon />} />
+          </div>
+          <div className={styles.twoRow}>
+            <Switch defaultChecked={true} label="On" />
+            <Switch label="Off" />
+          </div>
+          <div>
+            <Checkbox defaultChecked={true} label="Option 1" />
+            <Checkbox label="Option 2" />
+          </div>
+          <div>
+            <RadioGroup>
+              <Radio defaultChecked={true} label="Option 1" />
+              <Radio label="Option 2" />
+            </RadioGroup>
+          </div>
+        </div>
       </div>
     </FluentProvider>
   );

--- a/packages/react-components/theme-designer/src/components/Demo/Demo.tsx
+++ b/packages/react-components/theme-designer/src/components/Demo/Demo.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import {
+  FluentProvider,
+  teamsLightTheme,
+  Body1,
+  Title3,
+  TabList,
+  Tab,
+  Input,
+  Button,
+  Label,
+  Menu,
+  MenuTrigger,
+  MenuList,
+  MenuItemCheckbox,
+  MenuPopover,
+} from '@fluentui/react-components';
+import {
+  SearchRegular,
+  bundleIcon,
+  CutRegular,
+  CutFilled,
+  ClipboardPasteRegular,
+  ClipboardPasteFilled,
+  EditRegular,
+  EditFilled,
+} from '@fluentui/react-icons';
+
+export interface ContentProps {
+  className?: string;
+}
+
+const useStyles = makeStyles({
+  root: {
+    display: 'grid',
+    justifyContent: 'center',
+    gridTemplateColumns: '30% 30% 30%',
+    gridTemplateRows: 'auto',
+    gridColumnGap: '5%',
+  },
+  col: {
+    alignItems: 'center',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    rowGap: '20px',
+  },
+});
+
+export const Demo: React.FC<ContentProps> = props => {
+  const styles = useStyles();
+  const CutIcon = bundleIcon(CutFilled, CutRegular);
+  const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);
+  const EditIcon = bundleIcon(EditFilled, EditRegular);
+  return (
+    <FluentProvider theme={teamsLightTheme}>
+      <Label>Examples</Label>
+      <div className={mergeClasses(styles.root, props.className)}>
+        <div>
+          <Title3 block>Make an impression</Title3>
+          <br />
+          <Body1 block>
+            Make a big impression with this clean, modern, and mobile-friendly site. Use it to communicate information
+            to people inside or outside your team. Share your ideas, results, and more in this visually compelling
+            format.
+          </Body1>
+        </div>
+        <div className={styles.col}>
+          <TabList defaultSelectedValue="tab1">
+            <Tab value="tab1">Home</Tab>
+            <Tab value="tab2">Pages</Tab>
+            <Tab value="tab3">Documents</Tab>
+          </TabList>
+          <Input
+            placeholder="Find"
+            contentAfter={<Button aria-label="Find" appearance="transparent" icon={<SearchRegular />} size="small" />}
+          />
+          <Menu>
+            <MenuTrigger>
+              <Button>Select</Button>
+            </MenuTrigger>
+            <MenuPopover>
+              <MenuList>
+                <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut">
+                  Cut
+                </MenuItemCheckbox>
+                <MenuItemCheckbox icon={<PasteIcon />} name="edit" value="paste">
+                  Paste
+                </MenuItemCheckbox>
+                <MenuItemCheckbox icon={<EditIcon />} name="edit" value="edit">
+                  Edit
+                </MenuItemCheckbox>
+              </MenuList>
+            </MenuPopover>
+          </Menu>
+        </div>
+        <div>col3</div>
+      </div>
+    </FluentProvider>
+  );
+};

--- a/packages/react-components/theme-designer/src/components/Demo/Demo.tsx
+++ b/packages/react-components/theme-designer/src/components/Demo/Demo.tsx
@@ -46,15 +46,15 @@ export interface ContentProps {
 const useStyles = makeStyles({
   root: {
     display: 'grid',
-    alignItems: 'flex-start',
+    alignItems: 'start',
     justifyContent: 'center',
-    gridTemplateColumns: '30% 30% 30%',
+    gridTemplateColumns: '1fr 1fr 1fr',
     gridTemplateRows: 'auto',
     gridColumnGap: '5%',
   },
   col2: {
     display: 'grid',
-    gridTemplateRows: 'auto auto auto',
+    gridTemplateRows: '1fr 1fr 1fr',
     gridRowGap: '10%',
     justifyContent: 'center',
     alignItems: 'center',
@@ -62,7 +62,7 @@ const useStyles = makeStyles({
   col3: {
     display: 'grid',
     gridTemplateColumns: 'auto auto',
-    gridTemplateRows: 'auto auto auto auto',
+    gridTemplateRows: '1fr 1fr 1fr 1fr',
     gridRowGap: '5%',
     gridColumnGap: '5%',
     alignItems: 'center',
@@ -84,92 +84,124 @@ const useStyles = makeStyles({
   },
   twoRow: {
     display: 'grid',
-    gridTemplateRows: 'auto auto',
+    gridTemplateRows: '1fr 1fr',
     alignItems: 'center',
     justifyContent: 'center',
   },
 });
 
-export const Demo: React.FC<ContentProps> = props => {
-  const styles = useStyles();
+export const Column1 = () => {
+  return (
+    <div>
+      <Title3 block>Make an impression</Title3>
+      <br />
+      <Body1 block>
+        Make a big impression with this clean, modern, and mobile-friendly site. Use it to communicate information to
+        people inside or outside your team. Share your ideas, results, and more in this visually compelling format.
+      </Body1>
+    </div>
+  );
+};
+
+export const DemoMenu = () => {
   const CutIcon = bundleIcon(CutFilled, CutRegular);
   const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);
   const EditIcon = bundleIcon(EditFilled, EditRegular);
+  return (
+    <Menu>
+      <MenuTrigger>
+        <MenuButton>Select </MenuButton>
+      </MenuTrigger>
+      <MenuPopover>
+        <MenuList>
+          <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut">
+            Cut
+          </MenuItemCheckbox>
+          <MenuItemCheckbox icon={<PasteIcon />} name="edit" value="paste">
+            Paste
+          </MenuItemCheckbox>
+          <MenuItemCheckbox icon={<EditIcon />} name="edit" value="edit">
+            Edit
+          </MenuItemCheckbox>
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+};
+
+export const Column2 = () => {
+  const styles = useStyles();
+  return (
+    <div className={styles.col2}>
+      <TabList defaultSelectedValue="tab1">
+        <Tab value="tab1">Home</Tab>
+        <Tab value="tab2">Pages</Tab>
+        <Tab value="tab3">Documents</Tab>
+      </TabList>
+      <Input
+        placeholder="Find"
+        contentAfter={<Button aria-label="Find" appearance="transparent" icon={<SearchRegular />} size="small" />}
+      />
+      <DemoMenu />
+    </div>
+  );
+};
+
+export const DemoIcons = () => {
+  const styles = useStyles();
   const MeetNowIcon = bundleIcon(MeetNowFilled, MeetNowRegular);
   const CalendarLtrIcon = bundleIcon(CalendarLtrFilled, CalendarLtrRegular);
+  return (
+    <div className={styles.icons}>
+      <Badge size="medium" appearance="filled" icon={<CalendarLtrIcon />} />
+      <Badge size="medium" appearance="ghost" icon={<CalendarLtrIcon />} />
+      <Badge size="medium" appearance="outline" icon={<MeetNowIcon />} />
+      <Badge size="medium" appearance="tint" icon={<MeetNowIcon />} />
+    </div>
+  );
+};
+
+export const Column3 = () => {
+  const styles = useStyles();
+  return (
+    <div className={styles.col3}>
+      <div>
+        <Button appearance="primary">Sign Up</Button>
+      </div>
+      <div>
+        <Button appearance="transparent" icon={<ChevronRightRegular />} iconPosition="after">
+          Learn More
+        </Button>
+      </div>
+      <Slider className={styles.slider} defaultValue={20} />
+      <DemoIcons />
+      <div className={styles.twoRow}>
+        <Switch defaultChecked={true} label="On" />
+        <Switch label="Off" />
+      </div>
+      <div>
+        <Checkbox defaultChecked={true} label="Option 1" />
+        <Checkbox label="Option 2" />
+      </div>
+      <div>
+        <RadioGroup>
+          <Radio defaultChecked={true} label="Option 1" />
+          <Radio label="Option 2" />
+        </RadioGroup>
+      </div>
+    </div>
+  );
+};
+
+export const Demo: React.FC<ContentProps> = props => {
+  const styles = useStyles();
   return (
     <FluentProvider theme={teamsLightTheme}>
       <Label>Examples</Label>
       <div className={mergeClasses(styles.root, props.className)}>
-        <div>
-          <Title3 block>Make an impression</Title3>
-          <br />
-          <Body1 block>
-            Make a big impression with this clean, modern, and mobile-friendly site. Use it to communicate information
-            to people inside or outside your team. Share your ideas, results, and more in this visually compelling
-            format.
-          </Body1>
-        </div>
-        <div className={styles.col2}>
-          <TabList defaultSelectedValue="tab1">
-            <Tab value="tab1">Home</Tab>
-            <Tab value="tab2">Pages</Tab>
-            <Tab value="tab3">Documents</Tab>
-          </TabList>
-          <Input
-            placeholder="Find"
-            contentAfter={<Button aria-label="Find" appearance="transparent" icon={<SearchRegular />} size="small" />}
-          />
-          <Menu>
-            <MenuTrigger>
-              <MenuButton>Select </MenuButton>
-            </MenuTrigger>
-            <MenuPopover>
-              <MenuList>
-                <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut">
-                  Cut
-                </MenuItemCheckbox>
-                <MenuItemCheckbox icon={<PasteIcon />} name="edit" value="paste">
-                  Paste
-                </MenuItemCheckbox>
-                <MenuItemCheckbox icon={<EditIcon />} name="edit" value="edit">
-                  Edit
-                </MenuItemCheckbox>
-              </MenuList>
-            </MenuPopover>
-          </Menu>
-        </div>
-        <div className={styles.col3}>
-          <div>
-            <Button appearance="primary">Sign Up</Button>
-          </div>
-          <div>
-            <Button appearance="transparent" icon={<ChevronRightRegular />} iconPosition="after">
-              Learn More
-            </Button>
-          </div>
-          <Slider className={styles.slider} defaultValue={20} />
-          <div className={styles.icons}>
-            <Badge size="medium" appearance="filled" icon={<CalendarLtrIcon />} />
-            <Badge size="medium" appearance="ghost" icon={<CalendarLtrIcon />} />
-            <Badge size="medium" appearance="outline" icon={<MeetNowIcon />} />
-            <Badge size="medium" appearance="tint" icon={<MeetNowIcon />} />
-          </div>
-          <div className={styles.twoRow}>
-            <Switch defaultChecked={true} label="On" />
-            <Switch label="Off" />
-          </div>
-          <div>
-            <Checkbox defaultChecked={true} label="Option 1" />
-            <Checkbox label="Option 2" />
-          </div>
-          <div>
-            <RadioGroup>
-              <Radio defaultChecked={true} label="Option 1" />
-              <Radio label="Option 2" />
-            </RadioGroup>
-          </div>
-        </div>
+        <Column1 />
+        <Column2 />
+        <Column3 />
       </div>
     </FluentProvider>
   );

--- a/packages/react-components/theme-designer/src/components/Demo/Demo.tsx
+++ b/packages/react-components/theme-designer/src/components/Demo/Demo.tsx
@@ -20,8 +20,8 @@ import {
   Badge,
   Switch,
   Radio,
-  RadioGroup,
   Checkbox,
+  Avatar,
 } from '@fluentui/react-components';
 import {
   SearchRegular,
@@ -48,30 +48,39 @@ const useStyles = makeStyles({
     display: 'grid',
     alignItems: 'start',
     justifyContent: 'center',
-    gridTemplateColumns: '1fr 1fr 1fr',
-    gridTemplateRows: 'auto',
+    gridTemplateColumns: 'repeat(3, 1fr)',
     gridColumnGap: '5%',
+  },
+  col1: {
+    display: 'grid',
+    gridTemplateRows: 'repeat(3, auto)',
+    gridRowGap: '10%',
+    justifyContent: 'center',
+    alignItems: 'stretch',
   },
   col2: {
     display: 'grid',
-    gridTemplateRows: '1fr 1fr 1fr',
+    gridTemplateRows: 'repeat(3, 1fr)',
     gridRowGap: '10%',
     justifyContent: 'center',
-    alignItems: 'center',
+    alignItems: 'stretch',
   },
   col3: {
     display: 'grid',
-    gridTemplateColumns: 'auto auto',
-    gridTemplateRows: '1fr 1fr 1fr 1fr',
+    gridTemplateColumns: '1fr 1fr',
+    gridTemplateRows: 'repeat(4, auto)',
     gridRowGap: '5%',
     gridColumnGap: '5%',
-    alignItems: 'center',
     justifyContent: 'center',
+    alignItems: 'stretch',
   },
   slider: {
     gridColumnStart: 1,
     gridColumnEnd: 3,
-    width: '100%',
+  },
+  button: {
+    display: 'flex',
+    justifyContent: 'center',
   },
   icons: {
     display: 'grid',
@@ -79,26 +88,33 @@ const useStyles = makeStyles({
     gridTemplateRows: 'auto auto',
     gridRowGap: '20%',
     gridColumnGap: '20%',
-    alignItems: 'center',
     justifyContent: 'center',
   },
   twoRow: {
-    display: 'grid',
-    gridTemplateRows: '1fr 1fr',
+    display: 'flex',
+    flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
   },
 });
 
 export const Column1 = () => {
+  const styles = useStyles();
   return (
-    <div>
+    <div className={styles.col1}>
       <Title3 block>Make an impression</Title3>
-      <br />
       <Body1 block>
         Make a big impression with this clean, modern, and mobile-friendly site. Use it to communicate information to
         people inside or outside your team. Share your ideas, results, and more in this visually compelling format.
       </Body1>
+      <Avatar
+        color="brand"
+        initials="DF"
+        badge={{
+          status: 'available',
+          'aria-label': 'available',
+        }}
+      />
     </div>
   );
 };
@@ -165,10 +181,10 @@ export const Column3 = () => {
   const styles = useStyles();
   return (
     <div className={styles.col3}>
-      <div>
+      <div className={styles.button}>
         <Button appearance="primary">Sign Up</Button>
       </div>
-      <div>
+      <div className={styles.button}>
         <Button appearance="transparent" icon={<ChevronRightRegular />} iconPosition="after">
           Learn More
         </Button>
@@ -179,15 +195,13 @@ export const Column3 = () => {
         <Switch defaultChecked={true} label="On" />
         <Switch label="Off" />
       </div>
-      <div>
+      <div className={styles.twoRow}>
         <Checkbox defaultChecked={true} label="Option 1" />
         <Checkbox label="Option 2" />
       </div>
-      <div>
-        <RadioGroup>
-          <Radio defaultChecked={true} label="Option 1" />
-          <Radio label="Option 2" />
-        </RadioGroup>
+      <div className={styles.twoRow}>
+        <Radio defaultChecked={true} label="Option 1" />
+        <Radio label="Option 2" />
       </div>
     </div>
   );

--- a/packages/react-components/theme-designer/src/components/Demo/Demo.tsx
+++ b/packages/react-components/theme-designer/src/components/Demo/Demo.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { makeStyles, mergeClasses } from '@griffel/react';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import {
   FluentProvider,
   teamsLightTheme,
+  tokens,
   Body1,
   Title3,
   TabList,
@@ -49,45 +50,42 @@ const useStyles = makeStyles({
     alignItems: 'start',
     justifyContent: 'center',
     gridTemplateColumns: 'repeat(3, 1fr)',
-    gridColumnGap: '5%',
+    gridTemplateRows: 'auto',
+    gridColumnGap: tokens.spacingHorizontalXXXL,
   },
   col1: {
-    display: 'grid',
-    gridTemplateRows: 'repeat(3, auto)',
-    gridRowGap: '10%',
-    justifyContent: 'center',
-    alignItems: 'stretch',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'left',
+    flexDirection: 'column',
+    flexGrow: 1,
+    ...shorthands.gap(tokens.spacingVerticalL),
   },
   col2: {
-    display: 'grid',
-    gridTemplateRows: 'repeat(3, 1fr)',
-    gridRowGap: '10%',
-    justifyContent: 'center',
-    alignItems: 'stretch',
+    display: 'flex',
+    justifyContent: 'space-between',
+    flexDirection: 'column',
+    ...shorthands.gap(tokens.spacingVerticalL),
   },
   col3: {
     display: 'grid',
     gridTemplateColumns: '1fr 1fr',
     gridTemplateRows: 'repeat(4, auto)',
-    gridRowGap: '5%',
-    gridColumnGap: '5%',
+    gridRowGap: tokens.spacingVerticalS,
+    gridColumnGap: tokens.spacingHorizontalS,
     justifyContent: 'center',
-    alignItems: 'stretch',
+    alignItems: 'center',
   },
-  slider: {
+  twoCol: {
     gridColumnStart: 1,
     gridColumnEnd: 3,
-  },
-  button: {
-    display: 'flex',
-    justifyContent: 'center',
   },
   icons: {
     display: 'grid',
     gridTemplateColumns: 'auto auto',
     gridTemplateRows: 'auto auto',
-    gridRowGap: '20%',
-    gridColumnGap: '20%',
+    gridRowGap: tokens.spacingVerticalS,
+    gridColumnGap: tokens.spacingHorizontalS,
     justifyContent: 'center',
   },
   twoRow: {
@@ -181,15 +179,11 @@ export const Column3 = () => {
   const styles = useStyles();
   return (
     <div className={styles.col3}>
-      <div className={styles.button}>
-        <Button appearance="primary">Sign Up</Button>
-      </div>
-      <div className={styles.button}>
-        <Button appearance="transparent" icon={<ChevronRightRegular />} iconPosition="after">
-          Learn More
-        </Button>
-      </div>
-      <Slider className={styles.slider} defaultValue={20} />
+      <Button appearance="primary">Sign Up</Button>
+      <Button appearance="transparent" icon={<ChevronRightRegular />} iconPosition="after">
+        Learn More
+      </Button>
+      <Slider className={styles.twoCol} defaultValue={20} />
       <DemoIcons />
       <div className={styles.twoRow}>
         <Switch defaultChecked={true} label="On" />


### PR DESCRIPTION
Added the examples section to the content section of the theme designer.

<img width="773" alt="image" src="https://user-images.githubusercontent.com/31319479/170367224-144b850e-2f14-4678-8c8b-7f053df3410c.png">
