### PR TITLE
fix(react-menu): submenu indicator should be filled on hover

### DIFF
--- a/change/@fluentui-react-menu-9acac1a7-cc78-457e-9877-f60551efcb2a.json
+++ b/change/@fluentui-react-menu-9acac1a7-cc78-457e-9877-f60551efcb2a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: submenu indicator should be filled on hover",
+  "packageName": "@fluentui/react-menu",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-components/react-menu/src/components/MenuItem/useMenuItem.tsx
@@ -9,10 +9,19 @@ import {
 import { useFluent } from '@fluentui/react-shared-contexts';
 import { useCharacterSearch } from './useCharacterSearch';
 import { useMenuTriggerContext_unstable } from '../../contexts/menuTriggerContext';
-import { ChevronRightRegular as ChevronRightIcon, ChevronLeftRegular as ChevronLeftIcon } from '@fluentui/react-icons';
+import {
+  ChevronRightFilled,
+  ChevronRightRegular,
+  ChevronLeftFilled,
+  ChevronLeftRegular,
+  bundleIcon,
+} from '@fluentui/react-icons';
 import { useMenuListContext_unstable } from '../../contexts/menuListContext';
 import { useMenuContext_unstable } from '../../contexts/menuContext';
 import type { MenuItemProps, MenuItemState } from './MenuItem.types';
+
+const ChevronRightIcon = bundleIcon(ChevronRightFilled, ChevronRightRegular);
+const ChevronLeftIcon = bundleIcon(ChevronLeftFilled, ChevronLeftRegular);
 
 /**
  * Returns the props and state required to render the component

--- a/packages/react-components/react-menu/src/components/MenuItem/useMenuItemStyles.ts
+++ b/packages/react-components/react-menu/src/components/MenuItem/useMenuItemStyles.ts
@@ -38,10 +38,12 @@ const useStyles = makeStyles({
 
       [`& .${iconFilledClassName}`]: {
         display: 'inline',
-        color: tokens.colorNeutralForeground2BrandSelected,
       },
       [`& .${iconRegularClassName}`]: {
         display: 'none',
+      },
+      [`& .${menuItemClassNames.icon}`]: {
+        color: tokens.colorNeutralForeground2BrandSelected,
       },
     },
 


### PR DESCRIPTION
For submenu indicator, use filled icon on hover:
<img width="234" alt="Screenshot 2022-05-31 at 14 28 28" src="https://user-images.githubusercontent.com/28751745/171178927-4b049e59-0f46-4f9f-8139-0e804cb693ab.png">
