### PR TITLE
Button: Adding missing forced color adjust overrides

### DIFF
--- a/change/@fluentui-react-button-7276bbe3-2ce4-42d5-b717-c2c87e8b0c2b.json
+++ b/change/@fluentui-react-button-7276bbe3-2ce4-42d5-b717-c2c87e8b0c2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Button: Adding missing forced color adjust overrides.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-b1502248-3d52-496f-99be-70bf2247d014.json
+++ b/change/@fluentui-react-button-b1502248-3d52-496f-99be-70bf2247d014.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Button: Fixing hover styles in High Contrast mode.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
@@ -78,12 +78,14 @@ const useRootStyles = makeStyles({
         backgroundColor: 'HighlightText',
         ...shorthands.borderColor('Highlight'),
         color: 'Highlight',
+        forcedColorAdjust: 'none',
       },
 
       ':hover:active': {
         backgroundColor: 'HighlightText',
         ...shorthands.borderColor('Highlight'),
         color: 'Highlight',
+        forcedColorAdjust: 'none',
       },
     },
   },

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
@@ -75,11 +75,14 @@ const useRootStyles = makeStyles({
       },
 
       ':hover': {
+        backgroundColor: 'HighlightText',
         ...shorthands.borderColor('Highlight'),
         color: 'Highlight',
       },
 
       ':hover:active': {
+        backgroundColor: 'HighlightText',
+        ...shorthands.borderColor('Highlight'),
         color: 'Highlight',
       },
     },


### PR DESCRIPTION
## PR Description

#23384 fixed hover color styles in High Contrast for `Buttons`. However, we forgot to include a couple of forced color adjust overrides needed for them.

## Related Issue(s)

Follow up to #23384 
