### PR TITLE
fix: Dropdown search input

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -812,9 +812,9 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
   };
 
   const selectedItemsCountNarration = renderSelectedItemsCountNarration(selectedItemsCountNarrationId);
-  const renderSelectedItems = () => {
+  const renderSelectedItems = (searchInput: JSX.Element) => {
     if (value.length === 0) {
-      return null;
+      return searchInput;
     }
 
     const selectedItems = value.map((item: DropdownItemProps, index) =>
@@ -837,6 +837,7 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
       <>
         <div role="listbox" tabIndex={-1} aria-label={a11ySelectedItemsMessage}>
           {selectedItems}
+          {searchInput}
         </div>
         {selectedItemsCountNarration}
       </>
@@ -1627,6 +1628,17 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
           );
           const showClearIndicator = clearable && value.length > 0;
 
+          const searchInput = search
+            ? renderSearchInput(
+                accessibilityRootPropsRest,
+                highlightedIndex,
+                getInputProps,
+                selectItemAtIndex,
+                toggleMenu,
+                variables,
+              )
+            : undefined;
+
           return (
             <Ref innerRef={innerRef}>
               <div
@@ -1639,16 +1651,8 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
                     after listbox wrapper was introduced we moved it to before and
                      set as absolute to avoid visual regressions   */}
                   {!search && renderTriggerButton(getToggleButtonProps)}
-                  {multiple && renderSelectedItems()}
-                  {search &&
-                    renderSearchInput(
-                      accessibilityRootPropsRest,
-                      highlightedIndex,
-                      getInputProps,
-                      selectItemAtIndex,
-                      toggleMenu,
-                      variables,
-                    )}
+                  {multiple && renderSelectedItems(searchInput)}
+                  {search && !multiple && searchInput}
                 </div>
                 {showClearIndicator
                   ? Box.create(clearIndicator, {


### PR DESCRIPTION
# Overview 

The `Dropdown` when multiple and search is rendering the input bellow the list because it's being rendered in separated box element. 

![Screenshot (76)](https://user-images.githubusercontent.com/86579954/174621076-bd44d12c-cad5-46a6-9276-51914f325669.png)

To fix it we are moving it to same box element and then allowing it to be rendered side by side with the pills

![Screenshot (77)](https://user-images.githubusercontent.com/86579954/174621443-60ddfb25-523a-4627-aa69-8265c8d28aa3.png)

