### PR TITLE
Combobox: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxAppearance.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxAppearance.stories.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
-import { useId } from '@fluentui/react-utilities';
-import { Combobox, ComboboxProps, Option } from '@fluentui/react-combobox';
-import { tokens } from '@fluentui/react-theme';
+import { makeStyles, shorthands, tokens, useId } from '@fluentui/react-components';
+import { Combobox, Option } from '@fluentui/react-combobox';
+import type { ComboboxProps } from '@fluentui/react-combobox';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxCustomOptions.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxCustomOptions.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { useId } from '@fluentui/react-utilities';
+import { makeStyles, shorthands, useId } from '@fluentui/react-components';
 import { CheckmarkCircle20Filled } from '@fluentui/react-icons';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Combobox, ComboboxProps, Option, OptionProps, OptionGroup, OptionGroupProps } from '@fluentui/react-combobox';
+import { Combobox, Option, OptionGroup } from '@fluentui/react-combobox';
+import type { ComboboxProps, OptionProps, OptionGroupProps } from '@fluentui/react-combobox';
 
 const CustomOption = (props: OptionProps) => {
   return <Option {...props} checkIcon={<CheckmarkCircle20Filled />} />;

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxDefault.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxDefault.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Combobox, ComboboxProps, Option } from '@fluentui/react-combobox';
+import { makeStyles, shorthands, useId } from '@fluentui/react-components';
+import { Combobox, Option } from '@fluentui/react-combobox';
+import type { ComboboxProps } from '@fluentui/react-combobox';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxGrouped.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxGrouped.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Combobox, ComboboxProps, Option, OptionGroup } from '@fluentui/react-combobox';
+import { makeStyles, shorthands, useId } from '@fluentui/react-components';
+import { Combobox, Option, OptionGroup } from '@fluentui/react-combobox';
+import type { ComboboxProps } from '@fluentui/react-combobox';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxMultiselect.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxMultiselect.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Combobox, ComboboxProps, Option } from '@fluentui/react-combobox';
+import { makeStyles, shorthands, useId } from '@fluentui/react-components';
+import { Combobox, Option } from '@fluentui/react-combobox';
+import type { ComboboxProps } from '@fluentui/react-combobox';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxSize.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxSize.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Combobox, ComboboxProps, Option } from '@fluentui/react-combobox';
-import { useId } from '@fluentui/react-utilities';
+import { makeStyles, shorthands, useId } from '@fluentui/react-components';
+import { Combobox, Option } from '@fluentui/react-combobox';
+import type { ComboboxProps } from '@fluentui/react-combobox';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-combobox/src/stories/Dropdown/DropdownDefault.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Dropdown/DropdownDefault.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, shorthands } from '@griffel/react';
-import { Dropdown, DropdownProps, Option } from '@fluentui/react-combobox';
+import { makeStyles, shorthands, useId } from '@fluentui/react-components';
+import { Dropdown, Option } from '@fluentui/react-combobox';
+import type { DropdownProps } from '@fluentui/react-combobox';
 
 const useStyles = makeStyles({
   root: {


### PR DESCRIPTION
### Changes
- updates `react-combobox` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846