### PR TITLE
fix: Making thumb be vertically centered in Switch

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Switch.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Switch.stories.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { Switch } from '@fluentui/react-switch';
+import { TestWrapperDecorator } from '../utilities/TestWrapperDecorator';
 
 storiesOf('Switch Converged', module)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Steps()

--- a/change/@fluentui-react-switch-69aede67-89a3-43d5-bd02-fd516b545622.json
+++ b/change/@fluentui-react-switch-69aede67-89a3-43d5-bd02-fd516b545622.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Making thumb be vertically centered in Switch.",
+  "packageName": "@fluentui/react-switch",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -18,9 +18,9 @@ export const switchClassName = switchClassNames.root;
 
 // Thumb and track sizes used by the component.
 const spaceBetweenThumbAndTrack = 2;
-const thumbSize = 14;
 const trackHeight = 20;
 const trackWidth = 40;
+const thumbSize = trackHeight - spaceBetweenThumbAndTrack;
 
 const useRootStyles = makeStyles({
   base: {
@@ -47,7 +47,7 @@ const useIndicatorStyles = makeStyles({
     boxSizing: 'border-box',
     fill: 'currentColor',
     flexShrink: 0,
-    fontSize: `${thumbSize + spaceBetweenThumbAndTrack}px`,
+    fontSize: `${thumbSize}px`,
     height: `${trackHeight}px`,
     pointerEvents: 'none',
     transitionDuration: '200ms',
@@ -79,7 +79,7 @@ const useInputStyles = makeStyles({
     ':checked': {
       [`& ~ .${switchClassNames.indicator}`]: {
         '> *': {
-          transform: `translateX(${trackWidth - thumbSize - spaceBetweenThumbAndTrack * 2}px)`,
+          transform: `translateX(${trackWidth - thumbSize - spaceBetweenThumbAndTrack}px)`,
         },
       },
     },


### PR DESCRIPTION
## Current Behavior

The thumb of the `Switch` is not vertically centered because of some wrong math when calculating the styles of the component.

![image](https://user-images.githubusercontent.com/7798177/175428252-711c577c-8802-4964-a8ad-087ccc141db2.png)
![image](https://user-images.githubusercontent.com/7798177/175428350-3a086081-4af8-42e3-9038-babcf1825fc7.png)

## New Behavior

The thumb of the `Switch` is now vertically centered, with the correct math being applied when calculating the styles of the component.

![image](https://user-images.githubusercontent.com/7798177/175428328-a0c13637-bc15-4ce1-aa9b-b19591161304.png)
![image](https://user-images.githubusercontent.com/7798177/175428382-4d0cde49-c813-4baa-b67d-df8524efe4e9.png)

This PR also updates the visual regression tests for `Switch` so that they crop to the component.

## Related Issue(s)

Fixes #23470
