### PR TITLE
fix: Stopping dependency-mismatch generator from adding carets to prerelease dependencies that don't already specify it

### DIFF
--- a/tools/generators/dependency-mismatch/index.spec.ts
+++ b/tools/generators/dependency-mismatch/index.spec.ts
@@ -91,6 +91,40 @@ describe('dependency-mismatch generator', () => {
     `);
   });
 
+  it('should not add carets to prerelease dependencies that do not already have it specified', async () => {
+    const { readPackageJson: readTargetPackageJson } = setupDummyPackage(appTree, {
+      name: 'public-docsite-v9',
+      version: '9.0.0',
+      dependencies: {
+        [`${workspaceNpmScope}/react-select`]: '^9.0.0-beta.1',
+        [`${workspaceNpmScope}/react-spinbutton`]: '9.0.0-beta.1',
+      },
+      devDependencies: {},
+    });
+
+    setupDummyPackage(appTree, {
+      name: 'react-select',
+      version: '9.0.0-beta.2',
+      dependencies: {},
+      devDependencies: {},
+    });
+    setupDummyPackage(appTree, {
+      name: 'react-spinbutton',
+      version: '9.0.0-beta.2',
+      dependencies: {},
+      devDependencies: {},
+    });
+    await generator(appTree);
+
+    const packageJson: PackageJson = await readTargetPackageJson();
+    expect(packageJson.dependencies).toMatchInlineSnapshot(`
+      Object {
+        "proj/react-select": "^9.0.0-beta.2",
+        "proj/react-spinbutton": "9.0.0-beta.2",
+      }
+    `);
+  });
+
   it('should run non-converged package', async () => {
     const { readPackageJson: readTargetPackageJson } = setupDummyPackage(appTree, {
       name: 'react',

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -192,6 +192,11 @@ export function isPackageVersionConverged(versionString: string) {
   return version.major === 9;
 }
 
+export function isPackageVersionPrerelease(versionString: string) {
+  const version = semver.parse(versionString);
+  return version?.prerelease?.length && version?.prerelease?.length > 0;
+}
+
 export function isPackageConverged(tree: Tree, project: ProjectConfiguration) {
   const packageJson = readJson<PackageJson>(tree, joinPathFragments(project.root, 'package.json'));
   return isPackageVersionConverged(packageJson.version);


### PR DESCRIPTION
## Current Behavior

The dependency-mismatch generator adds a caret to all prerelease dependencies, even if they don't have one specified yet.

## New Behavior

The dependency-mismatch generator first checks if a prerelease dependency already has the caret specified, and does not add it if that is not the case.

## Related Issue(s)

Fixes #23917
