### PR TITLE
feat: Add `visible` prop to `Popover`

### DIFF
--- a/packages/react-components/react-combobox/src/components/Combobox/renderCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/renderCombobox.tsx
@@ -11,7 +11,7 @@ export const renderCombobox_unstable = (state: ComboboxState, contextValues: Com
   const { slots, slotProps } = getSlots<ComboboxSlots>(state);
 
   const listbox = <slots.listbox {...slotProps.listbox}>{slotProps.root.children}</slots.listbox>;
-  const popup = state.inline ? listbox : <Portal>{listbox}</Portal>;
+  const popup = state.inline ? listbox : <Portal visible={state.open}>{listbox}</Portal>;
 
   return (
     <slots.root {...slotProps.root}>

--- a/packages/react-components/react-menu/src/components/Menu/renderMenu.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/renderMenu.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Portal } from '@fluentui/react-portal';
 import { MenuProvider } from '../../contexts/menuContext';
 import type { MenuContextValues, MenuState } from './Menu.types';
 
@@ -9,7 +10,7 @@ export const renderMenu_unstable = (state: MenuState, contextValues: MenuContext
   return (
     <MenuProvider value={contextValues.menu}>
       {state.menuTrigger}
-      {state.open && state.menuPopover}
+      {state.inline ? state.menuPopover : <Portal visible={state.open}>{state.menuPopover}</Portal>}
     </MenuProvider>
   );
 };

--- a/packages/react-components/react-menu/src/components/MenuPopover/renderMenuPopover.tsx
+++ b/packages/react-components/react-menu/src/components/MenuPopover/renderMenuPopover.tsx
@@ -9,13 +9,5 @@ import { Portal } from '@fluentui/react-portal';
 export const renderMenuPopover_unstable = (state: MenuPopoverState) => {
   const { slots, slotProps } = getSlots<MenuPopoverSlots>(state);
 
-  if (state.inline) {
-    return <slots.root {...slotProps.root} />;
-  }
-
-  return (
-    <Portal>
-      <slots.root {...slotProps.root} />
-    </Portal>
-  );
+  return <slots.root {...slotProps.root} />;
 };

--- a/packages/react-components/react-popover/src/components/Popover/renderPopover.tsx
+++ b/packages/react-components/react-popover/src/components/Popover/renderPopover.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Portal } from '@fluentui/react-portal';
 import { PopoverContext } from '../../popoverContext';
 import type { PopoverState } from './Popover.types';
 
@@ -43,7 +44,7 @@ export const renderPopover_unstable = (state: PopoverState) => {
       }}
     >
       {state.popoverTrigger}
-      {state.open && state.popoverSurface}
+      {state.inline ? state.popoverSurface : <Portal visible={state.open}>{state.popoverSurface}</Portal>}
     </PopoverContext.Provider>
   );
 };

--- a/packages/react-components/react-popover/src/components/PopoverSurface/renderPopoverSurface.tsx
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/renderPopoverSurface.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Portal } from '@fluentui/react-portal';
 import { getSlots } from '@fluentui/react-utilities';
 import type { PopoverSurfaceSlots, PopoverSurfaceState } from './PopoverSurface.types';
 
@@ -9,16 +8,10 @@ import type { PopoverSurfaceSlots, PopoverSurfaceState } from './PopoverSurface.
 export const renderPopoverSurface_unstable = (state: PopoverSurfaceState) => {
   const { slots, slotProps } = getSlots<PopoverSurfaceSlots>(state);
 
-  const surface = (
+  return (
     <slots.root {...slotProps.root}>
       {state.withArrow && <div ref={state.arrowRef} className={state.arrowClassName} />}
       {slotProps.root.children}
     </slots.root>
   );
-
-  if (state.inline) {
-    return surface;
-  }
-
-  return <Portal mountNode={state.mountNode}>{surface}</Portal>;
 };

--- a/packages/react-components/react-portal/src/components/Portal/Portal.types.ts
+++ b/packages/react-components/react-portal/src/components/Portal/Portal.types.ts
@@ -12,6 +12,8 @@ export type PortalProps = {
    * @default a new element on document.body without any styling
    */
   mountNode?: HTMLElement | null;
+
+  visible: boolean;
 };
 
 export type PortalState = Pick<PortalProps, 'children'> &

--- a/packages/react-components/react-portal/src/components/Portal/usePortal.ts
+++ b/packages/react-components/react-portal/src/components/Portal/usePortal.ts
@@ -12,7 +12,7 @@ import type { PortalProps, PortalState } from './Portal.types';
  * @param props - props from this instance of Portal
  */
 export const usePortal_unstable = (props: PortalProps): PortalState => {
-  const { children, mountNode } = props;
+  const { children, mountNode, open } = props;
 
   const virtualParentRootRef = React.useRef<HTMLSpanElement>(null);
   const fallbackMountNode = usePortalMountNode({ disabled: !!mountNode });
@@ -20,7 +20,7 @@ export const usePortal_unstable = (props: PortalProps): PortalState => {
   const state: PortalState = {
     children,
     mountNode: mountNode ?? fallbackMountNode,
-    shouldRender: !useIsSSR(),
+    shouldRender: !useIsSSR() && open,
     virtualParentRootRef,
   };
 

--- a/packages/react-components/react-tooltip/src/components/Tooltip/renderTooltip.tsx
+++ b/packages/react-components/react-tooltip/src/components/Tooltip/renderTooltip.tsx
@@ -12,14 +12,12 @@ export const renderTooltip_unstable = (state: TooltipState) => {
   return (
     <>
       {state.children}
-      {state.shouldRenderTooltip && (
-        <Portal mountNode={state.mountNode}>
-          <slots.content {...slotProps.content}>
-            {state.withArrow && <div ref={state.arrowRef} className={state.arrowClassName} />}
-            {state.content.children}
-          </slots.content>
-        </Portal>
-      )}
+      <Portal visible={!!state.shouldRenderTooltip} mountNode={state.mountNode}>
+        <slots.content {...slotProps.content}>
+          {state.withArrow && <div ref={state.arrowRef} className={state.arrowClassName} />}
+          {state.content.children}
+        </slots.content>
+      </Portal>
     </>
   );
 };


### PR DESCRIPTION
Adds a `visible` prop to `Popover` and avoids conditional rendering.

A **nasty** half solution to this repro  https://codesandbox.io/s/proud-microservice-2wgo0p?file=/src/App.js which happens because `useIsSSR` forces a double render where the initial render of the `Portal` component is always `null`

pros 👍
* no need to understand the above problem (which is not intuitive)
* forces users to use the `visible` prop

cons 👎
* the `Portal` can still be rendered in something conditionally
