### PR TITLE
Chore: V8 Website: remove figma link from docs due to resource being private

### DIFF
--- a/apps/public-docsite/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDesignResources.md
+++ b/apps/public-docsite/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDesignResources.md
@@ -10,8 +10,6 @@ These design toolkits provide styles, controls and layout templates that enable 
   <li className="mdut--half">[Download Android toolkit (Sketch)](https://aka.ms/FluentToolkits/Android/Sketch)</li>
   <li className="mdut--half">[Download Android toolkit (Figma)](https://aka.ms/FluentToolkits/Android/Figma)</li>
   <li className="mdut--half">[Download Windows toolkit (Figma)](https://aka.ms/figmatoolkit)</li>
-  <li className="mdut--half">[Download Figma plug-in](https://www.figma.com/community/plugin/794492287931420611/Fluent-Theme-Designer)</li>
-
 </ul>
 
 <!-- headings get auto-generated IDs usually, and this page has two "SharePoint Framework" headings -->


### PR DESCRIPTION
I haven't looked into all the history, but I'm guessing at one point we had a public figma plugin....

But as of today, the Figma plugin is internal only and 3rd party will hit a 404 here. I don't think the value of having the link is worth the confusion. 


fixes #23329