### PR TITLE
fix contrast on ordered list and fix unordered marker layout

### DIFF
--- a/.storybook/docs-root.css
+++ b/.storybook/docs-root.css
@@ -105,13 +105,11 @@
   position: absolute;
   content: '•';
   color: #8d8d8d;
-  font-size: 16px;
-  line-height: 6px;
-  top: calc(50% - 3px);
-  left: -25px;
+  top: 0;
+  left: -15px;
 }
 
-#docs-root .sbdocs-ol .sbdocs-li {
+#docs-root .sbdocs-ol .sbdocs-li::marker {
   color: #8d8d8d;
 }
 


### PR DESCRIPTION
Ordered list item text did not meet contrast ratio, and unordered markers were too far away from text, and broke in nested scenarios.

New marker styles inherit font size/lineheight from parent, rather than trying to manually place with fixed line height, font size, and calculated to value. 

I'm guessing the original intent was to center the marker if the text wrapped, but it isn't possible to properly center on the <li> because nested content lives inside of that element. If this becomes a design concern in the future we can look at a custom markdown renderer that wraps list item content in spans so that the span can have the marker. 

Before:
![image](https://user-images.githubusercontent.com/1434956/173865602-bfdf3221-274c-4e17-8258-4340c3f7fe38.png)

After:
![image](https://user-images.githubusercontent.com/1434956/173865720-0b888b4e-96ab-494d-93b2-3cf78d47ed52.png)




