### PR TITLE
eslint-plugin: Add new rule to prevent cross package v9 imports

### DIFF
--- a/change/@fluentui-eslint-plugin-fe67cc34-ca23-4a21-9526-695ea0e4de26.json
+++ b/change/@fluentui-eslint-plugin-fe67cc34-ca23-4a21-9526-695ea0e4de26.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add new rule to prevent cross package v9 imports.",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -70,6 +70,28 @@ Example:
 ]
 ```
 
+### `no-cross-package-v9-imports`
+
+Prevents imports from each specific v9 component packages. Ensures that all v9 imports are coming from the `@fluentui/react-components` suite.
+
+**❌ Don't**
+
+```ts
+// src/stories/Component.stories.tsx
+import * as React from 'react';
+import { makeStyles, shorthands } from `@griffel/react`;
+import { Text } from `@fluentui/react-text`;
+import { webDarkTheme, webLightTheme } from `@fluentui/react-theme`;
+```
+
+**✅ Do**
+
+```ts
+// src/stories/Component.stories.tsx
+import * as React from 'react';
+import { makeStyles, shorthands, Text, webDarkTheme, webLightTheme } from `@fluentui/react-components`;
+```
+
 ### `deprecated-keyboard-event-props`
 
 Prevent using deprecated `KeyboardEvent` props `which` and `keyCode`, and recommend using `@fluentui/keyboard-key` instead.

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -27,6 +27,8 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "fs-extra": "^8.1.0",
+    "lerna-alias": "^3.0.3-0",
     "minimatch": "^3.0.4",
     "jju": "^1.4.0"
   },

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -16,6 +16,7 @@ module.exports = {
     'no-global-react': require('./rules/no-global-react'),
     'no-tslint-comments': require('./rules/no-tslint-comments'),
     'no-visibility-modifiers': require('./rules/no-visibility-modifiers'),
+    'no-cross-package-v9-imports': require('./rules/no-cross-package-v9-imports'),
   },
 
   // Not a standard eslint thing, just exported for convenience

--- a/packages/eslint-plugin/src/rules/no-cross-package-v9-imports.js
+++ b/packages/eslint-plugin/src/rules/no-cross-package-v9-imports.js
@@ -27,26 +27,23 @@ module.exports = createRule({
 
     return {
       ImportDeclaration: imprt => {
+        if (!imprt.source || (imprt.source && imprt.source.type !== AST_NODE_TYPES.Literal)) {
+          return;
+        }
+
         if (typeof imprt.source.value !== 'string') {
           return;
         }
 
         const specifiers = imprt.specifiers;
 
-        if (
-          imprt.source &&
-          imprt.source.type === AST_NODE_TYPES.Literal &&
-          imprt.source.value === '@fluentui/react-components'
-        ) {
+        if (imprt.source.value === '@fluentui/react-components' && !reactComponentsImportNode) {
           reactComponentsImportNode = specifiers[specifiers.length - 1];
         }
 
         if (
-          (imprt.source &&
-            imprt.source.type === AST_NODE_TYPES.Literal &&
-            imprt.source.value !== '@fluentui/react-components' &&
-            imprt.source.value.includes('@fluentui/react-')) ||
-          imprt.source.value.includes('@griffel/react')
+          (imprt.source.value.includes('@fluentui/react-') || imprt.source.value.includes('@griffel/react')) &&
+          imprt.source.value !== '@fluentui/react-components'
         ) {
           if (!reactComponentsImportNode) {
             reactComponentsImportNode = specifiers[specifiers.length - 1];

--- a/packages/eslint-plugin/src/rules/no-cross-package-v9-imports.js
+++ b/packages/eslint-plugin/src/rules/no-cross-package-v9-imports.js
@@ -1,0 +1,95 @@
+// @ts-check
+const { AST_NODE_TYPES } = require('@typescript-eslint/experimental-utils');
+const createRule = require('../utils/createRule');
+/**
+ * @typedef {import("@typescript-eslint/typescript-estree").TSESTree.Identifier} Identifier
+ */
+
+module.exports = createRule({
+  name: 'no-cross-package-v9-imports',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Ensures that v9 component imports are only coming from @fluentui/react-components.',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    messages: {
+      crossPackageImport:
+        'Cross package import from {{ importedPkg }} detected. Please import only from @fluentui/react-components',
+    },
+    fixable: 'code',
+    schema: [],
+  },
+  defaultOptions: [],
+  create: context => {
+    /**
+     * @type {import("@typescript-eslint/types/dist/ts-estree").Range}
+     */
+    let reactComponentsImportNodeRange;
+
+    /**
+     * @type {import("@typescript-eslint/types/dist/ts-estree").ImportClause[]}
+     */
+    const importedIdentifiers = [];
+
+    return {
+      ImportDeclaration: imprt => {
+        if (typeof imprt.source.value !== 'string') {
+          return;
+        }
+
+        if (
+          imprt.source &&
+          imprt.source.type === AST_NODE_TYPES.Literal &&
+          imprt.source.value === '@fluentui/react-components'
+        ) {
+          reactComponentsImportNodeRange = imprt.specifiers[imprt.specifiers.length - 1].range;
+        }
+
+        if (
+          (imprt.source &&
+            imprt.source.type === AST_NODE_TYPES.Literal &&
+            imprt.source.value !== '@fluentui/react-components' &&
+            imprt.source.value.includes('@fluentui/react-')) ||
+          imprt.source.value.includes('@griffel')
+        ) {
+          if (!reactComponentsImportNodeRange) {
+            reactComponentsImportNodeRange = imprt.specifiers[imprt.specifiers.length - 1].range;
+            context.report({
+              node: imprt,
+              messageId: 'crossPackageImport',
+              data: { importedPkg: imprt.source.value },
+              fix: fixer => {
+                const [start, end] = imprt.source.range;
+                return fixer.replaceTextRange([start + 1, end - 1], '@fluentui/react-components');
+              },
+            });
+          } else {
+            context.report({
+              node: imprt,
+              messageId: 'crossPackageImport',
+              data: { importedPkg: imprt.source.value },
+              fix: fixer => {
+                importedIdentifiers.push(...imprt.specifiers);
+                return fixer.remove(imprt);
+              },
+            });
+          }
+        }
+      },
+      onCodePathEnd: (/** @type {any} */ codePath, /** @type {Identifier} */ node) => {
+        if (importedIdentifiers.length) {
+          const importsToAdd = importedIdentifiers.map(specifier => specifier.local.name).join(', ');
+          context.report({
+            node: node,
+            messageId: 'crossPackageImport',
+            fix: fixer => {
+              return fixer.insertTextAfterRange(reactComponentsImportNodeRange, `, ${importsToAdd}`);
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/no-cross-package-v9-imports.js
+++ b/packages/eslint-plugin/src/rules/no-cross-package-v9-imports.js
@@ -1,9 +1,6 @@
 // @ts-check
 const { AST_NODE_TYPES } = require('@typescript-eslint/experimental-utils');
 const createRule = require('../utils/createRule');
-/**
- * @typedef {import("@typescript-eslint/typescript-estree").TSESTree.Identifier} Identifier
- */
 
 module.exports = createRule({
   name: 'no-cross-package-v9-imports',
@@ -16,7 +13,7 @@ module.exports = createRule({
     },
     messages: {
       crossPackageImport:
-        'Cross package import from {{ importedPkg }} detected. Please import only from @fluentui/react-components',
+        'Cross package import from {{ packageName }} detected. Please import only from @fluentui/react-components',
     },
     fixable: 'code',
     schema: [],
@@ -28,23 +25,20 @@ module.exports = createRule({
      */
     let reactComponentsImportNodeRange;
 
-    /**
-     * @type {import("@typescript-eslint/types/dist/ts-estree").ImportClause[]}
-     */
-    const importedIdentifiers = [];
-
     return {
       ImportDeclaration: imprt => {
         if (typeof imprt.source.value !== 'string') {
           return;
         }
 
+        const specifiers = imprt.specifiers;
+
         if (
           imprt.source &&
           imprt.source.type === AST_NODE_TYPES.Literal &&
           imprt.source.value === '@fluentui/react-components'
         ) {
-          reactComponentsImportNodeRange = imprt.specifiers[imprt.specifiers.length - 1].range;
+          reactComponentsImportNodeRange = specifiers[specifiers.length - 1].range;
         }
 
         if (
@@ -52,14 +46,14 @@ module.exports = createRule({
             imprt.source.type === AST_NODE_TYPES.Literal &&
             imprt.source.value !== '@fluentui/react-components' &&
             imprt.source.value.includes('@fluentui/react-')) ||
-          imprt.source.value.includes('@griffel')
+          imprt.source.value.includes('@griffel/react')
         ) {
           if (!reactComponentsImportNodeRange) {
-            reactComponentsImportNodeRange = imprt.specifiers[imprt.specifiers.length - 1].range;
+            reactComponentsImportNodeRange = specifiers[specifiers.length - 1].range;
             context.report({
               node: imprt,
               messageId: 'crossPackageImport',
-              data: { importedPkg: imprt.source.value },
+              data: { packageName: imprt.source.value },
               fix: fixer => {
                 const [start, end] = imprt.source.range;
                 return fixer.replaceTextRange([start + 1, end - 1], '@fluentui/react-components');
@@ -69,25 +63,13 @@ module.exports = createRule({
             context.report({
               node: imprt,
               messageId: 'crossPackageImport',
-              data: { importedPkg: imprt.source.value },
+              data: { packageName: imprt.source.value },
               fix: fixer => {
-                importedIdentifiers.push(...imprt.specifiers);
-                return fixer.remove(imprt);
+                const importsToAdd = `, ${imprt.specifiers.map(specifier => specifier.local.name).join(', ')}`;
+                return [fixer.insertTextAfterRange(reactComponentsImportNodeRange, importsToAdd), fixer.remove(imprt)];
               },
             });
           }
-        }
-      },
-      onCodePathEnd: (/** @type {any} */ codePath, /** @type {Identifier} */ node) => {
-        if (importedIdentifiers.length) {
-          const importsToAdd = importedIdentifiers.map(specifier => specifier.local.name).join(', ');
-          context.report({
-            node: node,
-            messageId: 'crossPackageImport',
-            fix: fixer => {
-              return fixer.insertTextAfterRange(reactComponentsImportNodeRange, `, ${importsToAdd}`);
-            },
-          });
         }
       },
     };

--- a/packages/eslint-plugin/src/rules/no-cross-package-v9-imports.js
+++ b/packages/eslint-plugin/src/rules/no-cross-package-v9-imports.js
@@ -21,9 +21,9 @@ module.exports = createRule({
   defaultOptions: [],
   create: context => {
     /**
-     * @type {import("@typescript-eslint/types/dist/ts-estree").Range}
+     * @type {import("@typescript-eslint/types/dist/ts-estree").ImportClause}
      */
-    let reactComponentsImportNodeRange;
+    let reactComponentsImportNode;
 
     return {
       ImportDeclaration: imprt => {
@@ -38,7 +38,7 @@ module.exports = createRule({
           imprt.source.type === AST_NODE_TYPES.Literal &&
           imprt.source.value === '@fluentui/react-components'
         ) {
-          reactComponentsImportNodeRange = specifiers[specifiers.length - 1].range;
+          reactComponentsImportNode = specifiers[specifiers.length - 1];
         }
 
         if (
@@ -48,8 +48,8 @@ module.exports = createRule({
             imprt.source.value.includes('@fluentui/react-')) ||
           imprt.source.value.includes('@griffel/react')
         ) {
-          if (!reactComponentsImportNodeRange) {
-            reactComponentsImportNodeRange = specifiers[specifiers.length - 1].range;
+          if (!reactComponentsImportNode) {
+            reactComponentsImportNode = specifiers[specifiers.length - 1];
             context.report({
               node: imprt,
               messageId: 'crossPackageImport',
@@ -66,7 +66,7 @@ module.exports = createRule({
               data: { packageName: imprt.source.value },
               fix: fixer => {
                 const importsToAdd = `, ${imprt.specifiers.map(specifier => specifier.local.name).join(', ')}`;
-                return [fixer.insertTextAfterRange(reactComponentsImportNodeRange, importsToAdd), fixer.remove(imprt)];
+                return [fixer.insertTextAfterRange(reactComponentsImportNode.range, importsToAdd), fixer.remove(imprt)];
               },
             });
           }

--- a/packages/eslint-plugin/src/utils/getAllPackageInfo.js
+++ b/packages/eslint-plugin/src/utils/getAllPackageInfo.js
@@ -1,0 +1,35 @@
+const fs = require('fs-extra');
+const path = require('path');
+const lernaAlias = require('lerna-alias');
+const { findGitRoot } = require('./configHelpers');
+
+/**
+ *  @typedef {{name: string, version: string, dependencies: {[key: string]: string}}} PackageJson
+ *  @typedef {{packagePath: string, packageJson: PackageJson}} PackageInfo
+ *  @typedef {{[packageName: string]: PackageInfo}} AllPackageInfo
+ */
+
+function getAllPackageInfo() {
+  /**
+   * @type AllPackageInfo
+   */
+  const allPackageInfo = {};
+
+  // Get mapping from package name to package path
+  // (rollup helper happens to be good for getting basic package name/path pairs)
+  const packagePaths = lernaAlias.rollup({ sourceDirectory: false });
+  delete packagePaths['@fluentui/noop']; // not a real package
+
+  const gitRoot = findGitRoot();
+
+  for (const [packageName, packagePath] of Object.entries(packagePaths)) {
+    allPackageInfo[packageName] = {
+      packagePath: path.relative(gitRoot, packagePath),
+      packageJson: fs.readJSONSync(path.join(packagePath, 'package.json')),
+    };
+  }
+
+  return allPackageInfo;
+}
+
+module.exports = getAllPackageInfo;


### PR DESCRIPTION
## Changes:
- Adds a new `no-cross-package-v9-imports` custom rule to our eslint-plugin package which will warn devs when they're importing from specific v9 component packages and not from `@fluentui/react-components`. Provides an auto fix with the eslint `--fix` CLI for the entire file. A follow-up PR will be made to add this rule to our v9 eslint config to lint storybook files.

## Demo:

https://user-images.githubusercontent.com/8649804/173133850-04579c63-579d-4360-bdc2-50e1d5cea1d9.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21907