### PR TITLE
chore: removes teams-prg ownership on accordion

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -130,7 +130,7 @@ common/_common.scss @microsoft/cxe-red @phkuo
 
 ## vNext packages
 packages/react-components/keyboard-keys @microsoft/teams-prg
-packages/react-components/react-accordion @microsoft/teams-prg @microsoft/cxe-coastal
+packages/react-components/react-accordion @microsoft/cxe-coastal
 packages/react-components/react-avatar @microsoft/cxe-red @behowell @khmakoto
 packages/react-components/react-badge @microsoft/teams-prg @microsoft/cxe-red @behowell
 packages/react-components/react-button @microsoft/cxe-red @khmakoto

--- a/.prettierignore
+++ b/.prettierignore
@@ -40,3 +40,5 @@ packages/web-components/src/default-palette.ts
 
 # template files which actually follow a different language's formatting
 *.hbs
+
+CODEOWNERS


### PR DESCRIPTION
Removes `teams-prg` ownership on Accordion component


## Extra

Adds CODEOWNERS file to `.prettierignore`