### PR TITLE
fix(react-avatar): Fixing focus indicator in dark theme for pie layout

### DIFF
--- a/change/@fluentui-react-avatar-a7db0772-2957-4fd1-a3c6-e995ae04cf46.json
+++ b/change/@fluentui-react-avatar-a7db0772-2957-4fd1-a3c6-e995ae04cf46.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing focus indicator for pie layouts.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -74,7 +74,6 @@ const useOverflowButtonStyles = makeStyles({
   // This custom focus indicator is required for the pie layout due to the clip-path applied to the root
   pieFocusIndicator: createCustomFocusIndicatorStyle({
     ...shorthands.border(tokens.strokeWidthThick, 'solid', tokens.colorStrokeFocus2),
-    ...shorthands.borderRadius(tokens.borderRadiusCircular),
   }),
 
   states: {

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -23,20 +23,12 @@ const useStyles = makeStyles({
   },
   pie: {
     clipPath: 'circle(50%)',
+    boxSizing: 'border-box',
     backgroundColor: tokens.colorTransparentStroke,
     '@media (forced-colors: active)': {
       backgroundColor: 'CanvasText',
     },
   },
-  focusIndicator: createCustomFocusIndicatorStyle(
-    {
-      ...shorthands.borderColor('transparent'),
-      outlineColor: tokens.colorStrokeFocus2,
-      outlineWidth: tokens.strokeWidthThick,
-      outlineStyle: 'solid',
-    },
-    { selector: 'focus-within' },
-  ),
   overflowSurface: {
     ...shorthands.padding(0),
   },
@@ -78,6 +70,11 @@ const useOverflowButtonStyles = makeStyles({
     outlineColor: tokens.colorStrokeFocus2,
     outlineWidth: tokens.strokeWidthThick,
     outlineStyle: 'solid',
+  }),
+
+  pieFocusIndicator: createCustomFocusIndicatorStyle({
+    ...shorthands.border(tokens.strokeWidthThick, 'solid', tokens.colorStrokeFocus2),
+    ...shorthands.borderRadius(tokens.borderRadiusCircular),
   }),
 
   states: {
@@ -134,7 +131,7 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
     styles.base,
     layout === 'pie' && styles.pie,
     layout === 'pie' && sizeStyles[size],
-    layout === 'pie' && styles.focusIndicator,
+    // layout === 'pie' && styles.focusIndicator,
     state.root.className,
   );
 
@@ -206,6 +203,7 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
       ...overflowButtonClasses,
       layout !== 'pie' && overflowButtonStyles.states,
       layout !== 'pie' && overflowButtonStyles.focusIndicator,
+      layout === 'pie' && overflowButtonStyles.pieFocusIndicator,
       layout === 'pie' && overflowButtonStyles.pie,
       groupChildClassName,
       state.overflowButton.className,

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -72,6 +72,7 @@ const useOverflowButtonStyles = makeStyles({
     outlineStyle: 'solid',
   }),
 
+  // This custom focus indicator is required for the pie layout due to the clip-path applied to the root
   pieFocusIndicator: createCustomFocusIndicatorStyle({
     ...shorthands.border(tokens.strokeWidthThick, 'solid', tokens.colorStrokeFocus2),
     ...shorthands.borderRadius(tokens.borderRadiusCircular),

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroupStyles.ts
@@ -23,7 +23,6 @@ const useStyles = makeStyles({
   },
   pie: {
     clipPath: 'circle(50%)',
-    boxSizing: 'border-box',
     backgroundColor: tokens.colorTransparentStroke,
     '@media (forced-colors: active)': {
       backgroundColor: 'CanvasText',
@@ -132,7 +131,6 @@ export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGr
     styles.base,
     layout === 'pie' && styles.pie,
     layout === 'pie' && sizeStyles[size],
-    // layout === 'pie' && styles.focusIndicator,
     state.root.className,
   );
 


### PR DESCRIPTION


## Current Behavior

<img width="157" alt="image" src="https://user-images.githubusercontent.com/5953191/178326224-5dd2c458-06f4-45f2-9269-a56475a55bff.png">

Focus indicator for the pie layout was showing up as black, this turned out to be because the actual focus indicator wasn't showing up.

## New Behavior

<img width="226" alt="image" src="https://user-images.githubusercontent.com/5953191/178326060-a7d9cd67-fe62-4631-a223-f94d88df7dda.png">

The focus indicator for the pie layout is now using border instead of outline and is now applied to the button.

