### PR TITLE
change v9docs start to use docs mode to replicate public view

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -12,7 +12,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
+    "start": "yarn storybook:docs",
     "storybook": "node ../../scripts/storybook/runner --port 3000 -s ./public --no-manager-cache",
     "storybook:docs": "yarn storybook --docs"
   },


### PR DESCRIPTION
Running start from the root runs the v9 docs in the non-docs mode, which is not what we publish to chromatic. This change will make it so you don't have to run storybook:dev from the v9 docs folder to get the correct options.