### PR TITLE
Fix getLayerCount() in Layer utilities

### DIFF
--- a/change/@fluentui-react-d7a1b6d2-1770-4d3e-b192-2225428c15f7.json
+++ b/change/@fluentui-react-d7a1b6d2-1770-4d3e-b192-2225428c15f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix:Fix getLayerCount",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Layer/Layer.notification.ts
+++ b/packages/react/src/components/Layer/Layer.notification.ts
@@ -61,7 +61,7 @@ export function unregisterLayer(hostId: string, callback: () => void) {
  * @returns The number of layers currently registered with the host.
  */
 export function getLayerCount(hostId: string): number {
-  const layers = _layerHostsById[hostId];
+  const layers = _layersByHostId[hostId];
 
   return layers ? layers.length : 0;
 }


### PR DESCRIPTION
Fixed an issue with the computation in `getLayerCount()`. It was referring to the whole internal state value.