### PR TITLE
Perf App: Add SpinButton scenario

### DIFF
--- a/apps/perf-test-react-components/package.json
+++ b/apps/perf-test-react-components/package.json
@@ -19,6 +19,7 @@
     "@fluentui/react-avatar": "^9.0.1",
     "@fluentui/react-button": "^9.0.1",
     "@fluentui/react-provider": "^9.0.1",
+    "@fluentui/react-spinbutton": "9.0.0-beta.13",
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/scripts": "^1.0.0",
     "@microsoft/load-themed-styles": "^1.10.26",

--- a/apps/perf-test-react-components/src/scenarios/SpinButton.tsx
+++ b/apps/perf-test-react-components/src/scenarios/SpinButton.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { SpinButton } from '@fluentui/react-spinbutton';
+import { FluentProvider } from '@fluentui/react-provider';
+import { webLightTheme } from '@fluentui/react-theme';
+
+const Scenario = () => <SpinButton defaultValue={0} min={0} max={0} />;
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/change/@fluentui-react-spinbutton-20ec90eb-d070-4e3a-82f6-4f12793367b2.json
+++ b/change/@fluentui-react-spinbutton-20ec90eb-d070-4e3a-82f6-4f12793367b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: alphabetize prop destructure",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -394,7 +394,7 @@ const useButtonDisabledStyles = makeStyles({
  * Apply styling to the SpinButton slots based on the state
  */
 export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButtonState => {
-  const { appearance, atBound, spinState, size } = state;
+  const { appearance, atBound, size, spinState } = state;
   const disabled = state.input.disabled;
   const filled = appearance.startsWith('filled');
 


### PR DESCRIPTION
## Current Behavior

The `perf-test-react-components` app does not have a `SpinButton` scenario.

## New Behavior

The `perf-test-react-components` app has a `SpinButton` scenario.

| v8 SpinButton Flamegrill Results | v9 SpinButton Flamegrill Results |
| --- | --- |
| ![spinbutton_v8](https://user-images.githubusercontent.com/93940821/175720597-0c51af1b-14db-4df9-8119-4c40240bdfc1.png) | ![spinbutton_v9](https://user-images.githubusercontent.com/93940821/175720610-b8bb730e-dee9-4fd0-b811-ef155db0edc3.png) |

**NOTE** the v9 "Master Ticks" is run on an essentially blank page as this scenario did not previously exist. There is no regression as this run is establishing the initial baseline.

These results obtained by running the perf-test apps locally on my development machine.

## Related Issue(s)

**NOTE** this PR depends on #23714
