### PR TITLE
(web-components) Fix issue loading Color Explorer values

### DIFF
--- a/change/@fluentui-web-components-80f9d773-bd90-490e-9d09-9a7c5518fa5b.json
+++ b/change/@fluentui-web-components-80f9d773-bd90-490e-9d09-9a7c5518fa5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "(web-components) Fix issue loading Color Explorer values",
+  "packageName": "@fluentui/web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/_docs/design-system/color-explorer/components/color-block.ts
+++ b/packages/web-components/src/_docs/design-system/color-explorer/components/color-block.ts
@@ -424,15 +424,10 @@ export class AppColorBlock extends FASTElement {
 
   @attr color: string;
   private colorChanged(): void {
-    this.updateColor();
+    DOM.queueUpdate(() => this.updateColor());
   }
 
   @attr({ attribute: 'layer-name' }) layerName?: string;
-
-  public connectedCallback() {
-    super.connectedCallback();
-    DOM.queueUpdate(() => this.updateColor());
-  }
 
   private updateColor(): void {
     if (this.color && this.$fastController.isConnected) {

--- a/packages/web-components/src/_docs/design-system/color-explorer/components/swatch.ts
+++ b/packages/web-components/src/_docs/design-system/color-explorer/components/swatch.ts
@@ -102,6 +102,17 @@ export class AppSwatch extends FoundationElement {
   public connectedCallback() {
     super.connectedCallback();
 
+    const fillColorChangeHandler = () => {
+      this.updateObservables();
+    };
+
+    fillColor.subscribe(
+      {
+        handleChange: fillColorChangeHandler,
+      },
+      this,
+    );
+
     this.updateObservables();
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The Color Explorer has been recently incorporated to the web component Storybook site. We discovered the hex values were not always updating correctly.

## New Behavior

This fixes a timing or dependency issue for evaluating the hex values for the color recipes.
