### PR TITLE
docs(public-docsite): Adding v9 release message.

### DIFF
--- a/apps/public-docsite/src/SiteDefinition/SiteDefinition.tsx
+++ b/apps/public-docsite/src/SiteDefinition/SiteDefinition.tsx
@@ -61,7 +61,23 @@ export const SiteDefinition: ISiteDefinition<Platforms> = {
     { from: '#/styles/web/fluent-theme', to: '#/controls/web/themes' },
     { from: '#/examples', to: '#/controls/web' },
   ],
-  messageBars: [],
+  messageBars: [
+    {
+      path: '#',
+      text: (
+        <span>
+          <p>🎉 Announcing Fluent UI React v9 stable release!</p>After nearly two years of development today Fluent Team
+          are proud to announce the release of Fluent UI Web-React stable version 9.0!
+          <br />
+          <br />
+          To see more
+        </span>
+      ),
+      linkText: 'Fluent Web React v9.',
+      linkUrl: 'https://react.fluentui.dev/',
+      sessionStoragePrefix: 'FluentUI9',
+    },
+  ],
   // This is defined by loadSite() from @fluentui/public-docsite-setup
   versionSwitcherDefinition: window.__versionSwitcherDefinition,
 };


### PR DESCRIPTION
## Current Behavior

<img width="1464" alt="image" src="https://user-images.githubusercontent.com/5953191/178769240-4bbeefa1-e652-4a67-960b-441d4b6db579.png">


## New Behavior

<img width="1465" alt="image" src="https://user-images.githubusercontent.com/5953191/178769297-7d7b447b-28a7-4a9b-a2dd-91ec60d2d1b6.png">

Note: issue linked has different requirements, this PR adds a different change to replace the issue's request. This is due to having an almost empty page for v9 seems to be too much for the message. An announcement would get the job done, and layer we can add another block to the pages in the v8 controls to reference v9.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23868
