### PR TITLE
docs(react-theme): add web light theme to colors stories

### DIFF
--- a/packages/react-components/react-theme/src/stories/Theme/ThemeColors.stories.tsx
+++ b/packages/react-components/react-theme/src/stories/Theme/ThemeColors.stories.tsx
@@ -1,12 +1,19 @@
 import * as React from 'react';
-import { teamsDarkTheme, teamsHighContrastTheme, teamsLightTheme, webDarkTheme } from '@fluentui/react-theme';
+import {
+  teamsDarkTheme,
+  teamsHighContrastTheme,
+  teamsLightTheme,
+  webLightTheme,
+  webDarkTheme,
+} from '@fluentui/react-theme';
 import { Theme } from '@fluentui/react-theme';
 import { ColorRampItem } from './ColorRamp.stories';
 
 // FIXME: hardcoded theme
 const theme = {
-  light: teamsLightTheme,
+  light: webLightTheme,
   dark: webDarkTheme,
+  teamsLight: teamsLightTheme,
   teamsDark: teamsDarkTheme,
   highContrast: teamsHighContrastTheme,
 };
@@ -135,7 +142,7 @@ export const Colors = () => {
       <div
         style={{
           display: 'inline-grid',
-          gridTemplateColumns: '24em repeat(4, auto)',
+          gridTemplateColumns: '24em repeat(5, auto)',
           columnGap: '1em',
           alignItems: 'stretch',
         }}
@@ -148,6 +155,9 @@ export const Colors = () => {
         </h3>
         <h3 key="hrDark" style={{ padding: '1em', margin: 0 }}>
           Dark
+        </h3>
+        <h3 key="hrTeamsLight" style={{ padding: '1em', margin: 0 }}>
+          Teams Light
         </h3>
         <h3 key="hrTeamsDark" style={{ padding: '1em', margin: 0 }}>
           Teams Dark
@@ -164,6 +174,7 @@ export const Colors = () => {
           </div>,
           <ColorRampItem key={`${name}Light`} value={theme.light[name]} />,
           <ColorRampItem key={`${name}Dark`} value={theme.dark[name]} />,
+          <ColorRampItem key={`${name}TeamsLight`} value={theme.teamsLight[name]} />,
           <ColorRampItem key={`${name}TeamsDark`} value={theme.teamsDark[name]} />,
           <ColorRampItem key={`${name}HC`} value={theme.highContrast[name]} />,
         ])}


### PR DESCRIPTION
## Current Behavior

Currently, the [Theme docs](https://react.fluentui.dev/?path=/docs/theme-theme--border-radii#colors) don't show mapping from tokens to color values for default web theme. Instead they show team light as the default light theme, which can be confusing to users expecting to see the default theme.

## New Behavior

Add the default light theme to list of shown palettes:

![image](https://user-images.githubusercontent.com/19153565/177739340-8926e2ae-6938-499e-8466-084e3c5662c7.png)

