### PR TITLE
chore: unscope cypress E2E in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,14 +104,9 @@ jobs:
           # This MUST have a trailing slash, or the links to PR deploy site assets won't work
           githubTargetLink: $(deployUrl)/
 
-      # only run e2e tests when the appropriate storybook is published by scoping to relevant packages
       - script: |
-          yarn e2e $(sinceArg) --scope @fluentui/react-components
-        displayName: v9 Cypress E2E tests
-
-      - script: |
-          yarn e2e $(sinceArg) --scope @fluentui/react
-        displayName: v8 Cypress E2E tests
+          yarn e2e $(sinceArg)
+        displayName: Cypress E2E tests
 
       - template: .devops/templates/cleanup.yml
 


### PR DESCRIPTION
There is no real reason to scope cypress tests because the `--since`
argument in lage should already help with running only affected tests
