### PR TITLE
README, spec and migration guide cleanup for react-badge

### DIFF
--- a/change/@fluentui-react-badge-32257dc9-7cf1-476b-a494-69cfd34b21e0.json
+++ b/change/@fluentui-react-badge-32257dc9-7cf1-476b-a494-69cfd34b21e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "README, spec and migration guide cleanup.",
+  "packageName": "@fluentui/react-badge",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-5ee2810f-0ca7-4282-afb2-db51ac8445ce.json
+++ b/change/@fluentui-react-link-5ee2810f-0ca7-4282-afb2-db51ac8445ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing mention of SpinButton in README.",
+  "packageName": "@fluentui/react-link",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-badge/MIGRATION.md
+++ b/packages/react-components/react-badge/MIGRATION.md
@@ -1,0 +1,59 @@
+# Badge Migration
+
+## Migration from v8
+
+v8 does not offer a component equivalent to v9's `Badge`. However, it does offer a `PersonaCoin` component that is similar in concept to v9's `PresenceBadge` component.
+
+Here's how the API of v8's `PersonaCoin` compares to the one from v9's `PresenceBadge` component:
+
+- `className` => `className`
+- `coinProps` => Use native HTML props sent directly to `root` slot instead
+- `coinSize` => `size`
+- `componentRef` => NOT SUPPORTED - use `ref` instead
+- `isOutOfOffice` => `outOfOffice`
+- `onRenderPersonaCoin` => Use slots customization instead
+- `presence` => `status`
+- `presenceTitle` => NOT SUPPORTED
+- `styles` => Use style customization through `className` instead
+
+## Migration from v0
+
+v0 does not offer a component equivalent to v9's `Badge`. However, it does offer an `AvatarStatus` component that is similar in concept to v9's `PresenceBadge` component.
+
+Here's how the API of v0's `AvatarStatus` compares to the one from v9's `PresenceBadge` component:
+
+- `accessibility` => NOT SUPPORTED
+- `as` => `as`
+- `className` => `className`
+- `color` => Use style customization through `className` instead
+- `design` => NOT SUPPORTED
+- `icon` => Use `icon` slot
+- `image` => NOT SUPPORTED
+- `key` => NOT SUPPORTED
+- `ref` => `ref`
+- `size` => `size`
+- `state` => `status`
+- `styles` => Use style customization through `className` instead
+- `variables` => NOT SUPPORTED
+
+## Property Mapping
+
+| v8 `PersonaCoin`      | v0 `AvatarStatus` | v9 `PresenceBadge` |
+| --------------------- | ----------------- | ------------------ |
+|                       | `acessibility`    |                    |
+|                       | `as`              | `as`               |
+| `className`           | `className`       | `className`        |
+| `coinProps`           |                   | `root` slot        |
+| `coinSize`            | `size`            | `size`             |
+|                       | `color`           |                    |
+| `componentRef`        | `ref`             | `ref`              |
+|                       | `design`          |                    |
+|                       | `icon`            | `icon` slot        |
+|                       | `image`           |                    |
+| `isOutOfOffice`       |                   | `outOfOffice`      |
+|                       | `key`             |                    |
+| `onRenderPersonaCoin` |                   | `root` slot        |
+| `presence`            | `state`           | `status`           |
+| `presenceTitle`       |                   |                    |
+| `styles`              | `styles`          |                    |
+|                       | `variables`       |                    |

--- a/packages/react-components/react-badge/README.md
+++ b/packages/react-components/react-badge/README.md
@@ -40,4 +40,4 @@ See [SPEC.md](./SPEC.md).
 
 ### Migration Guide
 
-If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest Badge implementation.
+If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest Badge component implementations.

--- a/packages/react-components/react-badge/README.md
+++ b/packages/react-components/react-badge/README.md
@@ -1,5 +1,43 @@
 # @fluentui/react-badge
 
