### PR TITLE
Correct typo on badges page

### DIFF
--- a/packages/react-components/react-badge/src/stories/Badge/BadgeColor.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/Badge/BadgeColor.stories.tsx
@@ -39,7 +39,7 @@ Color.parameters = {
       story:
         'A badge can have different colors.' +
         ' The available colors are `brand`, `danger`, `important`, `informative`, ' +
-        '`severe`, `severe`, `success` or `warning`.' +
+        '`severe`, `subtle`, `success` or `warning`.' +
         ' The default is `brand`.',
     },
   },


### PR DESCRIPTION
The color 'severe' appears twice in the colors list. It should be 'severe' and 'subtle'.

https://github.com/microsoft/fluentui/issues/23761