### PR TITLE
docs: README, spec and migration guide cleanup for react-spinner

### DIFF
--- a/change/@fluentui-react-spinner-d74cede6-32bf-4475-b2a5-fc7751352506.json
+++ b/change/@fluentui-react-spinner-d74cede6-32bf-4475-b2a5-fc7751352506.json
@@ -1,0 +1,6 @@
+{
+  "type": "prerelease",
+  "packageName": "@fluentui/react-spinner",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-d9447fdf-f58d-4170-a38a-ba7620ea11ad.json
+++ b/change/@fluentui-react-spinner-d9447fdf-f58d-4170-a38a-ba7620ea11ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: README, spec and migration guide cleanup.",
+  "packageName": "@fluentui/react-spinner",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-spinner/MIGRATION.md
+++ b/packages/react-components/react-spinner/MIGRATION.md
@@ -1,13 +1,5 @@
 # Spinner Migration
 
-## Migration from v0
-
-- `Loader`
-  - `inline` => Not supported.
-  - `labelPosition` => 'start' and 'end' changed to 'before' and 'after'
-  - `size` => There are the same number of sizes
-  - `delay` => Not supported.
-
 ## Migration from v8
 
 - `Spinner`
@@ -15,3 +7,24 @@
   - `ariaLive` => use `aria-live` instead.
   - `componentRef` => use `ref` instead.
   - `theme` => Not supported. Use a `ThemeProvider` control instead.
+
+## Migration from v0
+
+- `Loader`
+  - `delay` => Not supported.
+  - `inline` => Not supported.
+  - `labelPosition` => `labelPosition` => 'start' and 'end' changed to 'before' and 'after'
+  - `size` => `size` => There are the same number of sizes
+
+## Property mapping
+
+| v8 `Spinner`   | v0 `Loader`     | v9 `Spinner`    |
+| -------------- | --------------- | --------------- |
+| `ariaLabel`    | `aria-label`    | `aria-label`    |
+| `ariaLive`     | `aria-live`     | `aria-live`     |
+| `componentRef` | `ref`           | `ref`           |
+|                | `delay`         |                 |
+|                | `inline`        |                 |
+|                | `labelPosition` | `labelPosition` |
+|                | `size`          | `size`          |
+| `theme`        |                 |                 |

--- a/packages/react-components/react-spinner/README.md
+++ b/packages/react-components/react-spinner/README.md
@@ -1,23 +1,31 @@
 # @fluentui/react-spinner
 
-**React Spinner components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**Spinner components for [Fluent UI React](https://aka.ms/fluentui-storybook)**
 
-The Spinner is an outline of a circle which animates around itself indicating to the user that things are processing. Spinner is typically an indeterminate ProgressIndicator that is used when it is unknown how long a task will take to complete. They can be various sizes, located inline with content or centered. They generally appear while an action is being processed or committed. They are subtle and generally do not take up much space, but are transitions from the completed task
+The Spinner is an outline of a circle which animates around itself indicating to the user that things are processing. Spinners are typically indeterminate progress indicators that is used when it is unknown how long a task will take to complete. They can be various sizes, located inline with content or centered. They generally appear while an action is being processed or committed. They are subtle and generally do not take up much space, but are transitions from the completed task.
 
 ## Usage
 
 To import Spinner:
 
 ```js
-import { Spinner } from '@fluentui/react-spinner';
+import { Spinner } from '@fluentui/react-components';
 ```
 
 ### Examples
 
 ```js
 <Spinner label="Loading..." />
-<Spinner size="large" />
+<Spinner label="Loading..." appearance="inverted" />
+<Spinner label="Loading..." size="large" />
 ```
+
+See [Fluent UI Storybook](https://aka.ms/fluentui-storybook) for more detailed usage examples.
+
+Alternatively, run Storybook locally with:
+
+1. `yarn start`
+2. Select `react-spinner` from the list.
 
 #### Rendering Spinner without the animated circle
 
@@ -27,3 +35,11 @@ You can directly override the Spinner slot to render a Spinner without the anima
 <Spinner spinner={null} appearance="primary" label="Primary Spinner" />
 <Spinner spinner={{style:{visibility: 'hidden'}}} appearance="inverted" label="Inverted Spinner" />
 ```
+
+### Specification
+
+See [SPEC.md](./SPEC.md).
+
+### Migration Guide
+
+If you're upgrading to Fluent UI v9 see [MIGRATION.md](./MIGRATION.md) for guidance on updating to the latest Spinner implementation.

--- a/packages/react-components/react-spinner/Spec.md
+++ b/packages/react-components/react-spinner/Spec.md
@@ -68,8 +68,6 @@ The Spinner is represented as a circle with an arc of a darker shade rotating th
 
 ## API
 
-From [Spinner.types.tsx](https://github.com/microsoft/fluentui/blob/master/packages/react-spinner/src/components/Spinner/Spinner.types.ts)
-
 ### Slots
 
 - `root` - The root element of the Spinner. The html element is a `span`
@@ -78,18 +76,7 @@ From [Spinner.types.tsx](https://github.com/microsoft/fluentui/blob/master/packa
 
 ### Props
 
-```jsx
-export type SpinnerProps = ComponentProps &
-  React.HTMLAttributes<HTMLElement> & {
-    /* The appearance of the Spinner*/
-    appearance?: 'primary' | 'inverted',
-    /* The labelPosition prop allows user to set the location of the label*/
-    labelPosition?: 'above' | 'below' | 'before' | 'after',
-    /* The size prop sets the size of the Spinner
-     * @defaultValue "medium"*/
-    size?: 'tiny' | 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large' | 'huge',
-  };
-```
+See API at [Spinner.types.tsx](./src/components/Spinner/Spinner.types.ts).
 
 ## Structure
 
@@ -109,7 +96,7 @@ export type SpinnerProps = ComponentProps &
 
 ## Migration
 
-See [MIGRATION.md]().
+See [MIGRATION.md](./MIGRATION.md).
 
 ## Behaviors
 


### PR DESCRIPTION
## PR Description

This PR cleans up a bunch of things in `react-spinner`:
- It updates the migration guide to add a property mapping table between v8, v0 and v9.
- The README is updated to include links to the storybook, the spec and the migration guide.
- The spec is updated to add a link to the migration guide.

Fixes part of #23423.