### PR TITLE
chore(ssr-tests-v9): add `.png` and `.jpg` support on loader

### DIFF
--- a/apps/ssr-tests-v9/src/utils/buildAssets.ts
+++ b/apps/ssr-tests-v9/src/utils/buildAssets.ts
@@ -6,6 +6,8 @@ const commonOptions: BuildOptions = {
   bundle: true,
   jsx: 'transform',
   loader: {
+    '.jpg': 'dataurl',
+    '.png': 'dataurl',
     '.svg': 'dataurl',
   },
 };


### PR DESCRIPTION
## Current Behavior

PNG and JPEG extensions not supported on the loader.

```
ERR! ✘ [ERROR] No loader is configured for ".png" files: ../../packages/react-components/react-card/assets/office1.png
```

## New Behavior

Added support for the common image types.

## Related Issue(s)

Unblocks #23841
