### PR TITLE
fix: Use modern `::before` pseudoelement

### DIFF
--- a/change/@fluentui-react-menu-aac7f279-a6fd-4470-8446-66ec9860c2b0.json
+++ b/change/@fluentui-react-menu-aac7f279-a6fd-4470-8446-66ec9860c2b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Use modern `::before` pseudoelement",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuSplitGroup/useMenuSplitGroupStyles.ts
+++ b/packages/react-components/react-menu/src/components/MenuSplitGroup/useMenuSplitGroupStyles.ts
@@ -21,7 +21,7 @@ const useStyles = makeStyles({
       borderBottomLeftRadius: 0,
       paddingLeft: 0,
       marginLeft: 'auto',
-      ':before': {
+      '::before': {
         content: '""',
         width: tokens.strokeWidthThin,
         height: '24px',


### PR DESCRIPTION
## Current Behavior

Menu uses `:before`

## New Behavior

Menu uses `::before`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23176
