### PR TITLE
rfc: "No action" / default property value standardization

### DIFF
--- a/rfcs/react-components/no-action-prop-value-standardization.md
+++ b/rfcs/react-components/no-action-prop-value-standardization.md
@@ -42,6 +42,10 @@ i.e. `Card` component's `appearance` prop, should have a default appearance, as 
 Cases where nothing is done in our hooks as a default, we would leverage `undefined`.
 i.e. `Card` component's `focusMode` prop should be nullable instead of using an `off` string value, as that reflects the fact that nothing is applied to the component.
 
+```tsx
+<Card focusMode=">
+```
+
 ### Pros and Cons
 
 #### Pros
@@ -52,16 +56,29 @@ i.e. `Card` component's `focusMode` prop should be nullable instead of using an 
 
 #### Cons
 
-- New style map approach would require changes
-  ```ts
+- Using the lookup object pattern for styling would require changes
+
+  Proposal:
+
+  <!-- prettier-ignore -->
+  ```tsx
+  const state = { align: undefined } as const;
+
   const alignMap = {
-    none: undefined,
+    _default: undefined,
     start: styles.alignStart,
     center: styles.alignCenter,
     end: styles.alignEnd,
     justify: styles.alignJustify,
   } as const;
+
+  const className = mergeClasses(
+    classNames.root,
+    styles.root,
+    alignMap[props.align ?? '_default']
+  );
   ```
+
 - Users who dynamically set a property value would need to do something like:
   ```tsx
   <Text align={isItFriday ? 'center' : undefined} />

