### PR TITLE
chore(react-avatar): Adding warnings on use of AvatarGroup and AvatarGroupItem

### DIFF
--- a/change/@fluentui-react-avatar-d3231ec7-f72e-4a15-9ebe-873408209cd8.json
+++ b/change/@fluentui-react-avatar-d3231ec7-f72e-4a15-9ebe-873408209cd8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Added warning for AvatarGroup to check if children are of type AvatarGroupItem and for AvatarGroupItem to check if it's being used inside an AvatarGroup.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { AvatarGroupItem } from '../AvatarGroupItem/AvatarGroupItem';
 import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
 import { MoreHorizontalRegular } from '@fluentui/react-icons';
 import { PopoverSurface } from '@fluentui/react-popover';
@@ -17,6 +18,14 @@ export const useAvatarGroup_unstable = (props: AvatarGroupProps, ref: React.Ref<
   const { children, layout = 'spread', maxAvatars = 5, size = defaultAvatarGroupSize } = props;
   const { overflowIndicator = size < 24 ? 'icon' : 'count' } = props;
   const childrenArray = React.Children.toArray(children);
+
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    childrenArray.find(child => React.isValidElement(child) && child.type !== AvatarGroupItem)
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn("AvatarGroup's children must be of type AvatarGroupItems.");
+  }
 
   let rootChildren = childrenArray;
   let overflowChildren;

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
@@ -3,7 +3,7 @@ import { Avatar } from '../Avatar/Avatar';
 import { AvatarGroupContext } from '../../contexts/AvatarGroupContext';
 import { defaultAvatarGroupSize } from '../AvatarGroup/useAvatarGroup';
 import { resolveShorthand } from '@fluentui/react-utilities';
-import { useContextSelector } from '@fluentui/react-context-selector';
+import { useContextSelector, useHasParentContext } from '@fluentui/react-context-selector';
 import type { AvatarGroupItemProps, AvatarGroupItemState } from './AvatarGroupItem.types';
 
 /**
@@ -26,6 +26,12 @@ export const useAvatarGroupItem_unstable = (
   // Since the primary slot is not an intrinsic element, getPartitionedNativeProps cannot be used here.
   const { style, className, ...avatarSlotProps } = props;
   const size = groupSize ?? defaultAvatarGroupSize;
+  const hasAvatarGroupContext = useHasParentContext(AvatarGroupContext);
+
+  if (process.env.NODE_ENV !== 'production' && !hasAvatarGroupContext) {
+    // eslint-disable-next-line no-console
+    console.warn('AvatarGroupItem must only be used inside an AvatarGroup component.');
+  }
 
   return {
     nonOverflowAvatarsCount: nonOverflowAvatarsCount ?? 1,


### PR DESCRIPTION

## Current Behavior

* AvatarGroup does not warn if an Avatar component is used instead of AvatarGroupItem.
* AvatarGroupItem does not warn if it isn't being used inside an AvatarGroup.

## New Behavior

* AvatarGroup now warns if a child is not of type AvatarGroupItem.
* AvatarGroupItem now warns if it isn't being used inside an AvatarGroup.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#22240 
