### PR TITLE
fix: Fixing dependency mismatches after 9.1.1 release

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -24,7 +24,7 @@
     "@fluentui/react": "^8.81.0",
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/storybook": "^1.0.0",
-    "@fluentui/react-components": "^9.1.0",
+    "@fluentui/react-components": "^9.1.1",
     "@fluentui/react-storybook-addon": "^9.0.0-rc.1",
     "@fluentui/react-theme": "^9.0.0",
     "@griffel/react": "^1.2.0",


### PR DESCRIPTION
This PR fixes dependency mismatches that happened in `public-docsite-v9` after the v9.1.1 release.