### PR TITLE
chore: move toolbar stories to preview components

### DIFF
--- a/packages/react-components/react-toolbar/src/stories/Toolbar.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar.stories.tsx
@@ -11,7 +11,7 @@ export { WithPopover } from './ToolbarWithPopover.stories';
 export { Subtle } from './ToolbarSubtle.stories';
 
 export default {
-  title: 'Components/Toolbar',
+  title: 'Preview Components/Toolbar',
   component: Toolbar,
   parameters: {
     docs: {


### PR DESCRIPTION
# Overview

Move `Toolbar` stories to under **Preview Components**