### PR TITLE
react-avatar: Adding layout and overflow button styles to AvatarGroup

### DIFF
--- a/change/@fluentui-react-avatar-a3217e5a-2124-4a29-980e-e97081b08cf3.json
+++ b/change/@fluentui-react-avatar-a3217e5a-2124-4a29-980e-e97081b08cf3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding layout styles and overflow button styles to AvatarGroup.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -33,7 +33,7 @@ export const AvatarGroupItem: ForwardRefComponent<AvatarGroupItemProps>;
 export const avatarGroupItemClassNames: SlotClassNames<AvatarGroupItemSlots>;
 
 // @public
-export type AvatarGroupItemProps = ComponentProps<Partial<AvatarGroupItemSlots>, 'avatar'>;
+export type AvatarGroupItemProps = Omit<ComponentProps<Partial<AvatarGroupItemSlots>, 'avatar'>, 'size'>;
 
 // @public (undocumented)
 export type AvatarGroupItemSlots = {
@@ -45,6 +45,7 @@ export type AvatarGroupItemSlots = {
 // @public
 export type AvatarGroupItemState = ComponentState<AvatarGroupItemSlots> & {
     isOverflowItem?: boolean;
+    size: AvatarSizes;
 };
 
 // @public

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -59,8 +59,7 @@ export type AvatarGroupProps = ComponentProps<AvatarGroupSlots> & {
 export type AvatarGroupSlots = {
     root: NonNullable<Slot<'div'>>;
     overflowButton?: NonNullable<Slot<'button'>>;
-    overflowList?: NonNullable<Slot<'ul'>>;
-    overflowSurface?: NonNullable<Slot<typeof PopoverSurface>>;
+    overflowList?: NonNullable<Slot<typeof PopoverSurface>>;
 };
 
 // @public

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -59,7 +59,7 @@ export type AvatarGroupProps = ComponentProps<AvatarGroupSlots> & {
 export type AvatarGroupSlots = {
     root: NonNullable<Slot<'div'>>;
     overflowButton?: NonNullable<Slot<'button'>>;
-    overflowList?: NonNullable<Slot<typeof PopoverSurface>>;
+    overflowContent?: NonNullable<Slot<typeof PopoverSurface>>;
 };
 
 // @public

--- a/packages/react-components/react-avatar/package.json
+++ b/packages/react-components/react-avatar/package.json
@@ -37,6 +37,7 @@
     "@fluentui/react-context-selector": "9.0.0-rc.10",
     "@fluentui/react-icons": "^2.0.166-rc.3",
     "@fluentui/react-popover": "9.0.0-rc.13",
+    "@fluentui/react-tabster": "9.0.0-rc.13",
     "@fluentui/react-tooltip": "9.0.0-rc.13",
     "@fluentui/react-theme": "9.0.0-rc.9",
     "@fluentui/react-shared-contexts": "9.0.0-rc.10",

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/AvatarGroup.types.ts
@@ -14,12 +14,7 @@ export type AvatarGroupSlots = {
   /**
    * Unordered list that contains the overflow AvatarGroupItems.
    */
-  overflowList?: NonNullable<Slot<'ul'>>;
-
-  /**
-   * Popover surface that will be displayed when the popover is triggered.
-   */
-  overflowSurface?: NonNullable<Slot<typeof PopoverSurface>>;
+  overflowList?: NonNullable<Slot<typeof PopoverSurface>>;
 };
 
 /**

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/AvatarGroup.types.ts
@@ -12,9 +12,9 @@ export type AvatarGroupSlots = {
   overflowButton?: NonNullable<Slot<'button'>>;
 
   /**
-   * Unordered list that contains the overflow AvatarGroupItems.
+   * List that contains the overflow AvatarGroupItems.
    */
-  overflowList?: NonNullable<Slot<typeof PopoverSurface>>;
+  overflowContent?: NonNullable<Slot<typeof PopoverSurface>>;
 };
 
 /**

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
@@ -16,7 +16,7 @@ export const renderAvatarGroup_unstable = (state: AvatarGroupState) => {
     <AvatarGroupContext.Provider value={{ layout, size }}>
       <slots.root {...slotProps.root}>
         {state.root.children}
-        {state.hasOverflow && slots.overflowButton && slots.overflowList && (
+        {state.hasOverflow && slots.overflowButton && slots.overflowContent && (
           <Popover trapFocus size="small">
             <PopoverTrigger>
               <Tooltip content={state.tooltipContent} relationship="label">
@@ -24,7 +24,7 @@ export const renderAvatarGroup_unstable = (state: AvatarGroupState) => {
               </Tooltip>
             </PopoverTrigger>
             <AvatarGroupContext.Provider value={{ isOverflow: true, layout, size: 24 }}>
-              <slots.overflowList {...slotProps.overflowList} />
+              <slots.overflowContent {...slotProps.overflowContent} />
             </AvatarGroupContext.Provider>
           </Popover>
         )}

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
@@ -16,18 +16,16 @@ export const renderAvatarGroup_unstable = (state: AvatarGroupState) => {
     <AvatarGroupContext.Provider value={{ layout, size }}>
       <slots.root {...slotProps.root}>
         {state.root.children}
-        {state.hasOverflow && slots.overflowButton && slots.overflowSurface && slots.overflowList && (
+        {state.hasOverflow && slots.overflowButton && slots.overflowList && (
           <Popover trapFocus size="small">
             <PopoverTrigger>
               <Tooltip content={state.tooltipContent} relationship="label">
                 <slots.overflowButton {...slotProps.overflowButton} />
               </Tooltip>
             </PopoverTrigger>
-            <slots.overflowSurface {...slotProps.overflowSurface}>
-              <AvatarGroupContext.Provider value={{ isOverflow: true, layout, size: 24 }}>
-                <slots.overflowList {...slotProps.overflowList} />
-              </AvatarGroupContext.Provider>
-            </slots.overflowSurface>
+            <AvatarGroupContext.Provider value={{ isOverflow: true, layout, size: 24 }}>
+              <slots.overflowList {...slotProps.overflowList} />
+            </AvatarGroupContext.Provider>
           </Popover>
         )}
       </slots.root>

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
@@ -56,16 +56,10 @@ export const useAvatarGroup_unstable = (props: AvatarGroupProps, ref: React.Ref<
     },
   });
 
-  const overflowSurface = resolveShorthand(props.overflowSurface, {
-    required: true,
-    defaultProps: {
-      'aria-label': 'Overflow',
-    },
-  });
-
   const overflowList = resolveShorthand(props.overflowList, {
     required: true,
     defaultProps: {
+      'aria-label': 'Overflow',
       children: overflowChildren,
       role: 'list',
       tabIndex: 0,
@@ -81,14 +75,12 @@ export const useAvatarGroup_unstable = (props: AvatarGroupProps, ref: React.Ref<
 
     components: {
       root: 'div',
-      overflowSurface: PopoverSurface,
-      overflowList: 'ul',
+      overflowList: PopoverSurface,
       overflowButton: 'button',
     },
 
     root,
     overflowButton,
-    overflowSurface,
     overflowList,
   };
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
@@ -56,7 +56,7 @@ export const useAvatarGroup_unstable = (props: AvatarGroupProps, ref: React.Ref<
     },
   });
 
-  const overflowList = resolveShorthand(props.overflowList, {
+  const overflowContent = resolveShorthand(props.overflowContent, {
     required: true,
     defaultProps: {
       'aria-label': 'Overflow',
@@ -75,12 +75,12 @@ export const useAvatarGroup_unstable = (props: AvatarGroupProps, ref: React.Ref<
 
     components: {
       root: 'div',
-      overflowList: PopoverSurface,
+      overflowContent: PopoverSurface,
       overflowButton: 'button',
     },
 
     root,
     overflowButton,
-    overflowList,
+    overflowContent,
   };
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
@@ -14,7 +14,7 @@ import type { AvatarGroupProps, AvatarGroupState } from './AvatarGroup.types';
  * @param ref - reference to root HTMLElement of AvatarGroup
  */
 export const useAvatarGroup_unstable = (props: AvatarGroupProps, ref: React.Ref<HTMLElement>): AvatarGroupState => {
-  const { children, layout = 'spread', maxAvatars = 5, size = 32 } = props;
+  const { children, layout = 'spread', maxAvatars = 5, size = defaultAvatarGroupSize } = props;
   const { overflowIndicator = size < 24 ? 'icon' : 'count' } = props;
   const childrenArray = React.Children.toArray(children);
 
@@ -84,3 +84,5 @@ export const useAvatarGroup_unstable = (props: AvatarGroupProps, ref: React.Ref<
     overflowContent,
   };
 };
+
+export const defaultAvatarGroupSize = 32;

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -1,14 +1,18 @@
+import { avatarGroupItemMarginVar, avatarGroupItemOutlineVar } from '../AvatarGroupItem/useAvatarGroupItemStyles';
+import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { tokens, typographyStyles } from '@fluentui/react-theme';
 import { useSizeStyles } from '../Avatar/useAvatarStyles';
 import type { AvatarGroupSlots, AvatarGroupState } from './AvatarGroup.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
 export const avatarGroupClassNames: SlotClassNames<AvatarGroupSlots> = {
   root: 'fui-AvatarGroup',
-  overflowSurface: 'fui-AvatarGroup__overflowSurface',
   overflowList: 'fui-AvatarGroup__overflowList',
   overflowButton: 'fui-AvatarGroup__overflowButton',
 };
+
+const avatarGroupOverflowButtonBorderVar = '--fuiAvatarGroup--overflowbuttonBorderWidth';
 
 /**
  * Styles for the root slot.
@@ -18,13 +22,123 @@ const useStyles = makeStyles({
     display: 'inline-flex',
     position: 'relative',
   },
+  pie: {
+    clipPath: 'circle(50%)',
+  },
 });
 
+/**
+ * Styles for overflow button slot.
+ */
+const useOverflowButtonStyles = makeStyles({
+  base: {
+    display: 'inline-flex',
+    position: 'relative',
+    flexShrink: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+    color: tokens.colorNeutralForeground1,
+    backgroundColor: tokens.colorNeutralBackground1,
+    ...shorthands.borderWidth(`var(${avatarGroupOverflowButtonBorderVar})`),
+    ...shorthands.borderColor(tokens.colorNeutralStroke1),
+    ...shorthands.borderRadius(tokens.borderRadiusCircular),
+    ...shorthands.borderStyle('solid'),
+    ...shorthands.padding(tokens.spacingHorizontalNone),
+  },
+
+  // These styles match the default button styles
+  focusIndicator: createCustomFocusIndicatorStyle({
+    ...shorthands.borderColor('transparent'),
+    outlineColor: 'transparent',
+    outlineWidth: tokens.strokeWidthThick,
+    outlineStyle: 'solid',
+    boxShadow: `${tokens.shadow4} 0 0 0 2px ${tokens.colorStrokeFocus2}`,
+    zIndex: 1,
+  }),
+
+  states: {
+    ':hover': {
+      color: tokens.colorNeutralForeground1Hover,
+      backgroundColor: tokens.colorNeutralBackground1Hover,
+      ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
+    },
+    ':active': {
+      color: tokens.colorNeutralForeground1Pressed,
+      backgroundColor: tokens.colorNeutralBackground1Pressed,
+      ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
+    },
+    ':checked': {
+      color: tokens.colorNeutralForeground1Selected,
+      backgroundColor: tokens.colorNeutralBackground1Selected,
+      ...shorthands.borderColor(tokens.colorNeutralStroke1Selected),
+    },
+  },
+
+  pie: {
+    backgroundColor: tokens.colorTransparentBackground,
+    ...shorthands.borderColor(tokens.colorTransparentStroke),
+    color: 'transparent',
+  },
+
+  stack: {
+    marginLeft: `var(${avatarGroupItemMarginVar})`,
+    outlineColor: tokens.colorNeutralBackground2,
+    outlineStyle: 'solid',
+    outlineWidth: `var(${avatarGroupItemOutlineVar})`,
+  },
+
+  spread: {
+    marginLeft: `var(${avatarGroupItemMarginVar})`,
+  },
+
+  icon12: { fontSize: '12px' },
+  icon16: { fontSize: '16px' },
+  icon20: { fontSize: '20px' },
+  icon24: { fontSize: '24px' },
+  icon28: { fontSize: '28px' },
+  icon32: { fontSize: '32px' },
+  icon48: { fontSize: '48px' },
+  caption2Strong: { ...typographyStyles.caption2Strong },
+  caption1Strong: { ...typographyStyles.caption1Strong },
+  body1Strong: { ...typographyStyles.body1Strong },
+  subtitle2: { ...typographyStyles.subtitle2 },
+  subtitle1: { ...typographyStyles.subtitle1 },
+  title3: { ...typographyStyles.title3 },
+  thin: { [avatarGroupOverflowButtonBorderVar]: tokens.strokeWidthThin },
+  thick: { [avatarGroupOverflowButtonBorderVar]: tokens.strokeWidthThick },
+  thicker: { [avatarGroupOverflowButtonBorderVar]: tokens.strokeWidthThicker },
+  thickest: { [avatarGroupOverflowButtonBorderVar]: tokens.strokeWidthThickest },
+});
+
+const useStackStyles = makeStyles({
+  thick: { [avatarGroupItemOutlineVar]: tokens.strokeWidthThick },
+  thicker: { [avatarGroupItemOutlineVar]: tokens.strokeWidthThicker },
+  thickest: { [avatarGroupItemOutlineVar]: tokens.strokeWidthThickest },
+  xxs: { [avatarGroupItemMarginVar]: `calc(-1 * ${tokens.spacingHorizontalXXS})` },
+  xs: { [avatarGroupItemMarginVar]: `calc(-1 * ${tokens.spacingHorizontalXS})` },
+  s: { [avatarGroupItemMarginVar]: `calc(-1 * ${tokens.spacingHorizontalS})` },
+  l: { [avatarGroupItemMarginVar]: `calc(-1 * ${tokens.spacingHorizontalL})` },
+});
+
+const useSpreadStyles = makeStyles({
+  s: { [avatarGroupItemMarginVar]: tokens.spacingHorizontalS },
+  mNudge: { [avatarGroupItemMarginVar]: tokens.spacingHorizontalMNudge },
+  m: { [avatarGroupItemMarginVar]: tokens.spacingHorizontalM },
+  l: { [avatarGroupItemMarginVar]: tokens.spacingHorizontalL },
+  xl: { [avatarGroupItemMarginVar]: tokens.spacingHorizontalXL },
+});
+
+/**
+ * Styles for overflow list slot.
+ */
 const useOverflowListStyles = makeStyles({
   base: {
     listStyleType: 'none',
-    ...shorthands.margin(0),
-    ...shorthands.padding(0),
+    maxHeight: '220px',
+    minHeight: '80px',
+    ...shorthands.overflow('hidden', 'scroll'),
+    ...shorthands.padding(tokens.spacingHorizontalS),
+    width: '220px',
   },
 });
 
@@ -32,19 +146,54 @@ const useOverflowListStyles = makeStyles({
  * Apply styling to the AvatarGroup slots based on the state
  */
 export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGroupState => {
-  const { size } = state;
+  const { layout, overflowIndicator, size } = state;
   const styles = useStyles();
   const sizeStyles = useSizeStyles();
   const overflowListStyles = useOverflowListStyles();
+  const stackStyles = useStackStyles();
+  const spreadStyles = useSpreadStyles();
+  const overflowButtonStyles = useOverflowButtonStyles();
 
-  state.root.className = mergeClasses(avatarGroupClassNames.root, styles.base, state.root.className);
+  const rootClasses = [];
 
-  if (state.overflowSurface) {
-    state.overflowSurface.className = mergeClasses(
-      avatarGroupClassNames.overflowSurface,
-      state.overflowSurface.className,
-    );
+  if (layout === 'stack') {
+    if (size < 56) {
+      rootClasses.push(stackStyles.thick);
+    } else if (size < 72) {
+      rootClasses.push(stackStyles.thicker);
+    } else {
+      rootClasses.push(stackStyles.thickest);
+    }
+
+    if (size < 24) {
+      rootClasses.push(stackStyles.xxs);
+    } else if (size < 48) {
+      rootClasses.push(stackStyles.xs);
+    } else if (size < 96) {
+      rootClasses.push(stackStyles.s);
+    } else {
+      rootClasses.push(stackStyles.l);
+    }
+  } else if (layout === 'spread') {
+    if (size < 20) {
+      rootClasses.push(spreadStyles.s);
+    } else if (size < 32) {
+      rootClasses.push(spreadStyles.mNudge);
+    } else if (size < 64) {
+      rootClasses.push(spreadStyles.l);
+    } else {
+      rootClasses.push(spreadStyles.xl);
+    }
   }
+
+  state.root.className = mergeClasses(
+    avatarGroupClassNames.root,
+    styles.base,
+    layout === 'pie' && styles.pie,
+    layout === 'pie' && sizeStyles[size],
+    ...rootClasses,
+    state.root.className,
+  );
 
   if (state.overflowList) {
     state.overflowList.className = mergeClasses(
@@ -54,10 +203,61 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
     );
   }
 
+  const popoverTriggerClasses = [];
+
+  if (size < 36) {
+    rootClasses.push(overflowButtonStyles.thin);
+  } else if (size < 56) {
+    rootClasses.push(overflowButtonStyles.thick);
+  } else if (size < 72) {
+    rootClasses.push(overflowButtonStyles.thicker);
+  } else {
+    rootClasses.push(overflowButtonStyles.thickest);
+  }
+
+  if (overflowIndicator === 'count') {
+    if (size <= 24) {
+      popoverTriggerClasses.push(overflowButtonStyles.caption2Strong);
+    } else if (size <= 28) {
+      popoverTriggerClasses.push(overflowButtonStyles.caption1Strong);
+    } else if (size <= 40) {
+      popoverTriggerClasses.push(overflowButtonStyles.body1Strong);
+    } else if (size <= 56) {
+      popoverTriggerClasses.push(overflowButtonStyles.subtitle2);
+    } else if (size <= 96) {
+      popoverTriggerClasses.push(overflowButtonStyles.subtitle1);
+    } else {
+      popoverTriggerClasses.push(overflowButtonStyles.title3);
+    }
+  } else {
+    if (size <= 16) {
+      popoverTriggerClasses.push(overflowButtonStyles.icon12);
+    } else if (size <= 24) {
+      popoverTriggerClasses.push(overflowButtonStyles.icon16);
+    } else if (size <= 40) {
+      popoverTriggerClasses.push(overflowButtonStyles.icon20);
+    } else if (size <= 48) {
+      popoverTriggerClasses.push(overflowButtonStyles.icon24);
+    } else if (size <= 56) {
+      popoverTriggerClasses.push(overflowButtonStyles.icon28);
+    } else if (size <= 72) {
+      popoverTriggerClasses.push(overflowButtonStyles.icon32);
+    } else {
+      popoverTriggerClasses.push(overflowButtonStyles.icon48);
+    }
+  }
+
   if (state.overflowButton) {
     state.overflowButton.className = mergeClasses(
       avatarGroupClassNames.overflowButton,
       sizeStyles[size],
+      overflowButtonStyles.base,
+      overflowButtonStyles.focusIndicator,
+      layout !== 'pie' && overflowButtonStyles.states,
+      layout === 'pie' && overflowButtonStyles.pie,
+      layout === 'spread' && overflowButtonStyles.spread,
+      layout === 'stack' && overflowButtonStyles.stack,
+      ...popoverTriggerClasses,
       state.overflowButton.className,
     );
   }

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -4,7 +4,7 @@ import { tokens, typographyStyles } from '@fluentui/react-theme';
 import { useSizeStyles } from '../Avatar/useAvatarStyles';
 import type { AvatarGroupSlots, AvatarGroupState } from './AvatarGroup.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
-import { useLayoutClassName } from '../../AvatarGroupItem';
+import { useGroupChildClassName } from '../../AvatarGroupItem';
 
 export const avatarGroupClassNames: SlotClassNames<AvatarGroupSlots> = {
   root: 'fui-AvatarGroup',
@@ -114,7 +114,7 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
   const overflowContentStyles = useOverflowContentStyles();
   const overflowButtonStyles = useOverflowButtonStyles();
 
-  const layoutClassName = useLayoutClassName(layout, size);
+  const groupChildClassName = useGroupChildClassName(layout, size);
 
   state.root.className = mergeClasses(
     avatarGroupClassNames.root,
@@ -184,7 +184,7 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
       overflowButtonStyles.focusIndicator,
       layout !== 'pie' && overflowButtonStyles.states,
       layout === 'pie' && overflowButtonStyles.pie,
-      layoutClassName,
+      groupChildClassName,
       state.overflowButton.className,
     );
   }

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -4,6 +4,7 @@ import { tokens, typographyStyles } from '@fluentui/react-theme';
 import { useSizeStyles } from '../Avatar/useAvatarStyles';
 import type { AvatarGroupSlots, AvatarGroupState } from './AvatarGroup.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
+import { useLayoutClassName } from '../../AvatarGroupItem';
 
 export const avatarGroupClassNames: SlotClassNames<AvatarGroupSlots> = {
   root: 'fui-AvatarGroup',
@@ -21,13 +22,6 @@ const useStyles = makeStyles({
   },
   pie: {
     clipPath: 'circle(50%)',
-  },
-  stack: {
-    '& > *': {
-      outlineColor: tokens.colorNeutralBackground2,
-      outlineStyle: 'solid',
-      ...shorthands.borderRadius(tokens.borderRadiusCircular),
-    },
   },
 });
 
@@ -97,24 +91,6 @@ const useOverflowButtonStyles = makeStyles({
   borderThickest: { ...shorthands.borderWidth(tokens.strokeWidthThickest) },
 });
 
-const useStackStyles = makeStyles({
-  thick: { '& > *': { outlineWidth: tokens.strokeWidthThick } },
-  thicker: { '& > *': { outlineWidth: tokens.strokeWidthThicker } },
-  thickest: { '& > *': { outlineWidth: tokens.strokeWidthThickest } },
-  xxs: { '& > *:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalXXS})` } },
-  xs: { '& > *:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalXS})` } },
-  s: { '& > *:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalS})` } },
-  l: { '& > *:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalL})` } },
-});
-
-const useSpreadStyles = makeStyles({
-  s: { '& > *:not(:first-child)': { marginLeft: tokens.spacingHorizontalS } },
-  mNudge: { '& > *:not(:first-child)': { marginLeft: tokens.spacingHorizontalMNudge } },
-  m: { '& > *:not(:first-child)': { marginLeft: tokens.spacingHorizontalM } },
-  l: { '& > *:not(:first-child)': { marginLeft: tokens.spacingHorizontalL } },
-  xl: { '& > *:not(:first-child)': { marginLeft: tokens.spacingHorizontalXL } },
-});
-
 /**
  * Styles for overflow list slot.
  */
@@ -136,48 +112,17 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
   const styles = useStyles();
   const sizeStyles = useSizeStyles();
   const overflowContentStyles = useOverflowContentStyles();
-  const stackStyles = useStackStyles();
-  const spreadStyles = useSpreadStyles();
   const overflowButtonStyles = useOverflowButtonStyles();
 
-  const rootClasses = [];
+  const layoutClassName = useLayoutClassName(layout, size);
 
-  if (layout === 'stack') {
-    rootClasses.push(styles.stack);
-
-    if (size < 56) {
-      rootClasses.push(stackStyles.thick);
-    } else if (size < 72) {
-      rootClasses.push(stackStyles.thicker);
-    } else {
-      rootClasses.push(stackStyles.thickest);
-    }
-
-    if (size < 24) {
-      rootClasses.push(stackStyles.xxs);
-    } else if (size < 48) {
-      rootClasses.push(stackStyles.xs);
-    } else if (size < 96) {
-      rootClasses.push(stackStyles.s);
-    } else {
-      rootClasses.push(stackStyles.l);
-    }
-  } else if (layout === 'spread') {
-    if (size < 20) {
-      rootClasses.push(spreadStyles.s);
-    } else if (size < 32) {
-      rootClasses.push(spreadStyles.mNudge);
-    } else if (size < 64) {
-      rootClasses.push(spreadStyles.l);
-    } else {
-      rootClasses.push(spreadStyles.xl);
-    }
-  } else {
-    rootClasses.push(styles.pie);
-    rootClasses.push(sizeStyles[size]);
-  }
-
-  state.root.className = mergeClasses(avatarGroupClassNames.root, styles.base, ...rootClasses, state.root.className);
+  state.root.className = mergeClasses(
+    avatarGroupClassNames.root,
+    styles.base,
+    layout === 'pie' && styles.pie,
+    layout === 'pie' && sizeStyles[size],
+    state.root.className,
+  );
 
   if (state.overflowContent) {
     state.overflowContent.className = mergeClasses(
@@ -239,7 +184,7 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
       overflowButtonStyles.focusIndicator,
       layout !== 'pie' && overflowButtonStyles.states,
       layout === 'pie' && overflowButtonStyles.pie,
-      ...overflowButtonClasses,
+      layoutClassName,
       state.overflowButton.className,
     );
   }

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -8,11 +8,9 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 
 export const avatarGroupClassNames: SlotClassNames<AvatarGroupSlots> = {
   root: 'fui-AvatarGroup',
-  overflowList: 'fui-AvatarGroup__overflowList',
+  overflowContent: 'fui-AvatarGroup__overflowContent',
   overflowButton: 'fui-AvatarGroup__overflowButton',
 };
-
-const avatarGroupOverflowButtonBorderVar = '--fuiAvatarGroup--overflowbuttonBorderWidth';
 
 /**
  * Styles for the root slot.
@@ -39,7 +37,6 @@ const useOverflowButtonStyles = makeStyles({
     alignItems: 'center',
     color: tokens.colorNeutralForeground1,
     backgroundColor: tokens.colorNeutralBackground1,
-    ...shorthands.borderWidth(`var(${avatarGroupOverflowButtonBorderVar})`),
     ...shorthands.borderColor(tokens.colorNeutralStroke1),
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
     ...shorthands.borderStyle('solid'),
@@ -66,11 +63,6 @@ const useOverflowButtonStyles = makeStyles({
       color: tokens.colorNeutralForeground1Pressed,
       backgroundColor: tokens.colorNeutralBackground1Pressed,
       ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
-    },
-    ':checked': {
-      color: tokens.colorNeutralForeground1Selected,
-      backgroundColor: tokens.colorNeutralBackground1Selected,
-      ...shorthands.borderColor(tokens.colorNeutralStroke1Selected),
     },
   },
 
@@ -104,10 +96,10 @@ const useOverflowButtonStyles = makeStyles({
   subtitle2: { ...typographyStyles.subtitle2 },
   subtitle1: { ...typographyStyles.subtitle1 },
   title3: { ...typographyStyles.title3 },
-  thin: { [avatarGroupOverflowButtonBorderVar]: tokens.strokeWidthThin },
-  thick: { [avatarGroupOverflowButtonBorderVar]: tokens.strokeWidthThick },
-  thicker: { [avatarGroupOverflowButtonBorderVar]: tokens.strokeWidthThicker },
-  thickest: { [avatarGroupOverflowButtonBorderVar]: tokens.strokeWidthThickest },
+  thin: { ...shorthands.borderWidth(tokens.strokeWidthThin) },
+  thick: { ...shorthands.borderWidth(tokens.strokeWidthThick) },
+  thicker: { ...shorthands.borderWidth(tokens.strokeWidthThicker) },
+  thickest: { ...shorthands.borderWidth(tokens.strokeWidthThickest) },
 });
 
 const useStackStyles = makeStyles({
@@ -131,9 +123,8 @@ const useSpreadStyles = makeStyles({
 /**
  * Styles for overflow list slot.
  */
-const useOverflowListStyles = makeStyles({
+const useOverflowContentStyles = makeStyles({
   base: {
-    listStyleType: 'none',
     maxHeight: '220px',
     minHeight: '80px',
     ...shorthands.overflow('hidden', 'scroll'),
@@ -149,7 +140,7 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
   const { layout, overflowIndicator, size } = state;
   const styles = useStyles();
   const sizeStyles = useSizeStyles();
-  const overflowListStyles = useOverflowListStyles();
+  const overflowContentStyles = useOverflowContentStyles();
   const stackStyles = useStackStyles();
   const spreadStyles = useSpreadStyles();
   const overflowButtonStyles = useOverflowButtonStyles();
@@ -184,66 +175,62 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
     } else {
       rootClasses.push(spreadStyles.xl);
     }
+  } else {
+    rootClasses.push(styles.pie);
+    rootClasses.push(sizeStyles[size]);
   }
 
-  state.root.className = mergeClasses(
-    avatarGroupClassNames.root,
-    styles.base,
-    layout === 'pie' && styles.pie,
-    layout === 'pie' && sizeStyles[size],
-    ...rootClasses,
-    state.root.className,
-  );
+  state.root.className = mergeClasses(avatarGroupClassNames.root, styles.base, ...rootClasses, state.root.className);
 
-  if (state.overflowList) {
-    state.overflowList.className = mergeClasses(
-      avatarGroupClassNames.overflowList,
-      overflowListStyles.base,
-      state.overflowList.className,
+  if (state.overflowContent) {
+    state.overflowContent.className = mergeClasses(
+      avatarGroupClassNames.overflowContent,
+      overflowContentStyles.base,
+      state.overflowContent.className,
     );
   }
 
-  const popoverTriggerClasses = [];
+  const overflowButtonClasses = [];
 
   if (size < 36) {
-    rootClasses.push(overflowButtonStyles.thin);
+    overflowButtonClasses.push(overflowButtonStyles.thin);
   } else if (size < 56) {
-    rootClasses.push(overflowButtonStyles.thick);
+    overflowButtonClasses.push(overflowButtonStyles.thick);
   } else if (size < 72) {
-    rootClasses.push(overflowButtonStyles.thicker);
+    overflowButtonClasses.push(overflowButtonStyles.thicker);
   } else {
-    rootClasses.push(overflowButtonStyles.thickest);
+    overflowButtonClasses.push(overflowButtonStyles.thickest);
   }
 
   if (overflowIndicator === 'count') {
     if (size <= 24) {
-      popoverTriggerClasses.push(overflowButtonStyles.caption2Strong);
+      overflowButtonClasses.push(overflowButtonStyles.caption2Strong);
     } else if (size <= 28) {
-      popoverTriggerClasses.push(overflowButtonStyles.caption1Strong);
+      overflowButtonClasses.push(overflowButtonStyles.caption1Strong);
     } else if (size <= 40) {
-      popoverTriggerClasses.push(overflowButtonStyles.body1Strong);
+      overflowButtonClasses.push(overflowButtonStyles.body1Strong);
     } else if (size <= 56) {
-      popoverTriggerClasses.push(overflowButtonStyles.subtitle2);
+      overflowButtonClasses.push(overflowButtonStyles.subtitle2);
     } else if (size <= 96) {
-      popoverTriggerClasses.push(overflowButtonStyles.subtitle1);
+      overflowButtonClasses.push(overflowButtonStyles.subtitle1);
     } else {
-      popoverTriggerClasses.push(overflowButtonStyles.title3);
+      overflowButtonClasses.push(overflowButtonStyles.title3);
     }
   } else {
     if (size <= 16) {
-      popoverTriggerClasses.push(overflowButtonStyles.icon12);
+      overflowButtonClasses.push(overflowButtonStyles.icon12);
     } else if (size <= 24) {
-      popoverTriggerClasses.push(overflowButtonStyles.icon16);
+      overflowButtonClasses.push(overflowButtonStyles.icon16);
     } else if (size <= 40) {
-      popoverTriggerClasses.push(overflowButtonStyles.icon20);
+      overflowButtonClasses.push(overflowButtonStyles.icon20);
     } else if (size <= 48) {
-      popoverTriggerClasses.push(overflowButtonStyles.icon24);
+      overflowButtonClasses.push(overflowButtonStyles.icon24);
     } else if (size <= 56) {
-      popoverTriggerClasses.push(overflowButtonStyles.icon28);
+      overflowButtonClasses.push(overflowButtonStyles.icon28);
     } else if (size <= 72) {
-      popoverTriggerClasses.push(overflowButtonStyles.icon32);
+      overflowButtonClasses.push(overflowButtonStyles.icon32);
     } else {
-      popoverTriggerClasses.push(overflowButtonStyles.icon48);
+      overflowButtonClasses.push(overflowButtonStyles.icon48);
     }
   }
 
@@ -257,7 +244,7 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
       layout === 'pie' && overflowButtonStyles.pie,
       layout === 'spread' && overflowButtonStyles.spread,
       layout === 'stack' && overflowButtonStyles.stack,
-      ...popoverTriggerClasses,
+      ...overflowButtonClasses,
       state.overflowButton.className,
     );
   }

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -1,4 +1,3 @@
-import { avatarGroupItemMarginVar, avatarGroupItemOutlineVar } from '../AvatarGroupItem/useAvatarGroupItemStyles';
 import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
@@ -23,6 +22,13 @@ const useStyles = makeStyles({
   pie: {
     clipPath: 'circle(50%)',
   },
+  stack: {
+    '& > *': {
+      outlineColor: tokens.colorNeutralBackground2,
+      outlineStyle: 'solid',
+      ...shorthands.borderRadius(tokens.borderRadiusCircular),
+    },
+  },
 });
 
 /**
@@ -40,7 +46,7 @@ const useOverflowButtonStyles = makeStyles({
     ...shorthands.borderColor(tokens.colorNeutralStroke1),
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
     ...shorthands.borderStyle('solid'),
-    ...shorthands.padding(tokens.spacingHorizontalNone),
+    ...shorthands.padding(0),
   },
 
   // These styles match the default button styles
@@ -72,17 +78,6 @@ const useOverflowButtonStyles = makeStyles({
     color: 'transparent',
   },
 
-  stack: {
-    marginLeft: `var(${avatarGroupItemMarginVar})`,
-    outlineColor: tokens.colorNeutralBackground2,
-    outlineStyle: 'solid',
-    outlineWidth: `var(${avatarGroupItemOutlineVar})`,
-  },
-
-  spread: {
-    marginLeft: `var(${avatarGroupItemMarginVar})`,
-  },
-
   icon12: { fontSize: '12px' },
   icon16: { fontSize: '16px' },
   icon20: { fontSize: '20px' },
@@ -96,28 +91,28 @@ const useOverflowButtonStyles = makeStyles({
   subtitle2: { ...typographyStyles.subtitle2 },
   subtitle1: { ...typographyStyles.subtitle1 },
   title3: { ...typographyStyles.title3 },
-  thin: { ...shorthands.borderWidth(tokens.strokeWidthThin) },
-  thick: { ...shorthands.borderWidth(tokens.strokeWidthThick) },
-  thicker: { ...shorthands.borderWidth(tokens.strokeWidthThicker) },
-  thickest: { ...shorthands.borderWidth(tokens.strokeWidthThickest) },
+  borderThin: { ...shorthands.borderWidth(tokens.strokeWidthThin) },
+  borderThick: { ...shorthands.borderWidth(tokens.strokeWidthThick) },
+  borderThicker: { ...shorthands.borderWidth(tokens.strokeWidthThicker) },
+  borderThickest: { ...shorthands.borderWidth(tokens.strokeWidthThickest) },
 });
 
 const useStackStyles = makeStyles({
-  thick: { [avatarGroupItemOutlineVar]: tokens.strokeWidthThick },
-  thicker: { [avatarGroupItemOutlineVar]: tokens.strokeWidthThicker },
-  thickest: { [avatarGroupItemOutlineVar]: tokens.strokeWidthThickest },
-  xxs: { [avatarGroupItemMarginVar]: `calc(-1 * ${tokens.spacingHorizontalXXS})` },
-  xs: { [avatarGroupItemMarginVar]: `calc(-1 * ${tokens.spacingHorizontalXS})` },
-  s: { [avatarGroupItemMarginVar]: `calc(-1 * ${tokens.spacingHorizontalS})` },
-  l: { [avatarGroupItemMarginVar]: `calc(-1 * ${tokens.spacingHorizontalL})` },
+  thick: { '& > *': { outlineWidth: tokens.strokeWidthThick } },
+  thicker: { '& > *': { outlineWidth: tokens.strokeWidthThicker } },
+  thickest: { '& > *': { outlineWidth: tokens.strokeWidthThickest } },
+  xxs: { '& > *:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalXXS})` } },
+  xs: { '& > *:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalXS})` } },
+  s: { '& > *:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalS})` } },
+  l: { '& > *:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalL})` } },
 });
 
 const useSpreadStyles = makeStyles({
-  s: { [avatarGroupItemMarginVar]: tokens.spacingHorizontalS },
-  mNudge: { [avatarGroupItemMarginVar]: tokens.spacingHorizontalMNudge },
-  m: { [avatarGroupItemMarginVar]: tokens.spacingHorizontalM },
-  l: { [avatarGroupItemMarginVar]: tokens.spacingHorizontalL },
-  xl: { [avatarGroupItemMarginVar]: tokens.spacingHorizontalXL },
+  s: { '& > *:not(:first-child)': { marginLeft: tokens.spacingHorizontalS } },
+  mNudge: { '& > *:not(:first-child)': { marginLeft: tokens.spacingHorizontalMNudge } },
+  m: { '& > *:not(:first-child)': { marginLeft: tokens.spacingHorizontalM } },
+  l: { '& > *:not(:first-child)': { marginLeft: tokens.spacingHorizontalL } },
+  xl: { '& > *:not(:first-child)': { marginLeft: tokens.spacingHorizontalXL } },
 });
 
 /**
@@ -148,6 +143,8 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
   const rootClasses = [];
 
   if (layout === 'stack') {
+    rootClasses.push(styles.stack);
+
     if (size < 56) {
       rootClasses.push(stackStyles.thick);
     } else if (size < 72) {
@@ -193,13 +190,13 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
   const overflowButtonClasses = [];
 
   if (size < 36) {
-    overflowButtonClasses.push(overflowButtonStyles.thin);
+    overflowButtonClasses.push(overflowButtonStyles.borderThin);
   } else if (size < 56) {
-    overflowButtonClasses.push(overflowButtonStyles.thick);
+    overflowButtonClasses.push(overflowButtonStyles.borderThick);
   } else if (size < 72) {
-    overflowButtonClasses.push(overflowButtonStyles.thicker);
+    overflowButtonClasses.push(overflowButtonStyles.borderThicker);
   } else {
-    overflowButtonClasses.push(overflowButtonStyles.thickest);
+    overflowButtonClasses.push(overflowButtonStyles.borderThickest);
   }
 
   if (overflowIndicator === 'count') {
@@ -242,8 +239,6 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
       overflowButtonStyles.focusIndicator,
       layout !== 'pie' && overflowButtonStyles.states,
       layout === 'pie' && overflowButtonStyles.pie,
-      layout === 'spread' && overflowButtonStyles.spread,
-      layout === 'stack' && overflowButtonStyles.stack,
       ...overflowButtonClasses,
       state.overflowButton.className,
     );

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/AvatarGroupItem.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/AvatarGroupItem.types.ts
@@ -1,5 +1,5 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import type { Avatar } from '../../Avatar';
+import type { Avatar, AvatarSizes } from '../../Avatar';
 
 export type AvatarGroupItemSlots = {
   root: NonNullable<Slot<'div', 'li'>>;
@@ -19,7 +19,7 @@ export type AvatarGroupItemSlots = {
 /**
  * AvatarGroupItem Props
  */
-export type AvatarGroupItemProps = ComponentProps<Partial<AvatarGroupItemSlots>, 'avatar'>;
+export type AvatarGroupItemProps = Omit<ComponentProps<Partial<AvatarGroupItemSlots>, 'avatar'>, 'size'>;
 
 /**
  * State used in rendering AvatarGroupItem
@@ -31,4 +31,6 @@ export type AvatarGroupItemState = ComponentState<AvatarGroupItemSlots> & {
    * @default false
    */
   isOverflowItem?: boolean;
+
+  size: AvatarSizes;
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Avatar } from '../Avatar/Avatar';
 import { AvatarGroupContext } from '../../contexts/AvatarGroupContext';
+import { defaultAvatarGroupSize } from '../AvatarGroup';
 import { resolveShorthand } from '@fluentui/react-utilities';
 import { useContextSelector } from '@fluentui/react-context-selector';
 import type { AvatarGroupItemProps, AvatarGroupItemState } from './AvatarGroupItem.types';
@@ -22,8 +23,10 @@ export const useAvatarGroupItem_unstable = (
   const groupSize = useContextSelector(AvatarGroupContext, ctx => ctx.size);
   // Since the primary slot is not an intrinsic element, getPartitionedNativeProps cannot be used here.
   const { style, className, ...avatarSlotProps } = props;
+  const size = groupSize ?? defaultAvatarGroupSize;
 
   return {
+    size,
     isOverflowItem: groupIsOverflow,
     components: {
       root: 'div',
@@ -43,7 +46,7 @@ export const useAvatarGroupItem_unstable = (
       required: true,
       defaultProps: {
         ref,
-        size: groupSize,
+        size,
         color: 'colorful',
         ...avatarSlotProps,
       },

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Avatar } from '../Avatar/Avatar';
 import { AvatarGroupContext } from '../../contexts/AvatarGroupContext';
-import { defaultAvatarGroupSize } from '../AvatarGroup';
+import { defaultAvatarGroupSize } from '../AvatarGroup/useAvatarGroup';
 import { resolveShorthand } from '@fluentui/react-utilities';
 import { useContextSelector } from '@fluentui/react-context-selector';
 import type { AvatarGroupItemProps, AvatarGroupItemState } from './AvatarGroupItem.types';

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -67,7 +67,7 @@ const useSpreadStyles = makeStyles({
 export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): AvatarGroupItemState => {
   const layout = useContextSelector(AvatarGroupContext, ctx => ctx.layout);
   const { isOverflowItem } = state;
-  const { size = 32 } = state.avatar;
+  const { size } = state.avatar;
 
   const rootStyles = useRootStyles();
   const overflowLabelStyles = useOverflowLabelStyles();
@@ -99,40 +99,42 @@ export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): 
  * Hook for getting the className for the children of AvatarGroup. This hook will provide the spacing and outlines
  * needed for each layout.
  */
-export const useLayoutClassName = (layout: AvatarGroupProps['layout'], size: AvatarSizes): string => {
+export const useLayoutClassName = (layout: AvatarGroupProps['layout'], size?: AvatarSizes): string => {
   const stackStyles = useStackStyles();
   const spreadStyles = useSpreadStyles();
   const layoutClasses = [];
 
-  if (layout === 'stack') {
-    layoutClasses.push(stackStyles.base);
+  if (size) {
+    if (layout === 'stack') {
+      layoutClasses.push(stackStyles.base);
 
-    if (size < 56) {
-      layoutClasses.push(stackStyles.thick);
-    } else if (size < 72) {
-      layoutClasses.push(stackStyles.thicker);
-    } else {
-      layoutClasses.push(stackStyles.thickest);
-    }
+      if (size < 56) {
+        layoutClasses.push(stackStyles.thick);
+      } else if (size < 72) {
+        layoutClasses.push(stackStyles.thicker);
+      } else {
+        layoutClasses.push(stackStyles.thickest);
+      }
 
-    if (size < 24) {
-      layoutClasses.push(stackStyles.xxs);
-    } else if (size < 48) {
-      layoutClasses.push(stackStyles.xs);
-    } else if (size < 96) {
-      layoutClasses.push(stackStyles.s);
-    } else {
-      layoutClasses.push(stackStyles.l);
-    }
-  } else if (layout === 'spread') {
-    if (size < 20) {
-      layoutClasses.push(spreadStyles.s);
-    } else if (size < 32) {
-      layoutClasses.push(spreadStyles.mNudge);
-    } else if (size < 64) {
-      layoutClasses.push(spreadStyles.l);
-    } else {
-      layoutClasses.push(spreadStyles.xl);
+      if (size < 24) {
+        layoutClasses.push(stackStyles.xxs);
+      } else if (size < 48) {
+        layoutClasses.push(stackStyles.xs);
+      } else if (size < 96) {
+        layoutClasses.push(stackStyles.s);
+      } else {
+        layoutClasses.push(stackStyles.l);
+      }
+    } else if (layout === 'spread') {
+      if (size < 20) {
+        layoutClasses.push(spreadStyles.s);
+      } else if (size < 32) {
+        layoutClasses.push(spreadStyles.mNudge);
+      } else if (size < 64) {
+        layoutClasses.push(spreadStyles.l);
+      } else {
+        layoutClasses.push(spreadStyles.xl);
+      }
     }
   }
 

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -9,6 +9,9 @@ export const avatarGroupItemClassNames: SlotClassNames<AvatarGroupItemSlots> = {
   overflowLabel: 'fui-AvatarGroupItem__overflowLabel',
 };
 
+export const avatarGroupItemMarginVar = '--fuiAvatarGroupItem--margin';
+export const avatarGroupItemOutlineVar = '--fuiAvatarGroupItem--outline';
+
 /**
  * Styles for the root slot
  */

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -9,9 +9,6 @@ export const avatarGroupItemClassNames: SlotClassNames<AvatarGroupItemSlots> = {
   overflowLabel: 'fui-AvatarGroupItem__overflowLabel',
 };
 
-export const avatarGroupItemMarginVar = '--fuiAvatarGroupItem--margin';
-export const avatarGroupItemOutlineVar = '--fuiAvatarGroupItem--outline';
-
 /**
  * Styles for the root slot
  */
@@ -19,11 +16,10 @@ const useRootStyles = makeStyles({
   base: {
     alignItems: 'center',
     display: 'flex',
+    position: 'relative',
   },
   overflowItem: {
-    '&:not(:first-child)': {
-      ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingVerticalXS),
-    },
+    ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingVerticalXS),
   },
 });
 

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -66,19 +66,18 @@ const useSpreadStyles = makeStyles({
  */
 export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): AvatarGroupItemState => {
   const layout = useContextSelector(AvatarGroupContext, ctx => ctx.layout);
-  const { isOverflowItem } = state;
-  const { size } = state.avatar;
+  const { isOverflowItem, size } = state;
 
   const rootStyles = useRootStyles();
   const overflowLabelStyles = useOverflowLabelStyles();
 
-  const layoutClassName = useLayoutClassName(layout, size);
+  const groupChildClassName = useGroupChildClassName(layout, size);
 
   state.root.className = mergeClasses(
     avatarGroupItemClassNames.root,
     rootStyles.base,
     isOverflowItem ? rootStyles.overflowItem : rootStyles.nonOverflowItem,
-    !isOverflowItem && layoutClassName,
+    !isOverflowItem && groupChildClassName,
     state.root.className,
   );
 
@@ -99,7 +98,7 @@ export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): 
  * Hook for getting the className for the children of AvatarGroup. This hook will provide the spacing and outlines
  * needed for each layout.
  */
-export const useLayoutClassName = (layout: AvatarGroupProps['layout'], size?: AvatarSizes): string => {
+export const useGroupChildClassName = (layout: AvatarGroupProps['layout'], size: AvatarSizes): string => {
   const stackStyles = useStackStyles();
   const spreadStyles = useSpreadStyles();
   const layoutClasses = [];

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupLayout.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupLayout.stories.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { AvatarGroup } from '../../AvatarGroup';
+import { AvatarGroupItem } from '../../AvatarGroupItem';
+
+export const Layout = () => {
+  return (
+    <>
+      <div>
+        <AvatarGroup layout="spread">
+          <AvatarGroupItem name="Katri Athokas" />
+          <AvatarGroupItem name="Elvia Atkins" />
+          <AvatarGroupItem name="Cameron Evans" />
+          <AvatarGroupItem name="Wanda Howard" />
+          <AvatarGroupItem name="Mona Kane" />
+          <AvatarGroupItem name="Allan Munger" />
+          <AvatarGroupItem name="Daisy Phillips" />
+          <AvatarGroupItem name="Robert Tolbert" />
+          <AvatarGroupItem name="Kevin Sturgis" />
+        </AvatarGroup>
+      </div>
+      <div>
+        <AvatarGroup layout="stack">
+          <AvatarGroupItem name="Katri Athokas" />
+          <AvatarGroupItem name="Elvia Atkins" />
+          <AvatarGroupItem name="Cameron Evans" />
+          <AvatarGroupItem name="Wanda Howard" />
+          <AvatarGroupItem name="Mona Kane" />
+          <AvatarGroupItem name="Allan Munger" />
+          <AvatarGroupItem name="Daisy Phillips" />
+          <AvatarGroupItem name="Robert Tolbert" />
+          <AvatarGroupItem name="Kevin Sturgis" />
+        </AvatarGroup>
+      </div>
+      <div>
+        <AvatarGroup layout="pie">
+          <AvatarGroupItem name="Katri Athokas" />
+          <AvatarGroupItem name="Elvia Atkins" />
+          <AvatarGroupItem name="Cameron Evans" />
+          <AvatarGroupItem name="Wanda Howard" />
+          <AvatarGroupItem name="Mona Kane" />
+          <AvatarGroupItem name="Allan Munger" />
+          <AvatarGroupItem name="Daisy Phillips" />
+          <AvatarGroupItem name="Robert Tolbert" />
+          <AvatarGroupItem name="Kevin Sturgis" />
+        </AvatarGroup>
+      </div>
+    </>
+  );
+};

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/index.stories.beta.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/index.stories.beta.tsx
@@ -4,6 +4,7 @@ import descriptionMd from './AvatarGroupDescription.md';
 import bestPracticesMd from './AvatarGroupBestPractices.md';
 
 export { Default } from './AvatarGroupDefault.stories';
+export { Layout } from './AvatarGroupLayout.stories';
 
 export default {
   title: 'Preview Components/AvatarGroup',

--- a/packages/react-components/react-avatar/src/stories/AvatarGroupItem/index.stories.beta.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroupItem/index.stories.beta.tsx
@@ -6,7 +6,7 @@ import bestPracticesMd from './AvatarGroupItemBestPractices.md';
 export { Default } from './AvatarGroupItemDefault.stories';
 
 export default {
-  title: 'Components/AvatarGroupItem',
+  title: 'Preview Components/AvatarGroupItem',
   component: AvatarGroupItem,
   parameters: {
     docs: {


### PR DESCRIPTION
This PR adds the following changes:
* Removes overflow list slot and adds `role="list"` to the overflow surface.
* Adds styling for `pie`, `spread`, and `stacked` layouts.
  * Note that this PR does not change the `AvatarGroupItem`, so styles might seem off.
* Adds styling to overflow button to match design spec.
* Adds Layout story.

## Related Issue(s)

Related #23417 
