### PR TITLE
Convert @fluentui/react-aria stories to index.stories.tsx approach

### DIFF
--- a/change/@fluentui-react-aria-a0b33abf-fcb4-4568-954a-fe8fea127c7c.json
+++ b/change/@fluentui-react-aria-a0b33abf-fcb4-4568-954a-fe8fea127c7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Update Aria storybook config to index.stories.tsx entrypoint.",
+  "packageName": "@fluentui/react-aria",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-aria/.storybook/main.js
+++ b/packages/react-components/react-aria/.storybook/main.js
@@ -2,7 +2,7 @@ const rootMain = require('../../../../.storybook/main');
 
 module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
   ...rootMain,
-  stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/index.stories.@(ts|tsx)'],
   addons: [...rootMain.addons],
   webpackFinal: (config, options) => {
     const localConfig = { ...rootMain.webpackFinal(config, options) };


### PR DESCRIPTION
Fixes https://github.com/microsoft/fluentui/issues/23694

Update Aria storybook config to use index.stories.tsx entrypoint.