### PR TITLE
Docs: Layer event bubbling with React 17

### DIFF
--- a/packages/react-examples/src/react/Callout/docs/CalloutOverview.md
+++ b/packages/react-examples/src/react/Callout/docs/CalloutOverview.md
@@ -1,1 +1,5 @@
 A callout is an anchored tip that can be used to teach people or guide them through the app without blocking them.
+
+### React 17 event delegation
+
+Changes to event delegation in React 17 can cause issues with event bubbling when using Callout. [See `Layer` documentation](#/controls/web/layer) for details on how to resolve eventing issues with this control in React 17.

--- a/packages/react-examples/src/react/Callout/docs/CalloutOverview.md
+++ b/packages/react-examples/src/react/Callout/docs/CalloutOverview.md
@@ -2,4 +2,4 @@ A callout is an anchored tip that can be used to teach people or guide them 
 
 ### React 17 event delegation
 
-Changes to event delegation in React 17 can cause issues with event bubbling when using Callout. [See `Layer` documentation](#/controls/web/layer) for details on how to resolve eventing issues with this control in React 17.
+[Changes to event delegation in React 17](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation) can cause issues with event bubbling when using Callout. [See `Layer` documentation](#/controls/web/layer) for details on how to resolve eventing issues with this control in React 17.

--- a/packages/react-examples/src/react/Dialog/docs/DialogOverview.md
+++ b/packages/react-examples/src/react/Dialog/docs/DialogOverview.md
@@ -1,1 +1,5 @@
 A dialog box (`Dialog`) is a temporary pop-up that takes focus from the page or app and requires people to interact with it. It’s primarily used for confirming actions, such as deleting a file, or asking people to make a choice.
+
+### React 17 event delegation
+
+Changes to event delegation in React 17 can cause issues with event bubbling when using Dialog. [See `Layer` documentation](#/controls/web/layer) for details on how to resolve eventing issues with this control in React 17.

--- a/packages/react-examples/src/react/Dialog/docs/DialogOverview.md
+++ b/packages/react-examples/src/react/Dialog/docs/DialogOverview.md
@@ -2,4 +2,4 @@ A dialog box (`Dialog`) is a temporary pop-up that takes focus from the�
 
 ### React 17 event delegation
 
-Changes to event delegation in React 17 can cause issues with event bubbling when using Dialog. [See `Layer` documentation](#/controls/web/layer) for details on how to resolve eventing issues with this control in React 17.
+[Changes to event delegation in React 17](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation) can cause issues with event bubbling when using Dialog. [See `Layer` documentation](#/controls/web/layer) for details on how to resolve eventing issues with this control in React 17.

--- a/packages/react-examples/src/react/Layer/docs/LayerOverview.md
+++ b/packages/react-examples/src/react/Layer/docs/LayerOverview.md
@@ -3,3 +3,7 @@ A Layer is a technical component that does not have specific Design guidance.
 Layers are used to render content outside of a DOM tree, at the end of the document. This allows content to escape traditional boundaries caused by "overflow: hidden" CSS rules and keeps it on the top without using z-index rules. This is useful for example in ContextualMenu and Tooltip scenarios, where the content should always overlay everything else.
 
 There are some special considerations. Due to the nature of rendering content elsewhere asynchronously, React refs within content will not be resolvable synchronously at the time the Layer is mounted. Therefore, to use refs correctly, use functional refs `ref={ (el) => { this._root = el; }` rather than string refs `ref='root'`. Additionally measuring the physical Layer element will not include any of the children, since it won't render it. Events that propagate from within the content will not go through the Layer element as well.
+
+### React 17 event delegation
+
+[Changes to event delegation in React 17](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation) can cause issues with event bubbling when using Layer. Setting `eventBubblingEnabled` to `true` will allow events to bubble out of Layer and should resolve event bubbling issues.

--- a/packages/react-examples/src/react/Modal/docs/ModalOverview.md
+++ b/packages/react-examples/src/react/Modal/docs/ModalOverview.md
@@ -1,1 +1,5 @@
 Modals are temporary pop-ups that take focus from the page or app and require people to interact with them. Unlike a dialog box (`Dialog`), a modal should be used for hosting lengthy content, such as privacy statements or license agreements, or for asking people to perform complex or multiple actions, such as changing settings.
+
+### React 17 event delegation
+
+Changes to event delegation in React 17 can cause issues with event bubbling when using Modal. [See `Layer` documentation](#/controls/web/layer) for details on how to resolve eventing issues with this control in React 17.

--- a/packages/react-examples/src/react/Modal/docs/ModalOverview.md
+++ b/packages/react-examples/src/react/Modal/docs/ModalOverview.md
@@ -2,4 +2,4 @@ Modals are temporary pop-ups that take focus from the page or app and requi
 
 ### React 17 event delegation
 
-Changes to event delegation in React 17 can cause issues with event bubbling when using Modal. [See `Layer` documentation](#/controls/web/layer) for details on how to resolve eventing issues with this control in React 17.
+[Changes to event delegation in React 17](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation) can cause issues with event bubbling when using Modal. [See `Layer` documentation](#/controls/web/layer) for details on how to resolve eventing issues with this control in React 17.

--- a/packages/react-examples/src/react/Panel/docs/PanelOverview.md
+++ b/packages/react-examples/src/react/Panel/docs/PanelOverview.md
@@ -1,1 +1,5 @@
 Panels are overlays that contain supplementary content and are used for complex creation, edit, or management experiences.  For example, viewing details about an item in a list or editing settings.
+
+### React 17 event delegation
+
+Changes to event delegation in React 17 can cause issues with event bubbling when using Panel. [See `Layer` documentation](#/controls/web/layer) for details on how to resolve eventing issues with this control in React 17.

--- a/packages/react-examples/src/react/Panel/docs/PanelOverview.md
+++ b/packages/react-examples/src/react/Panel/docs/PanelOverview.md
@@ -2,4 +2,4 @@ Panels are overlays that contain supplementary content and are used for compl
 
 ### React 17 event delegation
 
-Changes to event delegation in React 17 can cause issues with event bubbling when using Panel. [See `Layer` documentation](#/controls/web/layer) for details on how to resolve eventing issues with this control in React 17.
+[Changes to event delegation in React 17](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation) can cause issues with event bubbling when using Panel. [See `Layer` documentation](#/controls/web/layer) for details on how to resolve eventing issues with this control in React 17.


### PR DESCRIPTION
## Current Behavior

Documentation for `Layer` (and components that use `Layer` under the hood) does not clearly explain how to enable event bubbling. This is an issue that has been [reported](https://github.com/microsoft/fluentui/issues/19299) a [few](https://github.com/microsoft/fluentui/issues/20009) [times](https://github.com/microsoft/fluentui/issues/20073) with respect to [React 17's changes to event delegation](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation).

## New Behavior

`Layer` documentation is updated to clearly explain how to enable event bubbling. Components that use `Layer` under the hood link to `Layer`'s documentation.

I don't feel there is a code change to be made here as, so far, changing the event bubbling behavior has been enough to resolve this issue for consumers. I've decided to only make a documentation change at this point so consumers can more easily discover this feature. If the problem persists and we need a code change we can consider that in the future.

## Related Issue(s)

Fixes #20073
