### PR TITLE
fix(Dropdown) Return selected value to the label

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove unnecessary `Ref` usage from `TreeItem` @chpalac ([#23105](https://github.com/microsoft/fluentui/pull/23105))
 - Render `selectionIndicator` in `TreeTitle` only when it's needed @layershifter ([#23131](https://github.com/microsoft/fluentui/pull/23131))
 - Setting `flex-schrink: 0` on listItemHeaderMediaStyle @simonmysun ([#23338](https://github.com/microsoft/fluentui/pull/23338))
+- Return selected value to the `Dropdown` label @jurokapsiar ([#23407](https://github.com/microsoft/fluentui/pull/23407))
 
 <!--------------------------------[ v0.63.0 ]------------------------------- -->
 ## [v0.63.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.63.0) (2022-05-18)

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -589,6 +589,7 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
 
             return {
               content:
+                // If `null` is passed we should not render the slot
                 predefinedProps.content === null ? null : { content, id: triggerButtonContentId, ...resolvedContent },
               onClick: e => {
                 onClick(e);

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -552,7 +552,7 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
   const renderTriggerButton = (getToggleButtonProps: (options?: GetToggleButtonPropsOptions) => any): JSX.Element => {
     const content = getSelectedItemAsString(value[0]);
     const triggerButtonId = triggerButton['id'] || defaultTriggerButtonId;
-
+    const triggerButtonContentId = `${triggerButtonId  }__content`;
     const triggerButtonProps = getToggleButtonProps({
       disabled,
       onFocus: handleTriggerButtonOrListFocus,
@@ -562,7 +562,7 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
       },
       'aria-invalid': ariaInvalid,
       'aria-label': undefined,
-      ...(ariaLabelledby && { 'aria-labelledby': ariaLabelledby }),
+      'aria-labelledby': [ariaLabelledby, triggerButtonContentId].filter(l => !!l).join(' '),
       ...(open && { 'aria-expanded': true }),
     });
 
@@ -573,7 +573,7 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
         {createShorthand(Button, triggerButton, {
           defaultProps: () => ({
             className: dropdownSlotClassNames.triggerButton,
-            content,
+            content: { content, id: triggerButtonContentId },
             disabled,
             id: triggerButtonId,
             fluid: true,

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -562,7 +562,7 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
       },
       'aria-invalid': ariaInvalid,
       'aria-label': undefined,
-      'aria-labelledby': [ariaLabelledby, triggerButtonContentId].filter(l => !!l).join(' '),
+      'aria-labelledby': [ariaLabelledby, triggerButtonContentId].filter(Boolean).join(' '),
       ...(open && { 'aria-expanded': true }),
     });
 

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -552,7 +552,7 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
   const renderTriggerButton = (getToggleButtonProps: (options?: GetToggleButtonPropsOptions) => any): JSX.Element => {
     const content = getSelectedItemAsString(value[0]);
     const triggerButtonId = triggerButton['id'] || defaultTriggerButtonId;
-    const triggerButtonContentId = `${triggerButtonId  }__content`;
+    const triggerButtonContentId = `${triggerButtonId}__content`;
     const triggerButtonProps = getToggleButtonProps({
       disabled,
       onFocus: handleTriggerButtonOrListFocus,
@@ -573,37 +573,47 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
         {createShorthand(Button, triggerButton, {
           defaultProps: () => ({
             className: dropdownSlotClassNames.triggerButton,
-            content: { content, id: triggerButtonContentId },
             disabled,
             id: triggerButtonId,
             fluid: true,
             styles: resolvedStyles.triggerButton,
             ...restTriggerButtonProps,
           }),
-          overrideProps: (predefinedProps: ButtonProps) => ({
-            onClick: e => {
-              onClick(e);
-              _.invoke(predefinedProps, 'onClick', e, predefinedProps);
-            },
-            onFocus: e => {
-              onFocus(e);
-              _.invoke(predefinedProps, 'onFocus', e, predefinedProps);
-            },
-            onBlur: e => {
-              if (!disabled) {
-                onBlur(e);
-              }
+          overrideProps: (predefinedProps: ButtonProps) => {
+            // It can be a shorthand
+            const resolvedContent = _.isPlainObject(predefinedProps.content)
+              ? (predefinedProps.content as {})
+              : predefinedProps.content
+              ? { children: predefinedProps.content }
+              : {};
 
-              _.invoke(predefinedProps, 'onBlur', e, predefinedProps);
-            },
-            onKeyDown: e => {
-              if (!disabled) {
-                onKeyDown(e);
-              }
+            return {
+              content:
+                predefinedProps.content === null ? null : { content, id: triggerButtonContentId, ...resolvedContent },
+              onClick: e => {
+                onClick(e);
+                _.invoke(predefinedProps, 'onClick', e, predefinedProps);
+              },
+              onFocus: e => {
+                onFocus(e);
+                _.invoke(predefinedProps, 'onFocus', e, predefinedProps);
+              },
+              onBlur: e => {
+                if (!disabled) {
+                  onBlur(e);
+                }
 
-              _.invoke(predefinedProps, 'onKeyDown', e, predefinedProps);
-            },
-          }),
+                _.invoke(predefinedProps, 'onBlur', e, predefinedProps);
+              },
+              onKeyDown: e => {
+                if (!disabled) {
+                  onKeyDown(e);
+                }
+
+                _.invoke(predefinedProps, 'onKeyDown', e, predefinedProps);
+              },
+            };
+          },
         })}
       </Ref>
     );

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -2030,6 +2030,37 @@ describe('Dropdown', () => {
       expect(triggerButtonNode.getAttribute('aria-labelledby')).toContain('__content');
     });
 
+    it('trigger button merges props correctly', () => {
+      const { triggerButtonNode } = renderDropdown({ items, triggerButton: { 'data-test': 'ok' } });
+      expect(triggerButtonNode.firstChild).toHaveAttribute('id');
+      const contentId = triggerButtonNode.firstElementChild.getAttribute('id');
+      expect(triggerButtonNode).toHaveAttribute('aria-labelledby');
+      expect(triggerButtonNode.getAttribute('aria-labelledby')).toContain(contentId);
+      expect(triggerButtonNode).toHaveAttribute('data-test');
+    });
+
+    it('trigger button merges props correctly when content is string', () => {
+      const { triggerButtonNode } = renderDropdown({ items, triggerButton: { content: 'ok' } });
+      expect(triggerButtonNode.firstChild).toHaveAttribute('id');
+      const contentId = triggerButtonNode.firstElementChild.getAttribute('id');
+      expect(triggerButtonNode).toHaveAttribute('aria-labelledby');
+      expect(triggerButtonNode.getAttribute('aria-labelledby')).toContain(contentId);
+      expect(triggerButtonNode.firstChild.textContent).toBe('ok');
+    });
+
+    it('trigger button merges props correctly when content is object', () => {
+      const { triggerButtonNode } = renderDropdown({
+        items,
+        triggerButton: { content: { content: 'ok', 'data-test': 'ok' } },
+      });
+      expect(triggerButtonNode.firstChild).toHaveAttribute('id');
+      const contentId = triggerButtonNode.firstElementChild.getAttribute('id');
+      expect(triggerButtonNode).toHaveAttribute('aria-labelledby');
+      expect(triggerButtonNode.getAttribute('aria-labelledby')).toContain(contentId);
+      expect(triggerButtonNode.firstChild.textContent).toBe('ok');
+      expect(triggerButtonNode.firstChild).toHaveAttribute('data-test');
+    });
+
     it('trigger button should have aria-labelledby from user prop', () => {
       const { triggerButtonNode } = renderDropdown({ items, 'aria-labelledby': 'form-label' });
       expect(triggerButtonNode.getAttribute('aria-labelledby')).toContain('form-label');

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -2024,14 +2024,16 @@ describe('Dropdown', () => {
       expect(triggerButtonNode).not.toHaveAttribute('aria-label');
     });
 
-    it('trigger button should not have aria-labelledby', () => {
+    it('trigger button should have aria-labelledby which points to trigger button content', () => {
       const { triggerButtonNode } = renderDropdown({ items });
-      expect(triggerButtonNode).not.toHaveAttribute('aria-labelledby');
+      expect(triggerButtonNode).toHaveAttribute('aria-labelledby');
+      expect(triggerButtonNode.getAttribute('aria-labelledby')).toContain('__content');
     });
 
     it('trigger button should have aria-labelledby from user prop', () => {
       const { triggerButtonNode } = renderDropdown({ items, 'aria-labelledby': 'form-label' });
-      expect(triggerButtonNode).toHaveAttribute('aria-labelledby', 'form-label');
+      expect(triggerButtonNode.getAttribute('aria-labelledby')).toContain('form-label');
+      expect(triggerButtonNode.getAttribute('aria-labelledby')).toContain('__content');
     });
 
     it('trigger button should not have aria-describedby', () => {


### PR DESCRIPTION
Following change reoved selected value from the Dropdown label:

Fix Dropdown not annoucing placeholder/default value with VoiceOver on macOS @aubreyquinn (https://github.com/microsoft/fluentui/pull/22173)

This PR fixes the original issue by pointing aria-labelledby to the trigger button content.

Empty state:
<img width="634" alt="image" src="https://user-images.githubusercontent.com/13742664/172120357-7193b7fd-f98b-445f-bbac-06763bfd5f83.png">

Selected item:
<img width="631" alt="image" src="https://user-images.githubusercontent.com/13742664/172120451-30af567b-717a-4159-b094-2249adff5ac5.png">

Fixes #21887