### PR TITLE
v7 Calendar cherry-pick: remove explicit readonly semantics from grid and gridcells

### DIFF
--- a/change/@uifabric-date-time-35097027-415c-4e27-aa17-e0ab9da80cd3.json
+++ b/change/@uifabric-date-time-35097027-415c-4e27-aa17-e0ab9da80cd3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove explicit readonly semantics from Calendar grid",
+  "packageName": "@uifabric/date-time",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-date-time-35097027-415c-4e27-aa17-e0ab9da80cd3.json
+++ b/change/@uifabric-date-time-35097027-415c-4e27-aa17-e0ab9da80cd3.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Remove explicit readonly semantics from Calendar grid",
+  "comment": "fix: Remove explicit readonly semantics from Calendar grid.",
   "packageName": "@uifabric/date-time",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/office-ui-fabric-react-f0ac52c6-050f-4369-b9ef-0d4bbb005c43.json
+++ b/change/office-ui-fabric-react-f0ac52c6-050f-4369-b9ef-0d4bbb005c43.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove explicit readonly semantics from Calendar grid",
+  "packageName": "office-ui-fabric-react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/office-ui-fabric-react-f0ac52c6-050f-4369-b9ef-0d4bbb005c43.json
+++ b/change/office-ui-fabric-react-f0ac52c6-050f-4369-b9ef-0d4bbb005c43.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Remove explicit readonly semantics from Calendar grid",
+  "comment": "fix: Remove explicit readonly semantics from Calendar grid.",
   "packageName": "office-ui-fabric-react",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -112,7 +112,6 @@ const CalendarYearGridCell = React.forwardRef(
         aria-label={String(year)}
         aria-selected={selected}
         ref={mergedRef}
-        aria-readonly={true} // prevent grid from being "editable"
       >
         {onRenderYear?.(year) ?? year}
       </button>

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -367,7 +367,6 @@ export const CalendarDayGridBase = React.forwardRef(
       <FocusZone className={classNames.wrapper} ref={forwardedRef}>
         <table
           className={classNames.table}
-          aria-readonly="true"
           aria-multiselectable="false"
           aria-labelledby={labelledBy}
           aria-activedescendant={activeDescendantId}

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -230,7 +230,6 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
       onKeyDown={!ariaHidden ? onDayKeyDown : undefined}
       role="gridcell"
       tabIndex={isNavigatedDate ? 0 : undefined}
-      aria-readonly="true"
       aria-current={day.isSelected ? 'date' : undefined}
       aria-selected={day.isInBounds ? day.isSelected : undefined}
       data-is-focusable={!ariaHidden && (allFocusable || (day.isInBounds ? true : undefined))}

--- a/packages/date-time/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
+++ b/packages/date-time/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
@@ -124,7 +124,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
     <table
       aria-activedescendant="id__0"
       aria-multiselectable="false"
-      aria-readonly="true"
       className=
 
           {
@@ -586,7 +585,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -700,7 +698,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -814,7 +811,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -928,7 +924,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -1042,7 +1037,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -1156,7 +1150,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -1270,7 +1263,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -1389,7 +1381,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
         >
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
                 
@@ -1519,7 +1510,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
                 
@@ -1649,7 +1639,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
                 
@@ -1779,7 +1768,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
                 
@@ -1910,7 +1898,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-current="date"
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={true}
             className=
                 
@@ -2083,7 +2070,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
                 
@@ -2209,7 +2195,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
                 
@@ -2351,7 +2336,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -2461,7 +2445,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -2571,7 +2554,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -2681,7 +2663,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -2791,7 +2772,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -2901,7 +2881,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -3011,7 +2990,6 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -3332,7 +3310,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
     <table
       aria-activedescendant="id__0"
       aria-multiselectable="false"
-      aria-readonly="true"
       className=
 
           {
@@ -3794,7 +3771,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -3908,7 +3884,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4022,7 +3997,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4136,7 +4110,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4250,7 +4223,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4364,7 +4336,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4478,7 +4449,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -4597,7 +4567,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
         >
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
                 
@@ -4727,7 +4696,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
                 
@@ -4858,7 +4826,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-current="date"
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={true}
             className=
                 
@@ -5031,7 +4998,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
                 
@@ -5157,7 +5123,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
                 
@@ -5283,7 +5248,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
                 
@@ -5409,7 +5373,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           </td>
           <td
             aria-disabled={false}
-            aria-readonly="true"
             aria-selected={false}
             className=
                 
@@ -5551,7 +5514,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -5661,7 +5623,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -5771,7 +5732,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -5881,7 +5841,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -5991,7 +5950,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -6101,7 +6059,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 
@@ -6211,7 +6168,6 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
           <td
             aria-disabled={false}
             aria-hidden={true}
-            aria-readonly="true"
             aria-selected={false}
             className=
 

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
@@ -203,7 +203,7 @@ export class CalendarMonth extends React.Component<ICalendarMonthProps, ICalenda
           </div>
         </div>
         <FocusZone>
-          <div className={css('ms-DatePicker-optionGrid', styles.optionGrid)} role="grid" aria-readonly="true">
+          <div className={css('ms-DatePicker-optionGrid', styles.optionGrid)} role="grid">
             {rowIndexes.map((rowNum: number) => {
               const monthsForRow = strings.shortMonths.slice(rowNum * MONTHS_PER_ROW, (rowNum + 1) * MONTHS_PER_ROW);
               return (

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -1208,7 +1208,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
               onMouseDownCapture={[Function]}
             >
               <div
-                aria-readonly="true"
                 className="ms-DatePicker-optionGrid"
                 role="grid"
               >


### PR DESCRIPTION
Cherry pick to v7 of #20324, fixes Android Talkback bug.