### PR TITLE
Some charts don't automatically adopt sentence case for labels and legends

### DIFF
--- a/change/@fluentui-react-charting-cbf9ca10-6d25-4940-a595-160e809329c6.json
+++ b/change/@fluentui-react-charting-cbf9ca10-6d25-4940-a595-160e809329c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "legends & labels are capitalized",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-hannapared@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -257,6 +257,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -567,6 +568,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1073,6 +1075,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1400,6 +1403,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1727,6 +1731,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2054,6 +2059,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -206,6 +206,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -295,6 +296,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -571,6 +573,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -660,6 +663,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1067,6 +1071,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1156,6 +1161,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1436,6 +1442,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1525,6 +1532,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -313,6 +313,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -402,6 +403,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -491,6 +493,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -857,6 +860,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -946,6 +950,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1035,6 +1040,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1653,6 +1659,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1742,6 +1749,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1831,6 +1839,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2214,6 +2223,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2303,6 +2313,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2392,6 +2403,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2775,6 +2787,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2864,6 +2877,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2953,6 +2967,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -3336,6 +3351,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -3425,6 +3441,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -3514,6 +3531,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -243,6 +243,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -556,6 +557,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -645,6 +647,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1126,6 +1129,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1439,6 +1443,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/react-charting/src/components/Legends/Legends.styles.ts
+++ b/packages/react-charting/src/components/Legends/Legends.styles.ts
@@ -32,6 +32,7 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
         border: 'none',
         padding: '8px',
         background: 'none',
