### PR TITLE
ci: align v9 release checks for v9 nightly releases

### DIFF
--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -82,11 +82,6 @@ jobs:
           artifactName: SBom-$(System.JobAttempt)
           targetPath: $(System.DefaultWorkingDirectory)/_manifest
 
-      # Since releases are scoped, this should warn for any packages that were mistakenly not included in scoping
-      - script: |
-          yarn syncpack list-mismatches
-        displayName: Check for dependency mismatches
-
       - task: ComponentGovernanceComponentDetection@0
         displayName: 'Component Detection'
         inputs:

--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -8,6 +8,8 @@ name: 'v9_nightly_$(Date:yyyyMMdd)$(Rev:.r)'
 variables:
   - group: 'Github and NPM secrets'
   - template: .devops/templates/variables.yml
+    parameters:
+      skipComponentGovernanceDetection: false
   - name: release.vnext # Used to scope beachball to release only vnext packages
     value: true
   - group: InfoSec-SecurityResults
@@ -79,6 +81,19 @@ jobs:
         inputs:
           artifactName: SBom-$(System.JobAttempt)
           targetPath: $(System.DefaultWorkingDirectory)/_manifest
+
+      # Since releases are scoped, this should warn for any packages that were mistakenly not included in scoping
+      - script: |
+          yarn syncpack list-mismatches
+        displayName: Check for dependency mismatches
+
+      - task: ComponentGovernanceComponentDetection@0
+        displayName: 'Component Detection'
+        inputs:
+          sourceScanPath: $(Agent.BuildDirectory)
+        condition: succeeded()
+        timeoutInMinutes: 5
+        continueOnError: true
 
       - template: .devops/templates/cleanup.yml
         parameters:


### PR DESCRIPTION
## Current Behavior

Nightly releases do not run `syncpack` or the component governance checks we do for normal releases.

## New Behavior

Added `syncpack` and component governance checks to nightly releases.

## ⚠️ Extra stuff ⚠️

Also noticed how we're using `continueOnError: true`, perhaps we should remove this?