### PR TITLE
Selectionzone/keyboard options

### DIFF
--- a/apps/public-docsite-resources/src/AppDefinition.tsx
+++ b/apps/public-docsite-resources/src/AppDefinition.tsx
@@ -217,6 +217,13 @@ export const AppDefinition: IAppDefinition = {
               name: 'DetailsList - Keyboard Column Reorder & Resize',
               url: '#/examples/detailslist/keyboardcolumnreorderresize',
             },
+            {
+              component: require<any>('./components/pages/DetailsList/DetailsListKeyboardOverridesPage')
+                .DetailsListKeyboardOverridesPage,
+              key: 'DetailsList - Keyboard Overrides',
+              name: 'DetailsList - Keyboard Overrides',
+              url: '#/examples/detailslist/keyboardoverrides',
+            },
           ],
         },
         {

--- a/apps/public-docsite-resources/src/components/pages/DetailsList/DetailsListKeyboardOverridesPage.tsx
+++ b/apps/public-docsite-resources/src/components/pages/DetailsList/DetailsListKeyboardOverridesPage.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { DemoPage } from '../../DemoPage';
+import { DetailsListKeyboardOverridesProps } from '@fluentui/react-examples/lib/react/DetailsList/DetailsList.doc';
+
+export const DetailsListKeyboardOverridesPage = (props: { isHeaderVisible: boolean }) => (
+  <DemoPage {...{ ...DetailsListKeyboardOverridesProps, ...props }} />
+);

--- a/apps/public-docsite/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/public-docsite/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -63,6 +63,7 @@ export const categories: { Other?: ICategory; [name: string]: ICategory } = {
         CustomGroupHeaders: { title: 'Custom Group Headers' },
         Advanced: { title: 'Variable Row Heights', url: 'variablerowheights' },
         KeyboardDragDrop: { title: 'Keyboard Column Reorder & Resize', url: 'keyboardcolumnreorderresize' },
+        KeyboardOverrides: { title: 'Keyboard Overrides', url: 'keyboardoverrides' },
         DragDrop: { title: 'Drag & Drop', url: 'draganddrop' },
         NavigatingFocus: { title: 'Inner Navigation', url: 'innernavigation' },
         Shimmer: {},

--- a/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListKeyboardOverrides.doc.ts
+++ b/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListKeyboardOverrides.doc.ts
@@ -1,0 +1,9 @@
+import { TFabricPlatformPageProps } from '../../../interfaces/Platforms';
+import { DetailsListKeyboardOverridesProps as ExternalProps } from '@fluentui/react-examples/lib/react/DetailsList/DetailsList.doc';
+
+export const DetailsListKeyboardOverridesProps: TFabricPlatformPageProps = {
+  web: {
+    ...(ExternalProps as any),
+    title: 'DetailsList - Keyboard Overrides',
+  },
+};

--- a/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListKeyboardOverridesPage.tsx
+++ b/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListKeyboardOverridesPage.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { ControlsAreaPage, IControlsPageProps } from '../ControlsAreaPage';
+import { DetailsListKeyboardOverridesProps } from './DetailsListKeyboardOverrides.doc';
+
+export const DetailsListKeyboardOverrides: React.FunctionComponent<IControlsPageProps> = props => {
+  return <ControlsAreaPage {...props} {...DetailsListKeyboardOverridesProps[props.platform]} />;
+};

--- a/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListKeyboardOverridesPage.tsx
+++ b/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListKeyboardOverridesPage.tsx
@@ -2,6 +2,6 @@ import * as React from 'react';
 import { ControlsAreaPage, IControlsPageProps } from '../ControlsAreaPage';
 import { DetailsListKeyboardOverridesProps } from './DetailsListKeyboardOverrides.doc';
 
-export const DetailsListKeyboardOverrides: React.FunctionComponent<IControlsPageProps> = props => {
+export const DetailsListKeyboardOverridesPage: React.FunctionComponent<IControlsPageProps> = props => {
   return <ControlsAreaPage {...props} {...DetailsListKeyboardOverridesProps[props.platform]} />;
 };

--- a/change/@fluentui-react-2ae81a6f-7d4e-4fe1-9742-64b0451d857b.json
+++ b/change/@fluentui-react-2ae81a6f-7d4e-4fe1-9742-64b0451d857b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: adds keyboard overrides to SelectionZone and DetailsList",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardOverrides.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardOverrides.Example.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import { Announced } from '@fluentui/react/lib/Announced';
+import { TextField, ITextFieldStyles } from '@fluentui/react/lib/TextField';
+import { DetailsList, DetailsListLayoutMode, Selection, IColumn } from '@fluentui/react/lib/DetailsList';
+import { MarqueeSelection } from '@fluentui/react/lib/MarqueeSelection';
+import { mergeStyles } from '@fluentui/react/lib/Styling';
+import { Text } from '@fluentui/react/lib/Text';
+
+const exampleChildClass = mergeStyles({
+  display: 'block',
+  marginBottom: '10px',
+});
+
+const textFieldStyles: Partial<ITextFieldStyles> = { root: { maxWidth: '300px' } };
+
+export interface IDetailsListBasicExampleItem {
+  key: number;
+  name: string;
+  value: number;
+}
+
+export interface IDetailsListBasicExampleState {
+  items: IDetailsListBasicExampleItem[];
+  selectionDetails: string;
+}
+
+export class DetailsListKeyboardOverridesExample extends React.Component<{}, IDetailsListBasicExampleState> {
+  private _selection: Selection;
+  private _allItems: IDetailsListBasicExampleItem[];
+  private _columns: IColumn[];
+
+  constructor(props: {}) {
+    super(props);
+
+    this._selection = new Selection({
+      onSelectionChanged: () => this.setState({ selectionDetails: this._getSelectionDetails() }),
+    });
+
+    // Populate with items for demos.
+    this._allItems = [];
+    for (let i = 0; i < 200; i++) {
+      this._allItems.push({
+        key: i,
+        name: 'Item ' + i,
+        value: i,
+      });
+    }
+
+    this._columns = [
+      { key: 'column1', name: 'Name', fieldName: 'name', minWidth: 100, maxWidth: 200, isResizable: true },
+      { key: 'column2', name: 'Value', fieldName: 'value', minWidth: 100, maxWidth: 200, isResizable: true },
+    ];
+
+    this.state = {
+      items: this._allItems,
+      selectionDetails: this._getSelectionDetails(),
+    };
+  }
+
+  public render(): JSX.Element {
+    const { items, selectionDetails } = this.state;
+
+    return (
+      <div>
+        <div className={exampleChildClass}>{selectionDetails}</div>
+        <Text block>
+          This example overrides the default keyboard selection behavior by setting isSelectedOnFocus=false. This
+          prevents the first item from being automatically selected when moving from the header to the main list content
+          via keyboard, allows the arrow keys to focus different rows without selecting those rows, and allows the space
+          key to toggle selected items without a modifier like the ctrl or meta key.
+        </Text>
+        <Text block>
+          Note: While focusing a row, pressing enter or double clicking will execute onItemInvoked, which in this
+          example will show an alert.
+        </Text>
+        <Announced message={selectionDetails} />
+        <TextField
+          className={exampleChildClass}
+          label="Filter by name:"
+          onChange={this._onFilter}
+          styles={textFieldStyles}
+        />
+        <Announced message={`Number of items after filter applied: ${items.length}.`} />
+        <MarqueeSelection selection={this._selection}>
+          <DetailsList
+            items={items}
+            columns={this._columns}
+            setKey="set"
+            layoutMode={DetailsListLayoutMode.justified}
+            selection={this._selection}
+            selectionPreservedOnEmptyClick={true}
+            isSelectedOnFocus={false}
+            ariaLabelForSelectionColumn="Toggle selection"
+            ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+            checkButtonAriaLabel="select row"
+            onItemInvoked={this._onItemInvoked}
+          />
+        </MarqueeSelection>
+      </div>
+    );
+  }
+
+  private _getSelectionDetails(): string {
+    const selectionCount = this._selection.getSelectedCount();
+
+    switch (selectionCount) {
+      case 0:
+        return 'No items selected';
+      case 1:
+        return '1 item selected: ' + (this._selection.getSelection()[0] as IDetailsListBasicExampleItem).name;
+      default:
+        return `${selectionCount} items selected`;
+    }
+  }
+
+  private _onFilter = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string): void => {
+    this.setState({
+      items: text ? this._allItems.filter(i => i.name.toLowerCase().indexOf(text) > -1) : this._allItems,
+    });
+  };
+
+  private _onItemInvoked = (item: IDetailsListBasicExampleItem): void => {
+    alert(`Item invoked: ${item.name}`);
+  };
+}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.doc.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.doc.tsx
@@ -50,6 +50,9 @@ const DetailsListCustomFooterExampleCode = require('!raw-loader?esModule=false!@
 import { DetailsListKeyboardAccessibleResizeAndReorderExample } from './DetailsList.KeyboardAccessibleResizeAndReorder.Example';
 const DetailsListKeyboardAccessibleResizeAndReorderExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx') as string;
 
+import { DetailsListKeyboardOverridesExample } from './DetailsList.KeyboardOverrides.Example';
+const DetailsListKeyboardOverridesExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/DetailsList/DetailsList.KeyboardOverrides.Example.tsx') as string;
+
 export const DetailsListPageProps: IDocPageProps = {
   title: 'DetailsList',
   componentName: 'DetailsList',
@@ -165,4 +168,10 @@ export const DetailsListKeyboardAccessibleResizeAndReorderProps: IDocPageProps =
   title: 'Keyboard-accessible column reordering and resizing',
   code: DetailsListKeyboardAccessibleResizeAndReorderExampleCode,
   view: <DetailsListKeyboardAccessibleResizeAndReorderExample />,
+});
+
+export const DetailsListKeyboardOverridesProps: IDocPageProps = generateProps({
+  title: 'Keyboard overrides for selection',
+  code: DetailsListKeyboardOverridesExampleCode,
+  view: <DetailsListKeyboardOverridesExample />,
 });

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -8118,9 +8118,11 @@ export interface ISelectionZoneProps extends React_2.ClassAttributes<SelectionZo
     onItemContextMenu?: (item?: any, index?: number, ev?: Event) => void | boolean;
     onItemInvoked?: (item?: IObjectWithKey, index?: number, ev?: Event) => void;
     selection: ISelection;
+    selectionClearedOnEscapePress?: boolean;
     selectionClearedOnSurfaceClick?: boolean;
     selectionMode?: SelectionMode_2;
     selectionPreservedOnEmptyClick?: boolean;
+    toggleWithoutModifierPressed?: boolean;
 }
 
 // @public (undocumented)
@@ -10431,7 +10433,9 @@ export class SelectionZone extends React_2.Component<ISelectionZoneProps, ISelec
     // (undocumented)
     static defaultProps: {
         isSelectedOnFocus: boolean;
+        toggleWithoutModifierPressed: boolean;
         selectionMode: SelectionMode_2;
+        selectionClearedOnEscapePress: boolean;
     };
     // (undocumented)
     static getDerivedStateFromProps(nextProps: ISelectionZoneProps, prevState: ISelectionZoneState): ISelectionZoneState;

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -724,6 +724,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
               selectionMode={selectionMode}
               isSelectedOnFocus={isSelectedOnFocus}
               selectionClearedOnEscapePress={isSelectedOnFocus}
+              toggleWithoutModifierPressed={!isSelectedOnFocus}
               onItemInvoked={onItemInvoked}
               onItemContextMenu={onItemContextMenu}
               enterModalOnTouch={enterModalSelectionOnTouch}

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -723,6 +723,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
               selectionPreservedOnEmptyClick={selectionPreservedOnEmptyClick}
               selectionMode={selectionMode}
               isSelectedOnFocus={isSelectedOnFocus}
+              selectionClearedOnEscapePress={isSelectedOnFocus}
               onItemInvoked={onItemInvoked}
               onItemContextMenu={onItemContextMenu}
               enterModalOnTouch={enterModalSelectionOnTouch}

--- a/packages/react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.test.tsx
@@ -406,6 +406,65 @@ describe('DetailsList', () => {
     );
   });
 