+        textTransform: 'capitalize',
       },
     ],
     rect: {

--- a/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -245,6 +245,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -543,6 +544,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1025,6 +1027,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1340,6 +1343,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1655,6 +1659,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1970,6 +1975,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -1424,6 +1424,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1513,6 +1514,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1249,6 +1249,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1338,6 +1339,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -182,6 +182,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -271,6 +272,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -360,6 +362,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -595,6 +598,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -684,6 +688,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -773,6 +778,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1129,6 +1135,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1218,6 +1225,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1307,6 +1315,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1559,6 +1568,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1648,6 +1658,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1737,6 +1748,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1989,6 +2001,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2078,6 +2091,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2167,6 +2181,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2419,6 +2434,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2508,6 +2524,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2597,6 +2614,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -179,6 +179,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -268,6 +269,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -500,6 +502,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -589,6 +592,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -939,6 +943,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1028,6 +1033,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1277,6 +1283,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1366,6 +1373,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1615,6 +1623,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1704,6 +1713,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1953,6 +1963,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2042,6 +2053,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2291,6 +2303,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2380,6 +2393,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx
@@ -154,7 +154,7 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
 
     return (
       <>
-        <label htmlFor="changeWidth_Basic">change Width:</label>
+        <label htmlFor="changeWidth_Basic">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -164,7 +164,7 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Basic">change Height:</label>
+        <label htmlFor="changeHeight_Basic">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx
@@ -145,7 +145,7 @@ export class AreaChartCustomAccessibilityExample extends React.Component<{}, IAr
 
     return (
       <>
-        <label htmlFor="changeWidth_Custom">change Width:</label>
+        <label htmlFor="changeWidth_Custom">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -155,7 +155,7 @@ export class AreaChartCustomAccessibilityExample extends React.Component<{}, IAr
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Custom">change Height:</label>
+        <label htmlFor="changeHeight_Custom">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.Multiple.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.Multiple.Example.tsx
@@ -184,7 +184,7 @@ export class AreaChartMultipleExample extends React.Component<{}, IAreaChartBasi
 
     return (
       <>
-        <label htmlFor="changeWidth_Multiple">change Width:</label>
+        <label htmlFor="changeWidth_Multiple">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -194,7 +194,7 @@ export class AreaChartMultipleExample extends React.Component<{}, IAreaChartBasi
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthslider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Multiple">change Height:</label>
+        <label htmlFor="changeHeight_Multiple">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.Styled.Example.tsx
@@ -110,7 +110,7 @@ export class AreaChartStyledExample extends React.Component<{}, IAreaChartBasicS
 
     return (
       <>
-        <label htmlFor="changeWidth_Styled">change Width:</label>
+        <label htmlFor="changeWidth_Styled">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -120,7 +120,7 @@ export class AreaChartStyledExample extends React.Component<{}, IAreaChartBasicS
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Styled">change Height:</label>
+        <label htmlFor="changeHeight_Styled">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
@@ -134,7 +134,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
     return (
       <>
-        <label htmlFor="changeWidth_Basic">change Width:</label>
+        <label htmlFor="changeWidth_Basic">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -144,7 +144,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Basic">change Height:</label>
+        <label htmlFor="changeHeight_Basic">Change Height:</label>
         <input
           type="range"
           value={this.state.height}
@@ -155,7 +155,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
           aria-valuetext={`ChangeHeightslider${this.state.height}`}
         />
         <br />
-        <label htmlFor="changeBarwidth">change Barwidth:</label>
+        <label htmlFor="changeBarwidth">Change Barwidth:</label>
         <input
           type="range"
           value={this.state.barwidth}

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
@@ -169,7 +169,7 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
     ];
     return (
       <>
-        <label htmlFor="changeWidth_Custom">change Width:</label>
+        <label htmlFor="changeWidth_Custom">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -179,7 +179,7 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Custom">change Height:</label>
+        <label htmlFor="changeHeight_Custom">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Styled.Example.tsx
@@ -112,7 +112,7 @@ export class GroupedVerticalBarChartStyledExample extends React.Component<{}, IG
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
     return (
       <>
-        <label htmlFor="changeWidth_Styled">change Width:</label>
+        <label htmlFor="changeWidth_Styled">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -122,7 +122,7 @@ export class GroupedVerticalBarChartStyledExample extends React.Component<{}, IG
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Styled">change Height:</label>
+        <label htmlFor="changeHeight_Styled">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Truncated.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Truncated.Example.tsx
@@ -80,7 +80,7 @@ export class GroupedVerticalBarChartTruncatedExample extends React.Component<{},
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
     return (
       <>
-        <label htmlFor="changeWidth_Truncated">change Width:</label>
+        <label htmlFor="changeWidth_Truncated">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -90,7 +90,7 @@ export class GroupedVerticalBarChartTruncatedExample extends React.Component<{},
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Truncated">change Height:</label>
+        <label htmlFor="changeHeight_Truncated">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/HeatMapChart/HeatMapChartBasic.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/HeatMapChart/HeatMapChartBasic.CustomAccessibility.Example.tsx
@@ -359,7 +359,7 @@ export class HeatMapChartCustomAccessibilityExample extends React.Component<{}, 
     ];
     return (
       <>
-        <label htmlFor="ChangeWidth_Custom">change Width:</label>
+        <label htmlFor="ChangeWidth_Custom">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -369,7 +369,7 @@ export class HeatMapChartCustomAccessibilityExample extends React.Component<{}, 
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="ChangeHeight_Custom">change Height:</label>
+        <label htmlFor="ChangeHeight_Custom">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/HeatMapChart/HeatMapChartBasic.Example.tsx
+++ b/packages/react-examples/src/react-charting/HeatMapChart/HeatMapChartBasic.Example.tsx
@@ -298,7 +298,7 @@ export class HeatMapChartBasicExample extends React.Component<{}, IHeatMapChartB
     ];
     return (
       <>
-        <label htmlFor="changeWidth_Example">change Width:</label>
+        <label htmlFor="changeWidth_Example">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -308,7 +308,7 @@ export class HeatMapChartBasicExample extends React.Component<{}, IHeatMapChartB
           id="changeWidth_Example"
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Example">change Height:</label>
+        <label htmlFor="changeHeight_Example">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx
@@ -141,7 +141,7 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
 
     return (
       <>
-        <label htmlFor="changeWidth_basic">change Width:</label>
+        <label htmlFor="changeWidth_basic">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -151,7 +151,7 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Basic">change Height:</label>
+        <label htmlFor="changeHeight_Basic">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.CustomAccessibility.Example.tsx
@@ -25,7 +25,7 @@ export class LineChartCustomAccessibilityExample extends React.Component<
   public render(): JSX.Element {
     return (
       <>
-        <label htmlFor="changeWidth_Custom">change Width:</label>
+        <label htmlFor="changeWidth_Custom">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -35,7 +35,7 @@ export class LineChartCustomAccessibilityExample extends React.Component<
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Custom">change Height:</label>
+        <label htmlFor="changeHeight_Custom">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Events.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Events.Example.tsx
@@ -29,7 +29,7 @@ export class LineChartEventsExample extends React.Component<{}, ILineChartEvents
   public render(): JSX.Element {
     return (
       <>
-        <label htmlFor="changeWidth_Events">change Width:</label>
+        <label htmlFor="changeWidth_Events">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -39,7 +39,7 @@ export class LineChartEventsExample extends React.Component<{}, ILineChartEvents
           id="changeWidth_Events"
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Events">change Height:</label>
+        <label htmlFor="changeHeight_Events">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Gaps.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Gaps.Example.tsx
@@ -236,7 +236,7 @@ export class LineChartGapsExample extends React.Component<{}, ILineChartGapsStat
 
     return (
       <>
-        <label htmlFor="changeWidth_Gaps">change Width:</label>
+        <label htmlFor="changeWidth_Gaps">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -246,7 +246,7 @@ export class LineChartGapsExample extends React.Component<{}, ILineChartGapsStat
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="ChangeHeight_Gaps">change Height:</label>
+        <label htmlFor="ChangeHeight_Gaps">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Multiple.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Multiple.Example.tsx
@@ -22,7 +22,7 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
   public render(): JSX.Element {
     return (
       <>
-        <label htmlFor="changeWidth_Multiple">change Width:</label>
+        <label htmlFor="changeWidth_Multiple">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -32,7 +32,7 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Multiple">change Height:</label>
+        <label htmlFor="changeHeight_Multiple">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Styled.Example.tsx
@@ -60,7 +60,7 @@ export class LineChartStyledExample extends React.Component<{}, IStyledLineChart
     };
     return (
       <>
-        <label htmlFor="changeWidth_Styled">change Width:</label>
+        <label htmlFor="changeWidth_Styled">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -70,7 +70,7 @@ export class LineChartStyledExample extends React.Component<{}, IStyledLineChart
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Styled">change Height:</label>
+        <label htmlFor="changeHeight_Styled">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/SankeyChart/SankeyChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/SankeyChart/SankeyChart.Basic.Example.tsx
@@ -116,7 +116,7 @@ export class SankeyChartBasicExample extends React.Component<{}, ISankeyChartBas
 
     return (
       <>
-        <label htmlFor="changeWidth_Basic">change Width:</label>
+        <label htmlFor="changeWidth_Basic">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -126,7 +126,7 @@ export class SankeyChartBasicExample extends React.Component<{}, ISankeyChartBas
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Basic">change Height:</label>
+        <label htmlFor="changeHeight_Basic">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
@@ -146,7 +146,7 @@ export class VerticalBarChartBasicExample extends React.Component<IVerticalBarCh
 
     return (
       <>
-        <label htmlFor="changeWidth">change Width:</label>
+        <label htmlFor="changeWidth">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -156,7 +156,7 @@ export class VerticalBarChartBasicExample extends React.Component<IVerticalBarCh
           id="changeWidth"
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight">change Height:</label>
+        <label htmlFor="changeHeight">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
@@ -192,7 +192,7 @@ export class VerticalStackedBarChartBasicExample extends React.Component<{}, IVe
 
     return (
       <>
-        <label htmlFor="changeWidth_Basic">change Width:</label>
+        <label htmlFor="changeWidth_Basic">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -202,7 +202,7 @@ export class VerticalStackedBarChartBasicExample extends React.Component<{}, IVe
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Basic">change Height:</label>
+        <label htmlFor="changeHeight_Basic">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Callout.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Callout.Example.tsx
@@ -189,7 +189,7 @@ export class VerticalStackedBarChartCalloutExample extends React.Component<{}, I
 
     return (
       <>
-        <label htmlFor="changeWidth_Callout">change Width:</label>
+        <label htmlFor="changeWidth_Callout">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -199,7 +199,7 @@ export class VerticalStackedBarChartCalloutExample extends React.Component<{}, I
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Callout">change Height:</label>
+        <label htmlFor="changeHeight_Callout">Change Height:</label>
         <input
           type="range"
           value={this.state.height}

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
@@ -156,7 +156,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
 
     return (
       <>
-        <label htmlFor="changeWidth_Custom">change Width:</label>
+        <label htmlFor="changeWidth_Custom">Change Width:</label>
         <input
           type="range"
           value={this.state.width}
@@ -166,7 +166,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
         />
-        <label htmlFor="changeHeight_Custom">change Height:</label>
+        <label htmlFor="changeHeight_Custom">Change Height:</label>
         <input
           type="range"
           value={this.state.height}


### PR DESCRIPTION

## Current Behavior

Some charts don't automatically adopt sentence cases for labels and legends

## New Behavior

After this fix, all the labels and legends are having Sentace cases.


Fixes #
All the labels and legends have Sentace cases.
