### PR TITLE
chore: Using ::before and ::after instead of :before and :after

### DIFF
--- a/change/@fluentui-react-avatar-1ba68c71-162c-4b9f-8630-535d9a4cf36c.json
+++ b/change/@fluentui-react-avatar-1ba68c71-162c-4b9f-8630-535d9a4cf36c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Using ::before and ::after instead of :before and :after.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-1066d1cd-c0c3-4192-b549-cb296750fb99.json
+++ b/change/@fluentui-react-divider-1066d1cd-c0c3-4192-b549-cb296750fb99.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Using ::before and ::after instead of :before and :after.",
+  "packageName": "@fluentui/react-divider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-b99bfbf7-2838-4af8-8995-0f2deacc190a.json
+++ b/change/@fluentui-react-positioning-b99bfbf7-2838-4af8-8995-0f2deacc190a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Using ::before and ::after instead of :before and :after.",
+  "packageName": "@fluentui/react-positioning",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-b3f66604-dd5a-4167-90b2-d20de51b9559.json
+++ b/change/@fluentui-react-select-b3f66604-dd5a-4167-90b2-d20de51b9559.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Using ::before and ::after instead of :before and :after.",
+  "packageName": "@fluentui/react-select",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-a36201c8-83ef-4fac-9ce4-79565421d5e6.json
+++ b/change/@fluentui-react-slider-a36201c8-83ef-4fac-9ce4-79565421d5e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Using ::before and ::after instead of :before and :after.",
+  "packageName": "@fluentui/react-slider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-1292f596-199f-4ce1-8f55-58aabf04cc25.json
+++ b/change/@fluentui-react-tabs-1292f596-199f-4ce1-8f55-58aabf04cc25.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Using ::before and ::after instead of :before and :after.",
+  "packageName": "@fluentui/react-tabs",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-9ce21a30-565f-44ef-b889-e3a4be30a145.json
+++ b/change/@fluentui-react-tabster-9ce21a30-565f-44ef-b889-e3a4be30a145.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Using ::before and ::after instead of :before and :after.",
+  "packageName": "@fluentui/react-tabster",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-575e5bf5-7a8e-41a2-bb64-db7d82cddd6a.json
+++ b/change/@fluentui-react-textarea-575e5bf5-7a8e-41a2-bb64-db7d82cddd6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Using ::before and ::after instead of :before and :after.",
+  "packageName": "@fluentui/react-textarea",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -99,7 +99,7 @@ const useStyles = makeStyles({
     transitionDuration: `${animationTiming.ultraSlow}, ${animationTiming.faster}`,
     transitionDelay: `${animations.fastEase}, ${animations.nullEasing}`,
 
-    ':before': {
+    '::before': {
       content: '""',
       position: 'absolute',
       top: 0,
@@ -115,34 +115,34 @@ const useStyles = makeStyles({
   },
 
   ring: {
-    ':before': {
+    '::before': {
       ...shorthands.borderColor(tokens.colorBrandBackgroundStatic),
       ...shorthands.borderStyle('solid'),
     },
   },
   ringThick: {
-    ':before': {
+    '::before': {
       ...shorthands.margin(`calc(-2 * ${tokens.strokeWidthThick})`),
       ...shorthands.borderWidth(tokens.strokeWidthThick),
     },
   },
   ringThicker: {
-    ':before': {
+    '::before': {
       ...shorthands.margin(`calc(-2 * ${tokens.strokeWidthThicker})`),
       ...shorthands.borderWidth(tokens.strokeWidthThicker),
     },
   },
   ringThickest: {
-    ':before': {
+    '::before': {
       ...shorthands.margin(`calc(-2 * ${tokens.strokeWidthThickest})`),
       ...shorthands.borderWidth(tokens.strokeWidthThickest),
     },
   },
 
-  shadow4: { ':before': { boxShadow: tokens.shadow4 } },
-  shadow8: { ':before': { boxShadow: tokens.shadow8 } },
-  shadow16: { ':before': { boxShadow: tokens.shadow16 } },
-  shadow28: { ':before': { boxShadow: tokens.shadow28 } },
+  shadow4: { '::before': { boxShadow: tokens.shadow4 } },
+  shadow8: { '::before': { boxShadow: tokens.shadow8 } },
+  shadow16: { '::before': { boxShadow: tokens.shadow16 } },
+  shadow28: { '::before': { boxShadow: tokens.shadow28 } },
 
   inactive: {
     opacity: '0.8',
@@ -152,7 +152,7 @@ const useStyles = makeStyles({
     transitionDuration: `${animationTiming.ultraSlow}, ${animationTiming.faster}`,
     transitionDelay: `${animations.fastOutSlowInMin}, ${animations.nullEasing}`,
 
-    ':before': {
+    '::before': {
       ...shorthands.margin(0),
       opacity: 0,
 

--- a/packages/react-components/react-divider/src/components/Divider/useDividerStyles.ts
+++ b/packages/react-components/react-divider/src/components/Divider/useDividerStyles.ts
@@ -29,13 +29,13 @@ const useBaseStyles = makeStyles({
     lineHeight: tokens.lineHeightBase200,
     textAlign: 'center',
 
-    ':before': {
+    '::before': {
       boxSizing: 'border-box',
       display: 'flex',
       flexGrow: 1,
     },
 
-    ':after': {
+    '::after': {
       boxSizing: 'border-box',
       display: 'flex',
       flexGrow: 1,
@@ -44,12 +44,12 @@ const useBaseStyles = makeStyles({
 
   // Childless styles
   childless: {
-    ':before': {
+    '::before': {
       marginBottom: 0,
       marginRight: 0,
     },
 
-    ':after': {
+    '::after': {
       marginLeft: 0,
       marginTop: 0,
     },
@@ -57,20 +57,20 @@ const useBaseStyles = makeStyles({
 
   // Alignment variations
   start: {
-    ':after': {
+    '::after': {
       content: '""',
     },
   },
   center: {
-    ':before': {
+    '::before': {
       content: '""',
     },
-    ':after': {
+    '::after': {
       content: '""',
     },
   },
   end: {
-    ':before': {
+    '::before': {
       content: '""',
     },
   },
@@ -79,44 +79,44 @@ const useBaseStyles = makeStyles({
   brand: {
     color: tokens.colorBrandForeground1,
 
-    ':before': {
+    '::before': {
       ...shorthands.borderColor(tokens.colorBrandStroke1),
     },
 
-    ':after': {
+    '::after': {
       ...shorthands.borderColor(tokens.colorBrandStroke1),
     },
   },
   default: {
     color: tokens.colorNeutralForeground2,
 
-    ':before': {
+    '::before': {
       ...shorthands.borderColor(tokens.colorNeutralStroke2),
     },
 
-    ':after': {
+    '::after': {
       ...shorthands.borderColor(tokens.colorNeutralStroke2),
     },
   },
   subtle: {
     color: tokens.colorNeutralForeground2,
 
-    ':before': {
+    '::before': {
       ...shorthands.borderColor(tokens.colorNeutralStroke3),
     },
 
-    ':after': {
+    '::after': {
       ...shorthands.borderColor(tokens.colorNeutralStroke3),
     },
   },
   strong: {
     color: tokens.colorNeutralForeground2,
 
-    ':before': {
+    '::before': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1),
     },
 
-    ':after': {
+    '::after': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1),
     },
   },
@@ -127,13 +127,13 @@ const useHorizontalStyles = makeStyles({
   base: {
     width: '100%',
 
-    ':before': {
+    '::before': {
       borderTopStyle: 'solid',
       borderTopWidth: tokens.strokeWidthThin,
       minWidth: minStartEndLength,
     },
 
-    ':after': {
+    '::after': {
       borderTopStyle: 'solid',
       borderTopWidth: tokens.strokeWidthThin,
       minWidth: minStartEndLength,
@@ -148,29 +148,29 @@ const useHorizontalStyles = makeStyles({
 
   // Alignment variations
   start: {
-    ':before': {
+    '::before': {
       content: '""',
       marginRight: contentSpacing,
       maxWidth: maxStartEndLength,
     },
 
-    ':after': {
+    '::after': {
       marginLeft: contentSpacing,
     },
   },
   center: {
-    ':before': {
+    '::before': {
       marginRight: contentSpacing,
     },
-    ':after': {
+    '::after': {
       marginLeft: contentSpacing,
     },
   },
   end: {
-    ':before': {
+    '::before': {
       marginRight: contentSpacing,
     },
-    ':after': {
+    '::after': {
       content: '""',
       marginLeft: contentSpacing,
       maxWidth: maxStartEndLength,
@@ -184,13 +184,13 @@ const useVerticalStyles = makeStyles({
     flexDirection: 'column',
     minHeight: '20px',
 
-    ':before': {
+    '::before': {
       borderRightStyle: 'solid',
       borderRightWidth: tokens.strokeWidthThin,
       minHeight: minStartEndLength,
     },
 
-    ':after': {
+    '::after': {
       borderRightStyle: 'solid',
       borderRightWidth: tokens.strokeWidthThin,
       minHeight: minStartEndLength,
@@ -210,29 +210,29 @@ const useVerticalStyles = makeStyles({
 
   // Alignment variations
   start: {
-    ':before': {
+    '::before': {
       content: '""',
       marginBottom: contentSpacing,
       maxHeight: maxStartEndLength,
     },
 
-    ':after': {
+    '::after': {
       marginTop: contentSpacing,
     },
   },
   center: {
-    ':before': {
+    '::before': {
       marginBottom: contentSpacing,
     },
-    ':after': {
+    '::after': {
       marginTop: contentSpacing,
     },
   },
   end: {
-    ':before': {
+    '::before': {
       marginBottom: contentSpacing,
     },
-    ':after': {
+    '::after': {
       content: '""',
       marginTop: contentSpacing,
       maxHeight: maxStartEndLength,

--- a/packages/react-components/react-divider/src/stories/DividerCustomStyles.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/DividerCustomStyles.stories.tsx
@@ -34,20 +34,20 @@ const useStyles = makeStyles({
     fontWeight: 'bold',
   },
   customLineColor: {
-    ':before': {
+    '::before': {
       ...shorthands.borderColor(tokens.colorPaletteRedBorder2),
     },
-    ':after': {
+    '::after': {
       ...shorthands.borderColor(tokens.colorPaletteRedBorder2),
     },
   },
   customLineStyle: {
     ...shorthands.borderWidth('2px'),
-    ':before': {
+    '::before': {
       borderTopStyle: 'dashed',
       borderTopWidth: '2px',
     },
-    ':after': {
+    '::after': {
       borderTopStyle: 'dashed',
       borderTopWidth: '2px',
     },

--- a/packages/react-components/react-positioning/src/createArrowStyles.ts
+++ b/packages/react-components/react-positioning/src/createArrowStyles.ts
@@ -74,7 +74,7 @@ export function createArrowStyles(options: CreateArrowStylesOptions): GriffelSty
 
     ...(arrowHeight && createArrowHeightStyles(arrowHeight)),
 
-    ':before': {
+    '::before': {
       content: '""',
       visibility: 'visible',
       position: 'absolute',

--- a/packages/react-components/react-select/src/components/Select/useSelectStyles.ts
+++ b/packages/react-components/react-select/src/components/Select/useSelectStyles.ts
@@ -42,7 +42,7 @@ const useRootStyles = makeStyles({
     fontFamily: tokens.fontFamilyBase,
     position: 'relative',
 
-    '&:after': {
+    '&::after': {
       backgroundImage: `linear-gradient(
         0deg,
         ${tokens.colorCompoundBrandStroke} 0%,

--- a/packages/react-components/react-slider/src/components/Slider/useSliderStyles.ts
+++ b/packages/react-components/react-slider/src/components/Slider/useSliderStyles.ts
@@ -131,7 +131,7 @@ const useRailStyles = makeStyles({
     outlineWidth: '1px',
     outlineStyle: 'solid',
     outlineColor: tokens.colorTransparentStroke,
-    ':before': {
+    '::before': {
       content: "''",
       position: 'absolute',
       // Repeating gradient represents the steps if provided
@@ -158,7 +158,7 @@ const useRailStyles = makeStyles({
   horizontal: {
     width: '100%',
     height: `var(${railSizeVar})`,
-    ':before': {
+    '::before': {
       left: '-1px',
       right: '-1px',
       height: `var(${railSizeVar})`,
@@ -168,7 +168,7 @@ const useRailStyles = makeStyles({
   vertical: {
     width: `var(${railSizeVar})`,
     height: '100%',
-    ':before': {
+    '::before': {
       width: `var(${railSizeVar})`,
       top: '-1px',
       bottom: '1px',
@@ -191,7 +191,7 @@ const useThumbStyles = makeStyles({
     boxShadow: `0 0 0 calc(var(${thumbSizeVar}) * .2) ${tokens.colorNeutralBackground1} inset`,
     backgroundColor: `var(${thumbColorVar})`,
     transform: 'translateX(-50%)',
-    ':before': {
+    '::before': {
       position: 'absolute',
       top: '0px',
       left: '0px',
@@ -204,7 +204,7 @@ const useThumbStyles = makeStyles({
     },
   },
   disabled: {
-    ':before': {
+    '::before': {
       ...shorthands.border(`calc(var(${thumbSizeVar}) * .05)`, 'solid', tokens.colorNeutralForegroundDisabled),
     },
   },

--- a/packages/react-components/react-tabs/src/components/Tab/useTabAnimatedIndicator.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTabAnimatedIndicator.ts
@@ -19,27 +19,27 @@ const useActiveIndicatorStyles = makeStyles({
     ...shorthands.overflow('visible'),
   },
   animated: {
-    ':after': {
+    '::after': {
       transitionProperty: 'transform',
       transitionDuration: `${tokens.durationSlow}`,
       transitionTimingFunction: `${tokens.curveDecelerateMax}`,
     },
     '@media (prefers-reduced-motion: reduce)': {
-      ':after': {
+      '::after': {
         transitionProperty: 'none',
         transitionDuration: '0.01ms',
       },
     },
   },
   horizontal: {
-    ':after': {
+    '::after': {
       transformOrigin: 'left',
       transform: `translateX(var(${tabIndicatorCssVars_unstable.offsetVar}))
     scaleX(var(${tabIndicatorCssVars_unstable.scaleVar}))`,
     },
   },
   vertical: {
-    ':after': {
+    '::after': {
       transformOrigin: 'top',
       transform: `translateY(var(${tabIndicatorCssVars_unstable.offsetVar}))
         scaleY(var(${tabIndicatorCssVars_unstable.scaleVar}))`,

--- a/packages/react-components/react-tabster/src/focus/createFocusOutlineStyle.ts
+++ b/packages/react-components/react-tabster/src/focus/createFocusOutlineStyle.ts
@@ -39,7 +39,7 @@ const getFocusOutlineStyles = (options: FocusOutlineStyleOptions): GriffelStyle 
 
   return {
     ...shorthands.borderColor('transparent'),
-    ':after': {
+    '::after': {
       content: '""',
       position: 'absolute',
       pointerEvents: 'none',

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
@@ -71,14 +71,14 @@ const useRootStyles = makeStyles({
       transitionDuration: tokens.durationUltraFast,
       transitionDelay: tokens.curveAccelerateMid,
     },
-    ':focus-within:after': {
+    ':focus-within::after': {
       // Animation for focus IN
       transform: 'scaleX(1)',
       transitionProperty: 'transform',
       transitionDuration: tokens.durationNormal,
       transitionDelay: tokens.curveDecelerateMid,
     },
-    ':focus-within:active:after': {
+    ':focus-within:active::after': {
       // This is if the user clicks the field again while it's already focused
       borderBottomColor: tokens.colorCompoundBrandStrokePressed,
     },

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
@@ -42,7 +42,7 @@ const useRootStyles = makeStyles({
   interactive: {
     // This is all for the bottom focus border.
     // It's supposed to be 2px flat all the way across and match the radius of the field's corners.
-    ':after': {
+    '::after': {
       boxSizing: 'border-box',
       content: '""',
       position: 'absolute',


### PR DESCRIPTION
## Current Behavior

Some components in `@fluentui/react-components` are still using the older `:before` and `:after` syntax, which is fine, however we should try to wholesale use the newer `::before` and `::after`.

## New Behavior

All components in `@fluentui/react-components` use the newer `::before` and `::after` syntax.