### PR TITLE
Tabs: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-tabs/src/stories/TabList/TabListAppearance.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList/TabListAppearance.stories.tsx
@@ -1,6 +1,5 @@
-import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
-import { Tab, TabList } from '@fluentui/react-tabs';
+import { makeStyles, shorthands, Tab, TabList } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-tabs/src/stories/TabList/TabListDefault.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList/TabListDefault.stories.tsx
@@ -1,7 +1,6 @@
-import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
-import { Tab, TabList } from '@fluentui/react-tabs';
-import type { TabListProps } from '@fluentui/react-tabs';
+import { makeStyles, shorthands, Tab, TabList } from '@fluentui/react-components';
+import type { TabListProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-tabs/src/stories/TabList/TabListDisabled.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList/TabListDisabled.stories.tsx
@@ -1,7 +1,6 @@
-import { CalendarMonthRegular } from '@fluentui/react-icons';
-import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
-import { Tab, TabList } from '@fluentui/react-tabs';
+import { CalendarMonthRegular } from '@fluentui/react-icons';
+import { makeStyles, shorthands, Tab, TabList } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-tabs/src/stories/TabList/TabListHorizontal.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList/TabListHorizontal.stories.tsx
@@ -1,6 +1,5 @@
-import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
-import { Tab, TabList } from '@fluentui/react-tabs';
+import { makeStyles, shorthands, Tab, TabList } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-tabs/src/stories/TabList/TabListIconOnly.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList/TabListIconOnly.stories.tsx
@@ -1,6 +1,5 @@
-import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
-import { Tab, TabList } from '@fluentui/react-tabs';
+import { makeStyles, shorthands, Tab, TabList } from '@fluentui/react-components';
 import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-tabs/src/stories/TabList/TabListSizeMedium.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList/TabListSizeMedium.stories.tsx
@@ -1,7 +1,6 @@
-import { CalendarMonthRegular } from '@fluentui/react-icons';
-import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
-import { Tab, TabList } from '@fluentui/react-tabs';
+import { CalendarMonthRegular } from '@fluentui/react-icons';
+import { makeStyles, shorthands, Tab, TabList } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-tabs/src/stories/TabList/TabListSizeSmall.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList/TabListSizeSmall.stories.tsx
@@ -1,7 +1,6 @@
-import { CalendarMonthRegular } from '@fluentui/react-icons';
-import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
-import { Tab, TabList } from '@fluentui/react-tabs';
+import { CalendarMonthRegular } from '@fluentui/react-icons';
+import { makeStyles, shorthands, Tab, TabList } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-tabs/src/stories/TabList/TabListVertical.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList/TabListVertical.stories.tsx
@@ -1,6 +1,5 @@
-import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
-import { Tab, TabList } from '@fluentui/react-tabs';
+import { makeStyles, shorthands, Tab, TabList } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-tabs/src/stories/TabList/TabListWithIcon.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList/TabListWithIcon.stories.tsx
@@ -1,6 +1,5 @@
-import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
-import { Tab, TabList } from '@fluentui/react-tabs';
+import { makeStyles, shorthands, Tab, TabList } from '@fluentui/react-components';
 import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-tabs/src/stories/TabList/TabListWithOverflow.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList/TabListWithOverflow.stories.tsx
@@ -1,5 +1,18 @@
 import * as React from 'react';
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import {
+  makeStyles,
+  mergeClasses,
+  shorthands,
+  tokens,
+  Button,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Tab,
+  TabList,
+} from '@fluentui/react-components';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {
   Calendar3DayRegular,
@@ -13,11 +26,7 @@ import {
   CalendarWorkWeekRegular,
   MoreHorizontalRegular,
 } from '@fluentui/react-icons';
-import { Button } from '@fluentui/react-button';
-import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
-import { Overflow, OverflowItem, useIsOverflowItemVisible, useOverflowMenu } from '@fluentui/react-overflow';
-import { tokens } from '@fluentui/react-theme';
-import { Tab, TabList } from '@fluentui/react-tabs';
+import { useIsOverflowItemVisible, useOverflowMenu, Overflow, OverflowItem } from '@fluentui/react-overflow';
 
 //----- Example Tab Data -----//
 

--- a/packages/react-components/react-tabs/src/stories/TabList/TabListWithPanels.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList/TabListWithPanels.stories.tsx
@@ -1,9 +1,7 @@
-import { makeStyles, shorthands } from '@griffel/react';
 import * as React from 'react';
-import { Tab, TabList } from '@fluentui/react-tabs';
-import type { SelectTabData, SelectTabEvent, TabValue } from '@fluentui/react-tabs';
+import { makeStyles, shorthands, tokens, Tab, TabList } from '@fluentui/react-components';
 import { AirplaneRegular, AirplaneTakeOffRegular, TimeAndWeatherRegular } from '@fluentui/react-icons';
-import { tokens } from '@fluentui/react-theme';
+import type { SelectTabData, SelectTabEvent, TabValue } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-tabs/src/stories/TabList/index.stories.tsx
+++ b/packages/react-components/react-tabs/src/stories/TabList/index.stories.tsx
@@ -1,4 +1,4 @@
-import { TabList } from '@fluentui/react-tabs';
+import { TabList } from '@fluentui/react-components';
 
 import descriptionMd from './TabListDescription.md';
 import bestPracticesMd from './TabListBestPractices.md';


### PR DESCRIPTION
### Changes
- updates `react-tabs` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846