### PR TITLE
Text: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-text/src/stories/Text/Default.stories.tsx
+++ b/packages/react-components/react-text/src/stories/Text/Default.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { makeStyles } from '@griffel/react';
-import { Text } from '@fluentui/react-text';
-import type { TextProps } from '@fluentui/react-text';
+import { makeStyles, Text } from '@fluentui/react-components';
+import type { TextProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {

--- a/packages/react-components/react-text/src/stories/Text/TextFont.stories.tsx
+++ b/packages/react-components/react-text/src/stories/Text/TextFont.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text } from '@fluentui/react-text';
+import { Text } from '@fluentui/react-components';
 
 export const Font = () => (
   <div style={{ display: 'flex', gap: 20 }}>

--- a/packages/react-components/react-text/src/stories/Text/TextItalic.stories.tsx
+++ b/packages/react-components/react-text/src/stories/Text/TextItalic.stories.tsx
@@ -1,4 +1,4 @@
 import * as React from 'react';
-import { Text } from '@fluentui/react-text';
+import { Text } from '@fluentui/react-components';
 
 export const Italic = () => <Text italic>Italic text</Text>;

--- a/packages/react-components/react-text/src/stories/Text/TextSize.stories.tsx
+++ b/packages/react-components/react-text/src/stories/Text/TextSize.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text } from '@fluentui/react-text';
+import { Text } from '@fluentui/react-components';
 
 export const Size = () => (
   <div style={{ display: 'flex', gap: 10, alignItems: 'baseline' }}>

--- a/packages/react-components/react-text/src/stories/Text/TextStrikeThrough.stories.tsx
+++ b/packages/react-components/react-text/src/stories/Text/TextStrikeThrough.stories.tsx
@@ -1,4 +1,4 @@
 import * as React from 'react';
-import { Text } from '@fluentui/react-text';
+import { Text } from '@fluentui/react-components';
 
 export const StrikeThrough = () => <Text strikethrough>Strikethrough text</Text>;

--- a/packages/react-components/react-text/src/stories/Text/TextTruncate.stories.tsx
+++ b/packages/react-components/react-text/src/stories/Text/TextTruncate.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text } from '@fluentui/react-text';
+import { Text } from '@fluentui/react-components';
 
 export const Truncate = () => (
   <Text truncate style={{ width: 100, overflow: 'hidden', whiteSpace: 'nowrap' }} block>

--- a/packages/react-components/react-text/src/stories/Text/TextTypography.stories.tsx
+++ b/packages/react-components/react-text/src/stories/Text/TextTypography.stories.tsx
@@ -2,15 +2,15 @@ import * as React from 'react';
 import {
   Body1,
   Caption1,
+  Caption2,
   Display,
-  Subtitle1,
   LargeTitle,
+  Subtitle1,
+  Subtitle2,
   Title1,
   Title2,
   Title3,
-  Subtitle2,
-  Caption2,
-} from '@fluentui/react-text';
+} from '@fluentui/react-components';
 
 export const Typography = () => (
   <>

--- a/packages/react-components/react-text/src/stories/Text/TextUnderline.stories.tsx
+++ b/packages/react-components/react-text/src/stories/Text/TextUnderline.stories.tsx
@@ -1,4 +1,4 @@
 import * as React from 'react';
-import { Text } from '@fluentui/react-text';
+import { Text } from '@fluentui/react-components';
 
 export const Underline = () => <Text underline>Underlined text</Text>;

--- a/packages/react-components/react-text/src/stories/Text/TextWeight.stories.tsx
+++ b/packages/react-components/react-text/src/stories/Text/TextWeight.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text } from '@fluentui/react-text';
+import { Text } from '@fluentui/react-components';
 
 export const Weight = () => (
   <div style={{ display: 'flex', gap: 20 }}>

--- a/packages/react-components/react-text/src/stories/Text/index.stories.tsx
+++ b/packages/react-components/react-text/src/stories/Text/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/react';
-import { Text } from '@fluentui/react-text';
+import { Text } from '@fluentui/react-components';
 import textDescriptionMd from './TextDescription.md';
 import textBestPractices from './TextBestPractices.md';
 


### PR DESCRIPTION
### Changes
- updates `react-text` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846