### PR TITLE
fix: Setting 'flex-schrink: 0' on listItemHeaderMediaStyle 

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Remove unnecessary `Ref` usage from `TreeItem` @chpalac ([#23105](https://github.com/microsoft/fluentui/pull/23105))
 - Render `selectionIndicator` in `TreeTitle` only when it's needed @layershifter ([#23131](https://github.com/microsoft/fluentui/pull/23131))
+- Setting `flex-schrink: 0` on listItemHeaderMediaStyle @simonmysun ([#23338](https://github.com/microsoft/fluentui/pull/23338))
 
 <!--------------------------------[ v0.63.0 ]------------------------------- -->
 ## [v0.63.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.63.0) (2022-05-18)

--- a/packages/fluentui/react-northstar/src/themes/teams/components/List/listItemHeaderMediaStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/List/listItemHeaderMediaStyles.ts
@@ -9,6 +9,7 @@ export const listItemHeaderMediaStyles: ComponentSlotStylesPrepared<
 > = {
   root: ({ variables: v }): ICSSInJSStyle => ({
     alignSelf: 'flex-end',
+    flexShrink: 0,
 
     fontSize: v.headerMediaFontSize,
     lineHeight: v.headerMediaLineHeight,


### PR DESCRIPTION
listItemHeaderMediaStyle should not shrink because it's sibling elment is truncatable. When the width is not enough, previous settings will cause listItemHeaderMedia wrapped to new lines.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

![bug](https://user-images.githubusercontent.com/3358854/171272429-23195cc0-5bf6-4753-b6af-1a69a28dab30.png)

<!-- This is the behavior we have today -->

## New Behavior

![fix](https://user-images.githubusercontent.com/3358854/171272452-44e215ba-ca21-41ab-9bd7-402ea401acfa.png)

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

No related issues found. 
