### PR TITLE
Input: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-input/src/stories/Input/InputAppearance.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputAppearance.stories.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
-import { Input } from '@fluentui/react-input';
+import { makeStyles, mergeClasses, shorthands, tokens, useId, Input, Label } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   base: {

--- a/packages/react-components/react-input/src/stories/Input/InputContentBeforeAfter.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputContentBeforeAfter.stories.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@griffel/react';
+import { makeStyles, shorthands, useId, Body1, Button, Input, Label, Text } from '@fluentui/react-components';
 import { PersonRegular, MicRegular } from '@fluentui/react-icons';
-import { Button } from '@fluentui/react-button';
-import type { ButtonProps } from '@fluentui/react-button';
-import { Body1, Text } from '@fluentui/react-text';
-import { Input } from '@fluentui/react-input';
+import type { ButtonProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-input/src/stories/Input/InputControlled.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputControlled.stories.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Input } from '@fluentui/react-input';
-import type { InputProps } from '@fluentui/react-input';
+import { makeStyles, shorthands, useId, Input, Label } from '@fluentui/react-components';
+import type { InputProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-input/src/stories/Input/InputDefault.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputDefault.stories.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import { ArgTypes } from '@storybook/api';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Input } from '@fluentui/react-input';
-import type { InputProps } from '@fluentui/react-input';
+import { makeStyles, shorthands, useId, Input, Label } from '@fluentui/react-components';
+import type { InputProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-input/src/stories/Input/InputDisabled.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputDisabled.stories.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Input } from '@fluentui/react-input';
+import { makeStyles, shorthands, useId, Input, Label } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-input/src/stories/Input/InputInline.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputInline.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { Input } from '@fluentui/react-input';
+import { useId, Input, Label } from '@fluentui/react-components';
 
 export const Inline = () => {
   const inputId = useId('input');

--- a/packages/react-components/react-input/src/stories/Input/InputPlaceholder.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputPlaceholder.stories.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import { Input } from '@fluentui/react-input';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles } from '@griffel/react';
+import { makeStyles, useId, Input, Label } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-input/src/stories/Input/InputSize.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputSize.stories.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Input } from '@fluentui/react-input';
+import { makeStyles, shorthands, useId, Input, Label } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-input/src/stories/Input/InputType.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputType.stories.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Input } from '@fluentui/react-input';
+import { makeStyles, shorthands, useId, Input, Label } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-input/src/stories/Input/InputUncontrolled.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputUncontrolled.stories.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Input } from '@fluentui/react-input';
-import type { InputProps } from '@fluentui/react-input';
+import { makeStyles, shorthands, useId, Input, Label } from '@fluentui/react-components';
+import type { InputProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-input/src/stories/Input/index.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/react';
-import { Input } from '@fluentui/react-input';
+import { Input } from '@fluentui/react-components';
 
 import descriptionMd from './InputDescription.md';
 import bestPracticesMd from './InputBestPractices.md';


### PR DESCRIPTION
### Changes
- updates `react-input` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846