### PR TITLE
fix: Add arrow padding to Popover arrrow

### DIFF
--- a/change/@fluentui-react-popover-a78f11b5-8028-4fd7-bc70-64dd01717b40.json
+++ b/change/@fluentui-react-popover-a78f11b5-8028-4fd7-bc70-64dd01717b40.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Add arrow padding to Popover arrrow",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/src/components/Popover/constants.ts
+++ b/packages/react-components/react-popover/src/components/Popover/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * @internal
+ * The default value of the tooltip's border radius (borderRadiusMedium).
+ *
+ * Unfortunately, Popper requires it to be specified as a variable instead of using CSS.
+ * While we could use getComputedStyle, that adds a performance penalty for something that
+ * will likely never change.
+ */
+export const popoverSurfaceBorderRadius = 4;

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -16,6 +16,7 @@ import { elementContains } from '@fluentui/react-portal';
 import { useFocusFinders } from '@fluentui/react-tabster';
 import { arrowHeights } from '../PopoverSurface/index';
 import type { OpenPopoverEvents, PopoverProps, PopoverState } from './Popover.types';
+import { popoverSurfaceBorderRadius } from './constants';
 
 /**
  * Create the state required to render Popover.
@@ -191,6 +192,7 @@ function usePopoverRefs(
   const positioningOptions = {
     position: 'above' as const,
     align: 'center' as const,
+    arrowPadding: 2 * popoverSurfaceBorderRadius,
     target: state.openOnContext ? state.contextTarget : undefined,
     ...resolvePositioningShorthand(state.positioning),
   };

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
@@ -22,7 +22,7 @@ const useStyles = makeStyles({
   root: {
     backgroundColor: tokens.colorNeutralBackground1,
     boxShadow: tokens.shadow16,
-    ...shorthands.borderRadius('4px'),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
     ...shorthands.border('1px', 'solid', tokens.colorTransparentStroke),
   },
 


### PR DESCRIPTION
Adds arrow padding value to the popover in the same way that `Tooltip`
does it.

## Current Behavior

Popover arrow has no padding

## New Behavior

Popover arrow has a padding value twice the border radius of the `PopoverSurface`

## Related Issue(s)


Fixes #23509
