### PR TITLE
README, spec and migration guide cleanup for react-image

### DIFF
--- a/change/@fluentui-react-image-68ae7370-4764-401f-a213-1672d7facee0.json
+++ b/change/@fluentui-react-image-68ae7370-4764-401f-a213-1672d7facee0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "README, spec and migration guide cleanup for react-image.",
+  "packageName": "@fluentui/react-image",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-image/MIGRATION.md
+++ b/packages/react-components/react-image/MIGRATION.md
@@ -2,13 +2,13 @@
 
 ## Introduction
 
-This guide is a reference for upgrading the Image component from v8 or v0 to v9 .
+This guide is a reference for upgrading the `Image` component from v8 or v0 to v9 .
 
 ## Migration from v8
 
 ### Property mapping
 
-The table below presents a mapping of props between the v8 and v9 Image components in order to clarify which properties require changes to achieve the same result.
+The table below presents a mapping of props between the v8 and v9 `Image` components in order to clarify which properties require changes to achieve the same result.
 
 > ⚠️ Note - Properties not in this table are considered deprecated.
 
@@ -156,8 +156,8 @@ The table below presents a mapping of props between the v0 and v9 versions of `I
 
 For v9, this property is no longer supported. It is recommended to follow the best practices of a11y in order for Image to be accessible to assistive tools. Thus:
 
-- It is important for Image to have the `alt` description.
-- In case the Image is decorative only, have either `role="presentation"` or `aria-hidden`. Ensure the correct usage of these two attributes, based on your objectives.
+- It is important for `Image` to have the `alt` description.
+- In case the `Image` is decorative only, have either `role="presentation"` or `aria-hidden`. Ensure the correct usage of these two attributes, based on your objectives.
 
 ### alt
 
@@ -169,7 +169,7 @@ _This property has not changed and can be left as is._
 
 ### as
 
-For v9, this property is no longer supported. The Image prop will always be an `<img/>` element, it is not possible to show an image as any other element.
+For v9, this property is no longer supported. The `Image` prop will always be an `<img/>` element, it is not possible to show an image as any other element.
 
 ### avatar
 

--- a/packages/react-components/react-image/MIGRATION.md
+++ b/packages/react-components/react-image/MIGRATION.md
@@ -2,28 +2,28 @@
 
 ## Introduction
 
-This guide is a reference for upgrading the Image component from v8 (Fabric) or v0 (Northstar) to v9 (FluentUI vNext).
+This guide is a reference for upgrading the Image component from v8 or v0 to v9 .
 
-## Migration from v8 (Fabric)
+## Migration from v8
 
 ### Property mapping
 
-The table below presents a mapping of props between the v8 (FabricUI) and v9 (Fluent UI vNext) in order to clarify which properties require changes to achieve the same result.
+The table below presents a mapping of props between the v8 and v9 Image components in order to clarify which properties require changes to achieve the same result.
 
 > ⚠️ Note - Properties not in this table are considered deprecated.
 
-| v7 / v8                 | v9      | Good to go? |
-| ----------------------- | ------- | ----------- |
-| `className`             | -       | ✔️          |
-| `coverStyle`            | `fit`   | ⚠️          |
-| `imageFit`              | `fit`   | ✔️          |
-| `maximizeFrame`         | `block` | ✔️          |
-| `loading`               | -       | ✔️          |
-| `onLoadingStateChanged` | -       | ❌          |
-| `shouldFadeIn`          | -       | ❌          |
-| `shouldStartVisible`    | -       | ❌          |
-| `styles`                | -       | ❌          |
-| `theme`                 | -       | ❓          |
+| v7 / v8                 | v9              | Good to go? |
+| ----------------------- | --------------- | ----------- |
+| `className`             | `className`     | ✔️          |
+| `coverStyle`            | `fit="cover"`   | ⚠️          |
+| `imageFit`              | `fit="contain"` | ✔️          |
+| `maximizeFrame`         | `block`         | ✔️          |
+| `loading`               | -               | ❌          |
+| `onLoadingStateChanged` | -               | ❌          |
+| `shouldFadeIn`          | -               | ❌          |
+| `shouldStartVisible`    | -               | ❌          |
+| `styles`                | -               | ❌          |
+| `theme`                 | -               | ❌          |
 
 ### className
 
@@ -55,7 +55,7 @@ This prop has been renamed to `block` which will result in the same behaviour as
 
 ### loading
 
-_This property has not changed and can be used as is._
+For v9, this feature is no longer supported. The alternative is to use the global events such as: `onLoad`, `onError` to detect the image loading state.
 
 ### onLoadingStateChanged
 
@@ -127,27 +127,27 @@ export default function App() {
 
 ### styles
 
-_This property has not changed and can be used as is. However, we highly recommend that you migrate to a `make-styles` styling solution for performance reasons._
+For v9, you should migrate to use `make-styles` and do style customizations through the `className` prop.
 
 ### theme
 
-_This property has not changed and can be used as is. However, we highly recommend that you migrate to a `make-styles` styling solution for performance reasons._
+For v9, you should use `tokens` in conjunction with `make-styles` and `FluentProvider` to achieve theming correctly.
 
-## Migration from v0 (Northstar)
+## Migration from v0
 
 ### Property mapping
 
-The table below presents a mapping of props between the v0 and v9 versions in order to make it clear which properties require changes to achieve the same result.
+The table below presents a mapping of props between the v0 and v9 versions of `Image` in order to make it clear which properties require changes to achieve the same result.
 
 | v0              | v9                 | Good to go? |
 | --------------- | ------------------ | ----------- |
 | `accessibility` | -                  | ❌          |
-| `alt`           | -                  | ✔️          |
-| `aria-label`    | -                  | ✔️          |
+| `alt`           | `alt`              | ✔️          |
+| `aria-label`    | `aria-label`       | ✔️          |
 | `as`            | -                  | ❌          |
 | `avatar`        | `shape="circular"` | ✔️          |
 | `circular`      | `shape="circular"` | ✔️          |
-| `className`     | -                  | ✔️          |
+| `className`     | `className`        | ✔️          |
 | `fluid`         | `block`            | ✔️          |
 | `styles`        | -                  | ❌          |
 | `variables`     | -                  | ❌          |
@@ -201,13 +201,13 @@ This prop has been renamed to `block` which will result into the same behaviour 
 
 ### styles
 
-_This property has not changed and can be used as is. However, we highly recommend that you migrate to a `make-styles` styling solution for performance reasons._
+For v9, you should migrate to use `make-styles` and do style customizations through the `className` prop.
 
 ### variables
 
 For v9, this feature is no longer supported. The alternative is to apply styles through `make-styles`. Below is an example of a migration:
 
-#### v0 (Northstar) implementation
+#### v0 implementation
 
 ```jsx
 const MyComponent = () => {
@@ -215,7 +215,7 @@ const MyComponent = () => {
 };
 ```
 
-#### v9 (Fluent UI vNext) implementation
+#### v9 implementation
 
 ```jsx
 import { Image } from '@fluentui/react-image';

--- a/packages/react-components/react-image/README.md
+++ b/packages/react-components/react-image/README.md
@@ -1,57 +1,39 @@
 # @fluentui/react-image
 
-**React Image component for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
-
-> WIP 🚧 - These are not production-ready components as we are still in a Beta phase.
+**Image components for [Fluent UI React](https://aka.ms/fluentui-storybook)**
 
 Usage of Image component ensures consistent styling and behaviour of images in your application based on the Fluent UI Design System.
 
 ## Usage
 
-To use the Image component, it is required to install the main package of Fluent UI components:
-
-```sh
-npm install @fluentui/react-components
-```
+To import Image:
 
 ```js
 import { Image } from '@fluentui/react-components';
-
-const App = () => {
-  return <Image src="example_image.png" />;
-};
 ```
 
-Or, installing only the `react-image` package:
-
-```sh
-npm install @fluentui/react-image
-npm install @fluentui/react-provider
-```
-
-```js
-import { Image } from '@fluentui/react-image';
-import { FluentProvider } from '@fluentui/react-provider';
-
-const App = () => (
-  <FluentProvider>
-    <Image src="example_image.png" alt="Example image" />;
-  </FluentProvider>
-);
-```
-
-The DOM structure will result into:
+### Examples
 
 ```jsx
-<img src="example_image.png" alt="Example image" />
+<Image src="example_image.png" />
+<Image src="example_image.png" alt="Example image" />;
+<Image src="example_image.png" bordered />;
+<Image src="example_image.png" fit="contain" />;
+<Image src="example_image.png" shadow />;
+<Image src="example_image.png" shape="circular" />;
 ```
 
-## API
+See [Fluent UI Storybook](https://aka.ms/fluentui-storybook) for more detailed usage examples.
 
-Image component is build upon the `<img/>` tag, which does support all the native attributes. Additionaly, the following properties are available: `bordered`, `fit`, `block`, `shape` and `shadow`.
+Alternatively, run Storybook locally with:
 
-For more information on the component, please refer to the [API documentation](https://aka.ms/fluentui-storybook).
+1. `yarn start`
+2. Select `react-image` from the list.
+
+### Specification
+
+See [SPEC.md](./SPEC.md).
 
 ## Migration
 
-For migrating from older versions of FluentUI, please check out the [migration guide](./MIGRATION.md)
+If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest Image implementation.

--- a/packages/react-components/react-image/Spec.md
+++ b/packages/react-components/react-image/Spec.md
@@ -73,18 +73,16 @@ n/a
 
 ## API proposal
 
-See [react-image/Image.types.ts] for the API.
-
-[react-image/image.types.ts]: https://github.com/microsoft/fluentui/blob/master/packages/react-image/src/components/Image/Image.types.ts
+See API at [Image.types.ts](./src/components/Image/Image.types.ts).
 
 Proposed component props:
 
 | Name       | Type      | Default value | Comments                                     |
 | ---------- | --------- | ------------- | -------------------------------------------- |
 | `bordered` | `boolean` | `false`       |                                              |
-| `fit`      | `string`  | "`none`"      | One of: `none`, `center`, `contain`, `cover` |
+| `fit`      | `string`  | `"none"`      | One of: `none`, `center`, `contain`, `cover` |
 | `block`    | `boolean` | `false`       |                                              |
-| `shape `   | `string ` | `false`       | One of: `square`, `circular` , `rounded`     |
+| `shape `   | `string ` | `"square"`    | One of: `square`, `circular` , `rounded`     |
 | `shadow`   | `boolean` | `false`       |                                              |
 
 All native html attributes of the `<img />` will be available to be used as props of the Image component.
@@ -153,12 +151,9 @@ Sample code based on the proposed API:
 <img src="..." class="...">
 ```
 
-<!-- ## Migration -->
+## Migration
 
-<!-- _Describe what will need to be done to upgrade from the existing implementations:_
-
-- _Migration from v8_
-- _Migration from v0_ -->
+See [MIGRATION.md](./MIGRATION.md).
 
 ## Accessibility
 


### PR DESCRIPTION
## PR Description

This PR cleans up a bunch of things in `react-image`:
- It updates the migration guide to make it up to date with the latest information.
- The README is updated to make it more inline with our other READMEs.
- The spec is updated to add links to both the types files and migration guide.

Fixes part of #23423.