### PR TITLE
react-select: add onChange handler with value data

### DIFF
--- a/change/@fluentui-react-select-cf0563de-cd23-46b9-b8f9-2c807285bc89.json
+++ b/change/@fluentui-react-select-cf0563de-cd23-46b9-b8f9-2c807285bc89.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add custom onChange with value data to react-select",
+  "packageName": "@fluentui/react-select",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-select/etc/react-select.api.md
+++ b/packages/react-components/react-select/etc/react-select.api.md
@@ -21,9 +21,10 @@ export const Select: ForwardRefComponent<SelectProps>;
 export const selectClassNames: SlotClassNames<SelectSlots>;
 
 // @public (undocumented)
-export type SelectProps = Omit<ComponentProps<Partial<SelectSlots>, 'select'>, 'size'> & {
+export type SelectProps = Omit<ComponentProps<Partial<SelectSlots>, 'select'>, 'size' | 'onChange'> & {
     appearance?: 'outline' | 'underline' | 'filled-darker' | 'filled-lighter';
     inline?: boolean;
+    onChange?: (ev: React_2.ChangeEvent<HTMLSelectElement>, data: SelectOnChangeData) => void;
     size?: 'small' | 'medium' | 'large';
 };
 

--- a/packages/react-components/react-select/src/components/Select/Select.test.tsx
+++ b/packages/react-components/react-select/src/components/Select/Select.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { Select } from './Select';
 import { isConformant } from '../../common/isConformant';
 
@@ -52,5 +52,38 @@ describe('Select', () => {
 
     expect(select.id).toEqual('select');
     expect(select.getAttribute('aria-label')).toEqual('test');
+  });
+
+  it('calls onChange with new value', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <Select onChange={onChange} data-testid="select">
+        <option>A</option>
+        <option>B</option>
+        <option>C</option>
+      </Select>,
+    );
+    fireEvent.change(getByTestId('select'), { target: { value: 'B' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][1]).toEqual({ value: 'B' });
+  });
+
+  it('does not call onChange with value changes', () => {
+    const onChange = jest.fn();
+    const component = render(
+      <Select value="B" onChange={onChange} data-testid="select">
+        <option>A</option>
+        <option>B</option>
+        <option>C</option>
+      </Select>,
+    );
+    component.rerender(
+      <Select value="C" onChange={onChange} data-testid="select">
+        <option>A</option>
+        <option>B</option>
+        <option>C</option>
+      </Select>,
+    );
+    expect(onChange).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/react-components/react-select/src/components/Select/Select.types.ts
+++ b/packages/react-components/react-select/src/components/Select/Select.types.ts
@@ -48,9 +48,11 @@ export type SelectProps = Omit<ComponentProps<Partial<SelectSlots>, 'select'>, '
 export type SelectState = ComponentState<SelectSlots> & Required<Pick<SelectProps, 'appearance' | 'inline' | 'size'>>;
 
 /**
- * Data passed to the `onChange` callback when a new option is selected
+ * Data passed to the `onChange` callback when a new option is selected.
  */
 export type SelectOnChangeData = {
-  /* Updated `<select>` value, taken from either the selected option's value prop or inner text */
+  /**
+   * Updated `<select>` value, taken from either the selected option's value prop or inner text.
+   */
   value: string;
 };

--- a/packages/react-components/react-select/src/components/Select/Select.types.ts
+++ b/packages/react-components/react-select/src/components/Select/Select.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type SelectSlots = {
@@ -15,7 +16,7 @@ export type SelectSlots = {
   icon: Slot<'span'>;
 };
 
-export type SelectProps = Omit<ComponentProps<Partial<SelectSlots>, 'select'>, 'size'> & {
+export type SelectProps = Omit<ComponentProps<Partial<SelectSlots>, 'select'>, 'size' | 'onChange'> & {
   /**
    * Controls the colors and borders of the Select.
    *
@@ -32,6 +33,11 @@ export type SelectProps = Omit<ComponentProps<Partial<SelectSlots>, 'select'>, '
   inline?: boolean;
 
   /**
+   * Called when the user changes the select element's value by selecting an option.
+   */
+  onChange?: (ev: React.ChangeEvent<HTMLSelectElement>, data: SelectOnChangeData) => void;
+
+  /**
    * Matches the Input sizes
    *
    * @default 'medium'
@@ -40,3 +46,11 @@ export type SelectProps = Omit<ComponentProps<Partial<SelectSlots>, 'select'>, '
 };
 
 export type SelectState = ComponentState<SelectSlots> & Required<Pick<SelectProps, 'appearance' | 'inline' | 'size'>>;
+
+/**
+ * Data passed to the `onChange` callback when a new option is selected
+ */
+export type SelectOnChangeData = {
+  /* Updated `<select>` value, taken from either the selected option's value prop or inner text */
+  value: string;
+};

--- a/packages/react-components/react-select/src/components/Select/useSelect.tsx
+++ b/packages/react-components/react-select/src/components/Select/useSelect.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getPartitionedNativeProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getPartitionedNativeProps, resolveShorthand, useEventCallback } from '@fluentui/react-utilities';
 import { ChevronDownRegular } from '@fluentui/react-icons';
 import type { SelectProps, SelectState } from './Select.types';
 
@@ -13,15 +13,15 @@ import type { SelectProps, SelectState } from './Select.types';
  * @param ref - reference to the `<select>` element in Select
  */
 export const useSelect_unstable = (props: SelectProps, ref: React.Ref<HTMLSelectElement>): SelectState => {
-  const { select, icon, root, size = 'medium', appearance = 'outline', inline = false } = props;
+  const { select, icon, root, appearance = 'outline', inline = false, onChange, size = 'medium' } = props;
 
   const nativeProps = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'select',
-    excludedPropNames: ['appearance', 'inline', 'size'],
+    excludedPropNames: ['appearance', 'inline', 'onChange', 'size'],
   });
 
-  return {
+  const state: SelectState = {
     size,
     appearance,
     inline,
@@ -46,4 +46,11 @@ export const useSelect_unstable = (props: SelectProps, ref: React.Ref<HTMLSelect
       defaultProps: nativeProps.root,
     }),
   };
+
+  state.select.onChange = useEventCallback(event => {
+    const value = (event.target as HTMLSelectElement).value;
+    onChange?.(event, { value });
+  });
+
+  return state;
 };

--- a/packages/react-components/react-select/src/stories/SelectControlled.stories.tsx
+++ b/packages/react-components/react-select/src/stories/SelectControlled.stories.tsx
@@ -1,20 +1,24 @@
 import * as React from 'react';
-import { Select } from '../index';
+import { Select, SelectProps } from '../index';
 import { useId } from '@fluentui/react-utilities';
 
 export const Controlled = () => {
   const selectId = useId();
-  const [value, setValue] = React.useState<'red' | 'green' | 'blue'>('red');
+  const [value, setValue] = React.useState('Red');
+
+  const onChange: SelectProps['onChange'] = (event, data) => {
+    setValue(data.value);
+  };
 
   return (
     <>
       <label htmlFor={selectId}>Color</label>
-      <Select id={selectId}>
-        <option selected={value === 'red'}>Red</option>
-        <option selected={value === 'green'}>Green</option>
-        <option selected={value === 'blue'}>Blue</option>
+      <Select id={selectId} onChange={onChange} value={value}>
+        <option>Red</option>
+        <option>Green</option>
+        <option>Blue</option>
       </Select>
-      <button onClick={() => setValue('blue')}>Select Blue</button>
+      <button onClick={() => setValue('Blue')}>Select Blue</button>
     </>
   );
 };


### PR DESCRIPTION
Updates react-select's onChange handler to match other form controls and include the value data as the second param.

Includes tests, and updates the Controlled example as well.