### PR TITLE
chore(eslint-plugin): upgrade error level of no-restricted-imports in v9 config

### DIFF
--- a/apps/vr-tests-react-components/.eslintrc.json
+++ b/apps/vr-tests-react-components/.eslintrc.json
@@ -5,6 +5,7 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/jsx-no-bind": "off",
     "deprecation/deprecation": "off",
+    "@fluentui/no-restricted-imports": "off",
     "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../.."] }]
   }
 }

--- a/apps/vr-tests-react-components/.eslintrc.json
+++ b/apps/vr-tests-react-components/.eslintrc.json
@@ -2,10 +2,10 @@
   "extends": ["plugin:@fluentui/eslint-plugin/react"],
   "root": true,
   "rules": {
+    "@fluentui/no-restricted-imports": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/jsx-no-bind": "off",
     "deprecation/deprecation": "off",
-    "@fluentui/no-restricted-imports": "off",
     "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../.."] }]
   }
 }

--- a/change/@fluentui-eslint-plugin-75882078-3d30-465e-b1b8-c6ecbf8c7c71.json
+++ b/change/@fluentui-eslint-plugin-75882078-3d30-465e-b1b8-c6ecbf8c7c71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: upgrade error level of no-restricted-imports to error in v9 config.",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -25,7 +25,7 @@ module.exports = {
       files: '**/*.stories.tsx',
       rules: {
         '@fluentui/no-restricted-imports': [
-          'warn',
+          'error',
           {
             paths: [
               {


### PR DESCRIPTION
### Changes:
- upgrades error level of `no-restricted-imports` to `error` in v9 config
- turns off `no-restricted-imports` rule for v9 vr-tests since this convention is not necessary in that package.

Part of #23846