### PR TITLE
(fix): CI now triggers against master PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pr:
-  - 9.0-rc
+  - master
 
 # There's a separate pipeline for CI which also uses this file, but with a trigger override in the UI
 # https://dev.azure.com/uifabric/fabricpublic/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=164&view=Tab_Triggers


### PR DESCRIPTION
## Current Behavior
- In the midst of all the build failures from yesterday, this #23370 PR which was only intended for the RC branch somehow made its way to master thus causing CI pipelines to not run for PRs against master.

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- PRs sent against master will now trigger CI.


