### PR TITLE
Only stop esc propagation if the date picker is open

### DIFF
--- a/change/@fluentui-react-535f80fc-7fe0-4cd7-8957-74ee2076c4f6.json
+++ b/change/@fluentui-react-535f80fc-7fe0-4cd7-8957-74ee2076c4f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Only stop esc key propagation when picker is open",
+  "packageName": "@fluentui/react",
+  "email": "tand@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -429,8 +429,10 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
   };
 
   const handleEscKey = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    ev.stopPropagation();
-    calendarDismissed();
+    if (isCalendarShown) {
+      ev.stopPropagation();
+      calendarDismissed();
+    }
   };
 
   const classNames = getClassNames(styles, {


### PR DESCRIPTION
## Current Behavior

Stops propagation on escape all the time

## New Behavior

Only stop propagation when the picker is open and esc dismisses it.

## Related Issue(s)

https://github.com/microsoft/fluentui/issues/23308
