### PR TITLE
Consider webview element type for outside click scenarios - v9

### DIFF
--- a/change/@fluentui-react-utilities-5c5c2f2d-aea2-4aeb-81aa-ddbd4dc01b0f.json
+++ b/change/@fluentui-react-utilities-5c5c2f2d-aea2-4aeb-81aa-ddbd4dc01b0f.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Consider webview element type for outside click scenarios",
+  "comment": "fix: useOnClickOutside should trigger for webviews",
   "packageName": "@fluentui/react-utilities",
   "email": "jukapsia@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-utilities-5c5c2f2d-aea2-4aeb-81aa-ddbd4dc01b0f.json
+++ b/change/@fluentui-react-utilities-5c5c2f2d-aea2-4aeb-81aa-ddbd4dc01b0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Consider webview element type for outside click scenarios",
+  "packageName": "@fluentui/react-utilities",
+  "email": "jukapsia@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/hooks/useOnClickOutside.test.ts
+++ b/packages/react-components/react-utilities/src/hooks/useOnClickOutside.test.ts
@@ -59,4 +59,20 @@ describe('useOnClickOutside', () => {
     // Assert
     expect(callback).toHaveBeenCalledTimes(1);
   });
+
+  it('should invoke callback when active element is a webview', () => {
+    // Arrange
+    jest.useFakeTimers();
+    const iframe = document.createElement('webview');
+    const callback = jest.fn();
+    document.body.appendChild(iframe);
+    renderHook(() => useOnClickOutside({ element: document, callback, refs: [] }));
+
+    // Act
+    iframe.focus();
+    jest.runOnlyPendingTimers();
+
+    // Assert
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react-components/react-utilities/src/hooks/useOnClickOutside.ts
+++ b/packages/react-components/react-utilities/src/hooks/useOnClickOutside.ts
@@ -145,7 +145,7 @@ const useIFrameFocus = (
     if (enableFrameFocusDispatch) {
       timeoutRef.current = targetDocument?.defaultView?.setInterval(() => {
         const activeElement = targetDocument?.activeElement;
-        if (activeElement?.tagName === 'IFRAME') {
+        if (activeElement?.tagName === 'IFRAME' || activeElement?.tagName === 'WEBVIEW') {
           const event = new CustomEvent(FUI_FRAME_EVENT, { bubbles: true });
           activeElement.dispatchEvent(event);
         }


### PR DESCRIPTION
In Electron, iframe can be replaced with webview element type. This has to behave the same as iframe with regards to outside click detection.