### PR TITLE
Use ClientWidth instead of InnerWidth (#23402)

### DIFF
--- a/change/@fluentui-react-20264996-adc8-470e-af8c-a896ac8775c0.json
+++ b/change/@fluentui-react-20264996-adc8-470e-af8c-a896ac8775c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "set defaultMode to responsive mode provided as props, so that in error scenarios we can fallback to this mode",
+  "packageName": "@fluentui/react",
+  "email": "shmiitian@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/office-ui-fabric-react-d010c2b4-a709-45d8-9375-c90432bec8e9.json
+++ b/change/office-ui-fabric-react-d010c2b4-a709-45d8-9375-c90432bec8e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "using clientWidth of window as a replacement for innerWidth",
+  "packageName": "office-ui-fabric-react",
+  "email": "shmiitian@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -34,6 +34,8 @@ describe('Dropdown', () => {
 
   beforeEach(() => {
     resetIds();
+    const win = window as any;
+    Object.defineProperty(win.HTMLHtmlElement.prototype, 'clientWidth', { configurable: true, value: 1024 });
   });
 
   afterEach(() => {
@@ -62,7 +64,7 @@ describe('Dropdown', () => {
       // version of createPortal first to allow some global setup to run properly.
       wrapper = mount(<div />);
       wrapper.unmount();
-      spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+      spyOn(ReactDOM, 'createPortal').and.callFake((node) => node);
 
       const ref = React.createRef<IDropdown>();
       wrapper = mount(<Dropdown options={RENDER_OPTIONS} componentRef={ref} />);
@@ -483,7 +485,7 @@ describe('Dropdown', () => {
 
     it('Renders correctly when open', () => {
       // Mock createPortal so that the options list ends up inside the wrapper for snapshotting
-      spyOn(ReactDOM, 'createPortal').and.callFake(node => node);
+      spyOn(ReactDOM, 'createPortal').and.callFake((node) => node);
       const ref = React.createRef<IDropdown>();
       wrapper = mount(<Dropdown multiSelect options={RENDER_OPTIONS} componentRef={ref} />);
       ref.current!.focus(true);

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
@@ -107,12 +107,20 @@ export function withResponsiveMode<TProps extends { responsiveMode?: ResponsiveM
   return hoistStatics(ComposedComponent, resultClass);
 }
 
+function getWidthOfCurrentWindow(currentWindow: Window): number {
+  try {
+    return currentWindow.document.documentElement.clientWidth;
+  } catch (e) {
+    return currentWindow.innerWidth;
+  }
+}
+
 export function getResponsiveMode(currentWindow: Window | undefined): ResponsiveMode {
   let responsiveMode = ResponsiveMode.small;
 
   if (currentWindow) {
     try {
-      while (currentWindow.innerWidth > RESPONSIVE_MAX_CONSTRAINT[responsiveMode]) {
+      while (getWidthOfCurrentWindow(currentWindow) > RESPONSIVE_MAX_CONSTRAINT[responsiveMode]) {
         responsiveMode++;
       }
     } catch (e) {

--- a/packages/office-ui-fabric-react/src/utilities/hooks/useResponsiveMode.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/hooks/useResponsiveMode.test.tsx
@@ -7,8 +7,7 @@ import { useResponsiveMode } from './useResponsiveMode';
 const resizeTo = (width: number, height: number = 100) => {
   ReactTestUtils.act(() => {
     const win = window as any;
-
-    win.innerWidth = width;
+    Object.defineProperty(win.HTMLHtmlElement.prototype, 'clientWidth', { configurable: true, value: width });
     win.innerHeight = height;
     win.dispatchEvent(new Event('resize'));
   });


### PR DESCRIPTION
* set defaultMode to responsive mode provided as props, so that in error scenarios we can fallback to this mode

* change files

* use documentElement.clientWidth instead of innerWidth

* modifying useResonsiveMode.test.tsx to mock clientWidth

* fixing the dropdown test

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
