### PR TITLE
Label: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-label/src/stories/Label/LabelDefault.stories.tsx
+++ b/packages/react-components/react-label/src/stories/Label/LabelDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import type { LabelProps } from '@fluentui/react-label';
+import { Label } from '@fluentui/react-components';
+import type { LabelProps } from '@fluentui/react-components';
 
 export const Default = (props: LabelProps) => <Label {...props}>This is a label</Label>;

--- a/packages/react-components/react-label/src/stories/Label/LabelDisabled.stories.tsx
+++ b/packages/react-components/react-label/src/stories/Label/LabelDisabled.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
+import { Label } from '@fluentui/react-components';
 
 export const Disabled = () => (
   <Label disabled required>

--- a/packages/react-components/react-label/src/stories/Label/LabelRequired.stories.tsx
+++ b/packages/react-components/react-label/src/stories/Label/LabelRequired.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
+import { Label } from '@fluentui/react-components';
 
 export const Required = () => (
   <>

--- a/packages/react-components/react-label/src/stories/Label/LabelSize.stories.tsx
+++ b/packages/react-components/react-label/src/stories/Label/LabelSize.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
+import { Label } from '@fluentui/react-components';
 
 export const Size = () => {
   return (

--- a/packages/react-components/react-label/src/stories/Label/LabelWeight.stories.tsx
+++ b/packages/react-components/react-label/src/stories/Label/LabelWeight.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
+import { Label } from '@fluentui/react-components';
 
 export const Weight = () => <Label weight="semibold">Strong label</Label>;
 

--- a/packages/react-components/react-label/src/stories/Label/index.stories.tsx
+++ b/packages/react-components/react-label/src/stories/Label/index.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Meta } from '@storybook/react';
-import { Label } from '@fluentui/react-label';
+import { Label } from '@fluentui/react-components';
 
 import descriptionMd from './LabelDescription.md';
 export { Default } from './LabelDefault.stories';


### PR DESCRIPTION
### Changes
- updates `react-label` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846