### PR TITLE
fix: remove unnecessary explicit role

### DIFF
--- a/change/@fluentui-react-590db4bc-b0a7-4d60-9ef1-dff4fc2125da.json
+++ b/change/@fluentui-react-590db4bc-b0a7-4d60-9ef1-dff4fc2125da.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(nav): remove unnecessary explicit navigation role",
+  "packageName": "@fluentui/react",
+  "email": "mborenkraout@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Nav/Nav.base.tsx
+++ b/packages/react/src/components/Nav/Nav.base.tsx
@@ -69,7 +69,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
 
     return (
       <FocusZone direction={FocusZoneDirection.vertical} componentRef={this._focusZone} {...this.props.focusZoneProps}>
-        <nav role="navigation" className={classNames.root} aria-label={this.props.ariaLabel}>
+        <nav className={classNames.root} aria-label={this.props.ariaLabel}>
           {groupElements}
         </nav>
       </FocusZone>

--- a/packages/react/src/components/Nav/Nav.test.tsx
+++ b/packages/react/src/components/Nav/Nav.test.tsx
@@ -146,7 +146,7 @@ describe('Nav', () => {
   it('sets ARIA label on the nav element', () => {
     const label = 'The navigation label';
     const nav = mount<NavBase>(<Nav ariaLabel={label} groups={[]} />);
-    expect(nav.find('[role="navigation"]').prop('aria-label')).toEqual(label);
+    expect(nav.find('nav').prop('aria-label')).toEqual(label);
   });
 
   it('uses location.href to determine link selected status if state/props is not set', () => {

--- a/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -25,7 +25,6 @@ exports[`Nav render Nav with overrides correctly 1`] = `
           overflow-y: auto;
           user-select: none;
         }
-    role="navigation"
   >
     <div
       className="ms-Nav-group is-expanded"
@@ -488,7 +487,6 @@ exports[`Nav renders Nav correctly 1`] = `
           overflow-y: auto;
           user-select: none;
         }
-    role="navigation"
   >
     <div
       className="ms-Nav-group is-expanded"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [X] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

An unnecessary explicit `role="navigation"` is added to `nav` element.
The `role="navigation"` is an implicit role based on the ARIA spec:
![image](https://user-images.githubusercontent.com/12711091/178504341-66c007dd-4f64-46aa-9fec-ca94be976c71.png)
https://www.w3.org/TR/2021/REC-html-aria-20211209/#att-min

## New Behavior

I removed the unnecessary explicit role.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
