### PR TITLE
theme designer: fixed the bug where custom theme overrides would not reset after brand ramp is changed

### DIFF
--- a/packages/react-components/theme-designer/src/components/ColorTokens/ColorTokens.tsx
+++ b/packages/react-components/theme-designer/src/components/ColorTokens/ColorTokens.tsx
@@ -71,7 +71,7 @@ export const ColorTokens: React.FunctionComponent<ColorTokensProps> = props => {
       case 'Reset Overrides':
         return { ...state, [themeLabel]: {} };
       case 'Reset Custom Overrides':
-        return { ...state, customLight: {}, customDark: {} };
+        return { ...state, [themeName + 'Light']: {}, [themeName + 'Dark']: {} };
       default:
         return state;
     }
@@ -88,6 +88,19 @@ export const ColorTokens: React.FunctionComponent<ColorTokensProps> = props => {
     dispatchAppState({ type: 'Override' });
     dispatchColorOverride({ type: 'Reset Overrides' });
   };
+
+  React.useEffect(() => {
+    // if app state overrides are reset (no entries), we want to reset local overrides if they exist
+    if (
+      (Object.keys(colorOverride[themeName + 'Light']).length > 0 ||
+        Object.keys(colorOverride[themeName + 'Dark']).length > 0) &&
+      Object.keys(appState.lightOverrides).length === 0 &&
+      Object.keys(appState.darkOverrides).length === 0
+    ) {
+      dispatchAppState({ type: 'Override' });
+      dispatchColorOverride({ type: 'Reset Custom Overrides' });
+    }
+  }, [appState]);
 
   return (
     <div className={styles.root}>

--- a/packages/react-components/theme-designer/src/components/ColorTokens/ColorTokens.tsx
+++ b/packages/react-components/theme-designer/src/components/ColorTokens/ColorTokens.tsx
@@ -100,7 +100,7 @@ export const ColorTokens: React.FunctionComponent<ColorTokensProps> = props => {
       dispatchAppState({ type: 'Override' });
       dispatchColorOverride({ type: 'Reset Custom Overrides' });
     }
-  }, [appState]);
+  }, [appState]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className={styles.root}>

