### PR TITLE
Cherry-pick logic to add focusZoneProps support for Nav #23806

### DIFF
--- a/change/office-ui-fabric-react-d83addbf-ad1d-483b-89b1-6de1d129de6b.json
+++ b/change/office-ui-fabric-react-d83addbf-ad1d-483b-89b1-6de1d129de6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Adding focusZoneProps support for Nav.",
+  "packageName": "office-ui-fabric-react",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "minor"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6156,6 +6156,7 @@ export interface INavProps {
     componentRef?: IRefObject<INav>;
     // @deprecated
     expandButtonAriaLabel?: string;
+    focusZoneProps?: IFocusZoneProps;
     groups: INavLinkGroup[] | null;
     initialSelectedKey?: string;
     isOnTop?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -67,7 +67,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     const classNames = getClassNames(styles!, { theme: theme!, className, isOnTop, groups });
 
     return (
-      <FocusZone direction={FocusZoneDirection.vertical} componentRef={this._focusZone}>
+      <FocusZone direction={FocusZoneDirection.vertical} componentRef={this._focusZone} {...this.props.focusZoneProps}>
         <nav role="navigation" className={classNames.root} aria-label={this.props.ariaLabel}>
           {groupElements}
         </nav>

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -3,6 +3,7 @@ import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IRenderFunction, IStyleFunctionOrObject, IComponentAs } from '../../Utilities';
 import { IIconProps } from '../Icon/Icon.types';
 import { IButtonProps } from '../Button/Button.types';
+import { IFocusZoneProps } from '../../FocusZone';
 
 /**
  * {@doccategory Nav}
@@ -125,6 +126,11 @@ export interface INavProps {
    * @deprecated Use ariaCurrent on links instead
    */
   selectedAriaLabel?: string;
+
+  /**
+   * (Optional) Used to define the props of the FocusZone wrapper.
+   */
+  focusZoneProps?: IFocusZoneProps;
 }
 
 /**

--- a/packages/react-examples/src/office-ui-fabric-react/Nav/Nav.FocusZone.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/Nav/Nav.FocusZone.Example.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Nav, INavStyles, INavLinkGroup } from 'office-ui-fabric-react/lib/Nav';
+
+const navStyles: Partial<INavStyles> = { root: { width: 300 } };
+
+const navLinkGroups: INavLinkGroup[] = [
+  {
+    name: 'Basic components',
+    links: [
+      {
+        key: 'ActivityItem',
+        name: 'ActivityItem',
+        url: '#/examples/activityitem',
+      },
+      {
+        key: 'Breadcrumb',
+        name: 'Breadcrumb',
+        url: '#/examples/breadcrumb',
+      },
+      {
+        key: 'Button',
+        name: 'Button',
+        url: '#/examples/button',
+      },
+    ],
+  },
+];
+
+export const NavFocusZoneExample: React.FunctionComponent = () => {
+  return (
+    <Nav
+      styles={navStyles}
+      groups={navLinkGroups}
+      focusZoneProps={{
+        defaultTabbableElement: "a[title='Breadcrumb']",
+        allowFocusRoot: false,
+      }}
+    />
+  );
+};

--- a/packages/react-examples/src/office-ui-fabric-react/Nav/Nav.doc.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/Nav/Nav.doc.tsx
@@ -4,10 +4,12 @@ import { IDocPageProps } from 'office-ui-fabric-react/lib/common/DocPage.types';
 import { NavFabricDemoAppExample } from './Nav.FabricDemoApp.Example';
 import { NavNestedExample } from './Nav.Nested.Example';
 import { NavCustomGroupHeadersExample } from './Nav.CustomGroupHeaders.Example';
+import { NavFocusZoneExample } from './Nav.FocusZone.Example';
 
 const NavBasicExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/Nav/Nav.Basic.Example.tsx') as string;
 const NavFabricDemoAppExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/Nav/Nav.FabricDemoApp.Example.tsx') as string;
 const NavNestedExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/Nav/Nav.Nested.Example.tsx') as string;
+const NavFocusZoneExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.FocusZone.Example.tsx') as string;
 const NavCustomGroupHeadersExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/Nav/Nav.CustomGroupHeaders.Example.tsx') as string;
 
 export const NavPageProps: IDocPageProps = {
@@ -29,6 +31,11 @@ export const NavPageProps: IDocPageProps = {
       title: 'Nav with nested links',
       code: NavNestedExampleCode,
       view: <NavNestedExample />,
+    },
+    {
+      title: 'Nav with FocusZone props override',
+      code: NavFocusZoneExampleCode,
+      view: <NavFocusZoneExample />,
     },
     {
       title: 'Nav with custom group header',

--- a/packages/react-examples/src/office-ui-fabric-react/Nav/Nav.doc.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/Nav/Nav.doc.tsx
@@ -9,7 +9,7 @@ import { NavFocusZoneExample } from './Nav.FocusZone.Example';
 const NavBasicExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/Nav/Nav.Basic.Example.tsx') as string;
 const NavFabricDemoAppExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/Nav/Nav.FabricDemoApp.Example.tsx') as string;
 const NavNestedExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/Nav/Nav.Nested.Example.tsx') as string;
-const NavFocusZoneExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/Nav/Nav.FocusZone.Example.tsx') as string;
+const NavFocusZoneExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/Nav/Nav.FocusZone.Example.tsx') as string;
 const NavCustomGroupHeadersExampleCode = require('!raw-loader!@fluentui/react-examples/src/office-ui-fabric-react/Nav/Nav.CustomGroupHeaders.Example.tsx') as string;
 
 export const NavPageProps: IDocPageProps = {


### PR DESCRIPTION
## Current Behavior

`Nav` used `FocusZone` but this `Nav` does not support related props to pass to `FocusZone`, like `defaultTabbableElement` of `FocusZone`, etc.

For example, if we want set `defaultTabbableElement` for Nav for a11y and support default landing link in `Nav`, there is no way to set it.

## New Behavior

Added `focusZoneProps` prop for Nav and passed to `FocusZone`, so that we can support all extra props to pass to `FocusZone`.

## Example

In example of packages/react-examples/src/react/Nav/Nav.FocusZone.Example.tsx

Added `focusZoneProps` for `Nav` like below:

```ts
focusZoneProps={{
  defaultTabbableElement: "a[title='MarqueeSelection']",
}}
```

When press tab, the default tabbable element will take effect, which proves the `focusZoneProps` take effect for `FocusZone` which used by `Nav`:

![image](https://user-images.githubusercontent.com/8678661/177392717-595b6d3c-ad41-4984-ac42-ce4c94e8139e.png)

