### PR TITLE
README, spec and migration guide cleanup for react-slider

### DIFF
--- a/change/@fluentui-react-slider-8e5f30f9-2e26-41ee-87f9-26704140ab06.json
+++ b/change/@fluentui-react-slider-8e5f30f9-2e26-41ee-87f9-26704140ab06.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "README, spec and migration guide cleanup.",
+  "packageName": "@fluentui/react-slider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-slider/MIGRATION.md
+++ b/packages/react-components/react-slider/MIGRATION.md
@@ -4,26 +4,50 @@ The Slider control is a thin wrapper around an `<input type="range"/>`. Addition
 
 ## Migration from v8
 
-- `componentRef` => use `ref` instead.
-- `styles` => pass classNames to individual slots
-- `theme` => use `FluentProvider` HOC instead
-- `label` => Use `Label` control with `htmlFor` and `id`
-- `inline` => use css, or wrap in flex parent
-- `showValue` and `valueFormat` => use explicitly rendered value instead
-- `onChanged` => use onChange and onMouse events
-- `ranged`, `defaultLowerValue` and `lowerValue` => Not supported. Multi value slider will be future work in separate control.
-- `origin` => no longer supported
-- `snapToStep` => use `step` instead
-- `originFromZero` => `origin`
-- `buttonProps` => Slider props, other than className and id, are passed to `input` element
 - `ariaLabel` => use `aria-label` instead
 - `ariaValueText` => explicitely set `aria-valuetext`
+- `buttonProps` => Slider props, other than className and id, are passed to `input` element
+- `componentRef` => use `ref` instead.
+- `inline` => use css, or wrap in flex parent
+- `label` => Use `Label` control with `htmlFor` and `id`
+- `onChanged` => use onChange and onMouse events
+- `origin` => no longer supported
+- `originFromZero` => no longer supported
+- `ranged`, `defaultLowerValue` and `lowerValue` => Not supported. Multi value slider will be future work in separate control.
+- `showValue` and `valueFormat` => use explicitly rendered value instead
+- `snapToStep` => use `step` instead
+- `styles` => pass classNames to individual slots
+- `theme` => use `FluentProvider` HOC instead
 
 ## Migration from v0
 
 - `accessibility` => use `aria-*` properties directly on `Slider`
 - `fluid` => use css, or wrap in flex parent
-- `inputRef` => `ref`
 - `getA11yValueMessageOnChange` => explicitely set `aria-value-text`
-- `label` => use explicitly rendered value instead
 - `input` => Slider props, other than className and id, are passed to `input` element
+- `inputRef` => `ref`
+- `label` => use explicitly rendered value instead
+
+## Property mapping
+
+| v8 `Slider`         | v0 `Slider`      | v9 `Slider`      |
+| ------------------- | ---------------- | ---------------- |
+|                     | `accessibility`  |                  |
+| `ariaLabel`         | `aria-label`     | `aria-label`     |
+| `ariaValueText`     | `aria-valuetext` | `aria-valuetext` |
+| `buttonProps`       |                  |                  |
+| `componentRef`      | `inputRef`       | `ref`            |
+| `defaultLowerValue` |                  |                  |
+| `inline`            |                  |                  |
+| `input`             |                  | `input`          |
+| `label`             | `label`          |                  |
+| `lowerValue`        |                  |                  |
+| `onChanged`         |                  | `onChange`       |
+| `origin`            |                  |                  |
+| `originFromZero`    |                  |                  |
+| `ranged`            |                  |                  |
+| `showValue`         |                  |                  |
+| `snapToStep`        |                  | `step`           |
+| `styles`            |                  | `className`      |
+| `theme`             |                  |                  |
+| `valueFormat`       |                  |                  |

--- a/packages/react-components/react-slider/README.md
+++ b/packages/react-components/react-slider/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-slider
 
-**Slider component for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**Slider component for [Fluent UI React](https://aka.ms/fluentui-storybook)**
 
 Slider allows users to quickly select a value (or range) by dragging a thumb across a rail. It is often used when setting values with a relaxed precision such as audio volume and screen brightness.
 
@@ -12,12 +12,6 @@ To import Slider:
 import { Slider } from '@fluentui/react-components';
 ```
 
-Or pull directly from slider package to pin to a specific version.
-
-```js
-import { Slider } from '@fluentui/react-slider';
-```
-
 ### Examples
 
 ```jsx
@@ -27,7 +21,21 @@ import { Slider } from '@fluentui/react-slider';
 <Slider min={0} max={10} />
 <Slider vertical />
 <Slider disabled />
-<Slider origin={2} />
 <Slider step={10} />
 <Slider size="small" />
 ```
+
+See [Fluent UI Storybook](https://aka.ms/fluentui-storybook) for more detailed usage examples.
+
+Alternatively, run Storybook locally with:
+
+1. `yarn start`
+2. Select `react-slider` from the list.
+
+### Specification
+
+See [SPEC.md](./Spec.md).
+
+### Migration Guide
+
+If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest Slider implementation.

--- a/packages/react-components/react-slider/Spec.md
+++ b/packages/react-components/react-slider/Spec.md
@@ -9,6 +9,19 @@ The Slider component allows users to quickly select a value by dragging an icon 
 - `vertical` displayed vertically.
 - `disabled` read-only and does not update state.
 
+## API
+
+### Slots
+
+- `root` - The outer container that wraps the slider structure.
+- `rail` - The Slider's base. It is used to visibly display the min and max selectable values.
+- `thumb` - The draggable icon used to select a given value from the Slider. This is the element containing `role = 'slider'`.
+- `input` - The hidden input for the Slider. This is the PRIMARY slot: all native properties specified directly on `<Slider>` will be applied to this slot, except `className` and `style`, which remain on the root slot.
+
+### Props
+
+See API at [Slider.types.ts](./src/components/Slider/Slider.types.ts).
+
 ## Structure
 
 - _**Public**_
@@ -34,6 +47,10 @@ The Slider component allows users to quickly select a value by dragging an icon 
   <div className="fui-Slider__thumb" />
 </div>
 ```
+
+## Migration
+
+See [MIGRATION.md](./MIGRATION.md).
 
 ## Behaviors
 


### PR DESCRIPTION
## PR Description

This PR cleans up a bunch of things in `react-slider`:
- The migration guide is updated to add a property mapping table between v0, v8 and v9.
- The README is updated to point to our storybook docs, reference importing from `react-components` instead of from `react-slider` in examples, and point to the spec and migration guides.
- The spec is updated to add a slots section and add links to both the types file and migration guide.