### PR TITLE
fix(react-avatar): Fix trapFocus in AvatarGroup's PopoverSurface and PopoverSurface's role override

### DIFF
--- a/change/@fluentui-react-avatar-a40b1502-1f8e-4281-997f-ae2bd9070c45.json
+++ b/change/@fluentui-react-avatar-a40b1502-1f8e-4281-997f-ae2bd9070c45.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Remove override of role=list in AvatarGroup's PopoverSurface and fix trapFocus when Popover is triggered.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -64,7 +64,8 @@ export type AvatarGroupProps = ComponentProps<AvatarGroupSlots> & {
 export type AvatarGroupSlots = {
     root: NonNullable<Slot<'div'>>;
     overflowButton?: NonNullable<Slot<'button'>>;
-    overflowContent?: NonNullable<Slot<typeof PopoverSurface>>;
+    overflowContent?: NonNullable<Slot<'div'>>;
+    overflowSurface?: NonNullable<Slot<typeof PopoverSurface>>;
 };
 
 // @public

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/AvatarGroup.types.ts
@@ -14,7 +14,12 @@ export type AvatarGroupSlots = {
   /**
    * List that contains the overflow AvatarGroupItems.
    */
-  overflowContent?: NonNullable<Slot<typeof PopoverSurface>>;
+  overflowContent?: NonNullable<Slot<'div'>>;
+
+  /**
+   * PopoverSurface that contains the overflow content.
+   */
+  overflowSurface?: NonNullable<Slot<typeof PopoverSurface>>;
 };
 
 /**

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
@@ -16,16 +16,18 @@ export const renderAvatarGroup_unstable = (state: AvatarGroupState) => {
     <AvatarGroupContext.Provider value={{ layout, size, nonOverflowAvatarsCount }}>
       <slots.root {...slotProps.root}>
         {state.root.children}
-        {state.hasOverflow && slots.overflowButton && slots.overflowContent && (
+        {state.hasOverflow && slots.overflowButton && slots.overflowContent && slots.overflowSurface && (
           <Popover trapFocus size="small">
             <PopoverTrigger>
               <Tooltip content={state.tooltipContent} relationship="label">
                 <slots.overflowButton {...slotProps.overflowButton} />
               </Tooltip>
             </PopoverTrigger>
-            <AvatarGroupContext.Provider value={{ isOverflow: true, layout, size: 24 }}>
-              <slots.overflowContent {...slotProps.overflowContent} />
-            </AvatarGroupContext.Provider>
+            <slots.overflowSurface {...slotProps.overflowSurface}>
+              <AvatarGroupContext.Provider value={{ isOverflow: true, layout, size: 24 }}>
+                <slots.overflowContent {...slotProps.overflowContent} />
+              </AvatarGroupContext.Provider>
+            </slots.overflowSurface>
           </Popover>
         )}
       </slots.root>

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
@@ -53,16 +53,23 @@ export const useAvatarGroup_unstable = (props: AvatarGroupProps, ref: React.Ref<
     required: true,
     defaultProps: {
       children: overflowButtonChildren,
+      type: 'button',
     },
   });
 
   const overflowContent = resolveShorthand(props.overflowContent, {
     required: true,
     defaultProps: {
-      'aria-label': 'Overflow',
       children: overflowChildren,
       role: 'list',
       tabIndex: 0,
+    },
+  });
+
+  const overflowSurface = resolveShorthand(props.overflowSurface, {
+    required: true,
+    defaultProps: {
+      'aria-label': 'Overflow',
     },
   });
 
@@ -76,13 +83,15 @@ export const useAvatarGroup_unstable = (props: AvatarGroupProps, ref: React.Ref<
 
     components: {
       root: 'div',
-      overflowContent: PopoverSurface,
+      overflowContent: 'div',
       overflowButton: 'button',
+      overflowSurface: PopoverSurface,
     },
 
     root,
     overflowButton,
     overflowContent,
+    overflowSurface,
   };
 };
 

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -10,6 +10,7 @@ export const avatarGroupClassNames: SlotClassNames<AvatarGroupSlots> = {
   root: 'fui-AvatarGroup',
   overflowContent: 'fui-AvatarGroup__overflowContent',
   overflowButton: 'fui-AvatarGroup__overflowButton',
+  overflowSurface: 'fui-AvatarGroup__overflowSurface',
 };
 
 /**
@@ -108,9 +109,9 @@ const useOverflowButtonStyles = makeStyles({
 });
 
 /**
- * Styles for overflow list slot.
+ * Styles for overflow surface slot.
  */
-const useOverflowContentStyles = makeStyles({
+const useOverflowSurfaceStyles = makeStyles({
   base: {
     maxHeight: '220px',
     minHeight: '80px',
@@ -127,7 +128,7 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
   const { layout, overflowIndicator, size } = state;
   const styles = useStyles();
   const sizeStyles = useSizeStyles();
-  const overflowContentStyles = useOverflowContentStyles();
+  const overflowSurfaceStyles = useOverflowSurfaceStyles();
   const overflowButtonStyles = useOverflowButtonStyles();
 
   const groupChildClassName = useGroupChildClassName(layout, size, true);
@@ -144,8 +145,15 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
   if (state.overflowContent) {
     state.overflowContent.className = mergeClasses(
       avatarGroupClassNames.overflowContent,
-      overflowContentStyles.base,
       state.overflowContent.className,
+    );
+  }
+
+  if (state.overflowSurface) {
+    state.overflowSurface.className = mergeClasses(
+      avatarGroupClassNames.overflowSurface,
+      overflowSurfaceStyles.base,
+      state.overflowSurface.className,
     );
   }
 


### PR DESCRIPTION
## Current Behavior

- When Popover is triggered, focus is not trapped inside its surface. This is due to the way AvatarGroup currently works, Popover is used as a container for AvatarGroupItems. Popover trapsFocus to the first focusable item inside the PopoverSurface, therefore this doesn't work.
- Since PopoverSurface is used as a container for AvatarGroupItems, its role is overriden and role `list` is not compatible with `aria-modal`.

## New Behavior

- An `overflowSurface` slot is added which will only contain the PopoverSurface. The purpose of this slot is to allow for further customization rather than having an internal wrapper. This slot will have `overflowContent` which now works correctly with `trapFocus`. 
- AvatarGroup doesn't override `PopoverSurface`'s role anymore and follows correct aria rules.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23822
