### PR TITLE
fix(react-alert): add live region attributes based on intent

### DIFF
--- a/change/@fluentui-react-alert-a5405e35-1c76-4ad7-9a7d-5fb41961c52d.json
+++ b/change/@fluentui-react-alert-a5405e35-1c76-4ad7-9a7d-5fb41961c52d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update Alert with live region attributes",
+  "packageName": "@fluentui/react-alert",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-alert/src/components/Alert/Alert.test.tsx
+++ b/packages/react-components/react-alert/src/components/Alert/Alert.test.tsx
@@ -59,4 +59,24 @@ describe('Alert', () => {
     );
     expect(screen.getByTestId('foo')).toBeTruthy();
   });
+
+  it('sets alert role based on intent', () => {
+    render(
+      <>
+        <Alert intent="error" data-testid="error">
+          Test
+        </Alert>
+        <Alert intent="error" data-testid="warning">
+          Test
+        </Alert>
+      </>,
+    );
+    expect(screen.getByTestId('error').getAttribute('role')).toBe('alert');
+    expect(screen.getByTestId('warning').getAttribute('role')).toBe('alert');
+  });
+
+  it('sets status role by default', () => {
+    render(<Alert data-testid="default">Test</Alert>);
+    expect(screen.getByTestId('default').getAttribute('role')).toBe('status');
+  });
 });

--- a/packages/react-components/react-alert/src/components/Alert/useAlert.tsx
+++ b/packages/react-components/react-alert/src/components/Alert/useAlert.tsx
@@ -19,17 +19,20 @@ import type { AlertProps, AlertState } from './Alert.types';
 export const useAlert_unstable = (props: AlertProps, ref: React.Ref<HTMLElement>): AlertState => {
   const { intent } = props;
 
-  /** Determine the icon to render based on the intent */
+  /** Determine the role and icon to render based on the intent */
   let defaultIcon;
+  let defaultRole = 'status';
   switch (intent) {
     case 'success':
       defaultIcon = <CheckmarkCircleFilled />;
       break;
     case 'error':
       defaultIcon = <DismissCircleFilled />;
+      defaultRole = 'alert';
       break;
     case 'warning':
       defaultIcon = <WarningFilled />;
+      defaultRole = 'alert';
       break;
     case 'info':
       defaultIcon = <InfoFilled />;
@@ -57,6 +60,8 @@ export const useAlert_unstable = (props: AlertProps, ref: React.Ref<HTMLElement>
     },
     root: getNativeElementProps('div', {
       ref,
+      role: defaultRole,
+      'aria-live': 'assertive',
       children: props.children,
       ...props,
     }),

--- a/packages/react-components/react-alert/src/components/Alert/useAlert.tsx
+++ b/packages/react-components/react-alert/src/components/Alert/useAlert.tsx
@@ -61,7 +61,6 @@ export const useAlert_unstable = (props: AlertProps, ref: React.Ref<HTMLElement>
     root: getNativeElementProps('div', {
       ref,
       role: defaultRole,
-      'aria-live': 'assertive',
       children: props.children,
       ...props,
     }),

--- a/packages/react-components/react-alert/src/stories/Alert/AlertAction.stories.tsx
+++ b/packages/react-components/react-alert/src/stories/Alert/AlertAction.stories.tsx
@@ -16,7 +16,7 @@ export const Action = () => (
     <Alert
       intent="error"
       action={{
-        icon: <DismissCircleRegular />,
+        icon: <DismissCircleRegular aria-label="dismiss message" />,
       }}
     >
       Save failed


### PR DESCRIPTION
I've added a role of `status` or `alert` based on the intent. I've also added `aria-live="assertive"` to all alerts, since my assumption is that any message important enough to use a component like Alert should probably be announced when it appears. This overrides the default live region priority of `status` while keeping `status` semantics.