### PR TITLE
ci: add missing `issues` permission for `add-to-milestone` action

### DIFF
--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -5,6 +5,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   label:


### PR DESCRIPTION
## Current Behavior

Action is only using `contents` and `pull-requests` permissions. This is not enough as `issues` is also required to modify the milestones.

Example of "failure": https://github.com/microsoft/fluentui/pull/23349/checks#step:2:314

GitHub's response after the update call shows a PR object with `milestone: null`.

![log showing milestone attribute on PR object as null](https://user-images.githubusercontent.com/39736248/171433894-481e425b-fc2e-42d9-85fb-a2d18011f42c.png)


## New Behavior

Added missing write permissions for `issues`.

PoC: https://github.com/andrefcdias/actions-test/runs/6691659508?check_suite_focus=true#step:2:192

GitHub response for the update call properly shows the milestone after adding explicit `issues: write` permissions.

![log showing the milestone object properly assigned to the PR object](https://user-images.githubusercontent.com/39736248/171433555-2735a879-1b41-4122-bbb5-ee90ed06a6d5.png)
