### PR TITLE
Calendar/Datepicker: preventDefault for FocusZone keys to prevent scroll

### DIFF
--- a/change/@fluentui-react-fbe1cb4e-6137-4002-b0f7-c14c18070af0.json
+++ b/change/@fluentui-react-fbe1cb4e-6137-4002-b0f7-c14c18070af0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Calendar/Datepicker: add preventDefault to FocusZone keys to prevent page scroll when hitting bounds",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -381,7 +381,7 @@ export const CalendarDayGridBase: React.FunctionComponent<ICalendarDayGridProps>
   } as const;
 
   return (
-    <FocusZone className={classNames.wrapper}>
+    <FocusZone className={classNames.wrapper} preventDefaultWhenHandled={true}>
       <table
         className={classNames.table}
         aria-multiselectable="false"


### PR DESCRIPTION
Fixes [14272](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/14272)

We had a bug where using arrow keys when hitting a min/max date boundary would close the datepicker. This was caused by the key's default behavior (scroll) not being prevented when focus didn't move.

This PR sets FocusZone's `preventDefaultWhenHandled` to `true` to prevent keyboard scroll behavior when focus is within the day grid.