### PR TITLE
SpinButton: Improve validation handling on step (increment/decrement)

### DIFF
--- a/change/@fluentui-react-23010cf2-999a-4f0a-bcd9-b3f5e2e0ef72.json
+++ b/change/@fluentui-react-23010cf2-999a-4f0a-bcd9-b3f5e2e0ef72.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Improve step handling for invalid intermediate SpinButton values",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/SpinButton/SpinButton.base.tsx
+++ b/packages/react/src/components/SpinButton/SpinButton.base.tsx
@@ -248,7 +248,7 @@ export const SpinButtonBase: React.FunctionComponent<ISpinButtonProps> = React.f
         // Edge case: if intermediateValue is set, this means that the user was editing the input
         // text and then started spinning (either with mouse or keyboard). We need to validate and
         // call onChange before starting to spin.
-        if (ev.type === 'keydown') {
+        if (ev.type === 'keydown' || ev.type === 'mousedown') {
           // For the arrow keys, we have to manually trigger validation.
           // (For the buttons, validation will happen automatically since the input's onBlur will
           // be triggered after mousedown on the button completes.)

--- a/packages/react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react/src/components/SpinButton/SpinButton.test.tsx
@@ -486,6 +486,40 @@ describe('SpinButton', () => {
       expect(onChange.mock.calls[0][1]).toBe('8');
     });
 
+    it('uses last known good value when stepping from invalid value via buttons', () => {
+      wrapper = mount(<SpinButton componentRef={ref} defaultValue="0" />);
+      jest.useFakeTimers();
+
+      const inputDOM = wrapper!.getDOMNode().querySelector('input')!;
+
+      ReactTestUtils.Simulate.focus(inputDOM);
+      ReactTestUtils.Simulate.input(inputDOM, mockEvent('2 2'));
+
+      simulateArrowButton('up');
+      ReactTestUtils.act(() => {
+        jest.runOnlyPendingTimers();
+      });
+
+      verifyValue('1');
+    });
+
+    it('uses last known good value when stepping from invalid value via keyboard', () => {
+      wrapper = mount(<SpinButton componentRef={ref} defaultValue="1" />);
+      jest.useFakeTimers();
+
+      const inputDOM = wrapper!.getDOMNode().querySelector('input')!;
+
+      ReactTestUtils.Simulate.focus(inputDOM);
+      ReactTestUtils.Simulate.input(inputDOM, mockEvent('garbage'));
+
+      simulateArrowKey(KeyCodes.down);
+      ReactTestUtils.act(() => {
+        jest.runOnlyPendingTimers();
+      });
+
+      verifyValue('0');
+    });
+
     it('resets value when input is cleared (empty)', () => {
       const onChange = jest.fn();
       wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" onChange={onChange} />);


### PR DESCRIPTION
## Current Behavior

In `SpinButton`, intermediate values are values that have been manually entered into the text field but not committed (i.e., `onChange` hasn't been called).

Currently, intermediate values are validated when they are stepped via the keyboard (up/down arrows) but not when stepped via the mouse (click on increment/decrement). When clicking to step an invalid intermediate value `SpinButton` gets into a bad state after it loses focus.

![screen recording of current behavior](https://user-images.githubusercontent.com/93940821/179857352-1e20751e-5a9e-4028-bd7f-6784620a842f.gif)


## New Behavior

`SpinButton` validates intermediate values when clicking step buttons.

![screen recording of new behavior](https://user-images.githubusercontent.com/93940821/179857463-877c228d-77e9-4ef6-a71f-6c722b993ad4.gif)


## Related Issue(s)

Fixes #23118
