### PR TITLE
chore(storybook): remove deprecated --static-dir CLI flag usage

### DIFF
--- a/apps/public-docsite-v9/.storybook/main.js
+++ b/apps/public-docsite-v9/.storybook/main.js
@@ -9,6 +9,7 @@ module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript
     '../src/**/*.stories.@(ts|tsx)',
     ...utils.getVnextStories(),
   ],
+  staticDirs: ['../public'],
   addons: [...rootMain.addons],
   webpackFinal: (config, options) => {
     const localConfig = { ...rootMain.webpackFinal(config, options) };

--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -5,7 +5,7 @@
   "description": "A collection of examples demonstrating how to upgrade from v8 to v9",
   "scripts": {
     "build": "just-scripts build",
-    "build-storybook": "build-storybook -s ./public -o ./dist/storybook --docs",
+    "build-storybook": "build-storybook -o ./dist/storybook --docs",
     "chromatic:branch": "npx chromatic@6.4.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name build-storybook",
     "chromatic": "npx chromatic@6.4.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name build-storybook --branch-name microsoft:master",
     "clean": "just-scripts clean",
@@ -13,7 +13,7 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "yarn storybook:docs",
-    "storybook": "node ../../scripts/storybook/runner --port 3000 -s ./public --no-manager-cache",
+    "storybook": "node ../../scripts/storybook/runner --port 3000 --no-manager-cache",
     "storybook:docs": "yarn storybook --docs"
   },
   "devDependencies": {

--- a/change/@fluentui-react-components-a578581d-7c18-442c-a376-8f8547e30e6f.json
+++ b/change/@fluentui-react-components-a578581d-7c18-442c-a376-8f8547e30e6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(storybook): remove deprecated --static-dir CLI flag usage",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-web-components-743638b6-0892-40f8-965e-56c8b2da0760.json
+++ b/change/@fluentui-web-components-743638b6-0892-40f8-965e-56c8b2da0760.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(storybook): remove deprecated --static-dir CLI flag usage",
+  "packageName": "@fluentui/web-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/.storybook/main.js
+++ b/packages/react-components/react-components/.storybook/main.js
@@ -9,6 +9,7 @@ module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescr
     '../src/**/*.stories.@(ts|tsx)',
     ...utils.getVnextStories(),
   ],
+  staticDirs: ['../public'],
   addons: [...rootMain.addons],
   webpackFinal: (config, options) => {
     const localConfig = { ...rootMain.webpackFinal(config, options) };

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -21,7 +21,7 @@
     "start": "yarn storybook",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",
     "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../../scripts/typescript/normalize-import --output ./dist/types/packages/react-components/react-components/src && yarn docs",
-    "storybook": "node ../../../scripts/storybook/runner --port 3000 -s ./public --no-manager-cache",
+    "storybook": "node ../../../scripts/storybook/runner --port 3000 --no-manager-cache",
     "test": "jest --passWithNoTests",
     "type-check": "tsc -b tsconfig.json"
   },

--- a/packages/react-components/theme-designer/.storybook/main.js
+++ b/packages/react-components/theme-designer/.storybook/main.js
@@ -3,6 +3,7 @@ const rootMain = require('../../../../.storybook/main');
 module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
   ...rootMain,
   stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  staticDirs: ['../public'],
   addons: [...rootMain.addons],
   webpackFinal: (config, options) => {
     const localConfig = { ...rootMain.webpackFinal(config, options) };

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "build-storybook": "build-storybook -s ./public -o ./dist/storybook",
+    "build-storybook": "build-storybook -o ./dist/storybook",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/web-components/.storybook/main.js
+++ b/packages/web-components/.storybook/main.js
@@ -2,6 +2,7 @@ const CircularDependencyPlugin = require('circular-dependency-plugin');
 
 module.exports = {
   stories: ['../src/**/*.stories.@(ts|mdx)'],
+  staticDirs: ['../public'],
   core: {
     builder: 'webpack4',
   },

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -31,7 +31,7 @@
     "prettier": "prettier --config ../../prettier.config.js --write 'src/**/(*.ts|*.html)' --ignore-path ../../.prettierignore",
     "prettier:diff": "prettier --config ../../prettier.config.js 'src/**/(*.ts|*.html)' --ignore-path ../../.prettierignore --list-different",
     "code-style": "npm run prettier && npm run lint",
-    "start": "yarn start-storybook -p 6006 -s ./public --docs",
+    "start": "yarn start-storybook -p 6006 --docs",
     "start-storybook": "node node_modules/@storybook/html/bin/index.js",
     "build-storybook": "node node_modules/@storybook/html/bin/build.js -o ./dist/storybook --docs -s ./public",
     "test": "yarn doc:ci && yarn test-chrome:verbose",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -33,7 +33,7 @@
     "code-style": "npm run prettier && npm run lint",
     "start": "yarn start-storybook -p 6006 --docs",
     "start-storybook": "node node_modules/@storybook/html/bin/index.js",
-    "build-storybook": "node node_modules/@storybook/html/bin/build.js -o ./dist/storybook --docs -s ./public",
+    "build-storybook": "node node_modules/@storybook/html/bin/build.js -o ./dist/storybook --docs",
     "test": "yarn doc:ci && yarn test-chrome:verbose",
     "test-node": "mocha --reporter min --exit dist/esm/__test__/setup-node.js './dist/esm/**/*.spec.js'",
     "test-node:verbose": "mocha --reporter spec --exit dist/esm/__test__/setup-node.js './dist/esm/**/*.spec.js'",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

we use [`storybook` deprecated CLI flags](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated---static-dir-cli-flag) to run storybook instances

![image](https://user-images.githubusercontent.com/1223799/179765144-1f86b616-0602-4398-8287-d342b6a50a34.png)


## New Behavior

no deprecation error

## Related Issue(s)


