### PR TITLE
Aria: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-aria/src/hooks/useARIAButton.stories.tsx
+++ b/packages/react-components/react-aria/src/hooks/useARIAButton.stories.tsx
@@ -1,7 +1,7 @@
-import { getSlots } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { useARIAButton } from './useARIAButton';
-import type { ComponentState, Slot } from '@fluentui/react-utilities';
+import { getSlots } from '@fluentui/react-components';
+import type { ComponentState, Slot } from '@fluentui/react-components';
 import type { ARIAButtonSlotProps } from './useARIAButton';
 
 type Slots = {


### PR DESCRIPTION
### Changes
- updates `react-aria` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846