### PR TITLE
fix: Adding optional way to show tooltip in Persona and removing tooltip within suggestions dropdown in PeoplePicker

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,5 +72,6 @@
   "javascript.preferences.importModuleSpecifier": "relative",
   "javascript.preferences.importModuleSpecifierEnding": "index",
   "typescript.preferences.importModuleSpecifier": "relative",
-  "typescript.preferences.importModuleSpecifierEnding": "index"
+  "typescript.preferences.importModuleSpecifierEnding": "index",
+  "cSpell.words": ["uifabric"]
 }

--- a/change/office-ui-fabric-react-0a2705c8-2996-4346-b525-85d4258becd8.json
+++ b/change/office-ui-fabric-react-0a2705c8-2996-4346-b525-85d4258becd8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Adding optional way to show tooltip in Persona, and removing tooltip within suggestions dropdown in PeoplePicker.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6606,6 +6606,7 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | 
     primaryText?: string;
     secondaryText?: string;
     showInitialsUntilImageLoads?: boolean;
+    showOverflowTooltip?: boolean;
     // (undocumented)
     showSecondaryText?: boolean;
     showUnknownPersonaCoin?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
@@ -22,6 +22,7 @@ export class PersonaBase extends React.Component<IPersonaProps, {}> {
     size: PersonaSize.size48,
     presence: PersonaPresenceEnum.none,
     imageAlt: '',
+    showOverflowTooltip: true,
   };
 
   constructor(props: IPersonaProps) {
@@ -34,10 +35,10 @@ export class PersonaBase extends React.Component<IPersonaProps, {}> {
 
   public render(): JSX.Element {
     // wrapping default render behavior based on various this.props properties
-    const _onRenderPrimaryText = this._onRenderText(this._getText());
-    const _onRenderSecondaryText = this._onRenderText(this.props.secondaryText);
-    const _onRenderTertiaryText = this._onRenderText(this.props.tertiaryText);
-    const _onRenderOptionalText = this._onRenderText(this.props.optionalText);
+    const _onRenderPrimaryText = this._onRenderText(this._getText(), this.props.showOverflowTooltip);
+    const _onRenderSecondaryText = this._onRenderText(this.props.secondaryText, this.props.showOverflowTooltip);
+    const _onRenderTertiaryText = this._onRenderText(this.props.tertiaryText, this.props.showOverflowTooltip);
+    const _onRenderOptionalText = this._onRenderText(this.props.optionalText, this.props.showOverflowTooltip);
 
     const {
       hidePersonaDetails,
@@ -171,21 +172,23 @@ export class PersonaBase extends React.Component<IPersonaProps, {}> {
    * to make it independent of the type of text passed
    * @param text - text to render
    */
-  private _onRenderText(text: string | undefined): IRenderFunction<IPersonaProps> | undefined {
-    // return default render behaviour for valid text or undefined
+  private _onRenderText(text: string | undefined, tooltip = true): IRenderFunction<IPersonaProps> | undefined {
+    // return default render behavior for valid text or undefined
     return text
-      ? (): JSX.Element => {
-          // default onRender behaviour
-          return (
-            <TooltipHost
-              content={text}
-              overflowMode={TooltipOverflowMode.Parent}
-              directionalHint={DirectionalHint.topLeftEdge}
-            >
-              {text}
-            </TooltipHost>
-          );
-        }
+      ? tooltip
+        ? (): JSX.Element => {
+            // default onRender behavior
+            return (
+              <TooltipHost
+                content={text}
+                overflowMode={TooltipOverflowMode.Parent}
+                directionalHint={DirectionalHint.topLeftEdge}
+              >
+                {text}
+              </TooltipHost>
+            );
+          }
+        : () => <>{text}</>
       : undefined;
   }
 

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -22,7 +22,7 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | 
 
   /**
    * Decides the size of the control.
-   * @defaultvalue PersonaSize.size48
+   * @default PersonaSize.size48
    */
   size?: PersonaSize;
 
@@ -45,7 +45,7 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | 
   /**
    * If true, the image starts as visible and is hidden on error. Otherwise, the image is hidden until
    * it is successfully loaded. This disables imageShouldFadeIn.
-   * @defaultvalue false
+   * @default false
    */
   imageShouldStartVisible?: boolean;
 
@@ -61,14 +61,14 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | 
 
   /**
    * The user's initials to display in the image area when there is no image.
-   * @defaultvalue [Derived from text]
+   * @default [Derived from text]
    */
   imageInitials?: string;
 
   /**
    * Whether initials are calculated for phone numbers and number sequences.
    * Example: Set property to true to get initials for project names consisting of numbers only.
-   * @defaultvalue false
+   * @default false
    */
   allowPhoneInitials?: boolean;
 
@@ -84,7 +84,7 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | 
 
   /**
    * The background color when the user's initials are displayed.
-   * @defaultvalue [Derived from text]
+   * @default [Derived from text]
    */
   initialsColor?: PersonaInitialsColor | string;
 
@@ -106,7 +106,7 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | 
 
   /**
    * Presence of the person to display - will not display presence if undefined.
-   * @defaultvalue PersonaPresence.none
+   * @default PersonaPresence.none
    */
   presence?: PersonaPresence;
 
@@ -156,7 +156,7 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | 
   /**
    * If true renders the initials while the image is loading.
    * This only applies when an imageUrl is provided.
-   * @defaultvalue false
+   * @default false
    */
   showInitialsUntilImageLoads?: boolean;
 
@@ -180,6 +180,12 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | 
    * @deprecated Use `text` instead.
    */
   primaryText?: string;
+
+  /**
+   * Controls whether clipped overflow text should render in a tooltip.
+   * @default true
+   */
+  showOverflowTooltip?: boolean;
 }
 
 /**
@@ -244,13 +250,13 @@ export interface IPersonaStyleProps {
 
   /**
    * Decides the size of the control.
-   * @defaultvalue PersonaSize.size48
+   * @default PersonaSize.size48
    */
   size?: PersonaSize;
 
   /**
    * Presence of the person to display - will not display presence if undefined.
-   * @defaultvalue PersonaPresence.none
+   * @default PersonaPresence.none
    */
   presence?: PersonaPresence;
 
@@ -289,7 +295,7 @@ export interface IPersonaCoinProps extends IPersonaSharedProps {
 
   /**
    * Additional css class to apply to the PersonaCoin
-   * @defaultvalue undefined
+   * @default undefined
    */
   className?: string;
 }
@@ -310,7 +316,7 @@ export interface IPersonaCoinStyleProps {
 
   /**
    * Decides the size of the control.
-   * @defaultvalue PersonaSize.size48
+   * @default PersonaSize.size48
    */
   size?: PersonaSize;
 

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.tsx
@@ -31,6 +31,7 @@ export const PeoplePickerItemSuggestionBase = (props: IPeoplePickerItemSuggestio
         styles={personaStyles}
         className={classNames.personaWrapper}
         showSecondaryText={!compact}
+        showOverflowTooltip={false}
         {...personaProps}
       />
     </div>

--- a/packages/react-examples/src/office-ui-fabric-react/PeoplePicker/PeoplePicker.List.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/PeoplePicker/PeoplePicker.List.Example.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
-import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
-import { IBasePickerSuggestionsProps, ListPeoplePicker, ValidationState } from 'office-ui-fabric-react/lib/Pickers';
+import { IPersonaProps, IPersonaStyles } from 'office-ui-fabric-react/lib/Persona';
+import {
+  IBasePickerSuggestionsProps,
+  ListPeoplePicker,
+  ValidationState,
+  PeoplePickerItemSuggestion,
+} from 'office-ui-fabric-react/lib/Pickers';
 import { people, mru } from '@uifabric/example-data';
 
 const suggestionProps: IBasePickerSuggestionsProps = {
@@ -12,6 +17,20 @@ const suggestionProps: IBasePickerSuggestionsProps = {
   showRemoveButtons: true,
   suggestionsAvailableAlertText: 'People Picker Suggestions available',
   suggestionsContainerAriaLabel: 'Suggested contacts',
+};
+
+const personaStyles: Partial<IPersonaStyles> = {
+  root: {
+    height: 'auto',
+  },
+  secondaryText: {
+    height: 'auto',
+    whiteSpace: 'normal',
+  },
+  primaryText: {
+    height: 'auto',
+    whiteSpace: 'normal',
+  },
 };
 
 const checkboxStyles = {
@@ -87,6 +106,15 @@ export const PeoplePickerListExample: React.FunctionComponent = () => {
     setDelayResults(!delayResults);
   };
 
+  const onRenderSuggestionItem = (personaProps: IPersonaProps, suggestionsProps: IBasePickerSuggestionsProps) => {
+    return (
+      <PeoplePickerItemSuggestion
+        personaProps={{ ...personaProps, styles: personaStyles }}
+        suggestionsProps={suggestionsProps}
+      />
+    );
+  };
+
   return (
     <div>
       <ListPeoplePicker
@@ -100,6 +128,8 @@ export const PeoplePickerListExample: React.FunctionComponent = () => {
         key={'list'}
         // eslint-disable-next-line react/jsx-no-bind
         onRemoveSuggestion={onRemoveSuggestion}
+        // eslint-disable-next-line react/jsx-no-bind
+        onRenderSuggestionsItem={onRenderSuggestionItem}
         onValidateInput={validateInput}
         inputProps={{
           onBlur: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onBlur called'),

--- a/packages/react-examples/src/office-ui-fabric-react/PeoplePicker/PeoplePicker.doc.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/PeoplePicker/PeoplePicker.doc.tsx
@@ -34,7 +34,7 @@ export const PeoplePickerPageProps: IDocPageProps = {
       view: <PeoplePickerCompactExample />,
     },
     {
-      title: 'List People Picker',
+      title: 'List People Picker with Wrapped Item text',
       code: PeoplePickerListExampleCode,
       view: <PeoplePickerListExample />,
     },

--- a/packages/react-examples/src/office-ui-fabric-react/PeoplePicker/docs/PeoplePickerBestPractices.md
+++ b/packages/react-examples/src/office-ui-fabric-react/PeoplePicker/docs/PeoplePickerBestPractices.md
@@ -2,3 +2,19 @@
 
 - Use the people picker to add someone to the To line of an email, or to add someone to a list.
 - Use the `MemberList PeoplePicker` to display selections below the input field.
+
+### Accessibility
+
+#### Mobile Accessibility
+
+PeoplePicker dropdowns render in their own layer by default to ensure they are not clipped by containers with `overflow: hidden` or `overflow: scroll`. This causes extra difficulty for people who use touch-based screen readers, so we recommend rendering the PeoplePicker inline unless it is in an overflow container. To do so, set the following property on the PeoplePicker:
+
+```js
+pickerCalloutProps={{ doNotLayer: true }}
+```
+
+#### Truncation
+
+By default, the PeoplePicker truncates item text in the dropdown instead of wrapping to a new line. To avoid losing meaningful information, adjusting styles to wrap the name while keeping additional secondary text short is recommended. Tooltips are not shown for truncated text within the dropdown to avoid nested popups and the usability and accessibility issues they cause.
+
+The List People Picker example demonstrates how to override truncation styles to support wrapping. The default style will continue to truncate to support existing implementations.

--- a/packages/react-examples/src/office-ui-fabric-react/Persona/docs/PersonaBestPractices.md
+++ b/packages/react-examples/src/office-ui-fabric-react/Persona/docs/PersonaBestPractices.md
@@ -8,3 +8,13 @@
 ### Content
 
 - Change the values of the color swatches in high contrast mode.
+
+### Accessibility
+
+#### Color
+
+The presence indicator for small personas of size 32 or less only uses color to indicate the current status. This can result in poor accessibility for anyone who has trouble perceiving color. If you use the presence indicator on small personas, we recommend adding a text alternative as we do in our examples.
+
+#### Tooltips
+
+By default, the Persona truncates text and displays a tooltip with the full text. If a tooltip is not desired (e.g. the Persona is used within a dropdown), the `showOverflowTooltip` property can be set to false.


### PR DESCRIPTION
## PR Description

_This PR is a cherrypick of #18469 to the 7.0 branch._

**Original PR description follows:**

Currently, the tooltip/truncation behavior in Persona means we have tooltips within the dropdown of PeoplePicker. To fix that, I've made these changes:
- Add a `showOverflowTooltip` prop to Persona that defaults to `true` (the current behavior)
- Set `showOverflowTooltip` to false on the Persona used within PeoplePicker
- Update the List example of PeoplePicker to demo styles for wrapping text instead of truncating
- Add docs wording to Persona and PeoplePicker about the changes
## Related Issue(s)

Fixes #23480
