### PR TITLE
fixed legends selected screen reader issue

### DIFF
--- a/change/@fluentui-react-charting-1a3d2996-0eb7-41cc-9b45-6252de1ce10f.json
+++ b/change/@fluentui-react-charting-1a3d2996-0eb7-41cc-9b45-6252de1ce10f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixed legends selected screen reader issue",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-hannapared@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -239,7 +239,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -549,7 +549,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
           role="none"
         >
           <button
-            aria-label="metaData1"
+            aria-label="metaData1 selected"
             aria-posinset={1}
             aria-selected={false}
             aria-setsize={1}
@@ -1055,7 +1055,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1382,7 +1382,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                 role="none"
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1709,7 +1709,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -2036,7 +2036,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="first"
+                  aria-label="first selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -277,7 +277,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="second"
+                  aria-label="second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -553,7 +553,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                 role="none"
               >
                 <button
-                  aria-label="first"
+                  aria-label="first selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -642,7 +642,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                 role="none"
               >
                 <button
-                  aria-label="second"
+                  aria-label="second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1049,7 +1049,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="first"
+                  aria-label="first selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1138,7 +1138,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="second"
+                  aria-label="second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1418,7 +1418,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="first"
+                  aria-label="first selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1507,7 +1507,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="second"
+                  aria-label="second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -295,7 +295,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                 role="none"
               >
                 <button
-                  aria-label="MetaData1"
+                  aria-label="MetaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -384,7 +384,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                 role="none"
               >
                 <button
-                  aria-label="MetaData2"
+                  aria-label="MetaData2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -473,7 +473,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                 role="none"
               >
                 <button
-                  aria-label="MetaData3"
+                  aria-label="MetaData3 selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -839,7 +839,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
           role="none"
         >
           <button
-            aria-label="MetaData1"
+            aria-label="MetaData1 selected"
             aria-posinset={1}
             aria-selected={false}
             aria-setsize={3}
@@ -928,7 +928,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
           role="none"
         >
           <button
-            aria-label="MetaData2"
+            aria-label="MetaData2 selected"
             aria-posinset={2}
             aria-selected={false}
             aria-setsize={3}
@@ -1017,7 +1017,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
           role="none"
         >
           <button
-            aria-label="MetaData3"
+            aria-label="MetaData3 selected"
             aria-posinset={3}
             aria-selected={false}
             aria-setsize={3}
@@ -1635,7 +1635,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                 role="none"
               >
                 <button
-                  aria-label="MetaData1"
+                  aria-label="MetaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1724,7 +1724,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                 role="none"
               >
                 <button
-                  aria-label="MetaData2"
+                  aria-label="MetaData2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1813,7 +1813,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                 role="none"
               >
                 <button
-                  aria-label="MetaData3"
+                  aria-label="MetaData3 selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2196,7 +2196,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                 role="none"
               >
                 <button
-                  aria-label="MetaData1"
+                  aria-label="MetaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2285,7 +2285,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                 role="none"
               >
                 <button
-                  aria-label="MetaData2"
+                  aria-label="MetaData2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2374,7 +2374,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                 role="none"
               >
                 <button
-                  aria-label="MetaData3"
+                  aria-label="MetaData3 selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2757,7 +2757,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                 role="none"
               >
                 <button
-                  aria-label="MetaData1"
+                  aria-label="MetaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2846,7 +2846,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                 role="none"
               >
                 <button
-                  aria-label="MetaData2"
+                  aria-label="MetaData2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2935,7 +2935,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                 role="none"
               >
                 <button
-                  aria-label="MetaData3"
+                  aria-label="MetaData3 selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -3318,7 +3318,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                 role="none"
               >
                 <button
-                  aria-label="MetaData1"
+                  aria-label="MetaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -3407,7 +3407,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                 role="none"
               >
                 <button
-                  aria-label="MetaData2"
+                  aria-label="MetaData2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -3496,7 +3496,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                 role="none"
               >
                 <button
-                  aria-label="MetaData3"
+                  aria-label="MetaData3 selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}

--- a/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -225,7 +225,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="Execllent (0-200)"
+                  aria-label="Execllent (0-200) selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -538,7 +538,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                 role="none"
               >
                 <button
-                  aria-label="Execllent (0-200)"
+                  aria-label="Execllent (0-200) selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -627,7 +627,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                 role="none"
               >
                 <button
-                  aria-label="Nasty"
+                  aria-label="Nasty selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1108,7 +1108,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="Execllent (0-200)"
+                  aria-label="Execllent (0-200) selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1421,7 +1421,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="Execllent (0-200)"
+                  aria-label="Execllent (0-200) selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -379,7 +379,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
         {...(allowFocusOnLegends && {
           'aria-selected': this.state.selectedLegend === legend.title,
           role: 'option',
-          'aria-label': legend.title,
+          'aria-label': `${legend.title} selected`,
           'aria-setsize': data['aria-setsize'],
           'aria-posinset': data['aria-posinset'],
         })}

--- a/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -227,7 +227,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -525,7 +525,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
           role="none"
         >
           <button
-            aria-label="metaData1"
+            aria-label="metaData1 selected"
             aria-posinset={1}
             aria-selected={false}
             aria-setsize={1}
@@ -1007,7 +1007,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1322,7 +1322,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                 role="none"
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1637,7 +1637,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1952,7 +1952,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -1406,7 +1406,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                 role="none"
               >
                 <button
