### PR TITLE
feat: Adding focusTrapZoneProps to Modal so we can customize inner FocusTrapZone

### DIFF
--- a/change/office-ui-fabric-react-da6a81a9-3c32-4a49-ad2d-2520b136bdd3.json
+++ b/change/office-ui-fabric-react-da6a81a9-3c32-4a49-ad2d-2520b136bdd3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Adding focusTrapZoneProps to Modal so we can customize inner FocusTrapZone.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6056,6 +6056,7 @@ export interface IModalProps extends React.ClassAttributes<ModalBase>, IWithResp
     containerClassName?: string;
     dragOptions?: IDragOptions;
     enableAriaHiddenSiblings?: boolean;
+    focusTrapZoneProps?: IFocusTrapZoneProps;
     isAlert?: boolean;
     isBlocking?: boolean;
     isDarkOverlay?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -227,6 +227,7 @@ export class ModalBase extends React.Component<IModalProps, IDialogState> implem
         }
         ignoreExternalFocusing={focusTrapZoneProps?.ignoreExternalFocusing ?? ignoreExternalFocusing}
         forceFocusInsideTrap={(focusTrapZoneProps?.forceFocusInsideTrap ?? forceFocusInsideTrap) && !isModeless}
+        // eslint-disable-next-line deprecation/deprecation
         firstFocusableSelector={focusTrapZoneProps?.firstFocusableSelector || firstFocusableSelector}
         focusPreviouslyFocusedInnerElement={focusTrapZoneProps?.focusPreviouslyFocusedInnerElement ?? true}
         onBlur={isInKeyboardMoveMode ? this._onExitKeyboardMoveMode : undefined}

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
 import {
-  classNamesFunction,
-  getId,
   allowScrollOnElement,
   allowOverscrollOnElement,
-  KeyCodes,
+  classNamesFunction,
+  createMergedRef,
+  css,
   elementContains,
+  getId,
   warnDeprecations,
   Async,
   EventGroup,
+  KeyCodes,
 } from '../../Utilities';
 import { FocusTrapZone, IFocusTrapZone } from '../FocusTrapZone/index';
 import { animationDuration } from './Modal.styles';
@@ -56,6 +58,7 @@ export class ModalBase extends React.Component<IModalProps, IDialogState> implem
 
   private _onModalCloseTimer: number;
   private _focusTrapZone = React.createRef<IFocusTrapZone>();
+  private _focusTrapZoneMergedRef = createMergedRef();
   private _scrollableContent: HTMLDivElement | null;
   private _lastSetX: number;
   private _lastSetY: number;
@@ -158,6 +161,7 @@ export class ModalBase extends React.Component<IModalProps, IDialogState> implem
       scrollableContentClassName,
       elementToFocusOnDismiss,
       firstFocusableSelector,
+      focusTrapZoneProps,
       forceFocusInsideTrap,
       ignoreExternalFocusing,
       isBlocking,
@@ -210,19 +214,23 @@ export class ModalBase extends React.Component<IModalProps, IDialogState> implem
       insertFirst: isModeless,
       className: classNames.layer,
     };
