### PR TITLE
chore: Update @fluentui/react-icons to latest version

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -24,7 +24,7 @@
     "@fluentui/react-card": "9.0.0-beta.18",
     "@fluentui/react-checkbox": "9.0.0-rc.5",
     "@fluentui/react-divider": "9.0.0-rc.11",
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@fluentui/react-image": "9.0.0-rc.11",
     "@fluentui/react-input": "9.0.0-rc.5",
     "@fluentui/react-label": "9.0.0-rc.5",

--- a/change/@fluentui-react-accordion-7e85dcbf-43cd-40fb-b4f4-42f6c75ba5e0.json
+++ b/change/@fluentui-react-accordion-7e85dcbf-43cd-40fb-b4f4-42f6c75ba5e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons to latest version",
+  "packageName": "@fluentui/react-accordion",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-alert-7a5123f6-2db2-4c2c-a730-41f5eaf5cfaa.json
+++ b/change/@fluentui-react-alert-7a5123f6-2db2-4c2c-a730-41f5eaf5cfaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons to latest version",
+  "packageName": "@fluentui/react-alert",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-634d9d3c-7ec3-4b4b-a4ec-fb05bc56c24e.json
+++ b/change/@fluentui-react-avatar-634d9d3c-7ec3-4b4b-a4ec-fb05bc56c24e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons to latest version",
+  "packageName": "@fluentui/react-avatar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-f69b168b-fbf8-45d1-8548-4890aefea428.json
+++ b/change/@fluentui-react-badge-f69b168b-fbf8-45d1-8548-4890aefea428.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons to latest version",
+  "packageName": "@fluentui/react-badge",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-f492a3fa-6c98-4d59-a80e-9e20bf83f29f.json
+++ b/change/@fluentui-react-button-f492a3fa-6c98-4d59-a80e-9e20bf83f29f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons to latest version",
+  "packageName": "@fluentui/react-button",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-db0297cf-eda3-4574-9b6b-38acb4530fc1.json
+++ b/change/@fluentui-react-checkbox-db0297cf-eda3-4574-9b6b-38acb4530fc1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons to latest version",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-038ec836-65e1-40b4-9275-fe412531c90b.json
+++ b/change/@fluentui-react-menu-038ec836-65e1-40b4-9275-fe412531c90b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons to latest version",
+  "packageName": "@fluentui/react-menu",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-e13a6c23-3f74-427e-9c56-44e7ae71f6f6.json
+++ b/change/@fluentui-react-radio-e13a6c23-3f74-427e-9c56-44e7ae71f6f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons to latest version",
+  "packageName": "@fluentui/react-radio",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-98d1caac-634c-4a9d-9263-f006d4191824.json
+++ b/change/@fluentui-react-select-98d1caac-634c-4a9d-9263-f006d4191824.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons to latest version",
+  "packageName": "@fluentui/react-select",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-74c1b95c-0b50-4c7e-bf35-6b1be8d1d7ad.json
+++ b/change/@fluentui-react-spinbutton-74c1b95c-0b50-4c7e-bf35-6b1be8d1d7ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons to latest version",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-2363144c-2d0e-4940-b313-58bc19ecf909.json
+++ b/change/@fluentui-react-switch-2363144c-2d0e-4940-b313-58bc19ecf909.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons to latest version",
+  "packageName": "@fluentui/react-switch",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toolbar-824e6ddb-0391-4c31-826d-3dbae488e7c4.json
+++ b/change/@fluentui-react-toolbar-824e6ddb-0391-4c31-826d-3dbae488e7c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons to latest version",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@ctrl/tinycolor": "3.3.4",
     "@cypress/react": "5.12.4",
     "@cypress/webpack-dev-server": "1.8.3",
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@griffel/babel-preset": "1.3.1",
     "@griffel/eslint-plugin": "1.0.0",
     "@griffel/jest-serializer": "1.0.5",

