### PR TITLE
Added mechanism for marking fluent-compatibility packages

### DIFF
--- a/change/@fluentui-react-portal-compat-context-41a04c0c-0c92-40f7-af9a-d10c6af04725.json
+++ b/change/@fluentui-react-portal-compat-context-41a04c0c-0c92-40f7-af9a-d10c6af04725.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added mechanism for marking fluent-compatibility packages",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-portal-compat-context/package.json
+++ b/packages/react-components/react-portal-compat-context/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
+  "fluent-compatibility": true,
   "scripts": {
     "build": "just-scripts build",
     "clean": "just-scripts clean",

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -23,6 +23,7 @@ import { postprocessCommonjsTask } from './tasks/postprocess-commonjs';
 import { startStorybookTask, buildStorybookTask } from './tasks/storybook';
 import { isConvergedPackage } from './monorepo/index';
 import { getJustArgv } from './tasks/argv';
+import isCompatibilityPackage from './monorepo/isCompatibilityPackage';
 
 /** Do only the bare minimum setup of options and resolve paths */
 function basicPreset() {
@@ -82,7 +83,7 @@ export function preset() {
           // Converged packages must always build commonjs because of babel-make-styles transforms
           condition('ts:commonjs', () => !args.min || isConvergedPackage()),
           'ts:esm',
-          condition('ts:amd', () => !!args.production && !isConvergedPackage()),
+          condition('ts:amd', () => isCompatibilityPackage() || (!!args.production && !isConvergedPackage())),
         );
   });
 

--- a/scripts/monorepo/index.d.ts
+++ b/scripts/monorepo/index.d.ts
@@ -36,6 +36,20 @@ export declare function findRepoDeps(options?: {
 export declare function getAllPackageInfo(): AllPackageInfo;
 
 /**
+ * Determines whether a package is a compatibility package
+ * between current and next versions.
+ *
+ * Compatibility packages are typicallv9 packages that provide
+ * backwards compatibility for v8.
+ *
+ * They may need special handling in the build.
+ * @param {PathOrPackageJson} [packagePathOrJson] optional different package path to run in OR previously-read package.json
+ * (defaults to reading package.json from `process.cwd()`)
+ * @returns {boolean} true if the package.json has the fluent-compatibility set to true.
+ */
+export declare function isCompatibilityPackage(packagePathOrJson?: string | PackageJson): boolean;
+
+/**
  * Determines whether a package is converged, based on its version.
  * @param packagePathOrJson optional different package path to run in OR previously-read package.json
  * (defaults to reading package.json from `process.cwd()`)

--- a/scripts/monorepo/index.js
+++ b/scripts/monorepo/index.js
@@ -4,6 +4,7 @@ module.exports = {
   findRepoDeps: require('./findRepoDeps'),
   getAllPackageInfo: require('./getAllPackageInfo'),
   isConvergedPackage: require('./isConvergedPackage'),
+  isCompatibilityPackage: require('./isCompatibilityPackage'),
   getAffectedPackages: require('./getAffectedPackages'),
   getNthCommit: require('./getNthCommit'),
 };

--- a/scripts/monorepo/isCompatibilityPackage.js
+++ b/scripts/monorepo/isCompatibilityPackage.js
@@ -1,0 +1,28 @@
+// @ts-check
+const { readConfig } = require('../read-config');
+
+/**
+ *  @typedef {string | import('./index').PackageJson}  PathOrPackageJson
+ */
+
+/**
+ * Determines whether a package is a compatibility package
+ * between current and next versions.
+ *
+ * Compatibility packages are typicallv9 packages that provide
+ * backwards compatibility for v8.
+ *
+ * They may need special handling in the build.
+ * @param {PathOrPackageJson} [packagePathOrJson] optional different package path to run in OR previously-read package.json
+ * (defaults to reading package.json from `process.cwd()`)
+ * @returns {boolean} true if the package.json has the fluent-compatibility set to true.
+ */
+function isCompatibilityPackage(packagePathOrJson) {
+  const packageJson =
+    !packagePathOrJson || typeof packagePathOrJson === 'string'
+      ? readConfig('package.json', /** @type {string|undefined} */ (packagePathOrJson))
+      : packagePathOrJson;
+  return !!packageJson && packageJson['fluent-compatibility'] === true;
+}
+
+module.exports = isCompatibilityPackage;


### PR DESCRIPTION
## Changes
- Added isCompatibilityPackage function to just build scripts
- Set for 'fluent-compatibility' marker in package.json file for react-portal-comptability-context
- Updated to output amd for packages marked with fluent-compatibility

## Issues
Fixes #23919

## Open Issues
If there is a better way to let packages note they are v8/v9 compat packages please LMK.