### PR TITLE
Button: Fixing hover styles in High Contrast mode

### DIFF
--- a/change/@fluentui-react-button-b1502248-3d52-496f-99be-70bf2247d014.json
+++ b/change/@fluentui-react-button-b1502248-3d52-496f-99be-70bf2247d014.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Button: Fixing hover styles in High Contrast mode.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
@@ -75,11 +75,14 @@ const useRootStyles = makeStyles({
       },
 
       ':hover': {
+        backgroundColor: 'HighlightText',
         ...shorthands.borderColor('Highlight'),
         color: 'Highlight',
       },
 
       ':hover:active': {
+        backgroundColor: 'HighlightText',
+        ...shorthands.borderColor('Highlight'),
         color: 'Highlight',
       },
     },


### PR DESCRIPTION
## Current Behavior

`Button` hover styles are not guaranteed to have correct contrast between background and foreground colors in High Contrast mode.

## New Behavior

`Button` hover styles are now guaranteed to have correct contrast between background and foreground colors since we are using `HighlightText` and `Highlight` for them respectively.

I don't have a way to show a non-contrasty enough set of colors in Windows 11 but you can see how it does change when using the `Dusk` High Contrast profile:

__Before:__
![Before](https://user-images.githubusercontent.com/7798177/171757284-964d04a6-3bf5-455c-8768-da2bf2e5d0ef.png)

__After:__
![image](https://user-images.githubusercontent.com/7798177/171758079-1449a2f4-abdd-4b5d-9a67-3fa85d9caca8.png)

## Related Issue(s)

Fixes #23340