+  it('clears selection when escape key is pressed and isSelectedOnFocus is `true`', () => {
+    jest.useFakeTimers();
+
+    let component: IDetailsList | null;
+    const onSelectionChanged = jest.fn();
+    const selection = new Selection({
+      onSelectionChanged,
+    });
+    safeMount(
+      <DetailsList
+        componentRef={ref => (component = ref)}
+        items={mockData(5)}
+        selection={selection}
+        skipViewportMeasures={true}
+        onShouldVirtualize={() => false}
+      />,
+      wrapper => {
+        expect(component).toBeTruthy();
+        selection.setAllSelected(true);
+        jest.runAllTimers();
+
+        onSelectionChanged.mockClear();
+        wrapper.find('.ms-SelectionZone').simulate('keyDown', { which: KeyCodes.escape });
+        expect(onSelectionChanged).toHaveBeenCalledTimes(1);
+        expect(selection.getSelectedCount()).toEqual(0);
+      },
+    );
+  });
+
+  it('does not clear selection when escape key is pressed and isSelectedOnFocus is `false`', () => {
+    jest.useFakeTimers();
+
+    let component: IDetailsList | null;
+    const onSelectionChanged = jest.fn();
+    const selection = new Selection({
+      onSelectionChanged,
+    });
+    safeMount(
+      <DetailsList
+        componentRef={ref => (component = ref)}
+        items={mockData(5)}
+        selection={selection}
+        skipViewportMeasures={true}
+        onShouldVirtualize={() => false}
+        isSelectedOnFocus={false}
+      />,
+      wrapper => {
+        expect(component).toBeTruthy();
+        selection.setAllSelected(true);
+        jest.runAllTimers();
+
+        onSelectionChanged.mockClear();
+        wrapper.find('.ms-SelectionZone').simulate('keyDown', { which: KeyCodes.escape });
+        expect(onSelectionChanged).toHaveBeenCalledTimes(0);
+        expect(selection.getSelectedCount()).toEqual(5);
+      },
+    );
+  });
+
   it('invokes optional onRenderMissingItem prop once per missing item rendered', () => {
     const onRenderMissingItem = jest.fn();
     const items = [...mockData(5), null, null];

--- a/packages/react/src/utilities/selection/SelectionZone.test.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.test.tsx
@@ -34,11 +34,13 @@ function _initializeSelection(props?: {
   selectionMode?: SelectionMode;
   enableTouchInvocationTarget?: boolean;
   selectionClearedOnEscapePress?: boolean;
+  toggleWithoutModifierPressed?: boolean;
 }): void {
   const {
     selectionMode = SelectionMode.multiple,
     enableTouchInvocationTarget = false,
     selectionClearedOnEscapePress = true,
+    toggleWithoutModifierPressed = false,
   } = props || {};
 
   _selection = new Selection();
@@ -48,6 +50,7 @@ function _initializeSelection(props?: {
       selection={_selection}
       selectionMode={selectionMode}
       selectionClearedOnEscapePress={selectionClearedOnEscapePress}
+      toggleWithoutModifierPressed={toggleWithoutModifierPressed}
       disableAutoSelectOnInputElements={true}
       enterModalOnTouch={true}
       enableTouchInvocationTarget={enableTouchInvocationTarget}
@@ -386,6 +389,21 @@ describe('SelectionZone - override default keyboard behavior', () => {
       _selection.setAllSelected(true);
       ReactTestUtils.Simulate.keyDown(_componentElement, { which: KeyCodes.escape });
       expect(_selection.getSelectedCount()).toEqual(5);
+    });
+  });
+
+  describe('toggle modifier', () => {
+    beforeEach(() => {
+      _initializeSelection({
+        toggleWithoutModifierPressed: true,
+      });
+    });
+
+    it('toggles value when pressing space key without a modifier key', () => {
+      ReactTestUtils.Simulate.keyDown(_surface0, { which: KeyCodes.space });
+      expect(_selection.isIndexSelected(0)).toEqual(true);
+      ReactTestUtils.Simulate.keyDown(_surface0, { which: KeyCodes.space });
+      expect(_selection.isIndexSelected(0)).toEqual(false);
     });
   });
 });

--- a/packages/react/src/utilities/selection/SelectionZone.test.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.test.tsx
@@ -30,8 +30,16 @@ let _invoke4: Element;
 let _onItemInvokeCalled: number;
 let _lastItemInvoked: any;
 
-function _initializeSelection(props?: { selectionMode?: SelectionMode; enableTouchInvocationTarget?: boolean }): void {
-  const { selectionMode = SelectionMode.multiple, enableTouchInvocationTarget = false } = props || {};
+function _initializeSelection(props?: {
+  selectionMode?: SelectionMode;
+  enableTouchInvocationTarget?: boolean;
+  selectionClearedOnEscapePress?: boolean;
+}): void {
+  const {
+    selectionMode = SelectionMode.multiple,
+    enableTouchInvocationTarget = false,
+    selectionClearedOnEscapePress = true,
+  } = props || {};
 
   _selection = new Selection();
   _selection.setItems(SELECTABLE_ITEMS);
@@ -39,6 +47,7 @@ function _initializeSelection(props?: { selectionMode?: SelectionMode; enableTou
     <SelectionZone
       selection={_selection}
       selectionMode={selectionMode}
+      selectionClearedOnEscapePress={selectionClearedOnEscapePress}
       disableAutoSelectOnInputElements={true}
       enterModalOnTouch={true}
       enableTouchInvocationTarget={enableTouchInvocationTarget}
@@ -361,6 +370,22 @@ describe('SelectionZone - disabled touch targets', () => {
 
       ReactTestUtils.Simulate.click(_invoke4);
       expect(_onItemInvokeCalled).toEqual(0);
+    });
+  });
+});
+
+describe('SelectionZone - override default keyboard behavior', () => {
+  describe('escape key', () => {
+    beforeEach(() => {
+      _initializeSelection({
+        selectionClearedOnEscapePress: false,
+      });
+    });
+
+    it('does not unselect all on escape when selectionClearedOnEscapePress is false', () => {
+      _selection.setAllSelected(true);
+      ReactTestUtils.Simulate.keyDown(_componentElement, { which: KeyCodes.escape });
+      expect(_selection.getSelectedCount()).toEqual(5);
     });
   });
 });

--- a/packages/react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.tsx
@@ -104,6 +104,13 @@ export interface ISelectionZoneProps extends React.ClassAttributes<SelectionZone
    * @defaultvalue true
    */
   selectionClearedOnSurfaceClick?: boolean;
+
+  /**
+   * Determines if pressing the Escape clears the selection.
+   *
+   * @defaultvalue true
+   */
+  selectionClearedOnEscapePress?: boolean;
   /**
    * Optional callback for when an item is
    * invoked via ENTER or double-click.
@@ -487,7 +494,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
 
     const isSelectionDisabled = this._isSelectionDisabled(target);
 
-    const { selection } = this.props;
+    const { selection, selectionClearedOnEscapePress } = this.props;
     // eslint-disable-next-line deprecation/deprecation
     const isSelectAllKey = ev.which === KeyCodes.a && (this._isCtrlPressed || this._isMetaPressed);
     // eslint-disable-next-line deprecation/deprecation
@@ -511,8 +518,9 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
       return;
     }
 
-    // If escape is pressed, clear selection (if any are selected.)
-    if (isClearSelectionKey && selection.getSelectedCount() > 0) {
+    // If escape is pressed and the component is configured to clear on escape press,
+    // clear selection (if any are selected.)
+    if (selectionClearedOnEscapePress && isClearSelectionKey && selection.getSelectedCount() > 0) {
       if (!isSelectionDisabled) {
         selection.setAllSelected(false);
       }

--- a/packages/react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.tsx
@@ -111,6 +111,16 @@ export interface ISelectionZoneProps extends React.ClassAttributes<SelectionZone
    * @defaultvalue true
    */
   selectionClearedOnEscapePress?: boolean;
+
+  /**
+   * Allows the default toggle behavior to be overridden.
+   * When set to `true` users do not have press a modifier key (e.g., ctrl or meta)
+   * to toggle values.
+   *
+   * @default false
+   */
+  toggleWithoutModifierPressed?: boolean;
+
   /**
    * Optional callback for when an item is
    * invoked via ENTER or double-click.
@@ -140,7 +150,9 @@ export interface ISelectionZoneState {
 export class SelectionZone extends React.Component<ISelectionZoneProps, ISelectionZoneState> {
   public static defaultProps = {
     isSelectedOnFocus: true,
+    toggleWithoutModifierPressed: false,
     selectionMode: SelectionMode.multiple,
+    selectionClearedOnEscapePress: true,
   };
 
   private _async: Async;
@@ -637,7 +649,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
   }
 
   private _onItemSurfaceClick(ev: React.SyntheticEvent<HTMLElement>, index: number): void {
-    const { selection } = this.props;
+    const { selection, toggleWithoutModifierPressed } = this.props;
     const isToggleModifierPressed = this._isCtrlPressed || this._isMetaPressed;
 
     const selectionMode = this._getSelectionMode();
@@ -645,7 +657,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
     if (selectionMode === SelectionMode.multiple) {
       if (this._isShiftPressed && !this._isTabPressed) {
         selection.selectToIndex(index, !isToggleModifierPressed);
-      } else if (isToggleModifierPressed) {
+      } else if (isToggleModifierPressed || toggleWithoutModifierPressed) {
         selection.toggleIndexSelected(index);
       } else {
         this._clearAndSelectIndex(index);

--- a/packages/react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.tsx
@@ -352,7 +352,8 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
           (target === itemRoot || this._shouldAutoSelect(target)) &&
           !this._isShiftPressed &&
           !this._isCtrlPressed &&
-          !this._isMetaPressed
+          !this._isMetaPressed &&
+          !this.props.toggleWithoutModifierPressed
         ) {
           this._onInvokeMouseDown(ev, this._getItemIndex(itemRoot));
           break;


### PR DESCRIPTION
## Current Behavior

1. When pressing the escape key in a SelectionZone any selected items in the zone are deselected.
2. When toggling values via the space key in a SelectionZone users must press a modifier key like `ctrl` to toggle the values.

## New Behavior

1. Authors can opt out of the default escape key behavior in SelectionZone by setting the `selectionClearedOnEscapePress` prop to false.
    1. The default value is `true` which preserves the current behavior
2. Authors can opt out of the default toggle behavior by setting the `toggleWithoutModifierPressed` to true
    1. The default value is `false` which preserves the current behavior
3. DetailsList has been updated to set the above values based on the recently added `isSelectedOnFocus` prop
    1. The default values are preserved so that authors must opt into the new behavior.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- #23383
- #23382
