### PR TITLE
add focus styles to back to top button on v8 website

### DIFF
--- a/apps/public-docsite/src/styles/_base.scss
+++ b/apps/public-docsite/src/styles/_base.scss
@@ -48,6 +48,11 @@
     outline: none;
   }
 
+  // Return the outline on the 'back to top' button
+  .back-to-top a[href]:focus {
+    @include focus-border(-2px);
+  }
+
   // Example card headers
   .ExampleCard-title {
     @include ms-fontSize-20;


### PR DESCRIPTION
The back to top button on the v8 website doesn't have focus styles due to us removing the MWF styles that spill into our own controls. This would add some back that match our site. 