### PR TITLE
Avatar: Replace relative imports with absolute imports in storybook files

### DIFF
--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarActive.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarActive.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 
 export const Active = () => (
   <div style={{ display: 'flex', gap: '20px' }}>

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarActiveAppearance.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarActiveAppearance.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 
 export const ActiveAppearance = () => (
   <div style={{ display: 'flex', gap: '20px' }}>

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarBadge.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarBadge.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 
 export const Badge = () => (
   <>

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarColorBrand.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarColorBrand.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 
 export const ColorBrand = () => <Avatar color="brand" initials="BR" name="brand color avatar" />;
 

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarColorColorful.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarColorColorful.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 import { GuestRegular } from '@fluentui/react-icons';
 
 export const ColorColorful = () => (

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarColorPalette.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarColorPalette.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 
 export const ColorPalette = () => (
   <>

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarDefault.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarDefault.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgTypes } from '@storybook/api';
 import * as React from 'react';
-import { Avatar, AvatarProps } from '../../index';
+import { Avatar, AvatarProps } from '@fluentui/react-avatar';
 
 export const Default = (props: Partial<AvatarProps>) => <Avatar aria-label="Guest" {...props} />;
 

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarIcon.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarIcon.stories.tsx
@@ -9,7 +9,7 @@ import {
   PersonCallRegular,
 } from '@fluentui/react-icons';
 
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 
 export const Icon = () => (
   <>

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarImage.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarImage.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 
 export const Image = () => (
   <Avatar

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarInitials.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarInitials.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 
 export const Initials = () => <Avatar name="Cecil Robin Folk" initials="CRF" />;
 

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarName.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarName.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 
 export const Name = () => <Avatar name="Ashley McCarthy" />;
 

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarSize.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarSize.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 
 export const Size = () => (
   <>

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarSquare.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarSquare.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 import { PeopleTeamRegular } from '@fluentui/react-icons';
 
 export const Square = () => <Avatar shape="square" aria-label="square avatar" icon={<PeopleTeamRegular />} />;

--- a/packages/react-components/react-avatar/src/stories/Avatar/index.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/index.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Avatar } from '../../index';
+import { Avatar } from '@fluentui/react-avatar';
 import { Meta } from '@storybook/react';
 
 export { Default } from './AvatarDefault.stories';

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupColor.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupColor.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { AvatarGroup } from '../../AvatarGroup';
-import { AvatarGroupItem } from '../../AvatarGroupItem';
+import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
 
 export const Color = () => {
   return (

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { AvatarGroup } from '../../AvatarGroup';
-import { AvatarGroupItem } from '../../AvatarGroupItem';
-import type { AvatarGroupProps } from '../../AvatarGroup';
+import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
+import type { AvatarGroupProps } from '@fluentui/react-avatar';
 
 export const Default = (props: Partial<AvatarGroupProps>) => {
   return (

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupIndicator.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupIndicator.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { AvatarGroup } from '../../AvatarGroup';
-import { AvatarGroupItem } from '../../AvatarGroupItem';
+import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
 import { makeStyles } from '@griffel/react';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupLayout.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupLayout.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { AvatarGroup } from '../../AvatarGroup';
-import { AvatarGroupItem } from '../../AvatarGroupItem';
+import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
 import { makeStyles } from '@griffel/react';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupMaxAvatars.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupMaxAvatars.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { AvatarGroup } from '../../AvatarGroup';
-import { AvatarGroupItem } from '../../AvatarGroupItem';
+import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
 import { makeStyles } from '@griffel/react';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizePie.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizePie.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { AvatarGroup } from '../../AvatarGroup';
-import { AvatarGroupItem } from '../../AvatarGroupItem';
+import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
 import { makeStyles } from '@griffel/react';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeSpread.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeSpread.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { AvatarGroup } from '../../AvatarGroup';
-import { AvatarGroupItem } from '../../AvatarGroupItem';
+import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
 import { makeStyles } from '@griffel/react';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeStack.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeStack.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { AvatarGroup } from '../../AvatarGroup';
-import { AvatarGroupItem } from '../../AvatarGroupItem';
+import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
 import { makeStyles } from '@griffel/react';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/index.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/index.stories.tsx
@@ -1,4 +1,4 @@
-import { AvatarGroup } from '../../index';
+import { AvatarGroup } from '@fluentui/react-avatar';
 
 import descriptionMd from './AvatarGroupDescription.md';
 import bestPracticesMd from './AvatarGroupBestPractices.md';


### PR DESCRIPTION
This was missed in https://github.com/microsoft/fluentui/pull/23354. PR updates Avatar and AvatarGroup's storybook files to use absolute imports instead of relative imports. Also renames AvatarGroups index.stories file to `index.stories.tsx` instead of `index.stories.beta.tsx` to follow current convention and to prevent beachball from requiring a changefile whenever that storyfile is modified. 