### PR TITLE
chore(react-card): add basic API documentation

### DIFF
--- a/change/@fluentui-react-card-57fe3e86-bc5b-449f-bde5-39bcefb0d557.json
+++ b/change/@fluentui-react-card-57fe3e86-bc5b-449f-bde5-39bcefb0d557.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: add basic API documentation",
+  "packageName": "@fluentui/react-card",
+  "email": "39736248+andrefcdias@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/etc/react-card.api.md
+++ b/packages/react-components/react-card/etc/react-card.api.md
@@ -14,10 +14,10 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 // @public
 export const Card: ForwardRefComponent<CardProps>;
 
-// @public (undocumented)
+// @public
 export const cardClassNames: SlotClassNames<CardSlots>;
 
-// @public (undocumented)
+// @public
 export const cardCSSVars: {
     cardSizeVar: string;
 };
@@ -25,13 +25,13 @@ export const cardCSSVars: {
 // @public
 export const CardFooter: ForwardRefComponent<CardFooterProps>;
 
-// @public (undocumented)
+// @public
 export const cardFooterClassNames: SlotClassNames<CardFooterSlots>;
 
 // @public
 export type CardFooterProps = ComponentProps<CardFooterSlots>;
 
-// @public (undocumented)
+// @public
 export type CardFooterSlots = {
     root: Slot<'div'>;
     action?: Slot<'div'>;
@@ -43,13 +43,13 @@ export type CardFooterState = ComponentState<CardFooterSlots>;
 // @public
 export const CardHeader: ForwardRefComponent<CardHeaderProps>;
 
-// @public (undocumented)
+// @public
 export const cardHeaderClassNames: SlotClassNames<CardHeaderSlots>;
 
 // @public
 export type CardHeaderProps = ComponentProps<Partial<CardHeaderSlots>>;
 
-// @public (undocumented)
+// @public
 export type CardHeaderSlots = {
     root: Slot<'div'>;
     image: Slot<'div'>;
@@ -65,13 +65,13 @@ export type CardHeaderState = ComponentState<CardHeaderSlots>;
 // @public
 export const CardPreview: ForwardRefComponent<CardPreviewProps>;
 
-// @public (undocumented)
+// @public
 export const cardPreviewClassNames: SlotClassNames<CardPreviewSlots>;
 
 // @public
 export type CardPreviewProps = ComponentProps<CardPreviewSlots>;
 
-// @public (undocumented)
+// @public
 export type CardPreviewSlots = {
     root: Slot<'div'>;
     logo?: Slot<'div'>;
@@ -88,7 +88,7 @@ export type CardProps = ComponentProps<CardSlots> & {
     size?: 'small' | 'medium' | 'large';
 };
 
-// @public (undocumented)
+// @public
 export type CardSlots = {
     root: Slot<'div'>;
 };

--- a/packages/react-components/react-card/src/components/Card/Card.types.ts
+++ b/packages/react-components/react-card/src/components/Card/Card.types.ts
@@ -34,17 +34,21 @@ export type CardProps = ComponentProps<CardSlots> & {
    * This behaviour will cycle through all elements inside of the Card when pressing the Tab key and then release focus
    * after the last inner element.
    *
-   * @defaultvalue off
+   * @default 'off'
    */
   focusMode?: 'off' | 'no-tab' | 'tab-exit' | 'tab-only';
 
   /**
+   * Defines the orientation of the card.
    *
+   * @default 'vertical'
    */
   orientation?: 'horizontal' | 'vertical';
 
   /**
+   * Controls the card's border radius and padding between inner elements.
    *
+   * @default 'medium'
    */
   size?: 'small' | 'medium' | 'large';
 };

--- a/packages/react-components/react-card/src/components/Card/Card.types.ts
+++ b/packages/react-components/react-card/src/components/Card/Card.types.ts
@@ -1,11 +1,17 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
+/**
+ * Slots available in the Card component.
+ */
 export type CardSlots = {
+  /**
+   * Root element of the component.
+   */
   root: Slot<'div'>;
 };
 
 /**
- * Card Props
+ * Card component props.
  */
 export type CardProps = ComponentProps<CardSlots> & {
   appearance?: 'filled' | 'filled-alternative' | 'outline' | 'subtle';
@@ -32,8 +38,14 @@ export type CardProps = ComponentProps<CardSlots> & {
    */
   focusMode?: 'off' | 'no-tab' | 'tab-exit' | 'tab-only';
 
+  /**
+   *
+   */
   orientation?: 'horizontal' | 'vertical';
 
+  /**
+   *
+   */
   size?: 'small' | 'medium' | 'large';
 };
 

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.ts
@@ -6,16 +6,20 @@ import { cardFooterClassNames } from '../CardFooter/useCardFooterStyles';
 import type { CardSlots, CardState } from './Card.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
+/**
+ * Static CSS class names used internally for the component slots.
+ */
 export const cardClassNames: SlotClassNames<CardSlots> = {
   root: 'fui-Card',
 };
+
+/**
+ * CSS variable names used internally for uniform styling in Card.
+ */
 export const cardCSSVars = {
   cardSizeVar: '--fui-Card--size',
 };
 
-/**
- * Styles for the root slot
- */
 const useStyles = makeStyles({
   root: {
     display: 'flex',

--- a/packages/react-components/react-card/src/components/CardFooter/CardFooter.types.ts
+++ b/packages/react-components/react-card/src/components/CardFooter/CardFooter.types.ts
@@ -1,7 +1,17 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
+/**
+ * Slots available in the CardFooter component.
+ */
 export type CardFooterSlots = {
+  /**
+   * Root element of the component.
+   */
   root: Slot<'div'>;
+
+  /**
+   * Container that renders on the far end of the footer, used for action buttons.
+   */
   action?: Slot<'div'>;
 };
 

--- a/packages/react-components/react-card/src/components/CardFooter/useCardFooterStyles.ts
+++ b/packages/react-components/react-card/src/components/CardFooter/useCardFooterStyles.ts
@@ -2,14 +2,14 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { CardFooterSlots, CardFooterState } from './CardFooter.types';
 
+/**
+ * Static CSS class names used internally for the component slots.
+ */
 export const cardFooterClassNames: SlotClassNames<CardFooterSlots> = {
   root: 'fui-CardFooter',
   action: 'fui-CardFooter__action',
 };
 
-/**
- * Styles for the root slot
- */
 const useStyles = makeStyles({
   root: {
     display: 'flex',

--- a/packages/react-components/react-card/src/components/CardHeader/CardHeader.types.ts
+++ b/packages/react-components/react-card/src/components/CardHeader/CardHeader.types.ts
@@ -1,11 +1,37 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
+/**
+ * Slots available in the CardHeader component.
+ */
 export type CardHeaderSlots = {
+  /**
+   * Root element of the component.
+   */
   root: Slot<'div'>;
+
+  /**
+   * Element used to render an image or avatar related to the card.
+   */
   image: Slot<'div'>;
+
+  /**
+   * Parent container of the header and description slots.
+   */
   content?: Slot<'div'>;
+
+  /**
+   * Element used to render the main header title.
+   */
   header: Slot<'span'>;
+
+  /**
+   * Element used to render short descriptions related to the title.
+   */
   description: Slot<'span'>;
+
+  /**
+   * Container that renders on the far end of the footer, used for action buttons.
+   */
   action?: Slot<'div'>;
 };
 

--- a/packages/react-components/react-card/src/components/CardHeader/useCardHeaderStyles.ts
+++ b/packages/react-components/react-card/src/components/CardHeader/useCardHeaderStyles.ts
@@ -2,6 +2,9 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { CardHeaderSlots, CardHeaderState } from './CardHeader.types';
 
+/**
+ * Static CSS class names used internally for the component slots.
+ */
 export const cardHeaderClassNames: SlotClassNames<CardHeaderSlots> = {
   root: 'fui-CardHeader',
   image: 'fui-CardHeader__image',
@@ -11,9 +14,6 @@ export const cardHeaderClassNames: SlotClassNames<CardHeaderSlots> = {
   action: 'fui-CardHeader__action',
 };
 
-/**
- * Styles for the root slot
- */
 const useStyles = makeStyles({
   root: {
     display: 'flex',

--- a/packages/react-components/react-card/src/components/CardPreview/CardPreview.types.ts
+++ b/packages/react-components/react-card/src/components/CardPreview/CardPreview.types.ts
@@ -1,7 +1,17 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
+/**
+ * Slots available in the Card component.
+ */
 export type CardPreviewSlots = {
+  /**
+   * Root element of the component.
+   */
   root: Slot<'div'>;
+
+  /**
+   * Container that holds a logo related to the image preview provided.
+   */
   logo?: Slot<'div'>;
 };
 

--- a/packages/react-components/react-card/src/components/CardPreview/useCardPreviewStyles.ts
+++ b/packages/react-components/react-card/src/components/CardPreview/useCardPreviewStyles.ts
@@ -2,14 +2,14 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 import { makeStyles, mergeClasses } from '@griffel/react';
 import type { CardPreviewSlots, CardPreviewState } from './CardPreview.types';
 
+/**
+ * Static CSS class names used internally for the component slots.
+ */
 export const cardPreviewClassNames: SlotClassNames<CardPreviewSlots> = {
   root: 'fui-CardPreview',
   logo: 'fui-CardPreview__logo',
 };
 
-/**
- * Styles for the root slot
- */
 const useStyles = makeStyles({
   root: {
     position: 'relative',


### PR DESCRIPTION
## Current Behavior

There was little documentation on the exported Card content.

## New Behavior

Added basic documentation for all of the undocumented API.

## Related Issue(s)

#19336
