### PR TITLE
Task 5525 and 5526 Accessible column text size and weight , color palette for columns and streams in sankey Chart

### DIFF
--- a/packages/react-charting/src/components/SankeyChart/SankeyChart.styles.ts
+++ b/packages/react-charting/src/components/SankeyChart/SankeyChart.styles.ts
@@ -1,7 +1,8 @@
 import { ISankeyChartStyleProps, ISankeyChartStyles } from './SankeyChart.types';
+import { FontSizes } from '@fluentui/react/lib/Styling';
 
 export const getStyles = (props: ISankeyChartStyleProps): ISankeyChartStyles => {
-  const { className, theme, pathColor } = props;
+  const { className, theme, pathColor, nodes } = props;
   return {
     root: [
       theme.fonts.medium,
@@ -17,6 +18,10 @@ export const getStyles = (props: ISankeyChartStyleProps): ISankeyChartStyles => 
     links: {
       stroke: pathColor ? pathColor : theme.palette.blue,
       fill: 'none',
+    },
+    nodes: {
+      fontWeight: nodes?.labelWeight ? nodes.labelWeight : 'normal',
+      fontSize: nodes?.labelSize ? nodes.labelSize : FontSizes.medium,
     },
   };
 };

--- a/packages/react-charting/src/components/SankeyChart/SankeyChart.types.ts
+++ b/packages/react-charting/src/components/SankeyChart/SankeyChart.types.ts
@@ -49,6 +49,24 @@ export interface ISankeyChartProps {
    * Color for path
    */
   pathColor?: string;
+
+  nodes?: ISankeyNodeProps;
+
+  links?: ISankeyLinkProps;
+
+  labelWeight?: string;
+
+  labelSize?: string;
+}
+
+export interface ISankeyNodeProps {
+  labelWeight?: string;
+  labelSize?: string;
+  colors?: string[];
+}
+
+export interface ISankeyLinkProps {
+  colors?: string[];
 }
 
 export interface ISankeyChartStyleProps {
@@ -57,6 +75,8 @@ export interface ISankeyChartStyleProps {
   width: number;
   height: number;
   pathColor?: string;
+  nodes?: ISankeyNodeProps;
+  links?: ISankeyLinkProps;
 }
 
 export interface ISankeyChartStyles {

--- a/packages/react-charting/src/components/SankeyChart/SankeyChart.types.ts
+++ b/packages/react-charting/src/components/SankeyChart/SankeyChart.types.ts
@@ -53,10 +53,6 @@ export interface ISankeyChartProps {
   nodes?: ISankeyNodeProps;
 
   links?: ISankeyLinkProps;
-
-  labelWeight?: string;
-
-  labelSize?: string;
 }
 
 export interface ISankeyNodeProps {

--- a/packages/react-charting/src/types/IDataPoint.ts
+++ b/packages/react-charting/src/types/IDataPoint.ts
@@ -385,13 +385,15 @@ export interface ISankeyChartData {
   links: SLink[];
 }
 
-interface ISNodeExtra {
+export interface ISNodeExtra {
   nodeId: number | string;
   name: string;
   color: string;
+  labelWeight?: string;
+  labelSize?: string;
 }
 
-interface ISLinkExtra {
+export interface ISLinkExtra {
   source: number;
   target: number;
   value: number;

--- a/packages/react-examples/src/react-charting/SankeyChart/SankeyChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/SankeyChart/SankeyChart.Basic.Example.tsx
@@ -126,6 +126,8 @@ export class SankeyChartBasicExample extends React.Component<{}, ISankeyChartBas
             height={this.state.height}
             width={this.state.width}
             shouldResize={this.state.width + this.state.height}
+            labelSize="12px"
+            labelWeight="bold"
           />
         </div>
       </>

--- a/packages/react-examples/src/react-charting/SankeyChart/SankeyChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/SankeyChart/SankeyChart.Basic.Example.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { IChartProps, ISankeyChartProps, SankeyChart } from '@fluentui/react-charting';
+import {
+  IChartProps,
+  ISankeyChartProps,
+  ISankeyLinkProps,
+  ISankeyNodeProps,
+  SankeyChart,
+} from '@fluentui/react-charting';
 
 interface ISankeyChartBasicState {
   width: number;
@@ -113,6 +119,14 @@ export class SankeyChartBasicExample extends React.Component<{}, ISankeyChartBas
     };
 
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+    const nodesProps: ISankeyNodeProps = {
+      labelWeight: 'bold',
+      labelSize: '12px',
+      colors: ['red', 'blue', 'green', 'voilet'],
+    };
+    const linksProps: ISankeyLinkProps = {
+      colors: ['red', 'blue', 'green'],
+    };
 
     return (
       <>
@@ -126,8 +140,8 @@ export class SankeyChartBasicExample extends React.Component<{}, ISankeyChartBas
             height={this.state.height}
             width={this.state.width}
             shouldResize={this.state.width + this.state.height}
-            labelSize="12px"
-            labelWeight="bold"
+            nodes={nodesProps}
+            links={linksProps}
           />
         </div>
       </>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x ] Code is up-to-date with the `master` branch
* [ x] Your changes are covered by tests (if possible)
* [ x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

![task5525_5526_Before](https://user-images.githubusercontent.com/103660888/173182393-9a5df716-1002-457e-838c-c08822362e38.png)


<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

![Task5525_5526_After](https://user-images.githubusercontent.com/103660888/173182148-f9ad8a11-0a0c-4c92-81db-1e9d0d176347.png)


-- Column text labelweight is bold and labelSie is 12.
--Column colors are accessible.
--Stream colors are also accessible. 
## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
