### PR TITLE
7.0 latest fixes

### DIFF
--- a/change/@uifabric-charting-62f1361d-9a51-4f46-9e0e-c7edefb85fa0.json
+++ b/change/@uifabric-charting-62f1361d-9a51-4f46-9e0e-c7edefb85fa0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "7.0 latest fixes",
+  "packageName": "@uifabric/charting",
+  "email": "v-hannapared@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -246,7 +246,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -264,6 +264,7 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -563,7 +564,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               }
         >
           <button
-            aria-label="metaData1"
+            aria-label="metaData1 selected"
             aria-posinset={1}
             aria-selected={false}
             aria-setsize={1}
@@ -581,6 +582,7 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1076,7 +1078,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1094,6 +1096,7 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1410,7 +1413,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                     }
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1428,6 +1431,7 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1744,7 +1748,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1762,6 +1766,7 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2078,7 +2083,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -2096,6 +2101,7 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="first"
+                  aria-label="first selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -213,6 +213,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -283,7 +284,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="second"
+                  aria-label="second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -301,6 +302,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -566,7 +568,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                     }
               >
                 <button
-                  aria-label="first"
+                  aria-label="first selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -584,6 +586,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -654,7 +657,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                     }
               >
                 <button
-                  aria-label="second"
+                  aria-label="second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -672,6 +675,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1068,7 +1072,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="first"
+                  aria-label="first selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1086,6 +1090,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1156,7 +1161,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="second"
+                  aria-label="second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1174,6 +1179,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1443,7 +1449,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                     }
               >
                 <button
-                  aria-label="first"
+                  aria-label="first selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1461,6 +1467,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1531,7 +1538,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                     }
               >
                 <button
-                  aria-label="second"
+                  aria-label="second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1549,6 +1556,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                     }
               >
                 <button
-                  aria-label="MetaData1"
+                  aria-label="MetaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -320,6 +320,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -390,7 +391,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                     }
               >
                 <button
-                  aria-label="MetaData2"
+                  aria-label="MetaData2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -408,6 +409,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -478,7 +480,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                     }
               >
                 <button
-                  aria-label="MetaData3"
+                  aria-label="MetaData3 selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -496,6 +498,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -851,7 +854,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
               }
         >
           <button
-            aria-label="MetaData1"
+            aria-label="MetaData1 selected"
             aria-posinset={1}
             aria-selected={false}
             aria-setsize={3}
@@ -869,6 +872,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -939,7 +943,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
               }
         >
           <button
-            aria-label="MetaData2"
+            aria-label="MetaData2 selected"
             aria-posinset={2}
             aria-selected={false}
             aria-setsize={3}
@@ -957,6 +961,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1027,7 +1032,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
               }
         >
           <button
-            aria-label="MetaData3"
+            aria-label="MetaData3 selected"
             aria-posinset={3}
             aria-selected={false}
             aria-setsize={3}
@@ -1045,6 +1050,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1652,7 +1658,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                     }
               >
                 <button
-                  aria-label="MetaData1"
+                  aria-label="MetaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1670,6 +1676,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1740,7 +1747,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                     }
               >
                 <button
-                  aria-label="MetaData2"
+                  aria-label="MetaData2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1758,6 +1765,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1828,7 +1836,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                     }
               >
                 <button
-                  aria-label="MetaData3"
+                  aria-label="MetaData3 selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1846,6 +1854,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2218,7 +2227,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                     }
               >
                 <button
-                  aria-label="MetaData1"
+                  aria-label="MetaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2236,6 +2245,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2306,7 +2316,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                     }
               >
                 <button
-                  aria-label="MetaData2"
+                  aria-label="MetaData2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2324,6 +2334,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2394,7 +2405,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                     }
               >
                 <button
-                  aria-label="MetaData3"
+                  aria-label="MetaData3 selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2412,6 +2423,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2784,7 +2796,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                     }
               >
                 <button
-                  aria-label="MetaData1"
+                  aria-label="MetaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2802,6 +2814,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2872,7 +2885,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                     }
               >
                 <button
-                  aria-label="MetaData2"
+                  aria-label="MetaData2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2890,6 +2903,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2960,7 +2974,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                     }
               >
                 <button
-                  aria-label="MetaData3"
+                  aria-label="MetaData3 selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2978,6 +2992,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -3350,7 +3365,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                     }
               >
                 <button
-                  aria-label="MetaData1"
+                  aria-label="MetaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -3368,6 +3383,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -3438,7 +3454,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                     }
               >
                 <button
-                  aria-label="MetaData2"
+                  aria-label="MetaData2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -3456,6 +3472,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -3526,7 +3543,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                     }
               >
                 <button
