### PR TITLE
Theme designer: minor fixes

### DIFF
--- a/packages/react-components/theme-designer/src/components/AccessibilityChecker/AccessibilityChecker.stories.tsx
+++ b/packages/react-components/theme-designer/src/components/AccessibilityChecker/AccessibilityChecker.stories.tsx
@@ -1,9 +1,9 @@
 import { AccessibilityChecker } from './AccessibilityChecker';
 import { getBrandTokensFromPalette } from '../../utils/getBrandTokensFromPalette';
-import { createDarkTheme } from '@fluentui/react-components';
+import { createLightTheme } from '@fluentui/react-components';
 export default { component: AccessibilityChecker };
 
 const brand = getBrandTokensFromPalette('#006bc7');
-const lightTheme = createDarkTheme(brand);
+const lightTheme = createLightTheme(brand);
 
 export const Default = { args: { theme: lightTheme } };

--- a/packages/react-components/theme-designer/src/components/ColorTokens/ColorTokens.stories.tsx
+++ b/packages/react-components/theme-designer/src/components/ColorTokens/ColorTokens.stories.tsx
@@ -1,9 +1,7 @@
 import { ColorTokens } from './ColorTokens';
 import { getBrandTokensFromPalette } from '../../utils/getBrandTokensFromPalette';
-import { createDarkTheme } from '@fluentui/react-components';
 export default { component: ColorTokens };
 
 const brand = getBrandTokensFromPalette('#006bc7');
-const lightTheme = createDarkTheme(brand);
 
-export const Default = { args: { theme: lightTheme } };
+export const Default = { args: { brand: brand, isDark: false } };

--- a/packages/react-components/theme-designer/src/components/Content/Content.stories.tsx
+++ b/packages/react-components/theme-designer/src/components/Content/Content.stories.tsx
@@ -1,10 +1,9 @@
 import { Content } from './Content';
 import { getBrandTokensFromPalette } from '../../utils/getBrandTokensFromPalette';
-import { createLightTheme, createDarkTheme } from '@fluentui/react-components';
+import { createLightTheme } from '@fluentui/react-components';
 export default { component: Content };
 
 const brand = getBrandTokensFromPalette('#006BC7');
 const lightTheme = createLightTheme(brand);
-const darkTheme = createDarkTheme(brand);
 
-export const Default = { args: { brand: brand, darkTheme: darkTheme, lightTheme: lightTheme } };
+export const Default = { args: { brand: brand, theme: lightTheme, isDark: false } };

--- a/packages/react-components/theme-designer/src/components/ExportButton/ExportLink.tsx
+++ b/packages/react-components/theme-designer/src/components/ExportButton/ExportLink.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link, BrandVariants, Theme, createDarkTheme, createLightTheme } from '@fluentui/react-components';
+import { Link, BrandVariants, Theme } from '@fluentui/react-components';
 import { getParameters } from 'codesandbox-import-utils/lib/api/define';
 import * as dedent from 'dedent';
 
