### PR TITLE
chore: Update @fluentui/react-icons dependency to v2.0.175

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -47,7 +47,7 @@ export const parameters = {
     },
     optionalDependencies: {
       '@fluentui/react-components': '^9.0.0', // necessary for FluentProvider
-      '@fluentui/react-icons': 'rc',
+      '@fluentui/react-icons': 'latest',
     },
     indexTsx: dedent`
           import * as ReactDOM from 'react-dom';

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -24,7 +24,7 @@
     "@fluentui/react-card": "9.0.0-beta.21",
     "@fluentui/react-checkbox": "^9.0.1",
     "@fluentui/react-divider": "^9.0.1",
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-image": "^9.0.1",
     "@fluentui/react-input": "^9.0.1",
     "@fluentui/react-label": "^9.0.1",

--- a/change/@fluentui-react-accordion-d07069ab-fc34-454c-8dc5-ce9ae7fa5ff1.json
+++ b/change/@fluentui-react-accordion-d07069ab-fc34-454c-8dc5-ce9ae7fa5ff1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update @fluentui/react-icons dependency to v2.0.175",
+  "packageName": "@fluentui/react-accordion",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-alert-94534580-8f6b-4ea7-ab95-86940adfa6bb.json
+++ b/change/@fluentui-react-alert-94534580-8f6b-4ea7-ab95-86940adfa6bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons dependency to v2.0.175",
+  "packageName": "@fluentui/react-alert",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-a263055a-f96d-44d0-972a-5d6d36f4c4ef.json
+++ b/change/@fluentui-react-avatar-a263055a-f96d-44d0-972a-5d6d36f4c4ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update @fluentui/react-icons dependency to v2.0.175",
+  "packageName": "@fluentui/react-avatar",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-fc8035ba-68a5-460e-91da-7dd49d2735c5.json
+++ b/change/@fluentui-react-badge-fc8035ba-68a5-460e-91da-7dd49d2735c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update @fluentui/react-icons dependency to v2.0.175",
+  "packageName": "@fluentui/react-badge",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-e8405dba-b481-4cd4-a516-ccf77e8f9e73.json
+++ b/change/@fluentui-react-button-e8405dba-b481-4cd4-a516-ccf77e8f9e73.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update @fluentui/react-icons dependency to v2.0.175",
+  "packageName": "@fluentui/react-button",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-e10f2f0b-c30b-44de-a033-3f9fec5c0791.json
+++ b/change/@fluentui-react-checkbox-e10f2f0b-c30b-44de-a033-3f9fec5c0791.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update @fluentui/react-icons dependency to v2.0.175",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-b5b55f1c-02b4-4c81-973e-3c2e9bb9bafe.json
+++ b/change/@fluentui-react-combobox-b5b55f1c-02b4-4c81-973e-3c2e9bb9bafe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons dependency to v2.0.175",
+  "packageName": "@fluentui/react-combobox",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-08896b59-8096-4e93-a522-b2e5909b921e.json
+++ b/change/@fluentui-react-menu-08896b59-8096-4e93-a522-b2e5909b921e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update @fluentui/react-icons dependency to v2.0.175",
+  "packageName": "@fluentui/react-menu",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-b48063a5-d986-488e-a808-5c03b4e58e57.json
+++ b/change/@fluentui-react-radio-b48063a5-d986-488e-a808-5c03b4e58e57.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update @fluentui/react-icons dependency to v2.0.175",
+  "packageName": "@fluentui/react-radio",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-3ee00d76-876c-4760-8048-85a2c62d521b.json
+++ b/change/@fluentui-react-select-3ee00d76-876c-4760-8048-85a2c62d521b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons dependency to v2.0.175",
+  "packageName": "@fluentui/react-select",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-1158c090-b16f-45b3-bab1-8a1c78998ae0.json
+++ b/change/@fluentui-react-spinbutton-1158c090-b16f-45b3-bab1-8a1c78998ae0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Update @fluentui/react-icons dependency to v2.0.175",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-4fe5a3f1-edd6-4fc3-8746-c04711a6f07a.json
+++ b/change/@fluentui-react-switch-4fe5a3f1-edd6-4fc3-8746-c04711a6f07a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update @fluentui/react-icons dependency to v2.0.175",
+  "packageName": "@fluentui/react-switch",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@ctrl/tinycolor": "3.3.4",
     "@cypress/react": "5.12.4",
     "@cypress/webpack-dev-server": "1.8.3",
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@griffel/babel-preset": "^1.3.3",
     "@griffel/eslint-plugin": "1.0.0",
     "@griffel/jest-serializer": "^1.0.5",

--- a/packages/react-components/react-accordion/package.json
+++ b/packages/react-components/react-accordion/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluentui/react-aria": "^9.0.0",
     "@fluentui/react-context-selector": "^9.0.0",
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-tabster": "^9.0.1",
     "@fluentui/react-theme": "^9.0.0",

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`AccordionHeader renders a default state 1`] = `
       >
         <path
           d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 01-.7-.7L12.8 10 7.65 4.85a.5.5 0 010-.7z"
