### PR TITLE
list: add utilities for reading and writing scroll values

### DIFF
--- a/change/@fluentui-react-42e62350-c4bd-4d7e-bf80-eb79ef462001.json
+++ b/change/@fluentui-react-42e62350-c4bd-4d7e-bf80-eb79ef462001.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: list add utilities for reading and writing scroll values",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-42e62350-c4bd-4d7e-bf80-eb79ef462001.json
+++ b/change/@fluentui-react-42e62350-c4bd-4d7e-bf80-eb79ef462001.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "feat: list add utilities for reading and writing scroll values",
+  "comment": "feat: add list utilities for reading and writing scroll values",
   "packageName": "@fluentui/react",
   "email": "seanmonahan@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.test.tsx
@@ -67,6 +67,16 @@ function customColumnDivider(
 }
 
 describe('DetailsList', () => {
+  let spy: jest.SpyInstance;
+  beforeAll(() => {
+    /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+    spy = jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    spy.mockRestore();
+  });
+
   beforeEach(() => {
     resetIds();
   });

--- a/packages/react/src/components/List/List.test.tsx
+++ b/packages/react/src/components/List/List.test.tsx
@@ -3,7 +3,6 @@ import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
 import { List } from './List';
-import { getScrollHeight, getScrollYPosition, setScrollYPosition } from './utils/scroll';
 import { isConformant } from '../../common/isConformant';
 import type { IPage, IListProps } from './List.types';
 
@@ -217,81 +216,6 @@ describe('List', () => {
       const rows = wrapper.find('.ms-List-cell');
 
       expect(rows).toHaveLength(100);
-    });
-  });
-
-  describe('utils', () => {
-    describe('getScrollHeight', () => {
-      it('should return scrollHeight for an HTML element', () => {
-        const mockElement = {
-          scrollHeight: 123,
-        };
-
-        expect(getScrollHeight(mockElement as HTMLElement)).toBe(123);
-      });
-
-      it('should return scrollHeight for a Window object', () => {
-        const mockWindow = {
-          document: {
-            documentElement: {
-              scrollHeight: 456,
-            },
-          },
-        };
-
-        expect(getScrollHeight(mockWindow as Window)).toBe(456);
-      });
-
-      it('should return 0 for an undefined object', () => {
-        expect(getScrollHeight(undefined)).toBe(0);
-      });
-    });
-
-    describe('getScrollYPosition', () => {
-      it('should return scrollTop for an HTML element', () => {
-        const mockElement = {
-          scrollTop: 1.2,
-        };
-
-        expect(getScrollYPosition(mockElement as HTMLElement)).toBe(2);
-      });
-
-      it('should return scrollY for a Window object', () => {
-        const mockWindow = {
-          scrollY: 5.6,
-        };
-
-        expect(getScrollYPosition(mockWindow as Window)).toBe(6);
-      });
-
-      it('should return 0 for an undefined object', () => {
-        expect(getScrollYPosition(undefined)).toBe(0);
-      });
-    });
-
-    describe('setScrollYPosition', () => {
-      it('should set scrollTop for an HTML element', () => {
-        const mockElement = {
-          scrollTop: 5,
-        };
-
-        setScrollYPosition(mockElement as HTMLElement, 6.7);
-        expect(mockElement.scrollTop).toBe(6.7);
-      });
-
-      it('should call scrollTo() on a Window object', () => {
-        const scrollTo = jest.fn();
-        const mockWindow = {
-          scrollX: 5,
-          scrollY: 5,
-          scrollTo,
-        };
-
-        setScrollYPosition((mockWindow as unknown) as Window, 7.5);
-
-        expect(scrollTo.mock.calls[0][0]).toBe(5);
-        expect(scrollTo.mock.calls[0][1]).toBe(7.5);
-      });
     });
   });
 });

--- a/packages/react/src/components/List/List.test.tsx
+++ b/packages/react/src/components/List/List.test.tsx
@@ -3,6 +3,7 @@ import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
 import { List } from './List';