@@ -248,7 +248,7 @@ export const Example: React.FC<ContentProps> = props => {
 
 const indexHtmlContent = '<div id="root"></div>';
 
-const createIndexContent = (brand: BrandVariants, overrides: Theme, isDark: boolean) => dedent`
+const createIndexContent = (brand: BrandVariants, overrides: Partial<Theme>, isDark: boolean) => dedent`
 import * as ReactDOM from 'react-dom';
 import { FluentProvider, ${isDark ? 'createDarkTheme' : 'createLightTheme'} } from '@fluentui/react-components';
 import type { BrandVariants, Theme } from '@fluentui/react-theme';
@@ -278,7 +278,6 @@ export const ExportLink: React.FC<ExportLinkProps> = props => {
   const { brand, isDark, overrides } = props;
 
   const link = React.useMemo(() => {
-    const theme = isDark ? createDarkTheme(brand) : createLightTheme(brand);
     const codeSandboxParameters = getParameters({
       files: {
         'example.tsx': {
@@ -291,7 +290,7 @@ export const ExportLink: React.FC<ExportLinkProps> = props => {
         },
         'index.tsx': {
           isBinary: false,
-          content: createIndexContent(brand, { ...theme, ...overrides }, isDark),
+          content: createIndexContent(brand, overrides, isDark),
         },
         'package.json': {
           isBinary: false,

--- a/packages/react-components/theme-designer/src/components/ExportButton/ExportLink.tsx
+++ b/packages/react-components/theme-designer/src/components/ExportButton/ExportLink.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link, BrandVariants, Theme } from '@fluentui/react-components';
+import { Link, BrandVariants, Theme, createDarkTheme, createLightTheme } from '@fluentui/react-components';
 import { getParameters } from 'codesandbox-import-utils/lib/api/define';
 import * as dedent from 'dedent';
 
@@ -9,288 +9,299 @@ export interface ExportLinkProps {
   overrides: Partial<Theme>;
 }
 
+const content = dedent`
+import * as React from 'react';
+import { makeStyles, makeStaticStyles, mergeClasses, shorthands } from '@griffel/react';
+import {
+  tokens,
+  Body1,
+  Title3,
+  TabList,
+  Tab,
+  Input,
+  Button,
+  Caption1,
+  Menu,
+  MenuTrigger,
+  MenuList,
+  MenuButton,
+  MenuItemCheckbox,
+  MenuPopover,
+  Slider,
+  Badge,
+  Switch,
+  Radio,
+  RadioGroup,
+  Checkbox,
+  Avatar,
+  Theme,
+} from '@fluentui/react-components';
+import {
+  SearchRegular,
+  bundleIcon,
+  CutRegular,
+  CutFilled,
+  ClipboardPasteRegular,
+  ClipboardPasteFilled,
+  EditRegular,
+  EditFilled,
+  ChevronRightRegular,
+  MeetNowRegular,
+  MeetNowFilled,
+  CalendarLtrFilled,
+  CalendarLtrRegular,
+} from '@fluentui/react-icons';
+
+export interface ContentProps {
+  className?: string;
+  theme: Theme;
+}
+
+const useStaticStyles = makeStaticStyles({
+  body: {
+    position: "fixed",
+    margin: "0px",
+    top: "0px",
+    left: "0px",
+    height: "100vh"
+  }
+});
+
+const useStyles = makeStyles({
+  root: {
+    height: "100vh",
+    display: 'grid',
+    alignItems: 'start',
+    justifyContent: 'center',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gridTemplateRows: 'auto',
+    gridColumnGap: tokens.spacingHorizontalXXXL,
+  },
+  col1: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'left',
+    flexDirection: 'column',
+    flexGrow: 1,
+    ...shorthands.gap(tokens.spacingVerticalL),
+  },
+  col2: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    ...shorthands.gap(tokens.spacingVerticalL),
+  },
+  col3: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gridTemplateRows: 'repeat(4, auto)',
+    gridRowGap: tokens.spacingVerticalS,
+    gridColumnGap: tokens.spacingHorizontalS,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  twoCol: {
+    gridColumnStart: 1,
+    gridColumnEnd: 3,
+  },
+  icons: {
+    display: 'grid',
+    gridTemplateColumns: 'auto auto',
+    gridTemplateRows: 'auto auto',
+    gridRowGap: tokens.spacingVerticalS,
+    gridColumnGap: tokens.spacingHorizontalS,
+    justifyContent: 'center',
+  },
+  twoRow: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export const Column1 = () => {
+  const styles = useStyles();
+  useStaticStyles();
+  return (
+    <div className={styles.col1}>
+      <Title3 block>Make an impression</Title3>
+      <Body1 block>
+        Make a big impression with this clean, modern, and mobile-friendly site. Use it to communicate
+        information to people inside or outside your team. Share your ideas, results, and more in this
+        visually compelling format.
+      </Body1>
+      <Avatar
+        color="brand"
+        initials="DF"
+        badge={{
+          status: 'available',
+          'aria-label': 'available',
+        }}
+      />
+    </div>
+  );
+};
+
+export const DemoMenu = () => {
+  const CutIcon = bundleIcon(CutFilled, CutRegular);
+  const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);
+  const EditIcon = bundleIcon(EditFilled, EditRegular);
+  return (
+    <Menu>
+      <MenuTrigger>
+        <MenuButton>Select </MenuButton>
+      </MenuTrigger>
+      <MenuPopover>
+        <MenuList>
+          <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut">
+            Cut
+          </MenuItemCheckbox>
+          <MenuItemCheckbox icon={<PasteIcon />} name="edit" value="paste">
+            Paste
+          </MenuItemCheckbox>
+          <MenuItemCheckbox icon={<EditIcon />} name="edit" value="edit">
+            Edit
+          </MenuItemCheckbox>
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+};
+
+export const Column2 = () => {
+  const styles = useStyles();
+  return (
+    <div className={styles.col2}>
+      <TabList defaultSelectedValue="tab1">
+        <Tab value="tab1">Home</Tab>
+        <Tab value="tab2">Pages</Tab>
+        <Tab value="tab3">Documents</Tab>
+      </TabList>
+      <Input
+        placeholder="Find"
+        contentAfter={
+          <Button aria-label="Find" appearance="transparent" icon={<SearchRegular />} size="small" />
+        }
+      />
+      <DemoMenu />
+    </div>
+  );
+};
+
+export const DemoIcons = () => {
+  const styles = useStyles();
+  const MeetNowIcon = bundleIcon(MeetNowFilled, MeetNowRegular);
+  const CalendarLtrIcon = bundleIcon(CalendarLtrFilled, CalendarLtrRegular);
+  return (
+    <div className={styles.icons}>
+      <Badge size="medium" appearance="filled" icon={<CalendarLtrIcon />} />
+      <Badge size="medium" appearance="ghost" icon={<CalendarLtrIcon />} />
+      <Badge size="medium" appearance="outline" icon={<MeetNowIcon />} />
+      <Badge size="medium" appearance="tint" icon={<MeetNowIcon />} />
+    </div>
+  );
+};
+
+export const Column3 = () => {
+  const styles = useStyles();
+  return (
+    <div className={styles.col3}>
+      <Button appearance="primary">Sign Up</Button>
+      <Button appearance="transparent" icon={<ChevronRightRegular />} iconPosition="after">
+        Learn More
+      </Button>
+      <Slider className={styles.twoCol} defaultValue={20} />
+      <DemoIcons />
+      <div className={styles.twoRow}>
+        <Switch defaultChecked={true} label="On" />
+        <Switch label="Off" />
+      </div>
+      <div className={styles.twoRow}>
+        <Checkbox defaultChecked={true} label="Option 1" />
+        <Checkbox label="Option 2" />
+      </div>
+      <div className={styles.twoRow}>
+        <RadioGroup>
+          <Radio defaultChecked={true} label="Option 1" />
+          <Radio label="Option 2" />
+        </RadioGroup>
+      </div>
+    </div>
+  );
+};
+
+export const Example: React.FC<ContentProps> = props => {
+  const styles = useStyles();
+  return (
+    <div>
+      <Caption1>Examples</Caption1>
+      <div className={mergeClasses(styles.root, props.className)}>
+        <Column1 />
+        <Column2 />
+        <Column3 />
+      </div>
+    </div>
+  );
+};
+`;
+
+const indexHtmlContent = '<div id="root"></div>';
+
+const createIndexContent = (brand: BrandVariants, overrides: Theme, isDark: boolean) => dedent`
+import * as ReactDOM from 'react-dom';
+import { FluentProvider, ${isDark ? 'createDarkTheme' : 'createLightTheme'} } from '@fluentui/react-components';
+import type { BrandVariants, Theme } from '@fluentui/react-theme';
+import { Example } from './example';
+
+const brand: BrandVariants = ${JSON.stringify(brand)};
+
+const overrides: Partial<Theme> = ${JSON.stringify(overrides)};
+
+const theme: Theme = { ...${isDark ? 'createDarkTheme' : 'createLightTheme'}(brand), ...overrides };
+
+ReactDOM.render(
+    <FluentProvider theme={theme}>
+        <Example />
+    </FluentProvider>,
+    document.getElementById('root'),
+);
+`;
+
+const packageContent = dedent`
+{"dependencies":{"@fluentui/react-components":"rc","react":"^17","react-dom":"^17","react-scripts":"latest"}}
+`;
+
+const defaultFileToPreview = encodeURIComponent('/index.tsx');
+
 export const ExportLink: React.FC<ExportLinkProps> = props => {
   const { brand, isDark, overrides } = props;
-  const defaultFileToPreview = encodeURIComponent('/index.tsx');
-  const codeSandboxParameters = getParameters({
-    files: {
-      'example.tsx': {
-        isBinary: false,
-        content: dedent`
-          import * as React from 'react';
-          import { makeStyles, makeStaticStyles, mergeClasses, shorthands } from '@griffel/react';
-          import {
-            tokens,
-            Body1,
-            Title3,
-            TabList,
-            Tab,
-            Input,
-            Button,
-            Caption1,
-            Menu,
-            MenuTrigger,
-            MenuList,
-            MenuButton,
-            MenuItemCheckbox,
-            MenuPopover,
-            Slider,
-            Badge,
-            Switch,
-            Radio,
-            RadioGroup,
-            Checkbox,
-            Avatar,
-            Theme,
-          } from '@fluentui/react-components';
-          import {
-            SearchRegular,
-            bundleIcon,
-            CutRegular,
-            CutFilled,
-            ClipboardPasteRegular,
-            ClipboardPasteFilled,
-            EditRegular,
-            EditFilled,
-            ChevronRightRegular,
-            MeetNowRegular,
-            MeetNowFilled,
-            CalendarLtrFilled,
-            CalendarLtrRegular,
-          } from '@fluentui/react-icons';
 
-          export interface ContentProps {
-            className?: string;
-            theme: Theme;
-          }
-
-          const useStaticStyles = makeStaticStyles({
-            body: {
-              position: "fixed",
-              margin: "0px",
-              top: "0px",
-              left: "0px",
-              height: "100vh"
-            }
-          });
-
-          const useStyles = makeStyles({
-            root: {
-              height: "100vh",
-              display: 'grid',
-              alignItems: 'start',
-              justifyContent: 'center',
-              gridTemplateColumns: 'repeat(3, 1fr)',
-              gridTemplateRows: 'auto',
-              gridColumnGap: tokens.spacingHorizontalXXXL,
-            },
-            col1: {
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'left',
-              flexDirection: 'column',
-              flexGrow: 1,
-              ...shorthands.gap(tokens.spacingVerticalL),
-            },
-            col2: {
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              ...shorthands.gap(tokens.spacingVerticalL),
-            },
-            col3: {
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
-              gridTemplateRows: 'repeat(4, auto)',
-              gridRowGap: tokens.spacingVerticalS,
-              gridColumnGap: tokens.spacingHorizontalS,
-              justifyContent: 'center',
-              alignItems: 'center',
-            },
-            twoCol: {
-              gridColumnStart: 1,
-              gridColumnEnd: 3,
-            },
-            icons: {
-              display: 'grid',
-              gridTemplateColumns: 'auto auto',
-              gridTemplateRows: 'auto auto',
-              gridRowGap: tokens.spacingVerticalS,
-              gridColumnGap: tokens.spacingHorizontalS,
-              justifyContent: 'center',
-            },
-            twoRow: {
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-            },
-          });
-
-          export const Column1 = () => {
-            const styles = useStyles();
-            useStaticStyles();
-            return (
-              <div className={styles.col1}>
-                <Title3 block>Make an impression</Title3>
-                <Body1 block>
-                  Make a big impression with this clean, modern, and mobile-friendly site. Use it to communicate
-                  information to people inside or outside your team. Share your ideas, results, and more in this
-                  visually compelling format.
-                </Body1>
-                <Avatar
-                  color="brand"
-                  initials="DF"
-                  badge={{
-                    status: 'available',
-                    'aria-label': 'available',
-                  }}
-                />
-              </div>
-            );
-          };
-
-          export const DemoMenu = () => {
-            const CutIcon = bundleIcon(CutFilled, CutRegular);
-            const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);
-            const EditIcon = bundleIcon(EditFilled, EditRegular);
-            return (
-              <Menu>
-                <MenuTrigger>
-                  <MenuButton>Select </MenuButton>
-                </MenuTrigger>
-                <MenuPopover>
-                  <MenuList>
-                    <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut">
-                      Cut
-                    </MenuItemCheckbox>
-                    <MenuItemCheckbox icon={<PasteIcon />} name="edit" value="paste">
-                      Paste
-                    </MenuItemCheckbox>
-                    <MenuItemCheckbox icon={<EditIcon />} name="edit" value="edit">
-                      Edit
-                    </MenuItemCheckbox>
-                  </MenuList>
-                </MenuPopover>
-              </Menu>
-            );
-          };
-
-          export const Column2 = () => {
-            const styles = useStyles();
-            return (
-              <div className={styles.col2}>
-                <TabList defaultSelectedValue="tab1">
-                  <Tab value="tab1">Home</Tab>
-                  <Tab value="tab2">Pages</Tab>
-                  <Tab value="tab3">Documents</Tab>
-                </TabList>
-                <Input
-                  placeholder="Find"
-                  contentAfter={
-                    <Button aria-label="Find" appearance="transparent" icon={<SearchRegular />} size="small" />
-                  }
-                />
-                <DemoMenu />
-              </div>
-            );
-          };
-
-          export const DemoIcons = () => {
-            const styles = useStyles();
-            const MeetNowIcon = bundleIcon(MeetNowFilled, MeetNowRegular);
-            const CalendarLtrIcon = bundleIcon(CalendarLtrFilled, CalendarLtrRegular);
-            return (
-              <div className={styles.icons}>
-                <Badge size="medium" appearance="filled" icon={<CalendarLtrIcon />} />
-                <Badge size="medium" appearance="ghost" icon={<CalendarLtrIcon />} />
-                <Badge size="medium" appearance="outline" icon={<MeetNowIcon />} />
-                <Badge size="medium" appearance="tint" icon={<MeetNowIcon />} />
-              </div>
-            );
-          };
-
-          export const Column3 = () => {
-            const styles = useStyles();
-            return (
-              <div className={styles.col3}>
-                <Button appearance="primary">Sign Up</Button>
-                <Button appearance="transparent" icon={<ChevronRightRegular />} iconPosition="after">
-                  Learn More
-                </Button>
-                <Slider className={styles.twoCol} defaultValue={20} />
-                <DemoIcons />
-                <div className={styles.twoRow}>
-                  <Switch defaultChecked={true} label="On" />
-                  <Switch label="Off" />
-                </div>
-                <div className={styles.twoRow}>
-                  <Checkbox defaultChecked={true} label="Option 1" />
-                  <Checkbox label="Option 2" />
-                </div>
-                <div className={styles.twoRow}>
-                  <RadioGroup>
-                    <Radio defaultChecked={true} label="Option 1" />
-                    <Radio label="Option 2" />
-                  </RadioGroup>
-                </div>
-              </div>
-            );
-          };
-
-          export const Example: React.FC<ContentProps> = props => {
-            const styles = useStyles();
-            return (
-              <div>
-                <Caption1>Examples</Caption1>
-                <div className={mergeClasses(styles.root, props.className)}>
-                  <Column1 />
-                  <Column2 />
-                  <Column3 />
-                </div>
-              </div>
-            );
-          };
-        `,
+  const link = React.useMemo(() => {
+    const theme = isDark ? createDarkTheme(brand) : createLightTheme(brand);
+    const codeSandboxParameters = getParameters({
+      files: {
+        'example.tsx': {
+          isBinary: false,
+          content: content,
+        },
+        'index.html': {
+          isBinary: false,
+          content: indexHtmlContent,
+        },
+        'index.tsx': {
+          isBinary: false,
+          content: createIndexContent(brand, { ...theme, ...overrides }, isDark),
+        },
+        'package.json': {
+          isBinary: false,
+          content: packageContent,
+        },
       },
-      'index.html': {
-        isBinary: false,
-        content: '<div id="root"></div>',
-      },
-      'index.tsx': {
-        isBinary: false,
-        content: dedent`
-          import * as ReactDOM from 'react-dom';
-          import { FluentProvider, ${
-            isDark ? 'createDarkTheme' : 'createLightTheme'
-          } } from '@fluentui/react-components';
-          import type { BrandVariants, Theme } from '@fluentui/react-theme';
-          import { Example } from './example';
+    });
 
-          const brand: BrandVariants = ${JSON.stringify(brand)};
-
-          const overrides: Partial<Theme> = ${JSON.stringify(overrides)};
-
-          const theme: Theme = { ...${isDark ? 'createDarkTheme' : 'createLightTheme'}(brand), ...overrides };
-
-          ReactDOM.render(
-              <FluentProvider theme={theme}>
-                  <Example />
-              </FluentProvider>,
-              document.getElementById('root'),
-          );
-        `,
-      },
-      'package.json': {
-        isBinary: false,
-        content: dedent`
-          {"dependencies":{"@fluentui/react-components":"rc","react":"^17","react-dom":"^17","react-scripts":"latest"}}
-        `,
-      },
-    },
-  });
-
-  const link = `https://codesandbox.io/api/v1/sandboxes/define?parameters=${codeSandboxParameters}&query=file%3D${defaultFileToPreview}`;
+    return `https://codesandbox.io/api/v1/sandboxes/define?parameters=${codeSandboxParameters}&query=file%3D${defaultFileToPreview}`;
+  }, [brand, overrides, isDark]);
 
   return (
     <div>

--- a/packages/react-components/theme-designer/src/components/ExportButton/ExportLink.tsx
+++ b/packages/react-components/theme-designer/src/components/ExportButton/ExportLink.tsx
@@ -9,273 +9,273 @@ export interface ExportLinkProps {
   overrides: Partial<Theme>;
 }
 
-const content = dedent`
-import * as React from 'react';
-import { makeStyles, makeStaticStyles, mergeClasses, shorthands } from '@griffel/react';
-import {
-  tokens,
-  Body1,
-  Title3,
-  TabList,
-  Tab,
-  Input,
-  Button,
-  Caption1,
-  Menu,
-  MenuTrigger,
-  MenuList,
-  MenuButton,
-  MenuItemCheckbox,
-  MenuPopover,
-  Slider,
-  Badge,
-  Switch,
-  Radio,
-  RadioGroup,
-  Checkbox,
-  Avatar,
-  Theme,
-} from '@fluentui/react-components';
-import {
-  SearchRegular,
-  bundleIcon,
-  CutRegular,
-  CutFilled,
-  ClipboardPasteRegular,
-  ClipboardPasteFilled,
-  EditRegular,
-  EditFilled,
-  ChevronRightRegular,
-  MeetNowRegular,
-  MeetNowFilled,
-  CalendarLtrFilled,
-  CalendarLtrRegular,
-} from '@fluentui/react-icons';
-
-export interface ContentProps {
-  className?: string;
-  theme: Theme;
-}
-
-const useStaticStyles = makeStaticStyles({
-  body: {
-    position: "fixed",
-    margin: "0px",
-    top: "0px",
-    left: "0px",
-    height: "100vh"
-  }
-});
-
-const useStyles = makeStyles({
-  root: {
-    height: "100vh",
-    display: 'grid',
-    alignItems: 'start',
-    justifyContent: 'center',
-    gridTemplateColumns: 'repeat(3, 1fr)',
-    gridTemplateRows: 'auto',
-    gridColumnGap: tokens.spacingHorizontalXXXL,
-  },
-  col1: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'left',
-    flexDirection: 'column',
-    flexGrow: 1,
-    ...shorthands.gap(tokens.spacingVerticalL),
-  },
-  col2: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    ...shorthands.gap(tokens.spacingVerticalL),
-  },
-  col3: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    gridTemplateRows: 'repeat(4, auto)',
-    gridRowGap: tokens.spacingVerticalS,
-    gridColumnGap: tokens.spacingHorizontalS,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  twoCol: {
-    gridColumnStart: 1,
-    gridColumnEnd: 3,
-  },
-  icons: {
-    display: 'grid',
-    gridTemplateColumns: 'auto auto',
-    gridTemplateRows: 'auto auto',
-    gridRowGap: tokens.spacingVerticalS,
-    gridColumnGap: tokens.spacingHorizontalS,
-    justifyContent: 'center',
-  },
-  twoRow: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
-
-export const Column1 = () => {
-  const styles = useStyles();
-  useStaticStyles();
-  return (
-    <div className={styles.col1}>
-      <Title3 block>Make an impression</Title3>
-      <Body1 block>
-        Make a big impression with this clean, modern, and mobile-friendly site. Use it to communicate
-        information to people inside or outside your team. Share your ideas, results, and more in this
-        visually compelling format.
-      </Body1>
-      <Avatar
-        color="brand"
-        initials="DF"
-        badge={{
-          status: 'available',
-          'aria-label': 'available',
-        }}
-      />
-    </div>
-  );
-};
-
-export const DemoMenu = () => {
-  const CutIcon = bundleIcon(CutFilled, CutRegular);
-  const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);
-  const EditIcon = bundleIcon(EditFilled, EditRegular);
-  return (
-    <Menu>
-      <MenuTrigger>
-        <MenuButton>Select </MenuButton>
-      </MenuTrigger>
-      <MenuPopover>
-        <MenuList>
-          <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut">
-            Cut
-          </MenuItemCheckbox>
-          <MenuItemCheckbox icon={<PasteIcon />} name="edit" value="paste">
-            Paste
-          </MenuItemCheckbox>
-          <MenuItemCheckbox icon={<EditIcon />} name="edit" value="edit">
-            Edit
-          </MenuItemCheckbox>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
-  );
-};
-
-export const Column2 = () => {
-  const styles = useStyles();
-  return (
-    <div className={styles.col2}>
-      <TabList defaultSelectedValue="tab1">
-        <Tab value="tab1">Home</Tab>
-        <Tab value="tab2">Pages</Tab>
-        <Tab value="tab3">Documents</Tab>
-      </TabList>
-      <Input
-        placeholder="Find"
-        contentAfter={
-          <Button aria-label="Find" appearance="transparent" icon={<SearchRegular />} size="small" />
-        }
-      />
-      <DemoMenu />
-    </div>
-  );
-};
-
-export const DemoIcons = () => {
-  const styles = useStyles();
-  const MeetNowIcon = bundleIcon(MeetNowFilled, MeetNowRegular);
-  const CalendarLtrIcon = bundleIcon(CalendarLtrFilled, CalendarLtrRegular);
-  return (
-    <div className={styles.icons}>
-      <Badge size="medium" appearance="filled" icon={<CalendarLtrIcon />} />
-      <Badge size="medium" appearance="ghost" icon={<CalendarLtrIcon />} />
-      <Badge size="medium" appearance="outline" icon={<MeetNowIcon />} />
-      <Badge size="medium" appearance="tint" icon={<MeetNowIcon />} />
-    </div>
-  );
-};
-
-export const Column3 = () => {
-  const styles = useStyles();
-  return (
-    <div className={styles.col3}>
-      <Button appearance="primary">Sign Up</Button>
-      <Button appearance="transparent" icon={<ChevronRightRegular />} iconPosition="after">
-        Learn More
-      </Button>
-      <Slider className={styles.twoCol} defaultValue={20} />
-      <DemoIcons />
-      <div className={styles.twoRow}>
-        <Switch defaultChecked={true} label="On" />
-        <Switch label="Off" />
-      </div>
-      <div className={styles.twoRow}>
-        <Checkbox defaultChecked={true} label="Option 1" />
-        <Checkbox label="Option 2" />
-      </div>
-      <div className={styles.twoRow}>
-        <RadioGroup>
-          <Radio defaultChecked={true} label="Option 1" />
-          <Radio label="Option 2" />
-        </RadioGroup>
-      </div>
-    </div>
-  );
-};
-
-export const Example: React.FC<ContentProps> = props => {
-  const styles = useStyles();
-  return (
-    <div>
-      <Caption1>Examples</Caption1>
-      <div className={mergeClasses(styles.root, props.className)}>
-        <Column1 />
-        <Column2 />
-        <Column3 />
-      </div>
-    </div>
-  );
-};
-`;
-
-const indexHtmlContent = '<div id="root"></div>';
-
-const createIndexContent = (brand: BrandVariants, overrides: Partial<Theme>, isDark: boolean) => dedent`
-import * as ReactDOM from 'react-dom';
-import { FluentProvider, ${isDark ? 'createDarkTheme' : 'createLightTheme'} } from '@fluentui/react-components';
-import type { BrandVariants, Theme } from '@fluentui/react-theme';
-import { Example } from './example';
-
-const brand: BrandVariants = ${JSON.stringify(brand)};
-
-const overrides: Partial<Theme> = ${JSON.stringify(overrides)};
-
-const theme: Theme = { ...${isDark ? 'createDarkTheme' : 'createLightTheme'}(brand), ...overrides };
-
-ReactDOM.render(
-    <FluentProvider theme={theme}>
-        <Example />
-    </FluentProvider>,
-    document.getElementById('root'),
-);
-`;
-
-const packageContent = dedent`
-{"dependencies":{"@fluentui/react-components":"rc","react":"^17","react-dom":"^17","react-scripts":"latest"}}
-`;
-
 const defaultFileToPreview = encodeURIComponent('/index.tsx');
 
 export const ExportLink: React.FC<ExportLinkProps> = props => {
   const { brand, isDark, overrides } = props;
+
+  const content = dedent`
+    import * as React from 'react';
+    import { makeStyles, makeStaticStyles, mergeClasses, shorthands } from '@griffel/react';
+    import {
+      tokens,
+      Body1,
+      Title3,
+      TabList,
+      Tab,
+      Input,
+      Button,
+      Caption1,
+      Menu,
+      MenuTrigger,
+      MenuList,
+      MenuButton,
+      MenuItemCheckbox,
+      MenuPopover,
+      Slider,
+      Badge,
+      Switch,
+      Radio,
+      RadioGroup,
+      Checkbox,
+      Avatar,
+      Theme,
+    } from '@fluentui/react-components';
+    import {
+      SearchRegular,
+      bundleIcon,
+      CutRegular,
+      CutFilled,
+      ClipboardPasteRegular,
+      ClipboardPasteFilled,
+      EditRegular,
+      EditFilled,
+      ChevronRightRegular,
+      MeetNowRegular,
+      MeetNowFilled,
+      CalendarLtrFilled,
+      CalendarLtrRegular,
+    } from '@fluentui/react-icons';
+
+    export interface ContentProps {
+      className?: string;
+      theme: Theme;
+    }
+
+    const useStaticStyles = makeStaticStyles({
+      body: {
+        position: "fixed",
+        margin: "0px",
+        top: "0px",
+        left: "0px",
+        height: "100vh"
+      }
+    });
+
+    const useStyles = makeStyles({
+      root: {
+        height: "100vh",
+        display: 'grid',
+        alignItems: 'start',
+        justifyContent: 'center',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+        gridTemplateRows: 'auto',
+        gridColumnGap: tokens.spacingHorizontalXXXL,
+      },
+      col1: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'left',
+        flexDirection: 'column',
+        flexGrow: 1,
+        ...shorthands.gap(tokens.spacingVerticalL),
+      },
+      col2: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        ...shorthands.gap(tokens.spacingVerticalL),
+      },
+      col3: {
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        gridTemplateRows: 'repeat(4, auto)',
+        gridRowGap: tokens.spacingVerticalS,
+        gridColumnGap: tokens.spacingHorizontalS,
+        justifyContent: 'center',
+        alignItems: 'center',
+      },
+      twoCol: {
+        gridColumnStart: 1,
+        gridColumnEnd: 3,
+      },
+      icons: {
+        display: 'grid',
+        gridTemplateColumns: 'auto auto',
+        gridTemplateRows: 'auto auto',
+        gridRowGap: tokens.spacingVerticalS,
+        gridColumnGap: tokens.spacingHorizontalS,
+        justifyContent: 'center',
+      },
+      twoRow: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+    });
+
+    export const Column1 = () => {
+      const styles = useStyles();
+      useStaticStyles();
+      return (
+        <div className={styles.col1}>
+          <Title3 block>Make an impression</Title3>
+          <Body1 block>
+            Make a big impression with this clean, modern, and mobile-friendly site. Use it to communicate
+            information to people inside or outside your team. Share your ideas, results, and more in this
+            visually compelling format.
+          </Body1>
+          <Avatar
+            color="brand"
+            initials="DF"
+            badge={{
+              status: 'available',
+              'aria-label': 'available',
+            }}
+          />
+        </div>
+      );
+    };
+
+    export const DemoMenu = () => {
+      const CutIcon = bundleIcon(CutFilled, CutRegular);
+      const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);
+      const EditIcon = bundleIcon(EditFilled, EditRegular);
+      return (
+        <Menu>
+          <MenuTrigger>
+            <MenuButton>Select </MenuButton>
+          </MenuTrigger>
+          <MenuPopover>
+            <MenuList>
+              <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut">
+                Cut
+              </MenuItemCheckbox>
+              <MenuItemCheckbox icon={<PasteIcon />} name="edit" value="paste">
+                Paste
+              </MenuItemCheckbox>
+              <MenuItemCheckbox icon={<EditIcon />} name="edit" value="edit">
+                Edit
+              </MenuItemCheckbox>
+            </MenuList>
+          </MenuPopover>
+        </Menu>
+      );
+    };
+
+    export const Column2 = () => {
+      const styles = useStyles();
+      return (
+        <div className={styles.col2}>
+          <TabList defaultSelectedValue="tab1">
+            <Tab value="tab1">Home</Tab>
+            <Tab value="tab2">Pages</Tab>
+            <Tab value="tab3">Documents</Tab>
+          </TabList>
+          <Input
+            placeholder="Find"
+            contentAfter={
+              <Button aria-label="Find" appearance="transparent" icon={<SearchRegular />} size="small" />
+            }
+          />
+          <DemoMenu />
+        </div>
+      );
+    };
+
+    export const DemoIcons = () => {
+      const styles = useStyles();
+      const MeetNowIcon = bundleIcon(MeetNowFilled, MeetNowRegular);
+      const CalendarLtrIcon = bundleIcon(CalendarLtrFilled, CalendarLtrRegular);
+      return (
+        <div className={styles.icons}>
+          <Badge size="medium" appearance="filled" icon={<CalendarLtrIcon />} />
+          <Badge size="medium" appearance="ghost" icon={<CalendarLtrIcon />} />
+          <Badge size="medium" appearance="outline" icon={<MeetNowIcon />} />
+          <Badge size="medium" appearance="tint" icon={<MeetNowIcon />} />
+        </div>
+      );
+    };
+
+    export const Column3 = () => {
+      const styles = useStyles();
+      return (
+        <div className={styles.col3}>
+          <Button appearance="primary">Sign Up</Button>
+          <Button appearance="transparent" icon={<ChevronRightRegular />} iconPosition="after">
+            Learn More
+          </Button>
+          <Slider className={styles.twoCol} defaultValue={20} />
+          <DemoIcons />
+          <div className={styles.twoRow}>
+            <Switch defaultChecked={true} label="On" />
+            <Switch label="Off" />
+          </div>
+          <div className={styles.twoRow}>
+            <Checkbox defaultChecked={true} label="Option 1" />
+            <Checkbox label="Option 2" />
+          </div>
+          <div className={styles.twoRow}>
+            <RadioGroup>
+              <Radio defaultChecked={true} label="Option 1" />
+              <Radio label="Option 2" />
+            </RadioGroup>
+          </div>
+        </div>
+      );
+    };
+
+    export const Example: React.FC<ContentProps> = props => {
+      const styles = useStyles();
+      return (
+        <div>
+          <Caption1>Examples</Caption1>
+          <div className={mergeClasses(styles.root, props.className)}>
+            <Column1 />
+            <Column2 />
+            <Column3 />
+          </div>
+        </div>
+      );
+    };
+    `;
+
+  const indexHtmlContent = '<div id="root"></div>';
+
+  const createIndexContent = dedent`
+    import * as ReactDOM from 'react-dom';
+    import { FluentProvider, ${isDark ? 'createDarkTheme' : 'createLightTheme'} } from '@fluentui/react-components';
+    import type { BrandVariants, Theme } from '@fluentui/react-theme';
+    import { Example } from './example';
+
+    const brand: BrandVariants = ${JSON.stringify(brand)};
+
+    const overrides: Partial<Theme> = ${JSON.stringify(overrides)};
+
+    const theme: Theme = { ...${isDark ? 'createDarkTheme' : 'createLightTheme'}(brand), ...overrides };
+
+    ReactDOM.render(
+        <FluentProvider theme={theme}>
+            <Example />
+        </FluentProvider>,
+        document.getElementById('root'),
+    );
+  `;
+
+  const packageContent = dedent`
+    {"dependencies":{"@fluentui/react-components":"rc","react":"^17","react-dom":"^17","react-scripts":"latest"}}
+    `;
 
   const link = React.useMemo(() => {
     const codeSandboxParameters = getParameters({
@@ -290,7 +290,7 @@ export const ExportLink: React.FC<ExportLinkProps> = props => {
         },
         'index.tsx': {
           isBinary: false,
-          content: createIndexContent(brand, overrides, isDark),
+          content: createIndexContent,
         },
         'package.json': {
           isBinary: false,
@@ -300,7 +300,7 @@ export const ExportLink: React.FC<ExportLinkProps> = props => {
     });
 
     return `https://codesandbox.io/api/v1/sandboxes/define?parameters=${codeSandboxParameters}&query=file%3D${defaultFileToPreview}`;
-  }, [brand, overrides, isDark]);
+  }, [content, createIndexContent, packageContent]);
 
   return (
     <div>

--- a/packages/react-components/theme-designer/src/components/ExportButton/ExportLink.tsx
+++ b/packages/react-components/theme-designer/src/components/ExportButton/ExportLink.tsx
@@ -294,7 +294,7 @@ export const ExportLink: React.FC<ExportLinkProps> = props => {
 
   return (
     <div>
-      <Link appearance="subtle" href={link}>
+      <Link appearance="subtle" href={link} target="_blank">
         Preview theme in CodeSandbox
       </Link>
     </div>

--- a/packages/react-components/theme-designer/src/components/Sidebar/EditTab.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/EditTab.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { makeStyles, shorthands } from '@griffel/react';
 import { Label, Input, Switch, Slider, tokens } from '@fluentui/react-components';
+import { useDebounce } from '../../utils/useDebounce';
 
 import type { CustomAttributes, DispatchTheme } from '../../useThemeDesignerReducer';
 
@@ -60,11 +61,18 @@ export const EditTab: React.FC<EditTabProps> = props => {
 
   const [form, dispatchForm] = React.useReducer(formReducer, initialForm);
 
+  const [lastForm, setLastForm] = React.useState<CustomAttributes>(initialForm);
+
+  const debouncedForm = useDebounce(lastForm, 10);
+  React.useEffect(() => {
+    dispatchForm({ attributes: debouncedForm, type: 'keyColor' });
+  }, [debouncedForm]);
+
   const toggleTheme = () => {
     dispatchForm({ attributes: { ...form, isDark: !form.isDark }, type: 'isDark' });
   };
   const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    dispatchForm({ attributes: { ...form, keyColor: e.target.value }, type: 'keyColor' });
+    setLastForm({ ...form, keyColor: e.target.value });
   };
   const handleHueTorsionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatchForm({ attributes: { ...form, hueTorsion: parseInt(e.target.value, 10) / 10 }, type: 'hueTorsion' });

--- a/packages/react-components/theme-designer/src/components/Sidebar/EditTab.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/EditTab.tsx
@@ -74,13 +74,13 @@ export const EditTab: React.FC<EditTabProps> = props => {
     setLastForm({ ...form, keyColor: e.target.value });
   };
   const handleHueTorsionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLastForm({ ...form, hueTorsion: parseInt(e.target.value, 10) / 10 });
+    setLastForm({ ...form, hueTorsion: parseInt(e.target.value, 10) });
   };
   const handleLightCpChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLastForm({ ...form, lightCp: parseInt(e.target.value, 10) / 100 });
+    setLastForm({ ...form, lightCp: parseInt(e.target.value, 10) });
   };
   const handleDarkCpChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLastForm({ ...form, darkCp: parseInt(e.target.value, 10) / 100 });
+    setLastForm({ ...form, darkCp: parseInt(e.target.value, 10) });
   };
 
   return (
@@ -102,32 +102,11 @@ export const EditTab: React.FC<EditTabProps> = props => {
         </div>
       </div>
       <Label htmlFor={sidebarId + 'hueTorsion'}>Hue Torsion</Label>
-      <Slider
-        size="small"
-        min={-50}
-        max={50}
-        id={sidebarId + 'hueTorsion'}
-        value={form.hueTorsion * 10}
-        onChange={handleHueTorsionChange}
-      />
+      <Slider size="small" min={-15} max={15} id={sidebarId + 'hueTorsion'} onChange={handleHueTorsionChange} />
       <Label htmlFor={sidebarId + 'lightCp'}>Light Control Point</Label>
-      <Slider
-        size="small"
-        min={0}
-        max={100}
-        id={sidebarId + 'lightCp'}
-        value={form.lightCp * 100}
-        onChange={handleLightCpChange}
-      />
+      <Slider size="small" min={0} max={100} id={sidebarId + 'lightCp'} onChange={handleLightCpChange} />
       <Label htmlFor={sidebarId + 'darkCp'}>Dark Control Point</Label>
-      <Slider
-        size="small"
-        min={0}
-        max={100}
-        id={sidebarId + 'darkCp'}
-        value={form.darkCp * 100}
-        onChange={handleDarkCpChange}
-      />
+      <Slider size="small" min={0} max={100} id={sidebarId + 'darkCp'} onChange={handleDarkCpChange} />
       <Switch checked={form.isDark} onChange={toggleTheme} label={form.isDark ? 'dark theme' : 'light theme'} />
     </div>
   );

--- a/packages/react-components/theme-designer/src/components/Sidebar/EditTab.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/EditTab.tsx
@@ -53,7 +53,7 @@ export const EditTab: React.FC<EditTabProps> = props => {
 
   const initialForm: CustomAttributes = formState;
 
-  const formReducer = (state: CustomAttributes, action: { attributes: CustomAttributes; type: string }) => {
+  const formReducer = (state: CustomAttributes, action: { attributes: CustomAttributes }) => {
     setFormState(action.attributes);
     dispatchState({ ...form, type: 'Custom', customAttributes: action.attributes, overrides: {} });
     return action.attributes;
@@ -62,26 +62,25 @@ export const EditTab: React.FC<EditTabProps> = props => {
   const [form, dispatchForm] = React.useReducer(formReducer, initialForm);
 
   const [lastForm, setLastForm] = React.useState<CustomAttributes>(initialForm);
-
   const debouncedForm = useDebounce(lastForm, 10);
   React.useEffect(() => {
-    dispatchForm({ attributes: debouncedForm, type: 'keyColor' });
+    dispatchForm({ attributes: debouncedForm });
   }, [debouncedForm]);
 
   const toggleTheme = () => {
-    dispatchForm({ attributes: { ...form, isDark: !form.isDark }, type: 'isDark' });
+    setLastForm({ ...form, ...form, isDark: !form.isDark });
   };
   const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setLastForm({ ...form, keyColor: e.target.value });
   };
   const handleHueTorsionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    dispatchForm({ attributes: { ...form, hueTorsion: parseInt(e.target.value, 10) / 10 }, type: 'hueTorsion' });
+    setLastForm({ ...form, hueTorsion: parseInt(e.target.value, 10) / 10 });
   };
   const handleLightCpChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    dispatchForm({ attributes: { ...form, lightCp: parseInt(e.target.value, 10) / 100 }, type: 'lightCp' });
+    setLastForm({ ...form, lightCp: parseInt(e.target.value, 10) / 100 });
   };
   const handleDarkCpChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    dispatchForm({ attributes: { ...form, darkCp: parseInt(e.target.value, 10) / 100 }, type: 'darkCp' });
+    setLastForm({ ...form, darkCp: parseInt(e.target.value, 10) / 100 });
   };
 
   return (

--- a/packages/react-components/theme-designer/src/utils/useDebounce.ts
+++ b/packages/react-components/theme-designer/src/utils/useDebounce.ts
@@ -1,6 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useState } from 'react';
 
-export function useDebounce(value: string, delay: number) {
+export function useDebounce(value: any, delay: number) {
   const [debouncedValue, setDebouncedValue] = useState(value);
   useEffect(() => {
     const handler = document.defaultView?.setTimeout(() => {


### PR DESCRIPTION
In the header on the toolbar the Preview Light/Dark Theme in CodeSandbox now opens a new tab rather than navigating away from the app (as suggested by Geoff). ColorTokens.tsx has an updated storybook entry. Extracted out the string constants from within the render method of ExportLink.tsx (as suggested by Geoff). Added a debounce to all inputs in the edit tab of the sidebar (the color pickers & the sliders).

To-do list: https://github.com/microsoft/fluentui/projects/30?fullscreen=true