### PR TITLE
fix(react-textarea): Adding missing spacing, min-height, and font family styles

### DIFF
--- a/change/@fluentui-react-textarea-089c5471-7d76-4622-b1a9-70af572fb526.json
+++ b/change/@fluentui-react-textarea-089c5471-7d76-4622-b1a9-70af572fb526.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Adding missing spacing to top+bottom padding, font family to large variant, and min-height to size variants.",
+  "comment": "fix: Adding missing spacing to top+bottom padding, font family to large variant, and min-height to size variants.",
   "packageName": "@fluentui/react-textarea",
   "email": "esteban.230@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-textarea-089c5471-7d76-4622-b1a9-70af572fb526.json
+++ b/change/@fluentui-react-textarea-089c5471-7d76-4622-b1a9-70af572fb526.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding missing spacing to top+bottom padding, font family to large variant, and min-height to size variants.",
+  "packageName": "@fluentui/react-textarea",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
@@ -154,8 +154,6 @@ const useTextareaStyles = makeStyles({
     minHeight: '40px',
     ...shorthands.padding(
       tokens.spacingVerticalXS,
-      `calc(${tokens.spacingHorizontalMNudge} + ${tokens.spacingHorizontalXXS})`,
-      tokens.spacingVerticalXS,
       `calc(${tokens.spacingHorizontalSNudge} + ${tokens.spacingHorizontalXXS})`,
     ),
     ...typographyStyles.caption1,

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
@@ -1,7 +1,7 @@
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
-import type { TextareaSlots, TextareaState } from './Textarea.types';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
 import { SlotClassNames } from '@fluentui/react-utilities';
+import type { TextareaSlots, TextareaState } from './Textarea.types';
 
 export const textareaClassNames: SlotClassNames<TextareaSlots> = {
   root: 'fui-Textarea',
@@ -132,6 +132,7 @@ const useTextareaStyles = makeStyles({
     backgroundColor: 'transparent',
     color: tokens.colorNeutralForeground1,
     flexGrow: 1,
+    fontFamily: tokens.fontFamilyBase,
 
     '::placeholder': {
       color: tokens.colorNeutralForeground4,
@@ -150,22 +151,31 @@ const useTextareaStyles = makeStyles({
   // affected by changing the padding of the root.
   small: {
     height: textareaHeight.small,
+    minHeight: '40px',
     ...shorthands.padding(
-      '0',
+      tokens.spacingVerticalXS,
       `calc(${tokens.spacingHorizontalMNudge} + ${tokens.spacingHorizontalXXS})`,
-      '0',
+      tokens.spacingVerticalXS,
       `calc(${tokens.spacingHorizontalSNudge} + ${tokens.spacingHorizontalXXS})`,
     ),
     ...typographyStyles.caption1,
   },
   medium: {
     height: textareaHeight.medium,
-    ...shorthands.padding('0', `calc(${tokens.spacingHorizontalMNudge} + ${tokens.spacingHorizontalXXS})`),
+    minHeight: '52px',
+    ...shorthands.padding(
+      tokens.spacingVerticalSNudge,
+      `calc(${tokens.spacingHorizontalMNudge} + ${tokens.spacingHorizontalXXS})`,
+    ),
     ...typographyStyles.body1,
   },
   large: {
     height: textareaHeight.large,
-    ...shorthands.padding('0', `calc(${tokens.spacingHorizontalM} + ${tokens.spacingHorizontalXXS})`),
+    minHeight: '64px',
+    ...shorthands.padding(
+      tokens.spacingVerticalS,
+      `calc(${tokens.spacingHorizontalM} + ${tokens.spacingHorizontalXXS})`,
+    ),
     fontSize: tokens.fontSizeBase400,
     lineHeight: tokens.lineHeightBase400,
   },


### PR DESCRIPTION
## Current Behavior

Textarea doesn't have the following styles:
- `min-height` for all size variants.
- Correct font family for `large` variant.
- Vertical padding.

<img width="651" alt="image" src="https://user-images.githubusercontent.com/5953191/172917684-5c815db0-a7b9-49d2-8d66-cd923489f6f6.png">
<img width="653" alt="image" src="https://user-images.githubusercontent.com/5953191/172917780-3a945888-e911-4cac-86c2-c8fc7bcd9013.png">
<img width="652" alt="image" src="https://user-images.githubusercontent.com/5953191/172917931-84285ac9-379e-457c-93f8-634f3f2cd66e.png">


## New Behavior

Textarea now has:
- `min-height` for all size variants.
- Correct font family for `large` variant.
- Vertical padding.

<img width="663" alt="image" src="https://user-images.githubusercontent.com/5953191/172917211-502401a5-99b3-48c2-9d43-8d6cea2cf91a.png">
<img width="660" alt="image" src="https://user-images.githubusercontent.com/5953191/172917285-1af02cf2-ef5c-44e4-b674-beb9824a1c94.png">
<img width="651" alt="image" src="https://user-images.githubusercontent.com/5953191/172917517-ffcc1854-96a6-4ca3-8966-85536c95e233.png">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23476
