### PR TITLE
Textarea: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-textarea/src/stories/Textarea/TextareaAppearance.stories.tsx
+++ b/packages/react-components/react-textarea/src/stories/Textarea/TextareaAppearance.stories.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import { Label } from '@fluentui/react-label';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Textarea } from '@fluentui/react-textarea';
-import { useId } from '@fluentui/react-utilities';
-import { tokens } from '@fluentui/react-theme';
+import { makeStyles, shorthands, tokens, useId, Label, Textarea } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   base: {

--- a/packages/react-components/react-textarea/src/stories/Textarea/TextareaControlled.stories.tsx
+++ b/packages/react-components/react-textarea/src/stories/Textarea/TextareaControlled.stories.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
-import { Textarea } from '@fluentui/react-textarea';
-import type { TextareaProps } from '@fluentui/react-textarea';
-import { useId } from '@fluentui/react-utilities';
-import { Label } from '@fluentui/react-label';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
+import { makeStyles, tokens, useId, Label, Textarea } from '@fluentui/react-components';
+import type { TextareaProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   base: {

--- a/packages/react-components/react-textarea/src/stories/Textarea/TextareaDefault.stories.tsx
+++ b/packages/react-components/react-textarea/src/stories/Textarea/TextareaDefault.stories.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
-import { useId } from '@fluentui/react-utilities';
-import { Textarea } from '@fluentui/react-textarea';
-import type { TextareaProps } from '@fluentui/react-textarea';
-import { Label } from '@fluentui/react-label';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
+import { makeStyles, tokens, useId, Label, Textarea } from '@fluentui/react-components';
+import type { TextareaProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   base: {

--- a/packages/react-components/react-textarea/src/stories/Textarea/TextareaDisabled.stories.tsx
+++ b/packages/react-components/react-textarea/src/stories/Textarea/TextareaDisabled.stories.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import { useId } from '@fluentui/react-utilities';
-import { Label } from '@fluentui/react-label';
-import { Textarea } from '@fluentui/react-textarea';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
+import { makeStyles, tokens, useId, Label, Textarea } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   base: {

--- a/packages/react-components/react-textarea/src/stories/Textarea/TextareaPlaceholder.stories.tsx
+++ b/packages/react-components/react-textarea/src/stories/Textarea/TextareaPlaceholder.stories.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import { Textarea } from '@fluentui/react-textarea';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
+import { makeStyles, tokens, useId, Label, Textarea } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   base: {

--- a/packages/react-components/react-textarea/src/stories/Textarea/TextareaResize.stories.tsx
+++ b/packages/react-components/react-textarea/src/stories/Textarea/TextareaResize.stories.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import { useId } from '@fluentui/react-utilities';
-import { Textarea } from '@fluentui/react-textarea';
-import { Label } from '@fluentui/react-label';
-import { makeStyles, shorthands } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
+import { makeStyles, shorthands, tokens, useId, Label, Textarea } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   base: {

--- a/packages/react-components/react-textarea/src/stories/Textarea/TextareaSize.stories.tsx
+++ b/packages/react-components/react-textarea/src/stories/Textarea/TextareaSize.stories.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
-import { useId } from '@fluentui/react-utilities';
-import { Label } from '@fluentui/react-label';
-import { Textarea } from '@fluentui/react-textarea';
-import { tokens } from '@fluentui/react-theme';
+import { makeStyles, shorthands, tokens, useId, Label, Textarea } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   base: {

--- a/packages/react-components/react-textarea/src/stories/Textarea/TextareaUncontrolled.stories.tsx
+++ b/packages/react-components/react-textarea/src/stories/Textarea/TextareaUncontrolled.stories.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
-import { Textarea } from '@fluentui/react-textarea';
-import type { TextareaProps } from '@fluentui/react-textarea';
-import { Label } from '@fluentui/react-label';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
+import { makeStyles, tokens, useId, Label, Textarea } from '@fluentui/react-components';
+import type { TextareaProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   base: {

--- a/packages/react-components/react-textarea/src/stories/Textarea/index.stories.tsx
+++ b/packages/react-components/react-textarea/src/stories/Textarea/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Textarea } from '@fluentui/react-textarea';
+import { Textarea } from '@fluentui/react-components';
 
 import descriptionMd from './TextareaDescription.md';
 import bestPracticesMd from './TextareaBestPractices.md';


### PR DESCRIPTION
### Changes
- updates `react-textarea` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846