### PR TITLE
feat: create no-context-default-value lint rule

### DIFF
--- a/change/@fluentui-eslint-plugin-8b1b38b2-2c2b-4b25-b911-1db1b1ead64d.json
+++ b/change/@fluentui-eslint-plugin-8b1b38b2-2c2b-4b25-b911-1db1b1ead64d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Create no-context-default-value lint rule",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-eslint-plugin-8b1b38b2-2c2b-4b25-b911-1db1b1ead64d.json
+++ b/change/@fluentui-eslint-plugin-8b1b38b2-2c2b-4b25-b911-1db1b1ead64d.json
@@ -3,5 +3,5 @@
   "comment": "Create no-context-default-value lint rule",
   "packageName": "@fluentui/eslint-plugin",
   "email": "bernardo.sunderhus@gmail.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@fluentui-global-context-f0018dc4-6cb6-4a51-b428-c227f873bdb9.json
+++ b/change/@fluentui-global-context-f0018dc4-6cb6-4a51-b428-c227f873bdb9.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/global-context",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-global-context-f0018dc4-6cb6-4a51-b428-c227f873bdb9.json
+++ b/change/@fluentui-global-context-f0018dc4-6cb6-4a51-b428-c227f873bdb9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/global-context",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-bc41e0b6-c9c3-48ac-ae08-64c359dd5425.json
+++ b/change/@fluentui-react-accordion-bc41e0b6-c9c3-48ac-ae08-64c359dd5425.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-accordion",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-accordion-bc41e0b6-c9c3-48ac-ae08-64c359dd5425.json
+++ b/change/@fluentui-react-accordion-bc41e0b6-c9c3-48ac-ae08-64c359dd5425.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-accordion",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-3f1c2ff7-0b2c-402c-ad14-aff8d6eb154d.json
+++ b/change/@fluentui-react-avatar-3f1c2ff7-0b2c-402c-ad14-aff8d6eb154d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-avatar",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-3f1c2ff7-0b2c-402c-ad14-aff8d6eb154d.json
+++ b/change/@fluentui-react-avatar-3f1c2ff7-0b2c-402c-ad14-aff8d6eb154d.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-avatar",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-combobox-dbd4e5a1-6884-4e03-9585-6f040c2b3a12.json
+++ b/change/@fluentui-react-combobox-dbd4e5a1-6884-4e03-9585-6f040c2b3a12.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-combobox",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-combobox-dbd4e5a1-6884-4e03-9585-6f040c2b3a12.json
+++ b/change/@fluentui-react-combobox-dbd4e5a1-6884-4e03-9585-6f040c2b3a12.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-combobox",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-context-selector-df8f054a-59af-4d55-89d6-3601b9274404.json
+++ b/change/@fluentui-react-context-selector-df8f054a-59af-4d55-89d6-3601b9274404.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-df8f054a-59af-4d55-89d6-3601b9274404.json
+++ b/change/@fluentui-react-context-selector-df8f054a-59af-4d55-89d6-3601b9274404.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-context-selector",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-menu-66760d83-6ea8-40c8-b814-5714939d32ea.json
+++ b/change/@fluentui-react-menu-66760d83-6ea8-40c8-b814-5714939d32ea.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-menu",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-menu-66760d83-6ea8-40c8-b814-5714939d32ea.json
+++ b/change/@fluentui-react-menu-66760d83-6ea8-40c8-b814-5714939d32ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-overflow-624ce153-8a4c-40a4-945b-c538c12b7264.json
+++ b/change/@fluentui-react-overflow-624ce153-8a4c-40a4-945b-c538c12b7264.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-overflow",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-overflow-624ce153-8a4c-40a4-945b-c538c12b7264.json
+++ b/change/@fluentui-react-overflow-624ce153-8a4c-40a4-945b-c538c12b7264.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-overflow",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-popover-3eb57b7d-a641-4da5-b1ca-a590ea04d28b.json
+++ b/change/@fluentui-react-popover-3eb57b7d-a641-4da5-b1ca-a590ea04d28b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-3eb57b7d-a641-4da5-b1ca-a590ea04d28b.json
+++ b/change/@fluentui-react-popover-3eb57b7d-a641-4da5-b1ca-a590ea04d28b.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-popover",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-portal-compat-context-759ea373-7ea3-4dd8-83f5-0457d84bd983.json
+++ b/change/@fluentui-react-portal-compat-context-759ea373-7ea3-4dd8-83f5-0457d84bd983.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-compat-context-759ea373-7ea3-4dd8-83f5-0457d84bd983.json
+++ b/change/@fluentui-react-portal-compat-context-759ea373-7ea3-4dd8-83f5-0457d84bd983.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-portal-compat-context",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-radio-18a27d29-5084-4f8f-a824-07ab42607717.json
+++ b/change/@fluentui-react-radio-18a27d29-5084-4f8f-a824-07ab42607717.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-radio",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-radio-18a27d29-5084-4f8f-a824-07ab42607717.json
+++ b/change/@fluentui-react-radio-18a27d29-5084-4f8f-a824-07ab42607717.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-radio",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-shared-contexts-62633cc8-c95f-4b5a-8ab8-d40591f3df12.json
+++ b/change/@fluentui-react-shared-contexts-62633cc8-c95f-4b5a-8ab8-d40591f3df12.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-62633cc8-c95f-4b5a-8ab8-d40591f3df12.json
+++ b/change/@fluentui-react-shared-contexts-62633cc8-c95f-4b5a-8ab8-d40591f3df12.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-shared-contexts",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-tabs-4f72d107-6991-4a8d-94b6-fe958f468978.json
+++ b/change/@fluentui-react-tabs-4f72d107-6991-4a8d-94b6-fe958f468978.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-tabs",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-4f72d107-6991-4a8d-94b6-fe958f468978.json
+++ b/change/@fluentui-react-tabs-4f72d107-6991-4a8d-94b6-fe958f468978.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-tabs",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-toolbar-94c82b5e-cf07-43da-addd-a91f61f643d5.json
+++ b/change/@fluentui-react-toolbar-94c82b5e-cf07-43da-addd-a91f61f643d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toolbar-94c82b5e-cf07-43da-addd-a91f61f643d5.json
+++ b/change/@fluentui-react-toolbar-94c82b5e-cf07-43da-addd-a91f61f643d5.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-toolbar",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-utilities-cc620e2e-3558-4121-88b8-f2f0e6ec378c.json
+++ b/change/@fluentui-react-utilities-cc620e2e-3558-4121-88b8-f2f0e6ec378c.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-utilities",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-utilities-cc620e2e-3558-4121-88b8-f2f0e6ec378c.json
+++ b/change/@fluentui-react-utilities-cc620e2e-3558-4121-88b8-f2f0e6ec378c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-window-provider-624ca504-ba28-4731-ae63-71e35aaef66f.json
+++ b/change/@fluentui-react-window-provider-624ca504-ba28-4731-ae63-71e35aaef66f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-window-provider-624ca504-ba28-4731-ae63-71e35aaef66f.json
+++ b/change/@fluentui-react-window-provider-624ca504-ba28-4731-ae63-71e35aaef66f.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "disables eslint rule @fluentui/no-context-default-value",
+  "comment": "disables eslint rule @fluentui/no-context-default-value for local component context",
   "packageName": "@fluentui/react-window-provider",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "none"

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -141,3 +141,32 @@ Ban `tslint:disable` and `tslint:enable` comments.
 Prevent visibility modifiers (`public`, `protected`, `private`) from being specified on class members/methods.
 
 Used in Fluent UI only by [`@fluentui/react-northstar`](https://aka.ms/fluent-ui), not `@fluentui/react`.
+
+### `no-context-default-value`
+
+Restricts usage of default values on React context creation. Imports should be provided to declare where the `createContex` function is coming from.
+
+**Example Configuration:**
+
+```
+"@fluentui/no-context-default-value": [
+  "error",
+  {
+    imports: ["react", "@fluentui/react-context-selector"]
+  }
+]
+```
+
+**❌ Don't**
+
+```ts
+import * as React from 'react';
+const context = React.createContext({ someValue: undefined });
+```
+
+**✅ Do**
+
+```ts
+import * as React from 'react';
+const context = React.createContext(undefined);
+```

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -144,7 +144,7 @@ Used in Fluent UI only by [`@fluentui/react-northstar`](https://aka.ms/fluent-ui
 
 ### `no-context-default-value`
 
-Restricts usage of default values on React context creation. Imports should be provided to declare where the `createContex` function is coming from.
+Restricts usage of default values on React context creation. Imports should be provided to declare where the `createContext` function is coming from. For more information why this is necessary please consult [#23624](https://github.com/microsoft/fluentui/issues/23624)
 
 **Example Configuration:**
 

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -17,7 +17,14 @@ const v9PackageDeps = Object.keys(
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   extends: [path.join(__dirname, 'base'), path.join(__dirname, 'react-config')],
-  rules: {},
+  rules: {
+    '@fluentui/no-context-default-value': [
+      'error',
+      {
+        imports: ['react', '@fluentui/react-context-selector'],
+      },
+    ],
+  },
   overrides: [
     // Enable rules requiring type info only for appropriate files/circumstances
     ...configHelpers.getTypeInfoRuleOverrides(typeAwareRules),

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -21,7 +21,7 @@ module.exports = {
     '@fluentui/no-context-default-value': [
       'error',
       {
-        imports: ['react', '@fluentui/react-context-selector'],
+        imports: ['react', '@fluentui/react-context-selector', '@fluentui/global-context'],
       },
     ],
   },

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'no-tslint-comments': require('./rules/no-tslint-comments'),
     'no-visibility-modifiers': require('./rules/no-visibility-modifiers'),
     'no-restricted-imports': require('./rules/no-restricted-imports'),
+    'no-context-default-value': require('./rules/no-context-default-value'),
   },
 
   // Not a standard eslint thing, just exported for convenience

--- a/packages/eslint-plugin/src/rules/no-context-default-value/index.js
+++ b/packages/eslint-plugin/src/rules/no-context-default-value/index.js
@@ -1,0 +1,121 @@
+// @ts-check
+const { AST_NODE_TYPES } = require('@typescript-eslint/experimental-utils');
+const createRule = require('../../utils/createRule');
+
+/**
+ * @typedef {import("@typescript-eslint/types/dist/ts-estree").ImportDeclaration} ImportDeclaration
+ * @typedef {import("@typescript-eslint/types/dist/ts-estree").CallExpression} CallExpression
+ * @typedef {import("@typescript-eslint/types/dist/ts-estree").Expression} Expression
+ * @typedef {import("@typescript-eslint/types/dist/ts-estree").Identifier} Identifier
+ * @typedef {import("@typescript-eslint/types/dist/ts-estree").LeftHandSideExpression} LeftHandSideExpression
+ *
+ * @typedef {{
+ *   imports: string[]
+ * }} Options
+ *
+ */
+
+module.exports = createRule({
+  name: 'no-context-default-value',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Restricts usage of default values on React context creation',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    messages: {
+      invalidDefaultValue: 'Invalid default value {{argumentValue}} for context declaration',
+      // restrictedImport: 'Import from {{ packageName }} detected which is not allowed.',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          imports: {
+            type: 'array',
+            minItems: 1,
+          },
+        },
+      },
+    ],
+  },
+  defaultOptions: [],
+  create: context => {
+    /** @type {Options[]} */
+    const options = context.options;
+    const { imports } = options[0];
+    /** @type {string[]} */
+    const createContextIdentifiers = [];
+    /** @type {string[]} */
+    const createContextParentIdentifiers = [];
+
+    /**
+     * @param {LeftHandSideExpression} callee
+     */
+    function isCalleeCreateContext(callee) {
+      if (
+        callee.type === AST_NODE_TYPES.MemberExpression &&
+        callee.object.type === AST_NODE_TYPES.Identifier &&
+        createContextParentIdentifiers.includes(callee.object.name) &&
+        callee.property.type === AST_NODE_TYPES.Identifier &&
+        callee.property.name === 'createContext'
+      ) {
+        return true;
+      }
+      if (callee.type === AST_NODE_TYPES.Identifier && createContextIdentifiers.includes(callee.name)) {
+        return true;
+      }
+      return false;
+    }
+
+    return {
+      /**
+       * @param {ImportDeclaration} importDeclaration
+       */
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      ImportDeclaration(importDeclaration) {
+        if (typeof importDeclaration.source.value !== 'string' || !imports.includes(importDeclaration.source.value)) {
+          return;
+        }
+        for (const specifier of importDeclaration.specifiers) {
+          if (
+            specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier ||
+            // I'm assuming here that the default import is just an accumulation of named imports
+            specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier
+          ) {
+            createContextParentIdentifiers.push(specifier.local.name);
+            continue;
+          }
+          if (specifier.type === AST_NODE_TYPES.ImportSpecifier && specifier.imported.name === 'createContext') {
+            createContextIdentifiers.push(specifier.local.name);
+            continue;
+          }
+        }
+      },
+      /**
+       * @param {CallExpression} callExpression
+       */
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      CallExpression(callExpression) {
+        const firstArgument = callExpression.arguments[0];
+        if (isCalleeCreateContext(callExpression.callee) && firstArgument && isArgumentNotUndefined(firstArgument)) {
+          context.report({
+            node: firstArgument,
+            messageId: 'invalidDefaultValue',
+            data: { argumentName: firstArgument.name },
+          });
+        }
+      },
+    };
+  },
+});
+
+/**
+ * @param {Expression} expression
+ * @returns {expression is Identifier}
+ */
+function isArgumentNotUndefined(expression) {
+  return expression.type !== AST_NODE_TYPES.Identifier || expression.name !== 'undefined';
+}

