### PR TITLE
docs: update v9 styling guide to include griffel devtools extension link

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/StylingComponents.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/StylingComponents.stories.mdx
@@ -132,6 +132,10 @@ function Component(props) {
 }
 ```
 
+### Debugging styles
+
+[Griffel devtools chrome extension](https://chrome.google.com/webstore/detail/griffel-devtools/bejhagjehnpgagkaaeehdpdadmffbigb) is especially useful for debugging style override. It shows all griffel styles applied on the currently selected DOM element∂ including the ones being overridden.
+
 ## Overriding FUI component styles
 
 To override an appearance of a FUI component, you use the exactly same approach - You call makeStyles/useStyles in your code and pass the resulting classes through `props`.

--- a/apps/public-docsite-v9/src/Concepts/StylingComponents.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/StylingComponents.stories.mdx
@@ -134,7 +134,7 @@ function Component(props) {
 
 ### Debugging styles
 
-[Griffel devtools chrome extension](https://chrome.google.com/webstore/detail/griffel-devtools/bejhagjehnpgagkaaeehdpdadmffbigb) is especially useful for debugging style override. It shows all griffel styles applied on the currently selected DOM element∂ including the ones being overridden.
+[Griffel devtools chrome extension](https://chrome.google.com/webstore/detail/griffel-devtools/bejhagjehnpgagkaaeehdpdadmffbigb) is especially useful for debugging style override. It shows all griffel styles applied on the currently selected DOM element, including the styles that are overridden in `mergeClasses`.
 
 ## Overriding FUI component styles
 


### PR DESCRIPTION
Add griffel devtools extension info to v9 'styling component' guide.