### PR TITLE
Portal: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-portal/src/stories/Portal/PortalDefault.stories.tsx
+++ b/packages/react-components/react-portal/src/stories/Portal/PortalDefault.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
+import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
 
 import { Portal } from '@fluentui/react-portal';
 

--- a/packages/react-components/react-portal/src/stories/Portal/PortalNested.stories.tsx
+++ b/packages/react-components/react-portal/src/stories/Portal/PortalNested.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
+import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
 
 import { Portal } from '@fluentui/react-portal';
 


### PR DESCRIPTION
### Changes
- updates `react-portal` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846