### PR TITLE
chore: Add `prerelease` as disallowed changetype for 9.0.0 packages

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -129,6 +129,7 @@ function getCodesandboxBabelOptions() {
   return Object.values(allPackageInfo).reduce((acc, cur) => {
     if (isConvergedPackage(cur.packageJson)) {
       const prereleaseTags = semver.prerelease(cur.packageJson.version);
+      console.log(prereleaseTags, cur.packageJson.name);
       const isNonRcPrerelease = prereleaseTags && !prereleaseTags[0].includes('rc');
       acc[cur.packageJson.name] = isNonRcPrerelease
         ? { replace: '@fluentui/react-components/unstable' }

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -129,7 +129,6 @@ function getCodesandboxBabelOptions() {
   return Object.values(allPackageInfo).reduce((acc, cur) => {
     if (isConvergedPackage(cur.packageJson)) {
       const prereleaseTags = semver.prerelease(cur.packageJson.version);
-      console.log(prereleaseTags, cur.packageJson.name);
       const isNonRcPrerelease = prereleaseTags && !prereleaseTags[0].includes('rc');
       acc[cur.packageJson.name] = isNonRcPrerelease
         ? { replace: '@fluentui/react-components/unstable' }

--- a/change/@fluentui-keyboard-keys-7020b471-e1d4-4b3a-ab40-a53578d16013.json
+++ b/change/@fluentui-keyboard-keys-7020b471-e1d4-4b3a-ab40-a53578d16013.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/keyboard-keys",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-65ef2d85-3555-482d-b0b3-32e573bad1c4.json
+++ b/change/@fluentui-react-accordion-65ef2d85-3555-482d-b0b3-32e573bad1c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-accordion",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-aria-2eec82b5-3129-499b-9e3d-b99ae58fcdc7.json
+++ b/change/@fluentui-react-aria-2eec82b5-3129-499b-9e3d-b99ae58fcdc7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-aria",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-7a43757f-ed06-4944-b146-854f65620705.json
+++ b/change/@fluentui-react-avatar-7a43757f-ed06-4944-b146-854f65620705.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-avatar",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-74a20989-1b34-4753-bffb-b57eee19d4c4.json
+++ b/change/@fluentui-react-badge-74a20989-1b34-4753-bffb-b57eee19d4c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-badge",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-66ad1f4a-bb37-4e5e-9234-fcf6bcd51995.json
+++ b/change/@fluentui-react-button-66ad1f4a-bb37-4e5e-9234-fcf6bcd51995.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-button",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-checkbox-1d2a4527-46d8-45c9-94ee-db7a7fd528ec.json
+++ b/change/@fluentui-react-checkbox-1d2a4527-46d8-45c9-94ee-db7a7fd528ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-dea5a85b-1058-4368-b8e0-66b113fc9f82.json
+++ b/change/@fluentui-react-context-selector-dea5a85b-1058-4368-b8e0-66b113fc9f82.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-divider-47e5c198-50f1-4f2f-a7b1-ce8a91f19810.json
+++ b/change/@fluentui-react-divider-47e5c198-50f1-4f2f-a7b1-ce8a91f19810.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-divider",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-991c74ec-4a7e-40e3-a878-7b9a0104676e.json
+++ b/change/@fluentui-react-image-991c74ec-4a7e-40e3-a878-7b9a0104676e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-image",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-input-8aed09d1-a035-4d77-aded-e20c0f7d9fe6.json
+++ b/change/@fluentui-react-input-8aed09d1-a035-4d77-aded-e20c0f7d9fe6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-input",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-b482b6f2-d030-4410-b14b-04161e518a6c.json
+++ b/change/@fluentui-react-label-b482b6f2-d030-4410-b14b-04161e518a6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-label",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-dd2f4362-af89-4766-925c-fa2a1cec04e8.json
+++ b/change/@fluentui-react-link-dd2f4362-af89-4766-925c-fa2a1cec04e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-link",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-d556347d-71ad-45b5-ac6d-bf2865f7fbf1.json
+++ b/change/@fluentui-react-menu-d556347d-71ad-45b5-ac6d-bf2865f7fbf1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-27be28be-146a-404d-b7b8-e78432e89184.json
+++ b/change/@fluentui-react-popover-27be28be-146a-404d-b7b8-e78432e89184.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-compat-463cbd65-ebc6-4761-9937-96d5b27a005f.json
+++ b/change/@fluentui-react-portal-compat-463cbd65-ebc6-4761-9937-96d5b27a005f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-compat-context-9d393573-2f9f-4f0e-aa1f-2f8693f98dc5.json
+++ b/change/@fluentui-react-portal-compat-context-9d393573-2f9f-4f0e-aa1f-2f8693f98dc5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-fd53a9aa-3f27-48fb-9a0c-a1f28a7fcd08.json
+++ b/change/@fluentui-react-portal-fd53a9aa-3f27-48fb-9a0c-a1f28a7fcd08.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-portal",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-26c7b06d-b649-49c3-8445-3bd280c73336.json
+++ b/change/@fluentui-react-provider-26c7b06d-b649-49c3-8445-3bd280c73336.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-provider",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-radio-07282495-e097-415e-8f7b-cda3789f6866.json
+++ b/change/@fluentui-react-radio-07282495-e097-415e-8f7b-cda3789f6866.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-radio",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-cd29d678-6523-46b7-8cba-542251dccd4c.json
+++ b/change/@fluentui-react-shared-contexts-cd29d678-6523-46b7-8cba-542251dccd4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-slider-13149633-e0e1-4fe5-aaa5-83064ea4ed83.json
+++ b/change/@fluentui-react-slider-13149633-e0e1-4fe5-aaa5-83064ea4ed83.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-slider",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-spinner-c3b379bc-19f6-4ce5-ac3a-9ba3f291b1b5.json
+++ b/change/@fluentui-react-spinner-c3b379bc-19f6-4ce5-ac3a-9ba3f291b1b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-spinner",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-switch-05a36765-88f6-4cf4-8da3-88f935264591.json
+++ b/change/@fluentui-react-switch-05a36765-88f6-4cf4-8da3-88f935264591.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-switch",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-06bc0e8b-1284-48ec-96d5-a153efddcd7e.json
+++ b/change/@fluentui-react-tabs-06bc0e8b-1284-48ec-96d5-a153efddcd7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-tabs",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-cd38b896-e43e-4ffc-9adf-fa281954986f.json
+++ b/change/@fluentui-react-tabster-cd38b896-e43e-4ffc-9adf-fa281954986f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-8c5ac32d-ef6b-450d-bccb-5ca589f385ed.json
+++ b/change/@fluentui-react-text-8c5ac32d-ef6b-450d-bccb-5ca589f385ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-text",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-textarea-b49fe9ad-adbf-4725-bea7-b42568730cf7.json
+++ b/change/@fluentui-react-textarea-b49fe9ad-adbf-4725-bea7-b42568730cf7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-textarea",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-9c4f4172-79ea-473f-a179-6a964cb489c8.json
+++ b/change/@fluentui-react-theme-9c4f4172-79ea-473f-a179-6a964cb489c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-theme",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-c31792cf-b470-495e-8e7a-8c187b41cc4e.json
+++ b/change/@fluentui-react-tooltip-c31792cf-b470-495e-8e7a-8c187b41cc4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-3d5926c7-47d7-4d65-aa5f-55374e456491.json
+++ b/change/@fluentui-react-utilities-3d5926c7-47d7-4d65-aa5f-55374e456491.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add `prerelease` as disallowed changetype for 9.0.0 packages",
+  "packageName": "@fluentui/react-utilities",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/keyboard-keys/package.json
+++ b/packages/react-components/keyboard-keys/package.json
@@ -31,7 +31,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-accordion/package.json
+++ b/packages/react-components/react-accordion/package.json
@@ -51,7 +51,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-aria/package.json
+++ b/packages/react-components/react-aria/package.json
@@ -42,7 +42,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-avatar/package.json
+++ b/packages/react-components/react-avatar/package.json
@@ -54,7 +54,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-badge/package.json
+++ b/packages/react-components/react-badge/package.json
@@ -46,7 +46,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-button/package.json
+++ b/packages/react-components/react-button/package.json
@@ -50,7 +50,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-checkbox/package.json
+++ b/packages/react-components/react-checkbox/package.json
@@ -47,7 +47,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-context-selector/package.json
+++ b/packages/react-components/react-context-selector/package.json
@@ -39,7 +39,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-divider/package.json
+++ b/packages/react-components/react-divider/package.json
@@ -45,7 +45,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-image/package.json
+++ b/packages/react-components/react-image/package.json
@@ -45,7 +45,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-input/package.json
+++ b/packages/react-components/react-input/package.json
@@ -46,7 +46,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-label/package.json
+++ b/packages/react-components/react-label/package.json
@@ -45,7 +45,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-link/package.json
+++ b/packages/react-components/react-link/package.json
@@ -48,7 +48,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-menu/package.json
+++ b/packages/react-components/react-menu/package.json
@@ -55,7 +55,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-popover/package.json
+++ b/packages/react-components/react-popover/package.json
@@ -53,7 +53,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-portal-compat-context/package.json
+++ b/packages/react-components/react-portal-compat-context/package.json
@@ -37,7 +37,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   }
 }

--- a/packages/react-components/react-portal-compat/package.json
+++ b/packages/react-components/react-portal-compat/package.json
@@ -41,7 +41,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   }
 }

--- a/packages/react-components/react-portal/package.json
+++ b/packages/react-components/react-portal/package.json
@@ -45,7 +45,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-provider/package.json
+++ b/packages/react-components/react-provider/package.json
@@ -48,7 +48,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-radio/package.json
+++ b/packages/react-components/react-radio/package.json
@@ -49,7 +49,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-shared-contexts/package.json
+++ b/packages/react-components/react-shared-contexts/package.json
@@ -36,7 +36,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-slider/package.json
+++ b/packages/react-components/react-slider/package.json
@@ -48,7 +48,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-spinner/package.json
+++ b/packages/react-components/react-spinner/package.json
@@ -46,7 +46,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-switch/package.json
+++ b/packages/react-components/react-switch/package.json
@@ -48,7 +48,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-tabs/package.json
+++ b/packages/react-components/react-tabs/package.json
@@ -47,7 +47,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -47,7 +47,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-text/package.json
+++ b/packages/react-components/react-text/package.json
@@ -45,7 +45,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-textarea/package.json
+++ b/packages/react-components/react-textarea/package.json
@@ -45,7 +45,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   }
 }

--- a/packages/react-components/react-theme/package.json
+++ b/packages/react-components/react-theme/package.json
@@ -41,7 +41,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-tooltip/package.json
+++ b/packages/react-components/react-tooltip/package.json
@@ -48,7 +48,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {

--- a/packages/react-components/react-utilities/package.json
+++ b/packages/react-components/react-utilities/package.json
@@ -37,7 +37,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {


### PR DESCRIPTION
Disallows prerelease changetypes for packages in full 9.0.0 release to avoid more of #23920

