### PR TITLE
README, spec and migration guide cleanup for react-button, react-checkbox and react-link

### DIFF
--- a/change/@fluentui-react-button-2692d635-528d-45d6-8b33-5d98028b6060.json
+++ b/change/@fluentui-react-button-2692d635-528d-45d6-8b33-5d98028b6060.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "README and migration guide cleanup.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-5f29fcf9-ff59-4c28-be1d-7b7a4a79268e.json
+++ b/change/@fluentui-react-checkbox-5f29fcf9-ff59-4c28-be1d-7b7a4a79268e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "README, spec and migration guide cleanup.",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-8aa95273-588e-44b2-a6cc-9a583e8cf800.json
+++ b/change/@fluentui-react-link-8aa95273-588e-44b2-a6cc-9a583e8cf800.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "README and migration guide cleanup.",
+  "packageName": "@fluentui/react-link",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/README.md
+++ b/packages/react-components/react-button/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-button
 
-**Button components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**Button components for [Fluent UI React](https://aka.ms/fluentui-storybook)**
 
 - Buttons enable users to trigger an action or event, such as submitting a form, opening a dialog, canceling an action, or performing a delete operation.
 - CompoundButtons are buttons that can have secondary content that adds extra information to the user.

--- a/packages/react-components/react-button/src/components/Button/MIGRATION.md
+++ b/packages/react-components/react-button/src/components/Button/MIGRATION.md
@@ -119,7 +119,7 @@ Common buttons now all map to `Button`:
 
 ## Property mapping
 
-| v8 `Button`                        | v0 `Button`         | Converged `Button`     |
+| v8 `Button`                        | v0 `Button`         | v9 `Button`            |
 | ---------------------------------- | ------------------- | ---------------------- |
 |                                    | `accessibility`     |                        |
 | `allowDisabledFocus`               | `disabledFocusable` | `disabledFocusable`    |

--- a/packages/react-components/react-checkbox/MIGRATION.md
+++ b/packages/react-components/react-checkbox/MIGRATION.md
@@ -1,16 +1,12 @@
 # Checkbox Migration
 
-## STATUS: WIP
-
-This Migration guide is a work in progress and is not yet ready for use.
-
 ## Migration from v0
 
 - `Checkbox`
   - `checked` => `checked`.
   - `defaultChecked` => `defaultChecked`.
-  - `disabled` => `disabled`.
-  - `indicator` => `icon`.
+  - `disabled` => Use native `disabled`.
+  - `indicator` => `indicator`.
   - `label` => `label`.
   - `labelPosition` => `labelPosition`.
   - `onChange` => `onChange`.
@@ -22,14 +18,34 @@ This Migration guide is a work in progress and is not yet ready for use.
 - `Checkbox`
   - `boxSide` => `labelPosition`.
   - `checked`, `indeterminate` => `checked`.
-  - `checkmarkIconProps` => `icon`.
+  - `checkmarkIconProps` => `indicator`.
   - `componentRef` => Not supported.
   - `defaultChecked`, `defaultIndeterminate` => `defaultChecked`.
-  - `disabled` => `disabled`.
-  - `id` => `rootId`.
+  - `disabled` => Use native `disabled`.
+  - `id` => Use native `id`.
   - `label` => `label`.
   - `name` => Not supported.
   - `onChange` => `onChange`.
-  - `onRenderLabel` => Not supported.
-  - `required` => `required`.
-  - `title` => Not supported.
+  - `onRenderLabel` => Use `label` slot.
+  - `required` => Use native `required`.
+  - `title` => Use native `title`.
+
+## Property Mapping
+
+| v8 `Checkbox`        | v0 `Checkbox`    | v9 `Checkbox`    |
+| -------------------- | ---------------- | ---------------- |
+| `boxSide`            | `labelPosition`  | `labelPosition`  |
+| `checked`            | `checked`        | `checked`        |
+| `checkmarkIconProps` | `indicator`      | `indicator`      |
+| `componentRef`       |                  |                  |
+| `defaultChecked`     | `defaultChecked` | `defaultChecked` |
+| `disabled`           | `disabled`       | `disabled`       |
+| `id`                 |                  | `id`             |
+| `label`              | `label`          | `label`          |
+| `name`               |                  |                  |
+| `onChange`           | `onChange`       | `onChange`       |
+|                      | `onClick`        | `onChange`       |
+| `onRenderLabel`      |                  | `label`          |
+| `required`           |                  | `required`       |
+| `title`              |                  | `title`          |
+|                      | `toggle`         |                  |

--- a/packages/react-components/react-checkbox/README.md
+++ b/packages/react-components/react-checkbox/README.md
@@ -2,8 +2,6 @@
 
 **Checkbox component for [Fluent UI React](https://aka.ms/fluentui-storybook)**
 
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
-
 Checkboxes give people a way to select one or more items from a group, or switch between
 two mutually exclusive options (checked or unchecked).
 
@@ -12,13 +10,13 @@ two mutually exclusive options (checked or unchecked).
 Import Checkbox:
 
 ```js
-import { Checkbox } from '@fluentui/react-checkbox';
+import { Checkbox } from '@fluentui/react-components';
 ```
 
 #### Examples
 
 ```jsx
-<Checkbox label="Default Checkbox" />
+<Checkbox label="Default checkbox" />
 <Checkbox disabled label="Disabled" />
 <Checkbox shape="circular" label="Circular" />
 ```

--- a/packages/react-components/react-checkbox/Spec.md
+++ b/packages/react-components/react-checkbox/Spec.md
@@ -32,23 +32,24 @@ The v0 `Checkbox` component supports a mixed state, which is the same as indeter
 ```
 
 Component props:
-|Prop|Description|
-|---|---|
-|accessibility|Accessibility behavior if overridden by the user.|
-|as|Render as given string or component.|
-|checked|Checkbox's checked state.|
-|className|Additional styles.|
-|defaultChecked|Whether the checkbox should be set to checked by default.|
-|design|...|
-|disabled|Whether the checkbox is disabled or not.|
-|indicator|Checkbox's icon indicator.|
-|label|Label text or jsx to be rendered in the label.|
-|labelPosition|Whether the label is rendered on left or right (`start` or `end`).|
-|onChange|Event handler to be called after checked state has changed.|
-|onClick|Event handler to be called after the checkbox is clicked.|
-|styles|Additional styles.|
-|toggle|Render a toggle style checkbox with on and off choices.|
-|variables|Additional styles.|
+
+| Prop           | Description                                                        |
+| -------------- | ------------------------------------------------------------------ |
+| accessibility  | Accessibility behavior if overridden by the user.                  |
+| as             | Render as given string or component.                               |
+| checked        | Checkbox's checked state.                                          |
+| className      | Additional styles.                                                 |
+| defaultChecked | Whether the checkbox should be set to checked by default.          |
+| design         | ...                                                                |
+| disabled       | Whether the checkbox is disabled or not.                           |
+| indicator      | Checkbox's icon indicator.                                         |
+| label          | Label text or jsx to be rendered in the label.                     |
+| labelPosition  | Whether the label is rendered on left or right (`start` or `end`). |
+| onChange       | Event handler to be called after checked state has changed.        |
+| onClick        | Event handler to be called after the checkbox is clicked.          |
+| styles         | Additional styles.                                                 |
+| toggle         | Render a toggle style checkbox with on and off choices.            |
+| variables      | Additional styles.                                                 |
 
 ### [Checkbox in v8/Fabric](https://developer.microsoft.com/en-us/fluentui#/controls/web/checkbox)
 
@@ -66,32 +67,33 @@ Example
 ```
 
 Component props:
-|Prop|Description|
-|---|---|
-|ariaDescribedBy|Id of the element that describes the checkbox.|
-|ariaLabel|Accessible label for the checkbox.|
-|ariaLabelledBy|Id of the element that contains the label information of the checkbox.|
-|ariaPositionInSet|Number in the parent set (if in a set) for aria-posinset.|
-|ariaSetSize|The total size of the parent set (if in a set) for aria-setsize.|
-|boxSide|Wheter the checkbox should be shown before or after the label.|
-|checked|Checkbox's checked state.|
-|checkmarkIconProps|Icon to be rendered in the checkbox.|
-|className|Additional styles.|
-|componentRef|Optional ref.|
-|defaultChecked|Whether the checkbox should be set to checked by default.|
-|defaultIndeterminate|Whether the checkbox should be set to indeterminate by default.|
-|disabled|Whether the checkbox is disabled or not.|
-|id|Id for the checkbox input.|
-|indeterminate|Checkbox's indeterminate state.|
-|inputProps|Optional props to be applied to the input element before applying other props.|
-|label|String to display next to the checkbox.|
-|name|Name for the checkbox input.|
-|onChange|Event handler to be called after the checked value has changed.|
-|onRenderLabel|Custom render for the label.|
-|required|Required state of the checkbox.|
-|styles|Additional styles.|
-|theme|Additional styles.|
-|title|Title text applied to the root element and the hidden checkbox input.|
+
+| Prop                 | Description                                                                    |
+| -------------------- | ------------------------------------------------------------------------------ |
+| ariaDescribedBy      | Id of the element that describes the checkbox.                                 |
+| ariaLabel            | Accessible label for the checkbox.                                             |
+| ariaLabelledBy       | Id of the element that contains the label information of the checkbox.         |
+| ariaPositionInSet    | Number in the parent set (if in a set) for aria-posinset.                      |
+| ariaSetSize          | The total size of the parent set (if in a set) for aria-setsize.               |
+| boxSide              | Wheter the checkbox should be shown before or after the label.                 |
+| checked              | Checkbox's checked state.                                                      |
+| checkmarkIconProps   | Icon to be rendered in the checkbox.                                           |
+| className            | Additional styles.                                                             |
+| componentRef         | Optional ref.                                                                  |
+| defaultChecked       | Whether the checkbox should be set to checked by default.                      |
+| defaultIndeterminate | Whether the checkbox should be set to indeterminate by default.                |
+| disabled             | Whether the checkbox is disabled or not.                                       |
+| id                   | Id for the checkbox input.                                                     |
+| indeterminate        | Checkbox's indeterminate state.                                                |
+| inputProps           | Optional props to be applied to the input element before applying other props. |
+| label                | String to display next to the checkbox.                                        |
+| name                 | Name for the checkbox input.                                                   |
+| onChange             | Event handler to be called after the checked value has changed.                |
+| onRenderLabel        | Custom render for the label.                                                   |
+| required             | Required state of the checkbox.                                                |
+| styles               | Additional styles.                                                             |
+| theme                | Additional styles.                                                             |
+| title                | Title text applied to the root element and the hidden checkbox input.          |
 
 ### Conclusion
 

--- a/packages/react-components/react-link/MIGRATION.md
+++ b/packages/react-components/react-link/MIGRATION.md
@@ -15,15 +15,15 @@ v0 does not currently export a `Link` component.
 
 ## Property mapping
 
-| v8 `Link`      | Converged `Link` |
-| -------------- | ---------------- |
-| `componentRef` | -                |
-| `disabled`     | `disabled`       |
-| `href`         | `href`           |
-| `onClick`      | `onClick`        |
-| `rel`          | `rel`            |
-| `styles`       | -                |
-| `target`       | `target`         |
-| `theme`        | -                |
-| `type`         | `type`           |
-| `underline`    | `inline`         |
+| v8 `Link`      | v9 `Link`  |
+| -------------- | ---------- |
+| `componentRef` | -          |
+| `disabled`     | `disabled` |
+| `href`         | `href`     |
+| `onClick`      | `onClick`  |
+| `rel`          | `rel`      |
+| `styles`       | -          |
+| `target`       | `target`   |
+| `theme`        | -          |
+| `type`         | `type`     |
+| `underline`    | `inline`   |

--- a/packages/react-components/react-link/README.md
+++ b/packages/react-components/react-link/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-link
 
-**Link components for [Fluent UI](https://dev.microsoft.com/fluentui)**
+**Link components for [Fluent UI](https://aka.ms/fluentui-storybook)**
 
 Links reference data that a user can follow by clicking or tapping it.
 


### PR DESCRIPTION
## PR Description

This PR cleans up the READMEs and migration guides of `react-button` and `react-link` so they link to the storybook and reference `v9` instead of `Converged` terminology.

This PR also cleans up a bunch of things in `react-checkbox`:
- The migration guide is updated to remove WIP warnings and to more correctly reflect new types. A new `Property mapping` table across v0, v8 and v9 versions is also added.
- The README is updated to remove WIP warnings and reference importing from `react-components` instead of from `react-checkbox` in examples.
- The spec is updated to properly format tables.