### PR TITLE
Checkbox: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxChecked.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxChecked.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Checkbox } from '@fluentui/react-checkbox';
-import type { CheckboxProps } from '@fluentui/react-checkbox';
+import { Checkbox } from '@fluentui/react-components';
+import type { CheckboxProps } from '@fluentui/react-components';
 
 export const Checked = () => {
   const [checked, setChecked] = React.useState<CheckboxProps['checked']>(true);

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxCircular.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxCircular.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from '@fluentui/react-checkbox';
+import { Checkbox } from '@fluentui/react-components';
 
 export const Circular = () => <Checkbox shape="circular" label="Circular" />;
 Circular.parameters = {

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxDefault.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxDefault.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Checkbox } from '@fluentui/react-checkbox';
-import type { CheckboxProps } from '@fluentui/react-checkbox';
+import { Checkbox } from '@fluentui/react-components';
+import type { CheckboxProps } from '@fluentui/react-components';
 
 export const Default = (props: CheckboxProps) => <Checkbox {...props} />;
 Default.argTypes = {

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxDisabled.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxDisabled.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from '@fluentui/react-checkbox';
+import { Checkbox } from '@fluentui/react-components';
 
 export const Disabled = () => (
   <>

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxLabelBefore.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxLabelBefore.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from '@fluentui/react-checkbox';
+import { Checkbox } from '@fluentui/react-components';
 
 export const LabelBefore = () => <Checkbox labelPosition="before" label="Label before" />;
 LabelBefore.parameters = {

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxLabelWrapping.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxLabelWrapping.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from '@fluentui/react-checkbox';
+import { Checkbox } from '@fluentui/react-components';
 
 export const LabelWrapping = () => (
   <Checkbox

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxLarge.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxLarge.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from '@fluentui/react-checkbox';
+import { Checkbox } from '@fluentui/react-components';
 
 export const Large = () => <Checkbox size="large" label="Large" />;
 Large.parameters = {

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxMixed.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxMixed.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from '@fluentui/react-checkbox';
+import { Checkbox } from '@fluentui/react-components';
 
 export const Mixed = () => {
   const [option1, setOption1] = React.useState(false);

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxRequired.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/CheckboxRequired.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from '@fluentui/react-checkbox';
+import { Checkbox } from '@fluentui/react-components';
 
 export const Required = () => <Checkbox required label="Required" />;
 Required.parameters = {

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/index.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/index.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Meta } from '@storybook/react';
-import { Checkbox, tokens } from '@fluentui/react-components';
+import { tokens, Checkbox } from '@fluentui/react-components';
 
 export { Default } from './CheckboxDefault.stories';
 export { Checked } from './CheckboxChecked.stories';

--- a/packages/react-components/react-checkbox/src/stories/Checkbox/index.stories.tsx
+++ b/packages/react-components/react-checkbox/src/stories/Checkbox/index.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Meta } from '@storybook/react';
-import { Checkbox } from '@fluentui/react-checkbox';
-import { tokens } from '@fluentui/react-theme';
+import { Checkbox, tokens } from '@fluentui/react-components';
 
 export { Default } from './CheckboxDefault.stories';
 export { Checked } from './CheckboxChecked.stories';


### PR DESCRIPTION
### Changes
- updates `react-checkbox` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846