--- a/packages/eslint-plugin/src/rules/no-context-default-value/index.js
+++ b/packages/eslint-plugin/src/rules/no-context-default-value/index.js
@@ -25,8 +25,7 @@ module.exports = createRule({
       recommended: false,
     },
     messages: {
-      invalidDefaultValue: 'Invalid default value {{argumentValue}} for context declaration',
-      // restrictedImport: 'Import from {{ packageName }} detected which is not allowed.',
+      invalidDefaultValue: 'Invalid default value for context declaration, default value should be undefined',
     },
     fixable: 'code',
     schema: [
@@ -104,7 +103,6 @@ module.exports = createRule({
           context.report({
             node: firstArgument,
             messageId: 'invalidDefaultValue',
-            data: { argumentName: firstArgument.name },
           });
         }
       },

--- a/packages/eslint-plugin/src/rules/no-context-default-value/index.test.js
+++ b/packages/eslint-plugin/src/rules/no-context-default-value/index.test.js
@@ -1,0 +1,108 @@
+// @ts-nocheck
+const { ESLintUtils } = require('@typescript-eslint/experimental-utils');
+const rule = require('./index');
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('no-context-default-value', rule, {
+  valid: [
+    {
+      code: `
+        import {createContext as createContext1} from 'react'
+        import {createContext as createContext2} from '@fluenui/react-context-selector'
+        const context1 = createContext1();
+        const context2 = createContext2();
+      `,
+      options: [
+        {
+          imports: ['react', '@fluenui/react-context-selector'],
+        },
+      ],
+    },
+    {
+      code: `
+        import {createContext as createContext1} from 'react'
+        import {createContext as createContext2} from '@fluenui/react-context-selector'
+        const context1 = createContext1(undefined);
+        const context2 = createContext2(undefined);
+      `,
+      options: [
+        {
+          imports: ['react', '@fluenui/react-context-selector'],
+        },
+      ],
+    },
+    {
+      code: `
+        import * as React from 'react'
+        import * as ContextSelector from '@fluenui/react-context-selector'
+        const context1 = React.createContext(undefined);
+        const context2 = ContextSelector.createContext(undefined);
+      `,
+      options: [
+        {
+          imports: ['react', '@fluenui/react-context-selector'],
+        },
+      ],
+    },
+    {
+      code: `
+        import React from 'react'
+        import ContextSelector from '@fluenui/react-context-selector'
+        const context1 = React.createContext(undefined);
+        const context2 = ContextSelector.createContext(undefined);
+      `,
+      options: [
+        {
+          imports: ['react', '@fluenui/react-context-selector'],
+        },
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import {createContext as createContext1} from 'react'
+        import {createContext as createContext2} from '@fluenui/react-context-selector'
+        const context1 = createContext1(defaultValue);
+        const context2 = createContext2(defaultValue);
+      `,
+      options: [
+        {
+          imports: ['react', '@fluenui/react-context-selector'],
+        },
+      ],
+      errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],
+    },
+    {
+      code: `
+        import * as React from 'react'
+        import * as ContextSelector from '@fluentui/react-context-selector'
+        const context1 = React.createContext(defaultValue);
+        const context2 = ContextSelector.createContext(defaultValue);
+      `,
+      options: [
+        {
+          imports: ['react', '@fluentui/react-context-selector'],
+        },
+      ],
+      errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],
+    },
+    {
+      code: `
+        import React from 'react'
+        import ContextSelector from '@fluentui/react-context-selector'
+        const context1 = React.createContext(defaultValue);
+        const context2 = ContextSelector.createContext(defaultValue);
+      `,
+      options: [
+        {
+          imports: ['react', '@fluentui/react-context-selector'],
+        },
+      ],
+      errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/no-context-default-value/index.test.js
+++ b/packages/eslint-plugin/src/rules/no-context-default-value/index.test.js
@@ -17,46 +17,46 @@ ruleTester.run('no-context-default-value', rule, {
       `,
       options: [
         {
-          imports: ['react', '@fluenui/react-context-selector'],
+          imports: ['react', '@fluentui/react-context-selector'],
         },
       ],
     },
     {
       code: `
         import {createContext as createContext1} from 'react'
-        import {createContext as createContext2} from '@fluenui/react-context-selector'
+        import {createContext as createContext2} from '@fluentui/react-context-selector'
         const context1 = createContext1(undefined);
         const context2 = createContext2(undefined);
       `,
       options: [
         {
-          imports: ['react', '@fluenui/react-context-selector'],
+          imports: ['react', '@fluentui/react-context-selector'],
         },
       ],
     },
     {
       code: `
         import * as React from 'react'
-        import * as ContextSelector from '@fluenui/react-context-selector'
+        import * as ContextSelector from '@fluentui/react-context-selector'
         const context1 = React.createContext(undefined);
         const context2 = ContextSelector.createContext(undefined);
       `,
       options: [
         {
-          imports: ['react', '@fluenui/react-context-selector'],
+          imports: ['react', '@fluentui/react-context-selector'],
         },
       ],
     },
     {
       code: `
         import React from 'react'
-        import ContextSelector from '@fluenui/react-context-selector'
+        import ContextSelector from '@fluentui/react-context-selector'
         const context1 = React.createContext(undefined);
         const context2 = ContextSelector.createContext(undefined);
       `,
       options: [
         {
-          imports: ['react', '@fluenui/react-context-selector'],
+          imports: ['react', '@fluentui/react-context-selector'],
         },
       ],
     },
@@ -65,13 +65,13 @@ ruleTester.run('no-context-default-value', rule, {
     {
       code: `
         import {createContext as createContext1} from 'react'
-        import {createContext as createContext2} from '@fluenui/react-context-selector'
+        import {createContext as createContext2} from '@fluentui/react-context-selector'
         const context1 = createContext1(null);
         const context2 = createContext2(null);
       `,
       options: [
         {
-          imports: ['react', '@fluenui/react-context-selector'],
+          imports: ['react', '@fluentui/react-context-selector'],
         },
       ],
       errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],
@@ -79,13 +79,13 @@ ruleTester.run('no-context-default-value', rule, {
     {
       code: `
         import {createContext as createContext1} from 'react'
-        import {createContext as createContext2} from '@fluenui/react-context-selector'
+        import {createContext as createContext2} from '@fluentui/react-context-selector'
         const context1 = createContext1({});
         const context2 = createContext2({});
       `,
       options: [
         {
-          imports: ['react', '@fluenui/react-context-selector'],
+          imports: ['react', '@fluentui/react-context-selector'],
         },
       ],
       errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],
@@ -93,13 +93,13 @@ ruleTester.run('no-context-default-value', rule, {
     {
       code: `
         import {createContext as createContext1} from 'react'
-        import {createContext as createContext2} from '@fluenui/react-context-selector'
+        import {createContext as createContext2} from '@fluentui/react-context-selector'
         const context1 = createContext1(defaultValue);
         const context2 = createContext2(defaultValue);
       `,
       options: [
         {
-          imports: ['react', '@fluenui/react-context-selector'],
+          imports: ['react', '@fluentui/react-context-selector'],
         },
       ],
       errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],

--- a/packages/eslint-plugin/src/rules/no-context-default-value/index.test.js
+++ b/packages/eslint-plugin/src/rules/no-context-default-value/index.test.js
@@ -11,7 +11,7 @@ ruleTester.run('no-context-default-value', rule, {
     {
       code: `
         import {createContext as createContext1} from 'react'
-        import {createContext as createContext2} from '@fluenui/react-context-selector'
+        import {createContext as createContext2} from '@fluentui/react-context-selector'
         const context1 = createContext1();
         const context2 = createContext2();
       `,

--- a/packages/eslint-plugin/src/rules/no-context-default-value/index.test.js
+++ b/packages/eslint-plugin/src/rules/no-context-default-value/index.test.js
@@ -66,6 +66,34 @@ ruleTester.run('no-context-default-value', rule, {
       code: `
         import {createContext as createContext1} from 'react'
         import {createContext as createContext2} from '@fluenui/react-context-selector'
+        const context1 = createContext1(null);
+        const context2 = createContext2(null);
+      `,
+      options: [
+        {
+          imports: ['react', '@fluenui/react-context-selector'],
+        },
+      ],
+      errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],
+    },
+    {
+      code: `
+        import {createContext as createContext1} from 'react'
+        import {createContext as createContext2} from '@fluenui/react-context-selector'
+        const context1 = createContext1({});
+        const context2 = createContext2({});
+      `,
+      options: [
+        {
+          imports: ['react', '@fluenui/react-context-selector'],
+        },
+      ],
+      errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],
+    },
+    {
+      code: `
+        import {createContext as createContext1} from 'react'
+        import {createContext as createContext2} from '@fluenui/react-context-selector'
         const context1 = createContext1(defaultValue);
         const context2 = createContext2(defaultValue);
       `,

--- a/packages/react-components/global-context/src/global-context-selector.ts
+++ b/packages/react-components/global-context/src/global-context-selector.ts
@@ -45,6 +45,7 @@ export const createContext = <T>(defaultValue: T, name: string, packageName: str
   const globalSymbols = Object.getOwnPropertySymbols(globalObject);
   if (!globalSymbols.includes(sym)) {
     // @ts-expect-error - Indexing object with symbols not supported until TS 4.4
+    // eslint-disable-next-line @fluentui/no-context-default-value
     globalObject[sym] = baseCreateContext(defaultValue);
   }
 

--- a/packages/react-components/global-context/src/global-context.ts
+++ b/packages/react-components/global-context/src/global-context.ts
@@ -44,6 +44,7 @@ export const createContext = <T>(defaultValue: T, name: string, packageName: str
   const globalSymbols = Object.getOwnPropertySymbols(globalObject);
   if (!globalSymbols.includes(sym)) {
     // @ts-expect-error - Indexing object with symbols not supported until TS 4.4
+    // eslint-disable-next-line @fluentui/no-context-default-value
     globalObject[sym] = React.createContext(defaultValue);
   }
 

--- a/packages/react-components/react-accordion/src/components/Accordion/AccordionContext.ts
+++ b/packages/react-components/react-accordion/src/components/Accordion/AccordionContext.ts
@@ -2,6 +2,7 @@ import { createContext, ContextSelector, useContextSelector } from '@fluentui/re
 import type { Context } from '@fluentui/react-context-selector';
 import type { AccordionContextValue } from './Accordion.types';
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const AccordionContext: Context<AccordionContextValue> = createContext<AccordionContextValue>({
   openItems: [],
   collapsible: false,

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/AccordionHeaderContext.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/AccordionHeaderContext.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { AccordionHeaderContextValue } from './AccordionHeader.types';
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const AccordionHeaderContext = React.createContext<AccordionHeaderContextValue>({
   open: false,
   disabled: false,

--- a/packages/react-components/react-accordion/src/components/AccordionItem/AccordionItemContext.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionItem/AccordionItemContext.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { AccordionItemContextValue } from './AccordionItem.types';
 
 // No default value.
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const AccordionItemContext = React.createContext<AccordionItemContextValue>({
   onHeaderClick() {
     /** */

--- a/packages/react-components/react-avatar/src/contexts/AvatarGroupContext.ts
+++ b/packages/react-components/react-avatar/src/contexts/AvatarGroupContext.ts
@@ -5,4 +5,5 @@ import type { AvatarGroupContextValue } from './AvatarGroupContext.types';
 /**
  * AvatarGroupContext is provided by AvatarGroup, and is consumed by Avatar to determine default values of some props.
  */
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const AvatarGroupContext: Context<AvatarGroupContextValue> = createContext({});

--- a/packages/react-components/react-combobox/src/contexts/ComboboxContext.ts
+++ b/packages/react-components/react-combobox/src/contexts/ComboboxContext.ts
@@ -9,6 +9,7 @@ export type ComboboxContextValue = Pick<
   'activeOption' | 'appearance' | 'onOptionClick' | 'open' | 'registerOption' | 'selectedOptions' | 'size'
 >;
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const ComboboxContext = createContext<ComboboxContextValue>({
   activeOption: undefined,
   appearance: 'outline',

--- a/packages/react-components/react-combobox/src/contexts/ListboxContext.ts
+++ b/packages/react-components/react-combobox/src/contexts/ListboxContext.ts
@@ -9,6 +9,7 @@ export type ListboxContextValue = Pick<
   'activeOption' | 'multiselect' | 'onOptionClick' | 'registerOption' | 'selectedOptions'
 >;
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const ListboxContext = createContext<ListboxContextValue>({
   activeOption: undefined,
   multiselect: false,

--- a/packages/react-components/react-context-selector/src/createContext.ts
+++ b/packages/react-components/react-context-selector/src/createContext.ts
@@ -48,6 +48,7 @@ const createProvider = <Value>(Original: React.Provider<ContextValue<Value>>) =>
  * @internal
  */
 export const createContext = <Value>(defaultValue: Value): Context<Value> => {
+  // eslint-disable-next-line @fluentui/no-context-default-value
   const context = React.createContext<ContextValue<Value>>({
     value: { current: defaultValue },
     version: { current: -1 },

--- a/packages/react-components/react-menu/src/contexts/menuContext.ts
+++ b/packages/react-components/react-menu/src/contexts/menuContext.ts
@@ -4,6 +4,7 @@ import type { ContextSelector, Context } from '@fluentui/react-context-selector'
 import type { MenuListProps } from '../components/index';
 import type { MenuState } from '../components/Menu/index';
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const MenuContext: Context<MenuContextValue> = createContext<MenuContextValue>({
   open: false,
   setOpen: () => false,

--- a/packages/react-components/react-menu/src/contexts/menuGroupContext.ts
+++ b/packages/react-components/react-menu/src/contexts/menuGroupContext.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 const MenuGroupContext = React.createContext<MenuGroupContextValue>({ headerId: '' });
 
 /**

--- a/packages/react-components/react-menu/src/contexts/menuListContext.tsx
+++ b/packages/react-components/react-menu/src/contexts/menuListContext.tsx
@@ -4,6 +4,7 @@ import type { ContextSelector, Context } from '@fluentui/react-context-selector'
 import type { SelectableHandler } from '../selectable/index';
 import type { MenuListProps } from '../components/index';
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const MenuListContext: Context<MenuListContextValue> = createContext<MenuListContextValue>({
   checkedValues: {},
   onCheckedValueChange: () => null,

--- a/packages/react-components/react-menu/src/contexts/menuTriggerContext.ts
+++ b/packages/react-components/react-menu/src/contexts/menuTriggerContext.ts
@@ -1,11 +1,10 @@
 import * as React from 'react';
 
-const newLocal = false;
 /**
  * Context used communicate with a child menu item that it is a trigger for a submenu
  */
 // eslint-disable-next-line @fluentui/no-context-default-value
-const MenuTriggerContext = React.createContext<boolean>(newLocal);
+const MenuTriggerContext = React.createContext<boolean>(false);
 
 export const MenuTriggerContextProvider = MenuTriggerContext.Provider;
 export const useMenuTriggerContext_unstable = () => React.useContext(MenuTriggerContext);

--- a/packages/react-components/react-menu/src/contexts/menuTriggerContext.ts
+++ b/packages/react-components/react-menu/src/contexts/menuTriggerContext.ts
@@ -1,9 +1,11 @@
 import * as React from 'react';
 
+const newLocal = false;
 /**
  * Context used communicate with a child menu item that it is a trigger for a submenu
  */
-const MenuTriggerContext = React.createContext<boolean>(false);
+// eslint-disable-next-line @fluentui/no-context-default-value
+const MenuTriggerContext = React.createContext<boolean>(newLocal);
 
 export const MenuTriggerContextProvider = MenuTriggerContext.Provider;
 export const useMenuTriggerContext_unstable = () => React.useContext(MenuTriggerContext);

--- a/packages/react-components/react-overflow/src/overflowContext.ts
+++ b/packages/react-components/react-overflow/src/overflowContext.ts
@@ -9,6 +9,7 @@ export interface OverflowContextValue {
   updateOverflow: (padding?: number) => void;
 }
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const OverflowContext = createContext<OverflowContextValue>({
   itemVisibility: {},
   groupVisibility: {},

--- a/packages/react-components/react-popover/src/popoverContext.ts
+++ b/packages/react-components/react-popover/src/popoverContext.ts
@@ -2,6 +2,7 @@ import { createContext, useContextSelector } from '@fluentui/react-context-selec
 import type { ContextSelector, Context } from '@fluentui/react-context-selector';
 import type { PopoverState } from './components/Popover/index';
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const PopoverContext: Context<PopoverContextValue> = createContext<PopoverContextValue>({
   open: false,
   setOpen: () => null,

--- a/packages/react-components/react-portal-compat-context/src/PortalCompatContext.ts
+++ b/packages/react-components/react-portal-compat-context/src/PortalCompatContext.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { RegisterPortalFn } from './types';
 
 const PortalCompatContext = React.createContext<RegisterPortalFn>(
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  // eslint-disable-next-line @typescript-eslint/no-empty-function, @fluentui/no-context-default-value
   () => () => {},
 );
 

--- a/packages/react-components/react-radio/src/contexts/RadioGroupContext.ts
+++ b/packages/react-components/react-radio/src/contexts/RadioGroupContext.ts
@@ -5,6 +5,7 @@ import type { RadioGroupContextValue } from '../RadioGroup';
 /**
  * RadioGroupContext is provided by RadioGroup, and is consumed by Radio to determine default values of some props.
  */
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const RadioGroupContext: Context<RadioGroupContextValue> = createContext({});
 
 export const RadioGroupProvider = RadioGroupContext.Provider;

--- a/packages/react-components/react-shared-contexts/src/ProviderContext/ProviderContext.ts
+++ b/packages/react-components/react-shared-contexts/src/ProviderContext/ProviderContext.ts
@@ -11,6 +11,7 @@ export type ProviderContextValue = {
 /**
  * @internal
  */
+// eslint-disable-next-line @fluentui/no-context-default-value
 const ProviderContext = React.createContext<ProviderContextValue>({
   targetDocument: typeof document === 'object' ? document : undefined,
   dir: 'ltr',

--- a/packages/react-components/react-shared-contexts/src/ThemeClassNameContext/ThemeClassNameContext.ts
+++ b/packages/react-components/react-shared-contexts/src/ThemeClassNameContext/ThemeClassNameContext.ts
@@ -8,6 +8,7 @@ export type ThemeClassNameContextValue = string;
  *
  * Useful for elements in the React tree (can read context) but not in the DOM Tree. E.g. Portals
  */
+// eslint-disable-next-line @fluentui/no-context-default-value
 const ThemeClassNameContext = React.createContext<ThemeClassNameContextValue>('');
 
 export const ThemeClassNameProvider = ThemeClassNameContext.Provider;

--- a/packages/react-components/react-shared-contexts/src/TooltipVisibilityContext/TooltipContext.ts
+++ b/packages/react-components/react-shared-contexts/src/TooltipVisibilityContext/TooltipContext.ts
@@ -18,6 +18,7 @@ export type TooltipVisibilityContextValue = {
  * @internal
  * Context shared by all of the tooltips in the app
  */
+// eslint-disable-next-line @fluentui/no-context-default-value
 const TooltipVisibilityContext = React.createContext<TooltipVisibilityContextValue>({});
 
 /**

--- a/packages/react-components/react-tabs/src/components/TabList/TabListContext.ts
+++ b/packages/react-components/react-tabs/src/components/TabList/TabListContext.ts
@@ -2,6 +2,7 @@ import { createContext } from '@fluentui/react-context-selector';
 import type { Context } from '@fluentui/react-context-selector';
 import { TabListContextValue } from './TabList.types';
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const TabListContext: Context<TabListContextValue> = createContext<TabListContextValue>({
   appearance: 'transparent',
   disabled: false,

--- a/packages/react-components/react-toolbar/src/components/Toolbar/ToolbarContext.tsx
+++ b/packages/react-components/react-toolbar/src/components/Toolbar/ToolbarContext.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { ToolbarContextValue } from './Toolbar.types';
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const ToolbarContext = React.createContext<ToolbarContextValue>({
   size: 'medium',
 });

--- a/packages/react-components/react-utilities/src/ssr/SSRContext.tsx
+++ b/packages/react-components/react-utilities/src/ssr/SSRContext.tsx
@@ -20,6 +20,7 @@ export const defaultSSRContextValue: SSRContextValue = {
   current: 0,
 };
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const SSRContext = React.createContext<SSRContextValue>(defaultSSRContextValue);
 
 /**

--- a/packages/react-components/theme-designer/src/ThemeDesigner.tsx
+++ b/packages/react-components/theme-designer/src/ThemeDesigner.tsx
@@ -13,6 +13,7 @@ export type AppContextValue = {
   dispatchAppState: React.Dispatch<DispatchTheme>;
 };
 
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const AppContext = createContext<AppContextValue>({
   appState: initialAppState,
   dispatchAppState: () => null,

--- a/packages/react-window-provider/src/WindowProvider.tsx
+++ b/packages/react-window-provider/src/WindowProvider.tsx
@@ -13,6 +13,7 @@ export type WindowProviderProps = {
 /**
  * Context for providing the window.
  */
+// eslint-disable-next-line @fluentui/no-context-default-value
 export const WindowContext = React.createContext<WindowProviderProps>({
   window: typeof window === 'object' ? window : undefined,
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

As stated at #23987, `createContext` should receive `undefined` as it's default value.

This PR does:

1. Creates new ESLint rule to ensure desired behaviors on `createContext`
2. Updates every single usage of `createContext` on v9 to contain a comment to disable the new rule

```tsx
// before ❌
const MenuTriggerContext = React.createContext<boolean>(false);

// after ✅
// eslint-disable-next-line @fluentui/no-context-default-value
const MenuTriggerContext = React.createContext<boolean>(false);
```

Fixes #23987 