### PR TITLE
feat: react-tabster - Split useModalAttributes

### DIFF
--- a/change/@fluentui-react-components-aa25e3a9-810e-4bd6-9ee2-f7b19c17b660.json
+++ b/change/@fluentui-react-components-aa25e3a9-810e-4bd6-9ee2-f7b19c17b660.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updates components to use useModalTriggerAttributes",
+  "packageName": "@fluentui/react-components",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-548a4675-b427-459e-9fc1-7c05f43499a6.json
+++ b/change/@fluentui-react-popover-548a4675-b427-459e-9fc1-7c05f43499a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updates components to use useModalTriggerAttributes",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-396be584-c27f-4cc9-b7f3-81d84ef40103.json
+++ b/change/@fluentui-react-tabster-396be584-c27f-4cc9-b7f3-81d84ef40103.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Splits useModalAttributes into useModalTriggerAttributes",
+  "packageName": "@fluentui/react-tabster",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -480,6 +480,7 @@ import { useMenuTriggerContext_unstable } from '@fluentui/react-menu';
 import { useMergedRefs } from '@fluentui/react-utilities';
 import { useModalAttributes } from '@fluentui/react-tabster';
 import { UseModalAttributesOptions } from '@fluentui/react-tabster';
+import { useModalTriggerAttributes } from '@fluentui/react-tabster';
 import { usePopover_unstable } from '@fluentui/react-popover';
 import { usePopoverContext_unstable } from '@fluentui/react-popover';
 import { usePopoverSurface_unstable } from '@fluentui/react-popover';
@@ -1472,6 +1473,8 @@ export { useModalAttributes }
 
 export { UseModalAttributesOptions }
 
+export { useModalTriggerAttributes }
+
 export { usePopover_unstable }
 
 export { usePopoverContext_unstable }
@@ -1529,7 +1532,6 @@ export { useTextarea_unstable }
 export { useTextareaStyles_unstable }
 
 export { useTextStyles_unstable }
-
 
 export { useThemeClassName }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -59,6 +59,7 @@ export {
   useFocusFinders,
   useKeyboardNavAttribute,
   useModalAttributes,
+  useModalTriggerAttributes,
 } from '@fluentui/react-tabster';
 export type {
   CreateCustomFocusIndicatorStyleOptions,

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
@@ -28,7 +28,7 @@ export const usePopoverSurface_unstable = (
   const trapFocus = usePopoverContext_unstable(context => context.trapFocus);
   const legacyTrapFocus = usePopoverContext_unstable(context => context.legacyTrapFocus);
   const inline = usePopoverContext_unstable(context => context.inline);
-  const { modalAttributes } = useModalAttributes({ trapFocus, legacyTrapFocus });
+  const modalAttributes = useModalAttributes({ trapFocus, legacyTrapFocus });
 
   const state: PopoverSurfaceState = {
     inline,

--- a/packages/react-components/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
+++ b/packages/react-components/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
@@ -7,7 +7,7 @@ import {
   useMergedEventCallbacks,
   useEventCallback,
 } from '@fluentui/react-utilities';
-import { useModalAttributes } from '@fluentui/react-tabster';
+import { useModalTriggerAttributes } from '@fluentui/react-tabster';
 import { usePopoverContext_unstable } from '../../popoverContext';
 import type { PopoverTriggerChildProps, PopoverTriggerProps, PopoverTriggerState } from './PopoverTrigger.types';
 
@@ -31,7 +31,7 @@ export const usePopoverTrigger_unstable = (props: PopoverTriggerProps): PopoverT
   const triggerRef = usePopoverContext_unstable(context => context.triggerRef);
   const openOnHover = usePopoverContext_unstable(context => context.openOnHover);
   const openOnContext = usePopoverContext_unstable(context => context.openOnContext);
-  const { triggerAttributes } = useModalAttributes();
+  const triggerAttributes = useModalTriggerAttributes();
 
   const onContextMenu = (e: React.MouseEvent<HTMLElement>) => {
     if (openOnContext) {

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -69,10 +69,7 @@ export const useFocusFinders: () => {
 export function useKeyboardNavAttribute<E extends HTMLElement>(): RefObject<E>;
 
 // @public
-export const useModalAttributes: (options?: UseModalAttributesOptions) => {
-    modalAttributes: Types.TabsterDOMAttribute;
-    triggerAttributes: Types.TabsterDOMAttribute;
-};
+export const useModalAttributes: (options?: UseModalAttributesOptions) => Types.TabsterDOMAttribute;
 
 // @public (undocumented)
 export interface UseModalAttributesOptions {
@@ -80,6 +77,9 @@ export interface UseModalAttributesOptions {
     legacyTrapFocus?: boolean;
     trapFocus?: boolean;
 }
+
+// @public
+export const useModalTriggerAttributes: () => Types.TabsterDOMAttribute;
 
 // Warning: (ae-internal-missing-underscore) The name "useTabsterAttributes" should be prefixed with an underscore because the declaration is marked as @internal
 //

--- a/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
@@ -27,15 +27,12 @@ export interface UseModalAttributesOptions {
 }
 
 /**
- * Applies modal dialog behaviour through DOM attributes
+ * Applies modal dialog behavior through DOM attributes
  * Modal element will focus trap and hide other content on the page
- * The trigger element will be focused if focus is lost after the modal element is removed
  *
- * @returns DOM attributes to apply to the modal element and its trigger
+ * @returns DOM attributes to apply to the modal element
  */
-export const useModalAttributes = (
-  options: UseModalAttributesOptions = {},
-): { modalAttributes: TabsterTypes.TabsterDOMAttribute; triggerAttributes: TabsterTypes.TabsterDOMAttribute } => {
+export const useModalAttributes = (options: UseModalAttributesOptions = {}): TabsterTypes.TabsterDOMAttribute => {
   const { trapFocus, alwaysFocusable, legacyTrapFocus } = options;
   const tabster = useTabster();
   // Initializes the modalizer and deloser APIs
@@ -45,7 +42,8 @@ export const useModalAttributes = (
   }
 
   const id = useId('modal-');
-  const modalAttributes = useTabsterAttributes({
+
+  return useTabsterAttributes({
     deloser: {},
     modalizer: {
       id,
@@ -54,10 +52,22 @@ export const useModalAttributes = (
       isTrapped: legacyTrapFocus,
     },
   });
+};
 
-  const triggerAttributes = useTabsterAttributes({
+/**
+ * Applies trigger behavior through DOM attributes
+ * element will be focused if focus is lost after a modal element is removed
+ *
+ * @returns DOM attributes to apply to the trigger element
+ */
+export const useModalTriggerAttributes = (): TabsterTypes.TabsterDOMAttribute => {
+  const tabster = useTabster();
+  // Initializes the deloser APIs
+  if (tabster) {
+    getDeloser(tabster);
+  }
+
+  return useTabsterAttributes({
     deloser: {},
   });
-
-  return { modalAttributes, triggerAttributes };
 };

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -4,6 +4,7 @@ export {
   useFocusFinders,
   useKeyboardNavAttribute,
   useModalAttributes,
+  useModalTriggerAttributes,
   useTabsterAttributes,
 } from './hooks/index';
 export type {


### PR DESCRIPTION

## Current Behavior

Currently `useModalAttributes` return both attributes for a `modal` element and it's `trigger`

## New Behavior

Split `useModalAttributes` into `useModalAttributes` and `useModalTriggerAttributes` as they're independant.
