### PR TITLE
chore(react-components): Re-export AvatarGroup and AvatarGroupItem in react-components/unstable

### DIFF
--- a/change/@fluentui-react-components-be758ba9-0ea3-4008-bf69-b7888148d832.json
+++ b/change/@fluentui-react-components-be758ba9-0ea3-4008-bf69-b7888148d832.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Re-exporting AvatarGroup and AvatarGroupItem in unstable.\"",
+  "packageName": "@fluentui/react-components",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-be758ba9-0ea3-4008-bf69-b7888148d832.json
+++ b/change/@fluentui-react-components-be758ba9-0ea3-4008-bf69-b7888148d832.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "chore: Re-exporting AvatarGroup and AvatarGroupItem in unstable.\"",
+  "comment": "chore: Re-exporting AvatarGroup and AvatarGroupItem in unstable.",
   "packageName": "@fluentui/react-components",
   "email": "esteban.230@hotmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -9,6 +9,16 @@ import { alertClassNames } from '@fluentui/react-alert';
 import { AlertProps } from '@fluentui/react-alert';
 import { AlertSlots } from '@fluentui/react-alert';
 import { AlertState } from '@fluentui/react-alert';
+import { AvatarGroup } from '@fluentui/react-avatar';
+import { avatarGroupClassNames } from '@fluentui/react-avatar';
+import { AvatarGroupItem } from '@fluentui/react-avatar';
+import { avatarGroupItemClassNames } from '@fluentui/react-avatar';
+import { AvatarGroupItemProps } from '@fluentui/react-avatar';
+import { AvatarGroupItemSlots } from '@fluentui/react-avatar';
+import { AvatarGroupItemState } from '@fluentui/react-avatar';
+import { AvatarGroupProps } from '@fluentui/react-avatar';
+import { AvatarGroupSlots } from '@fluentui/react-avatar';
+import { AvatarGroupState } from '@fluentui/react-avatar';
 import { Card } from '@fluentui/react-card';
 import { cardClassNames } from '@fluentui/react-card';
 import { cardCSSVars } from '@fluentui/react-card';
@@ -38,6 +48,8 @@ import { OverflowItem } from '@fluentui/react-overflow';
 import { OverflowItemProps } from '@fluentui/react-overflow';
 import { OverflowProps } from '@fluentui/react-overflow';
 import { renderAlert_unstable } from '@fluentui/react-alert';
+import { renderAvatarGroup_unstable } from '@fluentui/react-avatar';
+import { renderAvatarGroupItem_unstable } from '@fluentui/react-avatar';
 import { renderCard_unstable } from '@fluentui/react-card';
 import { renderCardFooter_unstable } from '@fluentui/react-card';
 import { renderCardHeader_unstable } from '@fluentui/react-card';
@@ -76,6 +88,10 @@ import { ToolbarToggleButtonProps } from '@fluentui/react-toolbar';
 import { ToolbarToggleButtonState } from '@fluentui/react-toolbar';
 import { useAlert_unstable } from '@fluentui/react-alert';
 import { useAlertStyles_unstable } from '@fluentui/react-alert';
+import { useAvatarGroup_unstable } from '@fluentui/react-avatar';
+import { useAvatarGroupItem_unstable } from '@fluentui/react-avatar';
+import { useAvatarGroupItemStyles_unstable } from '@fluentui/react-avatar';
+import { useAvatarGroupStyles_unstable } from '@fluentui/react-avatar';
 import { useCard_unstable } from '@fluentui/react-card';
 import { useCardFooter_unstable } from '@fluentui/react-card';
 import { useCardFooterStyles_unstable } from '@fluentui/react-card';
@@ -104,6 +120,26 @@ export { AlertProps }
 export { AlertSlots }
 
 export { AlertState }
+
+export { AvatarGroup }
+
+export { avatarGroupClassNames }
+
+export { AvatarGroupItem }
+
+export { avatarGroupItemClassNames }
+
+export { AvatarGroupItemProps }
+
+export { AvatarGroupItemSlots }
+
+export { AvatarGroupItemState }
+
+export { AvatarGroupProps }
+
+export { AvatarGroupSlots }
+
+export { AvatarGroupState }
 
 export { Card }
 
@@ -162,6 +198,10 @@ export { OverflowItemProps }
 export { OverflowProps }
 
 export { renderAlert_unstable }
+
+export { renderAvatarGroup_unstable }
+
+export { renderAvatarGroupItem_unstable }
 
 export { renderCard_unstable }
 
@@ -238,6 +278,14 @@ export { ToolbarToggleButtonState }
 export { useAlert_unstable }
 
 export { useAlertStyles_unstable }
+
+export { useAvatarGroup_unstable }
+
+export { useAvatarGroupItem_unstable }
+
+export { useAvatarGroupItemStyles_unstable }
+
+export { useAvatarGroupStyles_unstable }
 
 export { useCard_unstable }
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -9,6 +9,26 @@ export {
 } from '@fluentui/react-alert';
 export type { AlertProps, AlertSlots, AlertState } from '@fluentui/react-alert';
 export {
+  AvatarGroup,
+  AvatarGroupItem,
+  avatarGroupClassNames,
+  avatarGroupItemClassNames,
+  renderAvatarGroup_unstable,
+  renderAvatarGroupItem_unstable,
+  useAvatarGroup_unstable,
+  useAvatarGroupItem_unstable,
+  useAvatarGroupStyles_unstable,
+  useAvatarGroupItemStyles_unstable,
+} from '@fluentui/react-avatar';
+export type {
+  AvatarGroupProps,
+  AvatarGroupSlots,
+  AvatarGroupState,
+  AvatarGroupItemProps,
+  AvatarGroupItemSlots,
+  AvatarGroupItemState,
+} from '@fluentui/react-avatar';
+export {
   Card,
   CardFooter,
   CardHeader,


### PR DESCRIPTION
This PR re-exports AvatarGroup and AvatarGroupItem in `@fluentui/react-components/unstable`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#22240 
