### PR TITLE
feat: add isSelectedOnFocus prop to DetailsList

### DIFF
--- a/change/@fluentui-react-1c69b2a4-8b4f-43fd-bfb9-02d2307b9b4b.json
+++ b/change/@fluentui-react-1c69b2a4-8b4f-43fd-bfb9-02d2307b9b4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add isSelectedOnFocus prop to DetailsList",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -4599,6 +4599,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
     initialFocusedIndex?: number;
     isHeaderVisible?: boolean;
     isPlaceholderData?: boolean;
+    isSelectedOnFocus?: boolean;
     items: any[];
     layoutMode?: DetailsListLayoutMode;
     listProps?: IListProps;

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -168,6 +168,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
     onRowDidMount,
     onRowWillUnmount,
     disableSelectionZone,
+    isSelectedOnFocus = true,
     onColumnResized,
     onColumnAutoResized,
     onToggleCollapse,
@@ -635,7 +636,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
         if (focusZoneRef.current && focusZoneRef.current.focus()) {
           // select the first item in list after down arrow key event
           // only if nothing was selected; otherwise start with the already-selected item
-          if (selection.getSelectedIndices().length === 0) {
+          if (isSelectedOnFocus && selection.getSelectedIndices().length === 0) {
             selection.setIndexSelected(0, true, false);
           }
 
@@ -644,7 +645,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
         }
       }
     },
-    [selection, focusZoneRef],
+    [selection, focusZoneRef, isSelectedOnFocus],
   );
 
   const onContentKeyDown = React.useCallback(
@@ -721,6 +722,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
               selection={selection}
               selectionPreservedOnEmptyClick={selectionPreservedOnEmptyClick}
               selectionMode={selectionMode}
+              isSelectedOnFocus={isSelectedOnFocus}
               onItemInvoked={onItemInvoked}
               onItemContextMenu={onItemContextMenu}
               enterModalOnTouch={enterModalSelectionOnTouch}

--- a/packages/react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.test.tsx
@@ -349,6 +349,63 @@ describe('DetailsList', () => {
     );
   });
 
+  it('focuses row by arrow key', () => {
+    jest.useFakeTimers();
+
+    let component: IDetailsList | null;
+    const onSelectionChanged = jest.fn();
+    const selection = new Selection({
+      onSelectionChanged,
+    });
+    safeMount(
+      <DetailsList
+        componentRef={ref => (component = ref)}
+        items={mockData(5)}
+        selection={selection}
+        skipViewportMeasures={true}
+        onShouldVirtualize={() => false}
+      />,
+      wrapper => {
+        expect(component).toBeTruthy();
+        component!.focusIndex(0);
+        jest.runAllTimers();
+
+        onSelectionChanged.mockClear();
+        wrapper.find('.ms-DetailsList-headerWrapper').simulate('keyDown', { which: KeyCodes.down });
+        expect(onSelectionChanged).toHaveBeenCalledTimes(1);
+      },
+    );
+  });
+
+  it('does not focus by arrow key when isSelectedOnFocus is `false`', () => {
+    jest.useFakeTimers();
+
+    let component: IDetailsList | null;
+    const onSelectionChanged = jest.fn();
+    const selection = new Selection({
+      onSelectionChanged,
+    });
+    safeMount(
+      <DetailsList
+        componentRef={ref => (component = ref)}
+        items={mockData(5)}
+        selection={selection}
+        skipViewportMeasures={true}
+        onShouldVirtualize={() => false}
+        isSelectedOnFocus={false}
+      />,
+      wrapper => {
+        expect(component).toBeTruthy();
+        component!.focusIndex(0);
+        jest.runAllTimers();
+
+        onSelectionChanged.mockClear();
+        wrapper.find('.ms-DetailsList-headerWrapper').simulate('keyDown', { which: KeyCodes.down });
+        expect(onSelectionChanged).toHaveBeenCalledTimes(0);
+      },
+    );
+  });
+
   it('invokes optional onRenderMissingItem prop once per missing item rendered', () => {
     const onRenderMissingItem = jest.fn();
     const items = [...mockData(5), null, null];

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -332,6 +332,13 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   /** Whether to disable the built-in SelectionZone, so the host component can provide its own. */
   disableSelectionZone?: boolean;
 
+  /**
+   * Determines if an item is selected on focus.
+   *
+   * @defaultvalue true
+   */
+  isSelectedOnFocus?: boolean;
+
   /** Whether to animate updates */
   enableUpdateAnimations?: boolean;
 


### PR DESCRIPTION
## Current Behavior

When a user focuses on DetailsList's header and then uses the down arrow keys to focus the first item in the list [that item is always selected when there is no other selection.](https://github.com/microsoft/fluentui/blob/master/packages/react/src/components/DetailsList/DetailsList.base.tsx#L636-L637) When navigating DetailsList users can typically use `ctrl + arrow up/down` to navigate the list without changing the selection but this does not work when moving from the header to the first item in the list.

## New Behavior

Adds a new optional prop, `isSelectedOnFocus` to DetailsList to control whether items in the list are selected on focus. By default the value for this prop is `true` and the existing behavior of DetailsList is preserved.

When setting this value to `false` the behavior in `onHeaderKeyDown` is changed so that using the down arrow key to move from the header row to the list proper will _not_ select the first item in the list. When `isSelectedOnFocus` is set to `true` the first item in the list will always be selected when there is no prior selection in the list (this is the behavior prior to this change).

Additionally, this prop is passed down to DetailsList's internal SelectionZone as this prop also exists on that component. Previously users could only pass this prop via the `selectionZoneProps` prop on DetailsList. The default behavior for SelectionZone is also maintained as the default value for its `isSelectedOnFocus` prop is also `true`.

## Related Issue(s)

Fixes #23382

