### PR TITLE
fix(react-avatar): Fix outline styles for stack layout in webkit browsers.

### DIFF
--- a/change/@fluentui-react-avatar-0172fa1d-9de1-463f-9fe9-29f20a05717b.json
+++ b/change/@fluentui-react-avatar-0172fa1d-9de1-463f-9fe9-29f20a05717b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Fix wrong border radius for outline in webkit browsers.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -121,7 +121,7 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
   const overflowContentStyles = useOverflowContentStyles();
   const overflowButtonStyles = useOverflowButtonStyles();
 
-  const groupChildClassName = useGroupChildClassName(layout, size);
+  const groupChildClassName = useGroupChildClassName(layout, size, true);
 
   state.root.className = mergeClasses(
     avatarGroupClassNames.root,

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -121,7 +121,7 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
   const overflowContentStyles = useOverflowContentStyles();
   const overflowButtonStyles = useOverflowButtonStyles();
 
-  const groupChildClassName = useGroupChildClassName(layout, size, true);
+  const groupChildClassName = useGroupChildClassName(layout, size);
 
   state.root.className = mergeClasses(
     avatarGroupClassNames.root,

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -50,6 +50,11 @@ const useOverflowButtonStyles = makeStyles({
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
     ...shorthands.borderStyle('solid'),
     ...shorthands.padding(0),
+
+    // match color to Avatar's outline color
+    '@media (forced-colors: active)': {
+      ...shorthands.borderColor('CanvasText'),
+    },
   },
 
   // These styles match the default button styles

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -96,12 +96,44 @@ const usePieStyles = makeStyles({
 
 const useStackStyles = makeStyles({
   base: {
-    outlineColor: tokens.colorNeutralBackground2,
-    outlineStyle: 'solid',
+    '&::after': {
+      content: "''",
+      position: 'absolute',
+      display: 'block',
+      ...shorthands.borderRadius(tokens.borderRadiusCircular),
+      width: '100%',
+      height: '100%',
+      outlineStyle: 'solid',
+      outlineColor: tokens.colorNeutralBackground2,
+    },
   },
-  thick: { outlineWidth: tokens.strokeWidthThick },
-  thicker: { outlineWidth: tokens.strokeWidthThicker },
-  thickest: { outlineWidth: tokens.strokeWidthThickest },
+  thick: { '&::after': { outlineWidth: tokens.strokeWidthThick } },
+  thicker: { '&::after': { outlineWidth: tokens.strokeWidthThicker } },
+  thickest: { '&::after': { outlineWidth: tokens.strokeWidthThickest } },
+  overflowButtonThin: {
+    '&::after': {
+      width: `calc(100% + ${tokens.strokeWidthThin} * 2)`,
+      height: `calc(100% + ${tokens.strokeWidthThin} * 2)`,
+    },
+  },
+  overflowButtonThick: {
+    '&::after': {
+      width: `calc(100% + ${tokens.strokeWidthThick} * 2)`,
+      height: `calc(100% + ${tokens.strokeWidthThick} * 2)`,
+    },
+  },
+  overflowButtonThicker: {
+    '&::after': {
+      width: `calc(100% + ${tokens.strokeWidthThicker} * 2)`,
+      height: `calc(100% + ${tokens.strokeWidthThicker} * 2)`,
+    },
+  },
+  overflowButtonThickest: {
+    '&::after': {
+      width: `calc(100% + ${tokens.strokeWidthThickest} * 2)`,
+      height: `calc(100% + ${tokens.strokeWidthThickest} * 2)`,
+    },
+  },
   xxs: { '&:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalXXS})` } },
   xs: { '&:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalXS})` } },
   s: { '&:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalS})` } },
@@ -182,7 +214,11 @@ export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): 
  * Hook for getting the className for the children of AvatarGroup. This hook will provide the spacing and outlines
  * needed for each layout.
  */
-export const useGroupChildClassName = (layout: AvatarGroupProps['layout'], size: AvatarSizes): string => {
+export const useGroupChildClassName = (
+  layout: AvatarGroupProps['layout'],
+  size: AvatarSizes,
+  isOverflowButton?: boolean,
+): string => {
   const stackStyles = useStackStyles();
   const spreadStyles = useSpreadStyles();
   const layoutClasses = [];
@@ -197,6 +233,18 @@ export const useGroupChildClassName = (layout: AvatarGroupProps['layout'], size:
         layoutClasses.push(stackStyles.thicker);
       } else {
         layoutClasses.push(stackStyles.thickest);
+      }
+
+      if (isOverflowButton) {
+        if (size < 36) {
+          layoutClasses.push(stackStyles.overflowButtonThin);
+        } else if (size < 56) {
+          layoutClasses.push(stackStyles.overflowButtonThick);
+        } else if (size < 72) {
+          layoutClasses.push(stackStyles.overflowButtonThicker);
+        } else {
+          layoutClasses.push(stackStyles.overflowButtonThickest);
+        }
       }
 
       if (size < 24) {

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -277,6 +277,8 @@ export const useGroupChildClassName = (
       // When the child is an overflowButton, we have to calculate the overflowButton's border + width + outline width
       // since the ::after pseudo-element doesn't take the overflowButton's border for its size.
       if (isOverflowButton) {
+        layoutClasses.push(stackStyles.overflowButton);
+
         if (size < 36) {
           layoutClasses.push(stackStyles.borderThin);
         } else if (size < 56) {

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -99,11 +99,15 @@ const useStackStyles = makeStyles({
     '&::after': {
       content: "''",
       position: 'absolute',
-      display: 'block',
+      display: 'inline-flex',
       // Border is used instead of outline due to a bug in webkit browsers where border-radius is ignored in outline.
       ...shorthands.borderColor(tokens.colorNeutralBackground2),
       ...shorthands.borderRadius(tokens.borderRadiusCircular),
       ...shorthands.borderStyle('solid'),
+
+      '@media (forced-colors: active)': {
+        forcedColorAdjust: 'none',
+      },
     },
   },
   overflowButton: {
@@ -112,6 +116,10 @@ const useStackStyles = makeStyles({
       '&::after': {
         ...shorthands.borderColor('transparent'),
       },
+    },
+    // hide inner border when using high contrast mode and use the outer (::after) to match Avatar's outline
+    '@media (forced-colors: active)': {
+      ...shorthands.borderColor('Canvas'),
     },
   },
   thick: {

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -96,44 +96,14 @@ const usePieStyles = makeStyles({
 
 const useStackStyles = makeStyles({
   base: {
-    '&::after': {
-      content: "''",
-      position: 'absolute',
-      display: 'block',
-      ...shorthands.borderRadius(tokens.borderRadiusCircular),
-      width: '100%',
-      height: '100%',
-      outlineStyle: 'solid',
-      outlineColor: tokens.colorNeutralBackground2,
-    },
+    // Outline style should be auto since there's a bug in webkit browsers where border radius
+    // is ignored if auto is not used. Please refer to #23576 for more details.
+    outlineStyle: 'auto',
+    outlineColor: tokens.colorNeutralBackground2,
   },
-  thick: { '&::after': { outlineWidth: tokens.strokeWidthThick } },
-  thicker: { '&::after': { outlineWidth: tokens.strokeWidthThicker } },
-  thickest: { '&::after': { outlineWidth: tokens.strokeWidthThickest } },
-  overflowButtonThin: {
-    '&::after': {
-      width: `calc(100% + ${tokens.strokeWidthThin} * 2)`,
-      height: `calc(100% + ${tokens.strokeWidthThin} * 2)`,
-    },
-  },
-  overflowButtonThick: {
-    '&::after': {
-      width: `calc(100% + ${tokens.strokeWidthThick} * 2)`,
-      height: `calc(100% + ${tokens.strokeWidthThick} * 2)`,
-    },
-  },
-  overflowButtonThicker: {
-    '&::after': {
-      width: `calc(100% + ${tokens.strokeWidthThicker} * 2)`,
-      height: `calc(100% + ${tokens.strokeWidthThicker} * 2)`,
-    },
-  },
-  overflowButtonThickest: {
-    '&::after': {
-      width: `calc(100% + ${tokens.strokeWidthThickest} * 2)`,
-      height: `calc(100% + ${tokens.strokeWidthThickest} * 2)`,
-    },
-  },
+  thick: { outlineWidth: tokens.strokeWidthThick },
+  thicker: { outlineWidth: tokens.strokeWidthThicker },
+  thickest: { outlineWidth: tokens.strokeWidthThickest },
   xxs: { '&:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalXXS})` } },
   xs: { '&:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalXS})` } },
   s: { '&:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalS})` } },
@@ -214,11 +184,7 @@ export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): 
  * Hook for getting the className for the children of AvatarGroup. This hook will provide the spacing and outlines
  * needed for each layout.
  */
-export const useGroupChildClassName = (
-  layout: AvatarGroupProps['layout'],
-  size: AvatarSizes,
-  isOverflowButton?: boolean,
-): string => {
+export const useGroupChildClassName = (layout: AvatarGroupProps['layout'], size: AvatarSizes): string => {
   const stackStyles = useStackStyles();
   const spreadStyles = useSpreadStyles();
   const layoutClasses = [];
@@ -233,18 +199,6 @@ export const useGroupChildClassName = (
         layoutClasses.push(stackStyles.thicker);
       } else {
         layoutClasses.push(stackStyles.thickest);
-      }
-
-      if (isOverflowButton) {
-        if (size < 36) {
-          layoutClasses.push(stackStyles.overflowButtonThin);
-        } else if (size < 56) {
-          layoutClasses.push(stackStyles.overflowButtonThick);
-        } else if (size < 72) {
-          layoutClasses.push(stackStyles.overflowButtonThicker);
-        } else {
-          layoutClasses.push(stackStyles.overflowButtonThickest);
-        }
       }
 
       if (size < 24) {

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -100,9 +100,18 @@ const useStackStyles = makeStyles({
       content: "''",
       position: 'absolute',
       display: 'block',
+      // Border is used instead of outline due to a bug in webkit browsers where border-radius is ignored in outline.
       ...shorthands.borderColor(tokens.colorNeutralBackground2),
       ...shorthands.borderRadius(tokens.borderRadiusCircular),
       ...shorthands.borderStyle('solid'),
+    },
+  },
+  overflowButton: {
+    // border-color has to be set to transparent when there's focus due to the outline overlapping the focus ring.
+    '&:focus': {
+      '&::after': {
+        ...shorthands.borderColor('transparent'),
+      },
     },
   },
   thick: {

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItemStyles.ts
@@ -96,14 +96,74 @@ const usePieStyles = makeStyles({
 
 const useStackStyles = makeStyles({
   base: {
-    // Outline style should be auto since there's a bug in webkit browsers where border radius
-    // is ignored if auto is not used. Please refer to #23576 for more details.
-    outlineStyle: 'auto',
-    outlineColor: tokens.colorNeutralBackground2,
+    '&::after': {
+      content: "''",
+      position: 'absolute',
+      display: 'block',
+      ...shorthands.borderColor(tokens.colorNeutralBackground2),
+      ...shorthands.borderRadius(tokens.borderRadiusCircular),
+      ...shorthands.borderStyle('solid'),
+    },
   },
-  thick: { outlineWidth: tokens.strokeWidthThick },
-  thicker: { outlineWidth: tokens.strokeWidthThicker },
-  thickest: { outlineWidth: tokens.strokeWidthThickest },
+  thick: {
+    '&::after': {
+      width: '100%',
+      height: '100%',
+      left: `calc(-1 * ${tokens.strokeWidthThick})`,
+      top: `calc(-1 * ${tokens.strokeWidthThick})`,
+      ...shorthands.borderWidth(tokens.strokeWidthThick),
+    },
+  },
+  thicker: {
+    '&::after': {
+      width: '100%',
+      height: '100%',
+      left: `calc(-1 * ${tokens.strokeWidthThicker})`,
+      top: `calc(-1 * ${tokens.strokeWidthThicker})`,
+      ...shorthands.borderWidth(tokens.strokeWidthThicker),
+    },
+  },
+  thickest: {
+    '&::after': {
+      width: '100%',
+      height: '100%',
+      left: `calc(-1 * ${tokens.strokeWidthThickest})`,
+      top: `calc(-1 * ${tokens.strokeWidthThickest})`,
+      ...shorthands.borderWidth(tokens.strokeWidthThickest),
+    },
+  },
+  borderThin: {
+    '&::after': {
+      width: `calc(100% + ${tokens.strokeWidthThin} * 2)`,
+      height: `calc(100% + ${tokens.strokeWidthThin} * 2)`,
+      left: `calc(-1 * (${tokens.strokeWidthThick} + ${tokens.strokeWidthThin}))`,
+      top: `calc(-1 * (${tokens.strokeWidthThick} + ${tokens.strokeWidthThin}))`,
+    },
+  },
+  borderThick: {
+    '&::after': {
+      width: `calc(100% + ${tokens.strokeWidthThick} * 2)`,
+      height: `calc(100% + ${tokens.strokeWidthThick} * 2)`,
+      left: `calc(-1 * ${tokens.strokeWidthThick} * 2)`,
+      top: `calc(-1 * ${tokens.strokeWidthThick} * 2)`,
+    },
+  },
+  borderThicker: {
+    '&::after': {
+      width: `calc(100% + ${tokens.strokeWidthThicker} * 2)`,
+      height: `calc(100% + ${tokens.strokeWidthThicker} * 2)`,
+      left: `calc(-1 * ${tokens.strokeWidthThicker} * 2)`,
+      top: `calc(-1 * ${tokens.strokeWidthThicker} * 2)`,
+    },
+  },
+  borderThickest: {
+    '&::after': {
+      width: `calc(100% + ${tokens.strokeWidthThickest} * 2)`,
+      height: `calc(100% + ${tokens.strokeWidthThickest} * 2)`,
+      left: `calc(-1 * ${tokens.strokeWidthThickest} * 2)`,
+      top: `calc(-1 * ${tokens.strokeWidthThickest} * 2)`,
+    },
+  },
   xxs: { '&:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalXXS})` } },
   xs: { '&:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalXS})` } },
   s: { '&:not(:first-child)': { marginLeft: `calc(-1 * ${tokens.spacingHorizontalS})` } },
@@ -184,7 +244,11 @@ export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): 
  * Hook for getting the className for the children of AvatarGroup. This hook will provide the spacing and outlines
  * needed for each layout.
  */
-export const useGroupChildClassName = (layout: AvatarGroupProps['layout'], size: AvatarSizes): string => {
+export const useGroupChildClassName = (
+  layout: AvatarGroupProps['layout'],
+  size: AvatarSizes,
+  isOverflowButton?: boolean,
+): string => {
   const stackStyles = useStackStyles();
   const spreadStyles = useSpreadStyles();
   const layoutClasses = [];
@@ -199,6 +263,20 @@ export const useGroupChildClassName = (layout: AvatarGroupProps['layout'], size:
         layoutClasses.push(stackStyles.thicker);
       } else {
         layoutClasses.push(stackStyles.thickest);
+      }
+
+      // When the child is an overflowButton, we have to calculate the overflowButton's border + width + outline width
+      // since the ::after pseudo-element doesn't take the overflowButton's border for its size.
+      if (isOverflowButton) {
+        if (size < 36) {
+          layoutClasses.push(stackStyles.borderThin);
+        } else if (size < 56) {
+          layoutClasses.push(stackStyles.borderThick);
+        } else if (size < 72) {
+          layoutClasses.push(stackStyles.borderThicker);
+        } else {
+          layoutClasses.push(stackStyles.borderThickest);
+        }
       }
 
       if (size < 24) {


### PR DESCRIPTION
## Current Behavior

Border radius is ignored for the stack layout's outline. This is due to a bug in webkit browser where `outline` ignores both `-webkit-border-radius` and `border-radius`. For more details you can take a look at the bug filed in [here](https://bugs.webkit.org/show_bug.cgi?id=20807).

## New Behavior

Outline for stack layouts now works correctly in webkit browsers. To accomplish this, a border has to be added in an `::after` pseudo-element. This affects `useGroupChildClassName` by having to differentiate when the hook is used for the overflowButton. Mostly so that the width can be calculated correctly because the button is applied a border that is not picked up by setting `width: 100%` in the pseudo-element.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#23549 #22240
