### PR TITLE
fix: Fixing bad version bump of @fluentui/react-utilities and fixing dependency mismatch after 9.1.0 release

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -24,7 +24,7 @@
     "@fluentui/react": "^8.81.0",
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/storybook": "^1.0.0",
-    "@fluentui/react-components": "^9.0.1",
+    "@fluentui/react-components": "^9.1.0",
     "@fluentui/react-storybook-addon": "^9.0.0-rc.1",
     "@fluentui/react-theme": "^9.0.0",
     "@griffel/react": "^1.2.0",

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -45,7 +45,7 @@
     "@fluentui/react-textarea": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/react-tooltip": "^9.0.2",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@fluentui/scripts": "^1.0.0",
     "@griffel/react": "^1.2.0",
     "react": "16.14.0",

--- a/change/@fluentui-global-context-96d143a5-d134-4b24-a3f7-ac79dc6a7407.json
+++ b/change/@fluentui-global-context-96d143a5-d134-4b24-a3f7-ac79dc6a7407.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/global-context",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-accordion-9ddead98-053c-424c-892e-35df9c64bfb0.json
+++ b/change/@fluentui-react-accordion-9ddead98-053c-424c-892e-35df9c64bfb0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-accordion",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-alert-8814b9f1-5de2-4ff6-bb86-26c45066803a.json
+++ b/change/@fluentui-react-alert-8814b9f1-5de2-4ff6-bb86-26c45066803a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-alert",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-a5886b09-044f-49ac-a17d-0c0ee41b8849.json
+++ b/change/@fluentui-react-aria-a5886b09-044f-49ac-a17d-0c0ee41b8849.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-aria",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-07bf97e2-7540-44fa-aa9b-26d86090877b.json
+++ b/change/@fluentui-react-avatar-07bf97e2-7540-44fa-aa9b-26d86090877b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-d8b3b9ca-4fd6-4b98-b1bc-c63bde1c063b.json
+++ b/change/@fluentui-react-badge-d8b3b9ca-4fd6-4b98-b1bc-c63bde1c063b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-badge",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-50968222-82a8-45c5-980d-2ad56fa696c1.json
+++ b/change/@fluentui-react-button-50968222-82a8-45c5-980d-2ad56fa696c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-card-b618c069-e080-426b-b25b-e1bd27da2f43.json
+++ b/change/@fluentui-react-card-b618c069-e080-426b-b25b-e1bd27da2f43.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-card",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-78715bdc-c68d-4942-a969-ee8d2b48f8c1.json
+++ b/change/@fluentui-react-checkbox-78715bdc-c68d-4942-a969-ee8d2b48f8c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-5ee1206a-4359-4d8d-8fa6-d57c61f906f4.json
+++ b/change/@fluentui-react-combobox-5ee1206a-4359-4d8d-8fa6-d57c61f906f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-combobox",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-e3be447f-c353-4de7-92d1-ec4dee3f5d62.json
+++ b/change/@fluentui-react-components-e3be447f-c353-4de7-92d1-ec4dee3f5d62.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-components",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-context-selector-cc1fb4c6-7834-4a55-aff7-4f487aa227ff.json
+++ b/change/@fluentui-react-context-selector-cc1fb4c6-7834-4a55-aff7-4f487aa227ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-17985754-9d2a-4fea-b884-65555d21b2d2.json
+++ b/change/@fluentui-react-divider-17985754-9d2a-4fea-b884-65555d21b2d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-divider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-50d50305-0735-4429-a40c-a9d91f23fb42.json
+++ b/change/@fluentui-react-image-50d50305-0735-4429-a40c-a9d91f23fb42.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-image",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-2de64551-ee3e-4d7c-ae7d-ffefa0d35d57.json
+++ b/change/@fluentui-react-input-2de64551-ee3e-4d7c-ae7d-ffefa0d35d57.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-input",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-5e3a520e-193d-45d0-a996-4eec37aad2d1.json
+++ b/change/@fluentui-react-label-5e3a520e-193d-45d0-a996-4eec37aad2d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-label",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-fe6980c8-a3a8-426e-9fb3-b3d86bec9ad2.json
+++ b/change/@fluentui-react-link-fe6980c8-a3a8-426e-9fb3-b3d86bec9ad2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-link",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-1932aea9-74b8-450d-a356-f7592651f9fd.json
+++ b/change/@fluentui-react-menu-1932aea9-74b8-450d-a356-f7592651f9fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-menu",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-3aa21f4b-b088-4eae-ab95-bada4f0717fb.json
+++ b/change/@fluentui-react-overflow-3aa21f4b-b088-4eae-ab95-bada4f0717fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-overflow",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-938ce9d7-b1da-4be7-b4cf-baf818b5c2cd.json
+++ b/change/@fluentui-react-popover-938ce9d7-b1da-4be7-b4cf-baf818b5c2cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-popover",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-98a279f1-f27e-4c70-a4cf-54dbd1c961d9.json
+++ b/change/@fluentui-react-portal-98a279f1-f27e-4c70-a4cf-54dbd1c961d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-portal",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-dc72241b-0cdb-4ee6-8b89-4fa26e54e396.json
+++ b/change/@fluentui-react-positioning-dc72241b-0cdb-4ee6-8b89-4fa26e54e396.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-positioning",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-5ad80bc9-ec37-4c74-850a-4a0b035a14e1.json
+++ b/change/@fluentui-react-provider-5ad80bc9-ec37-4c74-850a-4a0b035a14e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-provider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-e15854dc-1678-44fe-b6da-215c67b18634.json
+++ b/change/@fluentui-react-radio-e15854dc-1678-44fe-b6da-215c67b18634.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-radio",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-498c0314-2a33-4943-9dc6-8e0960c2d7f5.json
+++ b/change/@fluentui-react-select-498c0314-2a33-4943-9dc6-8e0960c2d7f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-select",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-2975b1da-37f5-461d-b24d-7a6b3a69b76b.json
+++ b/change/@fluentui-react-slider-2975b1da-37f5-461d-b24d-7a6b3a69b76b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-slider",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-13ac142f-2dec-4d11-9429-f6c42a8d6ee7.json
+++ b/change/@fluentui-react-spinbutton-13ac142f-2dec-4d11-9429-f6c42a8d6ee7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-e4ba4575-da02-4262-945f-9211e8ebf147.json
+++ b/change/@fluentui-react-spinner-e4ba4575-da02-4262-945f-9211e8ebf147.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-spinner",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-fec0b2a2-9d5a-42ae-82a7-d4349ab64186.json
+++ b/change/@fluentui-react-switch-fec0b2a2-9d5a-42ae-82a7-d4349ab64186.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-switch",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-1dedb611-9ae2-4384-abdb-d367b75541c3.json
+++ b/change/@fluentui-react-tabs-1dedb611-9ae2-4384-abdb-d367b75541c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-tabs",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-005ffbdf-b181-4631-8253-6f3197e30fcb.json
+++ b/change/@fluentui-react-tabster-005ffbdf-b181-4631-8253-6f3197e30fcb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-tabster",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-470174be-bb02-4a42-8bb7-3027e58181bb.json
+++ b/change/@fluentui-react-text-470174be-bb02-4a42-8bb7-3027e58181bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-text",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-21e113b6-37e6-4d4b-88f8-a108898630dd.json
+++ b/change/@fluentui-react-textarea-21e113b6-37e6-4d4b-88f8-a108898630dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-textarea",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toolbar-b05c0338-3ae2-491e-be9f-fe750496336d.json
+++ b/change/@fluentui-react-toolbar-b05c0338-3ae2-491e-be9f-fe750496336d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-22319f8a-016e-4fe7-9d62-80f5ba4d9795.json
+++ b/change/@fluentui-react-tooltip-22319f8a-016e-4fe7-9d62-80f5ba4d9795.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-eed913f3-e475-4e72-b0f6-e22d85b0a384.json
+++ b/change/@fluentui-react-utilities-eed913f3-e475-4e72-b0f6-e22d85b0a384.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing bad version bump of @fluentui/react-utilities.",
+  "packageName": "@fluentui/react-utilities",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/global-context/package.json
+++ b/packages/react-components/global-context/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.0.1",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-accordion/package.json
+++ b/packages/react-components/react-accordion/package.json
@@ -38,7 +38,7 @@
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-alert/package.json
+++ b/packages/react-components/react-alert/package.json
@@ -36,7 +36,7 @@
     "@fluentui/react-button": "^9.0.2",
     "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-aria/package.json
