### PR TITLE
Fix FocusTrapZone tab looping out of an iframe

### DIFF
--- a/change/@fluentui-react-7dd046c0-8634-439c-a9bf-92c20a10be45.json
+++ b/change/@fluentui-react-7dd046c0-8634-439c-a9bf-92c20a10be45.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Handle when FocusTrapZone wraps an iframe",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/FocusTrapZone/FocusTrapZone.Box.Example.tsx
+++ b/packages/react-examples/src/react/FocusTrapZone/FocusTrapZone.Box.Example.tsx
@@ -8,7 +8,7 @@ import { Text } from '@fluentui/react/lib/Text';
 import { TextField, ITextFieldStyles } from '@fluentui/react/lib/TextField';
 import { Toggle, IToggle } from '@fluentui/react/lib/Toggle';
 import { memoizeFunction } from '@fluentui/react/lib/Utilities';
-import { useBoolean } from '@fluentui/react-hooks';
+import { useBoolean, useEventCallback } from '@fluentui/react-hooks';
 
 const getStackStyles = memoizeFunction(
   (useTrapZone: boolean): Partial<IStackStyles> => ({
@@ -64,7 +64,7 @@ export const FocusTrapZoneBoxExample: React.FunctionComponent = () => {
 };
 
 const IFrameWrapper = (props: { onClick: () => void }): JSX.Element => {
-  const { onClick } = props;
+  const onClick = useEventCallback(props.onClick);
 
   const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
 
@@ -79,7 +79,7 @@ const IFrameWrapper = (props: { onClick: () => void }): JSX.Element => {
         ReactDOM.render(<DefaultButton onClick={onClick}>Button in IFrame</DefaultButton>, root);
       }
     }
-  }, []);
+  }, [onClick]);
 
   return <iframe style={{ width: '400px', height: '100px' }} ref={iframeRef} />;
 };

--- a/packages/react-examples/src/react/FocusTrapZone/FocusTrapZone.Box.Example.tsx
+++ b/packages/react-examples/src/react/FocusTrapZone/FocusTrapZone.Box.Example.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { DefaultButton } from '@fluentui/react/lib/Button';
 import { FocusTrapZone } from '@fluentui/react/lib/FocusTrapZone';
 import { Link } from '@fluentui/react/lib/Link';
