### PR TITLE
feat(react-utilities): extend `Slot` to support `VoidFunctionComponents`

### DIFF
--- a/change/@fluentui-react-utilities-636b4fe0-b6f1-4d47-bc86-3e31c41ff2e3.json
+++ b/change/@fluentui-react-utilities-636b4fe0-b6f1-4d47-bc86-3e31c41ff2e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add void function component support to slots",
+  "packageName": "@fluentui/react-utilities",
+  "email": "39736248+andrefcdias@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -94,7 +94,7 @@ export type ResolveShorthandOptions<Props, Required extends boolean = false> = {
 export function shouldPreventDefaultOnKeyDown(e: KeyboardEvent | React_2.KeyboardEvent): boolean;
 
 // @public
-export type Slot<Type extends keyof JSX.IntrinsicElements | React_2.ComponentType | UnknownSlotProps, AlternateAs extends keyof JSX.IntrinsicElements = never> = IsSingleton<Extract<Type, string>> extends true ? WithSlotShorthandValue<Type extends keyof JSX.IntrinsicElements ? {
+export type Slot<Type extends keyof JSX.IntrinsicElements | React_2.ComponentType | React_2.VoidFunctionComponent | UnknownSlotProps, AlternateAs extends keyof JSX.IntrinsicElements = never> = IsSingleton<Extract<Type, string>> extends true ? WithSlotShorthandValue<Type extends keyof JSX.IntrinsicElements ? {
     as?: Type;
 } & WithSlotRenderFunction<IntrisicElementProps<Type>> : Type extends React_2.ComponentType<infer Props> ? WithSlotRenderFunction<Props> : Type> | {
     [As in AlternateAs]: {

--- a/packages/react-components/react-utilities/src/compose/types.ts
+++ b/packages/react-components/react-utilities/src/compose/types.ts
@@ -95,7 +95,7 @@ type IntrisicElementProps<Type extends keyof JSX.IntrinsicElements> = React.Prop
  * ```
  */
 export type Slot<
-  Type extends keyof JSX.IntrinsicElements | React.ComponentType | UnknownSlotProps,
+  Type extends keyof JSX.IntrinsicElements | React.ComponentType | React.VoidFunctionComponent | UnknownSlotProps,
   AlternateAs extends keyof JSX.IntrinsicElements = never
 > = IsSingleton<Extract<Type, string>> extends true
   ?


### PR DESCRIPTION
## Current Behavior

Our `Slot` type does not currently support components that take no `children` prop.

## New Behavior

`Slot` now extends `VoidFunctionComponent` to allow for such behavior.