+
     const modalContent = (
       <FocusTrapZone
+        {...focusTrapZoneProps}
         data-id={this.state.id}
-        componentRef={this._focusTrapZone}
-        className={classNames.main}
-        elementToFocusOnDismiss={elementToFocusOnDismiss}
-        isClickableOutsideFocusTrap={isModeless || isClickableOutsideFocusTrap || !isBlocking}
-        ignoreExternalFocusing={ignoreExternalFocusing}
-        forceFocusInsideTrap={isModeless ? !isModeless : forceFocusInsideTrap}
-        firstFocusableSelector={firstFocusableSelector}
-        focusPreviouslyFocusedInnerElement={true}
+        componentRef={this._focusTrapZoneMergedRef(this._focusTrapZone, focusTrapZoneProps?.componentRef)}
+        className={css(classNames.main, focusTrapZoneProps?.className)}
+        elementToFocusOnDismiss={focusTrapZoneProps?.elementToFocusOnDismiss ?? elementToFocusOnDismiss}
+        isClickableOutsideFocusTrap={
+          focusTrapZoneProps?.isClickableOutsideFocusTrap ?? (isModeless || isClickableOutsideFocusTrap || !isBlocking)
+        }
+        ignoreExternalFocusing={focusTrapZoneProps?.ignoreExternalFocusing ?? ignoreExternalFocusing}
+        forceFocusInsideTrap={(focusTrapZoneProps?.forceFocusInsideTrap ?? forceFocusInsideTrap) && !isModeless}
+        firstFocusableSelector={focusTrapZoneProps?.firstFocusableSelector || firstFocusableSelector}
+        focusPreviouslyFocusedInnerElement={focusTrapZoneProps?.focusPreviouslyFocusedInnerElement ?? true}
         onBlur={isInKeyboardMoveMode ? this._onExitKeyboardMoveMode : undefined}
-        enableAriaHiddenSiblings={enableAriaHiddenSiblings}
+        enableAriaHiddenSiblings={focusTrapZoneProps?.enableAriaHiddenSiblings ?? enableAriaHiddenSiblings}
       >
         {dragOptions && isInKeyboardMoveMode && (
           <div className={classNames.keyboardMoveIconContainer}>
@@ -514,7 +522,8 @@ export class ModalBase extends React.Component<IModalProps, IDialogState> implem
     this._events.on(window, 'keydown', this._onKeyDown, true /* useCapture */);
   };
 
-  private _onExitKeyboardMoveMode = () => {
+  private _onExitKeyboardMoveMode = (ev: React.FocusEvent<HTMLDivElement>) => {
+    this.props.focusTrapZoneProps?.onBlur?.(ev);
     this._lastSetX = 0;
     this._lastSetY = 0;
     this.setState({ isInKeyboardMoveMode: false });

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.types.ts
@@ -1,18 +1,19 @@
 import * as React from 'react';
-import { ModalBase } from './Modal.base';
-import { IWithResponsiveModeState } from '../../utilities/decorators/withResponsiveMode';
 import { IAccessiblePopupProps } from '../../common/IAccessiblePopupProps';
-import { IStyle, ITheme } from '../../Styling';
-import { ILayerProps } from '../../Layer';
-import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
-import { IIconProps } from '../../Icon';
+import { IWithResponsiveModeState } from '../../utilities/decorators/withResponsiveMode';
 import { IContextualMenuProps } from '../../ContextualMenu';
+import { IFocusTrapZoneProps } from '../../FocusTrapZone';
+import { IIconProps } from '../../Icon';
+import { ILayerProps } from '../../Layer';
 import { IOverlayProps } from '../../Overlay';
+import { IStyle, ITheme } from '../../Styling';
+import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import { ModalBase } from './Modal.base';
 
 export interface IDragOptions {
   /**
    * Optional selector for the element where the drag can be initiated. If not supplied when
-   * isDraggable is true dragging can be initated by the whole contents of the modal
+   * isDraggable is true dragging can be initiated by the whole contents of the modal
    */
   dragHandleSelector?: string;
 
@@ -74,13 +75,13 @@ export interface IModalProps extends React.ClassAttributes<ModalBase>, IWithResp
 
   /**
    * Whether the dialog is displayed.
-   * @defaultvalue false
+   * @default false
    */
   isOpen?: boolean;
 
   /**
    * Whether the overlay is dark themed.
-   * @defaultvalue true
+   * @default true
    */
   isDarkOverlay?: boolean;
 
@@ -106,7 +107,7 @@ export interface IModalProps extends React.ClassAttributes<ModalBase>, IWithResp
 
   /**
    * Whether the dialog can be light dismissed by clicking outside the dialog (on the overlay).
-   * @defaultvalue false
+   * @default false
    */
   isBlocking?: boolean;
 
@@ -169,7 +170,7 @@ export interface IModalProps extends React.ClassAttributes<ModalBase>, IWithResp
 
   /**
    * Allow body scroll on content and overlay on touch devices. Changing after mounting has no effect.
-   * @defaultvalue false
+   * @default false
    */
   allowTouchBodyScroll?: boolean;
 
@@ -179,6 +180,12 @@ export interface IModalProps extends React.ClassAttributes<ModalBase>, IWithResp
    * This flag will be removed with the next major release.
    */
   enableAriaHiddenSiblings?: boolean;
+
+  /**
+   * Set of props to customize the `FocusTrapZone` inside of the `Modal`.
+   * @default `{}`
+   */
+  focusTrapZoneProps?: IFocusTrapZoneProps;
 }
 
 /**


### PR DESCRIPTION
**Cherrypick of #23563**

_Original PR description follows:_

## Current Behavior

The internal `FocusTrapZone` in `Modal` can only be customized through select knobs, which limits how much a user can customize it to their needs.

## New Behavior

The internal `FocusTrapZone` in `Modal` can be fully customized by passing a `focusTrapZoneProps` object to `Modal`.

This PR also changes all `@defaultvalue` tags in `Modal.types.ts` to `@default`.