### PR TITLE
eslint-plugin: components exported from react-components/unstable should be excluded from forbidden rule

### DIFF
--- a/change/@fluentui-eslint-plugin-fdb18ddd-40cf-4f72-ae1c-cb9046a7b065.json
+++ b/change/@fluentui-eslint-plugin-fdb18ddd-40cf-4f72-ae1c-cb9046a7b065.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: don't forbid package imports from components being exported from react-components/unstable.",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -9,9 +9,10 @@ const typeAwareRules = {
 };
 
 const root = configHelpers.findGitRoot();
+const unstableV9Packages = configHelpers.getV9UnstablePackages(root);
 const v9PackageDeps = Object.keys(
   configHelpers.getPackageJson({ root, name: '@fluentui/react-components' }).dependencies,
-);
+).filter(pkg => !unstableV9Packages.has(pkg));
 
 /** @type {import("eslint").Linter.Config} */
 module.exports = {

--- a/packages/eslint-plugin/src/utils/configHelpers.js
+++ b/packages/eslint-plugin/src/utils/configHelpers.js
@@ -240,4 +240,27 @@ module.exports = {
 
     return packageJson;
   },
+
+  /**
+   * Gets a set of v9 packages that are currently being exported as unstable from @fluentui/react-components.
+   * @param {string} root folder of git repo.
+   * @returns {Set<string>} Returns a set of v9 packages that are currently unstable.
+   */
+  getV9UnstablePackages: (/** @type {string} */ root) => {
+    const nxWorkspace = JSON.parse(fs.readFileSync(path.join(root, 'workspace.json'), 'utf-8'));
+    const v9ProjectMetaData = nxWorkspace.projects['@fluentui/react-components'];
+    const v9PackagePath = path.join(root, v9ProjectMetaData.sourceRoot, 'unstable', 'index.ts');
+    const unstableV9Packages = new Set();
+    fs.readFileSync(v9PackagePath)
+      .toString()
+      .split(' ')
+      .forEach(str => {
+        if (str.includes('@fluentui')) {
+          const pkgName = str.split(';')[0].slice(1, -1);
+          unstableV9Packages.add(pkgName);
+        }
+      });
+
+    return unstableV9Packages;
+  },
 };


### PR DESCRIPTION
### Changes:
Follow-up to #23845
- the `no-restricted-imports` currently forbids storybook imports from packages that are listed as dependencies in `@fluentui/react-components`. However, it fails to account for packages that are listed as dependencies but are only being exported as _unstable_. Unstable component packages should be excluded from the `forbidden` variable of the `no-restricted-imports` rule so this PR does just that.

Part of #23846