### PR TITLE
README, spec and migration guide cleanup for react-divider

### DIFF
--- a/change/@fluentui-react-divider-f4ab1379-0588-464e-922d-979cd9d023ce.json
+++ b/change/@fluentui-react-divider-f4ab1379-0588-464e-922d-979cd9d023ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "README, spec and migration guide cleanup.",
+  "packageName": "@fluentui/react-divider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-97c56ec3-b7a8-4325-b158-602983349bdd.json
+++ b/change/@fluentui-react-slider-97c56ec3-b7a8-4325-b158-602983349bdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "README update.",
+  "packageName": "@fluentui/react-slider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-22e06122-91ad-46fe-b5ee-35c49c1b19ec.json
+++ b/change/@fluentui-react-switch-22e06122-91ad-46fe-b5ee-35c49c1b19ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "README update.",
+  "packageName": "@fluentui/react-switch",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-divider/MIGRATION.md
+++ b/packages/react-components/react-divider/MIGRATION.md
@@ -1,60 +1,36 @@
 # Divider Migration
 
-## STATUS: WIP 🚧
-
-This Migration guide is a work in progress and is not yet ready for use.
-
 ## Migration from v8
 
-The existing `Separator` control supports the `content` property as well as children nodes. The `content` property has been removed and now only supports children.
+The existing v8's `Separator` control supports a very similar set of props to the one being proposed for v9's `Divider` with a few differences that are outlined below:
 
-With the new converged capabilities, both the `styles` and `theme` properties are no longer supported.
-
-Properties that are still available are the `alignContent` and `vertical` with the same acceptable values that are currently defined.
+- `alignContent` => `alignContent`
+- `content` => NOT SUPPORTED - use `children` instead
+- `styles` => NOT SUPPORTED - use new styling system via `tokens` instead
+- `theme` => NOT SUPPORTED
+- `vertical` => `vertical`
 
 ## Migration from v0
 
-The v0 Divider is close to the converged Divider. Again, as with the Separator control, the `content` property in the converged component is not supported.
+The existing v0's `Divider` control supports a very similar set of props to the one being proposed for v9 with a few differences that are outlined below:
 
-Also, from design discussion, the converged component does not support the `size` component as it is redundant as it can be replicated through using the `borderSize` property and if needed, update the `fontSize` property to match desired style.
-
-The `fitted` property also is not in use as by default the `Divider` can use the standard `margin` | `marginLeft` | `marginRight` | `marginTop` | `marginBottom` properties to adjust as needed. The default margin for the divider is 0.
+- `content` => NOT SUPPORTED - use `children` instead
+- `fitted` => NOT SUPPORTED - use style customizations via `className` instead
+- `important` => NOT SUPPORTED
+- `vertical` => `vertical`
 
 ## Property mapping
 
-| v8 `Separator` | v0 `Divider` | Converged `Divider`   |
-| -------------- | ------------ | --------------------- |
-| alignContent   | -            | alignContent          |
-| vertical       | vertical     | vertical              |
-| theme          | -            | (tokens)              |
-| styles         | -            | (tokens)              |
-| -              | color        | color                 |
-| -              | size         | fontSize & borderSize |
-| -              | important    | important             |
-| -              | fitted       | margin properties     |
-| -              | -            | inset                 |
-| -              | -            | borderStyle           |
-| -              | -            | borderSize            |
-| -              | -            | appearance            |
-
-## Examples
-
-```
-<Divider content="My Content">
-<Divider>My Content</Divider>
-```
-
-_Note:_ The property theme from the separator control has been removed
-
-```
-<Separator theme={myTheme}>
-<Divider /> /* Handled by the theme provider */
-```
-
-_Note:_ The property styles from the separator control has been removed and now uses the inherent react style mechanics
-
-```
-<Separator styles={myStyles}>
-<Divider style={{ direction:ltr }}/>
-/* Handled by the theme provider / Tokens */
-```
+| v8 `Separator` | v0 `Divider` | v9 `Divider`   |
+| -------------- | ------------ | -------------- |
+| `alignContent` | -            | `alignContent` |
+| -              | -            | `appearance`   |
+| -              | `color`      |                |
+| `content`      | `content`    | `children`     |
+| -              | `fitted`     |                |
+| -              | `important`  |                |
+| -              | -            | `inset`        |
+| -              | `size`       |                |
+| `styles`       | -            |                |
+| `theme`        | -            |                |
+| `vertical`     | `vertical`   | `vertical`     |

--- a/packages/react-components/react-divider/MIGRATION.md
+++ b/packages/react-components/react-divider/MIGRATION.md
@@ -2,22 +2,19 @@
 
 ## Migration from v8
 
