### PR TITLE
fix: use React 17 in CodeSandbox exports

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -39,9 +39,11 @@ export const parameters = {
   },
   exportToCodeSandbox: {
     requiredDependencies: {
-      react: 'latest',
-      'react-dom': 'latest', // for React
-      'react-scripts': 'latest', // necessary when using typescript in CodeSandbox
+      // for React
+      react: '^17',
+      'react-dom': '^17',
+      // necessary when using typescript in CodeSandbox
+      'react-scripts': 'latest',
     },
     optionalDependencies: {
       '@fluentui/react-components': 'rc', // necessary for FluentProvider


### PR DESCRIPTION
## New Behavior

We don't support the latest and greatest React 18 (#22581), so let's use at least something that is supported currently.

## Related Issue(s)

Fixes #23242