### PR TITLE
fix(react-avatar): Fixing AvatarGroup's focus indicator 

### DIFF
--- a/change/@fluentui-react-avatar-a7934ea7-fa8b-4224-af3f-0a54d4fc9b82.json
+++ b/change/@fluentui-react-avatar-a7934ea7-fa8b-4224-af3f-0a54d4fc9b82.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "prerelease",
   "comment": "fix: Fixing focus indicator and adding a focus ring to root for the pie layout.",
   "packageName": "@fluentui/react-avatar",
   "email": "esteban.230@hotmail.com",

--- a/change/@fluentui-react-avatar-a7934ea7-fa8b-4224-af3f-0a54d4fc9b82.json
+++ b/change/@fluentui-react-avatar-a7934ea7-fa8b-4224-af3f-0a54d4fc9b82.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix: Fixing focus indicator and adding a focus ring to root for the pie layout.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -23,6 +23,15 @@ const useStyles = makeStyles({
   pie: {
     clipPath: 'circle(50%)',
   },
+  focusIndicator: createCustomFocusIndicatorStyle(
+    {
+      ...shorthands.borderColor('transparent'),
+      outlineColor: tokens.colorStrokeFocus2,
+      outlineWidth: tokens.strokeWidthThick,
+      outlineStyle: 'solid',
+    },
+    { selector: 'focus-within' },
+  ),
 });
 
 /**
@@ -46,11 +55,9 @@ const useOverflowButtonStyles = makeStyles({
   // These styles match the default button styles
   focusIndicator: createCustomFocusIndicatorStyle({
     ...shorthands.borderColor('transparent'),
-    outlineColor: 'transparent',
+    outlineColor: tokens.colorStrokeFocus2,
     outlineWidth: tokens.strokeWidthThick,
     outlineStyle: 'solid',
-    boxShadow: `${tokens.shadow4} 0 0 0 2px ${tokens.colorStrokeFocus2}`,
-    zIndex: 1,
   }),
 
   states: {
@@ -121,6 +128,7 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
     styles.base,
     layout === 'pie' && styles.pie,
     layout === 'pie' && sizeStyles[size],
+    layout === 'pie' && styles.focusIndicator,
     state.root.className,
   );
 
@@ -181,9 +189,9 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
       avatarGroupClassNames.overflowButton,
       sizeStyles[size],
       overflowButtonStyles.base,
-      overflowButtonStyles.focusIndicator,
       ...overflowButtonClasses,
       layout !== 'pie' && overflowButtonStyles.states,
+      layout !== 'pie' && overflowButtonStyles.focusIndicator,
       layout === 'pie' && overflowButtonStyles.pie,
       groupChildClassName,
       state.overflowButton.className,


### PR DESCRIPTION
## Current Behavior

Focus indicator is not rendering with the proper colors.

<img width="453" alt="image" src="https://user-images.githubusercontent.com/5953191/173470815-3c1e2195-df34-4bf6-bfa6-66ed2b84d8ae.png">


## New Behavior

`spread` and `stack` now have the correct focus indicator ring and `pie` has a custom ring on the root slot.

<img width="469" alt="image" src="https://user-images.githubusercontent.com/5953191/173470635-415c79b7-3058-44bb-861f-b45342f94fdb.png">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#22240
