### PR TITLE
fix(codeowners): make codeowners work with automation again

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -171,7 +171,7 @@ packages/react-components/global-context @microsoft/teams-prg
 packages/react-components/babel-preset-global-context @microsoft/teams-prg
 packages/react-components/react-table @microsoft/teams-prg
 packages/react-components/react-progress @microsoft/cxe-red @tomi-msft
-## <%= NX-CODEOWNER-PLACEHOLDER %>
+# <%= NX-CODEOWNER-PLACEHOLDER %>
 
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- codeowners placeholder is broken thus generating invalid codeowner when creating new packages

## New Behavior

- codeowners placeholder is in proper format

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->


https://github.com/microsoft/fluentui/pull/23995#pullrequestreview-1044185601