### PR TITLE
fix: Codesandbox exports should use ^9.0.0

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -46,8 +46,8 @@ export const parameters = {
       'react-scripts': 'latest',
     },
     optionalDependencies: {
-      '@fluentui/react-components': 'rc', // necessary for FluentProvider
-      '@fluentui/react-icons': 'beta',
+      '@fluentui/react-components': '^9.0.0', // necessary for FluentProvider
+      '@fluentui/react-icons': 'rc',
     },
     indexTsx: dedent`
           import * as ReactDOM from 'react-dom';


### PR DESCRIPTION
Currently our codesandbox exports are still configured for 9.0.0-rc. Use ^9.0.0 as version range after final release