### PR TITLE
chore: improve error message in useIsSSR()

### DIFF
--- a/change/@fluentui-react-utilities-02a46ee6-1b76-40d0-8e0f-8233baf7d8f4.json
+++ b/change/@fluentui-react-utilities-02a46ee6-1b76-40d0-8e0f-8233baf7d8f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: improve error message in useIsSSR()",
+  "packageName": "@fluentui/react-utilities",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/ssr/SSRContext.tsx
+++ b/packages/react-components/react-utilities/src/ssr/SSRContext.tsx
@@ -55,8 +55,14 @@ export function useIsSSR(): boolean {
     if (!isInSSRContext && !canUseDOM()) {
       // eslint-disable-next-line no-console
       console.error(
-        'When server rendering, you must wrap your application in an <SSRProvider> to ensure consistent ids are ' +
-          'generated between the client and server.',
+        [
+          '@fluentui/react-components: ',
+          'When server rendering, you must wrap your application in an <SSRProvider> to ensure consistent ids are ' +
+            'generated between the client and server.',
+          '\n',
+          '\n',
+          'Check documentation at https://aka.ms/fluentui-ssr',
+        ].join(''),
       );
     }
   }


### PR DESCRIPTION
## New Behavior

This PR improves an error that can be thrown by `useIsSSR()` hook to include source and documentation link as was suggested in https://github.com/microsoft/fluentui/issues/23620#issuecomment-1162440666.