### PR TITLE
fix(tools): don't add addition # when adding codeowners

### DIFF
--- a/tools/generators/add-codeowners.spec.ts
+++ b/tools/generators/add-codeowners.spec.ts
@@ -28,6 +28,12 @@ describe(`#addCodeowner`, () => {
       sourceRoot: '/packages/react-three/src',
       targets: {},
     });
+    addProjectConfiguration(tree, '@proj/react-four', {
+      root: '/packages/react-four',
+      projectType: 'library',
+      sourceRoot: '/packages/react-four/src',
+      targets: {},
+    });
   });
 
   it(`should throw if no CODEOWNER exists`, () => {
@@ -58,8 +64,17 @@ describe(`#addCodeowner`, () => {
       "/packages/react-one @org/team-one
       /packages/react-one @org/team-two
       /packages/react-three @org/team-three
-      ## <%= NX-CODEOWNER-PLACEHOLDER %>
-      "
+      # <%= NX-CODEOWNER-PLACEHOLDER %>"
+    `);
+
+    addCodeowner(tree, { packageName: '@proj/react-four', owner: '@org/team-four' });
+
+    expect(tree.read(workspacePaths.github.codeowners, 'utf8')).toMatchInlineSnapshot(`
+      "/packages/react-one @org/team-one
+      /packages/react-one @org/team-two
+      /packages/react-three @org/team-three
+      /packages/react-four @org/team-four
+      # <%= NX-CODEOWNER-PLACEHOLDER %>"
     `);
   });
 });

--- a/tools/generators/add-codeowners.ts
+++ b/tools/generators/add-codeowners.ts
@@ -30,7 +30,7 @@ function processCodeowners(tree: Tree, options: ReturnType<typeof getProjectConf
   const changes: StringChange[] = [
     {
       type: ChangeType.Delete,
-      start: placeholderPosition + 1,
+      start: placeholderPosition,
       length: placeholder.length,
     },
     {
@@ -40,8 +40,8 @@ function processCodeowners(tree: Tree, options: ReturnType<typeof getProjectConf
     },
     {
       type: ChangeType.Insert,
-      index: placeholderPosition + 1,
-      text: placeholder + '\n',
+      index: placeholderPosition,
+      text: placeholder,
     },
   ];
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

when `create-package` is invoked `migrate-converged-pkg` incorrectly copies codeowners placeholder, which creates consecutive packages with commented codeowner thus defeating its main purpose

## New Behavior

codeowners file is updated as expected

## Related Issue(s)


- https://github.com/microsoft/fluentui/commit/b37857d57e72e2f0c5787411ec1dde35b9145847#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R156
- https://github.com/microsoft/fluentui/pull/23320/files#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L167