### PR TITLE
fix(Portal): update to create new stacking context

### DIFF
--- a/change/@fluentui-react-portal-f582a5e9-5dde-4e66-a109-c3d55fdd0bbf.json
+++ b/change/@fluentui-react-portal-f582a5e9-5dde-4e66-a109-c3d55fdd0bbf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: update to create new stacking context",
+  "packageName": "@fluentui/react-portal",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-portal/src/components/Portal/usePortalMountNode.ts
+++ b/packages/react-components/react-portal/src/components/Portal/usePortalMountNode.ts
@@ -16,6 +16,7 @@ export type UsePortalMountNodeOptions = {
 
 const useStyles = makeStyles({
   root: {
+    position: 'relative',
     zIndex: 1000000,
   },
 });


### PR DESCRIPTION
## New Behavior

Follow up for #22933. This PR updates `Portal` to apply `position` to create [new stacking contexts](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context). 

Without a stacking context these is no sense to apply `z-index` (check before & after below).

- Before https://codesandbox.io/s/affectionate-mendeleev-vr6b8x
- After https://codesandbox.io/s/mystifying-bogdan-diw11s

----

~~I also had to refactor VR tests as Screener does not handle positioning properly on initial screenshots _sometimes_. New screenshots follow the same strategy as in N* where tooltips/popovers are opened and positioning after load as a new step.~~

_Moved to #23533._