-                  aria-label="MetaData3"
+                  aria-label="MetaData3 selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -3544,6 +3561,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -232,7 +232,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="Execllent (0-200)"
+                  aria-label="Execllent (0-200) selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -250,6 +250,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -552,7 +553,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                     }
               >
                 <button
-                  aria-label="Execllent (0-200)"
+                  aria-label="Execllent (0-200) selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -570,6 +571,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -640,7 +642,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                     }
               >
                 <button
-                  aria-label="Nasty"
+                  aria-label="Nasty selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -658,6 +660,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1128,7 +1131,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="Execllent (0-200)"
+                  aria-label="Execllent (0-200) selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1146,6 +1149,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1448,7 +1452,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="Execllent (0-200)"
+                  aria-label="Execllent (0-200) selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1466,6 +1470,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -379,7 +379,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
         {...(allowFocusOnLegends && {
           'aria-selected': this.state.selectedLegend === legend.title,
           role: 'option',
-          'aria-label': legend.title,
+          'aria-label': `${legend.title} selected`,
           'aria-setsize': data['aria-setsize'],
           'aria-posinset': data['aria-posinset'],
         })}

--- a/packages/charting/src/components/Legends/Legends.styles.ts
+++ b/packages/charting/src/components/Legends/Legends.styles.ts
@@ -37,6 +37,7 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
         border: 'none',
         padding: '8px',
         background: 'none',
+        textTransform: 'capitalize',
       },
     ],
     rect: {

--- a/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -252,6 +252,7 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -539,7 +540,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
               }
         >
           <button
-            aria-label="metaData1"
+            aria-label="metaData1 selected"
             aria-posinset={1}
             aria-selected={false}
             aria-setsize={1}
@@ -557,6 +558,7 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1028,7 +1030,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1046,6 +1048,7 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1350,7 +1353,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                     }
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1368,6 +1371,7 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1672,7 +1676,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -1690,6 +1694,7 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1994,7 +1999,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="metaData1"
+                  aria-label="metaData1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={1}
@@ -2012,6 +2017,7 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -1429,7 +1429,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                     }
               >
                 <button
-                  aria-label="Debit card numbers (EU and USA)"
+                  aria-label="Debit card numbers (EU and USA) selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1447,6 +1447,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1517,7 +1518,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                     }
               >
                 <button
-                  aria-label="Passport numbers (USA)"
+                  aria-label="Passport numbers (USA) selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1535,6 +1536,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -1238,7 +1238,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                     }
               >
                 <button
-                  aria-label="first Lorem ipsum dolor sit amet"
+                  aria-label="first Lorem ipsum dolor sit amet selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1256,6 +1256,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1326,7 +1327,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                     }
               >
                 <button
-                  aria-label="Winter is coming"
+                  aria-label="Winter is coming selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1344,6 +1345,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -171,7 +171,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                     }
               >
                 <button
-                  aria-label="First"
+                  aria-label="First selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -189,6 +189,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -259,7 +260,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                     }
               >
                 <button
-                  aria-label="Second"
+                  aria-label="Second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -277,6 +278,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -347,7 +349,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                     }
               >
                 <button
-                  aria-label="Third"
+                  aria-label="Third selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -365,6 +367,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -589,7 +592,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
               }
         >
           <button
-            aria-label="First"
+            aria-label="First selected"
             aria-posinset={1}
             aria-selected={false}
             aria-setsize={3}
@@ -607,6 +610,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -677,7 +681,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
               }
         >
           <button
-            aria-label="Second"
+            aria-label="Second selected"
             aria-posinset={2}
             aria-selected={false}
             aria-setsize={3}
@@ -695,6 +699,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -765,7 +770,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
               }
         >
           <button
-            aria-label="Third"
+            aria-label="Third selected"
             aria-posinset={3}
             aria-selected={false}
             aria-setsize={3}
@@ -783,6 +788,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1128,7 +1134,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="First"
+                  aria-label="First selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1146,6 +1152,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1216,7 +1223,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="Second"
+                  aria-label="Second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1234,6 +1241,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1304,7 +1312,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                     }
               >
                 <button
-                  aria-label="Third"
+                  aria-label="Third selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1322,6 +1330,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1563,7 +1572,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                     }
               >
                 <button
-                  aria-label="First"
+                  aria-label="First selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1581,6 +1590,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1651,7 +1661,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                     }
               >
                 <button
-                  aria-label="Second"
+                  aria-label="Second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1669,6 +1679,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1739,7 +1750,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                     }
               >
                 <button
-                  aria-label="Third"
+                  aria-label="Third selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -1757,6 +1768,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1998,7 +2010,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                     }
               >
                 <button
-                  aria-label="First"
+                  aria-label="First selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2016,6 +2028,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2086,7 +2099,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                     }
               >
                 <button