+++ b/packages/react-components/react-aria/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-avatar/package.json
+++ b/packages/react-components/react-avatar/package.json
@@ -41,7 +41,7 @@
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/react-tooltip": "^9.0.2",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-badge/package.json
+++ b/packages/react-components/react-badge/package.json
@@ -35,7 +35,7 @@
     "@fluentui/react-icons": "^2.0.175",
     "@griffel/react": "^1.2.0",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-button/package.json
+++ b/packages/react-components/react-button/package.json
@@ -38,7 +38,7 @@
     "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-card/package.json
+++ b/packages/react-components/react-card/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@griffel/react": "^1.2.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
     "tslib": "^2.1.0"

--- a/packages/react-components/react-checkbox/package.json
+++ b/packages/react-components/react-checkbox/package.json
@@ -35,7 +35,7 @@
     "@fluentui/react-label": "^9.0.2",
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-combobox/package.json
+++ b/packages/react-components/react-combobox/package.json
@@ -38,7 +38,7 @@
     "@fluentui/react-portal": "^9.0.2",
     "@fluentui/react-positioning": "^9.1.0",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -63,7 +63,7 @@
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/react-toolbar": "9.0.0-beta.3",
     "@fluentui/react-tooltip": "^9.0.2",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@fluentui/react-text": "^9.0.2",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"

