### PR TITLE
theme-designer: Update package version to 9.0.0 to auto-update package deps after new v9 releases

### DIFF
--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/theme-designer",
-  "version": "0.1.0",
+  "version": "9.0.0-alpha.0",
   "private": true,
   "description": "A theme designer",
   "main": "lib-commonjs/index.js",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- `theme-designer`'s dependencies are not automatically updated after every v9 release because it doesn't have 9.0.0 as its version which excludes it from v9 scoping. This results in having to manually upgrade its package dependencies to fix syncpack mistmatches.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- changes version scope to `9.0.0-alpha.0` so package dependencies should now get auto bumped whenever a new v9 release is made.



