### PR TITLE
feat(scripts): implement explicit `--module` configuration flag for just build task

### DIFF
--- a/change/@fluentui-api-docs-a3885ce3-efb6-4b85-9147-297abeee776f.json
+++ b/change/@fluentui-api-docs-a3885ce3-efb6-4b85-9147-297abeee776f.json
@@ -1,0 +1,7 @@
+{
+  "comment": "chore: update package.json main/types field to accomodate new 'build' task behaviours",
+  "type": "none",
+  "packageName": "@fluentui/api-docs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-babel-preset-global-context-7baa406d-f2d2-4966-96ef-ff94b3003b2c.json
+++ b/change/@fluentui-babel-preset-global-context-7baa406d-f2d2-4966-96ef-ff94b3003b2c.json
@@ -1,0 +1,7 @@
+{
+  "comment": "chore: update package.json main/types field to accomodate new 'build' task behaviours",
+  "type": "none",
+  "packageName": "@fluentui/babel-preset-global-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-codemods-ad8ea960-7cbd-43f2-ba00-eb2201c95709.json
+++ b/change/@fluentui-codemods-ad8ea960-7cbd-43f2-ba00-eb2201c95709.json
@@ -1,0 +1,7 @@
+{
+  "comment": "chore: update package.json main/types field to accomodate new 'build' task behaviours",
+  "type": "none",
+  "packageName": "@fluentui/codemods",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-jest-serializer-merge-styles-36cd8fb1-82bf-43d3-882f-fe3c26996762.json
+++ b/change/@fluentui-jest-serializer-merge-styles-36cd8fb1-82bf-43d3-882f-fe3c26996762.json
@@ -1,0 +1,7 @@
+{
+  "comment": "chore: update package.json main/types field to accomodate new 'build' task behaviours",
+  "type": "none",
+  "packageName": "@fluentui/jest-serializer-merge-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-3f09213e-f8d1-42f2-b4d5-720a8d07c98c.json
+++ b/change/@fluentui-react-conformance-3f09213e-f8d1-42f2-b4d5-720a8d07c98c.json
@@ -1,0 +1,7 @@
+{
+  "comment": "chore: update package.json main/types field to accomodate new 'build' task behaviours",
+  "type": "none",
+  "packageName": "@fluentui/react-conformance",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-griffel-79125086-6139-41de-8d4a-a6c4a2f37fa0.json
+++ b/change/@fluentui-react-conformance-griffel-79125086-6139-41de-8d4a-a6c4a2f37fa0.json
@@ -1,0 +1,7 @@
+{
+  "comment": "chore: update package.json main/types field to accomodate new 'build' task behaviours",
+  "type": "none",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-test-utilities-c016afb9-9819-4900-9611-102670d4a5f3.json
+++ b/change/@fluentui-test-utilities-c016afb9-9819-4900-9611-102670d4a5f3.json
@@ -1,0 +1,7 @@
+{
+  "comment": "chore: update package.json main/types field to accomodate new 'build' task behaviours",
+  "type": "none",
+  "packageName": "@fluentui/test-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-webpack-utilities-334e5ffa-d49c-4b45-82d6-b48686b4574c.json
+++ b/change/@fluentui-webpack-utilities-334e5ffa-d49c-4b45-82d6-b48686b4574c.json
@@ -1,0 +1,7 @@
+{
+  "comment": "chore: update package.json main/types field to accomodate new 'build' task behaviours",
+  "type": "none",
+  "packageName": "@fluentui/webpack-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
   },
   "scripts": {
     "build": "lage build --verbose",
-    "build:codesandbox": "yarn build --to @fluentui/react --to @fluentui/react-components --min",
+    "build:codesandbox": "yarn build --to @fluentui/react --to @fluentui/react-components",
     "build:fluentui:docs": "gulp build:docs",
-    "build:min": "yarn build --to @fluentui/react --to @fluentui/react-northstar --to @fluentui/react-components --min",
     "buildci": "lage build test lint type-check --verbose",
     "builddemo": "yarn build --to public-docsite-resources",
     "buildto": "lage build --verbose --to",

--- a/packages/a11y-testing/package.json
+++ b/packages/a11y-testing/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "description": "Fluent UI tests for a11y patterns.",
   "private": true,
-  "main": "lib/src/index.js",
-  "typings": "lib/src/index.d.ts",
+  "main": "lib-commonjs/src/index.js",
+  "typings": "lib-commonjs/src/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"

--- a/packages/api-docs/package.json
+++ b/packages/api-docs/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "main": "lib-commonjs/index.js",
+  "typings": "lib-commonjs/index.d.ts",
   "scripts": {
     "build": "just-scripts build",
     "clean": "just-scripts clean",

--- a/packages/codemods/bin/upgrade.js
+++ b/packages/codemods/bin/upgrade.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../lib/index');
+require('../lib-commonjs/index');

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -2,8 +2,8 @@
   "name": "@fluentui/codemods",
   "version": "8.4.1",
   "description": "Tool enabling easy upgrades to new Fluent UI versions",
-  "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "main": "lib-commonjs/index.js",
+  "typings": "lib-commonjs/index.d.ts",
   "bin": {
     "upgrade": "./bin/upgrade.js"
   },

--- a/packages/jest-serializer-merge-styles/package.json
+++ b/packages/jest-serializer-merge-styles/package.json
@@ -2,8 +2,8 @@
   "name": "@fluentui/jest-serializer-merge-styles",
   "version": "8.0.19",
   "description": "Jest serializer for merge-styles.",
-  "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "main": "lib-commonjs/index.js",
+  "typings": "lib-commonjs/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"

--- a/packages/react-components/babel-preset-global-context/package.json
+++ b/packages/react-components/babel-preset-global-context/package.json
@@ -2,7 +2,7 @@
   "name": "@fluentui/babel-preset-global-context",
   "version": "9.0.0-beta.3",
   "description": "Babel preset that transforms createContext calls to use global context shims",
-  "main": "lib/index.js",
+  "main": "lib-commonjs/index.js",
   "typings": "dist/index.d.ts",
   "repository": {
     "type": "git",
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "just-scripts build --commonjs",
+    "build": "just-scripts build --module cjs",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "pree2e": "yarn build",

--- a/packages/react-components/react-conformance-griffel/package.json
+++ b/packages/react-components/react-conformance-griffel/package.json
@@ -2,7 +2,7 @@
   "name": "@fluentui/react-conformance-griffel",
   "version": "9.0.0-beta.11",
   "description": "A set of conformance tests for Griffel CSS-in-JS",
-  "main": "lib/index.js",
+  "main": "lib-commonjs/index.js",
   "typings": "dist/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/react-conformance/package.json
+++ b/packages/react-conformance/package.json
@@ -2,8 +2,8 @@
   "name": "@fluentui/react-conformance",
   "version": "0.14.0",
   "description": "Customizable conformance testing utility for Fluent UI React components.",
-  "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "main": "lib-commonjs/index.js",
+  "typings": "lib-commonjs/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -2,8 +2,8 @@
   "name": "@fluentui/test-utilities",
   "version": "8.2.1",
   "description": "Utilities used when testing components.",
-  "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "main": "lib-commonjs/index.js",
+  "typings": "lib-commonjs/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"

--- a/packages/webpack-utilities/just.config.ts
+++ b/packages/webpack-utilities/just.config.ts
@@ -1,4 +1,30 @@
-import { preset, task } from '@fluentui/scripts';
+import * as path from 'path';
+import * as fs from 'fs';
+import { preset, task, series, TaskFunction } from '@fluentui/scripts';
 
 preset();
-task('build', 'build:node-lib').cached();
+
+/**
+ * Task that renames a folder
+ *
+ * during build task simplification every cjs module output will be emitted under `lib-commonjs` folder.
+ * because this package violates that rule and it docs specifies `lib` as public api in order
+ * to not introduce breaking change into this legacy package we need this workaround.
+ */
+function renameFolder(options: { from: string; to: string }): TaskFunction {
+  return done => {
+    fs.renameSync(options.from, options.to);
+    done();
+  };
+}
+
+task(
+  'build',
+  series(
+    'build:node-lib',
+    renameFolder({
+      from: path.join(process.cwd(), 'lib-commonjs'),
+      to: path.join(process.cwd(), 'lib'),
+    }),
+  ),
+).cached!();

--- a/scripts/create-package/plop-templates-node/package.json.hbs
+++ b/scripts/create-package/plop-templates-node/package.json.hbs
@@ -3,15 +3,15 @@
   "version": "{{{packageVersion}}}",
   "description": "{{{description}}}",
   "private": true,
-  "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "main": "lib-commonjs/index.js",
+  "typings": "lib-commonjs/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
   "scripts": {
-    "build": "just-scripts build --commonjs",
+    "build": "just-scripts build --module cjs",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/scripts/jest.config.js
+++ b/scripts/jest.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {jest.InitialOptions}
+ * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
   displayName: 'scripts',

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -21,9 +21,8 @@ import { postprocessTask } from './tasks/postprocess';
 import { postprocessAmdTask } from './tasks/postprocess-amd';
 import { postprocessCommonjsTask } from './tasks/postprocess-commonjs';
 import { startStorybookTask, buildStorybookTask } from './tasks/storybook';
-import { isConvergedPackage } from './monorepo/index';
+import { isConvergedPackage, isCompatibilityPackage } from './monorepo';
 import { getJustArgv } from './tasks/argv';
-import isCompatibilityPackage from './monorepo/isCompatibilityPackage';
 
 /** Do only the bare minimum setup of options and resolve paths */
 function basicPreset() {

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -111,17 +111,7 @@ export function preset() {
 
   task('build:node-lib', series('clean', 'copy', 'ts:commonjs')).cached();
 
-  task(
-    'build',
-    series(
-      'clean',
-      'copy',
-      'sass',
-      'ts',
-      // v9 needs to run api-extractor which generates rolluped .d.ts files that are shipped to npm
-      condition('api-extractor', () => isConvergedPackage()),
-    ),
-  ).cached();
+  task('build', series('clean', 'copy', 'sass', 'ts', 'api-extractor')).cached();
 
   task(
     'bundle',

--- a/scripts/tasks/argv.spec.ts
+++ b/scripts/tasks/argv.spec.ts
@@ -1,0 +1,71 @@
+/// <reference types="jest" />
+
+import { argv } from 'just-scripts';
+import { Arguments } from 'yargs';
+
+import { getJustArgv } from './argv';
+
+jest.mock('just-scripts', () => {
+  return {
+    __esModule: true,
+    argv: jest.fn(() => ({ _: [], $0: '' })),
+  };
+});
+
+const argvMock = argv as jest.Mock;
+
+describe(`argv`, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe(`#getJustArgv`, () => {
+    describe(`--module`, () => {
+      it(`should do nothing if not used`, () => {
+        argvMock.mockImplementationOnce(() => {
+          return { _: [], $0: '' } as Arguments;
+        });
+        const actual = getJustArgv();
+
+        expect(actual.module).toEqual(undefined);
+      });
+      it(`should process --module`, () => {
+        argvMock.mockImplementationOnce(() => {
+          return { module: 'esm', _: [], $0: '' } as Arguments;
+        });
+
+        let actual = getJustArgv();
+        let expected = { module: { esm: true, cjs: false, amd: false } };
+
+        expect(actual).toEqual(expect.objectContaining(expected));
+
+        argvMock.mockImplementationOnce(() => {
+          return { module: 'cjs', _: [], $0: '' } as Arguments;
+        });
+        actual = getJustArgv();
+        expected = { module: { esm: false, cjs: true, amd: false } };
+
+        expect(actual).toEqual(expect.objectContaining(expected));
+      });
+
+      it(`should process --module as array`, () => {
+        argvMock.mockImplementationOnce(() => {
+          return { module: 'esm,cjs', _: [], $0: '' } as Arguments;
+        });
+
+        let actual = getJustArgv();
+        let expected = { module: { esm: true, cjs: true, amd: false } };
+
+        expect(actual).toEqual(expect.objectContaining(expected));
+
+        argvMock.mockImplementationOnce(() => {
+          return { module: ['esm', 'cjs'], _: [], $0: '' } as Arguments;
+        });
+
+        actual = getJustArgv();
+
+        expect(actual).toEqual(expect.objectContaining(expected));
+      });
+    });
+  });
+});

--- a/scripts/tasks/ts.ts
+++ b/scripts/tasks/ts.ts
@@ -68,13 +68,4 @@ export const ts = {
 
     return tscTask(options);
   },
-  commonjsOnly: () => {
-    // Use default tsbuildinfo for this variant (since it's the only variant)
-    const options = prepareTsTaskConfig({
-      outDir: 'lib',
-      module: 'commonjs',
-    });
-
-    return tscTask(options);
-  },
 };

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -1071,7 +1071,7 @@ describe('migrate-converged-pkg generator', () => {
 
       updateJson(tree, `${projectConfig.root}/package.json`, (json: PackageJson) => {
         json.scripts = json.scripts || {};
-        json.scripts.build = 'just-scripts build --commonjs';
+        json.scripts.build = 'just-scripts build --module cjs';
         return json;
       });
 

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -485,7 +485,7 @@ function getPackageType(tree: Tree, options: NormalizedSchema) {
   const isNode =
     tags.includes('platform:node') ||
     Boolean(pkgJson.bin) ||
-    (scripts.build && scripts.build === 'just-scripts build --commonjs');
+    (scripts.build && scripts.build === 'just-scripts build --module cjs');
   const isWeb = tags.includes('platform:web') || !isNode;
 
   if (isNode) {

--- a/workspace.json
+++ b/workspace.json
@@ -4,7 +4,8 @@
     "@fluentui/a11y-testing": {
       "root": "packages/a11y-testing",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["platform:node"]
     },
     "@fluentui/ability-attributes": {
       "root": "packages/fluentui/ability-attributes",
@@ -19,7 +20,8 @@
     "@fluentui/api-docs": {
       "root": "packages/api-docs",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["v8", "platform:node"]
     },
     "@fluentui/azure-themes": {
       "root": "packages/azure-themes",
@@ -53,7 +55,8 @@
     "@fluentui/codemods": {
       "root": "packages/codemods",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["v8", "platform:node"]
     },
     "@fluentui/common-styles": {
       "root": "packages/common-styles",
@@ -125,7 +128,8 @@
     "@fluentui/jest-serializer-merge-styles": {
       "root": "packages/jest-serializer-merge-styles",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["v8", "platform:node"]
     },
     "@fluentui/keyboard-key": {
       "root": "packages/keyboard-key",
@@ -359,7 +363,8 @@
     "@fluentui/react-conformance": {
       "root": "packages/react-conformance",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["v8", "platform:node"]
     },
     "@fluentui/react-conformance-griffel": {
       "root": "packages/react-components/react-conformance-griffel",
@@ -768,7 +773,8 @@
     "@fluentui/test-utilities": {
       "root": "packages/test-utilities",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["v8", "platform:node"]
     },
     "@fluentui/theme": {
       "root": "packages/theme",
@@ -829,7 +835,8 @@
     "@fluentui/webpack-utilities": {
       "root": "packages/webpack-utilities",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["v8", "platform:node"]
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- `just build` is black bock that cannot be configured on call site
- non-obvious presence of `min` generic flag and `commonJsOnly`
- `api-extractor` task run only if 2 conditions are met

## New Behavior

just `build` task can be explicitly configured which js module type should be generated 

```sh
# both options are available (array or multiple flags)
just-scripts build --module esm,cjs # transpiles js to ESM module and CommonJS 
just-scripts build --module esm --module cjs
```

### Additional cleanup

- complete removal of `--min` and `commonJsOnly` task for broader unification and simplification
- 'api-extractor' is always executed and provides good DX to notify user if it was run at all and why

### Fallback(Legacy) behaviours changes.

Legacy behaviours works as before with some adjustments needed that are part of this PR.

```sh
just-scripts build
```

- will generate `esm`  and `cjs` by default and `amd` (only if `--production` is set)
- `cjs` will be generated  to `lib-commonjs` instead of `lib`, thus some packages contain `main` field changes and some needs additional tweak to not introduce breaking change (`webpack-utilities`)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes partially https://github.com/microsoft/fluentui/issues/23930