--- a/packages/react-components/react-context-selector/package.json
+++ b/packages/react-components/react-context-selector/package.json
@@ -27,7 +27,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-dialog/package.json
+++ b/packages/react-components/react-dialog/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@griffel/react": "^1.2.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-divider/package.json
+++ b/packages/react-components/react-divider/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@griffel/react": "^1.2.0",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-image/package.json
+++ b/packages/react-components/react-image/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@griffel/react": "^1.2.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@fluentui/react-theme": "^9.0.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-input/package.json
+++ b/packages/react-components/react-input/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-label/package.json
+++ b/packages/react-components/react-label/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-link/package.json
+++ b/packages/react-components/react-link/package.json
@@ -36,7 +36,7 @@
     "@fluentui/keyboard-keys": "^9.0.0",
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-list/package.json
+++ b/packages/react-components/react-list/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-menu/package.json
+++ b/packages/react-components/react-menu/package.json
@@ -42,7 +42,7 @@
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-overflow/package.json
+++ b/packages/react-components/react-overflow/package.json
@@ -33,7 +33,7 @@
     "@fluentui/priority-overflow": "^9.0.0-beta.2",
     "@fluentui/react-context-selector": "^9.0.1",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-popover/package.json
+++ b/packages/react-components/react-popover/package.json
@@ -40,7 +40,7 @@
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-portal/package.json
+++ b/packages/react-components/react-portal/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-tabster": "^9.0.2",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-positioning/package.json
+++ b/packages/react-components/react-positioning/package.json
@@ -31,7 +31,7 @@
     "@griffel/react": "^1.2.0",
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@popperjs/core": "~2.4.3",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-provider/package.json
+++ b/packages/react-components/react-provider/package.json
@@ -37,7 +37,7 @@
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-radio/package.json
+++ b/packages/react-components/react-radio/package.json
@@ -36,7 +36,7 @@
     "@fluentui/react-label": "^9.0.2",
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-select/package.json
+++ b/packages/react-components/react-select/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-slider/package.json
+++ b/packages/react-components/react-slider/package.json
@@ -37,7 +37,7 @@
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-spinbutton/package.json
+++ b/packages/react-components/react-spinbutton/package.json
@@ -38,7 +38,7 @@
     "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-input": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-spinner/package.json
+++ b/packages/react-components/react-spinner/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/react-label": "^9.0.2",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-switch/package.json
+++ b/packages/react-components/react-switch/package.json
@@ -36,7 +36,7 @@
     "@fluentui/react-label": "^9.0.2",
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-table/package.json
+++ b/packages/react-components/react-table/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-tabs/package.json
+++ b/packages/react-components/react-tabs/package.json
@@ -34,7 +34,7 @@
     "@fluentui/react-context-selector": "^9.0.1",
     "@fluentui/react-tabster": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -34,7 +34,7 @@
     "@griffel/react": "^1.2.0",
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "keyborg": "^1.1.0",
     "tabster": "^1.4.2",
     "tslib": "^2.1.0"

--- a/packages/react-components/react-text/package.json
+++ b/packages/react-components/react-text/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@griffel/react": "^1.2.0",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-textarea/package.json
+++ b/packages/react-components/react-textarea/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-toolbar/package.json
+++ b/packages/react-components/react-toolbar/package.json
@@ -34,7 +34,7 @@
     "@fluentui/react-button": "^9.0.2",
     "@fluentui/react-divider": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@fluentui/react-radio": "^9.0.2",
     "@fluentui/react-tabster": "^9.0.2",
     "@griffel/react": "^1.2.0",

--- a/packages/react-components/react-tooltip/package.json
+++ b/packages/react-components/react-tooltip/package.json
@@ -36,7 +36,7 @@
     "@fluentui/react-positioning": "^9.1.0",
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-utilities/package.json
+++ b/packages/react-components/react-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-utilities",
-  "version": "9.0.1-0",
+  "version": "9.0.1",
   "description": "A set of general React-specific utilities.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.0.0",
-    "@fluentui/react-utilities": "^9.0.1-0",
+    "@fluentui/react-utilities": "^9.0.1",
     "@griffel/react": "^1.2.0",
     "tslib": "^2.1.0",
     "@fluentui/react-components": "^9.1.0",


### PR DESCRIPTION
This PR fixes a bad version bump that happened on the `@fluentui/react-utilities` package (`prerelease` bump on a stable package) after v9.1.0 released. It also fixes the dependency mismatch that happened after that initial release.