### PR TITLE
Menu: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-menu/src/stories/Menu/MenuAligningWithIcons.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuAligningWithIcons.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
 import { bundleIcon, ClipboardPasteRegular, ClipboardPasteFilled } from '@fluentui/react-icons';
 
 const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);

--- a/packages/react-components/react-menu/src/stories/Menu/MenuAligningWithSelectableItems.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuAligningWithSelectableItems.stories.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuItemCheckbox, MenuPopover } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import {
+  Button,
+  Menu,
+  MenuTrigger,
+  MenuList,
+  MenuItem,
+  MenuItemCheckbox,
+  MenuPopover,
+} from '@fluentui/react-components';
 import { CutRegular, CutFilled, bundleIcon } from '@fluentui/react-icons';
 
 const CutIcon = bundleIcon(CutFilled, CutRegular);

--- a/packages/react-components/react-menu/src/stories/Menu/MenuAnchorToTarget.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuAnchorToTarget.stories.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 
-import { Menu, MenuList, MenuItem, MenuPopover, MenuProps } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
-import { PositioningImperativeRef } from '@fluentui/react-positioning';
+import { Button, Menu, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
+import type { MenuProps, PositioningImperativeRef } from '@fluentui/react-components';
 
 export const AnchorToCustomTarget = () => {
   const buttonRef = React.useRef<HTMLButtonElement>(null);

--- a/packages/react-components/react-menu/src/stories/Menu/MenuCheckboxItems.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuCheckboxItems.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItemCheckbox, MenuPopover } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuTrigger, MenuList, MenuItemCheckbox, MenuPopover } from '@fluentui/react-components';
 import {
   bundleIcon,
   CutRegular,

--- a/packages/react-components/react-menu/src/stories/Menu/MenuControlledCheckboxItems.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuControlledCheckboxItems.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItemCheckbox, MenuPopover, MenuProps } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuTrigger, MenuList, MenuItemCheckbox, MenuPopover } from '@fluentui/react-components';
 import {
   bundleIcon,
   CutRegular,
@@ -12,6 +10,7 @@ import {
   EditRegular,
   EditFilled,
 } from '@fluentui/react-icons';
+import type { MenuProps } from '@fluentui/react-components';
 
 const CutIcon = bundleIcon(CutFilled, CutRegular);
 const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);

--- a/packages/react-components/react-menu/src/stories/Menu/MenuControlledRadioItems.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuControlledRadioItems.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItemRadio, MenuPopover, MenuProps } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuTrigger, MenuList, MenuItemRadio, MenuPopover } from '@fluentui/react-components';
 import {
   bundleIcon,
   CutRegular,
@@ -12,6 +10,7 @@ import {
   EditRegular,
   EditFilled,
 } from '@fluentui/react-icons';
+import type { MenuProps } from '@fluentui/react-components';
 
 const CutIcon = bundleIcon(CutFilled, CutRegular);
 const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);

