### PR TITLE
Chore: Update component creation to use package-based imports

### DIFF
--- a/scripts/create-component/plop-templates/src/stories/{{componentName}}/index.stories.tsx.hbs
+++ b/scripts/create-component/plop-templates/src/stories/{{componentName}}/index.stories.tsx.hbs
@@ -1,4 +1,4 @@
-import { {{componentName}} } from '../../index';
+import { {{componentName}} } from '@fluentui/{{packageName}}';
 
 import descriptionMd from './{{componentName}}Description.md';
 import bestPracticesMd from './{{componentName}}BestPractices.md';

--- a/scripts/create-component/plop-templates/src/stories/{{componentName}}/{{componentName}}Default.stories.tsx.hbs
+++ b/scripts/create-component/plop-templates/src/stories/{{componentName}}/{{componentName}}Default.stories.tsx.hbs
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { {{componentName}}, {{componentName}}Props } from '../index';
+import { {{componentName}}, {{componentName}}Props } from '@fluentui/{{packageName}}';
 
 export const Default = (props: Partial<{{componentName}}Props>) => (
   <{{componentName}} {...props} />


### PR DESCRIPTION
fixes #23564

before, stories would import from ../../index

Now packages import from @fluentui/packageName

This avoids issues when needing to move stories around, and will better support future work where we publish our stories for consumption in an external website, or external storybook.