### PR TITLE
CommandBar: update cache key computation

### DIFF
--- a/change/@fluentui-react-76f7c216-9e4b-4345-bc6a-ecc15201cdba.json
+++ b/change/@fluentui-react-76f7c216-9e4b-4345-bc6a-ecc15201cdba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update CommandBar cacheKey computation to include farItems",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/react/src/components/CommandBar/CommandBar.base.tsx
@@ -88,6 +88,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
       cacheKey: this._computeCacheKey({
         primaryItems: [...items],
         overflow: overflowItems && overflowItems.length > 0,
+        farItems,
       }),
     };
 
@@ -248,8 +249,12 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
     return <OverflowButtonType {...(overflowProps as IButtonProps)} />;
   };
 
-  private _computeCacheKey(data: { primaryItems?: ICommandBarItemProps[]; overflow?: boolean }): string {
-    const { primaryItems, overflow } = data;
+  private _computeCacheKey(data: {
+    primaryItems?: ICommandBarItemProps[];
+    overflow?: boolean;
+    farItems?: ICommandBarItemProps[];
+  }): string {
+    const { primaryItems, overflow, farItems } = data;
     const returnKey = (acc: string, current: ICommandBarItemProps): string => {
       const { cacheKey = current.key } = current;
       return acc + cacheKey;
@@ -257,13 +262,15 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
 
     const primaryKey = primaryItems && primaryItems.reduce(returnKey, '');
     const overflowKey = overflow ? 'overflow' : '';
+    const farKey = farItems && farItems.reduce(returnKey, '');
 
-    return [primaryKey, overflowKey].join('');
+    return [primaryKey, overflowKey, farKey].join('');
   }
 
   private _onReduceData = (data: ICommandBarData): ICommandBarData | undefined => {
     const { shiftOnReduce, onDataReduced } = this.props;
     let { primaryItems, overflowItems, cacheKey } = data;
+    const { farItems } = data;
 
     // Use first item if shiftOnReduce, otherwise use last item
     const movedItem = primaryItems[shiftOnReduce ? 0 : primaryItems.length - 1];
@@ -275,7 +282,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
       primaryItems = shiftOnReduce ? primaryItems.slice(1) : primaryItems.slice(0, -1);
 
       const newData = { ...data, primaryItems, overflowItems };
-      cacheKey = this._computeCacheKey({ primaryItems, overflow: overflowItems.length > 0 });
+      cacheKey = this._computeCacheKey({ primaryItems, overflow: overflowItems.length > 0, farItems });
 
       if (onDataReduced) {
         onDataReduced(movedItem);
@@ -292,6 +299,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
     const { shiftOnReduce, onDataGrown } = this.props;
     const { minimumOverflowItems } = data;
     let { primaryItems, overflowItems, cacheKey } = data;
+    const { farItems } = data;
     const movedItem = overflowItems[0];
 
     // Make sure that moved item exists and is not one of the original overflow items
@@ -303,7 +311,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
       primaryItems = shiftOnReduce ? [movedItem, ...primaryItems] : [...primaryItems, movedItem];
 
       const newData = { ...data, primaryItems, overflowItems };
-      cacheKey = this._computeCacheKey({ primaryItems, overflow: overflowItems.length > 0 });
+      cacheKey = this._computeCacheKey({ primaryItems, overflow: overflowItems.length > 0, farItems });
 
       if (onDataGrown) {
         onDataGrown(movedItem);


### PR DESCRIPTION
## Current Behavior

`cacheKey` is used to resize `CommandBar` based on props like `items` changing. `farItems` is not included in the `cacheKey` computation so changes to `farItems` does not trigger a resize until/unless the window is resized or similar.

## New Behavior

`CommandBar` takes `farItems` into account when computing `cacheKey` so that is properly resizes when `farItems` changes.

## Related Issue(s)

Fixes #23502
