### PR TITLE
feat: Close context menu on scroll, new closeOnScroll prop

### DIFF
--- a/change/@fluentui-react-menu-f51ecf4d-30df-4712-89b0-3f2e9343ca0c.json
+++ b/change/@fluentui-react-menu-f51ecf4d-30df-4712-89b0-3f2e9343ca0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Close context menu on scroll, new closeOnScroll prop",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/e2e/Menu.e2e.tsx
+++ b/packages/react-components/react-menu/e2e/Menu.e2e.tsx
@@ -445,6 +445,29 @@ describe('Menu', () => {
       .get(menuSelector)
       .should('be.visible');
   });
+
+  it('should close on scroll when closeOnScroll is set', () => {
+    mount(
+      <Menu closeOnScroll>
+        <MenuTrigger>
+          <button>Menu</button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>,
+    );
+    cy.get(menuTriggerSelector)
+      .click()
+      .get(menuSelector)
+      .should('exist')
+      .get('body')
+      .trigger('wheel')
+      .get(menuSelector)
+      .should('not.exist');
+  });
 });
 
 describe('SplitMenuItem', () => {
@@ -821,6 +844,18 @@ describe('Context menu', () => {
       .should('exist')
       .get(menuTriggerSelector)
       .click()
+      .get(menuSelector)
+      .should('not.exist');
+  });
+
+  it('should close on scroll outside', () => {
+    mount(<ContextMenuExample />);
+    cy.get(menuTriggerSelector)
+      .rightclick()
+      .get(menuSelector)
+      .should('exist')
+      .get('body')
+      .trigger('wheel')
       .get(menuSelector)
       .should('not.exist');
   });

--- a/packages/react-components/react-menu/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/etc/react-menu.api.md
@@ -250,6 +250,7 @@ export type MenuProps = ComponentProps<MenuSlots> & Pick<MenuListProps, 'checked
     openOnHover?: boolean;
     persistOnItemClick?: boolean;
     positioning?: PositioningShorthand;
+    closeOnScroll?: boolean;
 };
 
 // @public (undocumented)
@@ -276,7 +277,7 @@ export type MenuSplitGroupSlots = {
 export type MenuSplitGroupState = ComponentState<MenuSplitGroupSlots>;
 
 // @public (undocumented)
-export type MenuState = ComponentState<MenuSlots> & Pick<MenuProps, 'defaultCheckedValues' | 'hasCheckmarks' | 'hasIcons' | 'inline' | 'onOpenChange' | 'openOnContext' | 'persistOnItemClick'> & Required<Pick<MenuProps, 'checkedValues' | 'onCheckedValueChange' | 'open' | 'openOnHover'>> & {
+export type MenuState = ComponentState<MenuSlots> & Pick<MenuProps, 'defaultCheckedValues' | 'hasCheckmarks' | 'hasIcons' | 'inline' | 'onOpenChange' | 'openOnContext' | 'persistOnItemClick'> & Required<Pick<MenuProps, 'checkedValues' | 'onCheckedValueChange' | 'open' | 'openOnHover' | 'closeOnScroll'>> & {
     contextTarget: ReturnType<typeof usePositioningMouseTarget>[0];
     isSubmenu: boolean;
     menuPopover: React_2.ReactNode;

--- a/packages/react-components/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-components/react-menu/src/components/Menu/Menu.types.ts
@@ -79,6 +79,13 @@ export type MenuProps = ComponentProps<MenuSlots> &
      * Configures the positioned menu
      */
     positioning?: PositioningShorthand;
+
+    /**
+     * Close when scroll outside of it
+     *
+     * @default false
+     */
+    closeOnScroll?: boolean;
   };
 
 export type MenuState = ComponentState<MenuSlots> &
@@ -92,7 +99,7 @@ export type MenuState = ComponentState<MenuSlots> &
     | 'openOnContext'
     | 'persistOnItemClick'
   > &
-  Required<Pick<MenuProps, 'checkedValues' | 'onCheckedValueChange' | 'open' | 'openOnHover'>> & {
+  Required<Pick<MenuProps, 'checkedValues' | 'onCheckedValueChange' | 'open' | 'openOnHover' | 'closeOnScroll'>> & {
     /**
      * Anchors the popper to the mouse click for context events
      */

--- a/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { usePositioningMouseTarget, usePositioning, resolvePositioningShorthand } from '@fluentui/react-positioning';
-import { useControllableState, useId, useOnClickOutside, useEventCallback } from '@fluentui/react-utilities';
+import {
+  useControllableState,
+  useId,
+  useOnClickOutside,
+  useEventCallback,
+  useOnScrollOutside,
+} from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { elementContains } from '@fluentui/react-portal';
 import { useFocusFinders } from '@fluentui/react-tabster';
@@ -61,6 +67,7 @@ export const useMenu_unstable = (props: MenuProps): MenuState => {
     contextTarget,
     setContextTarget,
     ...props,
+    closeOnScroll: props.closeOnScroll ?? false,
     menuTrigger,
     menuPopover,
     triggerRef,
@@ -111,7 +118,13 @@ const useMenuSelectableState = (
 const useMenuOpenState = (
   state: Pick<
     MenuState,
-    'isSubmenu' | 'menuPopoverRef' | 'onOpenChange' | 'setContextTarget' | 'triggerRef' | 'openOnContext'
+    | 'isSubmenu'
+    | 'menuPopoverRef'
+    | 'onOpenChange'
+    | 'setContextTarget'
+    | 'triggerRef'
+    | 'openOnContext'
+    | 'closeOnScroll'
   > &
     Pick<MenuProps, 'open' | 'defaultOpen'>,
 ) => {
@@ -185,6 +198,19 @@ const useMenuOpenState = (
     ) as React.MutableRefObject<HTMLElement>[],
     callback: e => setOpen(e, { open: false }),
   });
+
+  // only close on scroll for context, or when closeOnScroll is specified
+  const closeOnScroll = state.openOnContext || state.closeOnScroll;
+  useOnScrollOutside({
+    contains: elementContains,
+    element: targetDocument,
+    callback: ev => setOpen(ev, { open: false }),
+    refs: [state.menuPopoverRef, !state.openOnContext && state.triggerRef].filter(
+      Boolean,
+    ) as React.MutableRefObject<HTMLElement>[],
+    disabled: !open || !closeOnScroll,
+  });
+
   useOnMenuMouseEnter({
     element: targetDocument,
     callback: e => {


### PR DESCRIPTION
Context menus should close on scroll outside. Also adds a
`closeOnScroll` prop to be consistent with `Popover` introduced in #22784

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Menu with `openOnContext` does not close on scroll

## New Behavior

Menu with `openOnContext` closes on scroll

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
