### PR TITLE
fix(tools): setup/update storybook only if there stories do exist

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -506,6 +506,7 @@ describe('migrate-converged-pkg generator', () => {
           lib: `${projectConfig.root}/tsconfig.lib.json`,
           test: `${projectConfig.root}/tsconfig.spec.json`,
         },
+        packageJson: `${projectConfig.root}/package.json`,
       };
 
       if (config.createDummyStories) {
@@ -543,6 +544,13 @@ describe('migrate-converged-pkg generator', () => {
       await generator(tree, options);
 
       expect(tree.exists(projectStorybookConfigPath)).toBeTruthy();
+
+      expect(readJson(tree, paths.packageJson).scripts).toEqual(
+        expect.objectContaining({
+          start: 'yarn storybook',
+          storybook: 'node ../../scripts/storybook/runner',
+        }),
+      );
 
       expect(readJson(tree, paths.tsconfig.storybook)).toEqual({
         extends: '../tsconfig.json',
@@ -814,8 +822,6 @@ describe('migrate-converged-pkg generator', () => {
         'code-style': 'just-scripts code-style',
         just: 'just-scripts',
         lint: 'just-scripts lint',
-        start: 'yarn storybook',
-        storybook: 'node ../../../scripts/storybook/runner',
         test: 'jest --passWithNoTests',
         'type-check': 'tsc -b tsconfig.json',
       });

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -12,6 +12,7 @@ import {
   writeJson,
   updateProjectConfiguration,
   serializeJson,
+  offsetFromRoot,
 } from '@nrwl/devkit';
 import * as path from 'path';
 import * as os from 'os';
@@ -633,7 +634,15 @@ function setupStorybook(tree: Tree, options: NormalizedSchema) {
       return json;
     });
 
-    removeTsIgnorePragmas();
+    updateJson(tree, options.paths.packageJson, (json: PackageJson) => {
+      const scripts = {
+        storybook: `node ${offsetFromRoot(options.projectConfig.root)}scripts/storybook/runner`,
+        start: 'yarn storybook',
+      };
+      Object.assign(json.scripts, scripts);
+
+      return json;
+    });
   }
 
   if (sbAction === 'remove') {
@@ -667,6 +676,8 @@ function setupStorybook(tree: Tree, options: NormalizedSchema) {
       return json;
     });
   }
+
+  removeTsIgnorePragmas();
 
   function removeTsIgnorePragmas() {
     const stories: string[] = [];
@@ -703,7 +714,6 @@ function setupStorybook(tree: Tree, options: NormalizedSchema) {
 }
 
 function shouldSetupStorybook(tree: Tree, options: NormalizedSchema) {
-  const hasStorybookConfig = tree.exists(options.paths.storybook.main);
   let hasStories = false;
 
   visitNotIgnoredFiles(tree, options.projectConfig.root, treePath => {
@@ -713,13 +723,10 @@ function shouldSetupStorybook(tree: Tree, options: NormalizedSchema) {
     }
   });
 
-  const tags = options.projectConfig.tags || [];
-  const hasTags = tags.includes('vNext') && tags.includes('platform:web');
+  const shouldInit = hasStories;
+  const shouldDelete = !shouldInit;
 
-  const shouldInit = hasStories || hasTags;
-  const shouldDelete = !shouldInit && hasStorybookConfig;
-
-  if (shouldInit) {
+  if (hasStories) {
     return 'init';
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

storybook setup is added to packages where its not needed

## New Behavior

storybook is added only to packages that actually use/need storybook setup

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20724
