### PR TITLE
Provider: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-provider/src/stories/Provider/FluentProviderDefault.stories.tsx
+++ b/packages/react-components/react-provider/src/stories/Provider/FluentProviderDefault.stories.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-button';
-import { makeStyles, shorthands } from '@griffel/react';
-import { teamsDarkTheme, teamsLightTheme, tokens, webLightTheme } from '@fluentui/react-theme';
-
-import { FluentProvider } from '@fluentui/react-provider';
+import {
+  makeStyles,
+  shorthands,
+  teamsDarkTheme,
+  teamsLightTheme,
+  tokens,
+  webLightTheme,
+  Button,
+  FluentProvider,
+} from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   button: {

--- a/packages/react-components/react-provider/src/stories/Provider/FluentProviderDir.stories.tsx
+++ b/packages/react-components/react-provider/src/stories/Provider/FluentProviderDir.stories.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import { shorthands, makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
-
-import { FluentProvider } from '@fluentui/react-provider';
+import { makeStyles, shorthands, tokens, FluentProvider } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   example: {

--- a/packages/react-components/react-provider/src/stories/Provider/FluentProviderFrame.stories.tsx
+++ b/packages/react-components/react-provider/src/stories/Provider/FluentProviderFrame.stories.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Button } from '@fluentui/react-button';
-import { createDOMRenderer, makeStyles, RendererProvider, shorthands } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
-
-import { FluentProvider } from '@fluentui/react-provider';
+import {
+  createDOMRenderer,
+  makeStyles,
+  shorthands,
+  tokens,
+  Button,
+  FluentProvider,
+  RendererProvider,
+} from '@fluentui/react-components';
 
 const useExampleStyles = makeStyles({
   button: {

--- a/packages/react-components/react-provider/src/stories/Provider/FluentProviderNested.stories.tsx
+++ b/packages/react-components/react-provider/src/stories/Provider/FluentProviderNested.stories.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import { shorthands, makeStyles } from '@griffel/react';
-import { tokens, webLightTheme } from '@fluentui/react-theme';
-
-import { FluentProvider } from '@fluentui/react-provider';
+import { makeStyles, shorthands, tokens, webLightTheme, FluentProvider } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   example: {

--- a/packages/react-components/react-provider/src/stories/Provider/index.stories.tsx
+++ b/packages/react-components/react-provider/src/stories/Provider/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/react';
 
-import { FluentProvider } from '@fluentui/react-provider';
+import { FluentProvider } from '@fluentui/react-components';
 import descriptionMd from './FluentProviderDescription.md';
 import bestPracticesMd from './FluentProviderBestPractices.md';
 


### PR DESCRIPTION
### Changes
- updates `react-provider` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846