### PR TITLE
Convert @fluentui/react-overflow stories to index.stories.tsx approach

### DIFF
--- a/change/@fluentui-react-overflow-de8d01c5-6e47-41f7-bad1-45e28fa5fffb.json
+++ b/change/@fluentui-react-overflow-de8d01c5-6e47-41f7-bad1-45e28fa5fffb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Move Overflow stories to folder with index entry.",
+  "packageName": "@fluentui/react-overflow",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-overflow/.storybook/main.js
+++ b/packages/react-components/react-overflow/.storybook/main.js
@@ -2,7 +2,7 @@ const rootMain = require('../../../../.storybook/main');
 
 module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
   ...rootMain,
-  stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/index.stories.@(ts|tsx)'],
   addons: [...rootMain.addons],
   webpackFinal: (config, options) => {
     const localConfig = { ...rootMain.webpackFinal(config, options) };

--- a/packages/react-components/react-overflow/src/stories/Overflow/CustomPriorities.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/CustomPriorities.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeStyles, shorthands } from '@griffel/react';
-import { Overflow } from '../components/Overflow';
+import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 
 const useStyles = makeStyles({
@@ -12,18 +12,18 @@ const useStyles = makeStyles({
   },
 });
 
-export const MinimumVisible = () => {
+export const CustomPriorities = () => {
   const styles = useStyles();
 
-  const itemIds = new Array(8).fill(0).map((_, i) => i.toString());
+  const priorities = [2, 3, 6, 1, 4, 5, 0, 7];
 
   return (
-    <Overflow minimumVisible={4}>
+    <Overflow>
       <div className={styles.container}>
-        {itemIds.map(i => (
-          <TestOverflowItem key={i} id={i} />
+        {priorities.map(i => (
+          <TestOverflowItem key={i} id={i.toString()} priority={i} />
         ))}
-        <OverflowMenu itemIds={itemIds} />
+        <OverflowMenu itemIds={priorities.map(x => x.toString())} />
       </div>
     </Overflow>
   );

--- a/packages/react-components/react-overflow/src/stories/Overflow/Dividers.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/Dividers.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeStyles, shorthands } from '@griffel/react';
-import { Overflow } from '../components/Overflow';
+import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowGroupDivider, TestOverflowItem } from './utils.stories';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-overflow/src/stories/Overflow/DomOrder.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/DomOrder.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeStyles, shorthands } from '@griffel/react';
-import { Overflow } from '../components/Overflow';
+import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 
 const useStyles = makeStyles({
@@ -12,13 +12,13 @@ const useStyles = makeStyles({
   },
 });
 
-export const ReverseDomOrder = () => {
+export const DomOrder = () => {
   const styles = useStyles();
 
   const itemIds = new Array(8).fill(0).map((_, i) => i.toString());
 
   return (
-    <Overflow overflowDirection="start">
+    <Overflow>
       <div className={styles.container}>
         {itemIds.map(i => (
           <TestOverflowItem key={i} id={i} />

--- a/packages/react-components/react-overflow/src/stories/Overflow/MinimumVisible.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/MinimumVisible.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeStyles, shorthands } from '@griffel/react';
-import { Overflow } from '../components/Overflow';
+import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 
 const useStyles = makeStyles({
@@ -12,13 +12,13 @@ const useStyles = makeStyles({
   },
 });
 
-export const DomOrder = () => {
+export const MinimumVisible = () => {
   const styles = useStyles();
 
   const itemIds = new Array(8).fill(0).map((_, i) => i.toString());
 
   return (
-    <Overflow>
+    <Overflow minimumVisible={4}>
       <div className={styles.container}>
         {itemIds.map(i => (
           <TestOverflowItem key={i} id={i} />

--- a/packages/react-components/react-overflow/src/stories/Overflow/Pinned.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/Pinned.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button, makeStyles, shorthands } from '@fluentui/react-components';
-import { Overflow } from '../components/Overflow';
+import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-overflow/src/stories/Overflow/PriorityWithDividers.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/PriorityWithDividers.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeStyles, shorthands } from '@griffel/react';
-import { Overflow } from '../components/Overflow';
+import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowGroupDivider, TestOverflowItem } from './utils.stories';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-overflow/src/stories/Overflow/ReverseDomOrder.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/ReverseDomOrder.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { makeStyles, shorthands } from '@griffel/react';
-import { Overflow } from '../components/Overflow';
+import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 
 const useStyles = makeStyles({
@@ -12,18 +12,18 @@ const useStyles = makeStyles({
   },
 });
 
-export const CustomPriorities = () => {
+export const ReverseDomOrder = () => {
   const styles = useStyles();
 
-  const priorities = [2, 3, 6, 1, 4, 5, 0, 7];
+  const itemIds = new Array(8).fill(0).map((_, i) => i.toString());
 
   return (
-    <Overflow>
+    <Overflow overflowDirection="start">
       <div className={styles.container}>
-        {priorities.map(i => (
-          <TestOverflowItem key={i} id={i.toString()} priority={i} />
+        {itemIds.map(i => (
+          <TestOverflowItem key={i} id={i} />
         ))}
-        <OverflowMenu itemIds={priorities.map(x => x.toString())} />
+        <OverflowMenu itemIds={itemIds} />
       </div>
     </Overflow>
   );

--- a/packages/react-components/react-overflow/src/stories/Overflow/Selection.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/Selection.stories.tsx
@@ -9,8 +9,7 @@ import {
   MenuList,
   shorthands,
 } from '@fluentui/react-components';
-import { Overflow } from '../components/Overflow';
-import { useOverflowMenu } from '../useOverflowMenu';
+import { Overflow, useOverflowMenu } from '@fluentui/react-overflow';
 import { TestOverflowItem, TestOverflowItemProps, TestOverflowMenuItem } from './utils.stories';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-overflow/src/stories/Overflow/index.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/index.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Overflow } from '../components/Overflow';
+import { Overflow } from '@fluentui/react-overflow';
 import { ComponentMeta } from '@storybook/react';
 
 export { DomOrder } from './DomOrder.stories';

--- a/packages/react-components/react-overflow/src/stories/Overflow/utils.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/utils.stories.tsx
@@ -10,11 +10,13 @@ import {
   MenuItemProps,
   makeStyles,
 } from '@fluentui/react-components';
-import type { OverflowItemProps } from '../components/OverflowItem/OverflowItem.types';
-import { OverflowItem } from '../components/OverflowItem/OverflowItem';
-import { useOverflowMenu } from '../useOverflowMenu';
-import { useIsOverflowItemVisible } from '../useIsOverflowItemVisible';
-import { useIsOverflowGroupVisible } from '../useIsOverflowGroupVisible';
+import type { OverflowItemProps } from '@fluentui/react-overflow';
+import {
+  OverflowItem,
+  useIsOverflowGroupVisible,
+  useIsOverflowItemVisible,
+  useOverflowMenu,
+} from '@fluentui/react-overflow';
 
 const useStyles = makeStyles({
   overflowItem: {


### PR DESCRIPTION
Fixes https://github.com/microsoft/fluentui/issues/23393

Update Overflow stories to use index.stories.tsx entrypoint and creates new stories/Overflow path.