### PR TITLE
Theme: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-theme/src/stories/colors/ColorRamp.stories.tsx
+++ b/packages/react-components/react-theme/src/stories/colors/ColorRamp.stories.tsx
@@ -6,7 +6,7 @@
 // @ts-nocheck
 
 import * as React from 'react';
-import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
+import { useIsomorphicLayoutEffect } from '@fluentui/react-components';
 import { TinyColor } from '@ctrl/tinycolor';
 
 export type ColorRampProps = {

--- a/packages/react-components/react-theme/src/stories/colors/ThemeColors.stories.tsx
+++ b/packages/react-components/react-theme/src/stories/colors/ThemeColors.stories.tsx
@@ -5,8 +5,9 @@ import {
   teamsLightTheme,
   webLightTheme,
   webDarkTheme,
-} from '@fluentui/react-theme';
-import { Theme } from '@fluentui/react-theme';
+  Theme,
+} from '@fluentui/react-components';
+
 import { ColorRampItem } from './ColorRamp.stories';
 
 // FIXME: hardcoded theme

--- a/packages/react-components/react-theme/src/stories/colors/ThemeShadows.stories.tsx
+++ b/packages/react-components/react-theme/src/stories/colors/ThemeShadows.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { teamsDarkTheme, teamsHighContrastTheme, teamsLightTheme } from '@fluentui/react-theme';
-import type { ShadowTokens } from '@fluentui/react-theme';
+import { teamsDarkTheme, teamsHighContrastTheme, teamsLightTheme } from '@fluentui/react-components';
+import type { ShadowTokens } from '@fluentui/react-components';
 
 // FIXME: hardcoded theme
 const theme = {

--- a/packages/react-components/react-theme/src/stories/motion-size/ThemeBorderRadii.stories.tsx
+++ b/packages/react-components/react-theme/src/stories/motion-size/ThemeBorderRadii.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { teamsLightTheme } from '@fluentui/react-theme';
-import type { BorderRadiusTokens } from '@fluentui/react-theme';
+import { teamsLightTheme } from '@fluentui/react-components';
+import type { BorderRadiusTokens } from '@fluentui/react-components';
 
 const theme = teamsLightTheme;
 

--- a/packages/react-components/react-theme/src/stories/motion-size/ThemeMotion.stories.tsx
+++ b/packages/react-components/react-theme/src/stories/motion-size/ThemeMotion.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { teamsLightTheme } from '@fluentui/react-theme';
-import type { DurationTokens, CurveTokens } from '@fluentui/react-theme';
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles, shorthands, teamsLightTheme } from '@fluentui/react-components';
+import type { CurveTokens, DurationTokens } from '@fluentui/react-components';
 
 const theme = teamsLightTheme;
 

--- a/packages/react-components/react-theme/src/stories/motion-size/ThemeSpacing.stories.tsx
+++ b/packages/react-components/react-theme/src/stories/motion-size/ThemeSpacing.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { teamsLightTheme } from '@fluentui/react-theme';
-import type { HorizontalSpacingTokens, VerticalSpacingTokens } from '@fluentui/react-theme';
+import { teamsLightTheme } from '@fluentui/react-components';
+import type { HorizontalSpacingTokens, VerticalSpacingTokens } from '@fluentui/react-components';
 
 const theme = teamsLightTheme;
 

--- a/packages/react-components/react-theme/src/stories/motion-size/ThemeStrokeWidths.stories.tsx
+++ b/packages/react-components/react-theme/src/stories/motion-size/ThemeStrokeWidths.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { teamsLightTheme } from '@fluentui/react-theme';
-import type { StrokeWidthTokens } from '@fluentui/react-theme';
+import { teamsLightTheme } from '@fluentui/react-components';
+import type { StrokeWidthTokens } from '@fluentui/react-components';
 
 const theme = teamsLightTheme;
 

--- a/packages/react-components/react-theme/src/stories/typography/ThemeTypography.stories.tsx
+++ b/packages/react-components/react-theme/src/stories/typography/ThemeTypography.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { teamsLightTheme, typographyStyles } from '@fluentui/react-theme';
+import { teamsLightTheme, typographyStyles } from '@fluentui/react-components';
 import type {
   FontFamilyTokens,
   FontSizeTokens,
-  LineHeightTokens,
   FontWeightTokens,
+  LineHeightTokens,
   TypographyStyle,
-} from '@fluentui/react-theme';
+} from '@fluentui/react-components';
 
 const theme = teamsLightTheme;
 


### PR DESCRIPTION
### Changes
- updates `react-theme` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846