+          fill="currentColor"
         />
       </svg>
     </span>

--- a/packages/react-components/react-alert/package.json
+++ b/packages/react-components/react-alert/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluentui/react-avatar": "^9.0.1",
     "@fluentui/react-button": "^9.0.1",
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/react-utilities": "^9.0.0",
     "@griffel/react": "^1.2.0",

--- a/packages/react-components/react-avatar/package.json
+++ b/packages/react-components/react-avatar/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluentui/react-badge": "^9.0.1",
     "@fluentui/react-context-selector": "^9.0.0",
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-popover": "^9.0.1",
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-tabster": "^9.0.1",

--- a/packages/react-components/react-badge/package.json
+++ b/packages/react-components/react-badge/package.json
@@ -32,7 +32,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@griffel/react": "^1.2.0",
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/react-utilities": "^9.0.0",

--- a/packages/react-components/react-badge/src/components/PresenceBadge/__snapshots__/PresenceBadge.test.tsx.snap
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/__snapshots__/PresenceBadge.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`PresenceBadge renders a default state 1`] = `
     >
       <path
         d="M8 16A8 8 0 108 0a8 8 0 000 16zm3.7-9.3l-4 4a1 1 0 01-1.41 0l-2-2a1 1 0 111.42-1.4L7 8.58l3.3-3.3a1 1 0 011.4 1.42z"
+        fill="currentColor"
       />
     </svg>
   </span>

--- a/packages/react-components/react-button/package.json
+++ b/packages/react-components/react-button/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.0",
     "@fluentui/react-aria": "^9.0.0",
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-tabster": "^9.0.1",
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/react-utilities": "^9.0.0",

--- a/packages/react-components/react-checkbox/package.json
+++ b/packages/react-components/react-checkbox/package.json
@@ -31,7 +31,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-label": "^9.0.1",
     "@fluentui/react-tabster": "^9.0.1",
     "@fluentui/react-theme": "^9.0.0",

--- a/packages/react-components/react-checkbox/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -53,6 +53,7 @@ exports[`Checkbox renders a default state 1`] = `
       >
         <path
           d="M9.76 3.2c.3.29.32.76.04 1.06l-4.25 4.5a.75.75 0 01-1.08.02L2.22 6.53a.75.75 0 011.06-1.06l1.7 1.7L8.7 3.24a.75.75 0 011.06-.04z"
+          fill="currentColor"
         />
       </svg>
     </div>
@@ -86,6 +87,7 @@ exports[`Checkbox renders checked 1`] = `
       >
         <path
           d="M9.76 3.2c.3.29.32.76.04 1.06l-4.25 4.5a.75.75 0 01-1.08.02L2.22 6.53a.75.75 0 011.06-1.06l1.7 1.7L8.7 3.24a.75.75 0 011.06-.04z"
+          fill="currentColor"
         />
       </svg>
     </div>
@@ -124,6 +126,7 @@ exports[`Checkbox renders mixed 1`] = `
       >
         <path
           d="M2 4c0-1.1.9-2 2-2h4a2 2 0 012 2v4a2 2 0 01-2 2H4a2 2 0 01-2-2V4z"
+          fill="currentColor"
         />
       </svg>
     </div>
@@ -162,6 +165,7 @@ exports[`Checkbox renders with a label 1`] = `
       >
         <path
           d="M9.76 3.2c.3.29.32.76.04 1.06l-4.25 4.5a.75.75 0 01-1.08.02L2.22 6.53a.75.75 0 011.06-1.06l1.7 1.7L8.7 3.24a.75.75 0 011.06-.04z"
+          fill="currentColor"
         />
       </svg>
     </div>

--- a/packages/react-components/react-combobox/package.json
+++ b/packages/react-components/react-combobox/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.0",
     "@fluentui/react-context-selector": "^9.0.0",
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-portal": "^9.0.1",
     "@fluentui/react-positioning": "^9.0.1",
     "@fluentui/react-theme": "^9.0.0",

--- a/packages/react-components/react-combobox/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`Combobox renders a default state 1`] = `
       >
         <path
           d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 01-.78 0L4.15 8.35a.5.5 0 11.7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0z"
