### PR TITLE
theme designer: remove light/dark switch, add custom dark to dropdown

### DIFF
--- a/packages/react-components/theme-designer/src/ThemeDesigner.tsx
+++ b/packages/react-components/theme-designer/src/ThemeDesigner.tsx
@@ -27,7 +27,7 @@ export const ThemeDesigner: React.FC<ThemeDesignerProps> = props => {
           className={styles.content}
           brand={brand}
           theme={{ ...theme, ...overrides }}
-          isDark={state.isDark}
+          isDark={isDark}
           dispatchState={dispatchState}
         />
       </div>

--- a/packages/react-components/theme-designer/src/components/Sidebar/EditTab.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/EditTab.tsx
@@ -1,10 +1,17 @@
 /* eslint-disable react/jsx-no-bind */
 import * as React from 'react';
 import { makeStyles, shorthands } from '@griffel/react';
-import { Label, Input, Switch, Slider, tokens } from '@fluentui/react-components';
+import { Label, Input, Slider, tokens } from '@fluentui/react-components';
 import { useDebounce } from '../../utils/useDebounce';
 
 import type { CustomAttributes, DispatchTheme } from '../../useThemeDesignerReducer';
+
+type CustomPaletteAttributes = {
+  keyColor: string;
+  hueTorsion: number;
+  darkCp: number;
+  lightCp: number;
+};
 
 const useStyles = makeStyles({
   root: {
@@ -56,9 +63,15 @@ export const EditTab: React.FC<EditTabProps> = props => {
 
   const { sidebarId, dispatchState, formState, setFormState } = props;
 
-  const formReducer = (state: CustomAttributes, action: { attributes: CustomAttributes }) => {
-    setFormState(action.attributes);
-    dispatchState({ ...form, type: 'Custom', customAttributes: action.attributes, overrides: {} });
+  const formReducer = (state: CustomPaletteAttributes, action: { attributes: CustomPaletteAttributes }) => {
+    const newAttributes = { ...action.attributes, isDark: formState.isDark };
+    setFormState(newAttributes);
+    dispatchState({
+      ...form,
+      type: formState.isDark ? 'Custom Dark' : 'Custom Light',
+      customAttributes: newAttributes,
+      overrides: {},
+    });
     return action.attributes;
   };
 
@@ -66,20 +79,16 @@ export const EditTab: React.FC<EditTabProps> = props => {
   const [hueTorsion, setHueTorsion] = React.useState<number>(formState.hueTorsion);
   const [darkCp, setDarkCp] = React.useState<number>(formState.darkCp * 100);
   const [lightCp, setLightCp] = React.useState<number>(formState.lightCp * 100);
-  const [isDark, setIsDark] = React.useState<boolean>(formState.isDark);
 
   const [form, dispatchForm] = React.useReducer(formReducer, formState);
   const debouncedForm = useDebounce(
-    { keyColor, hueTorsion: hueTorsion / 100, darkCp: darkCp / 100, lightCp: lightCp / 100, isDark },
+    { keyColor, hueTorsion: hueTorsion / 100, darkCp: darkCp / 100, lightCp: lightCp / 100 },
     10,
   );
   React.useEffect(() => {
     dispatchForm({ attributes: debouncedForm });
   }, [debouncedForm]);
 
-  const handleIsDarkChange = () => {
-    setIsDark(!form.isDark);
-  };
   const handleKeyColorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setKeyColor(e.target.value);
   };
@@ -172,7 +181,6 @@ export const EditTab: React.FC<EditTabProps> = props => {
           onChange={handleDarkCpChange}
         />
       </div>
-      <Switch checked={form.isDark} onChange={handleIsDarkChange} label={form.isDark ? 'dark theme' : 'light theme'} />
     </div>
   );
 };

--- a/packages/react-components/theme-designer/src/components/Sidebar/Sidebar.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/Sidebar.tsx
@@ -77,17 +77,25 @@ export const Sidebar: React.FC<SidebarProps> = props => {
 
   const sidebarId = useId();
 
+  const [theme, setTheme] = React.useState<string>('Teams Light');
+
   const [tab, setTab] = React.useState<TabValue>('use');
   const handleTabChange = (event: SelectTabEvent, data: SelectTabData) => {
     if (data.value === 'edit') {
-      props.dispatchState({ type: 'Custom', customAttributes: formState, overrides: {} });
+      if (theme === 'Custom Dark') {
+        props.dispatchState({ type: 'Custom Dark', customAttributes: formState, overrides: {} });
+      } else {
+        props.dispatchState({ type: 'Custom Light', customAttributes: formState, overrides: {} });
+      }
     } else if (data.value === 'use') {
-      setTheme('Custom');
+      if (theme === 'Custom Dark') {
+        setTheme('Custom Dark');
+      } else {
+        setTheme('Custom Light');
+      }
     }
     setTab(data.value);
   };
-
-  const [theme, setTheme] = React.useState<string>('Teams Light');
 
   const [formState, setFormState] = React.useState<CustomAttributes>({
     keyColor: '#006bc7',
@@ -115,6 +123,7 @@ export const Sidebar: React.FC<SidebarProps> = props => {
           dispatchState={props.dispatchState}
           setTab={setTab}
           formState={formState}
+          setFormState={setFormState}
         />
       )}
       {tab === 'edit' && (

--- a/packages/react-components/theme-designer/src/components/Sidebar/UseTab.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/UseTab.tsx
@@ -38,18 +38,22 @@ export interface UseTabProps {
   sidebarId: string;
   setTab: React.Dispatch<TabValue>;
   formState: CustomAttributes;
+  setFormState: React.Dispatch<CustomAttributes>;
 }
 
 export const UseTab: React.FC<UseTabProps> = props => {
   const styles = useStyles();
 
-  const { theme, setTheme, dispatchState, sidebarId, formState } = props;
+  const { theme, setTheme, dispatchState, sidebarId, formState, setFormState } = props;
 
   const handleThemeChange: MenuProps['onCheckedValueChange'] = (e, data) => {
     const newTheme = data.checkedItems[0] as string;
-    if (newTheme === 'Custom') {
+    if (newTheme === 'Custom Light' || newTheme === 'Custom Dark') {
+      const isDark = newTheme === 'Custom Dark';
+      const newAttributes: CustomAttributes = { ...formState, isDark: isDark };
       props.setTab('edit');
-      dispatchState({ type: newTheme, customAttributes: formState, overrides: {} });
+      setFormState(newAttributes);
+      dispatchState({ type: newTheme, customAttributes: newAttributes, overrides: {} });
     } else {
       dispatchState({ type: newTheme, overrides: {} });
     }
@@ -79,8 +83,11 @@ export const UseTab: React.FC<UseTabProps> = props => {
                 Web Dark
               </MenuItemRadio>
               <MenuDivider />
-              <MenuItemRadio name="Custom" value="Custom">
-                Custom
+              <MenuItemRadio name="Custom Light" value="Custom Light">
+                Custom Light
+              </MenuItemRadio>
+              <MenuItemRadio name="Custom Dark" value="Custom Dark">
+                Custom Dark
               </MenuItemRadio>
             </MenuList>
           </MenuPopover>

--- a/packages/react-components/theme-designer/src/useThemeDesignerReducer.ts
+++ b/packages/react-components/theme-designer/src/useThemeDesignerReducer.ts
@@ -95,16 +95,28 @@ export const useThemeDesignerReducer = () => {
           isDark: true,
           overrides: action.overrides,
         };
-      case 'Custom':
+      case 'Custom Light':
         if (!action.customAttributes) {
           return state;
         }
-        const custom = createCustomTheme(action.customAttributes);
+        const customLight = createCustomTheme(action.customAttributes);
         return {
-          themeLabel: 'Custom',
-          brand: custom.brand,
-          theme: custom.theme,
-          isDark: action.customAttributes.isDark,
+          themeLabel: 'Custom Light',
+          brand: customLight.brand,
+          theme: customLight.theme,
+          isDark: false,
+          overrides: action.overrides,
+        };
+      case 'Custom Dark':
+        if (!action.customAttributes) {
+          return state;
+        }
+        const customDark = createCustomTheme({ ...action.customAttributes, isDark: true });
+        return {
+          themeLabel: 'Custom Dark',
+          brand: customDark.brand,
+          theme: customDark.theme,
+          isDark: true,
           overrides: action.overrides,
         };
       case 'Overrides':


### PR DESCRIPTION
All fluent themes want to use the same palette for light and dark theme, this update makes it easier for them to do so.
![image](https://user-images.githubusercontent.com/31319479/177420965-dfecf63f-0986-4b8a-8167-680b96684650.png)
