### PR TITLE
fix: Adding close button to Dropdown list when it opens as a panel.

### DIFF
--- a/change/@fluentui-react-d8a70a1c-bcd4-4dc2-a5c6-bb6c7fece86b.json
+++ b/change/@fluentui-react-d8a70a1c-bcd4-4dc2-a5c6-bb6c7fece86b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Adding close button to Dropdown list when it opens as a panel.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -48,6 +48,7 @@ import type { IPanelStyleProps, IPanelStyles } from '../../Panel';
 import type { IWithResponsiveModeState } from '../../ResponsiveMode';
 import type { ISelectableDroppableTextProps } from '../../SelectableOption';
 import type { ICheckboxStyleProps, ICheckboxStyles } from '../../Checkbox';
+import { IFocusTrapZoneProps } from '../FocusTrapZone/FocusTrapZone.types';
 
 const COMPONENT_NAME = 'Dropdown';
 const getClassNames = classNamesFunction<IDropdownStyleProps, IDropdownStyles>();
@@ -594,6 +595,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
     const isSmall = responsiveMode! <= ResponsiveMode.medium;
 
+    const focusTrapZoneProps: IFocusTrapZoneProps = { firstFocusableTarget: `#${this._listId}1` };
     const panelStyles = this._classNames.subComponentStyles
       ? (this._classNames.subComponentStyles.panel as IStyleFunctionOrObject<IPanelStyleProps, IPanelStyles>)
       : undefined;
@@ -608,6 +610,8 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
     return isSmall ? (
       <Panel
+        closeButtonAriaLabel="Close"
+        focusTrapZoneProps={focusTrapZoneProps}
         hasCloseButton
         isOpen={true}
         isLightDismiss={true}
@@ -664,7 +668,6 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
           aria-label={ariaLabel}
           aria-labelledby={label && !ariaLabel ? this._labelId : undefined}
           aria-multiselectable={multiSelect}
-          shouldFocusOnMount
         >
           {onRenderList(props, this._onRenderList)}
         </FocusZone>

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -608,10 +608,10 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
     return isSmall ? (
       <Panel
+        hasCloseButton
         isOpen={true}
         isLightDismiss={true}
         onDismiss={this._onDismiss}
-        hasCloseButton={false}
         styles={panelStyles}
         {...panelProps}
       >
@@ -664,6 +664,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
           aria-label={ariaLabel}
           aria-labelledby={label && !ariaLabel ? this._labelId : undefined}
           aria-multiselectable={multiSelect}
+          shouldFocusOnMount
         >
           {onRenderList(props, this._onRenderList)}
         </FocusZone>


### PR DESCRIPTION
## Current Behavior

`Dropdown` opens as a `Panel` on smaller screens, but this presents a problem for users of screen readers since they can't close the `Panel` as they are unable to access the backdrop to soft dismiss it.

## New Behavior

The `Panel` that opens when `Dropdown` is used on smaller screens now has a close button that can be accessed by screen reader users. Additionally, we are still keeping the focus by default going to the option list so there is no difference to how focus currently behaves when opening the `Dropdown`.

## Related Issue(s)

Fixes [ADO 14028](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/14028).
