### PR TITLE
V9 Docsite: Hide `Addons` tab from mobile viewports

### DIFF
--- a/apps/public-docsite-v9/.storybook/manager-head.html
+++ b/apps/public-docsite-v9/.storybook/manager-head.html
@@ -136,6 +136,13 @@
   }
 
   /*
+  * Hides "Addons" button from mobile view nav.
+  */
+  nav > button:last-child {
+    display: none;
+  }
+
+  /*
   Storybook has proposed a feature for this in https://github.com/storybookjs/storybook/issues/9209
   which will configure stories to exist in deeplink URL format, but do not appear in the nav tree or the docs page
   Usign suggested temporary workaround until storybook gets proper support


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- Addons tab visible on mobile viewports:
![image](https://user-images.githubusercontent.com/8649804/171278677-8e445c1d-299c-45b2-9aaf-87ace5232926.png)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- Addons tab now hidden on mobile viewports:

![image](https://user-images.githubusercontent.com/8649804/171278751-a1e417d9-c465-46d3-a6b8-213c23ca3ab8.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23161
