### PR TITLE
export addon decorator and use it explicitely

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -36,7 +36,6 @@ module.exports = /** @type {Omit<StorybookConfig,'typescript'|'babel'>} */ ({
     '@storybook/addon-knobs/preset',
     'storybook-addon-performance',
     'storybook-addon-export-to-codesandbox',
-    '@fluentui/react-storybook-addon',
   ],
   webpackFinal: config => {
     const tsPaths = new TsconfigPathsPlugin({

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
-import { withFluentProvider, withStrictMode } from '@fluentui/react-storybook';
+import { withStrictMode } from '@fluentui/react-storybook';
+import { withFluentProvider } from '@fluentui/react-storybook-addon';
 import 'cypress-storybook/react';
 import * as dedent from 'dedent';
 import './docs-root.css';

--- a/packages/react-components/react-storybook-addon/etc/react-storybook-addon.api.md
+++ b/packages/react-components/react-storybook-addon/etc/react-storybook-addon.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { Args } from '@storybook/api';
+import { DecoratorFunction } from '@storybook/addons';
 import { StoryContext } from '@storybook/addons';
 import type { Theme } from '@fluentui/react-theme';
 
@@ -48,6 +49,9 @@ export const themes: readonly [{
     readonly label: "Teams High Contrast";
     readonly theme: Theme;
 }];
+
+// @public (undocumented)
+export const withFluentProvider: DecoratorFunction<JSX.Element>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-storybook-addon/src/decorators/withFluentProvider.tsx
+++ b/packages/react-components/react-storybook-addon/src/decorators/withFluentProvider.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-
+import { DecoratorFunction } from '@storybook/addons';
 import { themes, defaultTheme, FluentProvider } from '../theme';
 import { THEME_ID } from '../constants';
-import { FluentGlobals, FluentStoryContext } from '../hooks';
+import { FluentGlobals } from '../hooks';
 
 import { Theme } from '@fluentui/react-theme';
 
@@ -13,7 +13,7 @@ const getActiveFluentTheme = (globals: FluentGlobals) => {
   return { theme };
 };
 
-export const withFluentProvider = (StoryFn: () => JSX.Element, context: FluentStoryContext) => {
+export const withFluentProvider: DecoratorFunction<JSX.Element> = (StoryFn, context) => {
   const { theme } = getActiveFluentTheme(context.globals);
 
   return (

--- a/packages/react-components/react-storybook-addon/src/index.ts
+++ b/packages/react-components/react-storybook-addon/src/index.ts
@@ -2,3 +2,4 @@ export type { FluentGlobals, FluentStoryContext } from './hooks';
 export type { ThemeIds } from './theme';
 export { themes } from './theme';
 export { THEME_ID } from './constants';
+export { withFluentProvider } from './decorators/withFluentProvider';


### PR DESCRIPTION
As of storybook 6.5, the react-storybook-addon is not automatically adding the decorator to the story preview. Importing the decorator in manually and adding it to the decorator array does work though. 

I'm not sure if this is a temporary bug in 6.5, or a change in the way addons work, but seeing as the addon already didn't work for macs/WSL (https://github.com/microsoft/fluentui/issues/22672), it might be best to do it this way anyway.