### PR TITLE
chore: Fixing dependency mismatch due to @fluentui/react-portal-compat-context bump

### DIFF
--- a/change/@fluentui-react-e250f82e-f2bd-4229-899c-6ddf13a1e19a.json
+++ b/change/@fluentui-react-e250f82e-f2bd-4229-899c-6ddf13a1e19a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Fixing dependency mismatch due to @fluentui/react-portal-compat-context bump.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -14,7 +14,7 @@
     "@fluentui/react-component-ref": "^0.63.1",
     "@fluentui/react-icons-northstar": "^0.63.1",
     "@fluentui/react-northstar-styles-renderer": "^0.63.1",
-    "@fluentui/react-portal-compat-context": "^9.0.0",
+    "@fluentui/react-portal-compat-context": "^9.0.1",
     "@fluentui/react-proptypes": "^0.63.1",
     "@fluentui/state": "^0.63.1",
     "@fluentui/styles": "^0.63.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -50,7 +50,7 @@
     "@fluentui/merge-styles": "^8.5.2",
     "@fluentui/react-focus": "^8.7.3",
     "@fluentui/react-hooks": "^8.6.1",
-    "@fluentui/react-portal-compat-context": "^9.0.0",
+    "@fluentui/react-portal-compat-context": "^9.0.1",
     "@fluentui/react-window-provider": "^2.2.1",
     "@fluentui/set-version": "^8.2.1",
     "@fluentui/style-utilities": "^8.7.2",


### PR DESCRIPTION
## PR description

This PR fixes the dependency mismatches that happened after a recent bump in `@fluentui/react-portal-compat-context` using the `dependency-mismatch` nx generator.