-                  aria-label="Second"
+                  aria-label="Second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2104,6 +2117,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2174,7 +2188,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                     }
               >
                 <button
-                  aria-label="Third"
+                  aria-label="Third selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2192,6 +2206,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2433,7 +2448,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                     }
               >
                 <button
-                  aria-label="First"
+                  aria-label="First selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2451,6 +2466,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2521,7 +2537,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                     }
               >
                 <button
-                  aria-label="Second"
+                  aria-label="Second selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2539,6 +2555,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2609,7 +2626,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                     }
               >
                 <button
-                  aria-label="Third"
+                  aria-label="Third selected"
                   aria-posinset={3}
                   aria-selected={false}
                   aria-setsize={3}
@@ -2627,6 +2644,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                     }
               >
                 <button
-                  aria-label="Metadata1"
+                  aria-label="Metadata1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -186,6 +186,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -256,7 +257,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                     }
               >
                 <button
-                  aria-label="Metadata2"
+                  aria-label="Metadata2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -274,6 +275,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -495,7 +497,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
               }
         >
           <button
-            aria-label="Metadata1"
+            aria-label="Metadata1 selected"
             aria-posinset={1}
             aria-selected={false}
             aria-setsize={2}
@@ -513,6 +515,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -583,7 +586,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
               }
         >
           <button
-            aria-label="Metadata2"
+            aria-label="Metadata2 selected"
             aria-posinset={2}
             aria-selected={false}
             aria-setsize={2}
@@ -601,6 +604,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
                   padding-right: 8px;
                   padding-top: 8px;
                   position: relative;
+                  text-transform: capitalize;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -940,7 +944,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                     }
               >
                 <button
-                  aria-label="Metadata1"
+                  aria-label="Metadata1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -958,6 +962,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1028,7 +1033,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                     }
               >
                 <button
-                  aria-label="Metadata2"
+                  aria-label="Metadata2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1046,6 +1051,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1284,7 +1290,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                     }
               >
                 <button
-                  aria-label="Metadata1"
+                  aria-label="Metadata1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1302,6 +1308,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1372,7 +1379,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                     }
               >
                 <button
-                  aria-label="Metadata2"
+                  aria-label="Metadata2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1390,6 +1397,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1628,7 +1636,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                     }
               >
                 <button
-                  aria-label="Metadata1"
+                  aria-label="Metadata1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1646,6 +1654,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1716,7 +1725,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                     }
               >
                 <button
-                  aria-label="Metadata2"
+                  aria-label="Metadata2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1734,6 +1743,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1972,7 +1982,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                     }
               >
                 <button
-                  aria-label="Metadata1"
+                  aria-label="Metadata1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -1990,6 +2000,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2060,7 +2071,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                     }
               >
                 <button
-                  aria-label="Metadata2"
+                  aria-label="Metadata2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -2078,6 +2089,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2316,7 +2328,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                     }
               >
                 <button
-                  aria-label="Metadata1"
+                  aria-label="Metadata1 selected"
                   aria-posinset={1}
                   aria-selected={false}
                   aria-setsize={2}
@@ -2334,6 +2346,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2404,7 +2417,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                     }
               >
                 <button
-                  aria-label="Metadata2"
+                  aria-label="Metadata2 selected"
                   aria-posinset={2}
                   aria-selected={false}
                   aria-setsize={2}
@@ -2422,6 +2435,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
                         padding-right: 8px;
                         padding-top: 8px;
                         position: relative;
+                        text-transform: capitalize;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/react-examples/src/charting/AreaChart/AreaChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/AreaChart/AreaChart.Basic.Example.tsx
@@ -153,9 +153,9 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
 
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <ChoiceGroup options={options} defaultSelectedKey="basicExample" onChange={this._onChange} label="Pick one" />
         <div style={rootStyle}>

--- a/packages/react-examples/src/charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx
@@ -145,9 +145,9 @@ export class AreaChartCustomAccessibilityExample extends React.Component<{}, IAr
 
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <AreaChart

--- a/packages/react-examples/src/charting/AreaChart/AreaChart.Multiple.Example.tsx
+++ b/packages/react-examples/src/charting/AreaChart/AreaChart.Multiple.Example.tsx
@@ -185,9 +185,9 @@ export class AreaChartMultipleExample extends React.Component<{}, IAreaChartBasi
 
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <AreaChart

--- a/packages/react-examples/src/charting/AreaChart/AreaChart.Styled.Example.tsx
+++ b/packages/react-examples/src/charting/AreaChart/AreaChart.Styled.Example.tsx
@@ -110,9 +110,9 @@ export class AreaChartStyledExample extends React.Component<{}, IAreaChartBasicS
 
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <AreaChart

