### PR TITLE
chore: update `add-to-milestone` action to latest version

### DIFF
--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign to latest milestone
-        uses: andrefcdias/add-to-milestone@v1.2.2
+        uses: andrefcdias/add-to-milestone@v1.2.4
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           use-expression: true


### PR DESCRIPTION
## Current Behavior

`add-to-milestone` action succeeds but does not add to latest milestone.

## New Behavior

New version brings more logging, allowing us to debug why the action is misbehaving exclusively on our repo.