### PR TITLE
Add focusZoneProps support for Nav

### DIFF
--- a/change/@fluentui-react-d83addbf-ad1d-483b-89b1-6de1d129de6b.json
+++ b/change/@fluentui-react-d83addbf-ad1d-483b-89b1-6de1d129de6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add defaultTabbableElement support for Nav",
+  "packageName": "@fluentui/react",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-d83addbf-ad1d-483b-89b1-6de1d129de6b.json
+++ b/change/@fluentui-react-d83addbf-ad1d-483b-89b1-6de1d129de6b.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "add defaultTabbableElement support for Nav",
   "packageName": "@fluentui/react",
   "email": "cqc@cuiqingcai.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "minor"
 }

--- a/change/@fluentui-react-d83addbf-ad1d-483b-89b1-6de1d129de6b.json
+++ b/change/@fluentui-react-d83addbf-ad1d-483b-89b1-6de1d129de6b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "add defaultTabbableElement support for Nav",
+  "comment": "add focusZoneProps support for Nav",
   "packageName": "@fluentui/react",
   "email": "cqc@cuiqingcai.com",
   "dependentChangeType": "minor"

--- a/change/@fluentui-react-d83addbf-ad1d-483b-89b1-6de1d129de6b.json
+++ b/change/@fluentui-react-d83addbf-ad1d-483b-89b1-6de1d129de6b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "add focusZoneProps support for Nav",
+  "comment": "feat: Adding focusZoneProps support for Nav.",
   "packageName": "@fluentui/react",
   "email": "cqc@cuiqingcai.com",
   "dependentChangeType": "minor"

