### PR TITLE
fix: Removing user-select: 'none' from AccordionHeader styles.

### DIFF
--- a/change/@fluentui-react-accordion-bcbc8c5b-15f9-4b93-a0bf-aa95f7c5e4af.json
+++ b/change/@fluentui-react-accordion-bcbc8c5b-15f9-4b93-a0bf-aa95f7c5e4af.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Removing user-select: 'none' from AccordionHeader styles.",
+  "packageName": "@fluentui/react-accordion",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
@@ -23,7 +23,6 @@ const useStyles = makeStyles({
     ...shorthands.overflow('visible'),
     ...shorthands.padding(0),
     WebkitAppearance: 'button',
-    userSelect: 'none',
     textAlign: 'unset',
   },
   focusIndicator: createFocusOutlineStyle(),


### PR DESCRIPTION
## Current Behavior

`AccordionHeader` has the `user-select: 'none'` style set on it, which makes its text impossible to copy and prevents people from using tools like read-aloud or dictionary lookup.

## New Behavior

`AccordionHeader` no longer has the `user-select: 'none'` style set on it, eliminating the problem described above.

## Related Issue(s)

Fixes part of #23589