-The existing v8's `Separator` control supports a very similar set of props to the one being proposed for v9's `Divider` with a few differences that are outlined below:
+The v8 `Separator` control supports a very similar set of props to the v9 `Divider` with a few differences that are outlined below:
 
-- `alignContent` => `alignContent`
-- `content` => NOT SUPPORTED - use `children` instead
-- `styles` => NOT SUPPORTED - use new styling system via `tokens` instead
+- `content` => `children` of the `Divider`
+- `styles` => NOT SUPPORTED - use new styling system via `FluentProvider`
 - `theme` => NOT SUPPORTED
-- `vertical` => `vertical`
 
 ## Migration from v0
 
-The existing v0's `Divider` control supports a very similar set of props to the one being proposed for v9 with a few differences that are outlined below:
+The v0 `Divider` control supports a very similar set of props to the v9 `Divider` with a few differences that are outlined below:
 
-- `content` => NOT SUPPORTED - use `children` instead
+- `content` => `children` of the `Divider`
 - `fitted` => NOT SUPPORTED - use style customizations via `className` instead
 - `important` => NOT SUPPORTED
-- `vertical` => `vertical`
 
 ## Property mapping
 

--- a/packages/react-components/react-divider/README.md
+++ b/packages/react-components/react-divider/README.md
@@ -1,23 +1,39 @@
 # @fluentui/react-divider
 
-**React Divider components for [Fluent UI](https://dev.microsoft.com/fluentui)**
+**Divider components for [Fluent UI](https://aka.ms/fluentui-storybook)**
 
 The Divider component represents a visual separator, that may contain content. A Divider can be vertical or horizontal.
-
-## STATUS: WIP 🚧
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
 
 ## Usage
 
 To import Divider:
 
 ```js
-import { Divider } from '@fluentui/react-divider';
-```
-
-Once the Divider component graduates to a production release, the component will be available at:
-
-```js
 import { Divider } from '@fluentui/react-components';
 ```
+
+### Examples
+
+```jsx
+<Divider />
+<Divider>This is a divider</Divider>
+<Divider alignContent="center">This is a divider</Divider>
+<Divider appearance="subtle">This is a divider</Divider>
+<Divider inset>This is a divider</Divider>
+<Divider vertical>This is a divider</Divider>
+```
+
+See [Fluent UI Storybook](https://aka.ms/fluentui-storybook) for more detailed usage examples.
+
+Alternatively, run Storybook locally with:
+
+1. `yarn start`
+2. Select `react-divider` from the list.
+
+### Specification
+
+See [SPEC.md](./SPEC.md).
+
+### Migration Guide
+
+If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest Divider implementation.

--- a/packages/react-components/react-divider/Spec.md
+++ b/packages/react-components/react-divider/Spec.md
@@ -59,7 +59,7 @@ The `Divider` component has four appearance variants:
 
 ## API
 
-From [Divider.types.tsx](https://github.com/microsoft/fluentui/blob/master/packages/react-divider/src/components/Divider/Divider.types.ts)
+See API at [Divider.types.tsx](./src/components/Divider/Divider.types.ts).
 
 ## HTML Structure
 
@@ -73,7 +73,7 @@ From [Divider.types.tsx](https://github.com/microsoft/fluentui/blob/master/packa
 
 ## Migration
 
-[See MIGRATION.md](./Migration.md)
+[See MIGRATION.md](./MIGRATION.md).
 
 ## Behaviors
 

--- a/packages/react-components/react-slider/README.md
+++ b/packages/react-components/react-slider/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-slider
 
-**Slider component for [Fluent UI React](https://aka.ms/fluentui-storybook)**
+**Slider components for [Fluent UI React](https://aka.ms/fluentui-storybook)**
 
 Slider allows users to quickly select a value (or range) by dragging a thumb across a rail. It is often used when setting values with a relaxed precision such as audio volume and screen brightness.
 

--- a/packages/react-components/react-switch/README.md
+++ b/packages/react-components/react-switch/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-switch
 
-**React Switch components for [Fluent UI React](https://aka.ms/fluentui-storybook)**
+**Switch components for [Fluent UI React](https://aka.ms/fluentui-storybook)**
 
 The `Switch` control enables users to trigger an option on or off through interacting with the component.
 


### PR DESCRIPTION
## PR Description

This PR cleans up a bunch of things in `react-divider`:
- It updates the migration guide to put it more in line with the guides in other packages.
- The README is updated to point to our storybook docs, reference importing from `react-components`, add usage examples, and point to the spec and migration guides.
- The spec is updated to add links to both the types files and migration guide.

This PR also includes small cleanups in `react-slider` and `react-switch` READMEs.

Fixes part of #23423.