--- a/packages/react-examples/src/react/Nav/Nav.FabricDemoApp.Example.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.FabricDemoApp.Example.tsx
@@ -74,6 +74,12 @@ const navLinkGroups: INavLinkGroup[] = [
 
 export const NavFabricDemoAppExample: React.FunctionComponent = () => {
   return (
-    <Nav styles={navStyles} ariaLabel="Nav example similar to one found in this demo page" groups={navLinkGroups} />
+    <Nav
+      defaultTabbableElement="a[title='MarqueeSelection']"
+      initialSelectedKey="MarqueeSelection"
+      styles={navStyles}
+      ariaLabel="Nav example similar to one found in this demo page"
+      groups={navLinkGroups}
+    />
   );
 };

--- a/packages/react-examples/src/react/Nav/Nav.FabricDemoApp.Example.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.FabricDemoApp.Example.tsx
@@ -74,13 +74,6 @@ const navLinkGroups: INavLinkGroup[] = [
 
 export const NavFabricDemoAppExample: React.FunctionComponent = () => {
   return (
-    <Nav
-      styles={navStyles}
-      ariaLabel="Nav example similar to one found in this demo page"
-      groups={navLinkGroups}
-      focusZoneProps={{
-        defaultTabbableElement: "a[title='MarqueeSelection']",
-      }}
-    />
+    <Nav styles={navStyles} ariaLabel="Nav example similar to one found in this demo page" groups={navLinkGroups} />
   );
 };

--- a/packages/react-examples/src/react/Nav/Nav.FabricDemoApp.Example.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.FabricDemoApp.Example.tsx
@@ -75,11 +75,12 @@ const navLinkGroups: INavLinkGroup[] = [
 export const NavFabricDemoAppExample: React.FunctionComponent = () => {
   return (
     <Nav
-      defaultTabbableElement="a[title='MarqueeSelection']"
-      initialSelectedKey="MarqueeSelection"
       styles={navStyles}
       ariaLabel="Nav example similar to one found in this demo page"
       groups={navLinkGroups}
+      focusZoneProps={{
+        defaultTabbableElement: "a[title='MarqueeSelection']",
+      }}
     />
   );
 };

--- a/packages/react-examples/src/react/Nav/Nav.FocusZone.Example.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.FocusZone.Example.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Nav, INavStyles, INavLinkGroup } from '@fluentui/react/lib/Nav';
+
+const navStyles: Partial<INavStyles> = { root: { width: 300 } };
+
+const navLinkGroups: INavLinkGroup[] = [
+  {
+    name: 'Basic components',
+    links: [
+      {
+        key: 'ActivityItem',
+        name: 'ActivityItem',
+        url: '#/examples/activityitem',
+      },
+      {
+        key: 'Breadcrumb',
+        name: 'Breadcrumb',
+        url: '#/examples/breadcrumb',
+      },
+      {
+        key: 'Button',
+        name: 'Button',
+        url: '#/examples/button',
+      },
+    ],
+  },
+];
+
+export const NavFocusZoneExample: React.FunctionComponent = () => {
+  return (
+    <Nav
+      styles={navStyles}
+      groups={navLinkGroups}
+      focusZoneProps={{
+        defaultTabbableElement: "a[title='Breadcrumb']",
+        allowFocusRoot: false,
+      }}
+    />
+  );
+};

--- a/packages/react-examples/src/react/Nav/Nav.doc.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.doc.tsx
@@ -5,11 +5,13 @@ import { IDocPageProps } from '@fluentui/react/lib/common/DocPage.types';
 import { NavFabricDemoAppExample } from './Nav.FabricDemoApp.Example';
 import { NavNestedExample } from './Nav.Nested.Example';
 import { NavCustomGroupHeadersExample } from './Nav.CustomGroupHeaders.Example';
+import { NavFocusZoneExample } from './Nav.FocusZone.Example';
 
 const NavBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.Basic.Example.tsx') as string;
 const NavWrappedExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.Wrapped.Example.tsx') as string;
 const NavFabricDemoAppExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.FabricDemoApp.Example.tsx') as string;
 const NavNestedExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.Nested.Example.tsx') as string;
+const NavFocusZoneExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.FocusZone.Example.tsx') as string;
 const NavCustomGroupHeadersExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.CustomGroupHeaders.Example.tsx') as string;
 
 export const NavPageProps: IDocPageProps = {
@@ -36,6 +38,11 @@ export const NavPageProps: IDocPageProps = {
       title: 'Nav with nested links',
       code: NavNestedExampleCode,
       view: <NavNestedExample />,
+    },
+    {
+      title: 'Nav with FocusZone props override',
+      code: NavFocusZoneExampleCode,
+      view: <NavFocusZoneExample />,
     },
     {
       title: 'Nav with custom group header',

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6949,6 +6949,7 @@ export interface INavProps {
     ariaLabel?: string;
     className?: string;
     componentRef?: IRefObject<INav>;
+    defaultTabbableElement?: string | ((root: HTMLElement) => HTMLElement);
     // @deprecated
     expandButtonAriaLabel?: string;
     groups: INavLinkGroup[] | null;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6949,9 +6949,9 @@ export interface INavProps {
     ariaLabel?: string;
     className?: string;
     componentRef?: IRefObject<INav>;
-    defaultTabbableElement?: string | ((root: HTMLElement) => HTMLElement);
     // @deprecated
     expandButtonAriaLabel?: string;
+    focusZoneProps?: IFocusZoneProps;
     groups: INavLinkGroup[] | null;
     initialSelectedKey?: string;
     isOnTop?: boolean;

--- a/packages/react/src/components/Nav/Nav.base.tsx
+++ b/packages/react/src/components/Nav/Nav.base.tsx
@@ -68,11 +68,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     const classNames = getClassNames(styles!, { theme: theme!, className, isOnTop, groups });
 
     return (
-      <FocusZone
-        direction={FocusZoneDirection.vertical}
-        componentRef={this._focusZone}
-        defaultTabbableElement={this.props.defaultTabbableElement}
-      >
+      <FocusZone direction={FocusZoneDirection.vertical} componentRef={this._focusZone} {...this.props.focusZoneProps}>
         <nav role="navigation" className={classNames.root} aria-label={this.props.ariaLabel}>
           {groupElements}
         </nav>

--- a/packages/react/src/components/Nav/Nav.base.tsx
+++ b/packages/react/src/components/Nav/Nav.base.tsx
@@ -68,7 +68,11 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     const classNames = getClassNames(styles!, { theme: theme!, className, isOnTop, groups });
 
     return (
-      <FocusZone direction={FocusZoneDirection.vertical} componentRef={this._focusZone}>
+      <FocusZone
+        direction={FocusZoneDirection.vertical}
+        componentRef={this._focusZone}
+        defaultTabbableElement={this.props.defaultTabbableElement}
+      >
         <nav role="navigation" className={classNames.root} aria-label={this.props.ariaLabel}>
           {groupElements}
         </nav>

--- a/packages/react/src/components/Nav/Nav.types.ts
+++ b/packages/react/src/components/Nav/Nav.types.ts
@@ -126,7 +126,7 @@ export interface INavProps {
   selectedAriaLabel?: string;
 
   /**
-   * (Optional) Used to define the props of FocusZone which is a wrapper of Nav
+   * (Optional) Used to define the props of the FocusZone wrapper.
    */
   focusZoneProps?: IFocusZoneProps;
 }

--- a/packages/react/src/components/Nav/Nav.types.ts
+++ b/packages/react/src/components/Nav/Nav.types.ts
@@ -3,6 +3,7 @@ import type { IStyle, ITheme } from '../../Styling';
 import type { IRefObject, IRenderFunction, IStyleFunctionOrObject, IComponentAs } from '../../Utilities';
 import type { IIconProps } from '../Icon/Icon.types';
 import type { IButtonProps } from '../../Button';
+import { IFocusZoneProps } from '@fluentui/react-focus';
 
 /**
  * {@doccategory Nav}
@@ -102,13 +103,6 @@ export interface INavProps {
   initialSelectedKey?: string;
 
   /**
-   * (Optional) Defines the initial tabbable nav item inside the Nav.
-   * If a string is passed then it is treated as a selector for identifying the initial tabbable nav item.
-   * If a function is passed then it uses the root element as a parameter to return the initial tabbable nav item.
-   */
-  defaultTabbableElement?: string | ((root: HTMLElement) => HTMLElement);
-
-  /**
    * (Optional) The key of the nav item selected by caller.
    */
   selectedKey?: string;
@@ -130,6 +124,11 @@ export interface INavProps {
    * @deprecated Use ariaCurrent on links instead
    */
   selectedAriaLabel?: string;
+
+  /**
+   * (Optional) Used to define the props of FocusZone which is a wrapper of Nav
+   */
+  focusZoneProps?: IFocusZoneProps;
 }
 
 /**

--- a/packages/react/src/components/Nav/Nav.types.ts
+++ b/packages/react/src/components/Nav/Nav.types.ts
@@ -102,6 +102,13 @@ export interface INavProps {
   initialSelectedKey?: string;
 
   /**
+   * (Optional) Defines the initial tabbable nav item inside the Nav.
+   * If a string is passed then it is treated as a selector for identifying the initial tabbable nav item.
+   * If a function is passed then it uses the root element as a parameter to return the initial tabbable nav item.
+   */
+  defaultTabbableElement?: string | ((root: HTMLElement) => HTMLElement);
+
+  /**
    * (Optional) The key of the nav item selected by caller.
    */
   selectedKey?: string;

--- a/packages/react/src/components/Nav/Nav.types.ts
+++ b/packages/react/src/components/Nav/Nav.types.ts
@@ -3,7 +3,7 @@ import type { IStyle, ITheme } from '../../Styling';
 import type { IRefObject, IRenderFunction, IStyleFunctionOrObject, IComponentAs } from '../../Utilities';
 import type { IIconProps } from '../Icon/Icon.types';
 import type { IButtonProps } from '../../Button';
-import { IFocusZoneProps } from '@fluentui/react-focus';
+import type { IFocusZoneProps } from '../../FocusZone';
 
 /**
  * {@doccategory Nav}


### PR DESCRIPTION
## Current Behavior

`Nav` used `FocusZone` but this `Nav` does not support related props to pass to `FocusZone`, like `defaultTabbableElement` of `FocusZone`, etc.

For example, if we want set `defaultTabbableElement` for Nav for a11y and support default landing link in `Nav`, there is no way to set it.

## New Behavior

Added `focusZoneProps` prop for Nav and passed to `FocusZone`, so that we can support all extra props to pass to `FocusZone`.

## Example

In example of packages/react-examples/src/react/Nav/Nav.FocusZone.Example.tsx

Added `focusZoneProps` for `Nav` like below:

```ts
focusZoneProps={{
  defaultTabbableElement: "a[title='MarqueeSelection']",
}}
```

When press tab, the default tabbable element will take effect, which proves the `focusZoneProps` take effect for `FocusZone` which used by `Nav`:

![image](https://user-images.githubusercontent.com/8678661/177392717-595b6d3c-ad41-4984-ac42-ce4c94e8139e.png)