+          fill="currentColor"
         />
       </svg>
     </span>
@@ -60,6 +61,7 @@ exports[`Combobox renders an open listbox 1`] = `
       >
         <path
           d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 01-.78 0L4.15 8.35a.5.5 0 11.7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0z"
+          fill="currentColor"
         />
       </svg>
     </span>
@@ -89,6 +91,7 @@ exports[`Combobox renders an open listbox 1`] = `
           >
             <path
               d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+              fill="currentColor"
             />
           </svg>
         </span>
@@ -115,6 +118,7 @@ exports[`Combobox renders an open listbox 1`] = `
           >
             <path
               d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+              fill="currentColor"
             />
           </svg>
         </span>
@@ -141,6 +145,7 @@ exports[`Combobox renders an open listbox 1`] = `
           >
             <path
               d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+              fill="currentColor"
             />
           </svg>
         </span>

--- a/packages/react-components/react-combobox/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`Dropdown renders a default state 1`] = `
         >
           <path
             d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 01-.78 0L4.15 8.35a.5.5 0 11.7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0z"
+            fill="currentColor"
           />
         </svg>
       </span>
@@ -59,6 +60,7 @@ exports[`Dropdown renders an open listbox 1`] = `
         >
           <path
             d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 01-.78 0L4.15 8.35a.5.5 0 11.7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0z"
+            fill="currentColor"
           />
         </svg>
       </span>
@@ -89,6 +91,7 @@ exports[`Dropdown renders an open listbox 1`] = `
           >
             <path
               d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+              fill="currentColor"
             />
           </svg>
         </span>
@@ -115,6 +118,7 @@ exports[`Dropdown renders an open listbox 1`] = `
           >
             <path
               d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+              fill="currentColor"
             />
           </svg>
         </span>
@@ -141,6 +145,7 @@ exports[`Dropdown renders an open listbox 1`] = `
           >
             <path
               d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+              fill="currentColor"
             />
           </svg>
         </span>

--- a/packages/react-components/react-combobox/src/components/Listbox/__snapshots__/Listbox.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Listbox/__snapshots__/Listbox.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`Listbox renders a default state 1`] = `
         >
           <path
             d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+            fill="currentColor"
           />
         </svg>
       </span>
@@ -54,6 +55,7 @@ exports[`Listbox renders a default state 1`] = `
         >
           <path
             d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+            fill="currentColor"
           />
         </svg>
       </span>
@@ -80,6 +82,7 @@ exports[`Listbox renders a default state 1`] = `
         >
           <path
             d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+            fill="currentColor"
           />
         </svg>
       </span>
@@ -117,6 +120,7 @@ exports[`Listbox renders with a selected option 1`] = `
         >
           <path
             d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+            fill="currentColor"
           />
         </svg>
       </span>
@@ -143,6 +147,7 @@ exports[`Listbox renders with a selected option 1`] = `
         >
           <path
             d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+            fill="currentColor"
           />
         </svg>
       </span>
@@ -169,6 +174,7 @@ exports[`Listbox renders with a selected option 1`] = `
         >
           <path
             d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+            fill="currentColor"
           />
         </svg>
       </span>

--- a/packages/react-components/react-combobox/src/components/Option/__snapshots__/Option.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Option/__snapshots__/Option.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Option renders a default multi-select state 1`] = `
       >
         <path
           d="M3 6a3 3 0 013-3h8a3 3 0 013 3v8a3 3 0 01-3 3H6a3 3 0 01-3-3V6zm3-1.5c-.83 0-1.5.67-1.5 1.5v8c0 .83.67 1.5 1.5 1.5h8c.83 0 1.5-.67 1.5-1.5V6c0-.83-.67-1.5-1.5-1.5H6z"
+          fill="currentColor"
         />
       </svg>
     </span>
@@ -54,6 +55,7 @@ exports[`Option renders a default single-select state 1`] = `
       >
         <path
           d="M7.03 13.9L3.56 10a.75.75 0 00-1.12 1l4 4.5c.29.32.79.34 1.09.03l10.5-10.5a.75.75 0 00-1.06-1.06l-9.94 9.94z"
+          fill="currentColor"
         />
       </svg>
     </span>
