### PR TITLE
Nav: add role prop

### DIFF
--- a/change/@fluentui-react-a8002da9-4136-42aa-bac3-8d4456b5f98a.json
+++ b/change/@fluentui-react-a8002da9-4136-42aa-bac3-8d4456b5f98a.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Nav: add role property to override navigation ARIA role",
+  "comment": "feat(Nav): Add role property to override navigation ARIA role.",
   "packageName": "@fluentui/react",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-a8002da9-4136-42aa-bac3-8d4456b5f98a.json
+++ b/change/@fluentui-react-a8002da9-4136-42aa-bac3-8d4456b5f98a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Nav: add role property to override navigation ARIA role",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6964,6 +6964,7 @@ export interface INavProps {
     onLinkExpandClick?: (ev?: React_2.MouseEvent<HTMLElement>, item?: INavLink) => void;
     onRenderGroupHeader?: IRenderFunction<IRenderGroupHeaderProps>;
     onRenderLink?: IRenderFunction<INavLink>;
+    role?: string;
     // @deprecated
     selectedAriaLabel?: string;
     selectedKey?: string;

--- a/packages/react/src/components/Nav/Nav.base.tsx
+++ b/packages/react/src/components/Nav/Nav.base.tsx
@@ -57,7 +57,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
   }
 
   public render(): JSX.Element | null {
-    const { styles, groups, className, isOnTop, theme } = this.props;
+    const { styles, groups, className, isOnTop, role = 'navigation', theme } = this.props;
 
     if (!groups) {
       return null;
@@ -69,7 +69,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
 
     return (
       <FocusZone direction={FocusZoneDirection.vertical} componentRef={this._focusZone} {...this.props.focusZoneProps}>
-        <nav role="navigation" className={classNames.root} aria-label={this.props.ariaLabel}>
+        <nav role={role} className={classNames.root} aria-label={this.props.ariaLabel}>
           {groupElements}
         </nav>
       </FocusZone>

--- a/packages/react/src/components/Nav/Nav.types.ts
+++ b/packages/react/src/components/Nav/Nav.types.ts
@@ -103,6 +103,12 @@ export interface INavProps {
   initialSelectedKey?: string;
 
   /**
+   * (Optional) Override the role of the `<nav>` element.
+   * This is only recommended if you're nesting `Nav` inside a parent navigation region.
+   */
+  role?: string;
+
+  /**
    * (Optional) The key of the nav item selected by caller.
    */
   selectedKey?: string;


### PR DESCRIPTION
Fixes #24011

Adds a role prop to v8 Nav so teams can override the default `navigation` role to nest it within a parent navigation region.