### PR TITLE
Slider v8: update to support ariaLabel

### DIFF
--- a/change/@fluentui-react-e0874dcd-a01c-4f6a-bead-d1bc2c92f914.json
+++ b/change/@fluentui-react-e0874dcd-a01c-4f6a-bead-d1bc2c92f914.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "update Slider to support ariaLabel",
+  "comment": "feat: Updating Slider to support ariaLabel prop.",
   "packageName": "@fluentui/react",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-e0874dcd-a01c-4f6a-bead-d1bc2c92f914.json
+++ b/change/@fluentui-react-e0874dcd-a01c-4f6a-bead-d1bc2c92f914.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update Slider to support ariaLabel",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Slider/Slider.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Slider/Slider.Basic.Example.tsx
@@ -11,7 +11,7 @@ export const SliderBasicExample: React.FunctionComponent = () => {
   const sliderOnChange = (value: number) => setSliderValue(value);
   return (
     <Stack tokens={stackTokens} styles={stackStyles}>
-      <Slider />
+      <Slider aria-label="Basic example" />
       <Slider label="Snapping slider example" min={0} max={50} step={10} defaultValue={20} showValue snapToStep />
       <Slider label="Disabled example" min={50} max={500} step={50} defaultValue={300} showValue disabled />
       <Slider

--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -42,6 +42,16 @@ describe('Slider', () => {
     expect(getByRole('slider').getAttribute('aria-labelledby')).toBe('custom-label');
   });
 
+  it('can set an aria-label attribute', () => {
+    const { getByRole } = render(<Slider aria-label="test" />);
+    expect(getByRole('slider').getAttribute('aria-label')).toBe('test');
+  });
+
+  it('can sets ariaLabel as an aria-label attribute', () => {
+    const { getByRole } = render(<Slider ariaLabel="test" />);
+    expect(getByRole('slider').getAttribute('aria-label')).toBe('test');
+  });
+
   it('can provide the current value', () => {
     const slider = React.createRef<ISlider>();
 

--- a/packages/react/src/components/Slider/Slider.test.tsx
+++ b/packages/react/src/components/Slider/Slider.test.tsx
@@ -47,7 +47,7 @@ describe('Slider', () => {
     expect(getByRole('slider').getAttribute('aria-label')).toBe('test');
   });
 
-  it('can sets ariaLabel as an aria-label attribute', () => {
+  it('can set ariaLabel as an aria-label attribute', () => {
     const { getByRole } = render(<Slider ariaLabel="test" />);
     expect(getByRole('slider').getAttribute('aria-label')).toBe('test');
   });

--- a/packages/react/src/components/Slider/useSlider.ts
+++ b/packages/react/src/components/Slider/useSlider.ts
@@ -94,7 +94,7 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
     theme,
     originFromZero,
     'aria-labelledby': ariaLabelledBy,
-    'aria-label': ariaLabel,
+    ariaLabel = props['aria-label'],
     ranged,
     onChange,
     onChanged,


### PR DESCRIPTION
Resolves #23757, [15029](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15029)

We have `ariaLabel` documented as a supported prop, but the current v8 Slider does not support it -- this PR adds support, updates our example to add a label for the first basic Slider, and maintains support for `aria-label`.