### PR TITLE
Update SelectionZone to support disallowing behaviors

### DIFF
--- a/change/@fluentui-react-6b751b3a-85c1-4d87-9f8e-c8604193d9e5.json
+++ b/change/@fluentui-react-6b751b3a-85c1-4d87-9f8e-c8604193d9e5.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Allow SelectionZone attributes to disallow behaviors",
+  "comment": "feat: Allow SelectionZone attributes to disallow behaviors.",
   "packageName": "@fluentui/react",
   "email": "tmichon@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-6b751b3a-85c1-4d87-9f8e-c8604193d9e5.json
+++ b/change/@fluentui-react-6b751b3a-85c1-4d87-9f8e-c8604193d9e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow SelectionZone attributes to disallow behaviors",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.tsx
@@ -775,7 +775,12 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
     let isToggle = false;
 
     while (!isToggle && element !== this._root.current) {
-      isToggle = element.getAttribute(attributeName) === 'true';
+      const value = element.getAttribute(attributeName);
+      if (value === 'false') {
+        isToggle = false;
+        break;
+      }
+      isToggle = value === 'true';
       element = getParent(element) as HTMLElement;
     }
 


### PR DESCRIPTION
## Current Behavior

`SelectionZone` works by marking up descendant elements with attributes, such as `data-selection-index`, `data-selection-invoke`, and `data-selection-disabled`. However, when `SelectionZone` receives an event, it recursively checks the event target's ancestors to find whether *any* element has an appropriate attribute set to `true`, but does not have any way to 'countermand' those searches.

## New Behavior

Added support for the `hasAttribute` check to forcibly return `false` if it encounters a closer element to a given target with the attribute explicitly set to `false` instead of `true`. This allows components which use `SelectionZone` to mark some elements up to disable certain behaviors.


One example scenario is using `data-selection-touch-invoke` on the root element of an item, but still inserting a `button` as a descendant. No matter what, the item will still be invoked, even if the button also activates. This is because the `data-selection-touch-invoke` behavior cannot be locally disabled: the most global element 'wins'.
