### PR TITLE
eslint-plugin: Add custom no-restricted-imports rule with fixer

### DIFF
--- a/change/@fluentui-eslint-plugin-ce5953c9-ee6d-4a78-98f6-74c8eb384e5e.json
+++ b/change/@fluentui-eslint-plugin-ce5953c9-ee6d-4a78-98f6-74c8eb384e5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add new no-restricted-imports with fixer",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-eslint-plugin-ce5953c9-ee6d-4a78-98f6-74c8eb384e5e.json
+++ b/change/@fluentui-eslint-plugin-ce5953c9-ee6d-4a78-98f6-74c8eb384e5e.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat: add new no-restricted-imports with fixer",
+  "comment": "feat: add custom no-restricted-imports rule with fixer",
   "packageName": "@fluentui/eslint-plugin",
   "email": "tristan.watanabe@gmail.com",
   "dependentChangeType": "none"

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -97,6 +97,41 @@ The rule requires an options object containing:
 
 Ban references to the `React` global namespace (in favor of explicitly importing React). Implicit global references cause problems for API Extractor and potentially other tools.
 
+### `no-restricted-imports`
+
+Prevents imports from `forbidden` packages. If a corresponding `preferred` import is provided, the lint error will be automatically fixable.
+
+**Example Configuration:**
+
+```
+"@fluentui/no-restricted-imports": [
+  'error',
+  {
+    paths: [
+      {
+        forbidden: ['@fluentui/react-theme', '@griffel/react`],
+        preferred: '@fluentui/react-components',
+      },
+    ],
+  },
+  ],
+```
+
+**❌ Don't**
+
+```ts
+import * as React from 'react';
+import { webDarkTheme } from '@fluentui/react-theme';
+import { makeStyles } from '@griffel/react';
+```
+
+**✅ Do**
+
+```ts
+import * as React from 'react';
+import { makeStyles, webDarkTheme } from '@fluentui/react-components';
+```
+
 ### `no-tslint-comments`
 
 Ban `tslint:disable` and `tslint:enable` comments.

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -16,6 +16,7 @@ module.exports = {
     'no-global-react': require('./rules/no-global-react'),
     'no-tslint-comments': require('./rules/no-tslint-comments'),
     'no-visibility-modifiers': require('./rules/no-visibility-modifiers'),
+    'no-restricted-imports': require('./rules/no-restricted-imports'),
   },
 
   // Not a standard eslint thing, just exported for convenience

--- a/packages/eslint-plugin/src/rules/no-restricted-imports/index.js
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports/index.js
@@ -4,6 +4,8 @@ const createRule = require('../../utils/createRule');
 
 /**
  * @typedef {import("@typescript-eslint/types/dist/ts-estree").ImportClause} ImportClause
+ *
+ * Lookup for insertion point for new imports when moving a restricted import to a preferred import.
  * @typedef {{[preferredPkgName: string] : ImportClause}} FixMap
  *
  * @typedef {{
@@ -78,6 +80,12 @@ module.exports = createRule({
     forbiddenPkgs.forEach(preferred => {
       if (preferred) {
         preferredPkgNames.add(preferred);
+      }
+    });
+
+    forbiddenPkgs.forEach((_, forbidden) => {
+      if (preferredPkgNames.has(forbidden)) {
+        throw new Error('no-restricted-imports: Forbidden and Preferred Packages are not mutually exclusive.');
       }
     });
 

--- a/packages/eslint-plugin/src/rules/no-restricted-imports/index.js
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports/index.js
@@ -59,7 +59,7 @@ module.exports = createRule({
     const options = context.options;
 
     if (!options.length) {
-      throw new Error('restrict-import-paths: Must specify a paths object.');
+      throw new Error('no-restricted-imports: Must specify a paths object.');
     }
 
     const paths = options[0].paths;

--- a/packages/eslint-plugin/src/rules/no-restricted-imports/index.js
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports/index.js
@@ -1,0 +1,156 @@
+// @ts-check
+const { AST_NODE_TYPES } = require('@typescript-eslint/experimental-utils');
+const createRule = require('../../utils/createRule');
+
+/**
+ * @typedef {import("@typescript-eslint/types/dist/ts-estree").ImportClause} ImportClause
+ * @typedef {{[preferredPkgName: string] : ImportClause}} FixMap
+ *
+ * @typedef {{
+ *   forbidden: string[],
+ *   preferred?: string
+ * }} PathOptions
+ *
+ * @typedef {{
+ *   paths: PathOptions[];
+ * }} Options
+ */
+
+module.exports = createRule({
+  name: 'no-restricted-imports',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Restricts imports of certain packages',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    messages: {
+      restrictedImport: 'Import from {{ packageName }} detected which is not allowed.',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          paths: {
+            type: 'array',
+            minItems: 1,
+            items: {
+              forbidden: {
+                type: 'array',
+                minItems: 1,
+                items: {
+                  type: 'string',
+                },
+              },
+              preferred: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+  defaultOptions: [],
+  create: context => {
+    /** @type {Options[]} */
+    const options = context.options;
+
+    if (!options.length) {
+      throw new Error('restrict-import-paths: Must specify a paths object.');
+    }
+
+    const paths = options[0].paths;
+    const restrictedToPreferred = new Map();
+    const preferredPkgNames = new Set();
+
+    paths.forEach(path => {
+      const { forbidden, preferred } = path;
+      forbidden.forEach(pkg => {
+        restrictedToPreferred.set(pkg, preferred);
+      });
+    });
+
+    restrictedToPreferred.forEach(preferred => {
+      preferredPkgNames.add(preferred);
+    });
+
+    /** @type {FixMap}*/
+    const typeImportKindFix = {};
+    /** @type {FixMap}*/
+    const valueImportKindFix = {};
+
+    return {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      ImportDeclaration: imprt => {
+        if (!imprt.source || (imprt.source && imprt.source.type !== AST_NODE_TYPES.Literal)) {
+          return;
+        }
+
+        if (typeof imprt.source.value !== 'string') {
+          return;
+        }
+
+        const packageName = imprt.source.value;
+        const specifiers = imprt.specifiers;
+
+        if (!restrictedToPreferred.has(packageName) && !preferredPkgNames.has(packageName)) {
+          return;
+        }
+
+        /**
+         * @param {FixMap} fixMap object mapping to track if a restricted package's preferred import is
+         * already present in the file.
+         */
+        function runLintRule(fixMap) {
+          const preferredImportForCurrentPkg = restrictedToPreferred.get(packageName);
+          if (preferredPkgNames.has(packageName) && !fixMap[packageName]) {
+            fixMap[packageName] = specifiers[specifiers.length - 1];
+          }
+
+          if (restrictedToPreferred.has(packageName) && !preferredPkgNames.has(packageName)) {
+            if (!fixMap[preferredImportForCurrentPkg]) {
+              fixMap[preferredImportForCurrentPkg] = specifiers[specifiers.length - 1];
+              context.report({
+                node: imprt,
+                messageId: 'restrictedImport',
+                data: { packageName },
+                fix: fixer => {
+                  const [start, end] = imprt.source.range;
+                  return preferredImportForCurrentPkg
+                    ? fixer.replaceTextRange([start + 1, end - 1], preferredImportForCurrentPkg)
+                    : null;
+                },
+              });
+            } else {
+              context.report({
+                node: imprt,
+                messageId: 'restrictedImport',
+                data: { packageName },
+                fix: fixer => {
+                  const importsToAdd = `, ${imprt.specifiers.map(specifier => specifier.local.name).join(', ')}`;
+                  return preferredImportForCurrentPkg
+                    ? [
+                        fixer.insertTextAfterRange(fixMap[preferredImportForCurrentPkg].range, importsToAdd),
+                        fixer.remove(imprt),
+                      ]
+                    : null;
+                },
+              });
+            }
+          }
+        }
+
+        if (imprt.importKind === 'value') {
+          runLintRule(valueImportKindFix);
+        }
+
+        if (imprt.importKind === 'type') {
+          runLintRule(typeImportKindFix);
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/no-restricted-imports/index.test.js
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports/index.test.js
@@ -1,0 +1,137 @@
+// @ts-nocheck
+const { ESLintUtils } = require('@typescript-eslint/experimental-utils');
+const rule = require('./index');
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('no-restricted-imports', rule, {
+  valid: [
+    {
+      code: `
+        import { webLightTheme } from '@fluentui/react-components';
+      `,
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-theme'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        import { webDarkTheme } from '@fluentui/react-components';
+      `,
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-theme'],
+              preferred: '@fluentui/react-components',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        import type { TypographyStyle } from '@fluentui/react-components';
+      `,
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-theme'],
+              preferred: '@fluentui/react-components',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        import type { TypographyStyle, SpinnerProps } from '@fluentui/react-components';
+        import { makeStyles } from '@fluentui/react-components';
+      `,
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-theme', '@fluentui/react-spinner'],
+              preferred: '@fluentui/react-components',
+            },
+            {
+              forbidden: ['@griffel/react'],
+              preferred: '@fluentui/react-components',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { webDarkTheme } from '@fluentui/react-theme';
+      `,
+      errors: [{ messageId: 'restrictedImport' }],
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-theme'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        import { webDarkTheme } from '@fluentui/react-theme';
+      `,
+      errors: [{ messageId: 'restrictedImport' }],
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-theme'],
+              preferred: '@fluentui/react-components',
+            },
+          ],
+        },
+      ],
+      output: `
+        import { webDarkTheme } from '@fluentui/react-components';
+      `,
+    },
+    {
+      code: `
+        import type { SpinnerProps, TypographyStyle } from '@fluentui/react-components';
+        import { makeStyles } from '@griffel/react';
+      `,
+      errors: [{ messageId: 'restrictedImport' }],
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-spinner', '@fluentui/react-theme'],
+              preferred: '@fluentui/react-components',
+            },
+            {
+              forbidden: ['@griffel/react'],
+              preferred: '@fluentui/react-components',
+            },
+          ],
+        },
+      ],
+      output: `
+        import type { SpinnerProps, TypographyStyle } from '@fluentui/react-components';
+        import { makeStyles } from '@fluentui/react-components';
+      `,
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/no-restricted-imports/index.test.js
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports/index.test.js
@@ -216,7 +216,28 @@ ruleTester.run('no-restricted-imports', rule, {
           ],
         },
       ],