--- a/packages/react-components/theme-designer/src/components/Sidebar/Form.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/Form.tsx
@@ -59,7 +59,18 @@ export const Form: React.FC<FormProps> = props => {
 
   const formReducer = (state: CustomAttributes, action: { attributes: CustomAttributes }) => {
     setFormState(action.attributes);
-    dispatchAppState({ ...form, type: 'Custom', customAttributes: action.attributes });
+
+    // returns true if form is the same
+    const sameForm =
+      state.keyColor === action.attributes.keyColor &&
+      state.hueTorsion === action.attributes.hueTorsion &&
+      state.darkCp === action.attributes.darkCp &&
+      state.lightCp === action.attributes.lightCp;
+
+    // only dispatch if form changes
+    if (!sameForm) {
+      dispatchAppState({ ...form, type: 'Custom', customAttributes: action.attributes });
+    }
     return action.attributes;
   };
 

--- a/packages/react-components/theme-designer/src/components/Sidebar/Sidebar.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/Sidebar.tsx
@@ -81,6 +81,7 @@ export const Sidebar: React.FC<SidebarProps> = props => {
 
   const [tab, setTab] = React.useState<TabValue>('use');
   const handleTabChange = (event: SelectTabEvent, data: SelectTabData) => {
+    // this is outdated, but i'm going to leave it until arman gives me more clarity on what the sidebar will look like
     if (data.value === 'edit') {
       dispatchAppState({ type: 'Custom', customAttributes: formState, overrides: {} });
     } else if (data.value === 'use') {

--- a/packages/react-components/theme-designer/src/useThemeDesignerReducer.ts
+++ b/packages/react-components/theme-designer/src/useThemeDesignerReducer.ts
@@ -4,7 +4,6 @@ import { getBrandTokensFromPalette } from './utils/getBrandTokensFromPalette';
 import { brandTeams } from './utils/brandColors';
 import type { BrandVariants, Theme } from '@fluentui/react-components';
 import { themeList, themeNames } from './utils/themeList';
-import { brandRamp } from './components/ColorTokens/getOverridableTokenBrandColors';
 
 export type CustomAttributes = {
   keyColor: string;
@@ -107,23 +106,10 @@ export const useThemeDesignerReducer = () => {
       if (!action.customAttributes) {
         return state;
       }
-      const newBrand = createCustomTheme(action.customAttributes);
+      brand = createCustomTheme(action.customAttributes);
 
-      const sameBrand = brandRamp
-        .map(num => {
-          return state.brand[num] === newBrand[num];
-        })
-        .reduce((prev, curr) => {
-          return prev && curr;
-        });
-
-      // check if the previous theme is also custom, if it is but the brand changes, clear overrides
-      if (!themeList[state.themeName].brand && !sameBrand) {
-        dispatchOverrideState({ type: themeName + 'Light' });
-        dispatchOverrideState({ type: themeName + 'Dark' });
-      }
-
-      brand = newBrand;
+      dispatchOverrideState({ type: themeName + 'Light' });
+      dispatchOverrideState({ type: themeName + 'Dark' });
     }
 
     return {

--- a/packages/react-components/theme-designer/src/useThemeDesignerReducer.ts
+++ b/packages/react-components/theme-designer/src/useThemeDesignerReducer.ts
@@ -4,6 +4,7 @@ import { getBrandTokensFromPalette } from './utils/getBrandTokensFromPalette';
 import { brandTeams } from './utils/brandColors';
 import type { BrandVariants, Theme } from '@fluentui/react-components';
 import { themeList, themeNames } from './utils/themeList';
+import { brandRamp } from './components/ColorTokens/getOverridableTokenBrandColors';
 
 export type CustomAttributes = {
   keyColor: string;
@@ -89,7 +90,9 @@ export const useThemeDesignerReducer = () => {
           overrides: action.overrides,
         });
       } else {
-        dispatchOverrideState({ type: stateThemeLabel });
+        dispatchOverrideState({
+          type: stateThemeLabel,
+        });
       }
       return { ...state, [state.isDark ? 'darkOverrides' : 'lightOverrides']: overrideState[stateThemeLabel] };
     }
@@ -104,7 +107,23 @@ export const useThemeDesignerReducer = () => {
       if (!action.customAttributes) {
         return state;
       }
-      brand = createCustomTheme(action.customAttributes);
+      const newBrand = createCustomTheme(action.customAttributes);
+
+      const sameBrand = brandRamp
+        .map(num => {
+          return state.brand[num] === newBrand[num];
+        })
+        .reduce((prev, curr) => {
+          return prev && curr;
+        });
+
+      // check if the previous theme is also custom, if it is but the brand changes, clear overrides
+      if (!themeList[state.themeName].brand && !sameBrand) {
+        dispatchOverrideState({ type: themeName + 'Light' });
+        dispatchOverrideState({ type: themeName + 'Dark' });
+      }
+
+      brand = newBrand;
     }
 
     return {

--- a/packages/react-components/theme-designer/src/utils/toString.ts
+++ b/packages/react-components/theme-designer/src/utils/toString.ts
@@ -21,7 +21,7 @@ export const getBrandValues = (brand: BrandVariants, overrideList: Partial<Theme
 export const objectToString = (input: Record<string, string>, spacer: string) => {
   return (
     Object.keys(input).map(key => {
-      return '\n' + spacer + key + ": '" + input[key] + "'";
+      return '\n' + spacer + key + ': "' + input[key] + '"';
     }) + '\n'
   );
 };


### PR DESCRIPTION
Changing anything in the left sidebar that affects the 16 color brand ramp now resets the overrides.

![image](https://user-images.githubusercontent.com/31319479/180087084-606d9ec0-b0b2-46bb-b035-4f838a357df8.png)
![image](https://user-images.githubusercontent.com/31319479/180087109-eb35c87b-ccf5-4099-9f36-94e24d4011da.png)
