### PR TITLE
fix: Making increment and decrement buttons of SpinButton have 'type=button' instead of 'type=submit'

### DIFF
--- a/change/@fluentui-react-spinbutton-f448dee9-4572-46fd-ae20-96874f4525ca.json
+++ b/change/@fluentui-react-spinbutton-f448dee9-4572-46fd-ae20-96874f4525ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Making increment and decrement buttons of SpinButton have 'type=button' instead of 'type=submit'.",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -124,6 +124,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
         children: <ChevronUp16Regular />,
         disabled: nativeProps.primary.disabled,
         'aria-label': 'Increment value',
+        type: 'button',
       },
     }),
     decrementButton: resolveShorthand(decrementButton, {
@@ -133,6 +134,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
         children: <ChevronDown16Regular />,
         disabled: nativeProps.primary.disabled,
         'aria-label': 'Decrement value',
+        type: 'button',
       },
     }),
   };


### PR DESCRIPTION
## Current Behavior

The increment and decrement buttons of our `SpinButton` component are of `type="submit"` which will not work as expected when put inside of a form.

## New Behavior

The increment and decrement buttons of our `SpinButton` component are of `type="button"` which should work as expected when put inside of a form.

## Related Issue(s)

Fixes #23316
