### PR TITLE
Docsite: remove Fluent's main landmark role since higher-level main landmark was added

### DIFF
--- a/apps/public-docsite/src/components/Site/Site.tsx
+++ b/apps/public-docsite/src/components/Site/Site.tsx
@@ -168,7 +168,6 @@ export class Site<TPlatforms extends string = string> extends React.Component<
             data-app-content-div="true"
             // This needs to be programmatically focusable for "jump to main content" functionality
             tabIndex={-1}
-            role="main"
           >
             {childrenWithPlatform}
           </div>


### PR DESCRIPTION
At some point, #maincontent received a `role="main"`, so now the main landmark role added in our public docsite creates nested main landmarks on the site.

Removing the Site.tsx main landmark role so there is only one on the page.