--- a/packages/react-components/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-components/react-accordion/etc/react-accordion.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import type { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';

--- a/packages/react-components/react-accordion/package.json
+++ b/packages/react-components/react-accordion/package.json
@@ -35,7 +35,7 @@
     "@fluentui/react-aria": "9.0.0-rc.10",
     "@fluentui/react-context-selector": "9.0.0-rc.10",
     "@fluentui/react-shared-contexts": "9.0.0-rc.10",
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@griffel/react": "1.1.0",
     "@fluentui/react-tabster": "9.0.0-rc.13",
     "@fluentui/react-theme": "9.0.0-rc.9",

--- a/packages/react-components/react-alert/etc/react-alert.api.md
+++ b/packages/react-components/react-alert/etc/react-alert.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import { Button } from '@fluentui/react-button';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';

--- a/packages/react-components/react-alert/package.json
+++ b/packages/react-components/react-alert/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluentui/react-button": "9.0.0-rc.13",
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@fluentui/react-theme": "9.0.0-rc.9",
     "@fluentui/react-utilities": "9.0.0-rc.10",
     "@griffel/react": "1.1.0",

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';

--- a/packages/react-components/react-avatar/package.json
+++ b/packages/react-components/react-avatar/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluentui/react-badge": "9.0.0-rc.12",
     "@fluentui/react-context-selector": "9.0.0-rc.10",
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@fluentui/react-popover": "9.0.0-rc.13",
     "@fluentui/react-tabster": "9.0.0-rc.13",
     "@fluentui/react-tooltip": "9.0.0-rc.13",

--- a/packages/react-components/react-badge/etc/react-badge.api.md
+++ b/packages/react-components/react-badge/etc/react-badge.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';

--- a/packages/react-components/react-badge/package.json
+++ b/packages/react-components/react-badge/package.json
@@ -32,7 +32,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@griffel/react": "1.1.0",
     "@fluentui/react-theme": "9.0.0-rc.9",
     "@fluentui/react-utilities": "9.0.0-rc.10",

--- a/packages/react-components/react-button/etc/react-button.api.md
+++ b/packages/react-components/react-button/etc/react-button.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import type { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';

--- a/packages/react-components/react-button/package.json
+++ b/packages/react-components/react-button/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "9.0.0-rc.6",
     "@fluentui/react-aria": "9.0.0-rc.10",
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@fluentui/react-tabster": "9.0.0-rc.13",
     "@fluentui/react-theme": "9.0.0-rc.9",
     "@fluentui/react-utilities": "9.0.0-rc.10",

--- a/packages/react-components/react-checkbox/etc/react-checkbox.api.md
+++ b/packages/react-components/react-checkbox/etc/react-checkbox.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import { ComponentProps } from '@fluentui/react-utilities';
 import { ComponentState } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';

--- a/packages/react-components/react-checkbox/package.json
+++ b/packages/react-components/react-checkbox/package.json
@@ -31,7 +31,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@fluentui/react-label": "9.0.0-rc.5",
     "@fluentui/react-tabster": "9.0.0-rc.13",
     "@fluentui/react-theme": "9.0.0-rc.9",

--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';

--- a/packages/react-components/react-combobox/package.json
+++ b/packages/react-components/react-combobox/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "9.0.0-rc.6",
     "@fluentui/react-context-selector": "9.0.0-rc.10",
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@fluentui/react-portal": "9.0.0-rc.13",
     "@fluentui/react-positioning": "9.0.0-rc.11",
     "@fluentui/react-theme": "9.0.0-rc.9",

--- a/packages/react-components/react-menu/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/etc/react-menu.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ContextSelector } from '@fluentui/react-context-selector';

--- a/packages/react-components/react-menu/package.json
+++ b/packages/react-components/react-menu/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "9.0.0-rc.6",
     "@fluentui/react-context-selector": "9.0.0-rc.10",
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@griffel/react": "1.1.0",
     "@fluentui/react-portal": "9.0.0-rc.13",
     "@fluentui/react-positioning": "9.0.0-rc.11",

--- a/packages/react-components/react-radio/etc/react-radio.api.md
+++ b/packages/react-components/react-radio/etc/react-radio.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import { ContextSelector } from '@fluentui/react-context-selector';

--- a/packages/react-components/react-radio/package.json
+++ b/packages/react-components/react-radio/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluentui/react-context-selector": "9.0.0-rc.10",
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@fluentui/react-label": "9.0.0-rc.5",
     "@fluentui/react-tabster": "9.0.0-rc.13",
     "@fluentui/react-theme": "9.0.0-rc.9",

--- a/packages/react-components/react-select/etc/react-select.api.md
+++ b/packages/react-components/react-select/etc/react-select.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';

--- a/packages/react-components/react-select/package.json
+++ b/packages/react-components/react-select/package.json
@@ -31,7 +31,7 @@
     "@fluentui/react-conformance-griffel": "9.0.0-beta.8"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@fluentui/react-theme": "9.0.0-rc.9",
     "@fluentui/react-utilities": "9.0.0-rc.10",
     "@griffel/react": "1.1.0",

--- a/packages/react-components/react-spinbutton/etc/react-spinbutton.api.md
+++ b/packages/react-components/react-spinbutton/etc/react-spinbutton.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';

--- a/packages/react-components/react-spinbutton/package.json
+++ b/packages/react-components/react-spinbutton/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@griffel/react": "1.1.0",
     "@fluentui/keyboard-keys": "9.0.0-rc.6",
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@fluentui/react-input": "9.0.0-rc.5",
     "@fluentui/react-theme": "9.0.0-rc.9",
     "@fluentui/react-utilities": "9.0.0-rc.10",

--- a/packages/react-components/react-switch/etc/react-switch.api.md
+++ b/packages/react-components/react-switch/etc/react-switch.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';

--- a/packages/react-components/react-switch/package.json
+++ b/packages/react-components/react-switch/package.json
@@ -32,7 +32,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@fluentui/react-label": "9.0.0-rc.5",
     "@fluentui/react-tabster": "9.0.0-rc.13",
     "@fluentui/react-theme": "9.0.0-rc.9",

--- a/packages/react-components/react-toolbar/etc/react-toolbar.api.md
+++ b/packages/react-components/react-toolbar/etc/react-toolbar.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import { ButtonProps } from '@fluentui/react-button';
 import { ButtonSlots } from '@fluentui/react-button';
 import { ButtonState } from '@fluentui/react-button';

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -33,7 +33,7 @@
     "@griffel/react": "1.1.0",
     "tslib": "^2.1.0",
     "@fluentui/react-components": "^9.0.0-rc.14",
-    "@fluentui/react-icons": "^2.0.166-rc.3",
+    "@fluentui/react-icons": "^2.0.172-rc.8",
     "@fluent-blocks/colors": "9.1.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,10 +1652,10 @@
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
 
-"@fluentui/react-icons@^2.0.166-rc.3":
-  version "2.0.166-rc.3"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.166-rc.3.tgz#6a66d104a4809ca9da1982f895bc24abb624e342"
-  integrity sha512-mhTti5DcCvG/UxRD+/P5Qjdo/QDOE57eRcRBVooOpfO2N1Q+9sE44NYczOeOHpV2AufNqomX0QYf5iPYZ1lEtg==
+"@fluentui/react-icons@^2.0.172-rc.8":
+  version "2.0.172-rc.8"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.172-rc.8.tgz#5daa62d1b11df87cdf26cbfd5e3aa7328e367e74"
+  integrity sha512-vXhOcnlsYA/XgiaiPo4Cyp5GeI+CZE2zRVBNLkygemrafKnboLwUh9dLb/qC4YLsQ4DTaYPrvFq4cKujXBhl4w==
 
 "@griffel/babel-preset@1.3.1", "@griffel/babel-preset@^1.3.1":
   version "1.3.1"


### PR DESCRIPTION
## New Behavior

Repo uses the latest version of `@fluentui/react-icons` to get the fix from https://github.com/microsoft/fluentui-system-icons/pull/439. It's blocking #23457 as it's actually SSR problem.