### PR TITLE
Toolbar: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarOverflow.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarOverflow.stories.tsx
@@ -14,8 +14,8 @@ import {
   useIsOverflowItemVisible,
   useIsOverflowGroupVisible,
 } from '@fluentui/react-overflow';
-import { Menu, MenuTrigger, MenuPopover, MenuList, MenuItem, MenuItemProps, MenuDivider } from '@fluentui/react-menu';
-import { Button } from '@fluentui/react-button';
+import { Button, Menu, MenuDivider, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-components';
+import type { MenuItemProps } from '@fluentui/react-components';
 
 export interface ToolbarOverflowMenuItemProps extends Omit<MenuItemProps, 'id'> {
   id: string;

--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarWithPopover.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarWithPopover.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Toolbar, ToolbarButton, ToolbarDivider } from '@fluentui/react-toolbar';
 import type { ToolbarProps } from '@fluentui/react-toolbar';
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
+import { Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
 import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 export const WithPopover = (props: Partial<ToolbarProps>) => (

--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarWithTooltip.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarWithTooltip.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Toolbar, ToolbarButton, ToolbarDivider } from '@fluentui/react-toolbar';
 import type { ToolbarProps } from '@fluentui/react-toolbar';
-import { Tooltip } from '@fluentui/react-tooltip';
+import { Tooltip } from '@fluentui/react-components';
 import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 export const WithTooltip = (props: Partial<ToolbarProps>) => (


### PR DESCRIPTION
### Changes
- updates `react-toolbar` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846