### PR TITLE
feat: extend CardPreview `logo` slot to allow `img` elements

### DIFF
--- a/change/@fluentui-react-card-767362bb-acfe-4251-aa59-3dd01ce45c25.json
+++ b/change/@fluentui-react-card-767362bb-acfe-4251-aa59-3dd01ce45c25.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add `img` as allowed element for CardPreview's logo slot",
+  "packageName": "@fluentui/react-card",
+  "email": "39736248+andrefcdias@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/etc/react-card.api.md
+++ b/packages/react-components/react-card/etc/react-card.api.md
@@ -79,7 +79,7 @@ export type CardPreviewProps = ComponentProps<CardPreviewSlots>;
 // @public
 export type CardPreviewSlots = {
     root: Slot<'div'>;
-    logo?: Slot<'div'>;
+    logo?: Slot<'div', 'img'>;
 };
 
 // @public

--- a/packages/react-components/react-card/src/components/CardPreview/CardPreview.types.ts
+++ b/packages/react-components/react-card/src/components/CardPreview/CardPreview.types.ts
@@ -12,7 +12,7 @@ export type CardPreviewSlots = {
   /**
    * Container that holds a logo related to the image preview provided.
    */
-  logo?: Slot<'div'>;
+  logo?: Slot<'div', 'img'>;
 };
 
 /**


### PR DESCRIPTION
## Current Behavior

Slot has only `div` as permitted element.

## New Behavior

Slot now allows `img` as an alternative element.

## Related Issue(s)

#19336 