### PR TITLE
Image: Replace relative imports with absolute imports in storybook files

### DIFF
--- a/packages/react-components/react-image/src/stories/Image/ImageBlock.stories.tsx
+++ b/packages/react-components/react-image/src/stories/Image/ImageBlock.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image } from '../../Image';
+import { Image } from '@fluentui/react-image';
 
 export const Block = () => (
   <>

--- a/packages/react-components/react-image/src/stories/Image/ImageBordered.stories.tsx
+++ b/packages/react-components/react-image/src/stories/Image/ImageBordered.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image } from '../../Image';
+import { Image } from '@fluentui/react-image';
 
 export const Bordered = () => (
   <div>

--- a/packages/react-components/react-image/src/stories/Image/ImageDefault.stories.tsx
+++ b/packages/react-components/react-image/src/stories/Image/ImageDefault.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import type { ImageProps } from '../../Image';
+import type { ImageProps } from '@fluentui/react-image';
 import type { ArgTypes, Parameters } from '@storybook/react';
-import { Image } from '../../Image';
+import { Image } from '@fluentui/react-image';
 
 export const Default = (props: ImageProps) => {
   return <Image {...props} />;

--- a/packages/react-components/react-image/src/stories/Image/ImageFallback.stories.tsx
+++ b/packages/react-components/react-image/src/stories/Image/ImageFallback.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image } from '../../Image';
+import { Image } from '@fluentui/react-image';
 
 export const Fallback = () => (
   <div style={{ display: 'flex', gap: 8 }}>

--- a/packages/react-components/react-image/src/stories/Image/ImageFit.stories.tsx
+++ b/packages/react-components/react-image/src/stories/Image/ImageFit.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image } from '../../Image';
+import { Image } from '@fluentui/react-image';
 
 export const Fit = () => (
   <>

--- a/packages/react-components/react-image/src/stories/Image/ImageShadow.stories.tsx
+++ b/packages/react-components/react-image/src/stories/Image/ImageShadow.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image } from '../../Image';
+import { Image } from '@fluentui/react-image';
 
 export const Shadow = () => (
   <Image shadow src="https://fabricweb.azureedge.net/fabric-website/placeholders/300x300.png" />

--- a/packages/react-components/react-image/src/stories/Image/ImageShape.stories.tsx
+++ b/packages/react-components/react-image/src/stories/Image/ImageShape.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image } from '../../Image';
+import { Image } from '@fluentui/react-image';
 
 export const Shape = () => (
   <div style={{ display: 'flex', gap: 8 }}>

--- a/packages/react-components/react-image/src/stories/Image/index.stories.tsx
+++ b/packages/react-components/react-image/src/stories/Image/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Image } from '../../Image';
+import { Image } from '@fluentui/react-image';
 import type { Meta } from '@storybook/react';
 import descriptionMd from './ImageDescription.md';
 import bestPracticesMd from './ImageBestPractices.md';


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/fluentui/pull/23527.

PR updates Image's storybook files to use absolute imports instead of relative imports.