### PR TITLE
fix(Checkbox): add indeterminate value to inputRef

### DIFF
--- a/change/@fluentui-react-c38b13e5-4388-4234-9299-0930336bdcd1.json
+++ b/change/@fluentui-react-c38b13e5-4388-4234-9299-0930336bdcd1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Checkbox): add indeterminate value to inputRef",
+  "packageName": "@fluentui/react",
+  "email": "marcosmoura@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.base.tsx
@@ -78,7 +78,7 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
     );
 
     const setNativeIndeterminate = React.useCallback(
-      (indeterminate: boolean | string) => {
+      (indeterminate: boolean | string | undefined) => {
         if (!inputRef.current) {
           return;
         }

--- a/packages/react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.base.tsx
@@ -75,6 +75,12 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
       [classNames.text],
     );
 
+    React.useEffect(() => {
+      if (inputRef.current) {
+        inputRef.current.indeterminate = !!isIndeterminate;
+      }
+    }, [isIndeterminate]);
+
     const onRenderLabel = props.onRenderLabel || defaultLabelRenderer;
 
     const ariaChecked: React.InputHTMLAttributes<HTMLInputElement>['aria-checked'] = isIndeterminate

--- a/packages/react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.base.tsx
@@ -37,7 +37,6 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
 
     useFocusRects(rootRef);
     useDebugWarning(props);
-    useComponentRef(props, isChecked, isIndeterminate, inputRef);
 
     const classNames = getClassNames(styles!, {
       theme: theme!,
@@ -48,6 +47,23 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
       reversed: boxSide !== 'start',
       isUsingCustomLabelRender: !!props.onRenderLabel,
     });
+
+    const setNativeIndeterminate = (indeterminate: boolean | string) => {
+      if (!inputRef.current) {
+        return;
+      }
+
+      let value = false;
+
+      if (typeof indeterminate === 'string') {
+        value = indeterminate.trim() === 'true';
+      } else {
+        value = !!indeterminate;
+      }
+
+      inputRef.current.indeterminate = value;
+      setIsIndeterminate(value);
+    };
 
     const onChange = (ev: React.ChangeEvent<HTMLElement>): void => {
       if (isIndeterminate) {
@@ -75,11 +91,9 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
       [classNames.text],
     );
 
-    React.useEffect(() => {
-      if (inputRef.current) {
-        inputRef.current.indeterminate = !!isIndeterminate;
-      }
-    }, [isIndeterminate]);
+    React.useEffect(() => setNativeIndeterminate(isIndeterminate), [isIndeterminate]);
+
+    useComponentRef(props, isChecked, isIndeterminate, setNativeIndeterminate, inputRef);
 
     const onRenderLabel = props.onRenderLabel || defaultLabelRenderer;
 
@@ -141,6 +155,7 @@ function useComponentRef(
   props: ICheckboxProps,
   isChecked: boolean | undefined,
   isIndeterminate: boolean | undefined,
+  setIndeterminate: (indeterminate: boolean | string) => void,
   checkBoxRef: React.RefObject<HTMLInputElement>,
 ) {
   React.useImperativeHandle(
@@ -151,6 +166,9 @@ function useComponentRef(
       },
       get indeterminate() {
         return !!isIndeterminate;
+      },
+      set indeterminate(indeterminate: boolean | string) {
+        setIndeterminate(indeterminate);
       },
       focus() {
         if (checkBoxRef.current) {

--- a/packages/react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.base.tsx
@@ -78,18 +78,12 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
     );
 
     const setNativeIndeterminate = React.useCallback(
-      (indeterminate: boolean | string | undefined) => {
+      (indeterminate: boolean | undefined) => {
         if (!inputRef.current) {
           return;
         }
 
-        let value = false;
-
-        if (typeof indeterminate === 'string') {
-          value = indeterminate.trim() === 'true';
-        } else {
-          value = !!indeterminate;
-        }
+        const value = !!indeterminate;
 
         inputRef.current.indeterminate = value;
         setIsIndeterminate(value);
@@ -160,7 +154,7 @@ function useComponentRef(
   props: ICheckboxProps,
   isChecked: boolean | undefined,
   isIndeterminate: boolean | undefined,
-  setIndeterminate: (indeterminate: boolean | string) => void,
+  setIndeterminate: (indeterminate: boolean) => void,
   checkBoxRef: React.RefObject<HTMLInputElement>,
 ) {
   React.useImperativeHandle(
@@ -172,7 +166,7 @@ function useComponentRef(
       get indeterminate() {
         return !!isIndeterminate;
       },
-      set indeterminate(indeterminate: boolean | string) {
+      set indeterminate(indeterminate: boolean) {
         setIndeterminate(indeterminate);
       },
       focus() {

--- a/packages/react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.base.tsx
@@ -48,34 +48,20 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
       isUsingCustomLabelRender: !!props.onRenderLabel,
     });
 
-    const setNativeIndeterminate = (indeterminate: boolean | string) => {
-      if (!inputRef.current) {
-        return;
-      }
-
-      let value = false;
-
-      if (typeof indeterminate === 'string') {
-        value = indeterminate.trim() === 'true';
-      } else {
-        value = !!indeterminate;
-      }
-
-      inputRef.current.indeterminate = value;
-      setIsIndeterminate(value);
-    };
-
-    const onChange = (ev: React.ChangeEvent<HTMLElement>): void => {
-      if (isIndeterminate) {
-        // If indeterminate, clicking the checkbox *only* removes the indeterminate state (or if
-        // controlled, lets the consumer know to change it by calling onChange). It doesn't
-        // change the checked state.
-        setIsChecked(!!isChecked, ev);
-        setIsIndeterminate(false);
-      } else {
-        setIsChecked(!isChecked, ev);
-      }
-    };
+    const onChange = React.useCallback(
+      (event: React.ChangeEvent<HTMLElement>): void => {
+        if (isIndeterminate) {
+          // If indeterminate, clicking the checkbox *only* removes the indeterminate state (or if
+          // controlled, lets the consumer know to change it by calling onChange). It doesn't
+          // change the checked state.
+          setIsChecked(!!isChecked, event);
+          setIsIndeterminate(false);
+        } else {
+          setIsChecked(!isChecked, event);
+        }
+      },
+      [setIsChecked, setIsIndeterminate, isIndeterminate, isChecked],
+    );
 
     const defaultLabelRenderer = React.useCallback(
       (checkboxProps?: ICheckboxProps): JSX.Element | null => {
@@ -91,9 +77,28 @@ export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwa
       [classNames.text],
     );
 
-    React.useEffect(() => setNativeIndeterminate(isIndeterminate), [isIndeterminate]);
+    const setNativeIndeterminate = React.useCallback(
+      (indeterminate: boolean | string) => {
+        if (!inputRef.current) {
+          return;
+        }
+
+        let value = false;
+
+        if (typeof indeterminate === 'string') {
+          value = indeterminate.trim() === 'true';
+        } else {
+          value = !!indeterminate;
+        }
+
+        inputRef.current.indeterminate = value;
+        setIsIndeterminate(value);
+      },
+      [setIsIndeterminate],
+    );
 
     useComponentRef(props, isChecked, isIndeterminate, setNativeIndeterminate, inputRef);
+    React.useEffect(() => setNativeIndeterminate(isIndeterminate), [setNativeIndeterminate, isIndeterminate]);
 
     const onRenderLabel = props.onRenderLabel || defaultLabelRenderer;
 
@@ -176,6 +181,6 @@ function useComponentRef(
         }
       },
     }),
-    [checkBoxRef, isChecked, isIndeterminate],
+    [checkBoxRef, isChecked, isIndeterminate, setIndeterminate],
   );
 }

--- a/packages/react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.test.tsx
@@ -201,4 +201,34 @@ describe('Checkbox', () => {
 
     expect(checkbox!.indeterminate).toEqual(true);
   });
+
+  it('set indeterminate value to native checkbox', () => {
+    const checkboxComponent = render(
+      <Checkbox title="indeterminate-title" indeterminate={true} checked={false} componentRef={checkboxRef} />,
+    );
+    const { getAllByTitle } = checkboxComponent;
+    const [, checkboxInput] = getAllByTitle('indeterminate-title') as HTMLInputElement[];
+
+    expect(checkbox!.indeterminate).toEqual(true);
+    expect(checkboxInput.indeterminate).toEqual(true);
+
+    checkboxComponent.rerender(
+      <Checkbox title="indeterminate-title" indeterminate={false} checked={false} componentRef={checkboxRef} />,
+    );
+
+    expect(checkbox!.indeterminate).toEqual(false);
+    expect(checkboxInput.indeterminate).toEqual(false);
+
+    checkboxComponent.rerender(<Checkbox title="indeterminate-title" checked={true} componentRef={checkboxRef} />);
+
+    expect(checkbox!.indeterminate).toEqual(false);
+    expect(checkboxInput.indeterminate).toEqual(false);
+
+    checkboxComponent.rerender(
+      <Checkbox title="indeterminate-title" indeterminate={true} checked={false} componentRef={checkboxRef} />,
+    );
+
+    expect(checkbox!.indeterminate).toEqual(true);
+    expect(checkboxInput.indeterminate).toEqual(true);
+  });
 });


### PR DESCRIPTION
## Current Behavior
Currently we use `aria-checked="mixed"` to represent an indeterminate checkbox, which is fine, but we can also use `indeterminate="true"` to improve browser compatibility.

## New Behavior
This PR adds the indeterminate value to the native checkbox to reflect the isIndeterminate internal value

## Related Issue(s)
Fixes [#20717](https://github.com/microsoft/fluentui/issues/20717)
