### PR TITLE
chore: update CODEOWNERS for react-badge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,7 +133,7 @@ common/_common.scss @microsoft/cxe-red @phkuo
 packages/react-components/keyboard-keys @microsoft/teams-prg
 packages/react-components/react-accordion @microsoft/cxe-coastal
 packages/react-components/react-avatar @microsoft/cxe-red @behowell @khmakoto @sopranopillow
-packages/react-components/react-badge @microsoft/teams-prg @microsoft/cxe-red @behowell
+packages/react-components/react-badge @microsoft/cxe-red @behowell
 packages/react-components/react-button @microsoft/cxe-red @khmakoto
 packages/react-components/react-card @microsoft/cxe-prg
 packages/react-components/react-checkbox @microsoft/cxe-red @khmakoto


### PR DESCRIPTION
## New Behavior

@microsoft/teams-prg does not own this package anymore, this PR updates `CODEOWNERS` to match the current state of things.