### PR TITLE
feat(react-card): add focus indicators

### DIFF
--- a/change/@fluentui-react-card-e777c74a-8a55-4940-928a-da44df8f760b.json
+++ b/change/@fluentui-react-card-e777c74a-8a55-4940-928a-da44df8f760b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Add focus indicators",
+  "packageName": "@fluentui/react-card",
+  "email": "39736248+andrefcdias@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/etc/react-card.api.md
+++ b/packages/react-components/react-card/etc/react-card.api.md
@@ -20,6 +20,7 @@ export const cardClassNames: SlotClassNames<CardSlots>;
 // @public
 export const cardCSSVars: {
     cardSizeVar: string;
+    cardBorderRadiusVar: string;
 };
 
 // @public

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.ts
@@ -28,9 +28,6 @@ const useStyles = makeStyles({
     position: 'relative',
     ...shorthands.overflow('hidden'),
     color: tokens.colorNeutralForeground1,
-    ...shorthands.borderRadius(`var(${cardCSSVars.cardBorderRadiusVar})`),
-    ...shorthands.padding(`var(${cardCSSVars.cardSizeVar})`),
-    ...shorthands.gap(`var(${cardCSSVars.cardSizeVar})`),
 
     // Border setting using after pseudo element to allow CardPreview to render behind it.
     '::after': {

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.ts
@@ -5,6 +5,7 @@ import { cardHeaderClassNames } from '../CardHeader/useCardHeaderStyles';
 import { cardFooterClassNames } from '../CardFooter/useCardFooterStyles';
 import type { CardSlots, CardState } from './Card.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 
 /**
  * Static CSS class names used internally for the component slots.
@@ -18,6 +19,7 @@ export const cardClassNames: SlotClassNames<CardSlots> = {
  */
 export const cardCSSVars = {
   cardSizeVar: '--fui-Card--size',
+  cardBorderRadiusVar: '--fui-Card--border-radius',
 };
 
 const useStyles = makeStyles({
@@ -26,6 +28,9 @@ const useStyles = makeStyles({
     position: 'relative',
     ...shorthands.overflow('hidden'),
     color: tokens.colorNeutralForeground1,
+    ...shorthands.borderRadius(`var(${cardCSSVars.cardBorderRadiusVar})`),
+    ...shorthands.padding(`var(${cardCSSVars.cardSizeVar})`),
+    ...shorthands.gap(`var(${cardCSSVars.cardSizeVar})`),
 
     // Border setting using after pseudo element to allow CardPreview to render behind it.
     '::after': {
@@ -39,8 +44,10 @@ const useStyles = makeStyles({
 
       ...shorthands.borderStyle('solid'),
       ...shorthands.borderWidth(tokens.strokeWidthThin),
+      ...shorthands.borderRadius(`var(${cardCSSVars.cardBorderRadiusVar})`),
     },
 
+    ...shorthands.borderRadius(`var(${cardCSSVars.cardBorderRadiusVar})`),
     ...shorthands.padding(`var(${cardCSSVars.cardSizeVar})`),
     ...shorthands.gap(`var(${cardCSSVars.cardSizeVar})`),
 
@@ -52,6 +59,14 @@ const useStyles = makeStyles({
     [`> :not(.${cardPreviewClassNames.root}):not(.${cardHeaderClassNames.root}):not(.${cardFooterClassNames.root})`]: {
       flexGrow: 1,
     },
+
+    ...createFocusOutlineStyle({
+      style: {
+        outlineRadius: `var(${cardCSSVars.cardBorderRadiusVar})`,
+        outlineWidth: tokens.strokeWidthThick,
+      },
+      selector: 'focus',
+    }),
   },
 
   orientationHorizontal: {
@@ -88,15 +103,15 @@ const useStyles = makeStyles({
 
   sizeSmall: {
     [cardCSSVars.cardSizeVar]: '8px',
-    ...shorthands.borderRadius(tokens.borderRadiusSmall),
+    [cardCSSVars.cardBorderRadiusVar]: tokens.borderRadiusSmall,
   },
   sizeMedium: {
     [cardCSSVars.cardSizeVar]: '12px',
-    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    [cardCSSVars.cardBorderRadiusVar]: tokens.borderRadiusMedium,
   },
   sizeLarge: {
     [cardCSSVars.cardSizeVar]: '16px',
-    ...shorthands.borderRadius(tokens.borderRadiusLarge),
+    [cardCSSVars.cardBorderRadiusVar]: tokens.borderRadiusLarge,
   },
 
   interactiveNoOutline: {


### PR DESCRIPTION
## Current Behavior

Card uses browser focus indicators

![old faulty focus indicators shown on card](https://user-images.githubusercontent.com/39736248/172595916-2150b86d-699e-4e40-8215-31fed4148753.png)

## New Behavior

Card applies the design specific focus indicators

![new focus indicator shown on card](https://user-images.githubusercontent.com/39736248/172595719-4dcc80c8-801a-4e52-9259-999d9ddb5658.png)

## Related Issue(s)

#19336
