### PR TITLE
v8 website: update custom SVG usage to mention unregistering icons

### DIFF
--- a/apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsSvgUsage.md
+++ b/apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsSvgUsage.md
@@ -21,6 +21,7 @@ import { unregisterIcons, registerIcons } from '@fluentui/react/lib/Styling';
 // Note: This approach works with any SVG icon set, not just @fluentui/react-icons-mdl2
 import { ChevronDownIcon, BadgeIcon } from '@fluentui/react-icons-mdl2';
 
+// Note: For any icon name that has an icon already registered to it, you need to unregister it first before registering a new one
 unregisterIcons(['ChevronDown']);
 
 registerIcons({

--- a/apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsSvgUsage.md
+++ b/apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsSvgUsage.md
@@ -17,13 +17,16 @@ ReactDOM.render(<ChevronDownIcon />, document.body.firstChild);
 If you do need to make SVG icons available to reference by name (for example, in Fluent UI React components which take `iconProps`), this can be done using `registerIcons` as follows:
 
 ```tsx
-import { registerIcons } from '@fluentui/react/lib/Styling';
+import { unregisterIcons, registerIcons } from '@fluentui/react/lib/Styling';
 // Note: This approach works with any SVG icon set, not just @fluentui/react-icons-mdl2
-import { ChevronDownIcon } from '@fluentui/react-icons-mdl2';
+import { ChevronDownIcon, BadgeIcon } from '@fluentui/react-icons-mdl2';
+
+unregisterIcons(['ChevronDown']);
 
 registerIcons({
   icons: {
     ChevronDown: <ChevronDownIcon />,
+    ANewIconName: <BadgeIcon />,
   },
 });
 ```


### PR DESCRIPTION
Our docs fail to mention that you cannot set the value for an existing icon without unregistering it first.

Demo here https://codesandbox.io/s/bold-sanne-kjpxd1?file=/src/index.tsx:200-209