### PR TITLE
theme designer: add WIP alert

### DIFF
--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -36,7 +36,8 @@
     "@fluentui/react-icons": "^2.0.172-rc.8",
     "@fluent-blocks/colors": "9.1.0",
     "codesandbox-import-utils": "2.2.3",
-    "@types/dedent": "0.7.0"
+    "@types/dedent": "0.7.0",
+    "@fluentui/react-alert": "9.0.0-beta.2"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <18.0.0",

--- a/packages/react-components/theme-designer/src/components/Content/Content.tsx
+++ b/packages/react-components/theme-designer/src/components/Content/Content.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { Divider, FluentProvider, tokens } from '@fluentui/react-components';
+import { Alert } from '@fluentui/react-components/unstable';
 
 import { Demo } from '../Demo/Demo';
 import { AccessibilityChecker } from '../AccessibilityChecker/AccessibilityChecker';
@@ -37,6 +38,9 @@ export const Content: React.FC<ContentProps> = props => {
 
   return (
     <FluentProvider theme={theme}>
+      <Alert intent="warning" action={{ appearance: 'transparent' }}>
+        This tool is still a work in progress - colors are still subject to adjustment.
+      </Alert>
       <div className={mergeClasses(styles.root, props.className)}>
         <Palette brandColors={props.brand} />
         <Demo theme={theme} />

--- a/packages/react-components/theme-designer/src/components/Content/Content.tsx
+++ b/packages/react-components/theme-designer/src/components/Content/Content.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { Divider, FluentProvider, tokens } from '@fluentui/react-components';
-import { Alert } from '@fluentui/react-components/unstable';
+import { Alert } from '@fluentui/react-alert';
 
 import { Demo } from '../Demo/Demo';
 import { AccessibilityChecker } from '../AccessibilityChecker/AccessibilityChecker';
@@ -39,7 +39,7 @@ export const Content: React.FC<ContentProps> = props => {
   return (
     <FluentProvider theme={theme}>
       <Alert intent="warning" action={{ appearance: 'transparent' }}>
-        This tool is a work in progress - colors are subject to adjustment.
+        This tool is still a work in progress - colors are still subject to adjustment.
       </Alert>
       <div className={mergeClasses(styles.root, props.className)}>
         <Palette brandColors={props.brand} />

--- a/packages/react-components/theme-designer/src/components/Content/Content.tsx
+++ b/packages/react-components/theme-designer/src/components/Content/Content.tsx
@@ -39,7 +39,7 @@ export const Content: React.FC<ContentProps> = props => {
   return (
     <FluentProvider theme={theme}>
       <Alert intent="warning" action={{ appearance: 'transparent' }}>
-        This tool is still a work in progress - colors are still subject to adjustment.
+        This tool is a work in progress - colors are subject to adjustment.
       </Alert>
       <div className={mergeClasses(styles.root, props.className)}>
         <Palette brandColors={props.brand} />


### PR DESCRIPTION
Many people who have looked at the theme designer noticed that some of the colors are a bit off and still need adjustments - those are features that will be implemented and tweaked in the future. This PR adds an alert that reminds users not to expect the colors to be completely accurate.

![image](https://user-images.githubusercontent.com/31319479/173641197-85259684-a019-436f-a26c-c36f056d9ece.png)
