### PR TITLE
chore(react-components): remove CSF warnings violation when running s…

### DIFF
--- a/change/@fluentui-react-components-5e0414d7-ed65-46c3-8c36-7df03867c6ce.json
+++ b/change/@fluentui-react-components-5e0414d7-ed65-46c3-8c36-7df03867c6ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(react-components): remove CSF warnings violation when running storybook",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/.storybook/main.js
+++ b/packages/react-components/react-components/.storybook/main.js
@@ -6,7 +6,7 @@ module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescr
   stories: [
     ...rootMain.stories,
     '../src/**/*.stories.mdx',
-    '../src/**/*.stories.@(ts|tsx)',
+    '../src/**/index.stories.@(ts|tsx)',
     ...utils.getVnextStories(),
   ],
   addons: [...rootMain.addons],

--- a/packages/react-components/react-components/.storybook/main.utils.js
+++ b/packages/react-components/react-components/.storybook/main.utils.js
@@ -19,7 +19,7 @@ function getVnextStories() {
     .filter(pkgName => pkgName.startsWith('@fluentui/') && !excludedDependencies.includes(pkgName))
     .map(pkgName => {
       const name = pkgName.replace('@fluentui/', '');
-      const storiesGlob = '/src/**/*.stories.@(ts|tsx|mdx)';
+      const storiesGlob = '/src/**/@(index.stories.@(ts|tsx)|*.stories.mdx)';
 
       return `../../${name}${storiesGlob}`;
     });

--- a/packages/react-components/react-components/.storybook/main.utils.test.js
+++ b/packages/react-components/react-components/.storybook/main.utils.test.js
@@ -7,14 +7,14 @@ describe(`main utils`, () => {
       const actual = utils.getVnextStories();
       const expected = [
         expect.stringContaining('../../react-'),
-        expect.stringContaining('/src/**/*.stories.@(ts|tsx|mdx)'),
+        expect.stringContaining('/src/**/@(index.stories.@(ts|tsx)|*.stories.mdx)'),
       ];
 
       expect(actual).toEqual(expect.arrayContaining(expected));
 
       const first = actual[0];
       expect(first.startsWith('../../react-')).toBeTruthy();
-      expect(first.endsWith('/src/**/*.stories.@(ts|tsx|mdx)')).toBeTruthy();
+      expect(first.endsWith('/src/**/@(index.stories.@(ts|tsx)|*.stories.mdx)')).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
…torybook

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

`yarn workspace @fluentui/react-components storybook`

produces huge amount of warnings which completely spams the console 

![image](https://user-images.githubusercontent.com/1223799/179779526-6cc4e195-54fe-4a82-8097-c133cddd8811.png)


## New Behavior

- no warnings
- unified main.utils with public-docsite-v9

![image](https://user-images.githubusercontent.com/1223799/179779282-38136e94-52c4-4962-b6a3-a9f542ae2a0c.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- https://github.com/microsoft/fluentui/issues/23393

