### PR TITLE
ci: change component governance task name

### DIFF
--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -83,7 +83,7 @@ jobs:
           targetPath: $(System.DefaultWorkingDirectory)/_manifest
 
       - task: ComponentGovernanceComponentDetection@0
-        displayName: 'Component Detection'
+        displayName: 'Component governance detection'
         inputs:
           sourceScanPath: $(Agent.BuildDirectory)
         condition: succeeded()

--- a/azure-pipelines.release-vnext.yml
+++ b/azure-pipelines.release-vnext.yml
@@ -99,7 +99,7 @@ jobs:
       # This would usually be run automatically (via a pipeline decorator from an extension), but the
       # thorough cleanup step prevents it from working. So run it manually here.
       - task: ComponentGovernanceComponentDetection@0
-        displayName: 'Component Detection'
+        displayName: 'Component governance detection'
         inputs:
           sourceScanPath: $(Agent.BuildDirectory)
         condition: succeeded()

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -189,7 +189,7 @@ jobs:
       # This would usually be run automatically (via a pipeline decorator from an extension), but the
       # thorough cleanup step prevents it from working. So run it manually here.
       - task: ComponentGovernanceComponentDetection@0
-        displayName: 'Component Detection'
+        displayName: 'Component governance detection'
         inputs:
           sourceScanPath: $(Agent.BuildDirectory)
         condition: succeeded()


### PR DESCRIPTION
## Current Behavior

The component governance task's name isn't clear.

## New Behavior

Task is now called `Component governance detection`.