### PR TITLE
replace slash with math.div as it is now deprecated and will be removed in Dart Sass 2

### DIFF
--- a/apps/public-docsite/src/pages/Overviews/StylesPage/StylesPage.module.scss
+++ b/apps/public-docsite/src/pages/Overviews/StylesPage/StylesPage.module.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import '../../../styles/common';
 
 .cardWrapper {
@@ -55,12 +57,12 @@
 
 @media screen and (min-width: $ms-screen-min-md) {
   .card {
-    width: calc(#{percentage(1/2)} - #{$App-padding-sm});
+    width: calc(#{percentage(math.div(1, 2))} - #{$App-padding-sm});
   }
 }
 
 @media screen and (min-width: $uhf-screen-min-lg) {
   .card {
-    width: calc(#{percentage(1/3)} - #{$App-padding-sm});
+    width: calc(#{percentage(math.div(1, 3))} - #{$App-padding-sm});
   }
 }


### PR DESCRIPTION
## Current Behavior
Depreciation notice during build of `@fluentui/public-docsite build`
```
verb @fluentui/public-docsite build |  : Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
verb @fluentui/public-docsite build |  
verb @fluentui/public-docsite build Recommendation: math.div(1, 2)
verb @fluentui/public-docsite build |  
verb @fluentui/public-docsite build More info and automated migrator: https://sass-lang.com/d/slash-div
verb @fluentui/public-docsite build |  
verb @fluentui/public-docsite build    ╷
verb @fluentui/public-docsite build |  58 │     width: calc(#{percentage(1/2)} - #{$App-padding-sm});
verb @fluentui/public-docsite build |     │                              ^^^
verb @fluentui/public-docsite build |     ╵
verb @fluentui/public-docsite build |      src/pages/Overviews/StylesPage/StylesPage.module.scss 58:30  root stylesheet
verb @fluentui/public-docsite build |  : Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
verb @fluentui/public-docsite build |  
verb @fluentui/public-docsite build Recommendation: math.div(1, 3)
verb @fluentui/public-docsite build |  
verb @fluentui/public-docsite build More info and automated migrator: https://sass-lang.com/d/slash-div
verb @fluentui/public-docsite build |  
verb @fluentui/public-docsite build    ╷
verb @fluentui/public-docsite build |  64 │     width: calc(#{percentage(1/3)} - #{$App-padding-sm});
verb @fluentui/public-docsite build |     │                              ^^^
verb @fluentui/public-docsite build |     ╵
verb @fluentui/public-docsite build |      src/pages/Overviews/StylesPage/StylesPage.module.scss 64:30  root stylesheet
```

## New Behavior

Use `math.div()` instead of the `/` operator to comply with Dart Sass 2.0.0