### PR TITLE
Popover: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-popover/src/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
+++ b/packages/react-components/react-popover/src/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Button, Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-components';
+import { makeStyles, shorthands, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
 import type { PositioningImperativeRef } from '@fluentui/react-components';
 const useStyles = makeStyles({
   container: {

--- a/packages/react-components/react-popover/src/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
+++ b/packages/react-components/react-popover/src/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-button';
-import { makeStyles, shorthands } from '@griffel/react';
-
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
-import { PositioningImperativeRef } from '@fluentui/react-positioning';
-
+import { makeStyles, shorthands, Button, Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-components';
+import type { PositioningImperativeRef } from '@fluentui/react-components';
 const useStyles = makeStyles({
   container: {
     display: 'flex',

--- a/packages/react-components/react-popover/src/stories/Popover/PopoverControllingOpenAndClose.stories.tsx
+++ b/packages/react-components/react-popover/src/stories/Popover/PopoverControllingOpenAndClose.stories.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-button';
-import { makeStyles } from '@griffel/react';
-
-import { Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-popover';
-import type { PopoverProps } from '@fluentui/react-popover';
+import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import type { PopoverProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   contentHeader: {

--- a/packages/react-components/react-popover/src/stories/Popover/PopoverCustomTrigger.stories.tsx
+++ b/packages/react-components/react-popover/src/stories/Popover/PopoverCustomTrigger.stories.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-button';
-import { makeStyles } from '@griffel/react';
-
-import { Popover, PopoverProps, PopoverSurface } from '@fluentui/react-popover';
-
+import { makeStyles, Button, Popover, PopoverSurface } from '@fluentui/react-components';
+import type { PopoverProps } from '@fluentui/react-components';
 const useStyles = makeStyles({
   contentHeader: {
     marginTop: '0',

--- a/packages/react-components/react-popover/src/stories/Popover/PopoverDefault.stories.tsx
+++ b/packages/react-components/react-popover/src/stories/Popover/PopoverDefault.stories.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-button';
-import { makeStyles } from '@griffel/react';
-
-import { Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-popover';
-import type { PopoverProps } from '@fluentui/react-popover';
+import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import type { PopoverProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   contentHeader: {

--- a/packages/react-components/react-popover/src/stories/Popover/PopoverInternalUpdateContent.stories.tsx
+++ b/packages/react-components/react-popover/src/stories/Popover/PopoverInternalUpdateContent.stories.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-button';
-import { makeStyles } from '@griffel/react';
-
-import { Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-popover';
-import type { PopoverProps } from '@fluentui/react-popover';
+import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import type { PopoverProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   contentHeader: {

--- a/packages/react-components/react-popover/src/stories/Popover/PopoverNestedPopovers.stories.tsx
+++ b/packages/react-components/react-popover/src/stories/Popover/PopoverNestedPopovers.stories.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-button';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles } from '@griffel/react';
-
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
+import { makeStyles, useId, Button, Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   contentHeader: {

--- a/packages/react-components/react-popover/src/stories/Popover/PopoverTrappingFocus.stories.tsx
+++ b/packages/react-components/react-popover/src/stories/Popover/PopoverTrappingFocus.stories.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-button';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles } from '@griffel/react';
-
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
+import { makeStyles, useId, Button, Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   contentHeader: {

--- a/packages/react-components/react-popover/src/stories/Popover/PopoverWithArrow.stories.tsx
+++ b/packages/react-components/react-popover/src/stories/Popover/PopoverWithArrow.stories.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-button';
-import { makeStyles } from '@griffel/react';
-
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
+import { makeStyles, Button, Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   contentHeader: {

--- a/packages/react-components/react-popover/src/stories/Popover/index.stories.tsx
+++ b/packages/react-components/react-popover/src/stories/Popover/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Popover } from '@fluentui/react-popover';
+import { Popover } from '@fluentui/react-components';
 import { Meta } from '@storybook/react';
 import descriptionMd from './PopoverDescription.md';
 import bestPracticesMd from './PopoverBestPractices.md';


### PR DESCRIPTION
### Changes
- updates `react-popover` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846