### PR TITLE
fix: Removing user-select: 'none' from label in input components with built-in labels

### DIFF
--- a/change/@fluentui-react-checkbox-81561378-0c3f-4f50-a665-ba6f5b52f422.json
+++ b/change/@fluentui-react-checkbox-81561378-0c3f-4f50-a665-ba6f5b52f422.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Removing user-select: 'none' from label.",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-ffb7b11e-bcc5-4b44-9efb-c358fbeeba7f.json
+++ b/change/@fluentui-react-radio-ffb7b11e-bcc5-4b44-9efb-c358fbeeba7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Removing user-select: 'none' from label.",
+  "packageName": "@fluentui/react-radio",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-98248aa5-d7bb-405e-a884-1e56297057fc.json
+++ b/change/@fluentui-react-slider-98248aa5-d7bb-405e-a884-1e56297057fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Removing user-select: 'none' from label.",
+  "packageName": "@fluentui/react-slider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-208b8863-6b08-4ecb-91ca-d3689e0d6771.json
+++ b/change/@fluentui-react-switch-208b8863-6b08-4ecb-91ca-d3689e0d6771.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Removing user-select: 'none' from label.",
+  "packageName": "@fluentui/react-switch",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -182,7 +182,6 @@ const useIndicatorStyles = makeStyles({
 const useLabelStyles = makeStyles({
   base: {
     alignSelf: 'center',
-    userSelect: 'none',
     cursor: 'inherit',
     color: 'inherit',
   },

--- a/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
+++ b/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
@@ -141,7 +141,6 @@ const useIndicatorStyles = makeStyles({
 const useLabelStyles = makeStyles({
   base: {
     alignSelf: 'center',
-    userSelect: 'none',
   },
 
   after: {

--- a/packages/react-components/react-slider/src/components/Slider/useSliderStyles.ts
+++ b/packages/react-components/react-slider/src/components/Slider/useSliderStyles.ts
@@ -34,7 +34,6 @@ const useRootStyles = makeStyles({
     position: 'relative',
     display: 'inline-grid',
     gridTemplateAreas: '"slider"',
-    userSelect: 'none',
     touchAction: 'none',
     alignItems: 'center',
     justifyItems: 'center',

--- a/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -179,10 +179,6 @@ const useInputStyles = makeStyles({
 });
 
 const useLabelStyles = makeStyles({
-  base: {
-    userSelect: 'none',
-  },
-
   above: {
     marginBottom: tokens.spacingVerticalXS,
   },
@@ -222,12 +218,7 @@ export const useSwitchStyles_unstable = (state: SwitchState): SwitchState => {
   );
 
   if (state.label) {
-    state.label.className = mergeClasses(
-      switchClassNames.label,
-      labelStyles.base,
-      labelStyles[labelPosition],
-      state.label.className,
-    );
+    state.label.className = mergeClasses(switchClassNames.label, labelStyles[labelPosition], state.label.className);
   }
 
   return state;


### PR DESCRIPTION
## Current Behavior

The input components that have built-in labels have `user-select: 'none'` set on them with makes their text impossible to copy and prevents people from using tools like read-aloud or dictionary lookup.

## New Behavior

The input components that have built-in labels no longer have `user-select: 'none'` set on them, eliminating the problem described above.

## Related Issue(s)

Fixes part of #23589
