### PR TITLE
docs: README, spec and migration guide cleanup for react-label

### DIFF
--- a/change/@fluentui-react-label-7c91e6ff-b4fa-4503-9f9c-2b70f5a62d15.json
+++ b/change/@fluentui-react-label-7c91e6ff-b4fa-4503-9f9c-2b70f5a62d15.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: README, spec and migration guide cleanup for react-label.",
+  "packageName": "@fluentui/react-label",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-label/MIGRATION.md
+++ b/packages/react-components/react-label/MIGRATION.md
@@ -1,19 +1,15 @@
 # Label Migration
 
-## STATUS: WIP
-
-This Migration guide is a work in progress and is not yet ready for use.
-
 ## Migration from v8
 
 - `Label`
-  - `componentRef` => Not supported.
+  - `componentRef` => Not supported. Consider using `ref` instead.
   - `disabled` => `disabled`.
   - `required` => `required`.
 
 ## Migration from v0
 
-The converged API does not support many of the features offered in v0. Some could potentially by addressed by already made slots or by adding either the additional features or more slots if needed.
+The v9 API does not support many of the features offered in v0. Some could potentially be addressed by using the already existing slots or by adding either the additional features or more slots if needed.
 
 - `Label`
   - `circular` => Not supported. Consider using `Badge` component.
@@ -23,3 +19,20 @@ The converged API does not support many of the features offered in v0. Some coul
   - `fluid` => Not supported. Use CSS styling such as flex-grow.
   - `icon`, `iconPosition` => Not supported. Consider using `Badge` component or add as a child.
   - `image`, `imagePosition` => Not supported. Add as a child.
+
+## Property mapping
+
+| v8 `Label`     | v0 `Label`      | v9 `Label` |
+| -------------- | --------------- | ---------- |
+| `children`     | `content`       | `children` |
+|                | `circular`      |            |
+|                | `color`         |            |
+| `componentRef` | `ref`           | `ref`      |
+|                | `design`        |            |
+| `disabled`     |                 | `disabled` |
+|                | `fluid`         |            |
+|                | `icon`          |            |
+|                | `iconPosition`  |            |
+|                | `image`         |            |
+|                | `imagePosition` |            |
+| `required`     |                 | `required` |

--- a/packages/react-components/react-label/README.md
+++ b/packages/react-components/react-label/README.md
@@ -1,14 +1,18 @@
 # @fluentui/react-label
 
-**React Label components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+**Label components for [Fluent UI React](https://aka.ms/fluentui-storybook)**
 
 Labels provide a name or title to a component or group of components, e.g., text fields, checkboxes, radio buttons, and dropdown menus.
 
 ## Usage
 
-To use the `Label` component import it from `@fluentui/react-components` and use it as shown below.
+To import `Label`:
+
+```js
+import { Label } from '@fluentui/react-components';
+```
+
+### Examples
 
 ```tsx
 import * as React from 'react';
@@ -39,3 +43,7 @@ Alternatively, run Storybook locally with:
 ### Specification
 
 See [Spec.md](./Spec.md).
+
+### Migration Guide
+
+If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest Label implementation.

--- a/packages/react-components/react-label/Spec.md
+++ b/packages/react-components/react-label/Spec.md
@@ -16,14 +16,15 @@ Labels provide a name or title to a component or group of components, e.g., text
 ```
 
 Props used in v8 Label:
-|Prop|Description|
-|---|---|
-|as|Element type to render Label as|
-|componentRef|Optional callback to access the ILabel interface. Use this instead of ref for accessing the public methods and properties of the component|
-|disabled|Renders label as disabled, changing the Label's foreground color|
-|required|Renders an asterisk next to the given text|
-|styles|Custom styles for the Label|
-|theme|Theme provided by HOC|
+
+| Prop         | Description                                                                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| as           | Element type to render Label as                                                                                                            |
+| componentRef | Optional callback to access the ILabel interface. Use this instead of ref for accessing the public methods and properties of the component |
+| disabled     | Renders label as disabled, changing the Label's foreground color                                                                           |
+| required     | Renders an asterisk next to the given text                                                                                                 |
+| styles       | Custom styles for the Label                                                                                                                |
+| theme        | Theme provided by HOC                                                                                                                      |
 
 ### Label in Northstar/v0
 
@@ -32,21 +33,22 @@ Props used in v8 Label:
 ```
 
 Props used in v0 Label:
-|Prop|Description|
-|---|---|
-|accessibility| Prop to override accessibility behavior|
-|as|Element type to render Label as|
-|circular|Renders Label with round corners|
-|className|Additional CSS class name to apply|
-|color|Color for the background of the label|
-|content|Label content|
-|fluid|Make it so Label takes the width of its container|
-|icon|Adds an icon to the label|
-|iconPosition|Choose where the icon is placed (Start or End)|
-|image|Adds an image to the label|
-|imagePosition|Choose where the image is placed (Start or End)|
-|styles|Additional custom styles for the component|
-|variables|Allows override of theme variables|
+
+| Prop          | Description                                       |
+| ------------- | ------------------------------------------------- |
+| accessibility | Prop to override accessibility behavior           |
+| as            | Element type to render Label as                   |
+| circular      | Renders Label with round corners                  |
+| className     | Additional CSS class name to apply                |
+| color         | Color for the background of the label             |
+| content       | Label content                                     |
+| fluid         | Make it so Label takes the width of its container |
+| icon          | Adds an icon to the label                         |
+| iconPosition  | Choose where the icon is placed (Start or End)    |
+| image         | Adds an image to the label                        |
+| imagePosition | Choose where the image is placed (Start or End)   |
+| styles        | Additional custom styles for the component        |
+| variables     | Allows override of theme variables                |
 
 ### Conclusion
 
@@ -74,50 +76,7 @@ The Label component should be simple as shown below. It will just need the text 
 
 ## API
 
-```ts
-export type LabelCommons = {
-  /**
-   * Renders the label as disabled
-   * @default false
-   */
-  disabled: boolean;
-
-  /**
-   * A label supports different sizes.
-   * @default 'medium'
-   */
-  size: 'small' | 'medium' | 'large';
-
-  /**
-   * A label supports semibold/strong fontweight.
-   * @default false
-   */
-  strong: boolean;
-};
-
-export type LabelSlots = {
-  root: IntrinsicSlotProps<'label'>;
-  required?: IntrinsicSlotProps<'span'>;
-};
-
-/**
- * State used in rendering Label
- */
-export type LabelState = ComponentState<LabelSlots> & LabelCommons;
-
-/**
- * Label Props
- */
-export type LabelProps = Omit<ComponentProps<LabelSlots>, 'required'> &
-  Partial<LabelCommons> & {
-    /**
-     * Displays an indicator that the label is for a required field. The required prop can be set to true to display
-     * an asterisk (*). Or it can be set to a string or jsx content to display a different indicator.
-     * @default false
-     */
-    required?: boolean | Slot<'span'>;
-  };
-```
+See API at [Label.types.ts](./src/components/Label/Label.types.ts).
 
 ## Structure
 


### PR DESCRIPTION
## PR Description

This PR cleans up a bunch of things in `react-label`:
- It updates the migration guide to remove WIP warnings, add better wording and a property mapping table between v8, v0 and v9.
- The README is updated to remove WIP warnings and add links to the migration guide.
- The spec is updated to properly format tables and add a link to the types file.

Fixes part of #23423.