@@ -20,6 +21,9 @@ const stackTokens = { childrenGap: 8 };
 export const FocusTrapZoneBoxExample: React.FunctionComponent = () => {
   const toggle = React.useRef<IToggle>(null);
   const [useTrapZone, { toggle: toggleUseTrapZone }] = useBoolean(false);
+
+  const [showIFrame, { toggle: toggleShowIFrame }] = useBoolean(false);
+
   return (
     <Stack tokens={stackTokens}>
       <Stack.Item>
@@ -42,6 +46,14 @@ export const FocusTrapZoneBoxExample: React.FunctionComponent = () => {
             offText="Off"
           />
           <TextField label="Input inside trap zone" styles={textFieldStyles} />
+          <Toggle
+            checked={showIFrame}
+            onChange={toggleShowIFrame}
+            label="Show IFrame"
+            onText="On (toggle to close)"
+            offText="Off"
+          />
+          {showIFrame ? <IFrameWrapper onClick={toggleShowIFrame} /> : null}
           <Link href="https://bing.com" target="_blank">
             Hyperlink inside trap zone
           </Link>
@@ -49,4 +61,25 @@ export const FocusTrapZoneBoxExample: React.FunctionComponent = () => {
       </FocusTrapZone>
     </Stack>
   );
+};
+
+const IFrameWrapper = (props: { onClick: () => void }): JSX.Element => {
+  const { onClick } = props;
+
+  const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
+
+  React.useEffect(() => {
+    if (iframeRef.current) {
+      const contentWindow = iframeRef.current.contentWindow;
+
+      if (contentWindow) {
+        const root = contentWindow.document.createElement('div');
+        contentWindow.document.body.appendChild(root);
+
+        ReactDOM.render(<DefaultButton onClick={onClick}>Button in IFrame</DefaultButton>, root);
+      }
+    }
+  }, []);
+
+  return <iframe style={{ width: '400px', height: '100px' }} ref={iframeRef} />;
 };

--- a/packages/react-examples/src/react/FocusTrapZone/FocusTrapZone.Nested.Example.tsx
+++ b/packages/react-examples/src/react/FocusTrapZone/FocusTrapZone.Nested.Example.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { DefaultButton } from '@fluentui/react/lib/Button';
 import { FocusTrapZone } from '@fluentui/react/lib/FocusTrapZone';
 import { Stack, IStackStyles } from '@fluentui/react/lib/Stack';
@@ -21,6 +22,8 @@ const FocusTrapComponent: React.FunctionComponent<React.PropsWithChildren<{ zone
     alert(`Button ${zoneNumber} clicked`);
   };
 
+  const [showIFrame, { toggle: toggleShowIFrame }] = useBoolean(false);
+
   return (
     <FocusTrapZone disabled={!isActive} forceFocusInsideTrap={false}>
       <Stack horizontalAlign="start" tokens={stackTokens} styles={getStackStyles(isActive)}>
@@ -33,6 +36,14 @@ const FocusTrapComponent: React.FunctionComponent<React.PropsWithChildren<{ zone
           // Set a width on these toggles in the horizontal zone to prevent jumping when enabled
           styles={zoneNumber >= 2 && zoneNumber <= 4 ? fixedWidthToggleStyles : undefined}
         />
+        <Toggle
+          checked={showIFrame}
+          onChange={toggleShowIFrame}
+          label="Show IFrame"
+          onText="On (toggle to close)"
+          offText="Off"
+        />
+        {showIFrame ? <IFrameWrapper onClick={toggleShowIFrame} /> : null}
         <DefaultButton
           // eslint-disable-next-line react/jsx-no-bind
           onClick={onStringButtonClicked}
@@ -55,3 +66,24 @@ export const FocusTrapZoneNestedExample = () => (
     </FocusTrapComponent>
   </div>
 );
+
+const IFrameWrapper = (props: { onClick: () => void }): JSX.Element => {
+  const { onClick } = props;
+
+  const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
+
+  React.useEffect(() => {
+    if (iframeRef.current) {
+      const contentWindow = iframeRef.current.contentWindow;
+
+      if (contentWindow) {
+        const root = contentWindow.document.createElement('div');
+        contentWindow.document.body.appendChild(root);
+
+        ReactDOM.render(<DefaultButton onClick={onClick}>Button in IFrame</DefaultButton>, root);
+      }
+    }
+  }, []);
+
+  return <iframe style={{ width: '400px', height: '100px' }} ref={iframeRef} />;
+};

--- a/packages/react-examples/src/react/FocusTrapZone/FocusTrapZone.Nested.Example.tsx
+++ b/packages/react-examples/src/react/FocusTrapZone/FocusTrapZone.Nested.Example.tsx
@@ -5,7 +5,7 @@ import { FocusTrapZone } from '@fluentui/react/lib/FocusTrapZone';
 import { Stack, IStackStyles } from '@fluentui/react/lib/Stack';
 import { Toggle, IToggleStyles } from '@fluentui/react/lib/Toggle';
 import { memoizeFunction } from '@fluentui/react/lib/Utilities';
-import { useBoolean } from '@fluentui/react-hooks';
+import { useBoolean, useEventCallback } from '@fluentui/react-hooks';
 
 const getStackStyles = memoizeFunction(
   (isActive: boolean): Partial<IStackStyles> => ({
@@ -68,7 +68,7 @@ export const FocusTrapZoneNestedExample = () => (
 );
 
 const IFrameWrapper = (props: { onClick: () => void }): JSX.Element => {
-  const { onClick } = props;
+  const onClick = useEventCallback(props.onClick);
 
   const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
 
@@ -83,7 +83,7 @@ const IFrameWrapper = (props: { onClick: () => void }): JSX.Element => {
         ReactDOM.render(<DefaultButton onClick={onClick}>Button in IFrame</DefaultButton>, root);
       }
     }
-  }, []);
+  }, [onClick]);
 
   return <iframe style={{ width: '400px', height: '100px' }} ref={iframeRef} />;
 };

--- a/packages/react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -241,8 +241,17 @@ export const FocusTrapZone: React.FunctionComponent<IFocusTrapZoneProps> & {
     if (internalState.focusStackId === FocusTrapZone.focusStack!.slice(-1)[0]) {
       const targetElement = ev.target as HTMLElement | null;
       if (targetElement && !elementContains(root.current, targetElement)) {
-        focusFTZ();
-        internalState.hasFocus = true; // set focus here since we stop event propagation
+        if (doc && doc.activeElement === doc.body) {
+          setTimeout(() => {
+            if (doc && doc.activeElement === doc.body) {
+              focusFTZ();
+              internalState.hasFocus = true; // set focus here since we stop event propagation
+            }
+          }, 0);
+        } else {
+          focusFTZ();
+          internalState.hasFocus = true; // set focus here since we stop event propagation
+        }
         ev.preventDefault();
         ev.stopPropagation();
       }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

When an `iframe` is nested under a `<FocusTrapZone>`, and the `FocusTrapZone` is enabled, tabbing out of the `iframe` loops immediately back to the start of the trap zone, rather than continuing to the next element within the zone.

## New Behavior

The issue is that when the user tabs out of an iframe, the focus briefly becomes `document.body` before it gets set to the correct element. With this change, `FocusTrapZone` checks whether the next-focused element is `document.body`, and then 'sleeps' for a moment before trying to recover focus. This ensures that the async focus update has a chance to continue out of the `iframe` and into the next element.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20116
