### PR TITLE
Slider: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-slider/src/stories/Slider/SliderControlled.stories.tsx
+++ b/packages/react-components/react-slider/src/stories/Slider/SliderControlled.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { Button } from '@fluentui/react-button';
-import { Slider, SliderProps } from '@fluentui/react-slider';
+import { useId, Button, Label, Slider } from '@fluentui/react-components';
+import type { SliderProps } from '@fluentui/react-components';
 
 export const Controlled = () => {
   const id = useId();

--- a/packages/react-components/react-slider/src/stories/Slider/SliderDefault.stories.tsx
+++ b/packages/react-components/react-slider/src/stories/Slider/SliderDefault.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { Slider } from '@fluentui/react-slider';
+import { useId, Label, Slider } from '@fluentui/react-components';
 
 export const Default = () => {
   const id = useId();

--- a/packages/react-components/react-slider/src/stories/Slider/SliderDisabled.stories.tsx
+++ b/packages/react-components/react-slider/src/stories/Slider/SliderDisabled.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { Slider } from '@fluentui/react-slider';
+import { useId, Label, Slider } from '@fluentui/react-components';
 
 export const Disabled = () => {
   const id = useId();

--- a/packages/react-components/react-slider/src/stories/Slider/SliderSize.stories.tsx
+++ b/packages/react-components/react-slider/src/stories/Slider/SliderSize.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { Slider } from '@fluentui/react-slider';
+import { useId, Label, Slider } from '@fluentui/react-components';
 
 export const Size = () => {
   const smallId = useId('small');

--- a/packages/react-components/react-slider/src/stories/Slider/SliderStep.stories.tsx
+++ b/packages/react-components/react-slider/src/stories/Slider/SliderStep.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { Slider } from '@fluentui/react-slider';
+import { useId, Label, Slider } from '@fluentui/react-components';
 
 export const Step = () => {
   const id = useId();

--- a/packages/react-components/react-slider/src/stories/Slider/SliderVertical.stories.tsx
+++ b/packages/react-components/react-slider/src/stories/Slider/SliderVertical.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { Slider } from '@fluentui/react-slider';
+import { useId, Label, Slider } from '@fluentui/react-components';
 
 export const Vertical = () => {
   const id = useId();

--- a/packages/react-components/react-slider/src/stories/Slider/index.stories.tsx
+++ b/packages/react-components/react-slider/src/stories/Slider/index.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Slider } from '@fluentui/react-slider';
+import { Slider } from '@fluentui/react-components';
 import type { Meta } from '@storybook/react';
 
 import bestPracticesMd from './SliderBestPractices.md';


### PR DESCRIPTION
### Changes
- updates `react-slider` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846