@@ -85,6 +87,7 @@ exports[`Option renders a selected multi-select state 1`] = `
       >
         <path
           d="M6 3a3 3 0 00-3 3v8a3 3 0 003 3h8a3 3 0 003-3V6a3 3 0 00-3-3H6zm7.85 4.85l-5 5a.5.5 0 01-.7 0l-2-2a.5.5 0 01.7-.7l1.65 1.64 4.65-4.64a.5.5 0 01.7.7z"
+          fill="currentColor"
         />
       </svg>
     </span>

--- a/packages/react-components/react-menu/package.json
+++ b/packages/react-components/react-menu/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.0",
     "@fluentui/react-context-selector": "^9.0.0",
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-portal": "^9.0.1",
     "@fluentui/react-positioning": "^9.0.1",
     "@fluentui/react-shared-contexts": "^9.0.0",

--- a/packages/react-components/react-menu/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
+++ b/packages/react-components/react-menu/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`MenuItemCheckbox conformance renders a default state 1`] = `
     >
       <path
         d="M14.05 3.49c.28.3.27.77-.04 1.06l-7.93 7.47A.85.85 0 014.9 12L2.22 9.28a.75.75 0 111.06-1.06l2.24 2.27 7.47-7.04a.75.75 0 011.06.04z"
+        fill="currentColor"
       />
     </svg>
   </span>

--- a/packages/react-components/react-menu/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
+++ b/packages/react-components/react-menu/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`MenuItemRadio renders a default state 1`] = `
     >
       <path
         d="M14.05 3.49c.28.3.27.77-.04 1.06l-7.93 7.47A.85.85 0 014.9 12L2.22 9.28a.75.75 0 111.06-1.06l2.24 2.27 7.47-7.04a.75.75 0 011.06.04z"
+        fill="currentColor"
       />
     </svg>
   </span>

--- a/packages/react-components/react-radio/package.json
+++ b/packages/react-components/react-radio/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.0.0",
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-label": "^9.0.1",
     "@fluentui/react-tabster": "^9.0.1",
     "@fluentui/react-theme": "^9.0.0",

--- a/packages/react-components/react-select/package.json
+++ b/packages/react-components/react-select/package.json
@@ -31,7 +31,7 @@
     "@fluentui/react-conformance-griffel": "9.0.0-beta.10"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/react-utilities": "^9.0.0",
     "@griffel/react": "^1.2.0",

--- a/packages/react-components/react-select/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-components/react-select/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -49,6 +49,7 @@ exports[`Select renders option children 1`] = `
       >
         <path
           d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 01-.78 0L4.15 8.35a.5.5 0 11.7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0z"
+          fill="currentColor"
         />
       </svg>
     </span>
@@ -78,6 +79,7 @@ exports[`Select renders the default state 1`] = `
       >
         <path
           d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 01-.78 0L4.15 8.35a.5.5 0 11.7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0z"
+          fill="currentColor"
         />
       </svg>
     </span>

--- a/packages/react-components/react-spinbutton/package.json
+++ b/packages/react-components/react-spinbutton/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@griffel/react": "^1.2.0",
     "@fluentui/keyboard-keys": "^9.0.0",
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-input": "^9.0.1",
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/react-utilities": "^9.0.0",

--- a/packages/react-components/react-switch/package.json
+++ b/packages/react-components/react-switch/package.json
@@ -32,7 +32,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-label": "^9.0.1",
     "@fluentui/react-tabster": "^9.0.1",
     "@fluentui/react-theme": "^9.0.0",

--- a/packages/react-components/react-tabs/src/components/Tab/__snapshots__/Tab.test.tsx.snap
+++ b/packages/react-components/react-tabs/src/components/Tab/__snapshots__/Tab.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`Tab renders default correctly with icon slotted 1`] = `
       >
         <path
           d="M14.5 3A2.5 2.5 0 0117 5.5v9a2.5 2.5 0 01-2.5 2.5h-9A2.5 2.5 0 013 14.5v-9A2.5 2.5 0 015.5 3h9zm0 1h-9C4.67 4 4 4.67 4 5.5v9c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-9c0-.83-.67-1.5-1.5-1.5zM7 11a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2zM7 7a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2z"
+          fill="currentColor"
         />
       </svg>
     </span>
@@ -93,6 +94,7 @@ exports[`Tab renders small size and vertical correctly with icon slotted 1`] = `
       >
         <path
           d="M14.5 3A2.5 2.5 0 0117 5.5v9a2.5 2.5 0 01-2.5 2.5h-9A2.5 2.5 0 013 14.5v-9A2.5 2.5 0 015.5 3h9zm0 1h-9C4.67 4 4 4.67 4 5.5v9c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-9c0-.83-.67-1.5-1.5-1.5zM7 11a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2zM7 7a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2z"
+          fill="currentColor"
         />
       </svg>
     </span>
@@ -128,6 +130,7 @@ exports[`Tab renders small size correctly with icon slotted 1`] = `
       >
         <path
           d="M14.5 3A2.5 2.5 0 0117 5.5v9a2.5 2.5 0 01-2.5 2.5h-9A2.5 2.5 0 013 14.5v-9A2.5 2.5 0 015.5 3h9zm0 1h-9C4.67 4 4 4.67 4 5.5v9c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-9c0-.83-.67-1.5-1.5-1.5zM7 11a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2zM7 7a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2z"
