### PR TITLE
chore(react-avatar): Adding AvatarGroup and AvatarGroupItem bundle size fixtures

### DIFF
--- a/change/@fluentui-react-avatar-2a79d125-b960-4f2f-9785-9234fa093640.json
+++ b/change/@fluentui-react-avatar-2a79d125-b960-4f2f-9785-9234fa093640.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Adding bundle size fixtures for AvatarGroup and AvatarGroupItem.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-avatar/bundle-size/AvatarGroup.fixture.js
+++ b/packages/react-components/react-avatar/bundle-size/AvatarGroup.fixture.js
@@ -1,0 +1,7 @@
+import { AvatarGroup } from '@fluentui/react-avatar';
+
+console.log(AvatarGroup);
+
+export default {
+  name: 'AvatarGroup',
+};

--- a/packages/react-components/react-avatar/bundle-size/AvatarGroupItem.fixture.js
+++ b/packages/react-components/react-avatar/bundle-size/AvatarGroupItem.fixture.js
@@ -1,0 +1,7 @@
+import { AvatarGroupItem } from '@fluentui/react-avatar';
+
+console.log(AvatarGroupItem);
+
+export default {
+  name: 'AvatarGroupItem',
+};


### PR DESCRIPTION
This PR adds bundle size fixtures for AvatarGroup and AvatarGroupItem.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#22240
