### PR TITLE
Badge: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-badge/src/stories/Badge/BadgeAppearance.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/Badge/BadgeAppearance.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Badge } from '@fluentui/react-badge';
+import { Badge } from '@fluentui/react-components';
 
 export const Appearance = () => {
   return (

--- a/packages/react-components/react-badge/src/stories/Badge/BadgeColor.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/Badge/BadgeColor.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Badge } from '@fluentui/react-badge';
+import { Badge } from '@fluentui/react-components';
 
 export const Color = () => {
   return (

--- a/packages/react-components/react-badge/src/stories/Badge/BadgeDefault.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/Badge/BadgeDefault.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
-import { Badge, BadgeProps } from '@fluentui/react-badge';
+import { Badge } from '@fluentui/react-components';
+import type { BadgeProps } from '@fluentui/react-components';
 
 export const Default = (props: BadgeProps) => <Badge {...props} />;

--- a/packages/react-components/react-badge/src/stories/Badge/BadgeIcon.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/Badge/BadgeIcon.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Badge } from '@fluentui/react-badge';
+import { Badge } from '@fluentui/react-components';
 import { ClipboardPasteRegular as PasteIcon } from '@fluentui/react-icons';
 
 export const Icon = () => {

--- a/packages/react-components/react-badge/src/stories/Badge/BadgeShapes.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/Badge/BadgeShapes.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Badge } from '@fluentui/react-badge';
+import { Badge } from '@fluentui/react-components';
 
 export const Shapes = () => {
   return (

--- a/packages/react-components/react-badge/src/stories/Badge/BadgeSizes.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/Badge/BadgeSizes.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Badge } from '@fluentui/react-badge';
+import { Badge } from '@fluentui/react-components';
 
 export const Sizes = () => {
   return (

--- a/packages/react-components/react-badge/src/stories/CounterBadge/CounterBadgeAppearance.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/CounterBadge/CounterBadgeAppearance.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { CounterBadge } from '@fluentui/react-badge';
+import { CounterBadge } from '@fluentui/react-components';
 
 export const Appearance = () => {
   return (

--- a/packages/react-components/react-badge/src/stories/CounterBadge/CounterBadgeColor.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/CounterBadge/CounterBadgeColor.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { CounterBadge } from '@fluentui/react-badge';
+import { CounterBadge } from '@fluentui/react-components';
 export const Color = () => {
   return (
     <>

--- a/packages/react-components/react-badge/src/stories/CounterBadge/CounterBadgeDefault.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/CounterBadge/CounterBadgeDefault.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
-import { CounterBadge, CounterBadgeProps } from '@fluentui/react-badge';
+import { CounterBadge } from '@fluentui/react-components';
+import type { CounterBadgeProps } from '@fluentui/react-components';
 
 export const Default = (args: CounterBadgeProps) => <CounterBadge {...args} />;
 

--- a/packages/react-components/react-badge/src/stories/CounterBadge/CounterBadgeDot.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/CounterBadge/CounterBadgeDot.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { CounterBadge } from '@fluentui/react-badge';
+import { CounterBadge } from '@fluentui/react-components';
 
 export const Dot = () => <CounterBadge count={0} dot />;
 

--- a/packages/react-components/react-badge/src/stories/CounterBadge/CounterBadgeShapes.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/CounterBadge/CounterBadgeShapes.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { CounterBadge } from '@fluentui/react-badge';
+import { CounterBadge } from '@fluentui/react-components';
 
 export const Shapes = () => {
   return (

--- a/packages/react-components/react-badge/src/stories/CounterBadge/CounterBadgeSizes.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/CounterBadge/CounterBadgeSizes.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { CounterBadge } from '@fluentui/react-badge';
+import { CounterBadge } from '@fluentui/react-components';
 
 export const Sizes = () => {
   return (

--- a/packages/react-components/react-badge/src/stories/PresenceBadge/PresenceBadgeDefault.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/PresenceBadge/PresenceBadgeDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
 
-import { PresenceBadge } from '@fluentui/react-badge';
+import { PresenceBadge } from '@fluentui/react-components';
 
 export const Default = () => <PresenceBadge />;

--- a/packages/react-components/react-badge/src/stories/PresenceBadge/PresenceBadgeOutOfOffice.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/PresenceBadge/PresenceBadgeOutOfOffice.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { PresenceBadge } from '@fluentui/react-badge';
+import { PresenceBadge } from '@fluentui/react-components';
 
 export const OutOfOffice = () => {
   return (

--- a/packages/react-components/react-badge/src/stories/PresenceBadge/PresenceBadgeSizes.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/PresenceBadge/PresenceBadgeSizes.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { PresenceBadge } from '@fluentui/react-badge';
+import { PresenceBadge } from '@fluentui/react-components';
 
 export const Sizes = () => {
   return (

--- a/packages/react-components/react-badge/src/stories/PresenceBadge/PresenceBadgeStatus.stories.tsx
+++ b/packages/react-components/react-badge/src/stories/PresenceBadge/PresenceBadgeStatus.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { PresenceBadge } from '@fluentui/react-badge';
+import { PresenceBadge } from '@fluentui/react-components';
 
 export const Status = () => {
   return (


### PR DESCRIPTION
### Changes
- updates `react-badge` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846