### PR TITLE
Change docsite glob to only pull index from react-components

### DIFF
--- a/apps/public-docsite-v9/.storybook/main.utils.js
+++ b/apps/public-docsite-v9/.storybook/main.utils.js
@@ -24,7 +24,7 @@ function getVnextStories() {
     .filter(pkgName => pkgName.startsWith('@fluentui/') && !excludedDependencies.includes(pkgName))
     .map(pkgName => {
       const name = pkgName.replace('@fluentui/', '');
-      const storiesGlob = '/src/**/*.stories.@(ts|tsx|mdx)';
+      const storiesGlob = '/src/**/@(index.stories.@(ts|tsx)|*.stories.mdx)';
 
       return `../../../packages/react-components/${name}${storiesGlob}`;
     });


### PR DESCRIPTION
fixes #23722

Small change that will now only import index.stories.tsx files from our components