### PR TITLE
README, spec and migration guide cleanup for react-switch

### DIFF
--- a/change/@fluentui-react-switch-6a55c865-0569-4729-81c9-4c5129b184da.json
+++ b/change/@fluentui-react-switch-6a55c865-0569-4729-81c9-4c5129b184da.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "README, spec and migration guide cleanup.",
+  "packageName": "@fluentui/react-switch",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-switch/MIGRATION.md
+++ b/packages/react-components/react-switch/MIGRATION.md
@@ -1,9 +1,5 @@
 # Switch Migration
 
-## STATUS: WIP 🚧
-
-This Migration guide is a work in progress and is not yet ready for use.
-
 ## Migration from v8's Toggle
 
 ### Props that remain as is
@@ -68,7 +64,7 @@ This Migration guide is a work in progress and is not yet ready for use.
 
 - `design`
 
-## Propery mapping
+## Property mapping
 
 | v8 `Toggle`      | v0 `Checkbox`   | v9 `Switch`      |
 | ---------------- | --------------- | ---------------- |

--- a/packages/react-components/react-switch/README.md
+++ b/packages/react-components/react-switch/README.md
@@ -35,4 +35,4 @@ See [SPEC.md](./Spec.md).
 
 ### Migration Guide
 
-If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest component implementations.
+If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest Switch implementation.

--- a/packages/react-components/react-switch/README.md
+++ b/packages/react-components/react-switch/README.md
@@ -1,22 +1,12 @@
 # @fluentui/react-switch
 
-**React Switch components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Switch components for [Fluent UI React](https://aka.ms/fluentui-storybook)**
 
-The `Switch` control (formerly `Toggle`) enables users to trigger an option on or off through pressing on the component.
-
-## STATUS: WIP 🚧
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+The `Switch` control enables users to trigger an option on or off through interacting with the component.
 
 ## Usage
 
 To import Switch:
-
-```js
-import { Switch } from '@fluentui/react-switch';
-```
-
-Once the Switch component graduates to a production release, the component will be available at:
 
 ```js
 import { Switch } from '@fluentui/react-components';
@@ -26,7 +16,23 @@ import { Switch } from '@fluentui/react-components';
 
 ```jsx
 <Switch />
-<Switch defaultChecked={true} />
-<Switch checked={switchValue} onChange={switchOnChange} />
+<Switch defaultChecked required />
+<Switch checked onChange={onChange} />
 <Switch disabled />
+<Switch label="Enable dark mode" labelPosition="after" />
 ```
+
+See [Fluent UI Storybook](https://aka.ms/fluentui-storybook) for more detailed usage examples.
+
+Alternatively, run Storybook locally with:
+
+1. `yarn start`
+2. Select `react-switch` from the list.
+
+### Specification
+
+See [SPEC.md](./Spec.md).
+
+### Migration Guide
+
+If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest component implementations.

--- a/packages/react-components/react-switch/Spec.md
+++ b/packages/react-components/react-switch/Spec.md
@@ -109,7 +109,7 @@ https://github.com/microsoft/fluentui/blob/master/packages/react-checkbox/src/co
 
 ### Switch Props
 
-See [Switch.types.ts](https://github.com/microsoft/fluentui/blob/master/packages/react-switch/src/components/Switch/Switch.types.ts).
+See API at [Switch.types.ts](./src/components/Switch/Switch.types.ts).
 
 ## Structure
 
@@ -165,7 +165,7 @@ _With label after the track thumb indicator:_
 
 ## Migration
 
-See [MIGRATION.md](MIGRATION.md).
+See [MIGRATION.md](./MIGRATION.md).
 
 ## Behaviors
 


### PR DESCRIPTION
## PR Description

This PR cleans up a bunch of things in `react-switch`:
- The migration guide is updated to remove WIP warnings and to fix some typos.
- The README is updated to remove WIP warnings, reference importing from `react-components` instead of from `react-switch` in examples, update examples in general, and point to the spec and migration guides.
- The links to the types file and migration guides are updated in the spec.