### PR TITLE
(web-components) Fixed Storybook loading page name check

### DIFF
--- a/change/@fluentui-web-components-d71434ba-1231-415e-89f8-d1007c320746.json
+++ b/change/@fluentui-web-components-d71434ba-1231-415e-89f8-d1007c320746.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fixed Storybook loading page name check",
+  "packageName": "@fluentui/web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/.storybook/preview.js
+++ b/packages/web-components/.storybook/preview.js
@@ -40,13 +40,13 @@ export const parameters = {
 };
 
 addons.getChannel().addListener(DOCS_RENDERED, name => {
-  if (name.toLowerCase() === 'components/accordion' || name.toLowerCase() === 'components/card') {
+  if (name.toLowerCase().includes('accordion') || name.toLowerCase().includes('card')) {
     fillColor.setValueFor(document.body, neutralLayer2);
   } else {
     fillColor.setValueFor(document.body, neutralLayer1);
   }
 
-  if (name.toLowerCase().indexOf('color-explorer') !== -1) {
+  if (name.toLowerCase().includes('color-explorer')) {
     document.body.classList.add('custom-fullscreen');
   } else {
     document.body.classList.remove('custom-fullscreen');

--- a/packages/web-components/src/card/card.stories.ts
+++ b/packages/web-components/src/card/card.stories.ts
@@ -5,7 +5,7 @@ import CardTemplate from './fixtures/card.html';
 import './index';
 
 addons.getChannel().addListener(DOCS_RENDERED, name => {
-  if (name.toLowerCase() === 'components/card') {
+  if (name.toLowerCase().includes('card')) {
     const els = document.getElementsByClassName('darkMode');
     for (let i = 0; i < els.length; i++) {
       const el = els[i];

--- a/packages/web-components/src/data-grid/data-grid.stories.ts
+++ b/packages/web-components/src/data-grid/data-grid.stories.ts
@@ -48,7 +48,7 @@ const customHeaderCellItemTemplate = html`
 `;
 
 addons.getChannel().addListener(DOCS_RENDERED, (name: string) => {
-  if (name.toLowerCase().includes('components/data grid')) {
+  if (name.toLowerCase().includes('data-grid')) {
     defaultGridElement = document.getElementById('defaultGrid') as DataGrid;
     reset();
 


### PR DESCRIPTION
## Current Behavior

A few pages in Storybook have some custom loading. These check the page name in the render callback, but the name has changed, probably with the switch to doc pages.

## New Behavior

Updated page name check to look for the key part of the name, not a specific format in case that changes.