-      output: "import type { SpinnerProps, TextProps } from '@fluentui/react-components';",
+      output:
+        // eslint-disable-next-line @fluentui/max-len
+        "import type { SpinnerProps, TextProps } from '@fluentui/react-components';",
+    },
+    {
+      code:
+        // eslint-disable-next-line @fluentui/max-len
+        "import { Spinner } from '@fluentui/react-spinner';import { Text } from '@fluentui/react-text';import type { SpinnerProps } from '@fluentui/react-spinner';",
+      errors: [{ messageId: 'restrictedImport' }, { messageId: 'restrictedImport' }, { messageId: 'restrictedImport' }],
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-spinner', '@fluentui/react-text'],
+              preferred: '@fluentui/react-components',
+            },
+          ],
+        },
+      ],
+      output:
+        // eslint-disable-next-line @fluentui/max-len
+        "import { Spinner, Text } from '@fluentui/react-components';import type { SpinnerProps } from '@fluentui/react-components';",
     },
   ],
 });

--- a/packages/eslint-plugin/src/rules/no-restricted-imports/index.test.js
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports/index.test.js
@@ -168,6 +168,25 @@ ruleTester.run('no-restricted-imports', rule, {
       `,
     },
     {
+      code: "import { Spinner, Text } from '@fluentui/react-components';import { makeStyles } from '@griffel/react';",
+      errors: [{ messageId: 'restrictedImport' }],
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-spinner', '@fluentui/react-theme'],
+              preferred: '@fluentui/react-components',
+            },
+            {
+              forbidden: ['@griffel/react'],
+              preferred: '@fluentui/react-components',
+            },
+          ],
+        },
+      ],
+      output: `import { Spinner, Text, makeStyles } from '@fluentui/react-components';`,
+    },
+    {
       code:
         // eslint-disable-next-line @fluentui/max-len
         "import type { SpinnerProps } from '@fluentui/react-components';import type { TextProps } from '@fluentui/react-text';",

--- a/packages/eslint-plugin/src/rules/no-restricted-imports/index.test.js
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports/index.test.js
@@ -91,6 +91,21 @@ ruleTester.run('no-restricted-imports', rule, {
     },
     {
       code: `
+        import type { TypographyStyle } from '@fluentui/react-theme';
+      `,
+      errors: [{ messageId: 'restrictedImport' }],
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-theme'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
         import { webDarkTheme } from '@fluentui/react-theme';
       `,
       errors: [{ messageId: 'restrictedImport' }],
@@ -106,6 +121,25 @@ ruleTester.run('no-restricted-imports', rule, {
       ],
       output: `
         import { webDarkTheme } from '@fluentui/react-components';
+      `,
+    },
+    {
+      code: `
+        import type { TypographyStyle } from '@fluentui/react-theme';
+      `,
+      errors: [{ messageId: 'restrictedImport' }],
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-theme'],
+              preferred: '@fluentui/react-components',
+            },
+          ],
+        },
+      ],
+      output: `
+        import type { TypographyStyle } from '@fluentui/react-components';
       `,
     },
     {
@@ -132,6 +166,57 @@ ruleTester.run('no-restricted-imports', rule, {
         import type { SpinnerProps, TypographyStyle } from '@fluentui/react-components';
         import { makeStyles } from '@fluentui/react-components';
       `,
+    },
+    {
+      code:
+        // eslint-disable-next-line @fluentui/max-len
+        "import type { SpinnerProps } from '@fluentui/react-components';import type { TextProps } from '@fluentui/react-text';",
+      errors: [{ messageId: 'restrictedImport' }],
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-text'],
+              preferred: '@fluentui/react-components',
+            },
+          ],
+        },
+      ],
+      output: "import type { SpinnerProps, TextProps } from '@fluentui/react-components';",
+    },
+    {
+      code: "import type { SpinnerProps } from '@fluentui/react-spinner';import { Text } from '@fluentui/react-text';",
+      errors: [{ messageId: 'restrictedImport' }, { messageId: 'restrictedImport' }],
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-spinner', '@fluentui/react-text'],
+              preferred: '@fluentui/react-components',
+            },
+          ],
+        },
+      ],
+      output:
+        // eslint-disable-next-line @fluentui/max-len
+        "import type { SpinnerProps } from '@fluentui/react-components';import { Text } from '@fluentui/react-components';",
+    },
+    {
+      code:
+        // eslint-disable-next-line @fluentui/max-len
+        "import type { SpinnerProps } from '@fluentui/react-spinner';import type { TextProps } from '@fluentui/react-text';",
+      errors: [{ messageId: 'restrictedImport' }, { messageId: 'restrictedImport' }],
+      options: [
+        {
+          paths: [
+            {
+              forbidden: ['@fluentui/react-spinner', '@fluentui/react-text'],
+              preferred: '@fluentui/react-components',
+            },
+          ],
+        },
+      ],
+      output: "import type { SpinnerProps, TextProps } from '@fluentui/react-components';",
     },
   ],
 });


### PR DESCRIPTION
## Changes:
- Redo of #23496 to generalize rule.
- Adds a new `no-restricted-imports` custom rule to our eslint-plugin package which will warn devs when they're importing from `forbidden` packages. If a corresponding `preferred` package import is provided, the import will be automatically fixable. 

- A follow-up PR will be made to add this rule to our v9 eslint config to prevent cross package v9 imports in storybook files.

## Demo:

https://user-images.githubusercontent.com/8649804/174653911-1d1db956-b93b-45cf-a3c7-b27614a94151.mp4


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #21907