--- a/packages/react-components/react-menu/src/stories/Menu/MenuControllingOpenAndClose.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuControllingOpenAndClose.stories.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuProps } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
-import { Checkbox, CheckboxProps } from '@fluentui/react-checkbox';
+import { Button, Checkbox, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
+import type { CheckboxProps, MenuProps } from '@fluentui/react-components';
 
 export const ControllingOpenAndClose = () => {
   const [open, setOpen] = React.useState(false);

--- a/packages/react-components/react-menu/src/stories/Menu/MenuCustomTrigger.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuCustomTrigger.stories.tsx
@@ -1,15 +1,6 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-button';
-
-import {
-  Menu,
-  MenuProps,
-  MenuTrigger,
-  MenuList,
-  MenuItem,
-  MenuPopover,
-  MenuTriggerChildProps,
-} from '@fluentui/react-menu';
+import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
+import type { MenuProps, MenuTriggerChildProps } from '@fluentui/react-components';
 
 const CustomMenuTrigger = React.forwardRef<HTMLButtonElement, Partial<MenuTriggerChildProps>>((props, ref) => {
   return (

--- a/packages/react-components/react-menu/src/stories/Menu/MenuDefault.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuDefault.stories.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuProps } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
+import type { MenuProps } from '@fluentui/react-components';
 
 export const Default = (props: Partial<MenuProps>) => (
   <Menu {...props}>

--- a/packages/react-components/react-menu/src/stories/Menu/MenuGroupingItems.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuGroupingItems.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Button,
   Menu,
   MenuTrigger,
   MenuList,
@@ -8,9 +9,7 @@ import {
   MenuDivider,
   MenuGroupHeader,
   MenuPopover,
-} from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+} from '@fluentui/react-components';
 import {
   bundleIcon,
   CutRegular,

--- a/packages/react-components/react-menu/src/stories/Menu/MenuInteraction.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuInteraction.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-button';
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuProps } from '@fluentui/react-menu';
+import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
 import {
   bundleIcon,
   ClipboardPasteRegular,
@@ -10,6 +9,7 @@ import {
   CopyRegular,
   CopyFilled,
 } from '@fluentui/react-icons';
+import type { MenuProps } from '@fluentui/react-components';
 
 const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);
 const CopyIcon = bundleIcon(CopyFilled, CopyRegular);

--- a/packages/react-components/react-menu/src/stories/Menu/MenuMemoizedMenuItems.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuMemoizedMenuItems.stories.tsx
@@ -1,15 +1,7 @@
 import * as React from 'react';
-import {
-  Menu,
-  MenuTrigger,
-  MenuList,
-  MenuItemCheckbox,
-  MenuPopover,
-  MenuItemCheckboxProps,
-} from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuTrigger, MenuList, MenuItemCheckbox, MenuPopover } from '@fluentui/react-components';
 import { EditFilled, EditRegular, bundleIcon } from '@fluentui/react-icons';
+import type { MenuItemCheckboxProps } from '@fluentui/react-components';
 
 const EditIcon = bundleIcon(EditFilled, EditRegular);
 

--- a/packages/react-components/react-menu/src/stories/Menu/MenuMenuItemsWithIcons.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuMenuItemsWithIcons.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
 import {
   bundleIcon,
   CutRegular,

--- a/packages/react-components/react-menu/src/stories/Menu/MenuNestedSubmenus.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuNestedSubmenus.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
 
 const EditorLayoutSubMenu = () => {
   return (

--- a/packages/react-components/react-menu/src/stories/Menu/MenuNestedSubmenusControlled.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuNestedSubmenusControlled.stories.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuProps } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
+import type { MenuProps } from '@fluentui/react-components';
 
 const EditorLayoutSubMenu = () => {
   const [open, setOpen] = React.useState(false);

--- a/packages/react-components/react-menu/src/stories/Menu/MenuRadioItems.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuRadioItems.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItemRadio, MenuPopover } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuTrigger, MenuList, MenuItemRadio, MenuPopover } from '@fluentui/react-components';
 import {
   bundleIcon,
   CutRegular,

--- a/packages/react-components/react-menu/src/stories/Menu/MenuRenderFunctionTrigger.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuRenderFunctionTrigger.stories.tsx
@@ -1,15 +1,8 @@
 import * as React from 'react';
 import { ChevronDownRegular } from '@fluentui/react-icons';
 
-import {
-  Menu,
-  MenuProps,
-  MenuTrigger,
-  MenuList,
-  MenuItem,
-  MenuPopover,
-  MenuTriggerChildProps,
-} from '@fluentui/react-menu';
+import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
+import type { MenuProps, MenuTriggerChildProps } from '@fluentui/react-components';
 
 const buttonStyle = { height: 22, verticalAlign: 'middle' };
 

--- a/packages/react-components/react-menu/src/stories/Menu/MenuSecondaryContentForMenuItems.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuSecondaryContentForMenuItems.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
 
 export const SecondaryContentForMenuItems = () => (
   <Menu>

--- a/packages/react-components/react-menu/src/stories/Menu/MenuSelectionGroup.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuSelectionGroup.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Button,
   Menu,
   MenuTrigger,
   MenuList,
@@ -9,9 +10,7 @@ import {
   MenuDivider,
   MenuGroupHeader,
   MenuPopover,
-} from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+} from '@fluentui/react-components';
 import {
   bundleIcon,
   CutRegular,

--- a/packages/react-components/react-menu/src/stories/Menu/MenuSplitMenuItem.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuSplitMenuItem.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuSplitGroup } from '@fluentui/react-menu';
-
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuSplitGroup } from '@fluentui/react-components';
 
 export const SplitMenuItem = () => (
   <Menu>

--- a/packages/react-components/react-menu/src/stories/Menu/MenuTriggerWithTooltip.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuTriggerWithTooltip.stories.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import { Tooltip } from '@fluentui/react-tooltip';
-import { Button } from '@fluentui/react-button';
-
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-menu';
+import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, Tooltip } from '@fluentui/react-components';
 
 export const MenuTriggerWithTooltip = () => (
   <Menu>

--- a/packages/react-components/react-menu/src/stories/Menu/MenuVisualDividerOnly.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/MenuVisualDividerOnly.stories.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuDivider, MenuPopover } from '@fluentui/react-menu';
+import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuDivider, MenuPopover } from '@fluentui/react-components';
 
-import { Button } from '@fluentui/react-button';
 import {
   bundleIcon,
   CutRegular,

--- a/packages/react-components/react-menu/src/stories/Menu/index.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/Menu/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Menu } from '@fluentui/react-menu';
+import { Menu } from '@fluentui/react-components';
 
 import descriptionMd from './MenuDescription.md';
 import bestPracticesMd from './MenuBestPractices.md';

--- a/packages/react-components/react-menu/src/stories/MenuList/MenuListDefault.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/MenuList/MenuListDefault.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
-import { MenuList, MenuItem } from '@fluentui/react-menu';
+import { makeStyles, tokens, MenuList, MenuItem } from '@fluentui/react-components';
 
 export const useMenuListContainerStyles = makeStyles({
   container: {

--- a/packages/react-components/react-menu/src/stories/MenuList/MenuListNestedSubmenus.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/MenuList/MenuListNestedSubmenus.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
-import { MenuList, MenuItem, Menu, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
+import { makeStyles, tokens, MenuList, MenuItem, Menu, MenuPopover, MenuTrigger } from '@fluentui/react-components';
 
 export const useMenuListContainerStyles = makeStyles({
   container: {

--- a/packages/react-components/react-menu/src/stories/MenuList/index.stories.tsx
+++ b/packages/react-components/react-menu/src/stories/MenuList/index.stories.tsx
@@ -1,4 +1,4 @@
-import { MenuList } from '@fluentui/react-menu';
+import { MenuList } from '@fluentui/react-components';
 import descriptionMd from './MenuListDescription.md';
 
 export { Default } from './MenuListDefault.stories';


### PR DESCRIPTION
### Changes
- updates `react-menu` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846