### PR TITLE
ci: add workflow to automatically create the monthly milestone

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -1,0 +1,22 @@
+name: Create milestone
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  create-milestone:
+    name: Create this month's milestone
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create milestone
+        run: |
+          month=$(date +"%B")
+          quarter=$(date +"%q")
+          year=$(date +"%Y")
+          title="${month} Project Cycle Q${quarter} ${year}"
+          echo "Using title '${title}'"
+          gh api --method POST repos/microsoft/fluentui/milestones -f title="${title}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## New Behavior

Added a GH workflow that will run on the first day of the month, can also be triggered manually, and create the milestone automatically. 
This aims to avoid unnecessary errors with the `add-to-milestone` action.

Title format: "January Project Cycle Q1 2022"
Sample run: https://github.com/andrefcdias/actions-test/runs/7183696473?check_suite_focus=true