### PR TITLE
High Contrast Selectors: Fix broken 2nd query

### DIFF
--- a/change/@fluentui-style-utilities-fa10c0ab-ee6b-412b-990e-d5d7a1448b4d.json
+++ b/change/@fluentui-style-utilities-fa10c0ab-ee6b-412b-990e-d5d7a1448b4d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix high contrast media query selector",
+  "packageName": "@fluentui/style-utilities",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-cards/src/components/Card/CardItem/__snapshots__/CardItem.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/CardItem/__snapshots__/CardItem.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Card Item renders correctly 1`] = `
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -98,7 +98,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -191,7 +191,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -284,7 +284,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -377,7 +377,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -470,7 +470,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -589,7 +589,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -708,7 +708,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -775,7 +775,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -842,7 +842,7 @@ exports[`Card Item renders correctly when having tokens passed to it 1`] = `
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}

--- a/packages/react-cards/src/components/Card/CardSection/__snapshots__/CardSection.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/CardSection/__snapshots__/CardSection.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Card Section renders correctly 1`] = `
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -109,7 +109,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -224,7 +224,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -339,7 +339,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -454,7 +454,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -569,7 +569,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -721,7 +721,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -873,7 +873,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -951,7 +951,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}
@@ -1029,7 +1029,7 @@ exports[`Card Section renders correctly when having tokens passed to it 1`] = `
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
   onKeyDown={[Function]}

--- a/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -60,7 +60,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -81,7 +81,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -91,7 +91,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -272,7 +272,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -295,7 +295,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
@@ -379,7 +379,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -387,7 +387,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -408,7 +408,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -418,7 +418,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -582,7 +582,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   outline-color: #605e5c;
                 }
             data-is-focusable={true}
@@ -605,7 +605,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                     margin-right: 8px;
                     width: 12px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     content: linear-gradient(to right, red, red);
                     opacity: ;
                   }
@@ -686,7 +686,7 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -694,7 +694,7 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -715,7 +715,7 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -725,7 +725,7 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -868,7 +868,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -876,7 +876,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -897,7 +897,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -907,7 +907,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1088,7 +1088,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1111,7 +1111,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
@@ -1195,7 +1195,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1203,7 +1203,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1224,7 +1224,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1234,7 +1234,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1415,7 +1415,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1438,7 +1438,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
@@ -1522,7 +1522,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1530,7 +1530,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1551,7 +1551,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1561,7 +1561,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1742,7 +1742,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1765,7 +1765,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
@@ -1849,7 +1849,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1857,7 +1857,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1878,7 +1878,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1888,7 +1888,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -2069,7 +2069,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2092,7 +2092,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, red, red);
                           opacity: ;
                         }

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                     fill: #323130;
                     font-size: 18px;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                  @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
                     fill: rgb(179, 179, 179);
                   }
               textAnchor="middle"
@@ -114,7 +114,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                     fill: #323130;
                     font-size: 18px;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                  @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
                     fill: rgb(179, 179, 179);
                   }
               textAnchor="middle"
@@ -221,7 +221,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -244,7 +244,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #E5E5E5, #E5E5E5);
                           opacity: ;
                         }
@@ -310,7 +310,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -333,7 +333,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078D4, #0078D4);
                           opacity: ;
                         }
@@ -440,7 +440,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                     fill: #323130;
                     font-size: 18px;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                  @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
                     fill: rgb(179, 179, 179);
                   }
               textAnchor="middle"
@@ -479,7 +479,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                     fill: #323130;
                     font-size: 18px;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                  @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
                     fill: rgb(179, 179, 179);
                   }
               textAnchor="middle"
@@ -586,7 +586,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -609,7 +609,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #E5E5E5, #E5E5E5);
                           opacity: ;
                         }
@@ -675,7 +675,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -698,7 +698,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078D4, #0078D4);
                           opacity: ;
                         }
@@ -805,7 +805,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
                     fill: #323130;
                     font-size: 18px;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                  @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
                     fill: rgb(179, 179, 179);
                   }
               textAnchor="middle"
@@ -844,7 +844,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
                     fill: #323130;
                     font-size: 18px;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                  @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
                     fill: rgb(179, 179, 179);
                   }
               textAnchor="middle"
@@ -936,7 +936,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                     fill: #323130;
                     font-size: 18px;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                  @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
                     fill: rgb(179, 179, 179);
                   }
               textAnchor="middle"
@@ -975,7 +975,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                     fill: #323130;
                     font-size: 18px;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                  @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
                     fill: rgb(179, 179, 179);
                   }
               textAnchor="middle"
@@ -1082,7 +1082,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1105,7 +1105,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #E5E5E5, #E5E5E5);
                           opacity: ;
                         }
@@ -1171,7 +1171,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1194,7 +1194,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078D4, #0078D4);
                           opacity: ;
                         }
@@ -1301,7 +1301,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                     fill: #323130;
                     font-size: 18px;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                  @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
                     fill: rgb(179, 179, 179);
                   }
               textAnchor="middle"
@@ -1342,7 +1342,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                     fill: #323130;
                     font-size: 18px;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                  @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
                     fill: rgb(179, 179, 179);
                   }
               textAnchor="middle"
@@ -1451,7 +1451,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1474,7 +1474,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #E5E5E5, #E5E5E5);
                           opacity: ;
                         }
@@ -1540,7 +1540,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1563,7 +1563,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078D4, #0078D4);
                           opacity: ;
                         }

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -59,7 +59,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -80,7 +80,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -90,7 +90,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -328,7 +328,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -351,7 +351,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -417,7 +417,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -440,7 +440,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -506,7 +506,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -529,7 +529,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00bcf2, #00bcf2);
                           opacity: ;
                         }
@@ -612,7 +612,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -620,7 +620,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -641,7 +641,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -651,7 +651,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -872,7 +872,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   outline-color: #605e5c;
                 }
             data-is-focusable={true}
@@ -895,7 +895,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                     margin-right: 8px;
                     width: 12px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     content: linear-gradient(to right, #0078d4, #0078d4);
                     opacity: ;
                   }
@@ -961,7 +961,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   outline-color: #605e5c;
                 }
             data-is-focusable={true}
@@ -984,7 +984,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                     margin-right: 8px;
                     width: 12px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     content: linear-gradient(to right, #00188f, #00188f);
                     opacity: ;
                   }
@@ -1050,7 +1050,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   outline-color: #605e5c;
                 }
             data-is-focusable={true}
@@ -1073,7 +1073,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                     margin-right: 8px;
                     width: 12px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     content: linear-gradient(to right, #00bcf2, #00bcf2);
                     opacity: ;
                   }
@@ -1153,7 +1153,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1161,7 +1161,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1182,7 +1182,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1192,7 +1192,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1391,7 +1391,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1399,7 +1399,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1420,7 +1420,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1430,7 +1430,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1668,7 +1668,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1691,7 +1691,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -1757,7 +1757,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1780,7 +1780,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -1846,7 +1846,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1869,7 +1869,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00bcf2, #00bcf2);
                           opacity: ;
                         }
@@ -1952,7 +1952,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1960,7 +1960,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1981,7 +1981,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1991,7 +1991,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -2229,7 +2229,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2252,7 +2252,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -2318,7 +2318,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2341,7 +2341,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -2407,7 +2407,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2430,7 +2430,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00bcf2, #00bcf2);
                           opacity: ;
                         }
@@ -2513,7 +2513,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -2521,7 +2521,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -2542,7 +2542,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -2552,7 +2552,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -2790,7 +2790,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2813,7 +2813,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -2879,7 +2879,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2902,7 +2902,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -2968,7 +2968,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2991,7 +2991,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00bcf2, #00bcf2);
                           opacity: ;
                         }
@@ -3074,7 +3074,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -3082,7 +3082,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -3103,7 +3103,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -3113,7 +3113,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -3351,7 +3351,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -3374,7 +3374,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -3440,7 +3440,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -3463,7 +3463,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -3529,7 +3529,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -3552,7 +3552,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00bcf2, #00bcf2);
                           opacity: ;
                         }

--- a/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -59,7 +59,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -80,7 +80,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -90,7 +90,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -258,7 +258,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -281,7 +281,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, rgb(144, 180, 215), rgb(144, 180, 215));
                           opacity: ;
                         }
@@ -364,7 +364,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -372,7 +372,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -393,7 +393,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -403,7 +403,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -571,7 +571,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -594,7 +594,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, rgb(255, 203, 169), rgb(255, 203, 169));
                           opacity: ;
                         }
@@ -660,7 +660,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -683,7 +683,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, rgb(255, 213, 135), rgb(255, 213, 135));
                           opacity: ;
                         }
@@ -766,7 +766,7 @@ exports[`HeatMapChart snapShot testing renders hideLegend correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -774,7 +774,7 @@ exports[`HeatMapChart snapShot testing renders hideLegend correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -795,7 +795,7 @@ exports[`HeatMapChart snapShot testing renders hideLegend correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -805,7 +805,7 @@ exports[`HeatMapChart snapShot testing renders hideLegend correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -934,7 +934,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -942,7 +942,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -963,7 +963,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -973,7 +973,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1141,7 +1141,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1164,7 +1164,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, rgb(144, 180, 215), rgb(144, 180, 215));
                           opacity: ;
                         }
@@ -1247,7 +1247,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1255,7 +1255,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1276,7 +1276,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1286,7 +1286,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1454,7 +1454,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1477,7 +1477,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, rgb(144, 180, 215), rgb(144, 180, 215));
                           opacity: ;
                         }

--- a/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -60,7 +60,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -81,7 +81,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -91,7 +91,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -260,7 +260,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -283,7 +283,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
@@ -367,7 +367,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -375,7 +375,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -396,7 +396,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -406,7 +406,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -558,7 +558,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   outline-color: #605e5c;
                 }
             data-is-focusable={true}
@@ -581,7 +581,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                     margin-right: 8px;
                     width: 12px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     content: linear-gradient(to right, red, red);
                     opacity: ;
                   }
@@ -662,7 +662,7 @@ exports[`LineChart snapShot testing renders hideLegend correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -670,7 +670,7 @@ exports[`LineChart snapShot testing renders hideLegend correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -691,7 +691,7 @@ exports[`LineChart snapShot testing renders hideLegend correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -701,7 +701,7 @@ exports[`LineChart snapShot testing renders hideLegend correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -832,7 +832,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -840,7 +840,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -861,7 +861,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -871,7 +871,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1040,7 +1040,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1063,7 +1063,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
@@ -1147,7 +1147,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1155,7 +1155,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1176,7 +1176,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1186,7 +1186,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1355,7 +1355,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1378,7 +1378,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
@@ -1462,7 +1462,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1470,7 +1470,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1491,7 +1491,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1501,7 +1501,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1670,7 +1670,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1693,7 +1693,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, red, red);
                           opacity: ;
                         }
@@ -1777,7 +1777,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1785,7 +1785,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1806,7 +1806,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1816,7 +1816,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1985,7 +1985,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2008,7 +2008,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, red, red);
                           opacity: ;
                         }

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -1439,7 +1439,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1462,7 +1462,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #e81123, #e81123);
                           opacity: ;
                         }
@@ -1528,7 +1528,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1551,7 +1551,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #107c10, #107c10);
                           opacity: ;
                         }

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1264,7 +1264,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1287,7 +1287,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #5c005c, #5c005c);
                           opacity: ;
                         }
@@ -1353,7 +1353,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1376,7 +1376,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #e81123, #e81123);
                           opacity: ;
                         }

--- a/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -59,7 +59,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -80,7 +80,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -90,7 +90,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -197,7 +197,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -220,7 +220,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -286,7 +286,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -309,7 +309,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #002050, #002050);
                           opacity: ;
                         }
@@ -375,7 +375,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -398,7 +398,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -481,7 +481,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -489,7 +489,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -510,7 +510,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -520,7 +520,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -610,7 +610,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   outline-color: #605e5c;
                 }
             data-is-focusable={true}
@@ -633,7 +633,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                     margin-right: 8px;
                     width: 12px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     content: linear-gradient(to right, #0078d4, #0078d4);
                     opacity: ;
                   }
@@ -699,7 +699,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   outline-color: #605e5c;
                 }
             data-is-focusable={true}
@@ -722,7 +722,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                     margin-right: 8px;
                     width: 12px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     content: linear-gradient(to right, #002050, #002050);
                     opacity: ;
                   }
@@ -788,7 +788,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   outline-color: #605e5c;
                 }
             data-is-focusable={true}
@@ -811,7 +811,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                     margin-right: 8px;
                     width: 12px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     content: linear-gradient(to right, #00188f, #00188f);
                     opacity: ;
                   }
@@ -891,7 +891,7 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -899,7 +899,7 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -920,7 +920,7 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -930,7 +930,7 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -998,7 +998,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1006,7 +1006,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1027,7 +1027,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1037,7 +1037,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1144,7 +1144,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1167,7 +1167,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -1233,7 +1233,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1256,7 +1256,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #002050, #002050);
                           opacity: ;
                         }
@@ -1322,7 +1322,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1345,7 +1345,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -1428,7 +1428,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1436,7 +1436,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1457,7 +1457,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1467,7 +1467,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1574,7 +1574,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1597,7 +1597,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -1663,7 +1663,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1686,7 +1686,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #002050, #002050);
                           opacity: ;
                         }
@@ -1752,7 +1752,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1775,7 +1775,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -1858,7 +1858,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1866,7 +1866,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1887,7 +1887,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1897,7 +1897,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -2004,7 +2004,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2027,7 +2027,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -2093,7 +2093,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2116,7 +2116,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #002050, #002050);
                           opacity: ;
                         }
@@ -2182,7 +2182,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2205,7 +2205,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -2288,7 +2288,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -2296,7 +2296,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -2317,7 +2317,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -2327,7 +2327,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -2434,7 +2434,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2457,7 +2457,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -2523,7 +2523,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2546,7 +2546,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #002050, #002050);
                           opacity: ;
                         }
@@ -2612,7 +2612,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2635,7 +2635,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -59,7 +59,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -80,7 +80,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -90,7 +90,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -194,7 +194,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -217,7 +217,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -283,7 +283,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -306,7 +306,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -389,7 +389,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -397,7 +397,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -418,7 +418,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -428,7 +428,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -515,7 +515,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   outline-color: #605e5c;
                 }
             data-is-focusable={true}
@@ -538,7 +538,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                     margin-right: 8px;
                     width: 12px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     content: linear-gradient(to right, #0078d4, #0078d4);
                     opacity: ;
                   }
@@ -604,7 +604,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   outline-color: #605e5c;
                 }
             data-is-focusable={true}
@@ -627,7 +627,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                     margin-right: 8px;
                     width: 12px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     content: linear-gradient(to right, #00188f, #00188f);
                     opacity: ;
                   }
@@ -707,7 +707,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideLegend correctly 1
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -715,7 +715,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideLegend correctly 1
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -736,7 +736,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideLegend correctly 1
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -746,7 +746,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideLegend correctly 1
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -811,7 +811,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -819,7 +819,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -840,7 +840,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -850,7 +850,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -954,7 +954,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -977,7 +977,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -1043,7 +1043,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1066,7 +1066,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -1149,7 +1149,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1157,7 +1157,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1178,7 +1178,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1188,7 +1188,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1292,7 +1292,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1315,7 +1315,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -1381,7 +1381,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1404,7 +1404,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -1487,7 +1487,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1495,7 +1495,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1516,7 +1516,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1526,7 +1526,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1630,7 +1630,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1653,7 +1653,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -1719,7 +1719,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1742,7 +1742,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -1825,7 +1825,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -1833,7 +1833,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1854,7 +1854,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -1864,7 +1864,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -1968,7 +1968,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -1991,7 +1991,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -2057,7 +2057,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2080,7 +2080,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }
@@ -2163,7 +2163,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & line {
@@ -2171,7 +2171,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
               stroke: #323130;
               width: 1px;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -2192,7 +2192,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
               font-size: 10px;
               font-weight: 600;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& text {
               fill: rgb(179, 179, 179);
             }
             & path {
@@ -2202,7 +2202,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
               opacity: 0.2;
               stroke: #323130;
             }
-            @media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
+            @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& line {
               opacity: 0.1;
               stroke: rgb(179, 179, 179);
             }
@@ -2306,7 +2306,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2329,7 +2329,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #0078d4, #0078d4);
                           opacity: ;
                         }
@@ -2395,7 +2395,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
                   data-is-focusable={true}
@@ -2418,7 +2418,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                           margin-right: 8px;
                           width: 12px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           content: linear-gradient(to right, #00188f, #00188f);
                           opacity: ;
                         }

--- a/packages/react-experiments/src/components/MicroFeedback/__snapshots__/MicroFeedback.test.tsx.snap
+++ b/packages/react-experiments/src/components/MicroFeedback/__snapshots__/MicroFeedback.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -108,7 +108,7 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
               background-color: #f3f2f1;
               color: #106ebe;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               border-color: Highlight;
               color: Highlight;
             }
@@ -220,7 +220,7 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -236,7 +236,7 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
               background-color: #f3f2f1;
               color: #106ebe;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               border-color: Highlight;
               color: Highlight;
             }
@@ -400,7 +400,7 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -416,7 +416,7 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
               background-color: #f3f2f1;
               color: #106ebe;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               border-color: Highlight;
               color: Highlight;
             }
@@ -528,7 +528,7 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -544,7 +544,7 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
               background-color: #f3f2f1;
               color: #106ebe;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               border-color: Highlight;
               color: Highlight;
             }

--- a/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -127,7 +127,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
                 margin-top: 0;
                 text-align: center;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: GrayText;
               }
           data-icon-name="Previous"
@@ -188,7 +188,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -256,7 +256,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
                 margin-top: 0;
                 text-align: center;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: GrayText;
               }
           data-icon-name="CaretSolidLeft"
@@ -318,7 +318,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -348,7 +348,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             background-color: #f3f2f1;
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             border-color: Highlight;
             color: Highlight;
           }
@@ -424,7 +424,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -454,7 +454,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             background-color: #f3f2f1;
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             border-color: Highlight;
             color: Highlight;
           }
@@ -530,7 +530,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -560,7 +560,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             background-color: #f3f2f1;
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             border-color: Highlight;
             color: Highlight;
           }
@@ -636,7 +636,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -666,7 +666,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             background-color: #f3f2f1;
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             border-color: Highlight;
             color: Highlight;
           }
@@ -742,7 +742,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -772,7 +772,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             background-color: #f3f2f1;
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             border-color: Highlight;
             color: Highlight;
           }
@@ -844,7 +844,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -860,7 +860,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             background-color: #f3f2f1;
             color: #106ebe;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             border-color: Highlight;
             color: Highlight;
           }
@@ -985,7 +985,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -1001,7 +1001,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
               background-color: #f3f2f1;
               color: #106ebe;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               border-color: Highlight;
               color: Highlight;
             }
@@ -1153,7 +1153,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           top: 2px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           bottom: -2px;
           left: -2px;
           outline-color: ButtonText;
@@ -1221,7 +1221,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               margin-top: 0;
               text-align: center;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               color: GrayText;
             }
         data-icon-name="Previous"
@@ -1282,7 +1282,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           top: 2px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           bottom: -2px;
           left: -2px;
           outline-color: ButtonText;
@@ -1350,7 +1350,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               margin-top: 0;
               text-align: center;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               color: GrayText;
             }
         data-icon-name="CaretSolidLeft"
