### PR TITLE
Divider: Replace relative imports with absolute imports in storybook files

### DIFF
--- a/packages/react-components/react-divider/src/stories/Divider/DividerAlignContent.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/DividerAlignContent.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
-import { Divider } from '../../Divider';
+import { Divider } from '@fluentui/react-divider';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-divider/src/stories/Divider/DividerAppearance.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/DividerAppearance.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
-import { Divider } from '../../Divider';
+import { Divider } from '@fluentui/react-divider';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-divider/src/stories/Divider/DividerCustomStyles.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/DividerCustomStyles.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { shorthands, makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
-import { Divider } from '../../Divider';
+import { Divider } from '@fluentui/react-divider';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-divider/src/stories/Divider/DividerDefault.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/DividerDefault.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
-import { Divider } from '../../Divider';
+import { Divider } from '@fluentui/react-divider';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-divider/src/stories/Divider/DividerInset.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/DividerInset.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
-import { Divider } from '../../Divider';
+import { Divider } from '@fluentui/react-divider';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-divider/src/stories/Divider/DividerVertical.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/DividerVertical.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
-import { Divider } from '../../Divider';
+import { Divider } from '@fluentui/react-divider';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-divider/src/stories/Divider/index.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/react';
-import { Divider } from '../../Divider';
+import { Divider } from '@fluentui/react-divider';
 import descriptionMd from './DividerDescription.md';
 export { Default } from './DividerDefault.stories';
 export { Vertical } from './DividerVertical.stories';


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/fluentui/pull/23526.

PR updates Divider's storybook files to use absolute imports instead of relative imports.