-**React Badge components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**Badge components for [Fluent UI](https://aka.ms/fluentui-storybook)**
 
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+A badge is an additional visual descriptor for UI elements. It can be used to denote numerical value, status or general information.
+
+## Usage
+
+To import Badge:
+
+```js
+import { Badge, CounterBadge, PresenceBadge } from '@fluentui/react-components';
+```
+
+### Examples
+
+```jsx
+<Badge>999+</Badge>
+<Badge appearance="filled">999+</Badge>
+<Badge shape="rounded" />
+<Badge size="medium" icon={<PasteIcon />} />
+<CounterBadge count={5} appearance="ghost" />
+<CounterBadge count={0} dot />
+<CounterBadge count={5} size="extra-large" />
+<PresenceBadge status="available" />
+<PresenceBadge status="away" />
+<PresenceBadge outOfOffice status="do-not-disturb" />
+```
+
+See [Fluent UI Storybook](https://aka.ms/fluentui-storybook) for more detailed usage examples.
+
+Alternatively, run Storybook locally with:
+
+1. `yarn start`
+2. Select `react-badge` from the list.
+
+### Specification
+
+See [SPEC.md](./SPEC.md).
+
+### Migration Guide
+
+If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest Badge implementation.

--- a/packages/react-components/react-badge/Spec.md
+++ b/packages/react-components/react-badge/Spec.md
@@ -25,44 +25,13 @@ A badge is an additional visual descriptor for UI elements. It can be used to de
 
 - Appearance: `default`, `rounded` and `circular`
 - Size: `tiny`, `extra-small`, `small`, `medium`, `large`, `extra-large`.
-- Styles: `filled`, `outline`, `ghost`, `tint`, `inverted filled`
+- Styles: `filled`, `outline`, `ghost`, `tint`
 
-## PROPS
+## API
 
-```typescript
-type BadgeAppearance = 'filled' | 'outline' | 'ghost' | 'tint';
+### Props
 
-type BadgeShape = 'rounded' | 'square' | 'circular';
-
-type BadgeSize = 'tiny' | 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large';
-
-type BadgeProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {
-  /**
-   * A Badge can be sized.
-   */
-  size?: BadgeSize;
-
-  /**
-   * A Badge can be square, circular or rounded
-   */
-  shape?: BadgeShape;
-
-  /**
-   * A Badge can be filled, outline, ghost, inverted
-   */
-  appearance?: BadgeAppearance;
-
-  /**
-   * Icon slot
-   */
-  icon?: ShorthandProps<HTMLElement>;
-
-  /**
-   * Position for Icon to be rendered
-   */
-  iconPosition?: 'before' | 'after';
-}
-```
+See API at [Badge.types.ts](./src/components/Badge/Badge.types.ts).
 
 ## Structure
 
@@ -118,40 +87,14 @@ type BadgeProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {
 
 A Presence Badge represents someone's availbility or status
 
-```typescript
-export type PresenceBadgeStatus = 'busy' | 'oof' | 'away' | 'available' | 'offline';
+#### Props
 
-export type PresenceBadgeProps = Omit<BadgeProps, 'shape' | 'appearance'> & {
-  /**
-   * A PresenceBadge can represent several status
-   * @defaultvalue available
-   */
-  status?: PresenceBadgeStatus;
-  /**
-   * A PresenceBadge can represent status of someone out of the office
-   * @defaultvalue true
-   */
-  inOffice?: boolean;
-};
-
-export type PresenceBadgeState = BadgeState & {
-  /**
-   * A PresenceBadge can represent several status
-   * @defaultvalue available
-   */
-  status: PresenceBadgeStatus;
-  /**
-   * A PresenceBadge can represent status of someone out of the office
-   * @defaultvalue true
-   */
-  inOffice: boolean;
-};
-```
+See API at [PresenceBadge.types.ts](./src/components/PresenceBadge/PresenceBadge.types.ts).
 
 ### Counter Badge
 
 A Counter Badge is a visual indicator for numeric values such as tallies and scores.
 
-```typescript
-export type CounterBadgeProps = Omit<BadgeProps, 'appearance' | 'shape'> & Partial<CounterBadgeCommons>;
-```
+#### Props
+
+See API at [CounterBadge.types.ts](./src/components/CounterBadge/CounterBadge.types.ts).

--- a/packages/react-components/react-badge/Spec.md
+++ b/packages/react-components/react-badge/Spec.md
@@ -55,13 +55,7 @@ See API at [Badge.types.ts](./src/components/Badge/Badge.types.ts).
 
 ## Migration
 
-- _Migration from v8_
-
-`Badge` can be passed to `Avatar`'s `badge` slot. The `PresenceBadge` will be the best replacement for `Persona` presence mapping status, icon and colors.
-
-- _Migration from v0_
-
-`Badge` can be passed to `Avatar`'s `badge` slot.
+See [MIGRATION.md](./MIGRATION.md).
 
 ## Behaviors
 

--- a/packages/react-components/react-link/README.md
+++ b/packages/react-components/react-link/README.md
@@ -36,4 +36,4 @@ See [SPEC.md](./SPEC.md).
 
 ### Migration Guide
 
-If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest SpinButton implementation.
+If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest Link implementation.


### PR DESCRIPTION
## PR Description

This PR cleans up a bunch of things in `react-badge`:
- A migration guide is added to compare v8's `PersonaCoin`, v0's `AvatarStatus` and v9's `PresenceBadge` components, complete with a property mapping table.
- The README is updated to point to our storybook docs, reference importing from `react-components` instead of from `react-slider`, add usage examples, and point to the spec and migration guides.
- The spec is updated to add links to both the types files and migration guide.

This PR also includes a removal of a copy-paste error in `react-link`'s README that mentioned `SpinButton` with the correct `Link` mention.

Fixes part of #23423.