### PR TITLE
feat(Avatar): add 'medium-large' avatar (36px)

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 - Consider webview element type for outside click scenarios for popups @jurokapsiar ([#23531](https://github.com/microsoft/fluentui/pull/23531))
 - Add `GlobeIcon` and `ArrowSyncIcon` @notandrew ([#23683](https://github.com/microsoft/fluentui/pull/23683))
+- Add size 'medium-large' to `Avatar` @yuanboxue-amber ([#23787](https://github.com/microsoft/fluentui/pull/23787))
 
 ### Fixes
 - Updating `Chat Message`'s `actionMenu` to use shadow8 @notandrew ([#23100](https://github.com/microsoft/fluentui/pull/23100))

--- a/packages/fluentui/docs/src/examples/components/Avatar/Variations/AvatarExampleSize.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Avatar/Variations/AvatarExampleSize.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar, Grid, SizeValue } from '@fluentui/react-northstar';
+import { Avatar, Grid, AvatarSizeValue } from '@fluentui/react-northstar';
 import { AcceptIcon, UserFriendsIcon } from '@fluentui/react-icons-northstar';
 
 const statusProps = {
@@ -10,7 +10,16 @@ const statusProps = {
 
 const AvatarExampleSizeShorthand = () => (
   <Grid columns="80px 1fr">
-    {(['smallest', 'smaller', 'small', 'medium', 'large', 'larger', 'largest'] as SizeValue[]).map(size => (
+    {([
+      'smallest',
+      'smaller',
+      'small',
+      'medium',
+      'medium-large',
+      'large',
+      'larger',
+      'largest',
+    ] as AvatarSizeValue[]).map(size => (
       <React.Fragment key={size}>
         <strong>{size}</strong>
         <div>

--- a/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
@@ -42,7 +42,7 @@ export interface AvatarProps extends UIComponentProps {
   square?: boolean;
 
   /** Size multiplier. */
-  size?: SizeValue;
+  size?: AvatarSizeValue;
 
   /** Shorthand for the status of the user. */
   status?: ShorthandValue<AvatarStatusProps>;
@@ -51,6 +51,7 @@ export interface AvatarProps extends UIComponentProps {
   getInitials?: (name: string) => string;
 }
 
+export type AvatarSizeValue = SizeValue | 'medium-large';
 export type AvatarStylesProps = Pick<AvatarProps, 'size' | 'square'>;
 export const avatarClassName = 'ui-avatar';
 

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarIcon.tsx
@@ -13,13 +13,13 @@ import * as PropTypes from 'prop-types';
 import {
   commonPropTypes,
   UIComponentProps,
-  SizeValue,
   ContentComponentProps,
   ChildrenComponentProps,
   childrenExist,
 } from '../../utils';
 import { FluentComponentStaticProps } from '../../types';
 import { Accessibility } from '@fluentui/accessibility';
+import { AvatarSizeValue } from './Avatar';
 
 export interface AvatarIconProps extends UIComponentProps, ContentComponentProps, ChildrenComponentProps {
   /** Accessibility behavior if overridden by the user. */
@@ -29,7 +29,7 @@ export interface AvatarIconProps extends UIComponentProps, ContentComponentProps
   square?: boolean;
 
   /** Size multiplier. */
-  size?: SizeValue;
+  size?: AvatarSizeValue;
 }
 
 export type AvatarIconStylesProps = Required<Pick<AvatarIconProps, 'size' | 'square'>>;

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarImage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarImage.tsx
@@ -11,9 +11,10 @@ import {
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 
-import { UIComponentProps, commonPropTypes, createShorthandFactory, SizeValue } from '../../utils';
+import { UIComponentProps, commonPropTypes, createShorthandFactory } from '../../utils';
 import { FluentComponentStaticProps } from '../../types';
 import { imageClassName } from '../Image/Image';
+import { AvatarSizeValue } from './Avatar';
 
 export interface AvatarImageProps extends UIComponentProps, ImageBehaviorProps {
   /** Alternative text. */
@@ -37,7 +38,7 @@ export interface AvatarImageProps extends UIComponentProps, ImageBehaviorProps {
   src?: string;
 
   /** Size multiplier. */
-  size?: SizeValue;
+  size?: AvatarSizeValue;
 }
 
 export type AvatarImageStylesProps = Pick<AvatarImageProps, 'avatar' | 'circular' | 'fluid' | 'size'>;

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarLabel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarLabel.tsx
@@ -19,11 +19,11 @@ import {
   ContentComponentProps,
   commonPropTypes,
   rtlTextContainer,
-  SizeValue,
 } from '../../utils';
 
 import { FluentComponentStaticProps } from '../../types';
 import { labelClassName } from '../Label/Label';
+import { AvatarSizeValue } from './Avatar';
 
 export interface AvatarLabelProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {
   /**
@@ -38,7 +38,7 @@ export interface AvatarLabelProps extends UIComponentProps, ChildrenComponentPro
   circular?: boolean;
 
   /** Size multiplier. */
-  size?: SizeValue;
+  size?: AvatarSizeValue;
 }
 
 export type AvatarLabelStylesProps = Pick<AvatarLabelProps, 'size' | 'square' | 'circular'>;

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarStatus.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarStatus.tsx
@@ -8,7 +8,7 @@ import {
   useUnhandledProps,
   ForwardRefWithAs,
 } from '@fluentui/react-bindings';
-import { commonPropTypes, SizeValue, UIComponentProps, createShorthandFactory, createShorthand } from '../../utils';
+import { commonPropTypes, UIComponentProps, createShorthandFactory, createShorthand } from '../../utils';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
 import { ShorthandValue, FluentComponentStaticProps } from '../../types';
@@ -16,6 +16,7 @@ import { Accessibility, statusBehavior as avatarStatusBehavior, StatusBehaviorPr
 import { AvatarStatusIcon, AvatarStatusIconProps } from './AvatarStatusIcon';
 import { AvatarStatusImage, AvatarStatusImageProps } from './AvatarStatusImage';
 import { statusClassName } from '../Status/Status';
+import { AvatarSizeValue } from './Avatar';
 
 export interface AvatarStatusProps extends UIComponentProps {
   /** Accessibility behavior if overridden by the user. */
@@ -31,7 +32,7 @@ export interface AvatarStatusProps extends UIComponentProps {
   image?: ShorthandValue<AvatarStatusImageProps>;
 
   /** Size multiplier */
-  size?: SizeValue;
+  size?: AvatarSizeValue;
 
   /** The pre-defined state values which can be consumed directly. */
   state?: 'success' | 'info' | 'warning' | 'error' | 'unknown';

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarStatusIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarStatusIcon.tsx
@@ -9,10 +9,11 @@ import {
   ForwardRefWithAs,
 } from '@fluentui/react-bindings';
 import * as PropTypes from 'prop-types';
-import { commonPropTypes, UIComponentProps, createShorthandFactory, SizeValue } from '../../utils';
+import { commonPropTypes, UIComponentProps, createShorthandFactory } from '../../utils';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import { FluentComponentStaticProps } from '../../types';
 import { Accessibility } from '@fluentui/accessibility';
+import { AvatarSizeValue } from './Avatar';
 
 export interface AvatarStatusIconProps extends UIComponentProps {
   /** Accessibility behavior if overridden by the user. */
@@ -22,7 +23,7 @@ export interface AvatarStatusIconProps extends UIComponentProps {
   state?: 'success' | 'info' | 'warning' | 'error' | 'unknown';
 
   /** Size multiplier */
-  size?: SizeValue;
+  size?: AvatarSizeValue;
 }
 
 export type AvatarStatusIconStylesProps = Required<Pick<AvatarStatusIconProps, 'size' | 'state'>>;

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarStatusImage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarStatusImage.tsx
@@ -13,14 +13,15 @@ import {
 import * as customPropTypes from '@fluentui/react-proptypes';
 
 import { FluentComponentStaticProps } from '../../types';
-import { commonPropTypes, createShorthandFactory, SizeValue, UIComponentProps } from '../../utils';
+import { commonPropTypes, createShorthandFactory, UIComponentProps } from '../../utils';
+import { AvatarSizeValue } from './Avatar';
 
 export interface AvatarStatusImageProps extends UIComponentProps {
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility<ImageBehaviorProps>;
 
   /** Size multiplier */
-  size?: SizeValue;
+  size?: AvatarSizeValue;
 
   /** AvatarImage source URL. */
   src?: string;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Avatar/avatarSizes.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Avatar/avatarSizes.ts
@@ -1,45 +1,50 @@
 import { ICSSInJSStyle } from '@fluentui/styles';
-import { pxToRem, SizeValue } from '../../../../utils';
+import { AvatarSizeValue } from '../../../../components/Avatar/Avatar';
+import { pxToRem } from '../../../../utils';
 
 /** Sizes for the Avatar and AvatarImage */
-export const sizeToPxValue: Record<SizeValue, number> = {
+export const sizeToPxValue: Record<AvatarSizeValue, number> = {
   smallest: 20,
   smaller: 24,
   small: 28,
   medium: 32,
+  'medium-large': 36,
   large: 44,
   larger: 64,
   largest: 96,
 };
 
 /** Sizes for the Icon inside the Avatar */
-export const iconSizeToPxValue: Record<SizeValue, number> = {
+export const iconSizeToPxValue: Record<AvatarSizeValue, number> = {
   smallest: 10,
   smaller: 12,
   small: 16,
   medium: 16,
+  'medium-large': 20,
   large: 20,
   larger: 32,
   largest: 40,
 };
 
 /** Sizes for the AvatarStatus and AvatarStatusImage */
-export const statusSizeToPxValue: Record<SizeValue, number> = {
+export const statusSizeToPxValue: Record<AvatarSizeValue, number> = {
   smallest: 6,
   smaller: 10,
   small: 10,
   medium: 10,
+  'medium-large': 10,
   large: 10,
   larger: 16,
   largest: 0,
 };
 
 /** Sizes for the AvaterStatusIcon */
-export const statusIconSizeToPxValue: Record<SizeValue, number> = {
+export const statusIconSizeToPxValue: Record<AvatarSizeValue, number> = {
   smallest: 4,
   smaller: 6,
   small: 6,
   medium: 6,
+  'medium-large': 6,
   large: 6,
   larger: 10,
   largest: 0,


### PR DESCRIPTION
Add @fluentui/react-northstar avatar with 'medium-large' size, aligning with the v9 size 36 avatar
<img width="559" alt="Screenshot 2022-06-30 at 17 10 33" src="https://user-images.githubusercontent.com/28751745/176713122-5292c8d5-4cbc-4a93-8121-4d53b4f30aff.png">
