### PR TITLE
Spinner: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-spinner/src/stories/Spinner/SpinnerAppearance.stories.tsx
+++ b/packages/react-components/react-spinner/src/stories/Spinner/SpinnerAppearance.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Spinner } from '@fluentui/react-spinner';
+import { makeStyles, shorthands, Spinner } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {

--- a/packages/react-components/react-spinner/src/stories/Spinner/SpinnerDefault.stories.tsx
+++ b/packages/react-components/react-spinner/src/stories/Spinner/SpinnerDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Spinner } from '@fluentui/react-spinner';
-import type { SpinnerProps } from '@fluentui/react-spinner';
+import { Spinner } from '@fluentui/react-components';
+import type { SpinnerProps } from '@fluentui/react-components';
 
 export const Default = (props: Partial<SpinnerProps>) => <Spinner {...props} />;

--- a/packages/react-components/react-spinner/src/stories/Spinner/SpinnerLabel.stories.tsx
+++ b/packages/react-components/react-spinner/src/stories/Spinner/SpinnerLabel.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Spinner } from '@fluentui/react-spinner';
+import { makeStyles, shorthands, Spinner } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {

--- a/packages/react-components/react-spinner/src/stories/Spinner/SpinnerSize.stories.tsx
+++ b/packages/react-components/react-spinner/src/stories/Spinner/SpinnerSize.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Spinner } from '@fluentui/react-spinner';
+import { makeStyles, shorthands, Spinner } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {

--- a/packages/react-components/react-spinner/src/stories/Spinner/index.stories.tsx
+++ b/packages/react-components/react-spinner/src/stories/Spinner/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from '@fluentui/react-spinner';
+import { Spinner } from '@fluentui/react-components';
 
 import descriptionMd from './SpinnerDescription.md';
 import bestPracticesMd from './SpinnerBestPractices.md';


### PR DESCRIPTION
### Changes
- updates `react-spinner` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846