### PR TITLE
react-spinner: Remove usage of :focus-visible to conform to browser matrix

### DIFF
--- a/change/@fluentui-react-spinner-905667c6-688b-417d-9a5b-9b0558e71c37.json
+++ b/change/@fluentui-react-spinner-905667c6-688b-417d-9a5b-9b0558e71c37.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove usage of focus-visible pseudo-class.",
+  "packageName": "@fluentui/react-spinner",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinner/src/components/Spinner/useSpinnerStyles.ts
+++ b/packages/react-components/react-spinner/src/components/Spinner/useSpinnerStyles.ts
@@ -73,8 +73,8 @@ const useRootStyles = makeStyles({
 const useLoaderStyles = makeStyles({
   // global SVG class
   spinnerSVG: {
-    ':focus-visible': {
-      outlineStyle: '3px solid transparent',
+    ':focus': {
+      ...shorthands.outline('3px', 'solid', 'transparent'),
     },
     ['& > svg']: {
       animationName: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
-  `react-spinner` uses `:focus-visible` to add custom focus styling but that pseudo-class would not be supported by our browser matrix. 

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- Use `:focus` pseudo-class instead to achieve same focus styling and behavior. 
- uses correct `outline` shorthands to apply focus outline style.

## Comparison
### Using `:focus-visible`: 

![Spinner focus-visible](https://user-images.githubusercontent.com/8649804/170739099-dff45696-3f15-4536-9c12-9ea612a91609.gif)

### Using `:focus`:

![Spinner focus](https://user-images.githubusercontent.com/8649804/170739128-dc25e209-0473-4e93-9f0b-f647b35ad81b.gif)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Partially addresses #23020