### PR TITLE
fix: Tagpicker remove button labels

### DIFF
--- a/change/@fluentui-react-db0248f0-0d58-4c5a-9e12-24fd187cab31.json
+++ b/change/@fluentui-react-db0248f0-0d58-4c5a-9e12-24fd187cab31.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: TagPicker no longer reads remove when narrating list of selected tags",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/TagPicker/TagItem.tsx
+++ b/packages/react/src/components/pickers/TagPicker/TagItem.tsx
@@ -57,10 +57,12 @@ export const TagItemBase = (props: ITagItemProps) => {
         iconProps={removeButtonIconProps ?? { iconName: 'Cancel' }}
         styles={{ icon: { fontSize: '12px' } }}
         className={classNames.close}
-        ariaLabel={removeButtonAriaLabel}
-        aria-labelledby={`${itemId} ${itemId}-text`}
+        aria-labelledby={`${itemId}-removeLabel ${itemId}-text`}
         data-selection-index={index}
       />
+      <span id={`${itemId}-removeLabel`} hidden>
+        {removeButtonAriaLabel}
+      </span>
     </div>
   );
 };

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`TagItem accepts title override 1`] = `
     Red
   </span>
   <button
-    aria-labelledby="id__0 id__0-text"
+    aria-labelledby="id__0-removeLabel id__0-text"
     className=
         ms-Button
         ms-Button--icon
@@ -218,6 +218,10 @@ exports[`TagItem accepts title override 1`] = `
       </i>
     </span>
   </button>
+  <span
+    hidden={true}
+    id="id__0-removeLabel"
+  />
 </div>
 `;
 
@@ -324,7 +328,7 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
     </i>
   </span>
   <button
-    aria-labelledby="id__0 id__0-text"
+    aria-labelledby="id__0-removeLabel id__0-text"
     className=
         ms-Button
         ms-Button--icon
@@ -463,6 +467,10 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
       </i>
     </span>
   </button>
+  <span
+    hidden={true}
+    id="id__0-removeLabel"
+  />
 </div>
 `;
 
@@ -545,7 +553,7 @@ exports[`TagItem renders correctly 1`] = `
     Red color
   </span>
   <button
-    aria-labelledby="id__0 id__0-text"
+    aria-labelledby="id__0-removeLabel id__0-text"
     className=
         ms-Button
         ms-Button--icon
@@ -684,5 +692,9 @@ exports[`TagItem renders correctly 1`] = `
       </i>
     </span>
   </button>
+  <span
+    hidden={true}
+    id="id__0-removeLabel"
+  />
 </div>
 `;

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`TagPicker renders correctly 1`] = `
             black
           </span>
           <button
-            aria-labelledby="id__1 id__1-text"
+            aria-labelledby="id__1-removeLabel id__1-text"
             className=
                 ms-Button
                 ms-Button--icon
@@ -295,6 +295,10 @@ exports[`TagPicker renders correctly 1`] = `
               </i>
             </span>
           </button>
+          <span
+            hidden={true}
+            id="id__1-removeLabel"
+          />
         </div>
       </span>
       <input
@@ -545,7 +549,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
             text
           </span>
           <button
-            aria-labelledby="id__1 id__1-text"
+            aria-labelledby="id__1-removeLabel id__1-text"
             className=
                 ms-Button
                 ms-Button--icon
@@ -684,6 +688,10 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
               </i>
             </span>
           </button>
+          <span
+            hidden={true}
+            id="id__1-removeLabel"
+          />
         </div>
       </span>
       <input


### PR DESCRIPTION
Fixes [14305](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/14305)

This uses sneaky `aria-labelledby` logic to get the TagPicker input to not use the "remove" text in its description calculation, while maintaining the button label of "Remove X".

Essentially by referencing the "remove" text via `aria-labelledby` instead of `aria-label`, it's not picked up in the input's `aria-describedby` calculation (taking advantage of the fact that id references aren't followed multiple levels deep).