### PR TITLE
Accordion: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionCollapsible.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionCollapsible.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-accordion';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
 
 export const Collapsible = () => (
   <Accordion collapsible>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionCollapsible.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionCollapsible.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@fluentui/react-components';
 
 export const Collapsible = () => (
   <Accordion collapsible>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionDefault.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-accordion';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
 
 export const Default = () => (
   <Accordion>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionDefault.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@fluentui/react-components';
 
 export const Default = () => (
   <Accordion>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionDisabled.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionDisabled.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@fluentui/react-components';
 
 export const Disabled = () => (
   <Accordion>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionDisabled.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionDisabled.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-accordion';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
 
 export const Disabled = () => (
   <Accordion>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionExpandIcon.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionExpandIcon.stories.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { Add20Filled, Subtract20Filled } from '@fluentui/react-icons';
 import {
-  AccordionItem,
-  AccordionHeader,
-  AccordionPanel,
   Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
   AccordionToggleEventHandler,
 } from '@fluentui/react-components';
 

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionExpandIcon.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionExpandIcon.stories.tsx
@@ -6,7 +6,7 @@ import {
   AccordionPanel,
   Accordion,
   AccordionToggleEventHandler,
-} from '@fluentui/react-accordion';
+} from '@fluentui/react-components';
 
 export const ExpandIcon = () => {
   const [openItem, setOpenItems] = React.useState(0);

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionExpandIconPosition.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionExpandIconPosition.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@fluentui/react-components';
 
 export const ExpandIconPosition = () => (
   <Accordion>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionExpandIconPosition.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionExpandIconPosition.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-accordion';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
 
 export const ExpandIconPosition = () => (
   <Accordion>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionHeaders.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionHeaders.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-accordion';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
 
 export const HeadingLevels = () => (
   <Accordion>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionHeaders.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionHeaders.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@fluentui/react-components';
 
 export const HeadingLevels = () => (
   <Accordion>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionInline.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionInline.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@fluentui/react-components';
 
 export const Inline = () => (
   <Accordion>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionInline.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionInline.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-accordion';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
 
 export const Inline = () => (
   <Accordion>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionMultiple.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionMultiple.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-accordion';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
 
 export const Multiple = () => (
   <Accordion multiple>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionMultiple.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionMultiple.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@fluentui/react-components';
 
 export const Multiple = () => (
   <Accordion multiple>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionNavigation.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionNavigation.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-accordion';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
 
 export const Navigation = () => (
   <Accordion navigation="linear">

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionNavigation.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionNavigation.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@fluentui/react-components';
 
 export const Navigation = () => (
   <Accordion navigation="linear">

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionOpenItems.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionOpenItems.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@fluentui/react-components';
 
 export const OpenItems = () => (
   <Accordion defaultOpenItems="1">

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionOpenItems.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionOpenItems.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-accordion';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
 
 export const OpenItems = () => (
   <Accordion defaultOpenItems="1">

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionSizes.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionSizes.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-accordion';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
 
 export const Sizes = () => (
   <>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionSizes.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionSizes.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@fluentui/react-components';
 
 export const Sizes = () => (
   <>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionWithIcon.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionWithIcon.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { RocketRegular } from '@fluentui/react-icons';
 
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-accordion';
+import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
 
 export const WithIcon = () => (
   <Accordion>

--- a/packages/react-components/react-accordion/src/stories/Accordion/AccordionWithIcon.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/AccordionWithIcon.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { RocketRegular } from '@fluentui/react-icons';
 
-import { AccordionItem, AccordionHeader, AccordionPanel, Accordion } from '@fluentui/react-components';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@fluentui/react-components';
 
 export const WithIcon = () => (
   <Accordion>

--- a/packages/react-components/react-accordion/src/stories/Accordion/index.stories.tsx
+++ b/packages/react-components/react-accordion/src/stories/Accordion/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Accordion } from '@fluentui/react-accordion';
+import { Accordion } from '@fluentui/react-components';
 export { Default } from './AccordionDefault.stories';
 export { Collapsible } from './AccordionCollapsible.stories';
 export { Multiple } from './AccordionMultiple.stories';


### PR DESCRIPTION
### Changes
- updates `react-accordion` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846