### PR TITLE
feat: re-export `__css` from Griffel

### DIFF
--- a/change/@fluentui-react-components-b71ce9f6-1c6d-406f-b8ef-192483756f06.json
+++ b/change/@fluentui-react-components-b71ce9f6-1c6d-406f-b8ef-192483756f06.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: re-export `__css` from Griffel",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { __css } from '@griffel/react';
 import { __styles } from '@griffel/react';
 import { Accordion } from '@fluentui/react-accordion';
 import { accordionClassNames } from '@fluentui/react-accordion';
@@ -519,6 +520,8 @@ import { useTooltipVisibility_unstable as useTooltipVisibility } from '@fluentui
 import { VerticalSpacingTokens } from '@fluentui/react-theme';
 import { webDarkTheme } from '@fluentui/react-theme';
 import { webLightTheme } from '@fluentui/react-theme';
+
+export { __css }
 
 export { __styles }
 
@@ -1529,7 +1532,6 @@ export { useTextarea_unstable }
 export { useTextareaStyles_unstable }
 
 export { useTextStyles_unstable }
-
 
 export { useThemeClassName }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -1,6 +1,7 @@
 // Utilities
 export {
   RendererProvider,
+  __css,
   __styles,
   createDOMRenderer,
   makeStaticStyles,


### PR DESCRIPTION
## New Behavior

This PR re-exports `__css` function from Griffel. This functional is similar to `__styles` and used with CSS extraction when the Webpack loader from `@griffel/webpack-extraction-plugin` rewrites imports:

```tsx
import { makeStyles } from "@fluentui/react-components";
// ⬇️⬇️⬇️ (works now, done even in our repo)
import { __styles } from "@fluentui/react-components";
// ⬇️⬇️⬇️ (done by Webpack loader)
import { __css } from "@fluentui/react-components";
```

As `__css` is not re-exported customers will get errors:

```
TypeError: (0 , _fluentui_react_components__WEBPACK_IMPORTED_MODULE_0__.__css) is not a function
```