### PR TITLE
Divider: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-divider/src/stories/Divider/DividerAlignContent.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/DividerAlignContent.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
-import { Divider } from '@fluentui/react-divider';
+import { makeStyles, tokens, Divider } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-divider/src/stories/Divider/DividerAppearance.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/DividerAppearance.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
-import { Divider } from '@fluentui/react-divider';
+import { makeStyles, tokens, Divider } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-divider/src/stories/Divider/DividerCustomStyles.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/DividerCustomStyles.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { shorthands, makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
-import { Divider } from '@fluentui/react-divider';
+import { makeStyles, shorthands, tokens, Divider } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-divider/src/stories/Divider/DividerDefault.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/DividerDefault.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
-import { Divider } from '@fluentui/react-divider';
+import { makeStyles, tokens, Divider } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-divider/src/stories/Divider/DividerInset.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/DividerInset.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
-import { Divider } from '@fluentui/react-divider';
+import { makeStyles, tokens, Divider } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-divider/src/stories/Divider/DividerVertical.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/DividerVertical.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
-import { Divider } from '@fluentui/react-divider';
+import { makeStyles, tokens, Divider } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-divider/src/stories/Divider/index.stories.tsx
+++ b/packages/react-components/react-divider/src/stories/Divider/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/react';
-import { Divider } from '@fluentui/react-divider';
+import { Divider } from '@fluentui/react-components';
 import descriptionMd from './DividerDescription.md';
 export { Default } from './DividerDefault.stories';
 export { Vertical } from './DividerVertical.stories';


### PR DESCRIPTION
### Changes
- updates `react-divider` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846