### PR TITLE
chore: Fix nightly releases

### DIFF
--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -45,7 +45,7 @@ jobs:
         # Deletes all existing changefiles so that only bump that happens is for nightly
       - script: |
           rm change/*
-        displayName: 'Bump and commit nightly versions'
+        displayName: 'Delete existing changefiles'
 
         # Bumps all v9 packages to a x.x.x-nightly.commitSha version and checks in change files
       - script: |

--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -42,6 +42,11 @@ jobs:
           filePath: yarn-ci.sh
         displayName: yarn
 
+        # Deletes all existing changefiles so that only bump that happens is for nightly
+      - script: |
+          rm change/*
+        displayName: 'Bump and commit nightly versions'
+
         # Bumps all v9 packages to a x.x.x-nightly.commitSha version and checks in change files
       - script: |
           date=$(date +"%Y%m%d-%H%M")
@@ -49,7 +54,7 @@ jobs:
           yarn nx workspace-generator version-bump --all --bumpType nightly --prereleaseTag "nightly-${date}"
           git add .
           git commit -m "bump nightly versions"
-          yarn change --type prerelease --message "Release nightly v9"
+          yarn change --type prerelease --message "Release nightly v9" --dependent-change-type "prerelease"
         displayName: 'Bump and commit nightly versions'
 
       # --only makes it only run tests (otherwise due to the missing --production arg, lage would re-run the build)

--- a/scripts/beachball/base.config.json
+++ b/scripts/beachball/base.config.json
@@ -1,5 +1,5 @@
 {
-  "disallowedChangeTypes": ["major", "prerelease"],
+  "disallowedChangeTypes": ["major"],
   "tag": "latest",
   "generateChangelog": true,
   "ignorePatterns": [

--- a/scripts/beachball/config.test.ts
+++ b/scripts/beachball/config.test.ts
@@ -8,7 +8,7 @@ describe(`beachball configs`, () => {
   it(`should generate shared config`, () => {
     expect(sharedConfig).toEqual({
       changehint: "Run 'yarn change' to generate a change file",
-      disallowedChangeTypes: ['major', 'prerelease'],
+      disallowedChangeTypes: ['major'],
       generateChangelog: true,
       ignorePatterns: [
         '**/*.{shot,snap}',

--- a/tools/generators/version-bump/index.ts
+++ b/tools/generators/version-bump/index.ts
@@ -1,7 +1,7 @@
 import { Tree, updateJson, getProjects, formatFiles, readJson } from '@nrwl/devkit';
 import * as semver from 'semver';
 import { VersionBumpGeneratorSchema } from './schema';
-import { getProjectConfig, printUserLogs, UserLog } from '../../utils';
+import { getProjectConfig, isPackageVersionConverged, printUserLogs, UserLog } from '../../utils';
 import { PackageJson } from '../../types';
 
 export default async function (host: Tree, schema: VersionBumpGeneratorSchema) {
@@ -63,7 +63,7 @@ function updatePackageDependent(
     if (packageJson.dependencies?.[dependencyName]) {
       userLog.push({
         type: 'info',
-        message: `bumping dependendcy ${dependencyName} in ${packageJsonPath}`,
+        message: `bumping dependency ${dependencyName} in ${packageJsonPath}`,
       });
 
       bumpDependency(packageJson.dependencies, dependencyName, nextVersion);
@@ -147,10 +147,8 @@ function isPackageConverged(packageName: string, host: Tree) {
   }
 
   const packageJson = readJson(host, config.paths.packageJson);
-  return packageJson.version.startsWith('9.');
+  return isPackageVersionConverged(packageJson.version);
 }
-
-type NormalizedSchema = ReturnType<typeof normalizeOptions>;
 
 function normalizeOptions(host: Tree, options: ValidatedSchema) {
   const defaults = {};


### PR DESCRIPTION
Nightly releases were broken because `@fluentui/react` took a v9
dependency on `@fluentui/react-portal-compat-context`.
No changefiles were generated during the nightly release pipeline
because `prerelease` is a default disallowed bump type.

Additionally, since v9 no longer allows only `prerelease` change
types, the nightly pipeline has been updated to delete all existing
changefiles so that no `patch` or `minor` changefile actually tries to
release a `0.0.0` version.
