### PR TITLE
chore: Adding AvatarGroup code-owner to react-avatar.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -132,7 +132,7 @@ common/_common.scss @microsoft/cxe-red @phkuo
 ## vNext packages
 packages/react-components/keyboard-keys @microsoft/teams-prg
 packages/react-components/react-accordion @microsoft/cxe-coastal
-packages/react-components/react-avatar @microsoft/cxe-red @behowell @khmakoto
+packages/react-components/react-avatar @microsoft/cxe-red @behowell @khmakoto @sopranopillow
 packages/react-components/react-badge @microsoft/teams-prg @microsoft/cxe-red @behowell
 packages/react-components/react-button @microsoft/cxe-red @khmakoto
 packages/react-components/react-card @microsoft/cxe-prg


### PR DESCRIPTION
This PR adds @sopranopillow as code-owner for react-avatar since AvatarGroup lives in react-avatar.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#22240 