### PR TITLE
Switch: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-switch/src/stories/Switch/SwitchChecked.stories.tsx
+++ b/packages/react-components/react-switch/src/stories/Switch/SwitchChecked.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Switch } from '@fluentui/react-switch';
+import { Switch } from '@fluentui/react-components';
 
 export const Checked = () => {
   const [checked, setChecked] = React.useState(true);

--- a/packages/react-components/react-switch/src/stories/Switch/SwitchDefault.stories.tsx
+++ b/packages/react-components/react-switch/src/stories/Switch/SwitchDefault.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Switch } from '@fluentui/react-switch';
-import type { SwitchProps } from '@fluentui/react-switch';
+import { Switch } from '@fluentui/react-components';
+import type { SwitchProps } from '@fluentui/react-components';
 
 export const Default = (props: SwitchProps) => <Switch label="This is a switch" {...props} />;
 

--- a/packages/react-components/react-switch/src/stories/Switch/SwitchDisabled.stories.tsx
+++ b/packages/react-components/react-switch/src/stories/Switch/SwitchDisabled.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Switch } from '@fluentui/react-switch';
+import { Switch } from '@fluentui/react-components';
 
 const wrapperStyle: React.CSSProperties = {
   display: 'flex',

--- a/packages/react-components/react-switch/src/stories/Switch/SwitchLabel.stories.tsx
+++ b/packages/react-components/react-switch/src/stories/Switch/SwitchLabel.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Switch } from '@fluentui/react-switch';
+import { Switch } from '@fluentui/react-components';
 
 const wrapperStyle: React.CSSProperties = {
   display: 'flex',

--- a/packages/react-components/react-switch/src/stories/Switch/SwitchLabelWrapping.stories.tsx
+++ b/packages/react-components/react-switch/src/stories/Switch/SwitchLabelWrapping.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Switch } from '@fluentui/react-switch';
+import { Switch } from '@fluentui/react-components';
 
 export const LabelWrapping = () => (
   <Switch

--- a/packages/react-components/react-switch/src/stories/Switch/SwitchRequired.stories.tsx
+++ b/packages/react-components/react-switch/src/stories/Switch/SwitchRequired.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Switch } from '@fluentui/react-switch';
+import { Switch } from '@fluentui/react-components';
 
 export const Required = () => <Switch required label="Required" />;
 Required.parameters = {

--- a/packages/react-components/react-switch/src/stories/Switch/index.stories.tsx
+++ b/packages/react-components/react-switch/src/stories/Switch/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Switch } from '@fluentui/react-switch';
+import { Switch } from '@fluentui/react-components';
 
 import descriptionMd from './SwitchDescription.md';
 import bestPracticesMd from './SwitchBestPractices.md';


### PR DESCRIPTION
### Changes
- updates `react-switch` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846