+          fill="currentColor"
         />
       </svg>
     </span>
@@ -163,6 +166,7 @@ exports[`Tab renders subtle appearance correctly with icon slotted 1`] = `
       >
         <path
           d="M14.5 3A2.5 2.5 0 0117 5.5v9a2.5 2.5 0 01-2.5 2.5h-9A2.5 2.5 0 013 14.5v-9A2.5 2.5 0 015.5 3h9zm0 1h-9C4.67 4 4 4.67 4 5.5v9c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-9c0-.83-.67-1.5-1.5-1.5zM7 11a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2zM7 7a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2z"
+          fill="currentColor"
         />
       </svg>
     </span>
@@ -198,6 +202,7 @@ exports[`Tab renders vertical correctly with icon slotted 1`] = `
       >
         <path
           d="M14.5 3A2.5 2.5 0 0117 5.5v9a2.5 2.5 0 01-2.5 2.5h-9A2.5 2.5 0 013 14.5v-9A2.5 2.5 0 015.5 3h9zm0 1h-9C4.67 4 4 4.67 4 5.5v9c0 .83.67 1.5 1.5 1.5h9c.83 0 1.5-.67 1.5-1.5v-9c0-.83-.67-1.5-1.5-1.5zM7 11a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2zM7 7a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2zm3 0a1 1 0 110 2 1 1 0 010-2z"
+          fill="currentColor"
         />
       </svg>
     </span>

--- a/packages/react-components/react-toolbar/src/components/ToolbarRadio/__snapshots__/ToolbarRadio.test.tsx.snap
+++ b/packages/react-components/react-toolbar/src/components/ToolbarRadio/__snapshots__/ToolbarRadio.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`ToolbarRadio renders a default state 1`] = `
       >
         <path
           d="M10 2a8 8 0 100 16 8 8 0 000-16z"
+          fill="currentColor"
         />
       </svg>
     </div>

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -33,7 +33,7 @@
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0",
     "@fluentui/react-components": "^9.0.1",
-    "@fluentui/react-icons": "^2.0.172-rc.8",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluent-blocks/colors": "9.1.0",
     "codesandbox-import-utils": "2.2.3",
     "@types/dedent": "0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,10 +1652,13 @@
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
 
-"@fluentui/react-icons@^2.0.172-rc.8":
-  version "2.0.172-rc.8"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.172-rc.8.tgz#5daa62d1b11df87cdf26cbfd5e3aa7328e367e74"
-  integrity sha512-vXhOcnlsYA/XgiaiPo4Cyp5GeI+CZE2zRVBNLkygemrafKnboLwUh9dLb/qC4YLsQ4DTaYPrvFq4cKujXBhl4w==
+"@fluentui/react-icons@^2.0.175":
+  version "2.0.175"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.175.tgz#70f60989b5792c1770253beeb0a1f4dc9329e59d"
+  integrity sha512-GQpG7aTHVh8Pesq8rJcgKoe8kb28T4OENgpg6ZKbNibVYAM/UKFLb+kzw/amj0kdKl5/OWV/og5kv0be+nnH+Q==
+  dependencies:
+    "@griffel/react" "^1.0.0"
+    tslib "^2.1.0"
 
 "@griffel/babel-preset@^1.3.3":
   version "1.3.3"
@@ -1698,7 +1701,7 @@
   dependencies:
     tslib "^2.1.0"
 
-"@griffel/react@^1.2.0":
+"@griffel/react@^1.0.0", "@griffel/react@^1.2.0":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@griffel/react/-/react-1.2.1.tgz#8150d6582dafad14815a3d7831839d98bf30c85e"
   integrity sha512-A5fFXl9GvwEETCrT2hapTaoRAmY8JzZXpO6WnfCPHat6R74GP9i3PyJft6OT+XGEi+/vW/Owyp2IpX+PKiY7CQ==


### PR DESCRIPTION
This PR updates `@fluentui/react-icons` to `v2.0.175`. This is to get this fix: https://github.com/microsoft/fluentui-system-icons/pull/473 which will allow for build systems that are more strict about deps being correctly set in the packages they come from to use packages that depend of `@fluentui/react-icons`.