### PR TITLE
Convert @fluentui/react-checkbox stories to index.stories.tsx approach

### DIFF
--- a/change/@fluentui-react-checkbox-e3435fe8-ffd4-469c-8c3d-62249afea0c3.json
+++ b/change/@fluentui-react-checkbox-e3435fe8-ffd4-469c-8c3d-62249afea0c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Move Checkbox stories to folder with index entry.",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-checkbox/.storybook/main.js
+++ b/packages/react-components/react-checkbox/.storybook/main.js
@@ -2,7 +2,7 @@ const rootMain = require('../../../../.storybook/main');
 
 module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
   ...rootMain,
-  stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/index.stories.@(ts|tsx)'],
   addons: [...rootMain.addons],
   webpackFinal: (config, options) => {
     const localConfig = { ...rootMain.webpackFinal(config, options) };

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxChecked.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxChecked.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox, CheckboxProps } from './index';
+import { Checkbox, CheckboxProps } from '../../index';
 
 export const Checked = () => {
   const [checked, setChecked] = React.useState<CheckboxProps['checked']>(true);

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxCircular.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxCircular.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from './index';
+import { Checkbox } from '../../index';
 
 export const Circular = () => <Checkbox shape="circular" label="Circular" />;
 Circular.parameters = {

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxDefault.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox, CheckboxProps } from './index';
+import { Checkbox, CheckboxProps } from '../../index';
 
 export const Default = (props: CheckboxProps) => <Checkbox {...props} />;
 Default.argTypes = {

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxDisabled.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxDisabled.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from './index';
+import { Checkbox } from '../../index';
 
 export const Disabled = () => (
   <>

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxLabelBefore.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxLabelBefore.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from './index';
+import { Checkbox } from '../../index';
 
 export const LabelBefore = () => <Checkbox labelPosition="before" label="Label before" />;
 LabelBefore.parameters = {

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxLabelWrapping.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxLabelWrapping.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from './index';
+import { Checkbox } from '../../index';
 
 export const LabelWrapping = () => (
   <Checkbox

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxLarge.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxLarge.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from './index';
+import { Checkbox } from '../../index';
 
 export const Large = () => <Checkbox size="large" label="Large" />;
 Large.parameters = {

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxMixed.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxMixed.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from './index';
+import { Checkbox } from '../../index';
 
 export const Mixed = () => {
   const [option1, setOption1] = React.useState(false);

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxRequired.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxRequired.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from './index';
+import { Checkbox } from '../../index';
 
 export const Required = () => <Checkbox required label="Required" />;
 Required.parameters = {

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/index.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/index.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Meta } from '@storybook/react';
-import { Checkbox } from './index';
+import { Checkbox } from '../../index';
 import { tokens } from '@fluentui/react-theme';
 
 export { Default } from './CheckboxDefault.stories';


### PR DESCRIPTION
Fixes #23519 

Update Checkbox stories to use index.stories.tsx entrypoint and creates new `stories/Checkbox` path 