+import { getScrollHeight, getScrollYPosition, setScrollYPosition } from './utils/scroll';
 import { isConformant } from '../../common/isConformant';
 import type { IPage, IListProps } from './List.types';
 
@@ -216,6 +217,81 @@ describe('List', () => {
       const rows = wrapper.find('.ms-List-cell');
 
       expect(rows).toHaveLength(100);
+    });
+  });
+
+  describe('utils', () => {
+    describe('getScrollHeight', () => {
+      it('should return scrollHeight for an HTML element', () => {
+        const mockElement = {
+          scrollHeight: 123,
+        };
+
+        expect(getScrollHeight(mockElement as HTMLElement)).toBe(123);
+      });
+
+      it('should return scrollHeight for a Window object', () => {
+        const mockWindow = {
+          document: {
+            documentElement: {
+              scrollHeight: 456,
+            },
+          },
+        };
+
+        expect(getScrollHeight(mockWindow as Window)).toBe(456);
+      });
+
+      it('should return 0 for an undefined object', () => {
+        expect(getScrollHeight(undefined)).toBe(0);
+      });
+    });
+
+    describe('getScrollYPosition', () => {
+      it('should return scrollTop for an HTML element', () => {
+        const mockElement = {
+          scrollTop: 1.2,
+        };
+
+        expect(getScrollYPosition(mockElement as HTMLElement)).toBe(2);
+      });
+
+      it('should return scrollY for a Window object', () => {
+        const mockWindow = {
+          scrollY: 5.6,
+        };
+
+        expect(getScrollYPosition(mockWindow as Window)).toBe(6);
+      });
+
+      it('should return 0 for an undefined object', () => {
+        expect(getScrollYPosition(undefined)).toBe(0);
+      });
+    });
+
+    describe('setScrollYPosition', () => {
+      it('should set scrollTop for an HTML element', () => {
+        const mockElement = {
+          scrollTop: 5,
+        };
+
+        setScrollYPosition(mockElement as HTMLElement, 6.7);
+        expect(mockElement.scrollTop).toBe(6.7);
+      });
+
+      it('should call scrollTo() on a Window object', () => {
+        const scrollTo = jest.fn();
+        const mockWindow = {
+          scrollX: 5,
+          scrollY: 5,
+          scrollTo,
+        };
+
+        setScrollYPosition((mockWindow as unknown) as Window, 7.5);
+
+        expect(scrollTo.mock.calls[0][0]).toBe(5);
+        expect(scrollTo.mock.calls[0][1]).toBe(7.5);
+      });
     });
   });
 });

--- a/packages/react/src/components/List/utils/scroll.test.ts
+++ b/packages/react/src/components/List/utils/scroll.test.ts
@@ -1,0 +1,76 @@
+import { getScrollHeight, getScrollYPosition, setScrollYPosition } from './scroll';
+
+describe('List scroll utils', () => {
+  describe('getScrollHeight', () => {
+    it('should return scrollHeight for an HTML element', () => {
+      const mockElement = {
+        scrollHeight: 123,
+      };
+
+      expect(getScrollHeight(mockElement as HTMLElement)).toBe(123);
+    });
+
+    it('should return scrollHeight for a Window object', () => {
+      const mockWindow = {
+        document: {
+          documentElement: {
+            scrollHeight: 456,
+          },
+        },
+      };
+
+      expect(getScrollHeight(mockWindow as Window)).toBe(456);
+    });
+
+    it('should return 0 for an undefined object', () => {
+      expect(getScrollHeight(undefined)).toBe(0);
+    });
+  });
+
+  describe('getScrollYPosition', () => {
+    it('should return scrollTop for an HTML element', () => {
+      const mockElement = {
+        scrollTop: 1.2,
+      };
+
+      expect(getScrollYPosition(mockElement as HTMLElement)).toBe(2);
+    });
+
+    it('should return scrollY for a Window object', () => {
+      const mockWindow = {
+        scrollY: 5.6,
+      };
+
+      expect(getScrollYPosition(mockWindow as Window)).toBe(6);
+    });
+
+    it('should return 0 for an undefined object', () => {
+      expect(getScrollYPosition(undefined)).toBe(0);
+    });
+  });
+
+  describe('setScrollYPosition', () => {
+    it('should set scrollTop for an HTML element', () => {
+      const mockElement = {
+        scrollTop: 5,
+      };
+
+      setScrollYPosition(mockElement as HTMLElement, 6.7);
+      expect(mockElement.scrollTop).toBe(6.7);
+    });
+
+    it('should call scrollTo() on a Window object', () => {
+      const scrollTo = jest.fn();
+      const mockWindow = {
+        scrollX: 5,
+        scrollY: 5,
+        scrollTo,
+      };
+
+      setScrollYPosition((mockWindow as unknown) as Window, 7.5);
+
+      expect(scrollTo.mock.calls[0][0]).toBe(5);
+      expect(scrollTo.mock.calls[0][1]).toBe(7.5);
+    });
+  });
+});