--- a/rfcs/react-components/no-action-prop-value-standardization.md
+++ b/rfcs/react-components/no-action-prop-value-standardization.md
@@ -36,8 +36,16 @@ useTextStyles_unstable({
 This RFC proposes that we leverage the standard JavaScript default, `undefined`, for attributes instead of a string.
 For this, we should stop using `Required` for all props in the `State` and decide case by case if something should / should not be optional.
 
-Cases where our component should have a default value, we would apply a primitive value for it, like a string or a boolean.
-i.e. `Card` component's `appearance` prop, should have a default value, as we don't want a card without a pre-defined appearance, as that's detrimental to the usage.
+Put simply, when a component has a default state/behavior, it SHOULD HAVE a default value.<br/>
+Example: Card.appearance has `'filled' | 'filled-alternative' | 'outline' | 'subtle'` and is `'filled'` by default.
+
+When a component does not have a default state/behavior, it SHOULD NOT HAVE a default value.<br/>
+Anti-example (current state): Text.font has `'base' | 'monospace' | 'numeric'` and defaults to `'base'`, where `'base'` does not apply any styles<br/>
+Example (proposal): Text.font has `'monospace' | 'numeric'` and has no defaults (i.e. `undefined`)
+
+### Usage
+
+#### With default
 
 ```tsx
 // Card.types.ts
@@ -74,21 +82,20 @@ state.root.className = mergeClasses(
 );
 ```
 
-Cases where nothing is done in our hooks as a default, we should leverage the JavaScript standard for no value - `undefined`.
-i.e. `Text` component's `font` prop should be optional/undefined, instead of using a `'default'` string value, as these values reflect the fact that there are no side-effects from it.
+#### Without default
 
 ```tsx
 // Text.types.ts
 type TextProps = {
-  font?: 'base' | 'monospace' | 'numeric';
+  font?: 'monospace' | 'numeric';
 };
 type TextState = {
   // Also nullable as the default does not overwrite styles
-  font?: 'base' | 'monospace' | 'numeric';
+  font?: 'monospace' | 'numeric';
 };
 
 // useText.ts
-const { font /* {...} */ } = props; // We no longer set the default here
+const { font /* {...} */ } = props; // We no longer set a default here
 
 const state = {
   font,
@@ -114,9 +121,21 @@ state.root.className = mergeClasses(
 );
 ```
 
-### Usage difference
+### Usage differences
 
-```ts
+#### Dynamically setting a prop value
+
+```jsx
+// Before
+<Text font={isNumeric ? 'numeric' : 'base'}>
+
+// After
+<Text font={isNumeric ? 'numeric' : undefined}>
+```
+
+#### Consuming style hooks directly
+
+```js
 // Before
 useTextStyles_unstable({
   // User has to check docs to double check what the default should be.
@@ -150,12 +169,11 @@ useTextStyles_unstable({
 
 ### Cons
 
-- Using the lookup object pattern for styling would require changes
+- Using the lookup object pattern for styling will require changes as `undefined` can't be used as an index type
 
   Proposal:
 
-  <!-- prettier-ignore -->
-  ```tsx
+  ```js
   const state = { align: undefined } as const;
 
   const alignMap = {
@@ -173,9 +191,9 @@ useTextStyles_unstable({
   );
   ```
 
-- Users who dynamically set a property value would need to do something like:
-  ```tsx
-  <Text align={isItFriday ? 'center' : undefined} />
+- Dynamically setting a property value requires explicit usage of `undefined`:
+  ```jsx
+  <Text font={isNumeric ? 'numeric' : undefined}>
   ```
 
 ## Discarded Solutions

--- a/rfcs/react-components/no-action-prop-value-standardization.md
+++ b/rfcs/react-components/no-action-prop-value-standardization.md
@@ -36,25 +36,118 @@ useTextStyles_unstable({
 This RFC proposes that we leverage the standard JavaScript default, `undefined`, for attributes instead of a string.
 For this, we should stop using `Required` for all props in the `State` and decide case by case if something should / should not be optional.
 
-Cases where our component should have a default value, we would apply the state that should be the default value.
-i.e. `Card` component's `appearance` prop, should have a default appearance, as we don't want a card without a pre-defined appearance as that's detrimental to the usage.
-
-Cases where nothing is done in our hooks as a default, we would leverage `undefined`.
-i.e. `Card` component's `focusMode` prop should be nullable instead of using an `off` string value, as that reflects the fact that nothing is applied to the component.
+Cases where our component should have a default value, we would apply a primitive value for it, like a string or a boolean.
+i.e. `Card` component's `appearance` prop, should have a default value, as we don't want a card without a pre-defined appearance, as that's detrimental to the usage.
 
 ```tsx
-<Card focusMode=">
+// Card.types.ts
+type CardProps = {
+  appearance?: 'filled' | 'filled-alternative' | 'outline' | 'subtle';
+};
+type CardState = {
+  // Required as we need a value for our hooks to work
+  appearance: 'filled' | 'filled-alternative' | 'outline' | 'subtle';
+};
+
+// useCard.ts
+const { appearance = 'filled' /* {...} */ } = props; // Default applied to enforce behavior
+
+const state = {
+  appearance,
+  // {...}
+};
+
+// useCardStyles.ts
+const appearanceLookup = {
+  filled: styles.filled,
+  'filled-alternative': styles.filledAlternative,
+  outline: styles.outline,
+  subtle: styles.subtle,
+} as const;
+
+state.root.className = mergeClasses(
+  cardClassNames.root,
+  styles.root,
+  appearanceLookup[state.appearance],
+  // {...}
+  state.root.className,
+);
 ```
 
-### Pros and Cons
+Cases where nothing is done in our hooks as a default, we should leverage `undefined`.
+i.e. `Text` component's `font` prop should be nullable instead of using a `'default'` string value, as that reflects the fact that there are no side-effects from it.
 
-#### Pros
+```tsx
+// Text.types.ts
+type TextProps = {
+  font?: 'base' | 'monospace' | 'numeric';
+};
+type TextState = {
+  // Also nullable as the default does not overwrite styles
+  font?: 'base' | 'monospace' | 'numeric';
+};
+
+// useText.ts
+const { font /* {...} */ } = props; // We no longer set the default here
+
+const state = {
+  font,
+  // {...}
+};
+
+// useTextStyles.ts
+const { font = '_default' } = state; // Applying a default to keep using a lookup
+
+const fontLookup = {
+  _default: undefined,
+  base: styles.fontBase,
+  monospace: styles.fontMonospace,
+  numeric: styles.fontNumeric,
+} as const;
+
+state.root.className = mergeClasses(
+  cardClassNames.root,
+  styles.root,
+  fontLookup[font],
+  // {...}
+  state.root.className,
+);
+```
+
+### Usage difference
+
+```ts
+// Before
+useTextStyles_unstable({
+  // User has to check docs to double check what the default shoud be.
+  align: 'start',
+  block: false,
+  font: 'monospace', // Only change from defaults
+  italic: false,
+  size: 300,
+  strikethrough: false,
+  truncate: false,
+  underline: false,
+  weight: 'regular',
+  wrap: true,
+});
+
+// After
+useTextStyles_unstable({
+  font: 'monospace',
+  // {...} - Required props
+});
+```
+
+## Pros and Cons
+
+### Pros
 
 - Follows JavaScript standards
 - Intuitive to the user because of the above pro - no need to read documentation
 - Consistency across our product - enables ease of use
 
-#### Cons
+### Cons
 
 - Using the lookup object pattern for styling would require changes
 

--- a/rfcs/react-components/no-action-prop-value-standardization.md
+++ b/rfcs/react-components/no-action-prop-value-standardization.md
@@ -1,0 +1,80 @@
+# RFC: "No action" / default property value standardization
+
+---
+
+_@andrefcdias @Hotell_
+
+## Summary
+
+This RFC aims to standardize what values we use in our components for cases where a prop value results in no action, i.e. defaults that apply no styles.
+
+## Background
+
+Currently, the approach we follow for all components is to use a string value like 'off', 'none' or 'default' for default values of a prop.
+
+## Problem statement
+
+There is no standardization for the naming, resulting in our users needing to read documentation to figure out what to use and requiring specific component knowledge as they can't reuse this information for other components. Given that we use TypeScript's `Required` to enforce these attributes to be non-nullable, a user will have to read through all the docs of said component to figure out what to use, when consuming a `useComponentStyles_unstable` hook. For a user that wants to consume the `useTextStyles` to apply only bold, they would need to write:
+
+```ts
+useTextStyles_unstable({
+  align: 'start',
+  block: false,
+  font: 'base',
+  italic: false,
+  size: 300,
+  strikethrough: false,
+  truncate: false,
+  underline: false,
+  weight: 'semibold', // Only change from defaults
+  wrap: true,
+});
+```
+
+## Detailed Design or Proposal
+
+This RFC proposes that we leverage the standard JavaScript default, `undefined`, for attributes instead of a string.
+For this, we should stop using `Required` for all props in the `State` and decide case by case if something should / should not be optional.
+
+Cases where our component should have a default value, we would apply the state that should be the default value.
+i.e. `Card` component's `appearance` prop, should have a default appearance, as we don't want a card without a pre-defined appearance as that's detrimental to the usage.
+
+Cases where nothing is done in our hooks as a default, we would leverage `undefined` and `null`.
+i.e. `Card` component's `focusMode` prop should be nullable instead of using an `off` string value, as that reflects the fact that nothing is applied to the component.
+
+### Pros and Cons
+
+#### Pros
+
+- Follows JavaScript standards
+- Intuitive to the user because of the above pro - no need to read documentation
+- Consistency across our product - enables ease of use
+
+#### Cons
+
+- New style map approach would require changes
+  ```ts
+  const alignMap = {
+    none: undefined,
+    start: styles.alignStart,
+    center: styles.alignCenter,
+    end: styles.alignEnd,
+    justify: styles.alignJustify,
+  } as const;
+  ```
+- Users who dynamically set a property value would need to do something like:
+  ```tsx
+  <Text align={isItFriday ? 'center' : undefined} />
+  ```
+
+## Discarded Solutions
+
+### Standardizing the string label used for default values
+
+Using a specific keyword for all possible scenarios would be difficult as there isn't a word that is neutral and appropriate for all the different cases.
+
+- `none` can be confused with CSS's `none`
+- `off` does not fit cases like an `align` property
+- `default` is ambiguous and does not convey the fact that nothing happens
+
+Even if we can get a word that fits all the cases, the user would still need to add every single property when consuming a styles hook, like the example shown in the [Problem Statement](##Problem_statement).

--- a/rfcs/react-components/no-action-prop-value-standardization.md
+++ b/rfcs/react-components/no-action-prop-value-standardization.md
@@ -119,7 +119,7 @@ state.root.className = mergeClasses(
 ```ts
 // Before
 useTextStyles_unstable({
-  // User has to check docs to double check what the default shoud be.
+  // User has to check docs to double check what the default should be.
   align: 'start',
   block: false,
   font: 'monospace', // Only change from defaults

--- a/rfcs/react-components/no-action-prop-value-standardization.md
+++ b/rfcs/react-components/no-action-prop-value-standardization.md
@@ -146,6 +146,7 @@ useTextStyles_unstable({
 - Follows JavaScript standards
 - Intuitive to the user because of the above pro - no need to read documentation
 - Consistency across our product - enables ease of use
+- Unified `Props` and `State` shape
 
 ### Cons
 

--- a/rfcs/react-components/no-action-prop-value-standardization.md
+++ b/rfcs/react-components/no-action-prop-value-standardization.md
@@ -10,31 +10,15 @@ This RFC aims to standardize what values we use in our components for cases wher
 
 ## Background
 
-Currently, the approach we follow for all components is to use a string value like 'off', 'none' or 'default' for default values of a prop.
+Currently, the approach we follow for all components is to use a string value like `'off'`, `'none'` or `'default'` for default values of a prop. This happens both on cases where the default prop has and doesn't have an effect on the component.
 
 ## Problem statement
 
-There is no standardization for the naming, resulting in our users needing to read documentation to figure out what to use and requiring specific component knowledge as they can't reuse this information for other components. Given that we use TypeScript's `Required` to enforce these attributes to be non-nullable, a user will have to read through all the docs of said component to figure out what to use, when consuming a `useComponentStyles_unstable` hook. For a user that wants to consume the `useTextStyles` to apply only bold, they would need to write:
-
-```ts
-useTextStyles_unstable({
-  align: 'start',
-  block: false,
-  font: 'base',
-  italic: false,
-  size: 300,
-  strikethrough: false,
-  truncate: false,
-  underline: false,
-  weight: 'semibold', // Only change from defaults
-  wrap: true,
-});
-```
+There is no standardization for the naming, resulting in our users needing to read documentation to figure out what to use, as the names used might be compared to CSS keywords (like `'unset'`), and requiring specific component knowledge as the user can't reuse this information for other components. It is also misleading to provide a string value that has no actual impact on the component.
 
 ## Detailed Design or Proposal
 
 This RFC proposes that we leverage the standard JavaScript default, `undefined`, for attributes instead of a string.
-For this, we should stop using `Required` for all props in the `State` and decide case by case if something should / should not be optional.
 
 Put simply, when a component has a default state/behavior, it SHOULD HAVE a default value.<br/>
 Example: Card.appearance has `'filled' | 'filled-alternative' | 'outline' | 'subtle'` and is `'filled'` by default.
@@ -131,31 +115,6 @@ state.root.className = mergeClasses(
 
 // After
 <Text font={isNumeric ? 'numeric' : undefined}>
-```
-
-#### Consuming style hooks directly
-
-```js
-// Before
-useTextStyles_unstable({
-  // User has to check docs to double check what the default should be.
-  align: 'start',
-  block: false,
-  font: 'monospace', // Only change from defaults
-  italic: false,
-  size: 300,
-  strikethrough: false,
-  truncate: false,
-  underline: false,
-  weight: 'regular',
-  wrap: true,
-});
-
-// After
-useTextStyles_unstable({
-  font: 'monospace',
-  // {...} - Required props
-});
 ```
 
 ## Pros and Cons

--- a/rfcs/react-components/no-action-prop-value-standardization.md
+++ b/rfcs/react-components/no-action-prop-value-standardization.md
@@ -96,7 +96,7 @@ const state = {
 };
 
 // useTextStyles.ts
-const { font = '_default' } = state; // Applying a default to keep using a lookup
+const { font } = state;
 
 const fontLookup = {
   _default: undefined,
@@ -108,7 +108,7 @@ const fontLookup = {
 state.root.className = mergeClasses(
   cardClassNames.root,
   styles.root,
-  fontLookup[font],
+  fontLookup[font ?? '_default'], // Applying a default to keep usage of a lookup
   // {...}
   state.root.className,
 );

--- a/rfcs/react-components/no-action-prop-value-standardization.md
+++ b/rfcs/react-components/no-action-prop-value-standardization.md
@@ -74,8 +74,8 @@ state.root.className = mergeClasses(
 );
 ```
 
-Cases where nothing is done in our hooks as a default, we should leverage `undefined`.
-i.e. `Text` component's `font` prop should be nullable instead of using a `'default'` string value, as that reflects the fact that there are no side-effects from it.
+Cases where nothing is done in our hooks as a default, we should leverage the JavaScript standard for no value - `undefined`.
+i.e. `Text` component's `font` prop should be optional/undefined, instead of using a `'default'` string value, as these values reflect the fact that there are no side-effects from it.
 
 ```tsx
 // Text.types.ts

--- a/rfcs/react-components/no-action-prop-value-standardization.md
+++ b/rfcs/react-components/no-action-prop-value-standardization.md
@@ -85,24 +85,6 @@ const state = {
   font,
   // {...}
 };
-
-// useTextStyles.ts
-const { font } = state;
-
-const fontLookup = {
-  _default: undefined,
-  base: styles.fontBase,
-  monospace: styles.fontMonospace,
-  numeric: styles.fontNumeric,
-} as const;
-
-state.root.className = mergeClasses(
-  cardClassNames.root,
-  styles.root,
-  fontLookup[font ?? '_default'], // Applying a default to keep usage of a lookup
-  // {...}
-  state.root.className,
-);
 ```
 
 ### Usage differences
@@ -129,27 +111,6 @@ state.root.className = mergeClasses(
 ### Cons
 
 - Using the lookup object pattern for styling will require changes as `undefined` can't be used as an index type
-
-  Proposal:
-
-  ```js
-  const state = { align: undefined } as const;
-
-  const alignMap = {
-    _default: undefined,
-    start: styles.alignStart,
-    center: styles.alignCenter,
-    end: styles.alignEnd,
-    justify: styles.alignJustify,
-  } as const;
-
-  const className = mergeClasses(
-    classNames.root,
-    styles.root,
-    alignMap[props.align ?? '_default']
-  );
-  ```
-
 - Dynamically setting a property value requires explicit usage of `undefined`:
   ```jsx
   <Text font={isNumeric ? 'numeric' : undefined}>

--- a/rfcs/react-components/no-action-prop-value-standardization.md
+++ b/rfcs/react-components/no-action-prop-value-standardization.md
@@ -39,7 +39,7 @@ For this, we should stop using `Required` for all props in the `State` and decid
 Cases where our component should have a default value, we would apply the state that should be the default value.
 i.e. `Card` component's `appearance` prop, should have a default appearance, as we don't want a card without a pre-defined appearance as that's detrimental to the usage.
 
-Cases where nothing is done in our hooks as a default, we would leverage `undefined` and `null`.
+Cases where nothing is done in our hooks as a default, we would leverage `undefined`.
 i.e. `Card` component's `focusMode` prop should be nullable instead of using an `off` string value, as that reflects the fact that nothing is applied to the component.
 
 ### Pros and Cons


### PR DESCRIPTION
## New Behavior

This RFC aims to standardize what values we use in our components for cases where a prop value results in no action, i.e. defaults that apply no styles.

Currently, the approach we follow for all components is to use a string value like 'off', 'none' or 'default' for default values of a prop.

[PREVIEW 🔍](https://github.com/andrefcdias/fluentui/blob/rfc-standardize-no-action-prop-values/rfcs/react-components/no-action-prop-value-standardization.md)

## Related Issue(s)

#23254
