### PR TITLE
theme designer: export fixes

### DIFF
--- a/packages/react-components/theme-designer/src/ThemeDesigner.tsx
+++ b/packages/react-components/theme-designer/src/ThemeDesigner.tsx
@@ -19,7 +19,7 @@ export const ThemeDesigner: React.FC<ThemeDesignerProps> = props => {
   return (
     <FluentProvider theme={teamsLightTheme}>
       <div className={styles.root}>
-        <Nav className={styles.nav} brand={state.brand} />
+        <Nav className={styles.nav} brand={state.brand} isDark={state.isDark} />
         <Sidebar className={styles.sidebar} dispatchState={dispatchState} />
         <Content className={styles.content} brand={state.brand} theme={state.theme} />
       </div>

--- a/packages/react-components/theme-designer/src/components/ExportButton/ExportButton.tsx
+++ b/packages/react-components/theme-designer/src/components/ExportButton/ExportButton.tsx
@@ -14,6 +14,7 @@ import { ExportLink } from './ExportLink';
 export interface ExportProps {
   className?: string;
   brand: BrandVariants;
+  isDark: boolean;
 }
 
 const useStyles = makeStyles({
@@ -39,10 +40,7 @@ export const ExportButton: React.FC<ExportProps> = props => {
         <MenuPopover>
           <MenuList>
             <MenuItem>
-              <ExportLink brand={props.brand} isLightTheme={true} />
-            </MenuItem>
-            <MenuItem>
-              <ExportLink brand={props.brand} isLightTheme={false} />
+              <ExportLink brand={props.brand} isDark={props.isDark} />
             </MenuItem>
           </MenuList>
         </MenuPopover>

--- a/packages/react-components/theme-designer/src/components/ExportButton/ExportLink.tsx
+++ b/packages/react-components/theme-designer/src/components/ExportButton/ExportLink.tsx
@@ -6,7 +6,7 @@ import * as dedent from 'dedent';
 export interface ExportLinkProps {
   className?: string;
   brand: BrandVariants;
-  isLightTheme: boolean;
+  isDark: boolean;
 }
 
 export const ExportLink: React.FC<ExportLinkProps> = props => {
@@ -261,13 +261,13 @@ export const ExportLink: React.FC<ExportLinkProps> = props => {
         content: dedent`
           import * as ReactDOM from 'react-dom';
           import { FluentProvider, ${
-            props.isLightTheme ? 'createLightTheme' : 'createDarkTheme'
+            props.isDark ? 'createDarkTheme' : 'createLightTheme'
           } } from '@fluentui/react-components';
           import { Example } from './example';
 
           const brand = ${JSON.stringify(props.brand)};
 
-          ${props.isLightTheme ? 'const theme = createLightTheme(brand);' : 'const theme = createDarkTheme(brand);'}
+          ${props.isDark ? 'const theme = createDarkTheme(brand);' : 'const theme = createLightTheme(brand);'}
 
           ReactDOM.render(
               <FluentProvider theme={theme}>
@@ -291,7 +291,7 @@ export const ExportLink: React.FC<ExportLinkProps> = props => {
   return (
     <div>
       <Link appearance="subtle" href={link}>
-        {props.isLightTheme ? 'Preview light theme in CodeSandbox' : 'Preview dark theme in CodeSandbox'}
+        Preview theme in CodeSandbox
       </Link>
     </div>
   );

--- a/packages/react-components/theme-designer/src/components/ExportButton/ExportLink.tsx
+++ b/packages/react-components/theme-designer/src/components/ExportButton/ExportLink.tsx
@@ -17,7 +17,7 @@ export const ExportLink: React.FC<ExportLinkProps> = props => {
         isBinary: false,
         content: dedent`
           import * as React from 'react';
-          import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+          import { makeStyles, makeStaticStyles, mergeClasses, shorthands } from '@griffel/react';
           import {
             tokens,
             Body1,
@@ -63,8 +63,19 @@ export const ExportLink: React.FC<ExportLinkProps> = props => {
             theme: Theme;
           }
 
+          const useStaticStyles = makeStaticStyles({
+            body: {
+              position: "fixed",
+              margin: "0px",
+              top: "0px",
+              left: "0px",
+              height: "100vh"
+            }
+          });
+
           const useStyles = makeStyles({
             root: {
+              height: "100vh",
               display: 'grid',
               alignItems: 'start',
               justifyContent: 'center',
@@ -117,6 +128,7 @@ export const ExportLink: React.FC<ExportLinkProps> = props => {
 
           export const Column1 = () => {
             const styles = useStyles();
+            useStaticStyles();
             return (
               <div className={styles.col1}>
                 <Title3 block>Make an impression</Title3>

--- a/packages/react-components/theme-designer/src/components/Nav/Nav.tsx
+++ b/packages/react-components/theme-designer/src/components/Nav/Nav.tsx
@@ -7,6 +7,7 @@ import { ExportButton } from '../ExportButton/ExportButton';
 export interface NavProps {
   className?: string;
   brand: BrandVariants;
+  isDark: boolean;
 }
 
 const useStyles = makeStyles({
@@ -55,7 +56,7 @@ export const Nav: React.FC<NavProps> = props => {
         UI Colors <ChevronRightRegular /> New palette
       </div>
       <Name />
-      <ExportButton brand={props.brand} />
+      <ExportButton brand={props.brand} isDark={props.isDark} />
     </FluentProvider>
   );
 };

--- a/packages/react-components/theme-designer/src/useThemeDesignerReducer.ts
+++ b/packages/react-components/theme-designer/src/useThemeDesignerReducer.ts
@@ -48,10 +48,11 @@ export const useThemeDesignerReducer = () => {
     themeLabel: 'Teams Light',
     brand: brandTeams,
     theme: teamsLightTheme,
+    isDark: false,
   };
 
   const stateReducer = (
-    state: { themeLabel: string; brand: BrandVariants; theme: Theme },
+    state: { themeLabel: string; brand: BrandVariants; theme: Theme; isDark: boolean },
     action: {
       type: string;
       customAttributes?: CustomAttributes;
@@ -63,24 +64,28 @@ export const useThemeDesignerReducer = () => {
           themeLabel: 'Teams Light',
           brand: brandTeams,
           theme: teamsLightTheme,
+          isDark: false,
         };
       case 'Teams Dark':
         return {
           themeLabel: 'Teams Dark',
           brand: brandTeams,
           theme: teamsDarkTheme,
+          isDark: true,
         };
       case 'Web Light':
         return {
           themeLabel: 'Web Light',
           brand: brandWeb,
           theme: webLightTheme,
+          isDark: false,
         };
       case 'Web Dark':
         return {
           themeLabel: 'Web Dark',
           brand: brandWeb,
           theme: webDarkTheme,
+          isDark: true,
         };
       case 'Custom':
         if (!action.customAttributes) {
@@ -91,6 +96,7 @@ export const useThemeDesignerReducer = () => {
           themeLabel: 'Custom',
           brand: custom.brand,
           theme: custom.theme,
+          isDark: action.customAttributes.isDark,
         };
       default:
         return state;


### PR DESCRIPTION
Fixes the dark theme background in CodeSandbox exports such that the entire background is now filled with the dark theme background color.
![image](https://user-images.githubusercontent.com/31319479/174896925-f4344b6e-9c22-48bf-a254-6e5f3f2146b8.png)


Reduces from two exports to one export with designated light/dark theme based on user input
![image](https://user-images.githubusercontent.com/31319479/174896950-7d68a4a2-f3a2-4741-a373-bf0251093608.png)

Current todo list: https://github.com/microsoft/fluentui/projects/30