### PR TITLE
Link: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-link/src/stories/Link/LinkAppearance.stories.tsx
+++ b/packages/react-components/react-link/src/stories/Link/LinkAppearance.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link } from '@fluentui/react-link';
+import { Link } from '@fluentui/react-components';
 
 export const Appearance = () => (
   <Link appearance="subtle" href="https://www.bing.com">

--- a/packages/react-components/react-link/src/stories/Link/LinkAsButton.stories.tsx
+++ b/packages/react-components/react-link/src/stories/Link/LinkAsButton.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link } from '@fluentui/react-link';
+import { Link } from '@fluentui/react-components';
 
 export const AsButton = () => <Link>Render as a button</Link>;
 

--- a/packages/react-components/react-link/src/stories/Link/LinkDefault.stories.tsx
+++ b/packages/react-components/react-link/src/stories/Link/LinkDefault.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Link, LinkProps } from '@fluentui/react-link';
+import { Link } from '@fluentui/react-components';
+import type { LinkProps } from '@fluentui/react-components';
 
 export const Default = (props: LinkProps & { as?: 'a' }) => (
   <Link href="https://www.bing.com" {...props}>

--- a/packages/react-components/react-link/src/stories/Link/LinkDisabled.stories.tsx
+++ b/packages/react-components/react-link/src/stories/Link/LinkDisabled.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link } from '@fluentui/react-link';
+import { Link } from '@fluentui/react-components';
 
 export const Disabled = () => (
   <Link disabled href="https://www.bing.com">

--- a/packages/react-components/react-link/src/stories/Link/LinkDisabledFocusable.stories.tsx
+++ b/packages/react-components/react-link/src/stories/Link/LinkDisabledFocusable.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link } from '@fluentui/react-link';
+import { Link } from '@fluentui/react-components';
 
 export const DisabledFocusable = () => (
   <Link inline disabled disabledFocusable href="https://www.bing.com">

--- a/packages/react-components/react-link/src/stories/Link/LinkInline.stories.tsx
+++ b/packages/react-components/react-link/src/stories/Link/LinkInline.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link } from '@fluentui/react-link';
+import { Link } from '@fluentui/react-components';
 
 export const Inline = () => (
   <div>

--- a/packages/react-components/react-link/src/stories/Link/index.stories.tsx
+++ b/packages/react-components/react-link/src/stories/Link/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@fluentui/react-link';
+import { Link } from '@fluentui/react-components';
 
 import descriptionMd from './LinkDescription.md';
 import bestPracticesMd from './LinkBestPractices.md';


### PR DESCRIPTION
### Changes
- updates `react-link` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846