### PR TITLE
fix: Datepicker hover color in HC theme

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Updating `Chat Message`'s `actionMenu` to use shadow8 @notandrew ([#23100](https://github.com/microsoft/fluentui/pull/23100))
 - Update `Pink` colors to new color palette @notandrew ([#23262](https://github.com/microsoft/fluentui/pull/23262))
+- Fix `Datepicker` hover background for HC theme @chpalac ([#23798](https://github.com/microsoft/fluentui/pull/23798))
 
 <!--------------------------------[ v0.63.1 ]------------------------------- -->
 ## [v0.63.1](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.63.1) (2022-06-06)

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/componentVariables.ts
@@ -42,5 +42,6 @@ export { labelVariables as Label } from './components/Label/labelVariables';
 export { tooltipContentVariables as TooltipContent } from './components/Tooltip/tooltipContentVariables';
 export { datepickerCalendarCellVariables as DatepickerCalendarCell } from './components/Datepicker/datepickerCalendarCellVariables';
 export { datepickerCalendarCellButtonVariables as DatepickerCalendarCellButton } from './components/Datepicker/datepickerCalendarCellButtonVariables';
+export { datepickerCalendarGridRowVariables as DatepickerCalendarGridRow } from './components/Datepicker/datepickerCalendarGridRowVariables';
 export { cardVariables as Card } from './components/Card/cardVariables';
 export { splitButtonVariables as SplitButtonDivider } from './components/SplitButton/splitButtonVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Datepicker/datepickerCalendarCellVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Datepicker/datepickerCalendarCellVariables.ts
@@ -7,5 +7,6 @@ export const datepickerCalendarCellVariables = (siteVars: any): Partial<Datepick
     calendarCellTodayColor: siteVars.colors.black,
     calendarCellQuietColor: siteVars.colors.white,
     calendarCellDisabledColor: siteVars.colors.white,
+    calendarCellHoverBackgroundColor: siteVars.accessibleCyan,
   };
 };

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Datepicker/datepickerCalendarGridRowVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Datepicker/datepickerCalendarGridRowVariables.ts
@@ -1,0 +1,8 @@
+import { DatepickerVariables } from '../../../teams/components/Datepicker/datepickerVariables';
+
+export const datepickerCalendarGridRowVariables = (siteVars: any): Partial<DatepickerVariables> => {
+  return {
+    calendarCellHoverBackgroundColor: siteVars.accessibleCyan,
+    calendarCellHoverColor: siteVars.colors.black,
+  };
+};


### PR DESCRIPTION
# Overview 

Fix hover color for `Datepicker` in HC theme. 

Before:

![Before](https://user-images.githubusercontent.com/86579954/177161537-e59b1dc5-e9f4-4054-a65b-37b045d48700.png)

After:

![After](https://user-images.githubusercontent.com/86579954/177161581-b3b40586-eca5-4b22-a307-da6cfc64726e.png)