-                  aria-label="Debit card numbers (EU and USA)"
+                  aria-label="Debit card numbers (EU and USA) selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1495,7 +1495,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                 role="none"
               >
                 <button
-                  aria-label="Passport numbers (USA)"
+                  aria-label="Passport numbers (USA) selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1231,7 +1231,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                 role="none"
               >
                 <button
-                  aria-label="first Lorem ipsum dolor sit amet"
+                  aria-label="first Lorem ipsum dolor sit amet selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1320,7 +1320,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                 role="none"
               >
                 <button
-                  aria-label="Winter is coming"
+                  aria-label="Winter is coming selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}

--- a/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -164,7 +164,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                 role="none"
               >
                 <button
-                  aria-label="First"
+                  aria-label="First selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -253,7 +253,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                 role="none"
               >
                 <button
-                  aria-label="Second"
+                  aria-label="Second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -342,7 +342,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                 role="none"
               >
                 <button
-                  aria-label="Third"
+                  aria-label="Third selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -577,7 +577,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
           role="none"
         >
           <button
-            aria-label="First"
+            aria-label="First selected"
             aria-posinset={1}
             aria-selected={false}
             aria-setsize={3}
@@ -666,7 +666,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
           role="none"
         >
           <button
-            aria-label="Second"
+            aria-label="Second selected"
             aria-posinset={2}
             aria-selected={false}
             aria-setsize={3}
@@ -755,7 +755,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
           role="none"
         >
           <button
-            aria-label="Third"
+            aria-label="Third selected"
             aria-posinset={3}
             aria-selected={false}
             aria-setsize={3}
@@ -1111,7 +1111,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="First"
+                  aria-label="First selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1200,7 +1200,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="Second"
+                  aria-label="Second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1289,7 +1289,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                 role="none"
               >
                 <button
-                  aria-label="Third"
+                  aria-label="Third selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1541,7 +1541,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                 role="none"
               >
                 <button
-                  aria-label="First"
+                  aria-label="First selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1630,7 +1630,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                 role="none"
               >
                 <button
-                  aria-label="Second"
+                  aria-label="Second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1719,7 +1719,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                 role="none"
               >
                 <button
-                  aria-label="Third"
+                  aria-label="Third selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1971,7 +1971,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                 role="none"
               >
                 <button
-                  aria-label="First"
+                  aria-label="First selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2060,7 +2060,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                 role="none"
               >
                 <button
-                  aria-label="Second"
+                  aria-label="Second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2149,7 +2149,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                 role="none"
               >
                 <button
-                  aria-label="Third"
+                  aria-label="Third selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2401,7 +2401,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                 role="none"
               >
                 <button
-                  aria-label="First"
+                  aria-label="First selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2490,7 +2490,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                 role="none"
               >
                 <button
-                  aria-label="Second"
+                  aria-label="Second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2579,7 +2579,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                 role="none"
               >
                 <button
-                  aria-label="Third"
+                  aria-label="Third selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                 role="none"
               >
                 <button
-                  aria-label="Metadata1"
+                  aria-label="Metadata1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -250,7 +250,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                 role="none"
               >
                 <button
-                  aria-label="Metadata2"
+                  aria-label="Metadata2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -482,7 +482,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
           role="none"
         >
           <button
-            aria-label="Metadata1"
+            aria-label="Metadata1 selected"
             aria-posinset={1}
             aria-selected={false}
             aria-setsize={2}
@@ -571,7 +571,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
           role="none"
         >
           <button
-            aria-label="Metadata2"
+            aria-label="Metadata2 selected"
             aria-posinset={2}
             aria-selected={false}
             aria-setsize={2}
@@ -921,7 +921,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                 role="none"
               >
                 <button
-                  aria-label="Metadata1"
+                  aria-label="Metadata1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1010,7 +1010,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                 role="none"
               >
                 <button
-                  aria-label="Metadata2"
+                  aria-label="Metadata2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1259,7 +1259,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                 role="none"
               >
                 <button
-                  aria-label="Metadata1"
+                  aria-label="Metadata1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1348,7 +1348,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                 role="none"
               >
                 <button
-                  aria-label="Metadata2"
+                  aria-label="Metadata2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1597,7 +1597,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                 role="none"
               >
                 <button
-                  aria-label="Metadata1"
+                  aria-label="Metadata1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1686,7 +1686,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                 role="none"
               >
                 <button
-                  aria-label="Metadata2"
+                  aria-label="Metadata2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1935,7 +1935,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                 role="none"
               >
                 <button
-                  aria-label="Metadata1"
+                  aria-label="Metadata1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -2024,7 +2024,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                 role="none"
               >
                 <button
-                  aria-label="Metadata2"
+                  aria-label="Metadata2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -2273,7 +2273,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                 role="none"
               >
                 <button
-                  aria-label="Metadata1"
+                  aria-label="Metadata1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -2362,7 +2362,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                 role="none"
               >
                 <button
-                  aria-label="Metadata2"
+                  aria-label="Metadata2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}


### PR DESCRIPTION

## Current Behavior

The screen reader is not announcing state(Selected) when the focus is on legends.

It is announcing as 'Second 2 of 4'.



## New Behavior

Screen reader is announcing state(Selected) when focus is on legends