--- a/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
@@ -132,11 +132,11 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
-        <label>change Barwidth:</label>
+        <label>Change Barwidth:</label>
         <input type="range" value={this.state.barwidth} min={10} max={70} onChange={this._onBarwidthChange} />
         <label>{this.state.barwidth}</label>
         <ChoiceGroup

--- a/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic2.Example.tsx
+++ b/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic2.Example.tsx
@@ -123,9 +123,9 @@ export class GroupedVerticalBarChartBasic2Example extends React.Component<{}, IG
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <GroupedVerticalBarChart

--- a/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
@@ -170,9 +170,9 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
     ];
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <ChoiceGroup
           options={options}

--- a/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Styled.Example.tsx
@@ -102,9 +102,9 @@ export class GroupedVerticalBarChartStyledExample extends React.Component<{}, IG
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <GroupedVerticalBarChart

--- a/packages/react-examples/src/charting/HeatMapChart/HeatMapChartBasic.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/HeatMapChart/HeatMapChartBasic.CustomAccessibility.Example.tsx
@@ -359,9 +359,9 @@ export class HeatMapChartCustomAccessibilityExample extends React.Component<{}, 
     ];
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <p>Heat map explaining the Air Quality Index</p>
         <div style={rootStyle}>

--- a/packages/react-examples/src/charting/HeatMapChart/HeatMapChartBasic.Example.tsx
+++ b/packages/react-examples/src/charting/HeatMapChart/HeatMapChartBasic.Example.tsx
@@ -298,9 +298,9 @@ export class HeatMapChartBasicExample extends React.Component<{}, IHeatMapChartB
     ];
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <p>Heat map explaining the Air Quality Index</p>
         <div style={rootStyle}>

--- a/packages/react-examples/src/charting/LineChart/LineChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/LineChart/LineChart.Basic.Example.tsx
@@ -141,9 +141,9 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
 
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <Toggle
           label="Enabled multiple shapes for each line"

--- a/packages/react-examples/src/charting/LineChart/LineChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/LineChart/LineChart.CustomAccessibility.Example.tsx
@@ -25,9 +25,9 @@ export class LineChartCustomAccessibilityExample extends React.Component<
   public render(): JSX.Element {
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <Toggle
           label="Enabled  multiple shapes for each line"

--- a/packages/react-examples/src/charting/LineChart/LineChart.Events.Example.tsx
+++ b/packages/react-examples/src/charting/LineChart/LineChart.Events.Example.tsx
@@ -29,9 +29,9 @@ export class LineChartEventsExample extends React.Component<{}, ILineChartEvents
   public render(): JSX.Element {
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <Toggle
           label="Enabled  multiple shapes for each line"

--- a/packages/react-examples/src/charting/LineChart/LineChart.Gap.Example.tsx
+++ b/packages/react-examples/src/charting/LineChart/LineChart.Gap.Example.tsx
@@ -236,9 +236,9 @@ export class LineChartGapsExample extends React.Component<{}, ILineChartGapsStat
 
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={500} max={1500} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <LineChart

--- a/packages/react-examples/src/charting/LineChart/LineChart.Multiple.Example.tsx
+++ b/packages/react-examples/src/charting/LineChart/LineChart.Multiple.Example.tsx
@@ -22,9 +22,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
   public render(): JSX.Element {
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <Toggle
           label="Enabled  multiple shapes for each line"

--- a/packages/react-examples/src/charting/LineChart/LineChart.Styled.Example.tsx
+++ b/packages/react-examples/src/charting/LineChart/LineChart.Styled.Example.tsx
@@ -60,9 +60,9 @@ export class LineChartStyledExample extends React.Component<{}, IStyledLineChart
     };
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
           <LineChart

--- a/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
@@ -146,9 +146,9 @@ export class VerticalBarChartBasicExample extends React.Component<IVerticalBarCh
 
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <ChoiceGroup options={options} defaultSelectedKey="basicExample" onChange={this._onChange} label="Pick one" />
         <Checkbox

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
@@ -191,9 +191,9 @@ export class VerticalStackedBarChartBasicExample extends React.Component<{}, IVe
 
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <label>BarGapMax:</label>
         <input

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Callout.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Callout.Example.tsx
@@ -189,9 +189,9 @@ export class VerticalStackedBarChartCalloutExample extends React.Component<{}, I
 
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <label>BarGapMax:</label>
         <input

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
@@ -156,9 +156,9 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
 
     return (
       <>
-        <label>change Width:</label>
+        <label>Change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
+        <label>Change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <label>BarGapMax:</label>
         <input


### PR DESCRIPTION
Current Behavior
The screen reader is not announcing state(Selected) when the focus is on legends.

Some charts don't automatically adopt sentence cases for labels and legends

It is announcing as 'Second 2 of 4'.

New Behavior
Screen reader is announcing state(Selected) when focus is on legends

All the labels and legends have Sentace cases.