### PR TITLE
Export setDefaultTarget from index file

### DIFF
--- a/change/@fluentui-react-127dff9d-e9c6-477e-979e-5e5c67f85cb1.json
+++ b/change/@fluentui-react-127dff9d-e9c6-477e-979e-5e5c67f85cb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Exporting setLayerHostSelector method to configure the default layerhost selector. This allows partners to opt back into the old behavior of appending layers to the body.",
+  "packageName": "@fluentui/react",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -10482,6 +10482,9 @@ export { setIconOptions }
 
 export { setLanguage }
 
+// @public
+export function setLayerHostSelector(selector?: string): void;
+
 export { setMemoizeWeakMap }
 
 export { setMonth }

--- a/packages/react/src/components/Layer/index.ts
+++ b/packages/react/src/components/Layer/index.ts
@@ -3,4 +3,4 @@ export * from './Layer.base';
 export * from './Layer.types';
 export * from './LayerHost';
 export * from './LayerHost.types';
-export { createDefaultLayerHost, cleanupDefaultLayerHost, setDefaultTarget } from './Layer.notification';
+export { createDefaultLayerHost, cleanupDefaultLayerHost, setDefaultTarget as setLayerHostSelector } from './Layer.notification';

--- a/packages/react/src/components/Layer/index.ts
+++ b/packages/react/src/components/Layer/index.ts
@@ -3,4 +3,4 @@ export * from './Layer.base';
 export * from './Layer.types';
 export * from './LayerHost';
 export * from './LayerHost.types';
-export { createDefaultLayerHost, cleanupDefaultLayerHost } from './Layer.notification';
+export { createDefaultLayerHost, cleanupDefaultLayerHost, setDefaultTarget } from './Layer.notification';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The current behavior does not allow users to opt out of the layer host rendering.

## New Behavior

By exporting the setDefaultTarget function, users can now override the default behavior. On app startup up, users can now call setDefaultTarget('body') for example to mimic the previous behavior.

## Related Issue(s)

https://github.com/microsoft/fluentui/issues/23575

Fixes #