@@ -1402,13 +1402,13 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-open {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-open:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-open:after {
             border-color: Highlight;
           }
           &:after {
@@ -1433,46 +1433,46 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           &:hover .ms-ComboBox-Input::placeholder {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
             color: GrayText;
           }
           &:hover .ms-ComboBox-Input:-ms-input-placeholder {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
             color: GrayText;
           }
           &:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: GrayText;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-ComboBox-Input {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-ComboBox-Input {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover:after {
             border-color: Highlight;
           }
           &:active {
             position: relative;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:after {
             border-color: Highlight;
           }
           &:focus {
@@ -1481,19 +1481,19 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           &:focus .ms-ComboBox-Input {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-ComboBox-Input {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-ComboBox-Input {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:after {
             border-color: Highlight;
           }
           &:focus:after {
@@ -1535,25 +1535,25 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             &::placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
               color: GrayText;
             }
             &:-ms-input-placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-input-placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-clear {
               display: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window;
               color: WindowText;
@@ -1631,7 +1631,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -1643,7 +1643,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: ButtonFace;
               border-color: ButtonText;
@@ -1655,7 +1655,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               color: #201f1e;
               cursor: pointer;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               background-color: Highlight;
               border-color: Highlight;
@@ -1666,7 +1666,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               background-color: #edebe9;
               color: #201f1e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               -ms-high-contrast-adjust: none;
               background-color: Highlight;
               border-color: Highlight;
@@ -1781,7 +1781,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           top: 2px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           bottom: -2px;
           left: -2px;
           outline-color: ButtonText;
@@ -1797,7 +1797,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           background-color: #f3f2f1;
           color: #106ebe;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           border-color: Highlight;
           color: Highlight;
         }
@@ -1908,7 +1908,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           top: 2px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           bottom: -2px;
           left: -2px;
           outline-color: ButtonText;
@@ -1924,7 +1924,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           background-color: #f3f2f1;
           color: #106ebe;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           border-color: Highlight;
           color: Highlight;
         }

--- a/packages/react-experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/react-experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`PersonaCoin renders presence correctly when a very large coin is render
           top: auto;
           width: 12px;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           background-color: WindowText;
           border-color: Window;
         }
@@ -264,7 +264,7 @@ exports[`PersonaCoin renders presence correctly when a very large coin is render
             speak: none;
             vertical-align: top;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             color: Window;
           }
       data-icon-name="SkypeMinus"
@@ -334,7 +334,7 @@ exports[`PersonaCoin renders presence when it is passed 1`] = `
           top: auto;
           width: 12px;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           background-color: WindowText;
           border-color: Window;
         }
@@ -363,7 +363,7 @@ exports[`PersonaCoin renders presence when it is passed 1`] = `
             speak: none;
             vertical-align: top;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             color: Window;
           }
       data-icon-name="SkypeMinus"

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -25,24 +25,24 @@ Array [
         &:hover {
           background: #deecf9;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           background: Highlight;
           border: 1px solid ButtonText;
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-PickerItem-content {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-PickerItem-content {
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-PickerItem-removeButton {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-PickerItem-removeButton {
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           -ms-high-contrast-adjust: none;
           background: ButtonFace;
           border: 1px solid ButtonText;
           color: ButtonText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-PickerItem-removeButton {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-PickerItem-removeButton {
           color: ButtonText;
         }
     data-is-focusable={true}
@@ -98,7 +98,7 @@ Array [
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -110,7 +110,7 @@ Array [
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: inherit;
               color: inherit;
             }
@@ -118,7 +118,7 @@ Array [
               background-color: #c7e0f4;
               color: #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               background: inherit;
               border-color: Highlight;
               color: inherit;
@@ -127,7 +127,7 @@ Array [
               background-color: #106ebe;
               color: #ffffff;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               background: inherit;
               color: inherit;
             }
@@ -279,7 +279,7 @@ Array [
                       height: 32px;
                       line-height: 32px;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                       -ms-high-contrast-adjust: none;
                       background-color: Window !important;
                       border: 1px solid WindowText;
@@ -327,10 +327,10 @@ Array [
                   &:hover {
                     color: #005a9e;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                     color: inherit;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     color: inherit;
                   }
               dir="auto"
@@ -417,7 +417,7 @@ Array [
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -429,7 +429,7 @@ Array [
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: inherit;
               color: inherit;
             }
@@ -437,7 +437,7 @@ Array [
               background-color: #c7e0f4;
               color: #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               background: inherit;
               border-color: Highlight;
               color: inherit;
@@ -446,7 +446,7 @@ Array [
               background-color: #106ebe;
               color: #ffffff;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               background: inherit;
               color: inherit;
             }
@@ -533,24 +533,24 @@ Array [
         &:hover {
           background: #deecf9;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           background: Highlight;
           border: 1px solid ButtonText;
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-PickerItem-content {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-PickerItem-content {
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-PickerItem-removeButton {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-PickerItem-removeButton {
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           -ms-high-contrast-adjust: none;
           background: ButtonFace;
           border: 1px solid ButtonText;
           color: ButtonText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-PickerItem-removeButton {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-PickerItem-removeButton {
           color: ButtonText;
         }
     data-is-focusable={true}
@@ -606,7 +606,7 @@ Array [
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -618,7 +618,7 @@ Array [
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: inherit;
               color: inherit;
             }
@@ -626,7 +626,7 @@ Array [
               background-color: #c7e0f4;
               color: #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               background: inherit;
               border-color: Highlight;
               color: inherit;
@@ -635,7 +635,7 @@ Array [
               background-color: #106ebe;
               color: #ffffff;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               background: inherit;
               color: inherit;
             }
@@ -787,7 +787,7 @@ Array [
                       height: 32px;
                       line-height: 32px;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                       -ms-high-contrast-adjust: none;
                       background-color: Window !important;
                       border: 1px solid WindowText;
@@ -835,10 +835,10 @@ Array [
                   &:hover {
                     color: #005a9e;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                     color: inherit;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     color: inherit;
                   }
               dir="auto"
@@ -925,7 +925,7 @@ Array [
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -937,7 +937,7 @@ Array [
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: inherit;
               color: inherit;
             }
@@ -945,7 +945,7 @@ Array [
               background-color: #c7e0f4;
               color: #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               background: inherit;
               border-color: Highlight;
               color: inherit;
@@ -954,7 +954,7 @@ Array [
               background-color: #106ebe;
               color: #ffffff;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               background: inherit;
               color: inherit;
             }
@@ -1046,24 +1046,24 @@ Array [
         &:hover {
           background: #deecf9;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           background: Highlight;
           border: 1px solid ButtonText;
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-PickerItem-content {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-PickerItem-content {
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-PickerItem-removeButton {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-PickerItem-removeButton {
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           -ms-high-contrast-adjust: none;
           background: ButtonFace;
           border: 1px solid ButtonText;
           color: ButtonText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-PickerItem-removeButton {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-PickerItem-removeButton {
           color: ButtonText;
         }
     data-is-focusable={true}
@@ -1119,7 +1119,7 @@ Array [
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -1131,7 +1131,7 @@ Array [
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: inherit;
               color: inherit;
             }
@@ -1139,7 +1139,7 @@ Array [
               background-color: #c7e0f4;
               color: #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               background: inherit;
               border-color: Highlight;
               color: inherit;
@@ -1148,7 +1148,7 @@ Array [
               background-color: #106ebe;
               color: #ffffff;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               background: inherit;
               color: inherit;
             }
@@ -1300,7 +1300,7 @@ Array [
                       height: 32px;
                       line-height: 32px;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                       -ms-high-contrast-adjust: none;
                       background-color: Window !important;
                       border: 1px solid WindowText;
@@ -1348,10 +1348,10 @@ Array [
                   &:hover {
                     color: #005a9e;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                     color: inherit;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     color: inherit;
                   }
               dir="auto"
@@ -1438,7 +1438,7 @@ Array [
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -1450,7 +1450,7 @@ Array [
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: inherit;
               color: inherit;
             }
@@ -1458,7 +1458,7 @@ Array [
               background-color: #c7e0f4;
               color: #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               background: inherit;
               border-color: Highlight;
               color: inherit;
@@ -1467,7 +1467,7 @@ Array [
               background-color: #106ebe;
               color: #ffffff;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               background: inherit;
               color: inherit;
             }
@@ -1554,24 +1554,24 @@ Array [
         &:hover {
           background: #deecf9;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           background: Highlight;
           border: 1px solid ButtonText;
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-PickerItem-content {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-PickerItem-content {
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-PickerItem-removeButton {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-PickerItem-removeButton {
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           -ms-high-contrast-adjust: none;
           background: ButtonFace;
           border: 1px solid ButtonText;
           color: ButtonText;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-PickerItem-removeButton {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-PickerItem-removeButton {
           color: ButtonText;
         }
     data-is-focusable={true}
@@ -1627,7 +1627,7 @@ Array [
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -1639,7 +1639,7 @@ Array [
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: inherit;
               color: inherit;
             }
@@ -1647,7 +1647,7 @@ Array [
               background-color: #c7e0f4;
               color: #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               background: inherit;
               border-color: Highlight;
               color: inherit;
@@ -1656,7 +1656,7 @@ Array [
               background-color: #106ebe;
               color: #ffffff;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               background: inherit;
               color: inherit;
             }
@@ -1808,7 +1808,7 @@ Array [
                       height: 32px;
                       line-height: 32px;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                       -ms-high-contrast-adjust: none;
                       background-color: Window !important;
                       border: 1px solid WindowText;
@@ -1856,10 +1856,10 @@ Array [
                   &:hover {
                     color: #005a9e;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                     color: inherit;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     color: inherit;
                   }
               dir="auto"
@@ -1946,7 +1946,7 @@ Array [
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -1958,7 +1958,7 @@ Array [
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: inherit;
               color: inherit;
             }
@@ -1966,7 +1966,7 @@ Array [
               background-color: #c7e0f4;
               color: #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               background: inherit;
               border-color: Highlight;
               color: inherit;
@@ -1975,7 +1975,7 @@ Array [
               background-color: #106ebe;
               color: #ffffff;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               background: inherit;
               color: inherit;
             }

--- a/packages/react-experiments/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/react-experiments/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -126,49 +126,49 @@ exports[`Slider renders correctly 1`] = `
           &:active .ms-Slider-active {
             background-color: #005a9e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Slider-active {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Slider-active {
             background-color: Highlight;
           }
           &:hover .ms-Slider-active {
             background-color: #0078d4;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Slider-active {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Slider-active {
             background-color: Highlight;
           }
           &:active .ms-Slider-inactive {
             background-color: #deecf9;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Slider-inactive {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Slider-inactive {
             border-color: Highlight;
           }
           &:hover .ms-Slider-inactive {
             background-color: #deecf9;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Slider-inactive {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Slider-inactive {
             border-color: Highlight;
           }
           &:active .ms-Slider-thumb {
             border: 2px solid #005a9e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Slider-thumb {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Slider-thumb {
             border-color: Highlight;
           }
           &:hover .ms-Slider-thumb {
             border: 2px solid #005a9e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Slider-thumb {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Slider-thumb {
             border-color: Highlight;
           }
           &:active .ms-Slider-zeroTick {
             background-color: #deecf9;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Slider-zeroTick {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Slider-zeroTick {
             background-color: Highlight;
           }
           &:hover .ms-Slider-zeroTick {
             background-color: #deecf9;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Slider-zeroTick {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Slider-zeroTick {
             background-color: Highlight;
           }
       data-is-focusable={true}
@@ -198,7 +198,7 @@ exports[`Slider renders correctly 1`] = `
                 position: absolute;
                 transform: translateX(-50%);
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background-color: WindowText;
               }
           style={
@@ -219,7 +219,7 @@ exports[`Slider renders correctly 1`] = `
                 position: absolute;
                 transform: translateX(-50%);
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background-color: WindowText;
               }
           style={
@@ -268,7 +268,7 @@ exports[`Slider renders correctly 1`] = `
                 background: #605e5c;
                 transition: width 0.367s cubic-bezier(.1,.9,.2,1);
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background-color: WindowText;
               }
           style={
@@ -290,7 +290,7 @@ exports[`Slider renders correctly 1`] = `
                 background: #c8c6c4;
                 transition: width 0.367s cubic-bezier(.1,.9,.2,1);
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
               }
           style={

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -248,24 +248,24 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                 &:hover {
                   background: #deecf9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   background: Highlight;
                   border: 1px solid ButtonText;
                   color: HighlightText;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-PickerItem-content {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-PickerItem-content {
                   color: HighlightText;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-PickerItem-removeButton {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-PickerItem-removeButton {
                   color: HighlightText;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background: ButtonFace;
                   border: 1px solid ButtonText;
                   color: ButtonText;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-PickerItem-removeButton {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-PickerItem-removeButton {
                   color: ButtonText;
                 }
             data-is-draggable={true}
@@ -324,7 +324,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                       top: 2px;
                       z-index: 1;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                       bottom: -2px;
                       left: -2px;
                       outline-color: ButtonText;
@@ -336,7 +336,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                       position: relative;
                       top: 0px;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                       background-color: inherit;
                       color: inherit;
                     }
@@ -344,7 +344,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                       background-color: #c7e0f4;
                       color: #005a9e;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                       background: inherit;
                       border-color: Highlight;
                       color: inherit;
@@ -353,7 +353,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                       background-color: #106ebe;
                       color: #ffffff;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
                       background: inherit;
                       color: inherit;
                     }
@@ -560,7 +560,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                               top: auto;
                               width: 8px;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background-color: Highlight;
                               border-color: Window;
                             }
@@ -598,10 +598,10 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                           &:hover {
                             color: #005a9e;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             color: inherit;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                             color: inherit;
                           }
                       dir="auto"
@@ -833,7 +833,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                       top: 2px;
                       z-index: 1;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                       bottom: -2px;
                       left: -2px;
                       outline-color: ButtonText;
@@ -845,7 +845,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                       position: relative;
                       top: 0px;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                       background-color: inherit;
                       color: inherit;
                     }
@@ -853,7 +853,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                       background-color: #c7e0f4;
                       color: #005a9e;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                       background: inherit;
                       border-color: Highlight;
                       color: inherit;
@@ -862,7 +862,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                       background-color: #106ebe;
                       color: #ffffff;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
                       background: inherit;
                       color: inherit;
                     }

--- a/packages/react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
+++ b/packages/react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`ActivityItem renders compact with a single persona correctly 1`] = `
           margin-right: 0;
           margin-top: -2px;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-Persona-imageArea {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-Persona-imageArea {
           border: none;
           margin-bottom: 0;
           margin-left: 0;
@@ -112,7 +112,7 @@ exports[`ActivityItem renders compact with a single persona correctly 1`] = `
                   height: 16px;
                   line-height: 16px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window !important;
                   border: 1px solid WindowText;
@@ -201,7 +201,7 @@ exports[`ActivityItem renders compact with an icon correctly 1`] = `
           margin-right: 0;
           margin-top: -2px;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-Persona-imageArea {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-Persona-imageArea {
           border: none;
           margin-bottom: 0;
           margin-left: 0;
@@ -299,7 +299,7 @@ exports[`ActivityItem renders compact with animation correctly 1`] = `
           margin-right: 0;
           margin-top: -2px;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-Persona-imageArea {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-Persona-imageArea {
           border: none;
           margin-bottom: 0;
           margin-left: 0;
@@ -390,7 +390,7 @@ exports[`ActivityItem renders compact with animation correctly 1`] = `
                   height: 16px;
                   line-height: 16px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window !important;
                   border: 1px solid WindowText;
@@ -482,7 +482,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
           margin-right: 0;
           margin-top: -2px;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-Persona-imageArea {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-Persona-imageArea {
           border: none;
           margin-bottom: 0;
           margin-left: 0;
@@ -554,7 +554,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
                   height: 16px;
                   line-height: 16px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window !important;
                   border: 1px solid WindowText;
@@ -711,7 +711,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
                   height: 16px;
                   line-height: 16px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window !important;
                   border: 1px solid WindowText;
@@ -838,7 +838,7 @@ exports[`ActivityItem renders with a single persona correctly 1`] = `
                   height: 32px;
                   line-height: 32px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window !important;
                   border: 1px solid WindowText;
@@ -1081,7 +1081,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
                   height: 16px;
                   line-height: 16px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window !important;
                   border: 1px solid WindowText;
@@ -1216,7 +1216,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
                   height: 16px;
                   line-height: 16px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window !important;
                   border: 1px solid WindowText;

--- a/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         bottom: -2px;
                         left: -2px;
                         outline-color: ButtonText;
@@ -128,7 +128,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                         background-color: transparent;
                         border-color: Highlight;
                         color: Highlight;
@@ -203,7 +203,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                         font-weight: normal;
                         speak: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                         -ms-high-contrast-adjust: none;
                         color: WindowText;
                         forced-color-adjust: none;
@@ -240,7 +240,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -299,7 +299,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                         font-weight: normal;
                         speak: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                         -ms-high-contrast-adjust: none;
                         color: WindowText;
                         forced-color-adjust: none;
@@ -336,7 +336,7 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -462,7 +462,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -521,7 +521,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                         font-weight: normal;
                         speak: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                         -ms-high-contrast-adjust: none;
                         color: WindowText;
                         forced-color-adjust: none;
@@ -558,7 +558,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -617,7 +617,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                         font-weight: normal;
                         speak: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                         -ms-high-contrast-adjust: none;
                         color: WindowText;
                         forced-color-adjust: none;
@@ -654,7 +654,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -713,7 +713,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                         font-weight: normal;
                         speak: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                         -ms-high-contrast-adjust: none;
                         color: WindowText;
                         forced-color-adjust: none;
@@ -750,7 +750,7 @@ exports[`Breadcrumb rendering renders correctly 1`] = `
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -876,7 +876,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -945,7 +945,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -1014,7 +1014,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -1083,7 +1083,7 @@ exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -1209,7 +1209,7 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -1268,7 +1268,7 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                         font-weight: normal;
                         speak: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                         -ms-high-contrast-adjust: none;
                         color: WindowText;
                         forced-color-adjust: none;
@@ -1343,7 +1343,7 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         bottom: -2px;
                         left: -2px;
                         outline-color: ButtonText;
@@ -1361,7 +1361,7 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                         background-color: transparent;
                         border-color: Highlight;
                         color: Highlight;
@@ -1556,7 +1556,7 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         bottom: -2px;
                         left: -2px;
                         outline-color: ButtonText;
@@ -1574,7 +1574,7 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                         background-color: transparent;
                         border-color: Highlight;
                         color: Highlight;
@@ -1769,7 +1769,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         bottom: -2px;
                         left: -2px;
                         outline-color: ButtonText;
@@ -1787,7 +1787,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                         background-color: transparent;
                         border-color: Highlight;
                         color: Highlight;
@@ -1877,7 +1877,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                         font-weight: normal;
                         speak: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                         -ms-high-contrast-adjust: none;
                         color: WindowText;
                         forced-color-adjust: none;
@@ -1914,7 +1914,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -1973,7 +1973,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                         font-weight: normal;
                         speak: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                         -ms-high-contrast-adjust: none;
                         color: WindowText;
                         forced-color-adjust: none;
@@ -2010,7 +2010,7 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -2136,7 +2136,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }
@@ -2195,7 +2195,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                         font-weight: normal;
                         speak: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                         -ms-high-contrast-adjust: none;
                         color: WindowText;
                         forced-color-adjust: none;
@@ -2270,7 +2270,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         bottom: -2px;
                         left: -2px;
                         outline-color: ButtonText;
@@ -2288,7 +2288,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                         background-color: transparent;
                         border-color: Highlight;
                         color: Highlight;
@@ -2378,7 +2378,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                         font-weight: normal;
                         speak: none;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                         -ms-high-contrast-adjust: none;
                         color: WindowText;
                         forced-color-adjust: none;
@@ -2415,7 +2415,7 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                       color: #323130;
                       font-weight: 600;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:last-child .ms-Breadcrumb-itemLink {
                       -ms-high-contrast-adjust: auto;
                       forced-color-adjust: auto;
                     }

--- a/packages/react/src/components/Button/__snapshots__/Button.deprecated.test.tsx.snap
+++ b/packages/react/src/components/Button/__snapshots__/Button.deprecated.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`Button renders CompoundButton correctly 1`] = `
         top: 2px;
         z-index: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
         bottom: -2px;
         left: -2px;
         outline-color: ButtonText;
@@ -63,7 +63,7 @@ exports[`Button renders CompoundButton correctly 1`] = `
         background-color: #f3f2f1;
         color: #201f1e;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
         border-color: Highlight;
         color: Highlight;
       }

--- a/packages/react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`Button renders ActionButton correctly 1`] = `
           top: 2px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           bottom: -2px;
           left: -2px;
           outline-color: ButtonText;
@@ -57,13 +57,13 @@ exports[`Button renders ActionButton correctly 1`] = `
           position: relative;
           top: 0px;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           border-color: Window;
         }
         &:hover {
           color: #0078d4;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           color: Highlight;
         }
         &:hover .ms-Button-icon {
@@ -166,7 +166,7 @@ exports[`Button renders CommandBarButton correctly 1`] = `
           top: 3px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           border: none;
           bottom: 4px;
           left: 4px;
@@ -179,14 +179,14 @@ exports[`Button renders CommandBarButton correctly 1`] = `
           position: relative;
           top: 0px;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           border: none;
         }
         &:hover {
           background-color: #f3f2f1;
           color: #201f1e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           color: Highlight;
         }
         &:hover .ms-Button-icon {
@@ -306,7 +306,7 @@ exports[`Button renders CommandBarButton correctly 1`] = `
               margin-top: 0;
               text-align: center;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               color: GrayText;
             }
         data-icon-name="ChevronDown"
@@ -367,7 +367,7 @@ exports[`Button renders CompoundButton correctly 1`] = `
           top: 2px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           bottom: -2px;
           left: -2px;
           outline-color: ButtonText;
@@ -383,7 +383,7 @@ exports[`Button renders CompoundButton correctly 1`] = `
           background-color: #f3f2f1;
           color: #201f1e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           border-color: Highlight;
           color: Highlight;
         }
@@ -511,7 +511,7 @@ exports[`Button renders DefaultButton correctly 1`] = `
           top: 2px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           bottom: -2px;
           left: -2px;
           outline-color: ButtonText;
@@ -527,7 +527,7 @@ exports[`Button renders DefaultButton correctly 1`] = `
           background-color: #f3f2f1;
           color: #201f1e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           border-color: Highlight;
           color: Highlight;
         }
@@ -626,7 +626,7 @@ exports[`Button renders IconButton correctly 1`] = `
           top: 2px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           bottom: -2px;
           left: -2px;
           outline-color: ButtonText;
@@ -642,7 +642,7 @@ exports[`Button renders IconButton correctly 1`] = `
           background-color: #f3f2f1;
           color: #106ebe;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           border-color: Highlight;
           color: Highlight;
         }
@@ -749,7 +749,7 @@ exports[`Button renders a DefaultButton with a keytip correctly 1`] = `
           top: 2px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           bottom: -2px;
           left: -2px;
           outline-color: ButtonText;
@@ -765,7 +765,7 @@ exports[`Button renders a DefaultButton with a keytip correctly 1`] = `
           background-color: #f3f2f1;
           color: #201f1e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           border-color: Highlight;
           color: Highlight;
         }

--- a/packages/react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
+++ b/packages/react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`Callout renders Callout correctly 1`] = `
             outline: transparent;
             position: absolute;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: WindowText;
             border-style: solid;
             border-width: 1px;

--- a/packages/react/src/components/Check/__snapshots__/Check.test.tsx.snap
+++ b/packages/react/src/components/Check/__snapshots__/Check.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`Check renders Check (correctly) 1`] = `
       &:focus {
         opacity: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
         background: Window;
       }
 >
@@ -76,7 +76,7 @@ exports[`Check renders Check (correctly) 1`] = `
           vertical-align: middle;
           width: 18px;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: WindowText;
         }
     data-icon-name="CircleRing"
@@ -123,7 +123,7 @@ exports[`Check renders Check (correctly) 1`] = `
         &:hover {
           opacity: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           -ms-high-contrast-adjust: none;
           border: none;
           color: WindowText;

--- a/packages/react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -19,32 +19,32 @@ exports[`Checkbox renders checked correctly 1`] = `
           background: #005a9e;
           border-color: #005a9e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
           background: Highlight;
           border-color: Highlight;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Checkbox-checkbox {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Checkbox-checkbox {
           background: Highlight;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:hover .ms-Checkbox-checkbox {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:hover .ms-Checkbox-checkbox {
           background: Highlight;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:hover .ms-Checkbox-checkmark {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:hover .ms-Checkbox-checkmark {
           color: Window;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
           color: Window;
         }
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-text {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-text {
           color: WindowText;
         }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Checkbox-text {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Checkbox-text {
           color: WindowText;
         }
   >
@@ -61,7 +61,7 @@ exports[`Checkbox renders checked correctly 1`] = `
             outline-offset: 2px;
             outline: 1px solid #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target="true"
@@ -116,7 +116,7 @@ exports[`Checkbox renders checked correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background: Highlight;
               border-color: Highlight;
@@ -139,7 +139,7 @@ exports[`Checkbox renders checked correctly 1`] = `
                 opacity: 1;
                 speak: none;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 -ms-high-contrast-adjust: none;
                 color: Window;
                 forced-color-adjust: none;
@@ -158,7 +158,7 @@ exports[`Checkbox renders checked correctly 1`] = `
               line-height: 20px;
               margin-left: 4px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -184,7 +184,7 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
         &:hover .ms-Checkbox-checkbox {
           border-color: #005a9e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
           border-color: WindowText;
         }
         &:focus .ms-Checkbox-checkbox {
@@ -194,25 +194,25 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
           color: #605e5c;
           opacity: 0;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
           color: Highlight;
         }
         &:hover .ms-Checkbox-checkbox:after {
           border-color: #005a9e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox:after {
           border-color: WindowText;
         }
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-text {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-text {
           color: WindowText;
         }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Checkbox-text {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Checkbox-text {
           color: WindowText;
         }
   >
@@ -229,7 +229,7 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
             outline-offset: 2px;
             outline: 1px solid #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target="true"
@@ -299,10 +299,10 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 10px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
               border-color: WindowText;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               border-color: WindowText;
               forced-color-adjust: none;
@@ -324,7 +324,7 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
                 opacity: 0;
                 speak: none;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 -ms-high-contrast-adjust: none;
                 color: Window;
                 forced-color-adjust: none;
@@ -343,7 +343,7 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
               line-height: 20px;
               margin-left: 4px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -369,7 +369,7 @@ exports[`Checkbox renders unchecked correctly 1`] = `
         &:hover .ms-Checkbox-checkbox {
           border-color: #323130;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
           border-color: Highlight;
         }
         &:focus .ms-Checkbox-checkbox {
@@ -379,19 +379,19 @@ exports[`Checkbox renders unchecked correctly 1`] = `
           color: #605e5c;
           opacity: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
           color: Highlight;
         }
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-text {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-text {
           color: WindowText;
         }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Checkbox-text {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Checkbox-text {
           color: WindowText;
         }
   >
@@ -407,7 +407,7 @@ exports[`Checkbox renders unchecked correctly 1`] = `
             outline-offset: 2px;
             outline: 1px solid #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
             outline: 1px solid WindowText;
           }
       data-ktp-execute-target="true"
@@ -460,7 +460,7 @@ exports[`Checkbox renders unchecked correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               border-color: WindowText;
               forced-color-adjust: none;
@@ -482,7 +482,7 @@ exports[`Checkbox renders unchecked correctly 1`] = `
                 opacity: 0;
                 speak: none;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 -ms-high-contrast-adjust: none;
                 color: Window;
                 forced-color-adjust: none;
@@ -501,7 +501,7 @@ exports[`Checkbox renders unchecked correctly 1`] = `
               line-height: 20px;
               margin-left: 4px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -569,7 +569,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:after {
             border-color: WindowText;
             border-width: 2px;
           }
@@ -721,7 +721,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:after {
             border-color: WindowText;
             border-width: 2px;
           }
@@ -800,7 +800,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
               background: Window;
               border-color: Highlight;
               forced-color-adjust: none;
@@ -823,7 +823,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 10px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
               border-color: Highlight;
               forced-color-adjust: none;
             }
@@ -915,7 +915,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
               -ms-high-contrast-adjust: none;
               background: Window;
               border-color: GrayText;
@@ -937,7 +937,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             & .ms-ChoiceFieldLabel {
               color: #a19f9d;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
               -ms-high-contrast-adjust: none;
               color: GrayText;
               forced-color-adjust: none;
@@ -1033,7 +1033,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
               -ms-high-contrast-adjust: none;
               background: Window;
               border-color: Highlight;
@@ -1057,14 +1057,14 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 10px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
               border-color: Highlight;
               forced-color-adjust: none;
             }
             & .ms-ChoiceFieldLabel {
               color: #a19f9d;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
               -ms-high-contrast-adjust: none;
               color: GrayText;
               forced-color-adjust: none;
@@ -1330,7 +1330,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:after {
             border-color: WindowText;
             border-width: 1px;
           }
@@ -1635,7 +1635,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
               background: Window;
               border-color: Highlight;
               forced-color-adjust: none;
@@ -1658,7 +1658,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 10px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
               border-color: Highlight;
               forced-color-adjust: none;
             }
@@ -1833,7 +1833,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
               -ms-high-contrast-adjust: none;
               background: Window;
               border-color: GrayText;
@@ -1855,7 +1855,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             & .ms-ChoiceFieldLabel {
               color: #a19f9d;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-ChoiceFieldLabel {
               -ms-high-contrast-adjust: none;
               color: GrayText;
               forced-color-adjust: none;
@@ -1871,7 +1871,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
                 padding-right: 30px;
                 position: relative;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: GrayText;
                 opacity: 1;
               }

--- a/packages/react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:after {
                   border-color: WindowText;
                   border-width: 2px;
                 }
@@ -543,7 +543,7 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:after {
                   border-color: WindowText;
                   border-width: 2px;
                 }

--- a/packages/react/src/components/Coachmark/__snapshots__/Coachmark.test.tsx.snap
+++ b/packages/react/src/components/Coachmark/__snapshots__/Coachmark.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`Coachmark renders Coachmark (color properties) 1`] = `
                 outline: transparent;
                 position: absolute;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
               }
               &::-moz-focus-inner {
@@ -153,7 +153,7 @@ exports[`Coachmark renders Coachmark (color properties) 1`] = `
                             display: block;
                             fill: red;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                             fill: windowtext;
                           }
                       height="10"
@@ -176,7 +176,7 @@ exports[`Coachmark renders Coachmark (color properties) 1`] = `
                           transition: border-radius 250ms, width 500ms, height 500ms cubic-bezier(0.5, 0, 0, 1);
                           visibility: hidden;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           background-color: Window;
                           border: 2px solid WindowText;
                         }
@@ -277,7 +277,7 @@ exports[`Coachmark renders Coachmark (correctly) 1`] = `
                 outline: transparent;
                 position: absolute;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
               }
               &::-moz-focus-inner {
@@ -386,7 +386,7 @@ exports[`Coachmark renders Coachmark (correctly) 1`] = `
                             display: block;
                             fill: #0078d4;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                             fill: windowtext;
                           }
                       height="10"
@@ -409,7 +409,7 @@ exports[`Coachmark renders Coachmark (correctly) 1`] = `
                           transition: border-radius 250ms, width 500ms, height 500ms cubic-bezier(0.5, 0, 0, 1);
                           visibility: hidden;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           background-color: Window;
                           border: 2px solid WindowText;
                         }
@@ -512,7 +512,7 @@ exports[`Coachmark renders Coachmark (isCollapsed) 1`] = `
                 outline: transparent;
                 position: absolute;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
               }
               &::-moz-focus-inner {
@@ -587,7 +587,7 @@ exports[`Coachmark renders Coachmark (isCollapsed) 1`] = `
                           transition: border-radius 250ms, width 500ms, height 500ms cubic-bezier(0.5, 0, 0, 1);
                           visibility: visible;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           background-color: Window;
                           border: 2px solid WindowText;
                         }

--- a/packages/react/src/components/ColorPicker/ColorRectangle/__snapshots__/ColorRectangle.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/ColorRectangle/__snapshots__/ColorRectangle.test.tsx.snap
@@ -19,14 +19,14 @@ exports[`ColorRectangle renders correctly 1`] = `
         outline: none;
         position: relative;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         forced-color-adjust: none;
       }
       .ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 2px solid CanvasText;
       }
   data-is-focusable={true}

--- a/packages/react/src/components/ColorPicker/ColorSlider/__snapshots__/ColorSlider.deprecated.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/ColorSlider/__snapshots__/ColorSlider.deprecated.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`ColorSlider renders alpha slider correctly 1`] = `
       .ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 2px solid CanvasText;
       }
   data-is-focusable={true}
@@ -98,7 +98,7 @@ exports[`ColorSlider renders hue slider correctly 1`] = `
       .ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 2px solid CanvasText;
       }
   data-is-focusable={true}

--- a/packages/react/src/components/ColorPicker/ColorSlider/__snapshots__/ColorSlider.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/ColorSlider/__snapshots__/ColorSlider.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`ColorSlider renders alpha slider correctly 1`] = `
       .ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 2px solid CanvasText;
       }
   data-is-focusable={true}
@@ -98,7 +98,7 @@ exports[`ColorSlider renders hue slider correctly 1`] = `
       .ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 2px solid CanvasText;
       }
   data-is-focusable={true}
@@ -156,7 +156,7 @@ exports[`ColorSlider renders transparency slider correctly 1`] = `
       .ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 2px solid CanvasText;
       }
   data-is-focusable={true}

--- a/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -45,14 +45,14 @@ exports[`ColorPicker renders correctly 1`] = `
               outline: none;
               position: relative;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               forced-color-adjust: none;
             }
             .ms-Fabric--isFocusVisible &:focus {
               outline: 1px solid #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
               outline: 2px solid CanvasText;
             }
         data-is-focusable="true"
@@ -171,7 +171,7 @@ exports[`ColorPicker renders correctly 1`] = `
                 .ms-Fabric--isFocusVisible &:focus {
                   outline: 1px solid #605e5c;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
                   outline: 2px solid CanvasText;
                 }
             data-is-focusable="true"
@@ -221,7 +221,7 @@ exports[`ColorPicker renders correctly 1`] = `
                 .ms-Fabric--isFocusVisible &:focus {
                   outline: 1px solid #605e5c;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
                   outline: 2px solid CanvasText;
                 }
             data-is-focusable="true"
@@ -393,7 +393,7 @@ exports[`ColorPicker renders correctly 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -443,7 +443,7 @@ exports[`ColorPicker renders correctly 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -451,21 +451,21 @@ exports[`ColorPicker renders correctly 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField2"
@@ -559,7 +559,7 @@ exports[`ColorPicker renders correctly 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -609,7 +609,7 @@ exports[`ColorPicker renders correctly 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -617,21 +617,21 @@ exports[`ColorPicker renders correctly 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField8"
@@ -725,7 +725,7 @@ exports[`ColorPicker renders correctly 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -775,7 +775,7 @@ exports[`ColorPicker renders correctly 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -783,21 +783,21 @@ exports[`ColorPicker renders correctly 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField14"
@@ -891,7 +891,7 @@ exports[`ColorPicker renders correctly 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -941,7 +941,7 @@ exports[`ColorPicker renders correctly 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -949,21 +949,21 @@ exports[`ColorPicker renders correctly 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField20"
@@ -1057,7 +1057,7 @@ exports[`ColorPicker renders correctly 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -1107,7 +1107,7 @@ exports[`ColorPicker renders correctly 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -1115,21 +1115,21 @@ exports[`ColorPicker renders correctly 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField26"
@@ -1200,14 +1200,14 @@ exports[`ColorPicker renders correctly with preview 1`] = `
               outline: none;
               position: relative;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               forced-color-adjust: none;
             }
             .ms-Fabric--isFocusVisible &:focus {
               outline: 1px solid #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
               outline: 2px solid CanvasText;
             }
         data-is-focusable="true"
@@ -1326,7 +1326,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                 .ms-Fabric--isFocusVisible &:focus {
                   outline: 1px solid #605e5c;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
                   outline: 2px solid CanvasText;
                 }
             data-is-focusable="true"
@@ -1376,7 +1376,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                 .ms-Fabric--isFocusVisible &:focus {
                   outline: 1px solid #605e5c;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
                   outline: 2px solid CanvasText;
                 }
             data-is-focusable="true"
@@ -1571,7 +1571,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -1621,7 +1621,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -1629,21 +1629,21 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField2"
@@ -1737,7 +1737,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -1787,7 +1787,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -1795,21 +1795,21 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField8"
@@ -1903,7 +1903,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -1953,7 +1953,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -1961,21 +1961,21 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField14"
@@ -2069,7 +2069,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -2119,7 +2119,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -2127,21 +2127,21 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField20"
@@ -2235,7 +2235,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -2285,7 +2285,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -2293,21 +2293,21 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField26"
@@ -2378,14 +2378,14 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
               outline: none;
               position: relative;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               forced-color-adjust: none;
             }
             .ms-Fabric--isFocusVisible &:focus {
               outline: 1px solid #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
               outline: 2px solid CanvasText;
             }
         data-is-focusable="true"
@@ -2504,7 +2504,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                 .ms-Fabric--isFocusVisible &:focus {
                   outline: 1px solid #605e5c;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
                   outline: 2px solid CanvasText;
                 }
             data-is-focusable="true"
@@ -2554,7 +2554,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                 .ms-Fabric--isFocusVisible &:focus {
                   outline: 1px solid #605e5c;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
                   outline: 2px solid CanvasText;
                 }
             data-is-focusable="true"
@@ -2730,7 +2730,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -2780,7 +2780,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -2788,21 +2788,21 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField2"
@@ -2896,7 +2896,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -2946,7 +2946,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -2954,21 +2954,21 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField8"
@@ -3062,7 +3062,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -3112,7 +3112,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -3120,21 +3120,21 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField14"
@@ -3228,7 +3228,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -3278,7 +3278,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -3286,21 +3286,21 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField20"
@@ -3394,7 +3394,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                           &:hover {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             -ms-high-contrast-adjust: none;
                             border-color: Highlight;
                             forced-color-adjust: none;
@@ -3444,7 +3444,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
                             }
@@ -3452,21 +3452,21 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                               color: GrayText;
                             }
                             &:-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                               color: GrayText;
                             }
                             &::-ms-input-placeholder {
                               color: #605e5c;
                               opacity: 1;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                               color: GrayText;
                             }
                         id="TextField26"

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -34,13 +34,13 @@ exports[`ComboBox Renders correctly 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-open {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-open:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-open:after {
             border-color: Highlight;
           }
           &:after {
@@ -65,46 +65,46 @@ exports[`ComboBox Renders correctly 1`] = `
           &:hover .ms-ComboBox-Input::placeholder {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
             color: GrayText;
           }
           &:hover .ms-ComboBox-Input:-ms-input-placeholder {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
             color: GrayText;
           }
           &:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: GrayText;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-ComboBox-Input {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-ComboBox-Input {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover:after {
             border-color: Highlight;
           }
           &:active {
             position: relative;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:after {
             border-color: Highlight;
           }
           &:focus {
@@ -113,19 +113,19 @@ exports[`ComboBox Renders correctly 1`] = `
           &:focus .ms-ComboBox-Input {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-ComboBox-Input {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-ComboBox-Input {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:after {
             border-color: Highlight;
           }
           &:focus:after {
@@ -167,25 +167,25 @@ exports[`ComboBox Renders correctly 1`] = `
             &::placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
               color: GrayText;
             }
             &:-ms-input-placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-input-placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-clear {
               display: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window;
               color: WindowText;
@@ -248,7 +248,7 @@ exports[`ComboBox Renders correctly 1`] = `
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -260,7 +260,7 @@ exports[`ComboBox Renders correctly 1`] = `
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: ButtonFace;
               border-color: ButtonText;
@@ -272,7 +272,7 @@ exports[`ComboBox Renders correctly 1`] = `
               color: #201f1e;
               cursor: pointer;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               background-color: Highlight;
               border-color: Highlight;
@@ -283,7 +283,7 @@ exports[`ComboBox Renders correctly 1`] = `
               background-color: #edebe9;
               color: #201f1e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               -ms-high-contrast-adjust: none;
               background-color: Highlight;
               border-color: Highlight;
@@ -383,13 +383,13 @@ exports[`ComboBox Renders correctly when open 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-open {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-open:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-open:after {
             border-color: Highlight;
           }
           &:after {
@@ -409,31 +409,31 @@ exports[`ComboBox Renders correctly when open 1`] = `
           & .ms-ComboBox-Input {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-ComboBox-Input {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-ComboBox-Input {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
             border-color: Highlight;
           }
           &:active {
             position: relative;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:after {
             border-color: Highlight;
           }
           &:focus {
@@ -442,19 +442,19 @@ exports[`ComboBox Renders correctly when open 1`] = `
           &:focus .ms-ComboBox-Input {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-ComboBox-Input {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-ComboBox-Input {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:after {
             border-color: Highlight;
           }
           &:focus:after {
@@ -498,25 +498,25 @@ exports[`ComboBox Renders correctly when open 1`] = `
             &::placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
               color: GrayText;
             }
             &:-ms-input-placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-input-placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-clear {
               display: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window;
               color: WindowText;
@@ -580,7 +580,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -592,7 +592,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Highlight;
               border-color: Highlight;
@@ -603,7 +603,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
               background-color: #e1dfdd;
               color: #201f1e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               background-color: Highlight;
               border-color: Highlight;
@@ -712,7 +712,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                   outline: transparent;
                   position: absolute;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: WindowText;
                   border-style: solid;
                   border-width: 1px;
@@ -774,7 +774,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                             text-align: left;
                             user-select: none;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                             -ms-high-contrast-adjust: none;
                             color: GrayText;
                             forced-color-adjust: none;
@@ -851,7 +851,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                             top: 2px;
                             z-index: 1;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                             bottom: -2px;
                             left: -2px;
                             outline-color: ButtonText;
@@ -863,7 +863,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                             position: relative;
                             top: 0px;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                             border-color: Background;
                             border: none;
                           }
@@ -881,7 +881,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                             background-color: #f3f2f1;
                             color: #201f1e;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             color: Highlight;
                           }
                           &:hover .ms-Button-icon {
@@ -1006,7 +1006,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                           top: 2px;
                           z-index: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                           bottom: -2px;
                           left: -2px;
                           outline-color: ButtonText;
@@ -1018,7 +1018,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                           position: relative;
                           top: 0px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           background-color: Highlight;
                           border-color: Highlight;
@@ -1039,7 +1039,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                         &:hover {
                           background-color: #f3f2f1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                           -ms-high-contrast-adjust: none;
                           background-color: Highlight;
                           border-color: Highlight;
@@ -1151,13 +1151,13 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-open {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-open:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-open:after {
             border-color: Highlight;
           }
           &:after {
@@ -1177,31 +1177,31 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
           & .ms-ComboBox-Input {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& .ms-ComboBox-Input {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-ComboBox-Input {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
             border-color: Highlight;
           }
           &:active {
             position: relative;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:after {
             border-color: Highlight;
           }
           &:focus {
@@ -1210,19 +1210,19 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
           &:focus .ms-ComboBox-Input {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-ComboBox-Input {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-ComboBox-Input {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:after {
             border-color: Highlight;
           }
           &:focus:after {
@@ -1266,25 +1266,25 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
             &::placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
               color: GrayText;
             }
             &:-ms-input-placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-input-placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-clear {
               display: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window;
               color: WindowText;
@@ -1349,7 +1349,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -1361,7 +1361,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Highlight;
               border-color: Highlight;
@@ -1372,7 +1372,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
               background-color: #e1dfdd;
               color: #201f1e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               background-color: Highlight;
               border-color: Highlight;
@@ -1481,7 +1481,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                   outline: transparent;
                   position: absolute;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: WindowText;
                   border-style: solid;
                   border-width: 1px;
@@ -1544,7 +1544,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                             text-align: left;
                             user-select: none;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                             -ms-high-contrast-adjust: none;
                             color: GrayText;
                             forced-color-adjust: none;
@@ -1603,7 +1603,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                           &:hover .ms-Checkbox-checkbox {
                             border-color: #323130;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
                             border-color: Highlight;
                           }
                           &:focus .ms-Checkbox-checkbox {
@@ -1613,22 +1613,22 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                             color: #605e5c;
                             opacity: 1;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
                             color: Highlight;
                           }
                           &:hover .ms-Checkbox-text {
                             color: #201f1e;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-text {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-text {
                             color: WindowText;
                           }
                           &:focus .ms-Checkbox-text {
                             color: #201f1e;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Checkbox-text {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Checkbox-text {
                             color: WindowText;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                             border-color: Background;
                             border: none;
                           }
@@ -1656,7 +1656,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                               outline-offset: 2px;
                               outline: 1px solid #605e5c;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
                               outline: 1px solid WindowText;
                             }
                         data-index="1"
@@ -1712,7 +1712,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                                 width: 20px;
                               }
-                              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                 -ms-high-contrast-adjust: none;
                                 border-color: WindowText;
                                 forced-color-adjust: none;
@@ -1734,7 +1734,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                                   opacity: 0;
                                   speak: none;
                                 }
-                                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                   -ms-high-contrast-adjust: none;
                                   color: Window;
                                   forced-color-adjust: none;
@@ -1813,36 +1813,36 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                           background: #005a9e;
                           border-color: #005a9e;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           border-color: Background;
                           border: none;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
                           background: Highlight;
                           border-color: Highlight;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Checkbox-checkbox {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Checkbox-checkbox {
                           background: Highlight;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:hover .ms-Checkbox-checkbox {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:hover .ms-Checkbox-checkbox {
                           background: Highlight;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:hover .ms-Checkbox-checkmark {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:hover .ms-Checkbox-checkmark {
                           color: Window;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
                           color: Window;
                         }
                         &:hover .ms-Checkbox-text {
                           color: #201f1e;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-text {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-text {
                           color: WindowText;
                         }
                         &:focus .ms-Checkbox-text {
                           color: #201f1e;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Checkbox-text {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Checkbox-text {
                           color: WindowText;
                         }
                         &.ms-Checkbox {
@@ -1870,7 +1870,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                             outline-offset: 2px;
                             outline: 1px solid #605e5c;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
                             outline: 1px solid WindowText;
                           }
                       data-index="3"
@@ -1928,7 +1928,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                               width: 20px;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               -ms-high-contrast-adjust: none;
                               background: Highlight;
                               border-color: Highlight;
@@ -1951,7 +1951,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                                 opacity: 1;
                                 speak: none;
                               }
-                              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                 -ms-high-contrast-adjust: none;
                                 color: Window;
                                 forced-color-adjust: none;
@@ -2024,13 +2024,13 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-open {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-open:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-open:after {
             border-color: Highlight;
           }
           &:after {
@@ -2055,46 +2055,46 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
           &:hover .ms-ComboBox-Input::placeholder {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-ComboBox-Input::placeholder {
             color: GrayText;
           }
           &:hover .ms-ComboBox-Input:-ms-input-placeholder {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-ComboBox-Input:-ms-input-placeholder {
             color: GrayText;
           }
           &:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: GrayText;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-ComboBox-Input {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-ComboBox-Input {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover:after {
             border-color: Highlight;
           }
           &:active {
             position: relative;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:after {
             border-color: Highlight;
           }
           &:focus {
@@ -2103,19 +2103,19 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
           &:focus .ms-ComboBox-Input {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-ComboBox-Input {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-ComboBox-Input {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: WindowText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
             color: HighlightText;
             forced-color-adjust: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:after {
             border-color: Highlight;
           }
           &:focus:after {
@@ -2158,25 +2158,25 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
             &::placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
               color: GrayText;
             }
             &:-ms-input-placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-input-placeholder {
               color: #605e5c;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-clear {
               display: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window;
               color: WindowText;
@@ -2239,7 +2239,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -2251,7 +2251,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
               position: relative;
               top: 0px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: ButtonFace;
               border-color: ButtonText;
@@ -2263,7 +2263,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
               color: #201f1e;
               cursor: pointer;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               background-color: Highlight;
               border-color: Highlight;
@@ -2274,7 +2274,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
               background-color: #edebe9;
               color: #201f1e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               -ms-high-contrast-adjust: none;
               background-color: Highlight;
               border-color: Highlight;

--- a/packages/react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
+++ b/packages/react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
@@ -113,7 +113,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                     top: 3px;
                     z-index: 1;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
                     bottom: 4px;
                     left: 4px;
@@ -126,14 +126,14 @@ exports[`CommandBar renders commands correctly 1`] = `
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     border: none;
                   }
                   &:hover {
                     background-color: #f3f2f1;
                     color: #201f1e;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                     color: Highlight;
                   }
                   &:hover .ms-Button-icon {
@@ -257,7 +257,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                     top: 3px;
                     z-index: 1;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
                     bottom: 4px;
                     left: 4px;
@@ -270,14 +270,14 @@ exports[`CommandBar renders commands correctly 1`] = `
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     border: none;
                   }
                   &:hover {
                     background-color: #f3f2f1;
                     color: #201f1e;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                     color: Highlight;
                   }
                   &:hover .ms-Button-icon {

--- a/packages/react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                       top: 3px;
                       z-index: 1;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                       border: none;
                       bottom: 4px;
                       left: 4px;
@@ -115,14 +115,14 @@ exports[`CommandBar renders commands correctly 1`] = `
                       position: relative;
                       top: 0px;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                       border: none;
                     }
                     &:hover {
                       background-color: #f3f2f1;
                       color: #201f1e;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                       color: Highlight;
                     }
                     &:hover .ms-Button-icon {
@@ -240,7 +240,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                       top: 3px;
                       z-index: 1;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                       border: none;
                       bottom: 4px;
                       left: 4px;
@@ -253,14 +253,14 @@ exports[`CommandBar renders commands correctly 1`] = `
                       position: relative;
                       top: 0px;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                       border: none;
                     }
                     &:hover {
                       background-color: #f3f2f1;
                       color: #201f1e;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                       color: Highlight;
                     }
                     &:hover .ms-Button-icon {
@@ -433,7 +433,7 @@ exports[`CommandBar renders empty farItems correctly 1`] = `
                       top: 3px;
                       z-index: 1;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                       border: none;
                       bottom: 4px;
                       left: 4px;
@@ -446,14 +446,14 @@ exports[`CommandBar renders empty farItems correctly 1`] = `
                       position: relative;
                       top: 0px;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                       border: none;
                     }
                     &:hover {
                       background-color: #f3f2f1;
                       color: #201f1e;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                       color: Highlight;
                     }
                     &:hover .ms-Button-icon {
@@ -571,7 +571,7 @@ exports[`CommandBar renders empty farItems correctly 1`] = `
                       top: 3px;
                       z-index: 1;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                       border: none;
                       bottom: 4px;
                       left: 4px;
@@ -584,14 +584,14 @@ exports[`CommandBar renders empty farItems correctly 1`] = `
                       position: relative;
                       top: 0px;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                       border: none;
                     }
                     &:hover {
                       background-color: #f3f2f1;
                       color: #201f1e;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                       color: Highlight;
                     }
                     &:hover .ms-Button-icon {

--- a/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
         top: 2px;
         z-index: 1;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
         bottom: -2px;
         left: -2px;
         outline-color: ButtonText;
@@ -64,7 +64,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
         background-color: #f3f2f1;
         color: #201f1e;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
         border-color: Highlight;
         color: Highlight;
       }
@@ -214,7 +214,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                   outline: transparent;
                   position: absolute;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: WindowText;
                   border-style: solid;
                   border-width: 1px;

--- a/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`DatePicker renders DatePicker allowing text input correctly 1`] = `
               &:hover {
                 border-color: #323130;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 border-color: Highlight;
                 forced-color-adjust: none;
@@ -132,7 +132,7 @@ exports[`DatePicker renders DatePicker allowing text input correctly 1`] = `
                 &::-ms-clear {
                   display: none;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   background: Window;
                   color: WindowText;
                 }
@@ -140,21 +140,21 @@ exports[`DatePicker renders DatePicker allowing text input correctly 1`] = `
                   color: #605e5c;
                   opacity: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                   color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   color: #605e5c;
                   opacity: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                   color: GrayText;
                 }
                 &::-ms-input-placeholder {
                   color: #605e5c;
                   opacity: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                   color: GrayText;
                 }
             id="DatePicker0-label"
@@ -307,7 +307,7 @@ exports[`DatePicker renders DatePicker with value correctly 1`] = `
               &:hover {
                 border-color: #323130;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 border-color: Highlight;
                 forced-color-adjust: none;
@@ -358,7 +358,7 @@ exports[`DatePicker renders DatePicker with value correctly 1`] = `
                 &::-ms-clear {
                   display: none;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   background: Window;
                   color: WindowText;
                 }
@@ -366,21 +366,21 @@ exports[`DatePicker renders DatePicker with value correctly 1`] = `
                   color: #605e5c;
                   opacity: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                   color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   color: #605e5c;
                   opacity: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                   color: GrayText;
                 }
                 &::-ms-input-placeholder {
                   color: #605e5c;
                   opacity: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                   color: GrayText;
                 }
                 {
@@ -539,7 +539,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
               &:hover {
                 border-color: #323130;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 border-color: Highlight;
                 forced-color-adjust: none;
@@ -590,7 +590,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                 &::-ms-clear {
                   display: none;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   background: Window;
                   color: WindowText;
                 }
@@ -598,21 +598,21 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   color: #605e5c;
                   opacity: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                   color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   color: #605e5c;
                   opacity: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                   color: GrayText;
                 }
                 &::-ms-input-placeholder {
                   color: #605e5c;
                   opacity: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                   color: GrayText;
                 }
                 {
@@ -638,7 +638,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   {
                     color: #605e5c;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     color: GrayText;
                   }
             />

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsColumn.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsColumn.test.tsx.snap
@@ -267,7 +267,7 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column when showSo
                           vertical-align: middle;
                           width: 18px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           color: WindowText;
                         }
                     data-icon-name="CircleRing"
@@ -313,7 +313,7 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column when showSo
                         &:hover {
                           opacity: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -224,7 +224,7 @@ exports[`DetailsHeader can render 1`] = `
                   vertical-align: middle;
                   width: 18px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   color: WindowText;
                 }
             data-icon-name="CircleRing"
@@ -270,7 +270,7 @@ exports[`DetailsHeader can render 1`] = `
                 &:hover {
                   opacity: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   forced-color-adjust: none;
                 }
@@ -1926,7 +1926,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
                   vertical-align: middle;
                   width: 18px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   color: WindowText;
                 }
             data-icon-name="CircleRing"
@@ -1972,7 +1972,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
                 &:hover {
                   opacity: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   forced-color-adjust: none;
                 }

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -2115,7 +2115,7 @@ exports[`DetailsList renders List correctly 1`] = `
                           vertical-align: middle;
                           width: 18px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           color: WindowText;
                         }
                     data-icon-name="CircleRing"
@@ -2161,7 +2161,7 @@ exports[`DetailsList renders List correctly 1`] = `
                         &:hover {
                           opacity: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
@@ -3099,7 +3099,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                           vertical-align: middle;
                           width: 18px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           color: WindowText;
                         }
                     data-icon-name="CircleRing"
@@ -3145,7 +3145,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                         &:hover {
                           opacity: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
@@ -4180,7 +4180,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                           vertical-align: middle;
                           width: 18px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           color: WindowText;
                         }
                     data-icon-name="CircleRing"
@@ -4226,7 +4226,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                         &:hover {
                           opacity: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
@@ -5165,7 +5165,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                           vertical-align: middle;
                           width: 18px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           color: WindowText;
                         }
                     data-icon-name="CircleRing"
@@ -5211,7 +5211,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                         &:hover {
                           opacity: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
@@ -6149,7 +6149,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                           vertical-align: middle;
                           width: 18px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           color: WindowText;
                         }
                     data-icon-name="CircleRing"
@@ -6195,7 +6195,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                         &:hover {
                           opacity: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -267,7 +267,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                           vertical-align: middle;
                           width: 18px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           color: WindowText;
                         }
                     data-icon-name="CircleRing"
@@ -313,7 +313,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                         &:hover {
                           opacity: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
@@ -1103,7 +1103,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                           vertical-align: middle;
                           width: 18px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           color: WindowText;
                         }
                     data-icon-name="CircleRing"
@@ -1149,7 +1149,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                         &:hover {
                           opacity: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
@@ -1933,7 +1933,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
                 vertical-align: middle;
                 width: 18px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: WindowText;
               }
           data-icon-name="CircleRing"
@@ -1979,7 +1979,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
               &:hover {
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 -ms-high-contrast-adjust: none;
                 forced-color-adjust: none;
               }
@@ -2459,7 +2459,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                           vertical-align: middle;
                           width: 18px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           color: WindowText;
                         }
                     data-icon-name="CircleRing"
@@ -2505,7 +2505,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                         &:hover {
                           opacity: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
@@ -3295,7 +3295,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                           vertical-align: middle;
                           width: 18px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           color: WindowText;
                         }
                     data-icon-name="CircleRing"
@@ -3341,7 +3341,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                         &:hover {
                           opacity: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }

--- a/packages/react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -268,7 +268,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           vertical-align: middle;
                           width: 18px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           color: WindowText;
                         }
                     data-icon-name="CircleRing"
@@ -314,7 +314,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                         &:hover {
                           opacity: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
@@ -425,7 +425,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             & > * {
                               transform: translateZ(0);
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
@@ -513,7 +513,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -563,7 +563,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -611,7 +611,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             & > * {
                               transform: translateZ(0);
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
@@ -699,7 +699,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -749,7 +749,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -797,7 +797,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             & > * {
                               transform: translateZ(0);
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
@@ -885,7 +885,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -935,7 +935,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -983,7 +983,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             & > * {
                               transform: translateZ(0);
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
@@ -1071,7 +1071,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -1121,7 +1121,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -1169,7 +1169,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             & > * {
                               transform: translateZ(0);
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
@@ -1257,7 +1257,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -1307,7 +1307,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -1355,7 +1355,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             & > * {
                               transform: translateZ(0);
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
@@ -1443,7 +1443,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -1493,7 +1493,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -1541,7 +1541,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             & > * {
                               transform: translateZ(0);
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
@@ -1629,7 +1629,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -1679,7 +1679,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -1727,7 +1727,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             & > * {
                               transform: translateZ(0);
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
@@ -1815,7 +1815,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -1865,7 +1865,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -1913,7 +1913,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             & > * {
                               transform: translateZ(0);
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
@@ -2001,7 +2001,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -2051,7 +2051,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -2099,7 +2099,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             & > * {
                               transform: translateZ(0);
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               -ms-high-contrast-adjust: none;
                               background: WindowText
                                                     linear-gradient(
@@ -2187,7 +2187,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }
@@ -2237,7 +2237,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-weight: 400;
                                     height: 43px;
                                   }
-                                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                     background-color: Window;
                                     border-color: Window;
                                   }

--- a/packages/react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
+++ b/packages/react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`Dialog deprecated props renders Dialog with className 1`] = `
                 right: 0px;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
                 opacity: 0;
               }
@@ -424,7 +424,7 @@ exports[`Dialog deprecated props renders Dialog with containerClassName 1`] = `
                 right: 0px;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
                 opacity: 0;
               }
@@ -737,7 +737,7 @@ exports[`Dialog deprecated props renders Dialog with isBlocking set to true 1`] 
                 right: 0px;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
                 opacity: 0;
               }
@@ -916,7 +916,7 @@ exports[`Dialog deprecated props renders Dialog with isBlocking set to true 1`] 
                           top: 2px;
                           z-index: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                           bottom: -2px;
                           left: -2px;
                           outline-color: ButtonText;
@@ -932,7 +932,7 @@ exports[`Dialog deprecated props renders Dialog with isBlocking set to true 1`] 
                           background-color: #f3f2f1;
                           color: #106ebe;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                           border-color: Highlight;
                           color: Highlight;
                         }
@@ -1180,7 +1180,7 @@ exports[`Dialog deprecated props renders Dialog with isDarkOverlay set to true 1
                 right: 0px;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
                 opacity: 0;
               }

--- a/packages/react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
         right: -1px;
         top: -1px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
         border-color: Highlight;
       }
       & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
@@ -91,7 +91,7 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
           right: -1px;
           top: -1px;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           border-color: Highlight;
         }
     title=""
@@ -177,7 +177,7 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
                     height: 32px;
                     line-height: 32px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     -ms-high-contrast-adjust: none;
                     background-color: Window !important;
                     border: 1px solid WindowText;

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -36,13 +36,13 @@ exports[`Dropdown multi-select Renders correctly 1`] = `
             border-color: #323130;
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Dropdown-title {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Dropdown-title {
             border-color: Highlight;
           }
           &:focus .ms-Dropdown-title {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Dropdown-title {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Dropdown-title {
             color: Highlight;
           }
           &:focus:after {
@@ -57,14 +57,14 @@ exports[`Dropdown multi-select Renders correctly 1`] = `
             top: 0px;
             width: 100%;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:after {
             color: Highlight;
           }
           &:active .ms-Dropdown-title {
             border-color: #0078d4;
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Dropdown-title {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Dropdown-title {
             border-color: Highlight;
           }
           &:hover .ms-Dropdown-caretDown {
@@ -73,7 +73,7 @@ exports[`Dropdown multi-select Renders correctly 1`] = `
           &:focus .ms-Dropdown-caretDown {
             color: #323130;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Dropdown-caretDown {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Dropdown-caretDown {
             color: Highlight;
           }
           &:active .ms-Dropdown-caretDown {
@@ -248,7 +248,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                   position: absolute;
                   width: 200px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: WindowText;
                   border-style: solid;
                   border-width: 1px;
@@ -325,7 +325,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             text-align: left;
                             user-select: none;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                             -ms-high-contrast-adjust: none;
                             color: GrayText;
                             forced-color-adjust: none;
@@ -388,38 +388,38 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             background: #005a9e;
                             border-color: #005a9e;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                             background-color: Highlight;
                             border-color: Highlight;
                             border: none;
                             color: HighlightText;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
                             background: Highlight;
                             border-color: Highlight;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Checkbox-checkbox {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Checkbox-checkbox {
                             background: Highlight;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:hover .ms-Checkbox-checkbox {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:hover .ms-Checkbox-checkbox {
                             background: Highlight;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:hover .ms-Checkbox-checkmark {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:hover .ms-Checkbox-checkmark {
                             color: Window;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
                             color: Window;
                           }
                           &:hover .ms-Checkbox-text {
                             color: #201f1e;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-text {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-text {
                             color: WindowText;
                           }
                           &:focus .ms-Checkbox-text {
                             color: #201f1e;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Checkbox-text {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Checkbox-text {
                             color: WindowText;
                           }
                           & .ms-Button-flexContainer {
@@ -429,24 +429,24 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             background-color: #edebe9;
                             color: #201f1e;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover:focus {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover:focus {
                             background-color: Highlight;
                             border-color: Highlight;
                             color: HighlightText;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){&:hover:focus {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:hover:focus {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
                           }
                           &:focus {
                             background-color: #edebe9;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
                             background-color: Highlight;
                             border-color: Highlight;
                             color: HighlightText;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){&:focus {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:focus {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
                           }
@@ -454,12 +454,12 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             background-color: #f3f2f1;
                             color: #201f1e;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
                             background-color: Highlight;
                             border-color: Highlight;
                             color: HighlightText;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){&:active {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:active {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
                           }
@@ -469,7 +469,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             right: 0px;
                             top: 0px;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){& {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
                           }
@@ -490,7 +490,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                               outline-offset: 0px;
                               outline: 1px solid #605e5c;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
                               outline: 1px solid WindowText;
                             }
                         data-index="1"
@@ -555,7 +555,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                                 width: 20px;
                               }
-                              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                 -ms-high-contrast-adjust: none;
                                 background: Highlight;
                                 border-color: Highlight;
@@ -578,7 +578,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                                   opacity: 1;
                                   speak: none;
                                 }
-                                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                   -ms-high-contrast-adjust: none;
                                   color: Window;
                                   forced-color-adjust: none;
@@ -648,7 +648,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                         &:hover .ms-Checkbox-checkbox {
                           border-color: #323130;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
                           border-color: Highlight;
                         }
                         &:focus .ms-Checkbox-checkbox {
@@ -658,19 +658,19 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           color: #605e5c;
                           opacity: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkmark {
                           color: Highlight;
                         }
                         &:hover .ms-Checkbox-text {
                           color: #201f1e;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Checkbox-text {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-text {
                           color: WindowText;
                         }
                         &:focus .ms-Checkbox-text {
                           color: #201f1e;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Checkbox-text {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Checkbox-text {
                           color: WindowText;
                         }
                         & .ms-Button-flexContainer {
@@ -680,24 +680,24 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           background-color: #f3f2f1;
                           color: #201f1e;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover:focus {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover:focus {
                           background-color: Highlight;
                           border-color: Highlight;
                           color: HighlightText;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){&:hover:focus {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:hover:focus {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
                         &:focus {
                           background-color: transparent;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
                           background-color: Highlight;
                           border-color: Highlight;
                           color: HighlightText;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){&:focus {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:focus {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
@@ -705,12 +705,12 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           background-color: #ffffff;
                           color: #201f1e;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
                           background-color: Highlight;
                           border-color: Highlight;
                           color: HighlightText;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){&:active {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:active {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
@@ -720,7 +720,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           right: 0px;
                           top: 0px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           border: none;
                         }
                     title="test"
@@ -740,7 +740,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             outline-offset: 0px;
                             outline: 1px solid #605e5c;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus + label::before {
                             outline: 1px solid WindowText;
                           }
                       data-index="3"
@@ -804,7 +804,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                               width: 20px;
                             }
-                            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               -ms-high-contrast-adjust: none;
                               border-color: WindowText;
                               forced-color-adjust: none;
@@ -826,7 +826,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                                 opacity: 0;
                                 speak: none;
                               }
-                              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                                 -ms-high-contrast-adjust: none;
                                 color: Window;
                                 forced-color-adjust: none;
@@ -904,13 +904,13 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
               border-color: #605e5c;
               color: #201f1e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Dropdown-title {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Dropdown-title {
               border-color: Highlight;
             }
             &:focus .ms-Dropdown-title {
               color: #201f1e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Dropdown-title {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Dropdown-title {
               color: Highlight;
             }
             &:focus:after {
@@ -925,14 +925,14 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
               top: 0px;
               width: 100%;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:after {
               color: Highlight;
             }
             &:active .ms-Dropdown-title {
               border-color: #0078d4;
               color: #201f1e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Dropdown-title {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Dropdown-title {
               border-color: Highlight;
             }
             &:hover .ms-Dropdown-caretDown {
@@ -941,7 +941,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
             &:focus .ms-Dropdown-caretDown {
               color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Dropdown-caretDown {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Dropdown-caretDown {
               color: Highlight;
             }
             &:active .ms-Dropdown-caretDown {
@@ -1082,13 +1082,13 @@ exports[`Dropdown single-select Renders correctly 1`] = `
             border-color: #323130;
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Dropdown-title {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Dropdown-title {
             border-color: Highlight;
           }
           &:focus .ms-Dropdown-title {
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Dropdown-title {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Dropdown-title {
             color: Highlight;
           }
           &:focus:after {
@@ -1103,14 +1103,14 @@ exports[`Dropdown single-select Renders correctly 1`] = `
             top: 0px;
             width: 100%;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:after {
             color: Highlight;
           }
           &:active .ms-Dropdown-title {
             border-color: #0078d4;
             color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Dropdown-title {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Dropdown-title {
             border-color: Highlight;
           }
           &:hover .ms-Dropdown-caretDown {
@@ -1119,7 +1119,7 @@ exports[`Dropdown single-select Renders correctly 1`] = `
           &:focus .ms-Dropdown-caretDown {
             color: #323130;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Dropdown-caretDown {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Dropdown-caretDown {
             color: Highlight;
           }
           &:active .ms-Dropdown-caretDown {
@@ -1259,13 +1259,13 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
               border-color: #605e5c;
               color: #201f1e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Dropdown-title {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Dropdown-title {
               border-color: Highlight;
             }
             &:focus .ms-Dropdown-title {
               color: #201f1e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Dropdown-title {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Dropdown-title {
               color: Highlight;
             }
             &:focus:after {
@@ -1280,14 +1280,14 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
               top: 0px;
               width: 100%;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus:after {
               color: Highlight;
             }
             &:active .ms-Dropdown-title {
               border-color: #0078d4;
               color: #201f1e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Dropdown-title {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Dropdown-title {
               border-color: Highlight;
             }
             &:hover .ms-Dropdown-caretDown {
@@ -1296,7 +1296,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
             &:focus .ms-Dropdown-caretDown {
               color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus .ms-Dropdown-caretDown {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Dropdown-caretDown {
               color: Highlight;
             }
             &:active .ms-Dropdown-caretDown {
@@ -1470,7 +1470,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                   position: absolute;
                   width: 200px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: WindowText;
                   border-style: solid;
                   border-width: 1px;
@@ -1546,7 +1546,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                             text-align: left;
                             user-select: none;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                             -ms-high-contrast-adjust: none;
                             color: GrayText;
                             forced-color-adjust: none;
@@ -1626,7 +1626,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                             top: 0px;
                             z-index: 1;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                             bottom: -2px;
                             left: -2px;
                             outline-color: ButtonText;
@@ -1638,7 +1638,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                             position: relative;
                             top: 0px;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                             background-color: Highlight;
                             border-color: Highlight;
                             border: none;
@@ -1647,7 +1647,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                           &:hover {
                             color: #0078d4;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                             color: Highlight;
                           }
                           &:hover .ms-Button-icon {
@@ -1670,34 +1670,34 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                             background-color: #edebe9;
                             color: #201f1e;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover:focus {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover:focus {
                             background-color: Highlight;
                             border-color: Highlight;
                             color: HighlightText;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){&:hover:focus {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:hover:focus {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
                             background-color: Highlight;
                             border-color: Highlight;
                             color: HighlightText;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){&:focus {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:focus {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
                             background-color: Highlight;
                             border-color: Highlight;
                             color: HighlightText;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){&:active {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:active {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
                           }
-                          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){& {
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){& {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
                           }
@@ -1804,7 +1804,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                           top: 0px;
                           z-index: 1;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                           bottom: -2px;
                           left: -2px;
                           outline-color: ButtonText;
@@ -1816,14 +1816,14 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                           position: relative;
                           top: 0px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           border-color: Window;
                           border: none;
                         }
                         &:hover {
                           color: #0078d4;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                           color: Highlight;
                         }
                         &:hover .ms-Button-icon {
@@ -1846,30 +1846,30 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                           background-color: #f3f2f1;
                           color: #201f1e;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover:focus {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover:focus {
                           background-color: Highlight;
                           border-color: Highlight;
                           color: HighlightText;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){&:hover:focus {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:hover:focus {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
                           background-color: Highlight;
                           border-color: Highlight;
                           color: HighlightText;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){&:focus {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:focus {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
                           background-color: Highlight;
                           border-color: Highlight;
                           color: HighlightText;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light){&:active {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:active {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
                         }

--- a/packages/react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -313,7 +313,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   top: 2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   bottom: -2px;
                   left: -2px;
                   outline-color: ButtonText;
@@ -379,7 +379,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                           height: 32px;
                           line-height: 32px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           -ms-high-contrast-adjust: none;
                           background-color: Window !important;
                           border: 1px solid WindowText;

--- a/packages/react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
               outline: transparent;
               position: absolute;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               border-color: WindowText;
               border-style: solid;
               border-width: 1px;
@@ -251,7 +251,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
               outline: transparent;
               position: absolute;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               border-color: WindowText;
               border-style: solid;
               border-width: 1px;

--- a/packages/react/src/components/Keytip/__snapshots__/KeytipContent.test.tsx.snap
+++ b/packages/react/src/components/Keytip/__snapshots__/KeytipContent.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`Keytip renders visible disabled Keytip correctly 1`] = `
         background-color: #201f1e;
         opacity: 0.5;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         color: GrayText;
         opacity: 1;
       }

--- a/packages/react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -18,10 +18,10 @@ exports[`Link renders Link correctly 1`] = `
         box-shadow: 0 0 0 1px #605e5c inset;
         outline: 1px auto #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: auto;
         border-bottom: none;
         forced-color-adjust: auto;
@@ -30,27 +30,27 @@ exports[`Link renders Link correctly 1`] = `
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
         color: LinkText;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
         color: LinkText;
       }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:hover {
         color: LinkText;
       }
       &:focus {
         color: #0078d4;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
         color: LinkText;
       }
   href="#"
@@ -97,10 +97,10 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
         box-shadow: 0 0 0 1px #605e5c inset;
         outline: 1px auto #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border-bottom: none;
         color: LinkText;
         forced-color-adjust: none;
@@ -109,27 +109,27 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
         color: LinkText;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
         color: LinkText;
       }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:hover {
         color: LinkText;
       }
       &:focus {
         color: #0078d4;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
         color: LinkText;
       }
   onClick={[Function]}
@@ -157,10 +157,10 @@ exports[`Link renders Link with a custom class name 1`] = `
         box-shadow: 0 0 0 1px #605e5c inset;
         outline: 1px auto #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: auto;
         border-bottom: none;
         forced-color-adjust: auto;
@@ -169,27 +169,27 @@ exports[`Link renders Link with a custom class name 1`] = `
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
         color: LinkText;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
         color: LinkText;
       }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:hover {
         color: LinkText;
       }
       &:focus {
         color: #0078d4;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
         color: LinkText;
       }
   href="#"
@@ -235,10 +235,10 @@ exports[`Link renders Link with no href as a button 1`] = `
         box-shadow: 0 0 0 1px #605e5c inset;
         outline: 1px auto #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border-bottom: none;
         color: LinkText;
         forced-color-adjust: none;
@@ -247,27 +247,27 @@ exports[`Link renders Link with no href as a button 1`] = `
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
         color: LinkText;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
         color: LinkText;
       }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:hover {
         color: LinkText;
       }
       &:focus {
         color: #0078d4;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
         color: LinkText;
       }
   onClick={[Function]}
@@ -298,10 +298,10 @@ exports[`Link renders disabled Link correctly 1`] = `
         box-shadow: 0 0 0 1px #605e5c inset;
         outline: 1px auto #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: auto;
         border-bottom: none;
         forced-color-adjust: auto;
@@ -356,10 +356,10 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
         box-shadow: 0 0 0 1px #605e5c inset;
         outline: 1px auto #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border-bottom: none;
         color: LinkText;
         forced-color-adjust: none;
@@ -415,10 +415,10 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
         box-shadow: 0 0 0 1px #605e5c inset;
         outline: 1px auto #605e5c;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border-bottom: none;
         color: LinkText;
         forced-color-adjust: none;
@@ -427,27 +427,27 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
         color: LinkText;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
         color: LinkText;
       }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:hover {
         color: LinkText;
       }
       &:focus {
         color: #0078d4;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
         color: LinkText;
       }
   onClick={[Function]}

--- a/packages/react/src/components/MarqueeSelection/__snapshots__/MarqueeSelection.test.tsx.snap
+++ b/packages/react/src/components/MarqueeSelection/__snapshots__/MarqueeSelection.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`MarqueeSelection renders MarqueeSelection correctly 1`] = `
           right: 0px;
           top: 0px;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           background-color: transparent;
           background: none;
         }
@@ -35,7 +35,7 @@ exports[`MarqueeSelection renders MarqueeSelection correctly 1`] = `
           position: absolute;
           z-index: 10;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           border-color: Highlight;
         }
     style="left: 0px; top: 0px; width: 100px; height: 100px;"
@@ -53,7 +53,7 @@ exports[`MarqueeSelection renders MarqueeSelection correctly 1`] = `
             right: 0px;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             background-color: transparent;
             background: none;
           }

--- a/packages/react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`MessageBar snapshots renders MessageBar correctly 1`] = `
       & .ms-Link:hover {
         color: #004578;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         background: Window;
         border: 1px solid WindowText;
@@ -72,7 +72,7 @@ exports[`MessageBar snapshots renders MessageBar correctly 1`] = `
               font-weight: normal;
               speak: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -100,7 +100,7 @@ exports[`MessageBar snapshots renders MessageBar correctly 1`] = `
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             forced-color-adjust: none;
           }
@@ -152,7 +152,7 @@ exports[`MessageBar snapshots renders a error MessageBar correctly 1`] = `
       & .ms-Link:hover {
         color: #004578;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         background: rgba(255, 0, 0, 0.3);
         border: 1px solid WindowText;
@@ -199,7 +199,7 @@ exports[`MessageBar snapshots renders a error MessageBar correctly 1`] = `
               font-weight: normal;
               speak: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -227,7 +227,7 @@ exports[`MessageBar snapshots renders a error MessageBar correctly 1`] = `
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             forced-color-adjust: none;
           }
@@ -278,7 +278,7 @@ exports[`MessageBar snapshots renders a info MessageBar correctly 1`] = `
       & .ms-Link:hover {
         color: #004578;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         background: Window;
         border: 1px solid WindowText;
@@ -325,7 +325,7 @@ exports[`MessageBar snapshots renders a info MessageBar correctly 1`] = `
               font-weight: normal;
               speak: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -353,7 +353,7 @@ exports[`MessageBar snapshots renders a info MessageBar correctly 1`] = `
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             forced-color-adjust: none;
           }
@@ -404,7 +404,7 @@ exports[`MessageBar snapshots renders a multiline MessageBar correctly 1`] = `
       & .ms-Link:hover {
         color: #004578;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         background: Window;
         border: 1px solid WindowText;
@@ -451,7 +451,7 @@ exports[`MessageBar snapshots renders a multiline MessageBar correctly 1`] = `
               font-weight: normal;
               speak: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -479,7 +479,7 @@ exports[`MessageBar snapshots renders a multiline MessageBar correctly 1`] = `
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             forced-color-adjust: none;
           }
@@ -531,7 +531,7 @@ exports[`MessageBar snapshots renders a multiline error MessageBar correctly 1`]
       & .ms-Link:hover {
         color: #004578;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         background: rgba(255, 0, 0, 0.3);
         border: 1px solid WindowText;
@@ -578,7 +578,7 @@ exports[`MessageBar snapshots renders a multiline error MessageBar correctly 1`]
               font-weight: normal;
               speak: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -606,7 +606,7 @@ exports[`MessageBar snapshots renders a multiline error MessageBar correctly 1`]
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             forced-color-adjust: none;
           }
@@ -657,7 +657,7 @@ exports[`MessageBar snapshots renders a multiline info MessageBar correctly 1`] 
       & .ms-Link:hover {
         color: #004578;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         background: Window;
         border: 1px solid WindowText;
@@ -704,7 +704,7 @@ exports[`MessageBar snapshots renders a multiline info MessageBar correctly 1`] 
               font-weight: normal;
               speak: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -732,7 +732,7 @@ exports[`MessageBar snapshots renders a multiline info MessageBar correctly 1`] 
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             forced-color-adjust: none;
           }
@@ -784,7 +784,7 @@ exports[`MessageBar snapshots renders a multiline severeWarning MessageBar corre
       & .ms-Link:hover {
         color: #004578;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         background: rgba(255, 0, 0, 0.3);
         border: 1px solid WindowText;
@@ -831,7 +831,7 @@ exports[`MessageBar snapshots renders a multiline severeWarning MessageBar corre
               font-weight: normal;
               speak: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -859,7 +859,7 @@ exports[`MessageBar snapshots renders a multiline severeWarning MessageBar corre
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             forced-color-adjust: none;
           }
@@ -911,7 +911,7 @@ exports[`MessageBar snapshots renders a multiline success MessageBar correctly 1
       & .ms-Link:hover {
         color: #004578;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         background: rgba(48, 241, 73, 0.3);
         border: 1px solid WindowText;
@@ -958,7 +958,7 @@ exports[`MessageBar snapshots renders a multiline success MessageBar correctly 1
               font-weight: normal;
               speak: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -986,7 +986,7 @@ exports[`MessageBar snapshots renders a multiline success MessageBar correctly 1
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             forced-color-adjust: none;
           }
@@ -1038,7 +1038,7 @@ exports[`MessageBar snapshots renders a multiline warning MessageBar correctly 1
       & .ms-Link:hover {
         color: #004578;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         background: rgba(255, 254, 57, 0.3);
         border: 1px solid WindowText;
@@ -1085,7 +1085,7 @@ exports[`MessageBar snapshots renders a multiline warning MessageBar correctly 1
               font-weight: normal;
               speak: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -1113,7 +1113,7 @@ exports[`MessageBar snapshots renders a multiline warning MessageBar correctly 1
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             forced-color-adjust: none;
           }
@@ -1165,7 +1165,7 @@ exports[`MessageBar snapshots renders a severeWarning MessageBar correctly 1`] =
       & .ms-Link:hover {
         color: #004578;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         background: rgba(255, 0, 0, 0.3);
         border: 1px solid WindowText;
@@ -1212,7 +1212,7 @@ exports[`MessageBar snapshots renders a severeWarning MessageBar correctly 1`] =
               font-weight: normal;
               speak: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -1240,7 +1240,7 @@ exports[`MessageBar snapshots renders a severeWarning MessageBar correctly 1`] =
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             forced-color-adjust: none;
           }
@@ -1292,7 +1292,7 @@ exports[`MessageBar snapshots renders a success MessageBar correctly 1`] = `
       & .ms-Link:hover {
         color: #004578;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         background: rgba(48, 241, 73, 0.3);
         border: 1px solid WindowText;
@@ -1339,7 +1339,7 @@ exports[`MessageBar snapshots renders a success MessageBar correctly 1`] = `
               font-weight: normal;
               speak: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -1367,7 +1367,7 @@ exports[`MessageBar snapshots renders a success MessageBar correctly 1`] = `
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             forced-color-adjust: none;
           }
@@ -1419,7 +1419,7 @@ exports[`MessageBar snapshots renders a warning MessageBar correctly 1`] = `
       & .ms-Link:hover {
         color: #004578;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: none;
         background: rgba(255, 254, 57, 0.3);
         border: 1px solid WindowText;
@@ -1466,7 +1466,7 @@ exports[`MessageBar snapshots renders a warning MessageBar correctly 1`] = `
               font-weight: normal;
               speak: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               color: WindowText;
               forced-color-adjust: none;
@@ -1494,7 +1494,7 @@ exports[`MessageBar snapshots renders a warning MessageBar correctly 1`] = `
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             forced-color-adjust: none;
           }

--- a/packages/react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -257,7 +257,7 @@ exports[`Modal renders Modal correctly 1`] = `
                     right: 0px;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     border: 1px solid WindowText;
                     opacity: 0;
                   }

--- a/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -215,7 +215,7 @@ exports[`Nav render Nav with overrides correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         bottom: -2px;
                         left: -2px;
                         outline-color: ButtonText;
@@ -227,14 +227,14 @@ exports[`Nav render Nav with overrides correctly 1`] = `
                         position: relative;
                         top: 0px;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                         border-color: Window;
                         border: 0px;
                       }
                       &:hover {
                         color: #0078d4;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                         color: Highlight;
                       }
                       &:hover .ms-Button-icon {
@@ -246,7 +246,7 @@ exports[`Nav render Nav with overrides correctly 1`] = `
                       &:active .ms-Button-icon {
                         color: #004578;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
                         border: 1px solid WindowText;
                       }
                       .ms-Nav-compositeLink:hover & {
@@ -372,7 +372,7 @@ exports[`Nav render Nav with overrides correctly 1`] = `
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                         bottom: -2px;
                         left: -2px;
                         outline-color: ButtonText;
@@ -384,14 +384,14 @@ exports[`Nav render Nav with overrides correctly 1`] = `
                         position: relative;
                         top: 0px;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                         border-color: Window;
                         border: 0px;
                       }
                       &:hover {
                         color: #0078d4;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                         color: Highlight;
                       }
                       &:hover .ms-Button-icon {
@@ -403,7 +403,7 @@ exports[`Nav render Nav with overrides correctly 1`] = `
                       &:active .ms-Button-icon {
                         color: #004578;
                       }
-                      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+                      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
                         border: 1px solid WindowText;
                       }
                       .ms-Nav-compositeLink:hover & {
@@ -591,7 +591,7 @@ exports[`Nav renders Nav correctly 1`] = `
                       top: 1px;
                       z-index: 1;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                       bottom: -2px;
                       left: -2px;
                       outline-color: ButtonText;
@@ -603,14 +603,14 @@ exports[`Nav renders Nav correctly 1`] = `
                       position: relative;
                       top: 0px;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                       border-color: Window;
                       border: 0px;
                     }
                     &:hover {
                       color: #0078d4;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                       color: Highlight;
                     }
                     &:hover .ms-Button-icon {
@@ -622,7 +622,7 @@ exports[`Nav renders Nav correctly 1`] = `
                     &:active .ms-Button-icon {
                       color: #004578;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:focus {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus {
                       border: 1px solid WindowText;
                     }
                     .ms-Nav-compositeLink:hover & {

--- a/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`Panel renders Panel correctly 1`] = `
             right: 0px;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border: 1px solid WindowText;
             opacity: 0;
           }
@@ -78,7 +78,7 @@ exports[`Panel renders Panel correctly 1`] = `
             top: 0px;
             width: 100%;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-left: 3px solid #edebe9;
             border-right: 3px solid #edebe9;
           }
@@ -212,7 +212,7 @@ exports[`Panel renders Panel correctly 1`] = `
                       top: 2px;
                       z-index: 1;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                       bottom: -2px;
                       left: -2px;
                       outline-color: ButtonText;
@@ -228,7 +228,7 @@ exports[`Panel renders Panel correctly 1`] = `
                       background-color: #f3f2f1;
                       color: #323130;
                     }
-                    @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                       border-color: Highlight;
                       color: Highlight;
                     }

--- a/packages/react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
+++ b/packages/react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`PersonaCoin renders correctly 1`] = `
             height: 48px;
             line-height: 46px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: Window !important;
             border: 1px solid WindowText;
@@ -190,7 +190,7 @@ exports[`PersonaCoin renders correctly with provided initials 1`] = `
             height: 48px;
             line-height: 46px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: Window !important;
             border: 1px solid WindowText;
@@ -249,7 +249,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
             height: 48px;
             line-height: 46px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: Window !important;
             border: 1px solid WindowText;

--- a/packages/react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`Persona renders Persona children correctly 1`] = `
               height: 48px;
               line-height: 46px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window !important;
               border: 1px solid WindowText;
@@ -231,7 +231,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
               height: 48px;
               line-height: 46px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window !important;
               border: 1px solid WindowText;
@@ -580,7 +580,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
               height: 48px;
               line-height: 46px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window !important;
               border: 1px solid WindowText;
@@ -738,7 +738,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
               height: 48px;
               line-height: 46px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window !important;
               border: 1px solid WindowText;
@@ -860,7 +860,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
               height: 100px;
               line-height: 100px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window !important;
               border: 1px solid WindowText;
@@ -898,7 +898,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
               top: auto;
               width: 28px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: WindowText;
               border-color: Window;
             }
@@ -912,7 +912,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
               transform: translateY(-50%) rotate(-45deg);
               width: 100%;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
               background-color: Window;
               left: 2px;
               width: calc(100% - 4px);
@@ -928,7 +928,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
               top: 0px;
               width: 100%;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
               border-color: Window;
               height: calc(100% - 2px);
               left: 1px;
@@ -950,7 +950,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
                 vertical-align: top;
                 width: 1em;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Window;
               }
           data-icon-name=""
@@ -1559,7 +1559,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
               top: auto;
               width: 28px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: WindowText;
               border-color: Window;
             }
@@ -1573,7 +1573,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
               transform: translateY(-50%) rotate(-45deg);
               width: 100%;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
               background-color: Window;
               left: 2px;
               width: calc(100% - 4px);
@@ -1589,7 +1589,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
               top: 0px;
               width: 100%;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
               border-color: Window;
               height: calc(100% - 2px);
               left: 1px;
@@ -1611,7 +1611,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
                 vertical-align: top;
                 width: 1em;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Window;
               }
           data-icon-name=""
@@ -1949,7 +1949,7 @@ exports[`PersonaCoin renders correctly 1`] = `
             height: 48px;
             line-height: 46px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: Window !important;
             border: 1px solid WindowText;
@@ -2100,7 +2100,7 @@ exports[`PersonaCoin renders correctly with onRender callback 1`] = `
             height: 100px;
             line-height: 100px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: Window !important;
             border: 1px solid WindowText;
@@ -2159,7 +2159,7 @@ exports[`PersonaCoin renders correctly with provided initials 1`] = `
             height: 48px;
             line-height: 46px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: Window !important;
             border: 1px solid WindowText;
@@ -2218,7 +2218,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
             height: 48px;
             line-height: 46px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: Window !important;
             border: 1px solid WindowText;
@@ -2277,7 +2277,7 @@ exports[`PersonaCoin renders the initials before the image is loaded 1`] = `
             height: 48px;
             line-height: 46px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: Window !important;
             border: 1px solid WindowText;

--- a/packages/react/src/components/Persona/PersonaPresence/__snapshots__/PersonaPresence.test.tsx.snap
+++ b/packages/react/src/components/Persona/PersonaPresence/__snapshots__/PersonaPresence.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`PersonaPresence renders available + out of office 1`] = `
         top: auto;
         width: 12px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         background-color: WindowText;
         border-color: Window;
       }
@@ -35,7 +35,7 @@ exports[`PersonaPresence renders available + out of office 1`] = `
         top: 0px;
         width: 100%;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
         border-color: Window;
         height: calc(100% - 2px);
         left: 1px;
@@ -62,7 +62,7 @@ exports[`PersonaPresence renders available + out of office 1`] = `
           speak: none;
           vertical-align: top;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: Window;
         }
     data-icon-name="SkypeCheck"
@@ -92,7 +92,7 @@ exports[`PersonaPresence renders available 1`] = `
         top: auto;
         width: 12px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         background-color: Highlight;
         border-color: Window;
       }
@@ -115,7 +115,7 @@ exports[`PersonaPresence renders available 1`] = `
           speak: none;
           vertical-align: top;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: Window;
         }
     data-icon-name="SkypeCheck"
@@ -145,7 +145,7 @@ exports[`PersonaPresence renders away + out of office 1`] = `
         top: auto;
         width: 12px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         background-color: WindowText;
         border-color: Window;
       }
@@ -160,7 +160,7 @@ exports[`PersonaPresence renders away + out of office 1`] = `
         top: 0px;
         width: 100%;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
         border-color: Window;
         height: calc(100% - 2px);
         left: 1px;
@@ -188,7 +188,7 @@ exports[`PersonaPresence renders away + out of office 1`] = `
           speak: none;
           vertical-align: top;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: Window;
         }
     data-icon-name="SkypeArrow"
@@ -218,7 +218,7 @@ exports[`PersonaPresence renders away 1`] = `
         top: auto;
         width: 12px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         background-color: WindowText;
         border-color: Window;
       }
@@ -243,7 +243,7 @@ exports[`PersonaPresence renders away 1`] = `
           speak: none;
           vertical-align: top;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: Window;
         }
     data-icon-name="SkypeClock"
@@ -273,11 +273,11 @@ exports[`PersonaPresence renders blocked + out of office 1`] = `
         top: auto;
         width: 12px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         background-color: WindowText;
         border-color: Window;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:after {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
         background-color: Window;
         left: 2px;
         width: calc(100% - 4px);
@@ -293,7 +293,7 @@ exports[`PersonaPresence renders blocked + out of office 1`] = `
         top: 0px;
         width: 100%;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
         border-color: Window;
         height: calc(100% - 2px);
         left: 1px;
@@ -315,7 +315,7 @@ exports[`PersonaPresence renders blocked + out of office 1`] = `
           vertical-align: top;
           width: 1em;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: Window;
         }
     data-icon-name=""
@@ -343,11 +343,11 @@ exports[`PersonaPresence renders blocked 1`] = `
         top: auto;
         width: 12px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         background-color: WindowText;
         border-color: Window;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:after {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
         background-color: Window;
         left: 2px;
         width: calc(100% - 4px);
@@ -363,7 +363,7 @@ exports[`PersonaPresence renders blocked 1`] = `
         top: 0px;
         width: 100%;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
         border-color: Window;
         height: calc(100% - 2px);
         left: 1px;
@@ -385,7 +385,7 @@ exports[`PersonaPresence renders blocked 1`] = `
           vertical-align: top;
           width: 1em;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: Window;
         }
     data-icon-name=""
@@ -413,7 +413,7 @@ exports[`PersonaPresence renders busy + out of office 1`] = `
         top: auto;
         width: 12px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         background-color: WindowText;
         border-color: Window;
       }
@@ -428,7 +428,7 @@ exports[`PersonaPresence renders busy + out of office 1`] = `
         top: 0px;
         width: 100%;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
         border-color: Window;
         height: calc(100% - 2px);
         left: 1px;
@@ -451,7 +451,7 @@ exports[`PersonaPresence renders busy + out of office 1`] = `
           vertical-align: top;
           width: 1em;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: Window;
         }
     data-icon-name=""
@@ -479,7 +479,7 @@ exports[`PersonaPresence renders busy 1`] = `
         top: auto;
         width: 12px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         background-color: WindowText;
         border-color: Window;
       }
@@ -498,7 +498,7 @@ exports[`PersonaPresence renders busy 1`] = `
           vertical-align: top;
           width: 1em;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: Window;
         }
     data-icon-name=""
@@ -526,7 +526,7 @@ exports[`PersonaPresence renders do not disturb + out of office 1`] = `
         top: auto;
         width: 12px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         background-color: WindowText;
         border-color: Window;
       }
@@ -541,7 +541,7 @@ exports[`PersonaPresence renders do not disturb + out of office 1`] = `
         top: 0px;
         width: 100%;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
         border-color: Window;
         height: calc(100% - 2px);
         left: 1px;
@@ -568,7 +568,7 @@ exports[`PersonaPresence renders do not disturb + out of office 1`] = `
           speak: none;
           vertical-align: top;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: Window;
         }
     data-icon-name="SkypeMinus"
@@ -598,7 +598,7 @@ exports[`PersonaPresence renders do not disturb 1`] = `
         top: auto;
         width: 12px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         background-color: WindowText;
         border-color: Window;
       }
@@ -621,7 +621,7 @@ exports[`PersonaPresence renders do not disturb 1`] = `
           speak: none;
           vertical-align: top;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: Window;
         }
     data-icon-name="SkypeMinus"
@@ -655,7 +655,7 @@ exports[`PersonaPresence renders offline + out of office 1`] = `
         top: auto;
         width: 12px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         background-color: WindowText;
         border-color: Window;
       }
@@ -670,7 +670,7 @@ exports[`PersonaPresence renders offline + out of office 1`] = `
         top: 0px;
         width: 100%;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
         border-color: Window;
         height: calc(100% - 2px);
         left: 1px;
@@ -697,7 +697,7 @@ exports[`PersonaPresence renders offline + out of office 1`] = `
           speak: none;
           vertical-align: top;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: Window;
         }
     data-icon-name="SkypeArrow"
@@ -727,7 +727,7 @@ exports[`PersonaPresence renders offline 1`] = `
         top: auto;
         width: 12px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         background-color: WindowText;
         border-color: Window;
       }
@@ -742,7 +742,7 @@ exports[`PersonaPresence renders offline 1`] = `
         top: 0px;
         width: 100%;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
         border-color: Window;
         height: calc(100% - 2px);
         left: 1px;
@@ -765,7 +765,7 @@ exports[`PersonaPresence renders offline 1`] = `
           vertical-align: top;
           width: 1em;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           color: Window;
         }
     data-icon-name=""

--- a/packages/react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -247,7 +247,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
               height: 48px;
               line-height: 46px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window !important;
               border: 1px solid WindowText;
@@ -405,7 +405,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
               height: 48px;
               line-height: 46px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window !important;
               border: 1px solid WindowText;

--- a/packages/react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`Persona renders Persona children correctly 1`] = `
               height: 48px;
               line-height: 46px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window !important;
               border: 1px solid WindowText;
@@ -231,7 +231,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
               height: 48px;
               line-height: 46px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window !important;
               border: 1px solid WindowText;
@@ -580,7 +580,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
               height: 48px;
               line-height: 46px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window !important;
               border: 1px solid WindowText;
@@ -738,7 +738,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
               height: 48px;
               line-height: 46px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window !important;
               border: 1px solid WindowText;
@@ -860,7 +860,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
               height: 100px;
               line-height: 100px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window !important;
               border: 1px solid WindowText;
@@ -898,7 +898,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
               top: auto;
               width: 28px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: WindowText;
               border-color: Window;
             }
@@ -912,7 +912,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
               transform: translateY(-50%) rotate(-45deg);
               width: 100%;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
               background-color: Window;
               left: 2px;
               width: calc(100% - 4px);
@@ -928,7 +928,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
               top: 0px;
               width: 100%;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
               border-color: Window;
               height: calc(100% - 2px);
               left: 1px;
@@ -950,7 +950,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
                 vertical-align: top;
                 width: 1em;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Window;
               }
           data-icon-name=""
@@ -1559,7 +1559,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
               top: auto;
               width: 28px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: WindowText;
               border-color: Window;
             }
@@ -1573,7 +1573,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
               transform: translateY(-50%) rotate(-45deg);
               width: 100%;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
               background-color: Window;
               left: 2px;
               width: calc(100% - 4px);
@@ -1589,7 +1589,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
               top: 0px;
               width: 100%;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
               border-color: Window;
               height: calc(100% - 2px);
               left: 1px;
@@ -1611,7 +1611,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
                 vertical-align: top;
                 width: 1em;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Window;
               }
           data-icon-name=""

--- a/packages/react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
+++ b/packages/react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -95,7 +95,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
             color: Highlight;
           }
@@ -104,7 +104,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -146,7 +146,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
             background-color: Highlight;
           }
           &:hover::before {
@@ -252,7 +252,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -264,7 +264,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
           }
           &:hover {
@@ -272,7 +272,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {

--- a/packages/react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -95,7 +95,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
             color: Highlight;
           }
@@ -104,7 +104,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -146,7 +146,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
             background-color: Highlight;
           }
           &:hover::before {
@@ -252,7 +252,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -264,7 +264,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
           }
           &:hover {
@@ -272,7 +272,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -480,7 +480,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -492,7 +492,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
             color: Highlight;
           }
@@ -501,7 +501,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -543,7 +543,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
             background-color: Highlight;
           }
           &:hover::before {
@@ -649,7 +649,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -661,7 +661,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
           }
           &:hover {
@@ -669,7 +669,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -865,7 +865,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -877,7 +877,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
             color: Highlight;
           }
@@ -886,7 +886,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -928,7 +928,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
             background-color: Highlight;
           }
           &:hover::before {
@@ -1034,7 +1034,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -1046,7 +1046,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
           }
           &:hover {
@@ -1054,7 +1054,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -1207,7 +1207,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -1219,7 +1219,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
           }
           &:hover {
@@ -1227,7 +1227,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -1442,7 +1442,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -1454,7 +1454,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
             color: Highlight;
           }
@@ -1463,7 +1463,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -1505,7 +1505,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
             background-color: Highlight;
           }
           &:hover::before {
@@ -1611,7 +1611,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -1623,7 +1623,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
           }
           &:hover {
@@ -1631,7 +1631,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -1778,7 +1778,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -1790,7 +1790,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
           }
           &:hover {
@@ -1798,7 +1798,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -2006,7 +2006,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -2018,7 +2018,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
             color: Highlight;
           }
@@ -2027,7 +2027,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -2069,7 +2069,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
             background-color: Highlight;
           }
           &:hover::before {
@@ -2175,7 +2175,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -2187,7 +2187,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
           }
           &:hover {
@@ -2195,7 +2195,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -2392,7 +2392,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -2404,7 +2404,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
             color: Highlight;
           }
@@ -2413,7 +2413,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             color: #ffffff;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -2479,7 +2479,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             background-color: #106ebe;
             color: #ffffff;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-selected {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-selected {
             -ms-high-contrast-adjust: none;
             background: Highlight;
             color: HighlightText;
@@ -2489,7 +2489,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
             background-color: Highlight;
           }
           &:hover::before {
@@ -2596,7 +2596,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -2608,7 +2608,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
           }
           &:hover {
@@ -2616,7 +2616,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             color: #ffffff;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -2682,7 +2682,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             background-color: #106ebe;
             color: #ffffff;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-selected {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-selected {
             -ms-high-contrast-adjust: none;
             background: Highlight;
             color: HighlightText;
@@ -2844,7 +2844,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -2856,7 +2856,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
             color: Highlight;
           }
@@ -2865,7 +2865,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -2907,7 +2907,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
             background-color: Highlight;
           }
           &:hover::before {
@@ -3013,7 +3013,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -3025,7 +3025,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
           }
           &:hover {
@@ -3033,7 +3033,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -3229,7 +3229,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -3241,7 +3241,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
             color: Highlight;
           }
@@ -3250,7 +3250,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             color: #ffffff;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -3316,7 +3316,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             background-color: #106ebe;
             color: #ffffff;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-selected {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-selected {
             -ms-high-contrast-adjust: none;
             background: Highlight;
             color: HighlightText;
@@ -3326,7 +3326,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
             background-color: Highlight;
           }
           &:hover::before {
@@ -3433,7 +3433,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -3445,7 +3445,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
           }
           &:hover {
@@ -3453,7 +3453,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             color: #ffffff;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -3519,7 +3519,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             background-color: #106ebe;
             color: #ffffff;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.is-selected {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-selected {
             -ms-high-contrast-adjust: none;
             background: Highlight;
             color: HighlightText;
@@ -3680,7 +3680,7 @@ exports[`Pivot supports JSX expressions 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -3692,7 +3692,7 @@ exports[`Pivot supports JSX expressions 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
           }
           &:hover {
@@ -3700,7 +3700,7 @@ exports[`Pivot supports JSX expressions 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -3842,7 +3842,7 @@ exports[`Pivot supports JSX expressions 1`] = `
             top: 2px;
             z-index: 1;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
             bottom: -2px;
             left: -2px;
             outline-color: ButtonText;
@@ -3854,7 +3854,7 @@ exports[`Pivot supports JSX expressions 1`] = `
             position: relative;
             top: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-color: Window;
             color: Highlight;
           }
@@ -3863,7 +3863,7 @@ exports[`Pivot supports JSX expressions 1`] = `
             color: #201f1e;
             cursor: pointer;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             color: Highlight;
           }
           &:hover .ms-Button-icon {
@@ -3905,7 +3905,7 @@ exports[`Pivot supports JSX expressions 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:before {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:before {
             background-color: Highlight;
           }
           &:hover::before {

--- a/packages/react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
             position: absolute;
             width: 100%;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-bottom: 1px solid WindowText;
           }
     />
@@ -68,7 +68,7 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
             transition: width .15s linear;
             width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: highlight;
             forced-color-adjust: none;
@@ -148,7 +148,7 @@ exports[`ProgressIndicator renders React content 1`] = `
             position: absolute;
             width: 100%;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-bottom: 1px solid WindowText;
           }
     />
@@ -167,7 +167,7 @@ exports[`ProgressIndicator renders React content 1`] = `
             transition: width .3s ease;
             width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: highlight;
             background: highlight;
@@ -248,7 +248,7 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
             position: absolute;
             width: 100%;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-bottom: 1px solid WindowText;
           }
     />
@@ -267,7 +267,7 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
             transition: width .3s ease;
             width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: highlight;
             background: highlight;
@@ -331,7 +331,7 @@ exports[`ProgressIndicator renders with ariaLabel 1`] = `
             position: absolute;
             width: 100%;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-bottom: 1px solid WindowText;
           }
     />
@@ -349,7 +349,7 @@ exports[`ProgressIndicator renders with ariaLabel 1`] = `
             transition: width .3s ease;
             width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: highlight;
             background: highlight;
@@ -401,7 +401,7 @@ exports[`ProgressIndicator renders with no label or description 1`] = `
             position: absolute;
             width: 100%;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             border-bottom: 1px solid WindowText;
           }
     />
@@ -418,7 +418,7 @@ exports[`ProgressIndicator renders with no label or description 1`] = `
             transition: width .3s ease;
             width: 0px;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
             background-color: highlight;
             background: highlight;

--- a/packages/react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Rating renders correctly 1`] = `
       &:hover .ms-RatingStar-back {
         color: #323130;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-RatingStar-back {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-RatingStar-back {
         color: Highlight;
       }
       {
@@ -104,13 +104,13 @@ exports[`Rating renders correctly 1`] = `
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
           }
           &:hover .ms-RatingStar-back {
@@ -204,7 +204,7 @@ exports[`Rating renders correctly 1`] = `
                 top: 0;
                 vertical-align: middle;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Highlight;
               }
           data-icon-name="FavoriteStarFill"
@@ -262,13 +262,13 @@ exports[`Rating renders correctly 1`] = `
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
           }
           &:hover .ms-RatingStar-back {
@@ -361,7 +361,7 @@ exports[`Rating renders correctly 1`] = `
                 top: 0;
                 vertical-align: middle;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Highlight;
               }
           data-icon-name="FavoriteStar"
@@ -419,13 +419,13 @@ exports[`Rating renders correctly 1`] = `
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
           }
           &:hover .ms-RatingStar-back {
@@ -518,7 +518,7 @@ exports[`Rating renders correctly 1`] = `
                 top: 0;
                 vertical-align: middle;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Highlight;
               }
           data-icon-name="FavoriteStar"
@@ -576,13 +576,13 @@ exports[`Rating renders correctly 1`] = `
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
           }
           &:hover .ms-RatingStar-back {
@@ -675,7 +675,7 @@ exports[`Rating renders correctly 1`] = `
                 top: 0;
                 vertical-align: middle;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Highlight;
               }
           data-icon-name="FavoriteStar"
@@ -733,13 +733,13 @@ exports[`Rating renders correctly 1`] = `
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
           }
           &:hover .ms-RatingStar-back {
@@ -832,7 +832,7 @@ exports[`Rating renders correctly 1`] = `
                 top: 0;
                 vertical-align: middle;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Highlight;
               }
           data-icon-name="FavoriteStar"
@@ -866,7 +866,7 @@ exports[`Rating renders correctly with half star 1`] = `
       &:hover .ms-RatingStar-back {
         color: #323130;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-RatingStar-back {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-RatingStar-back {
         color: Highlight;
       }
       {
@@ -954,13 +954,13 @@ exports[`Rating renders correctly with half star 1`] = `
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
           }
           &:hover .ms-RatingStar-back {
@@ -1053,7 +1053,7 @@ exports[`Rating renders correctly with half star 1`] = `
                 top: 0;
                 vertical-align: middle;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Highlight;
               }
           data-icon-name="FavoriteStarFill"
@@ -1111,13 +1111,13 @@ exports[`Rating renders correctly with half star 1`] = `
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
           }
           &:hover .ms-RatingStar-back {
@@ -1210,7 +1210,7 @@ exports[`Rating renders correctly with half star 1`] = `
                 top: 0;
                 vertical-align: middle;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Highlight;
               }
           data-icon-name="FavoriteStarFill"
@@ -1268,13 +1268,13 @@ exports[`Rating renders correctly with half star 1`] = `
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
           }
           &:hover .ms-RatingStar-back {
@@ -1368,7 +1368,7 @@ exports[`Rating renders correctly with half star 1`] = `
                 top: 0;
                 vertical-align: middle;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Highlight;
               }
           data-icon-name="FavoriteStarFill"
@@ -1426,13 +1426,13 @@ exports[`Rating renders correctly with half star 1`] = `
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
           }
           &:hover .ms-RatingStar-back {
@@ -1525,7 +1525,7 @@ exports[`Rating renders correctly with half star 1`] = `
                 top: 0;
                 vertical-align: middle;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Highlight;
               }
           data-icon-name="FavoriteStar"
@@ -1583,13 +1583,13 @@ exports[`Rating renders correctly with half star 1`] = `
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: #605e5c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
           }
           &:hover .ms-RatingStar-back {
@@ -1682,7 +1682,7 @@ exports[`Rating renders correctly with half star 1`] = `
                 top: 0;
                 vertical-align: middle;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 color: Highlight;
               }
           data-icon-name="FavoriteStar"

--- a/packages/react/src/components/ScrollablePane/__snapshots__/ScrollablePane.test.tsx.snap
+++ b/packages/react/src/components/ScrollablePane/__snapshots__/ScrollablePane.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`ScrollablePane renders correctly 1`] = `
           top: 0px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           border-bottom: 1px solid WindowText;
         }
     style={
@@ -61,7 +61,7 @@ exports[`ScrollablePane renders correctly 1`] = `
           pointer-events: none;
           position: absolute;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           border-top: 1px solid WindowText;
         }
     style={

--- a/packages/react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -30,13 +30,13 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
         padding-right: 0;
         padding-top: 1px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border-color: WindowText;
       }
       &:hover {
         border-color: #323130;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
         border-color: Highlight;
       }
       &:hover .ms-SearchBox-iconContainer {
@@ -164,13 +164,13 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
         padding-right: 0;
         padding-top: 1px;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border-color: WindowText;
       }
       &:hover {
         border-color: #323130;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
         border-color: Highlight;
       }
       &:hover .ms-SearchBox-iconContainer {

--- a/packages/react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
+++ b/packages/react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
         & > * {
           transform: translateZ(0);
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           -ms-high-contrast-adjust: none;
           background: WindowText
                                 linear-gradient(
@@ -109,7 +109,7 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
               min-width: 30px;
               width: 30px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               border-color: Window;
             }
       >
@@ -120,7 +120,7 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
                 display: block;
                 fill: #ffffff;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 fill: Window;
               }
           height={30}
@@ -150,7 +150,7 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
               font-weight: 400;
               height: 16px;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background-color: Window;
               border-color: Window;
             }
@@ -180,10 +180,10 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
               height: 20px;
               position: relative;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               border-color: Window;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& > * {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& > * {
               fill: Window;
             }
         style={
@@ -290,7 +290,7 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
         & > * {
           transform: translateZ(0);
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           -ms-high-contrast-adjust: none;
           background: WindowText
                                 linear-gradient(
@@ -379,10 +379,10 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
                 height: 40px;
                 position: relative;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& > * {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& > * {
                 fill: Window;
               }
           style={
@@ -475,7 +475,7 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
                 font-weight: 400;
                 height: 40px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background-color: Window;
                 border-color: Window;
               }
@@ -526,10 +526,10 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
                 height: 10px;
                 position: relative;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& > * {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& > * {
                 fill: Window;
               }
           style={
@@ -623,10 +623,10 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
                 height: 10px;
                 position: relative;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& > * {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& > * {
                 fill: Window;
               }
           style={
@@ -719,7 +719,7 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
                 font-weight: 400;
                 height: 20px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background-color: Window;
                 border-color: Window;
               }

--- a/packages/react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -97,52 +97,52 @@ exports[`Slider renders correctly 1`] = `
             &:active .ms-Slider-active {
               background-color: #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Slider-active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Slider-active {
               background-color: Highlight;
             }
             &:hover .ms-Slider-active {
               background-color: #0078d4;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Slider-active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Slider-active {
               background-color: Highlight;
             }
             &:active .ms-Slider-inactive {
               background-color: #8a8886;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Slider-inactive {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Slider-inactive {
               border-color: Highlight;
             }
             &:hover .ms-Slider-inactive {
               background-color: #8a8886;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Slider-inactive {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Slider-inactive {
               border-color: Highlight;
             }
             &:active .ms-Slider-thumb {
               border: 2px solid #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Slider-thumb {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Slider-thumb {
               border-color: Highlight;
             }
             &:hover .ms-Slider-thumb {
               border: 2px solid #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Slider-thumb {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Slider-thumb {
               border-color: Highlight;
             }
             &:active .ms-Slider-zeroTick {
               background-color: #deecf9;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Slider-zeroTick {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Slider-zeroTick {
               background-color: Highlight;
             }
             &:hover .ms-Slider-zeroTick {
               background-color: #deecf9;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Slider-zeroTick {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         data-is-focusable="true"
@@ -192,7 +192,7 @@ exports[`Slider renders correctly 1`] = `
                   background: #8a8886;
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border: 1px solid WindowText;
                 }
             style="width: 0%;"
@@ -210,7 +210,7 @@ exports[`Slider renders correctly 1`] = `
                   background: #323130;
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   background-color: WindowText;
                 }
             style="width: 0%;"
@@ -228,7 +228,7 @@ exports[`Slider renders correctly 1`] = `
                   background: #8a8886;
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border: 1px solid WindowText;
                 }
             style="width: 100%;"
@@ -379,52 +379,52 @@ exports[`Slider renders range slider correctly 1`] = `
             &:active .ms-Slider-active {
               background-color: #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Slider-active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Slider-active {
               background-color: Highlight;
             }
             &:hover .ms-Slider-active {
               background-color: #0078d4;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Slider-active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Slider-active {
               background-color: Highlight;
             }
             &:active .ms-Slider-inactive {
               background-color: #8a8886;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Slider-inactive {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Slider-inactive {
               border-color: Highlight;
             }
             &:hover .ms-Slider-inactive {
               background-color: #8a8886;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Slider-inactive {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Slider-inactive {
               border-color: Highlight;
             }
             &:active .ms-Slider-thumb {
               border: 2px solid #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Slider-thumb {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Slider-thumb {
               border-color: Highlight;
             }
             &:hover .ms-Slider-thumb {
               border: 2px solid #005a9e;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Slider-thumb {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Slider-thumb {
               border-color: Highlight;
             }
             &:active .ms-Slider-zeroTick {
               background-color: #deecf9;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active .ms-Slider-zeroTick {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active .ms-Slider-zeroTick {
               background-color: Highlight;
             }
             &:hover .ms-Slider-zeroTick {
               background-color: #deecf9;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Slider-zeroTick {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               forced-color-adjust: none;
             }
         id="Slider0"
@@ -541,7 +541,7 @@ exports[`Slider renders range slider correctly 1`] = `
                   background: #8a8886;
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border: 1px solid WindowText;
                 }
             style="width: 0%;"
@@ -559,7 +559,7 @@ exports[`Slider renders range slider correctly 1`] = `
                   background: #323130;
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   background-color: WindowText;
                 }
             style="width: 50%;"
@@ -577,7 +577,7 @@ exports[`Slider renders range slider correctly 1`] = `
                   background: #8a8886;
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border: 1px solid WindowText;
                 }
             style="width: 50%;"

--- a/packages/react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`SpinButton snapshots renders correctly 1`] = `
         &:hover:after {
           border-color: #323130;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover:after {
           border-color: Highlight;
         }
     data-ktp-target={true}
@@ -130,7 +130,7 @@ exports[`SpinButton snapshots renders correctly 1`] = `
             background-color: #0078d4;
             color: #ffffff;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::selection {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::selection {
             background-color: Highlight;
             border-color: Highlight;
             color: HighlightText;
@@ -202,7 +202,7 @@ exports[`SpinButton snapshots renders correctly 1`] = `
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -224,7 +224,7 @@ exports[`SpinButton snapshots renders correctly 1`] = `
               background-color: #f3f2f1;
               color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               border-color: Highlight;
               color: Highlight;
             }
@@ -232,7 +232,7 @@ exports[`SpinButton snapshots renders correctly 1`] = `
               background-color: #edebe9;
               color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               background-color: Highlight;
               color: HighlightText;
             }
@@ -341,7 +341,7 @@ exports[`SpinButton snapshots renders correctly 1`] = `
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -363,7 +363,7 @@ exports[`SpinButton snapshots renders correctly 1`] = `
               background-color: #f3f2f1;
               color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               border-color: Highlight;
               color: Highlight;
             }
@@ -371,7 +371,7 @@ exports[`SpinButton snapshots renders correctly 1`] = `
               background-color: #edebe9;
               color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               background-color: Highlight;
               color: HighlightText;
             }
@@ -525,7 +525,7 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
         &:hover:after {
           border-color: #323130;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover:after {
           border-color: Highlight;
         }
     data-ktp-target={true}
@@ -573,7 +573,7 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
             background-color: #0078d4;
             color: #ffffff;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::selection {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::selection {
             background-color: Highlight;
             border-color: Highlight;
             color: HighlightText;
@@ -645,7 +645,7 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -667,7 +667,7 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
               background-color: #f3f2f1;
               color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               border-color: Highlight;
               color: Highlight;
             }
@@ -675,7 +675,7 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
               background-color: #edebe9;
               color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               background-color: Highlight;
               color: HighlightText;
             }
@@ -784,7 +784,7 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -806,7 +806,7 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
               background-color: #f3f2f1;
               color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               border-color: Highlight;
               color: Highlight;
             }
@@ -814,7 +814,7 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
               background-color: #edebe9;
               color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
               background-color: Highlight;
               color: HighlightText;
             }

--- a/packages/react/src/components/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/packages/react/src/components/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Spinner renders Spinner correctly 1`] = `
           height: 20px;
           width: 20px;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           -ms-high-contrast-adjust: none;
           border-top-color: Highlight;
           forced-color-adjust: none;

--- a/packages/react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   top: 0px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   border: none;
                   bottom: -2px;
                   left: -2px;
@@ -114,7 +114,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
@@ -126,7 +126,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
                   outline: 1px solid ButtonText;
                 }
                 &:hover {
@@ -163,7 +163,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   padding-right: 2px;
                   padding-top: 2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   color: Highlight;
                 }
             data-index={0}
@@ -276,7 +276,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   top: 0px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   border: none;
                   bottom: -2px;
                   left: -2px;
@@ -289,7 +289,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
@@ -301,7 +301,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
                   outline: 1px solid ButtonText;
                 }
                 &:hover {
@@ -338,7 +338,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   padding-right: 2px;
                   padding-top: 2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   color: Highlight;
                 }
             data-index={1}
@@ -451,7 +451,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   top: 0px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   border: none;
                   bottom: -2px;
                   left: -2px;
@@ -464,7 +464,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
@@ -476,7 +476,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
                   outline: 1px solid ButtonText;
                 }
                 &:hover {
@@ -513,7 +513,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   padding-right: 2px;
                   padding-top: 2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   color: Highlight;
                 }
             data-index={2}
@@ -626,7 +626,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   top: 0px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   border: none;
                   bottom: -2px;
                   left: -2px;
@@ -639,7 +639,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
@@ -651,7 +651,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
                   outline: 1px solid ButtonText;
                 }
                 &:hover {
@@ -688,7 +688,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   padding-right: 2px;
                   padding-top: 2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   color: Highlight;
                 }
             data-index={3}
@@ -805,7 +805,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   top: 0px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   border: none;
                   bottom: -2px;
                   left: -2px;
@@ -818,7 +818,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
@@ -830,7 +830,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
                   outline: 1px solid ButtonText;
                 }
                 &:hover {
@@ -867,7 +867,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   padding-right: 2px;
                   padding-top: 2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   color: Highlight;
                 }
             data-index={4}
@@ -980,7 +980,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   top: 0px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   border: none;
                   bottom: -2px;
                   left: -2px;
@@ -993,7 +993,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
@@ -1005,7 +1005,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
                   outline: 1px solid ButtonText;
                 }
                 &:hover {
@@ -1042,7 +1042,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   padding-right: 2px;
                   padding-top: 2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   color: Highlight;
                 }
             data-index={5}
@@ -1155,7 +1155,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   top: 0px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   border: none;
                   bottom: -2px;
                   left: -2px;
@@ -1168,7 +1168,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
@@ -1180,7 +1180,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
                   outline: 1px solid ButtonText;
                 }
                 &:hover {
@@ -1217,7 +1217,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   padding-right: 2px;
                   padding-top: 2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   color: Highlight;
                 }
             data-index={6}
@@ -1330,7 +1330,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   top: 0px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   border: none;
                   bottom: -2px;
                   left: -2px;
@@ -1343,7 +1343,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
@@ -1355,7 +1355,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
                   outline: 1px solid ButtonText;
                 }
                 &:hover {
@@ -1392,7 +1392,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   padding-right: 2px;
                   padding-top: 2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   color: Highlight;
                 }
             data-index={7}
@@ -1509,7 +1509,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   top: 0px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   border: none;
                   bottom: -2px;
                   left: -2px;
@@ -1522,7 +1522,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
@@ -1534,7 +1534,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
                   outline: 1px solid ButtonText;
                 }
                 &:hover {
@@ -1571,7 +1571,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   padding-right: 2px;
                   padding-top: 2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   color: Highlight;
                 }
             data-index={8}
@@ -1684,7 +1684,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   top: 0px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   border: none;
                   bottom: -2px;
                   left: -2px;
@@ -1697,7 +1697,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
@@ -1709,7 +1709,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
                   outline: 1px solid ButtonText;
                 }
                 &:hover {
@@ -1746,7 +1746,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   padding-right: 2px;
                   padding-top: 2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   color: Highlight;
                 }
             data-index={9}
@@ -1859,7 +1859,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   top: 0px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   border: none;
                   bottom: -2px;
                   left: -2px;
@@ -1872,7 +1872,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
@@ -1884,7 +1884,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
                   outline: 1px solid ButtonText;
                 }
                 &:hover {
@@ -1921,7 +1921,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   padding-right: 2px;
                   padding-top: 2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   color: Highlight;
                 }
             data-index={10}
@@ -2034,7 +2034,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   top: 0px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   border: none;
                   bottom: -2px;
                   left: -2px;
@@ -2047,7 +2047,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
@@ -2059,7 +2059,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   right: -2px;
                   top: -2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus::after {
                   outline: 1px solid ButtonText;
                 }
                 &:hover {
@@ -2096,7 +2096,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   padding-right: 2px;
                   padding-top: 2px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   color: Highlight;
                 }
             data-index={11}

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -212,7 +212,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   bottom: -2px;
                   left: -2px;
                   outline-color: ButtonText;
@@ -224,7 +224,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: WindowText;
                   border-color: WindowText;
@@ -237,7 +237,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   border: 1px solid #106ebe;
                   color: #005a9e;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   background-color: Highlight;
                   border-color: Highlight;
                   color: Window;
@@ -255,7 +255,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   border: 1px solid #005a9e;
                   color: #0078d4;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
                   -ms-high-contrast-adjust: none;
                   background-color: WindowText;
                   border-color: WindowText;
@@ -364,7 +364,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   bottom: -2px;
                   left: -2px;
                   outline-color: ButtonText;
@@ -381,7 +381,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   border-color: #ffffff;
                   color: #201f1e;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   border-color: Highlight;
                   color: Highlight;
                 }
@@ -504,7 +504,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -521,7 +521,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
               background: #106ebe;
               color: #ffffff;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               border-color: Highlight;
               color: Highlight;
             }

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
           width: calc(100% + 1px);
           z-index: 1000000;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
           border-color: WindowText;
           border-style: solid;
           border-width: 1px;
@@ -494,7 +494,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   bottom: -2px;
                   left: -2px;
                   outline-color: ButtonText;
@@ -506,7 +506,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: WindowText;
                   border-color: WindowText;
@@ -519,7 +519,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   border: 1px solid #106ebe;
                   color: #005a9e;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   background-color: Highlight;
                   border-color: Highlight;
                   color: Window;
@@ -537,7 +537,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   border: 1px solid #005a9e;
                   color: #0078d4;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:active {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active {
                   -ms-high-contrast-adjust: none;
                   background-color: WindowText;
                   border-color: WindowText;
@@ -646,7 +646,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   top: 1px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   bottom: -2px;
                   left: -2px;
                   outline-color: ButtonText;
@@ -663,7 +663,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   border-color: #ffffff;
                   color: #201f1e;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   border-color: Highlight;
                   color: Highlight;
                 }
@@ -786,7 +786,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
               top: 2px;
               z-index: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
               bottom: -2px;
               left: -2px;
               outline-color: ButtonText;
@@ -803,7 +803,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
               background: #106ebe;
               color: #ffffff;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               border-color: Highlight;
               color: Highlight;
             }

--- a/packages/react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`MaskedTextField renders correctly 1`] = `
           &:hover {
             border-color: #323130;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
             border-color: Highlight;
             forced-color-adjust: none;
@@ -131,7 +131,7 @@ exports[`MaskedTextField renders correctly 1`] = `
             &::-ms-clear {
               display: none;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background: Window;
               color: WindowText;
             }
@@ -139,21 +139,21 @@ exports[`MaskedTextField renders correctly 1`] = `
               color: #605e5c;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
               color: GrayText;
             }
             &:-ms-input-placeholder {
               color: #605e5c;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-input-placeholder {
               color: #605e5c;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
               color: GrayText;
             }
         id="TextField0"

--- a/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`TextField snapshots renders correctly 1`] = `
             &:hover {
               border-color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               border-color: Highlight;
               forced-color-adjust: none;
@@ -134,7 +134,7 @@ exports[`TextField snapshots renders correctly 1`] = `
               &::-ms-clear {
                 display: none;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -142,21 +142,21 @@ exports[`TextField snapshots renders correctly 1`] = `
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                 color: GrayText;
               }
               &:-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                 color: GrayText;
               }
               &::-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                 color: GrayText;
               }
           id="TextField0"
@@ -205,7 +205,7 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
           &:hover {
             border-bottom-color: #a4262c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
             border-bottom-color: Highlight;
             forced-color-adjust: none;
@@ -271,7 +271,7 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
             &:hover {
               border-color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               border-color: Highlight;
               forced-color-adjust: none;
@@ -293,7 +293,7 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
                 padding-top: 0;
                 white-space: nowrap;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -350,7 +350,7 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               &::-ms-clear {
                 display: none;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -358,21 +358,21 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                 color: GrayText;
               }
               &:-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                 color: GrayText;
               }
               &::-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                 color: GrayText;
               }
           id="TextField0"
@@ -395,7 +395,7 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
                 padding-top: 0;
                 white-space: nowrap;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -456,7 +456,7 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
           &:hover {
             border-bottom-color: #a4262c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
             border-bottom-color: Highlight;
             forced-color-adjust: none;
@@ -522,7 +522,7 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
             &:hover {
               border-color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               border-color: Highlight;
               forced-color-adjust: none;
@@ -544,7 +544,7 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
                 padding-top: 0;
                 white-space: nowrap;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -601,7 +601,7 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               &::-ms-clear {
                 display: none;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -609,21 +609,21 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                 color: GrayText;
               }
               &:-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                 color: GrayText;
               }
               &::-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                 color: GrayText;
               }
           id="TextField0"
@@ -646,7 +646,7 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
                 padding-top: 0;
                 white-space: nowrap;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -756,7 +756,7 @@ exports[`TextField snapshots renders multiline non resizable correctly 1`] = `
             &:hover {
               border-color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               border-color: Highlight;
               forced-color-adjust: none;
@@ -811,7 +811,7 @@ exports[`TextField snapshots renders multiline non resizable correctly 1`] = `
               &::-ms-clear {
                 display: none;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -819,21 +819,21 @@ exports[`TextField snapshots renders multiline non resizable correctly 1`] = `
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                 color: GrayText;
               }
               &:-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                 color: GrayText;
               }
               &::-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                 color: GrayText;
               }
           id="TextField0"
@@ -929,7 +929,7 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
             &:hover {
               border-color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               border-color: Highlight;
               forced-color-adjust: none;
@@ -982,7 +982,7 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
               &::-ms-clear {
                 display: none;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -990,21 +990,21 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                 color: GrayText;
               }
               &:-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                 color: GrayText;
               }
               &::-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                 color: GrayText;
               }
           id="TextField0"
@@ -1100,7 +1100,7 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
             &:hover {
               border-color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               border-color: Highlight;
               forced-color-adjust: none;
@@ -1153,7 +1153,7 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
               &::-ms-clear {
                 display: none;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -1161,21 +1161,21 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                 color: GrayText;
               }
               &:-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                 color: GrayText;
               }
               &::-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                 color: GrayText;
               }
           id="TextField0"
@@ -1241,7 +1241,7 @@ exports[`TextField snapshots renders with reveal password button 1`] = `
             &:hover {
               border-color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               border-color: Highlight;
               forced-color-adjust: none;
@@ -1289,7 +1289,7 @@ exports[`TextField snapshots renders with reveal password button 1`] = `
               &::-ms-clear {
                 display: none;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -1297,21 +1297,21 @@ exports[`TextField snapshots renders with reveal password button 1`] = `
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                 color: GrayText;
               }
               &:-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                 color: GrayText;
               }
               &::-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                 color: GrayText;
               }
           id="TextField0"
@@ -1356,7 +1356,7 @@ exports[`TextField snapshots renders with reveal password button 1`] = `
                 color: #106ebe;
                 outline: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 border-color: Highlight;
                 color: Highlight;
               }
@@ -1446,7 +1446,7 @@ exports[`TextField snapshots should respect user component and subcomponent styl
           &:hover {
             border-bottom-color: #a4262c;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             -ms-high-contrast-adjust: none;
             border-bottom-color: Highlight;
             forced-color-adjust: none;
@@ -1513,7 +1513,7 @@ exports[`TextField snapshots should respect user component and subcomponent styl
             &:hover {
               border-color: #323130;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
               -ms-high-contrast-adjust: none;
               border-color: Highlight;
               forced-color-adjust: none;
@@ -1535,7 +1535,7 @@ exports[`TextField snapshots should respect user component and subcomponent styl
                 padding-top: 0;
                 white-space: nowrap;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -1592,7 +1592,7 @@ exports[`TextField snapshots should respect user component and subcomponent styl
               &::-ms-clear {
                 display: none;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }
@@ -1600,21 +1600,21 @@ exports[`TextField snapshots should respect user component and subcomponent styl
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
                 color: GrayText;
               }
               &:-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
                 color: GrayText;
               }
               &::-ms-input-placeholder {
                 color: #605e5c;
                 opacity: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                 color: GrayText;
               }
           id="TextField0"
@@ -1637,7 +1637,7 @@ exports[`TextField snapshots should respect user component and subcomponent styl
                 padding-top: 0;
                 white-space: nowrap;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
               }

--- a/packages/react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -67,10 +67,10 @@ exports[`Toggle renders hidden toggle correctly 1`] = `
           &:hover .ms-Toggle-thumb {
             background-color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Toggle-thumb {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Toggle-thumb {
             border-color: Highlight;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             border-color: Highlight;
           }
       data-is-focusable={true}
@@ -199,10 +199,10 @@ exports[`Toggle renders toggle correctly 1`] = `
           &:hover .ms-Toggle-thumb {
             background-color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Toggle-thumb {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Toggle-thumb {
             border-color: Highlight;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             border-color: Highlight;
           }
       data-is-focusable={true}
@@ -336,10 +336,10 @@ exports[`Toggle renders toggle correctly with inline label (JSX Element) 1`] = `
           &:hover .ms-Toggle-thumb {
             background-color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Toggle-thumb {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Toggle-thumb {
             border-color: Highlight;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             border-color: Highlight;
           }
       data-is-focusable={true}
@@ -471,10 +471,10 @@ exports[`Toggle renders toggle correctly with inline label (string) 1`] = `
           &:hover .ms-Toggle-thumb {
             background-color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Toggle-thumb {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Toggle-thumb {
             border-color: Highlight;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             border-color: Highlight;
           }
       data-is-focusable={true}
@@ -605,10 +605,10 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
           &:hover .ms-Toggle-thumb {
             background-color: #201f1e;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover .ms-Toggle-thumb {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Toggle-thumb {
             border-color: Highlight;
           }
-          @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
             border-color: Highlight;
           }
       data-is-focusable={true}

--- a/packages/react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
               outline: transparent;
               position: absolute;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               border-color: WindowText;
               border-style: solid;
               border-width: 1px;

--- a/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
+++ b/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
@@ -187,7 +187,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -197,7 +197,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -205,12 +205,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -263,7 +263,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -273,7 +273,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -281,12 +281,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -339,7 +339,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -349,7 +349,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -357,12 +357,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -415,7 +415,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -425,7 +425,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -433,12 +433,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -491,7 +491,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -501,7 +501,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -509,12 +509,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -567,7 +567,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -577,7 +577,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -585,12 +585,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -643,7 +643,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -653,7 +653,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -661,12 +661,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -735,7 +735,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -745,7 +745,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -753,12 +753,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -847,7 +847,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -857,7 +857,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -865,12 +865,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -959,7 +959,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -969,7 +969,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -977,12 +977,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -1071,7 +1071,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -1081,7 +1081,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -1089,12 +1089,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -1183,7 +1183,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -1193,7 +1193,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -1201,12 +1201,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -1295,7 +1295,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -1305,7 +1305,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -1313,12 +1313,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -1407,7 +1407,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -1417,7 +1417,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -1425,12 +1425,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -1524,7 +1524,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -1534,7 +1534,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -1542,12 +1542,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -1664,7 +1664,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -1674,7 +1674,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -1682,12 +1682,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -1804,7 +1804,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -1814,7 +1814,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -1822,12 +1822,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -1944,7 +1944,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -1954,7 +1954,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -1962,12 +1962,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -2085,7 +2085,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -2095,7 +2095,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -2103,12 +2103,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -2150,25 +2150,25 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &:hover {
                   background-color: #edebe9!important;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   background: Highlight!important;
                   color: HighlightText!important;
                 }
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #edebe9!important;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background: Highlight!important;
                   color: HighlightText!important;
                 }
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9!important;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background: Highlight!important;
                   color: HighlightText!important;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background: Highlight!important;
                   border-color: Highlight!important;
@@ -2216,7 +2216,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                     color: #ffffff!important;
                     font-weight: 600!important;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     -ms-high-contrast-adjust: none;
                     background: WindowText!important;
                     border-color: WindowText!important;
@@ -2275,7 +2275,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -2285,7 +2285,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -2293,12 +2293,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -2411,7 +2411,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -2421,7 +2421,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -2429,12 +2429,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -2563,7 +2563,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -2573,7 +2573,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -2581,12 +2581,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -2671,7 +2671,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -2681,7 +2681,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -2689,12 +2689,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -2779,7 +2779,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -2789,7 +2789,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -2797,12 +2797,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -2887,7 +2887,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -2897,7 +2897,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -2905,12 +2905,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -2995,7 +2995,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -3005,7 +3005,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -3013,12 +3013,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -3103,7 +3103,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -3113,7 +3113,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -3121,12 +3121,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -3211,7 +3211,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -3221,7 +3221,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -3229,12 +3229,12 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -3564,7 +3564,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -3574,7 +3574,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -3582,12 +3582,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -3640,7 +3640,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -3650,7 +3650,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -3658,12 +3658,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -3716,7 +3716,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -3726,7 +3726,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -3734,12 +3734,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -3792,7 +3792,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -3802,7 +3802,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -3810,12 +3810,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -3868,7 +3868,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -3878,7 +3878,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -3886,12 +3886,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -3944,7 +3944,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -3954,7 +3954,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -3962,12 +3962,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -4020,7 +4020,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -4030,7 +4030,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -4038,12 +4038,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -4112,7 +4112,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -4122,7 +4122,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -4130,12 +4130,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -4224,7 +4224,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -4234,7 +4234,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -4242,12 +4242,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -4336,7 +4336,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -4346,7 +4346,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -4354,12 +4354,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -4448,7 +4448,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -4458,7 +4458,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -4466,12 +4466,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -4560,7 +4560,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -4570,7 +4570,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -4578,12 +4578,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -4672,7 +4672,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -4682,7 +4682,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -4690,12 +4690,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -4784,7 +4784,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -4794,7 +4794,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -4802,12 +4802,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -4901,7 +4901,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -4911,7 +4911,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -4919,12 +4919,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -5041,7 +5041,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -5051,7 +5051,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -5059,12 +5059,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -5182,7 +5182,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -5192,7 +5192,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -5200,12 +5200,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -5247,25 +5247,25 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &:hover {
                   background-color: #edebe9!important;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   background: Highlight!important;
                   color: HighlightText!important;
                 }
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #edebe9!important;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background: Highlight!important;
                   color: HighlightText!important;
                 }
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9!important;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background: Highlight!important;
                   color: HighlightText!important;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background: Highlight!important;
                   border-color: Highlight!important;
@@ -5313,7 +5313,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                     color: #ffffff!important;
                     font-weight: 600!important;
                   }
-                  @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                     -ms-high-contrast-adjust: none;
                     background: WindowText!important;
                     border-color: WindowText!important;
@@ -5372,7 +5372,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -5382,7 +5382,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -5390,12 +5390,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -5508,7 +5508,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -5518,7 +5518,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -5526,12 +5526,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -5644,7 +5644,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -5654,7 +5654,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -5662,12 +5662,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -5780,7 +5780,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -5790,7 +5790,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -5798,12 +5798,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -5932,7 +5932,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -5942,7 +5942,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -5950,12 +5950,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -6040,7 +6040,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -6050,7 +6050,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -6058,12 +6058,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -6148,7 +6148,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -6158,7 +6158,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -6166,12 +6166,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -6256,7 +6256,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -6266,7 +6266,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -6274,12 +6274,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -6364,7 +6364,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -6374,7 +6374,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -6382,12 +6382,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -6472,7 +6472,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -6482,7 +6482,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -6490,12 +6490,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }
@@ -6580,7 +6580,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   top: -2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   -ms-high-contrast-adjust: none;
                   background-color: Window;
                   color: WindowText;
@@ -6590,7 +6590,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-hoverStyle {
                   background-color: #f3f2f1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                   z-index: 3;
@@ -6598,12 +6598,12 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                 &.ms-CalendarDay-pressedStyle {
                   background-color: #edebe9;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle {
                   background-color: Window;
                   border-color: Highlight;
                   color: Highlight;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
                   background-color: Window;
                   outline: 1px solid Highlight;
                 }

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`PeoplePicker renders correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
               color: GrayText;
             }
             &:-ms-input-placeholder {
@@ -117,7 +117,7 @@ exports[`PeoplePicker renders correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-input-placeholder {
@@ -129,7 +129,7 @@ exports[`PeoplePicker renders correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
               color: GrayText;
             }
         data-lpignore={true}
@@ -272,7 +272,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
               &:hover {
                 background: #edebe9;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
               }
           role="listitem"
@@ -412,7 +412,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                           top: auto;
                           width: 8px;
                         }
-                        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           background-color: Highlight;
                           border-color: Window;
                         }
@@ -679,7 +679,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                   top: 2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   bottom: -2px;
                   left: -2px;
                   outline-color: ButtonText;
@@ -696,7 +696,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                   background: #c8c6c4;
                   color: #201f1e;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   border-color: Highlight;
                   color: Highlight;
                 }
@@ -807,7 +807,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
               font-weight: 400;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
               color: GrayText;
             }
             &:-ms-input-placeholder {
@@ -819,7 +819,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
               font-weight: 400;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-input-placeholder {
@@ -831,7 +831,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
               font-weight: 400;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
               color: GrayText;
             }
         data-lpignore={true}

--- a/packages/react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -111,7 +111,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 border-color: Window;
@@ -122,7 +122,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 background: #c8c6c4;
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -238,7 +238,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -250,14 +250,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -373,7 +373,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -385,14 +385,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -508,7 +508,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -520,14 +520,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -643,7 +643,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -655,14 +655,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -778,7 +778,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -790,14 +790,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -913,7 +913,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -925,14 +925,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -1048,7 +1048,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -1060,14 +1060,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -1183,7 +1183,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -1195,14 +1195,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -1318,7 +1318,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -1330,14 +1330,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -1453,7 +1453,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -1465,14 +1465,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -1588,7 +1588,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -1600,14 +1600,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -1723,7 +1723,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -1735,14 +1735,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -1858,7 +1858,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -1870,14 +1870,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -1993,7 +1993,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -2005,14 +2005,14 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -2173,7 +2173,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -2185,7 +2185,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 border-color: Window;
@@ -2196,7 +2196,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 background: #c8c6c4;
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -2312,7 +2312,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -2324,14 +2324,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -2447,7 +2447,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -2459,14 +2459,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -2582,7 +2582,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -2594,14 +2594,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -2717,7 +2717,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -2729,14 +2729,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -2852,7 +2852,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -2864,14 +2864,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -2987,7 +2987,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -2999,14 +2999,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -3122,7 +3122,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -3134,14 +3134,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -3257,7 +3257,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -3269,14 +3269,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -3392,7 +3392,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -3404,14 +3404,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -3527,7 +3527,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -3539,14 +3539,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -3662,7 +3662,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -3674,14 +3674,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -3797,7 +3797,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -3809,14 +3809,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -3932,7 +3932,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -3944,14 +3944,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -4067,7 +4067,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -4079,14 +4079,14 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -4220,7 +4220,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -4232,14 +4232,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -4355,7 +4355,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -4367,14 +4367,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -4490,7 +4490,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -4502,14 +4502,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -4625,7 +4625,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -4637,14 +4637,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -4760,7 +4760,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -4772,14 +4772,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -4895,7 +4895,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -4907,14 +4907,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -5030,7 +5030,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -5042,14 +5042,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -5165,7 +5165,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -5177,14 +5177,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -5316,7 +5316,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -5328,7 +5328,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 border-color: Window;
@@ -5339,7 +5339,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 background: #c8c6c4;
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -5455,7 +5455,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -5467,14 +5467,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -5590,7 +5590,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -5602,14 +5602,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -5725,7 +5725,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -5737,14 +5737,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -5860,7 +5860,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -5872,14 +5872,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -5995,7 +5995,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -6007,14 +6007,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
@@ -6130,7 +6130,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 top: 2px;
                 z-index: 1;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                 bottom: -2px;
                 left: -2px;
                 outline-color: ButtonText;
@@ -6142,14 +6142,14 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: relative;
                 top: 0px;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border-color: Window;
                 color: WindowText;
               }
               &:hover {
                 color: #201f1e;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`TagItem accepts title override 1`] = `
         background: #0078d4;
         color: #ffffff;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border: 1px solid WindowText;
       }
   role="listitem"
@@ -124,7 +124,7 @@ exports[`TagItem accepts title override 1`] = `
           top: 2px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           bottom: -2px;
           left: -2px;
           outline-color: ButtonText;
@@ -141,7 +141,7 @@ exports[`TagItem accepts title override 1`] = `
           background: #e1dfdd;
           color: #323130;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           border-color: Highlight;
           color: Highlight;
         }
@@ -276,7 +276,7 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
         background: #0078d4;
         color: #ffffff;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border: 1px solid WindowText;
       }
   role="listitem"
@@ -369,7 +369,7 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
           top: 2px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           bottom: -2px;
           left: -2px;
           outline-color: ButtonText;
@@ -386,7 +386,7 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
           background: #e1dfdd;
           color: #323130;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           border-color: Highlight;
           color: Highlight;
         }
@@ -521,7 +521,7 @@ exports[`TagItem renders correctly 1`] = `
         background: #0078d4;
         color: #ffffff;
       }
-      @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+      @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border: 1px solid WindowText;
       }
   role="listitem"
@@ -590,7 +590,7 @@ exports[`TagItem renders correctly 1`] = `
           top: 2px;
           z-index: 1;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
           bottom: -2px;
           left: -2px;
           outline-color: ButtonText;
@@ -607,7 +607,7 @@ exports[`TagItem renders correctly 1`] = `
           background: #e1dfdd;
           color: #323130;
         }
-        @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
           border-color: Highlight;
           color: Highlight;
         }

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`TagPicker renders correctly 1`] = `
                 background: #0078d4;
                 color: #ffffff;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
               }
           role="listitem"
@@ -201,7 +201,7 @@ exports[`TagPicker renders correctly 1`] = `
                   top: 2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   bottom: -2px;
                   left: -2px;
                   outline-color: ButtonText;
@@ -218,7 +218,7 @@ exports[`TagPicker renders correctly 1`] = `
                   background: #e1dfdd;
                   color: #323130;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   border-color: Highlight;
                   color: Highlight;
                 }
@@ -337,7 +337,7 @@ exports[`TagPicker renders correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
               color: GrayText;
             }
             &:-ms-input-placeholder {
@@ -349,7 +349,7 @@ exports[`TagPicker renders correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-input-placeholder {
@@ -361,7 +361,7 @@ exports[`TagPicker renders correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
               color: GrayText;
             }
         data-lpignore={true}
@@ -521,7 +521,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                 background: #0078d4;
                 color: #ffffff;
               }
-              @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){& {
+              @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
               }
           role="listitem"
@@ -590,7 +590,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                   top: 2px;
                   z-index: 1;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                   bottom: -2px;
                   left: -2px;
                   outline-color: ButtonText;
@@ -607,7 +607,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                   background: #e1dfdd;
                   color: #323130;
                 }
-                @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:hover {
+                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
                   border-color: Highlight;
                   color: Highlight;
                 }
@@ -726,7 +726,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::placeholder {
               color: GrayText;
             }
             &:-ms-input-placeholder {
@@ -738,7 +738,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&:-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:-ms-input-placeholder {
               color: GrayText;
             }
             &::-ms-input-placeholder {
@@ -750,7 +750,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
-            @media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active){&::-ms-input-placeholder {
+            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
               color: GrayText;
             }
         data-lpignore={true}

--- a/packages/style-utilities/etc/style-utilities.api.md
+++ b/packages/style-utilities/etc/style-utilities.api.md
@@ -79,7 +79,7 @@ export { DefaultFontStyles }
 export { DefaultPalette }
 
 // @public @deprecated (undocumented)
-export const EdgeChromiumHighContrastSelector = "@media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active)";
+export const EdgeChromiumHighContrastSelector = "@media screen and (-ms-high-contrast: active), screen and (forced-colors: active)";
 
 // @public
 export function focusClear(): IRawStyle;
@@ -148,13 +148,13 @@ export type GlobalClassNames<IStyles> = Record<keyof IStyles, string>;
 export const hiddenContentStyle: IRawStyle;
 
 // @public (undocumented)
-export const HighContrastSelector = "@media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active)";
+export const HighContrastSelector = "@media screen and (-ms-high-contrast: active), screen and (forced-colors: active)";
 
 // @public (undocumented)
-export const HighContrastSelectorBlack = "@media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark)";
+export const HighContrastSelectorBlack = "@media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark)";
 
 // @public (undocumented)
-export const HighContrastSelectorWhite = "@media screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light)";
+export const HighContrastSelectorWhite = "@media screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light)";
 
 export { IAnimationStyles }
 

--- a/packages/style-utilities/src/styles/CommonStyles.ts
+++ b/packages/style-utilities/src/styles/CommonStyles.ts
@@ -1,18 +1,17 @@
 import type { IRawStyle } from '../MergeStyles';
 
-export const HighContrastSelector =
-  '@media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active)';
+export const HighContrastSelector = '@media screen and (-ms-high-contrast: active), screen and (forced-colors: active)';
 export const HighContrastSelectorWhite =
   // eslint-disable-next-line @fluentui/max-len
-  '@media screen and (-ms-high-contrast: black-on-white), @media screen and (forced-colors: active) and (prefers-color-scheme: light)';
+  '@media screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light)';
 export const HighContrastSelectorBlack =
   // eslint-disable-next-line @fluentui/max-len
-  '@media screen and (-ms-high-contrast: white-on-black), @media screen and (forced-colors: active) and (prefers-color-scheme: dark)';
+  '@media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark)';
 /**
  * @deprecated Use `HighContrastSelector`
  */
 export const EdgeChromiumHighContrastSelector =
-  '@media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active)';
+  '@media screen and (-ms-high-contrast: active), screen and (forced-colors: active)';
 
 export const ScreenWidthMinSmall = 320;
 export const ScreenWidthMinMedium = 480;


### PR DESCRIPTION
fixes #23716

selectors with multiple media queries do not need to duplicate @media

  ``` 
@media screen and (-ms-high-contrast: active), screen and (forced-colors: active) {
  .cs {color: green }
}

not

@media screen and (-ms-high-contrast: active), @media screen and (forced-colors: active) {
  .cs {color: green }
}
```