--- a/packages/react/src/components/List/utils/scroll.ts
+++ b/packages/react/src/components/List/utils/scroll.ts
@@ -1,0 +1,42 @@
+export const getScrollHeight = (el?: HTMLElement | Window): number => {
+  if (el === undefined) {
+    return 0;
+  }
+
+  let scrollHeight = 0;
+  if ('scrollHeight' in el) {
+    scrollHeight = el.scrollHeight;
+  } else if ('document' in el) {
+    scrollHeight = el.document.documentElement.scrollHeight;
+  }
+
+  // No need to round as scrollHeight is already rounded for us.
+  // See: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight
+  return scrollHeight;
+};
+
+export const getScrollYPosition = (el?: HTMLElement | Window): number => {
+  if (el === undefined) {
+    return 0;
+  }
+
+  let scrollPos = 0;
+  if ('scrollTop' in el) {
+    scrollPos = el.scrollTop;
+  } else if ('scrollY' in el) {
+    scrollPos = el.scrollY;
+  }
+
+  // Round this value to an integer as it may be fractional.
+  // See: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop
+  // See: https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY
+  return Math.ceil(scrollPos);
+};
+
+export const setScrollYPosition = (el: HTMLElement | Window, pos: number): void => {
+  if ('scrollTop' in el) {
+    el.scrollTop = pos;
+  } else if ('scrollY' in el) {
+    el.scrollTo(el.scrollX, pos);
+  }
+};


### PR DESCRIPTION
## Current Behavior

On mount, `List` [finds its scrollable parent](https://github.com/microsoft/fluentui/blob/master/packages/utilities/src/scroll.ts#L164) which can be an `HTMLElement` or `Window` object. `List` directly accesses `HTMLElement`'s scrolling API via properties like [`scrollTop`](https://github.com/microsoft/fluentui/blob/master/packages/react/src/components/List/List.tsx#L238) but these APIs are not directly available on `Window` (there are equivalents though).

When `List`'s scroll parent is a `Window` default values like `0` or `undefined` are returned and used in computations for scrolling.

## New Behavior

Three new utilities have been added:

1. `getScrollHeight`: to read the scroll height of a List parent
2. `getScrollYPosition`: to read the Y scroll position of a List parent
3. `setScrollYPosition`: to set the Y scroll position of a List parent

These utilities handle reading and writing scroll values for both `HTMLElement` and `Window`.

Additionally, `componentDidMount` has been updated to initialize the scrolling values before calling `_updatePages()` which may call `_updateRenderRects()` which uses scrolling values.

In practice the old behavior was likely never a problem in an application as it only manifests if `List`'s scroll parent is the `Window` object and most applications likely have lists inside scrollable containers. I noticed this issue when debugging a different issue with `List` and I had it as the only component on a page.

| Values before change with Window scroll parent | Values after change with Window scroll parent |
| --- | --- |
| ![list_basic_before](https://user-images.githubusercontent.com/93940821/177437572-57fb8b13-fedc-4634-a354-2641257c7142.gif) | ![list_basic_after](https://user-images.githubusercontent.com/93940821/177437590-775fa7a8-f354-40da-b254-07474a5cfb8e.gif) |


