### PR TITLE
fix(Nav): remove separate labels for expand/collapse state

### DIFF
--- a/change/@fluentui-react-7b59898b-33af-43ba-981d-96c48f4a471b.json
+++ b/change/@fluentui-react-7b59898b-33af-43ba-981d-96c48f4a471b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update Nav to not use separate labels for expand/collapse state",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-7b59898b-33af-43ba-981d-96c48f4a471b.json
+++ b/change/@fluentui-react-7b59898b-33af-43ba-981d-96c48f4a471b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "update Nav to not use separate labels for expand/collapse state",
+  "comment": "fix: Update Nav to not use separate labels for expand/collapse state.",
   "packageName": "@fluentui/react",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-examples/src/react/Nav/Nav.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.Basic.Example.tsx
@@ -18,7 +18,6 @@ const navLinkGroups: INavLinkGroup[] = [
         name: 'Home',
         url: 'http://example.com',
         expandAriaLabel: 'Expand Home section',
-        collapseAriaLabel: 'Collapse Home section',
         links: [
           {
             name: 'Activity',

--- a/packages/react-examples/src/react/Nav/Nav.FabricDemoApp.Example.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.FabricDemoApp.Example.tsx
@@ -6,8 +6,7 @@ const navStyles: Partial<INavStyles> = { root: { width: 300 } };
 const navLinkGroups: INavLinkGroup[] = [
   {
     name: 'Basic components',
-    expandAriaLabel: 'Expand Basic components section',
-    collapseAriaLabel: 'Collapse Basic components section',
+    expandAriaLabel: 'Show more Basic components',
     links: [
       {
         key: 'ActivityItem',
@@ -28,8 +27,7 @@ const navLinkGroups: INavLinkGroup[] = [
   },
   {
     name: 'Extended components',
-    expandAriaLabel: 'Expand Extended components section',
-    collapseAriaLabel: 'Collapse Extended components section',
+    expandAriaLabel: 'Show more Extended components',
     links: [
       {
         key: 'ColorPicker',
@@ -50,8 +48,7 @@ const navLinkGroups: INavLinkGroup[] = [
   },
   {
     name: 'Utilities',
-    expandAriaLabel: 'Expand Utilities section',
-    collapseAriaLabel: 'Collapse Utilities section',
+    expandAriaLabel: 'Show more Utilities',
     links: [
       {
         key: 'FocusTrapZone',

--- a/packages/react-examples/src/react/Nav/Nav.Nested.Example.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.Nested.Example.tsx
@@ -8,8 +8,7 @@ const navLinkGroups: INavLinkGroup[] = [
         name: 'Parent link 1',
         url: 'http://example.com',
         target: '_blank',
-        expandAriaLabel: 'Expand Parent link 1',
-        collapseAriaLabel: 'Collapse Parent link 1',
+        expandAriaLabel: 'Show more Parent link 1',
         links: [
           {
             name: 'Child link 1',
@@ -20,8 +19,7 @@ const navLinkGroups: INavLinkGroup[] = [
             name: 'Child link 2',
             url: 'http://example.com',
             target: '_blank',
-            expandAriaLabel: 'Expand Child link 2',
-            collapseAriaLabel: 'Collapse Child link 2',
+            expandAriaLabel: 'Show more Child link 2',
             links: [
               {
                 name: '3rd level link 1',
@@ -46,8 +44,7 @@ const navLinkGroups: INavLinkGroup[] = [
         name: 'Parent link 2',
         url: 'http://example.com',
         target: '_blank',
-        expandAriaLabel: 'Expand Parent link 2',
-        collapseAriaLabel: 'Collapse Parent link 2',
+        expandAriaLabel: 'Show more Parent link 2',
         links: [
           {
             name: 'Child link 4',

--- a/packages/react-examples/src/react/Nav/Nav.Wrapped.Example.tsx
+++ b/packages/react-examples/src/react/Nav/Nav.Wrapped.Example.tsx
@@ -25,7 +25,6 @@ const navLinkGroups: INavLinkGroup[] = [
         name: 'Home',
         url: 'http://example.com',
         expandAriaLabel: 'Expand Home section',
-        collapseAriaLabel: 'Collapse Home section',
         title: '',
         links: [
           {

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6937,6 +6937,7 @@ export interface INavLink {
 // @public (undocumented)
 export interface INavLinkGroup {
     automationId?: string;
+    // @deprecated
     collapseAriaLabel?: string;
     collapseByDefault?: boolean;
     expandAriaLabel?: string;

--- a/packages/react/src/components/Nav/Nav.base.tsx
+++ b/packages/react/src/components/Nav/Nav.base.tsx
@@ -161,7 +161,10 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     let finalExpandBtnAriaLabel = '';
     if (link.links && link.links.length > 0) {
       if (link.collapseAriaLabel || link.expandAriaLabel) {
-        finalExpandBtnAriaLabel = link.isExpanded ? link.collapseAriaLabel! : link.expandAriaLabel!;
+        // still respect link.collapseAriaLabel, even though it's deprecated in favor of expandAriaLabel
+        const collapseAriaLabel = link.collapseAriaLabel ?? link.expandAriaLabel;
+
+        finalExpandBtnAriaLabel = link.isExpanded ? collapseAriaLabel! : link.expandAriaLabel!;
       } else {
         // TODO remove when `expandButtonAriaLabel` is removed. This is not an ideal concatenation for localization.
         finalExpandBtnAriaLabel = expandButtonAriaLabel ? `${link.name} ${expandButtonAriaLabel}` : link.name;
@@ -261,7 +264,10 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
       groups,
     });
 
-    const label = (isExpanded ? group.collapseAriaLabel : group.expandAriaLabel) || expandButtonAriaLabel;
+    // respect deprecated collapseAriaLabel, but default to expandAriaLabel for both states
+    // eslint-disable-next-line deprecation/deprecation
+    const collapseAriaLabel = group.collapseAriaLabel ?? group.expandAriaLabel;
+    const label = (isExpanded ? collapseAriaLabel : group.expandAriaLabel) || expandButtonAriaLabel;
 
     const { onHeaderClick } = group;
 

--- a/packages/react/src/components/Nav/Nav.types.ts
+++ b/packages/react/src/components/Nav/Nav.types.ts
@@ -169,7 +169,7 @@ export interface INavLinkGroup {
    * ARIA label when group is collapsed and can be expanded.
    * WARNING: using separate labels for expanded and collapsed state is not recommended.
    *
-   * @deprecated Use `expandAriaLabel` instead.
+   * @deprecated Use `expandAriaLabel` on its own instead.
    */
   collapseAriaLabel?: string;
 

--- a/packages/react/src/components/Nav/Nav.types.ts
+++ b/packages/react/src/components/Nav/Nav.types.ts
@@ -167,6 +167,9 @@ export interface INavLinkGroup {
 
   /**
    * ARIA label when group is collapsed and can be expanded.
+   * WARNING: using separate labels for expanded and collapsed state is not recommended.
+   *
+   * @deprecated Use `expandAriaLabel` instead.
    */
   collapseAriaLabel?: string;
 


### PR DESCRIPTION
Fixes [14975](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/14975)

Using labels for state information is generally not recommended, especially since we also have `aria-expanded` communicating the expand/collapse state. Changing the label as well as the expanded state prop means that the button reads multiple times (once for the state change, and then again for the name change).

This PR deprecates `collapseAriaLabel`, and updates the label calculation to always use `expandAriaLabel` if `collapseAriaLabel` is not provided. If both or neither are provided, the behavior does not change.

Our docsite examples are also updated to only use `expandAriaLabel`