### PR TITLE
Tooltip: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipControlled.stories.tsx
+++ b/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipControlled.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from '@fluentui/react-checkbox';
-import { Tooltip } from '@fluentui/react-tooltip';
+import { Checkbox, Tooltip } from '@fluentui/react-components';
 
 export const Controlled = () => {
   const [visible, setVisible] = React.useState(false);

--- a/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipCustomMount.stories.tsx
+++ b/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipCustomMount.stories.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 
-import { Tooltip } from '@fluentui/react-tooltip';
-import type { TooltipProps } from '@fluentui/react-tooltip';
-import { Button } from '@fluentui/react-button';
+import { Button, Tooltip } from '@fluentui/react-components';
 import { SlideTextRegular } from '@fluentui/react-icons';
+import type { TooltipProps } from '@fluentui/react-components';
 
 export const CustomMount = (props: Partial<TooltipProps>) => {
   const [ref, setRef] = React.useState<HTMLElement | null>();

--- a/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipDefault.stories.tsx
+++ b/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipDefault.stories.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 
-import { Tooltip } from '@fluentui/react-tooltip';
-import type { TooltipProps } from '@fluentui/react-tooltip';
-import { Button } from '@fluentui/react-button';
+import { Button, Tooltip } from '@fluentui/react-components';
 import { SlideTextRegular } from '@fluentui/react-icons';
+import type { TooltipProps } from '@fluentui/react-components';
 
 export const Default = (props: Partial<TooltipProps>) => (
   <Tooltip content="Example tooltip" relationship="label" {...props}>

--- a/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipInverted.stories.tsx
+++ b/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipInverted.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Tooltip } from '@fluentui/react-tooltip';
-import { Button } from '@fluentui/react-button';
+import { Button, Tooltip } from '@fluentui/react-components';
 import { SlideTextFilled } from '@fluentui/react-icons';
 
 export const Inverted = () => (

--- a/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipPositioning.stories.tsx
+++ b/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipPositioning.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Tooltip } from '@fluentui/react-tooltip';
-import { Button } from '@fluentui/react-button';
+import { Button, Tooltip } from '@fluentui/react-components';
 import { ArrowStepOutRegular, ArrowStepOverRegular } from '@fluentui/react-icons';
 
 export const Positioning = () => {

--- a/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipRelationshipDescription.stories.tsx
+++ b/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipRelationshipDescription.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-button';
-import { Tooltip } from '@fluentui/react-tooltip';
+import { Button, Tooltip } from '@fluentui/react-components';
 
 export const RelationshipDescription = () => (
   <Tooltip content="This is the description of the button" relationship="description">

--- a/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipRelationshipLabel.stories.tsx
+++ b/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipRelationshipLabel.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { TextBoldRegular, TextItalicRegular, TextUnderlineRegular } from '@fluentui/react-icons';
-import { Button } from '@fluentui/react-button';
-import { Tooltip } from '@fluentui/react-tooltip';
+import { Button, Tooltip } from '@fluentui/react-components';
 
 export const RelationshipLabel = () => (
   <>

--- a/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipStyled.stories.tsx
+++ b/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipStyled.stories.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
 
-import { Tooltip } from '@fluentui/react-tooltip';
-import type { TooltipProps } from '@fluentui/react-tooltip';
-import { Button } from '@fluentui/react-button';
+import { makeStyles, tokens, Button, Tooltip } from '@fluentui/react-components';
 import { SlideTextRegular } from '@fluentui/react-icons';
-import { makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
+import type { TooltipProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   tooltip: {

--- a/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipTarget.stories.tsx
+++ b/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipTarget.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Tooltip } from '@fluentui/react-tooltip';
-import { Button } from '@fluentui/react-button';
+import { Button, Tooltip } from '@fluentui/react-components';
 import { ArrowRoutingRegular } from '@fluentui/react-icons';
 
 export const Target = () => {

--- a/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipWithArrow.stories.tsx
+++ b/packages/react-components/react-tooltip/src/stories/Tooltip/TooltipWithArrow.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Tooltip } from '@fluentui/react-tooltip';
-import { Button } from '@fluentui/react-button';
+import { Button, Tooltip } from '@fluentui/react-components';
 import { ArrowStepInRegular } from '@fluentui/react-icons';
 
 export const WithArrow = () => (

--- a/packages/react-components/react-tooltip/src/stories/Tooltip/index.stories.tsx
+++ b/packages/react-components/react-tooltip/src/stories/Tooltip/index.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Meta } from '@storybook/react';
-import { Tooltip } from '@fluentui/react-tooltip';
+import { Tooltip } from '@fluentui/react-components';
 import descriptionMd from './TooltipDescription.md';
 export { Default } from './TooltipDefault.stories';
 export { RelationshipLabel } from './TooltipRelationshipLabel.stories';


### PR DESCRIPTION
### Changes
- updates `react-tooltip` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846