### PR TITLE
docs(react-avatar): Adding @internal api access modifier to getInitials

### DIFF
--- a/change/@fluentui-react-avatar-4f8775b1-d717-49c5-a688-4998bc9773e3.json
+++ b/change/@fluentui-react-avatar-4f8775b1-d717-49c5-a688-4998bc9773e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: Adding @internal to getInitials.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -105,7 +105,9 @@ export type AvatarState = ComponentState<AvatarSlots> & Required<Pick<AvatarProp
     color: NonNullable<Exclude<AvatarProps['color'], 'colorful'>>;
 };
 
-// @public
+// Warning: (ae-internal-missing-underscore) The name "getInitials" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
 export function getInitials(displayName: string | undefined | null, isRtl: boolean, options?: {
     allowPhoneInitials?: boolean;
     firstInitialOnly?: boolean;

--- a/packages/react-components/react-avatar/src/utils/getInitials.ts
+++ b/packages/react-components/react-avatar/src/utils/getInitials.ts
@@ -75,6 +75,8 @@ function cleanupDisplayName(displayName: string): string {
  *
  * @returns The 1 or 2 character initials based on the name. Or an empty string if no initials
  * could be derived from the name.
+ *
+ * @internal
  */
 export function getInitials(
   displayName: string | undefined | null,


### PR DESCRIPTION
As per #23577 this PR adds `@internal` to `getInitials` since it is exported in the package, but not in `@fluentui/react-components`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#23577
