### PR TITLE
react-avatar: Adding styles to AvatarGroupItem

### DIFF
--- a/change/@fluentui-react-avatar-9515b813-271c-4458-945c-07b16c7c979b.json
+++ b/change/@fluentui-react-avatar-9515b813-271c-4458-945c-07b16c7c979b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding layout styles to AvatarGroupItem.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -37,7 +37,7 @@ export type AvatarGroupItemProps = Omit<ComponentProps<Partial<AvatarGroupItemSl
 
 // @public (undocumented)
 export type AvatarGroupItemSlots = {
-    root: NonNullable<Slot<'div', 'li'>>;
+    root: NonNullable<Slot<'div'>>;
     avatar: NonNullable<Slot<typeof Avatar>>;
     overflowLabel: NonNullable<Slot<'span'>>;
 };

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -45,6 +45,8 @@ export type AvatarGroupItemSlots = {
 // @public
 export type AvatarGroupItemState = ComponentState<AvatarGroupItemSlots> & {
     isOverflowItem?: boolean;
+    avatarCount: number;
+    layout: AvatarGroupProps['layout'];
     size: AvatarSizes;
 };
 

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -33,7 +33,7 @@ export const AvatarGroupItem: ForwardRefComponent<AvatarGroupItemProps>;
 export const avatarGroupItemClassNames: SlotClassNames<AvatarGroupItemSlots>;
 
 // @public
-export type AvatarGroupItemProps = Omit<ComponentProps<Partial<AvatarGroupItemSlots>, 'avatar'>, 'size'>;
+export type AvatarGroupItemProps = Omit<ComponentProps<Partial<AvatarGroupItemSlots>, 'avatar'>, 'size' | 'shape'>;
 
 // @public (undocumented)
 export type AvatarGroupItemSlots = {
@@ -45,7 +45,7 @@ export type AvatarGroupItemSlots = {
 // @public
 export type AvatarGroupItemState = ComponentState<AvatarGroupItemSlots> & {
     isOverflowItem?: boolean;
-    avatarCount: number;
+    nonOverflowAvatarsCount: number;
     layout: AvatarGroupProps['layout'];
     size: AvatarSizes;
 };
@@ -69,6 +69,7 @@ export type AvatarGroupSlots = {
 export type AvatarGroupState = ComponentState<AvatarGroupSlots> & Required<Pick<AvatarGroupProps, 'layout' | 'size' | 'overflowIndicator'>> & {
     hasOverflow: boolean;
     tooltipContent: TooltipProps['content'];
+    nonOverflowAvatarsCount: number;
 };
 
 // @public

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/AvatarGroup.types.ts
@@ -63,4 +63,6 @@ export type AvatarGroupState = ComponentState<AvatarGroupSlots> &
      * Tooltip content for the overflow indicator.
      */
     tooltipContent: TooltipProps['content'];
+
+    nonOverflowAvatarsCount: number;
   };

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
@@ -10,11 +10,10 @@ import type { AvatarGroupState, AvatarGroupSlots } from './AvatarGroup.types';
  */
 export const renderAvatarGroup_unstable = (state: AvatarGroupState) => {
   const { slots, slotProps } = getSlots<AvatarGroupSlots>(state);
-  const { layout, size } = state;
-  const avatarCount = React.Children.count(state.root.children);
+  const { layout, size, nonOverflowAvatarsCount } = state;
 
   return (
-    <AvatarGroupContext.Provider value={{ layout, size, avatarCount }}>
+    <AvatarGroupContext.Provider value={{ layout, size, nonOverflowAvatarsCount }}>
       <slots.root {...slotProps.root}>
         {state.root.children}
         {state.hasOverflow && slots.overflowButton && slots.overflowContent && (

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
@@ -11,9 +11,10 @@ import type { AvatarGroupState, AvatarGroupSlots } from './AvatarGroup.types';
 export const renderAvatarGroup_unstable = (state: AvatarGroupState) => {
   const { slots, slotProps } = getSlots<AvatarGroupSlots>(state);
   const { layout, size } = state;
+  const avatarCount = React.Children.count(state.root.children);
 
   return (
-    <AvatarGroupContext.Provider value={{ layout, size }}>
+    <AvatarGroupContext.Provider value={{ layout, size, avatarCount }}>
       <slots.root {...slotProps.root}>
         {state.root.children}
         {state.hasOverflow && slots.overflowButton && slots.overflowContent && (

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
@@ -67,6 +67,7 @@ export const useAvatarGroup_unstable = (props: AvatarGroupProps, ref: React.Ref<
   });
 
   return {
+    nonOverflowAvatarsCount: rootChildren.length,
     hasOverflow: !!overflowChildren,
     layout,
     overflowIndicator,

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/AvatarGroupItem.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/AvatarGroupItem.types.ts
@@ -20,7 +20,7 @@ export type AvatarGroupItemSlots = {
 /**
  * AvatarGroupItem Props
  */
-export type AvatarGroupItemProps = Omit<ComponentProps<Partial<AvatarGroupItemSlots>, 'avatar'>, 'size'>;
+export type AvatarGroupItemProps = Omit<ComponentProps<Partial<AvatarGroupItemSlots>, 'avatar'>, 'size' | 'shape'>;
 
 /**
  * State used in rendering AvatarGroupItem
@@ -33,7 +33,7 @@ export type AvatarGroupItemState = ComponentState<AvatarGroupItemSlots> & {
    */
   isOverflowItem?: boolean;
 
-  avatarCount: number;
+  nonOverflowAvatarsCount: number;
   layout: AvatarGroupProps['layout'];
   size: AvatarSizes;
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/AvatarGroupItem.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/AvatarGroupItem.types.ts
@@ -2,7 +2,7 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 import type { Avatar, AvatarSizes } from '../../Avatar';
 
 export type AvatarGroupItemSlots = {
-  root: NonNullable<Slot<'div', 'li'>>;
+  root: NonNullable<Slot<'div'>>;
 
   /**
    * Avatar that represents a person or entity.

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/AvatarGroupItem.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/AvatarGroupItem.types.ts
@@ -1,5 +1,6 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import type { Avatar, AvatarSizes } from '../../Avatar';
+import { AvatarGroupProps } from '../AvatarGroup/AvatarGroup.types';
 
 export type AvatarGroupItemSlots = {
   root: NonNullable<Slot<'div'>>;
@@ -32,5 +33,7 @@ export type AvatarGroupItemState = ComponentState<AvatarGroupItemSlots> & {
    */
   isOverflowItem?: boolean;
 
+  avatarCount: number;
+  layout: AvatarGroupProps['layout'];
   size: AvatarSizes;
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
@@ -19,7 +19,7 @@ export const useAvatarGroupItem_unstable = (
   props: AvatarGroupItemProps,
   ref: React.Ref<HTMLElement>,
 ): AvatarGroupItemState => {
-  const avatarCount = useContextSelector(AvatarGroupContext, ctx => ctx.avatarCount);
+  const nonOverflowAvatarsCount = useContextSelector(AvatarGroupContext, ctx => ctx.nonOverflowAvatarsCount);
   const groupIsOverflow = useContextSelector(AvatarGroupContext, ctx => ctx.isOverflow);
   const layout = useContextSelector(AvatarGroupContext, ctx => ctx.layout);
   const groupSize = useContextSelector(AvatarGroupContext, ctx => ctx.size);
@@ -28,7 +28,7 @@ export const useAvatarGroupItem_unstable = (
   const size = groupSize ?? defaultAvatarGroupSize;
 
   return {
-    avatarCount: avatarCount!,
+    nonOverflowAvatarsCount: nonOverflowAvatarsCount ?? 1,
     layout,
     size,
     isOverflowItem: groupIsOverflow,

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
@@ -19,13 +19,17 @@ export const useAvatarGroupItem_unstable = (
   props: AvatarGroupItemProps,
   ref: React.Ref<HTMLElement>,
 ): AvatarGroupItemState => {
+  const avatarCount = useContextSelector(AvatarGroupContext, ctx => ctx.avatarCount);
   const groupIsOverflow = useContextSelector(AvatarGroupContext, ctx => ctx.isOverflow);
+  const layout = useContextSelector(AvatarGroupContext, ctx => ctx.layout);
   const groupSize = useContextSelector(AvatarGroupContext, ctx => ctx.size);
   // Since the primary slot is not an intrinsic element, getPartitionedNativeProps cannot be used here.
   const { style, className, ...avatarSlotProps } = props;
   const size = groupSize ?? defaultAvatarGroupSize;
 
   return {
+    avatarCount: avatarCount!,
+    layout,
     size,
     isOverflowItem: groupIsOverflow,
     components: {
@@ -38,7 +42,6 @@ export const useAvatarGroupItem_unstable = (
       defaultProps: {
         style,
         className,
-        as: 'div',
         role: groupIsOverflow ? 'listitem' : undefined,
       },
     }),

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
@@ -38,7 +38,7 @@ export const useAvatarGroupItem_unstable = (
       defaultProps: {
         style,
         className,
-        as: groupIsOverflow ? 'li' : 'div',
+        as: 'div',
         role: groupIsOverflow ? 'listitem' : undefined,
       },
     }),

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -1,8 +1,6 @@
 import { useSizeStyles } from '../../Avatar';
-import { AvatarGroupContext } from '../../contexts/AvatarGroupContext';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
-import { useContextSelector } from '@fluentui/react-context-selector';
 import type { AvatarSizes } from '../../Avatar';
 import type { AvatarGroupProps } from '../../AvatarGroup';
 import type { AvatarGroupItemSlots, AvatarGroupItemState } from './AvatarGroupItem.types';
@@ -14,7 +12,7 @@ export const avatarGroupItemClassNames: SlotClassNames<AvatarGroupItemSlots> = {
   overflowLabel: 'fui-AvatarGroupItem__overflowLabel',
 };
 
-const avatarGroupItemDividerWidthVar = '--fuiAvatarGroupItem--divierWidth';
+const avatarGroupItemDividerWidthVar = '--fuiAvatarGroupItem__divier--width';
 
 /**
  * Styles for the root slot
@@ -27,7 +25,7 @@ const useRootStyles = makeStyles({
     position: 'relative',
   },
   overflowItem: {
-    ...shorthands.padding(tokens.spacingHorizontalXS),
+    ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingHorizontalXS),
   },
   nonOverflowItem: {
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
@@ -122,9 +120,7 @@ const useSpreadStyles = makeStyles({
  * Apply styling to the AvatarGroupItem slots based on the state
  */
 export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): AvatarGroupItemState => {
-  const avatarCount = useContextSelector(AvatarGroupContext, ctx => ctx.avatarCount);
-  const layout = useContextSelector(AvatarGroupContext, ctx => ctx.layout);
-  const { isOverflowItem, size } = state;
+  const { avatarCount, isOverflowItem, layout, size } = state;
 
   const rootStyles = useRootStyles();
   const pieStyles = usePieStyles();
@@ -136,7 +132,7 @@ export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): 
 
   const rootClasses = [rootStyles.base];
 
-  if (!isOverflowItem && avatarCount) {
+  if (!isOverflowItem) {
     rootClasses.push(rootStyles.nonOverflowItem);
     rootClasses.push(groupChildClassName);
     rootClasses.push(sizeStyles[size]);

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -62,7 +62,7 @@ const usePieStyles = makeStyles({
   base: {
     position: 'absolute',
   },
-  twoPies: {
+  twoSlices: {
     '&:first-child': {
       clipPath: `inset(0 calc(25% + (var(${avatarGroupItemDividerWidthVar}) / 2)) 0 25%)`,
       left: '-25%',
@@ -72,7 +72,7 @@ const usePieStyles = makeStyles({
       left: '25%',
     },
   },
-  threePies: {
+  threeSlices: {
     '&:first-child': {
       clipPath: `inset(0 calc(25% + (var(${avatarGroupItemDividerWidthVar}) / 2)) 0 25%)`,
       left: '-25%',
@@ -84,7 +84,7 @@ const usePieStyles = makeStyles({
       transform: 'scale(0.5)',
       transformOrigin: '0 0',
     },
-    '&:nth-of-type(3)': {
+    '&:nth-child(3)': {
       clipPath: `inset(var(${avatarGroupItemDividerWidthVar}) 0 0 var(${avatarGroupItemDividerWidthVar}))`,
       top: '50%',
     },
@@ -120,7 +120,7 @@ const useSpreadStyles = makeStyles({
  * Apply styling to the AvatarGroupItem slots based on the state
  */
 export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): AvatarGroupItemState => {
-  const { avatarCount, isOverflowItem, layout, size } = state;
+  const { nonOverflowAvatarsCount, isOverflowItem, layout, size } = state;
 
   const rootStyles = useRootStyles();
   const pieStyles = usePieStyles();
@@ -148,10 +148,10 @@ export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): 
         rootClasses.push(pieStyles.thickest);
       }
 
-      if (avatarCount === 2) {
-        rootClasses.push(pieStyles.twoPies);
-      } else if (avatarCount === 3) {
-        rootClasses.push(pieStyles.threePies);
+      if (nonOverflowAvatarsCount === 2) {
+        rootClasses.push(pieStyles.twoSlices);
+      } else if (nonOverflowAvatarsCount === 3) {
+        rootClasses.push(pieStyles.threeSlices);
       }
     }
   } else {

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -1,11 +1,12 @@
+import { useSizeStyles } from '../../Avatar';
+import { AvatarGroupContext } from '../../contexts/AvatarGroupContext';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
+import { tokens, typographyStyles } from '@fluentui/react-theme';
+import { useContextSelector } from '@fluentui/react-context-selector';
+import type { AvatarSizes } from '../../Avatar';
 import type { AvatarGroupProps } from '../../AvatarGroup';
 import type { AvatarGroupItemSlots, AvatarGroupItemState } from './AvatarGroupItem.types';
-import type { AvatarSizes } from '../../Avatar';
 import type { SlotClassNames } from '@fluentui/react-utilities';
-import { useContextSelector } from '@fluentui/react-context-selector';
-import { AvatarGroupContext } from '../../contexts/AvatarGroupContext';
 
 export const avatarGroupItemClassNames: SlotClassNames<AvatarGroupItemSlots> = {
   root: 'fui-AvatarGroupItem',
@@ -13,17 +14,20 @@ export const avatarGroupItemClassNames: SlotClassNames<AvatarGroupItemSlots> = {
   overflowLabel: 'fui-AvatarGroupItem__overflowLabel',
 };
 
+const avatarGroupItemDividerWidthVar = '--fuiAvatarGroupItem--divierWidth';
+
 /**
  * Styles for the root slot
  */
 const useRootStyles = makeStyles({
   base: {
     alignItems: 'center',
-    display: 'flex',
+    display: 'inline-flex',
+    flexShrink: 0,
     position: 'relative',
   },
   overflowItem: {
-    ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingVerticalXS),
+    ...shorthands.padding(tokens.spacingHorizontalXS),
   },
   nonOverflowItem: {
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
@@ -31,12 +35,65 @@ const useRootStyles = makeStyles({
 });
 
 /**
+ * Styles for the avatar slot
+ */
+const useAvatarStyles = makeStyles({
+  nonOverflowItem: {
+    position: 'absolute',
+  },
+  pie: {
+    ...shorthands.borderRadius(0),
+  },
+});
+
+/**
  * Styles for the label slot
  */
 const useOverflowLabelStyles = makeStyles({
-  overflowItem: {
+  base: {
     marginLeft: tokens.spacingHorizontalS,
+    color: tokens.colorNeutralForeground1,
+    ...typographyStyles.body1,
   },
+});
+
+/**
+ * Styles for the pie layout
+ */
+const usePieStyles = makeStyles({
+  base: {
+    position: 'absolute',
+  },
+  twoPies: {
+    '&:first-child': {
+      clipPath: `inset(0 calc(25% + (var(${avatarGroupItemDividerWidthVar}) / 2)) 0 25%)`,
+      left: '-25%',
+    },
+    '&:nth-child(2)': {
+      clipPath: `inset(0 25% 0 calc(25% + (var(${avatarGroupItemDividerWidthVar}) / 2)))`,
+      left: '25%',
+    },
+  },
+  threePies: {
+    '&:first-child': {
+      clipPath: `inset(0 calc(25% + (var(${avatarGroupItemDividerWidthVar}) / 2)) 0 25%)`,
+      left: '-25%',
+    },
+    '&:not(:first-child)': {
+      // Since the two AvatarGroupItems on the right are scaled by 0.5, the divider width should not be halved.
+      clipPath: `inset(0 0 var(${avatarGroupItemDividerWidthVar}) var(${avatarGroupItemDividerWidthVar}))`,
+      left: '50%',
+      transform: 'scale(0.5)',
+      transformOrigin: '0 0',
+    },
+    '&:nth-of-type(3)': {
+      clipPath: `inset(var(${avatarGroupItemDividerWidthVar}) 0 0 var(${avatarGroupItemDividerWidthVar}))`,
+      top: '50%',
+    },
+  },
+  thick: { [avatarGroupItemDividerWidthVar]: tokens.strokeWidthThick },
+  thicker: { [avatarGroupItemDividerWidthVar]: tokens.strokeWidthThicker },
+  thickest: { [avatarGroupItemDividerWidthVar]: tokens.strokeWidthThickest },
 });
 
 const useStackStyles = makeStyles({
@@ -65,28 +122,59 @@ const useSpreadStyles = makeStyles({
  * Apply styling to the AvatarGroupItem slots based on the state
  */
 export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): AvatarGroupItemState => {
+  const avatarCount = useContextSelector(AvatarGroupContext, ctx => ctx.avatarCount);
   const layout = useContextSelector(AvatarGroupContext, ctx => ctx.layout);
   const { isOverflowItem, size } = state;
 
   const rootStyles = useRootStyles();
+  const pieStyles = usePieStyles();
+  const sizeStyles = useSizeStyles();
   const overflowLabelStyles = useOverflowLabelStyles();
+  const avatarStyles = useAvatarStyles();
 
   const groupChildClassName = useGroupChildClassName(layout, size);
 
-  state.root.className = mergeClasses(
-    avatarGroupItemClassNames.root,
-    rootStyles.base,
-    isOverflowItem ? rootStyles.overflowItem : rootStyles.nonOverflowItem,
-    !isOverflowItem && groupChildClassName,
-    state.root.className,
-  );
+  const rootClasses = [rootStyles.base];
 
-  state.avatar.className = mergeClasses(avatarGroupItemClassNames.avatar, state.avatar.className);
+  if (!isOverflowItem && avatarCount) {
+    rootClasses.push(rootStyles.nonOverflowItem);
+    rootClasses.push(groupChildClassName);
+    rootClasses.push(sizeStyles[size]);
+
+    if (layout === 'pie') {
+      rootClasses.push(pieStyles.base);
+
+      if (size < 56) {
+        rootClasses.push(pieStyles.thick);
+      } else if (size < 72) {
+        rootClasses.push(pieStyles.thicker);
+      } else {
+        rootClasses.push(pieStyles.thickest);
+      }
+
+      if (avatarCount === 2) {
+        rootClasses.push(pieStyles.twoPies);
+      } else if (avatarCount === 3) {
+        rootClasses.push(pieStyles.threePies);
+      }
+    }
+  } else {
+    rootClasses.push(rootStyles.overflowItem);
+  }
+
+  state.root.className = mergeClasses(avatarGroupItemClassNames.root, ...rootClasses, state.root.className);
+
+  state.avatar.className = mergeClasses(
+    avatarGroupItemClassNames.avatar,
+    !isOverflowItem && avatarStyles.nonOverflowItem,
+    !isOverflowItem && layout === 'pie' && avatarStyles.pie,
+    state.avatar.className,
+  );
 
   if (state.overflowLabel) {
     state.overflowLabel.className = mergeClasses(
       avatarGroupItemClassNames.overflowLabel,
-      isOverflowItem && overflowLabelStyles.overflowItem,
+      overflowLabelStyles.base,
       state.overflowLabel.className,
     );
   }

--- a/packages/react-components/react-avatar/src/contexts/AvatarGroupContext.types.ts
+++ b/packages/react-components/react-avatar/src/contexts/AvatarGroupContext.types.ts
@@ -2,5 +2,5 @@ import type { AvatarGroupProps } from '../AvatarGroup';
 
 export type AvatarGroupContextValue = Pick<AvatarGroupProps, 'size' | 'layout'> & {
   isOverflow?: boolean;
-  avatarCount?: number;
+  nonOverflowAvatarsCount?: number;
 };

--- a/packages/react-components/react-avatar/src/contexts/AvatarGroupContext.types.ts
+++ b/packages/react-components/react-avatar/src/contexts/AvatarGroupContext.types.ts
@@ -2,4 +2,5 @@ import type { AvatarGroupProps } from '../AvatarGroup';
 
 export type AvatarGroupContextValue = Pick<AvatarGroupProps, 'size' | 'layout'> & {
   isOverflow?: boolean;
+  avatarCount?: number;
 };

--- a/packages/react-components/react-avatar/src/stories/AvatarGroupItem/AvatarGroupItemOverflow.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroupItem/AvatarGroupItemOverflow.stories.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { AvatarGroupItem, AvatarGroupItemProps } from '../../AvatarGroupItem';
+import { AvatarGroupContext } from '../../contexts/AvatarGroupContext';
+
+export const Overflow = (props: Partial<AvatarGroupItemProps>) => (
+  <AvatarGroupContext.Provider value={{ isOverflow: true }}>
+    <AvatarGroupItem name="Katri Athokas" {...props} />
+  </AvatarGroupContext.Provider>
+);

--- a/packages/react-components/react-avatar/src/stories/AvatarGroupItem/index.stories.beta.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroupItem/index.stories.beta.tsx
@@ -4,6 +4,7 @@ import descriptionMd from './AvatarGroupItemDescription.md';
 import bestPracticesMd from './AvatarGroupItemBestPractices.md';
 
 export { Default } from './AvatarGroupItemDefault.stories';
+export { Overflow } from './AvatarGroupItemOverflow.stories';
 
 export default {
   title: 'Preview Components/AvatarGroupItem',


### PR DESCRIPTION
This PR does the following:
* Adds styles to `AvatarGroupItem` for each layout.
* Makes it so `AvatarGroupItem` doesn't render as `<li>` anymore.
* Adds `avatarCount` to `AvatarGroupContext`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#23417 #22240 
