### PR TITLE
Select: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-select/src/stories/Select/SelectAppearance.stories.tsx
+++ b/packages/react-components/react-select/src/stories/Select/SelectAppearance.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { Select } from '@fluentui/react-select';
-import { useId } from '@fluentui/react-utilities';
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
+import { makeStyles, mergeClasses, shorthands, tokens, useId } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   base: {

--- a/packages/react-components/react-select/src/stories/Select/SelectControlled.stories.tsx
+++ b/packages/react-components/react-select/src/stories/Select/SelectControlled.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Select } from '@fluentui/react-select';
-import { useId } from '@fluentui/react-utilities';
+import { useId } from '@fluentui/react-components';
 import type { SelectProps } from '@fluentui/react-select';
 
 export const Controlled = () => {

--- a/packages/react-components/react-select/src/stories/Select/SelectDefault.stories.tsx
+++ b/packages/react-components/react-select/src/stories/Select/SelectDefault.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Select } from '@fluentui/react-select';
-import { useId } from '@fluentui/react-utilities';
+import { useId } from '@fluentui/react-components';
 import type { SelectProps } from '@fluentui/react-select';
 
 export const Default = (props: SelectProps) => {

--- a/packages/react-components/react-select/src/stories/Select/SelectDisabled.stories.tsx
+++ b/packages/react-components/react-select/src/stories/Select/SelectDisabled.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Select } from '@fluentui/react-select';
-import { useId } from '@fluentui/react-utilities';
+import { useId } from '@fluentui/react-components';
 
 export const Disabled = () => {
   const selectId = useId();

--- a/packages/react-components/react-select/src/stories/Select/SelectInitialValue.stories.tsx
+++ b/packages/react-components/react-select/src/stories/Select/SelectInitialValue.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Select } from '@fluentui/react-select';
-import { useId } from '@fluentui/react-utilities';
+import { useId } from '@fluentui/react-components';
 
 export const InitialValue = () => {
   const selectId = useId();

--- a/packages/react-components/react-select/src/stories/Select/SelectSize.stories.tsx
+++ b/packages/react-components/react-select/src/stories/Select/SelectSize.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Select } from '@fluentui/react-select';
-import { useId } from '@fluentui/react-utilities';
+import { useId } from '@fluentui/react-components';
 
 export const Size = () => {
   const selectId = useId();


### PR DESCRIPTION
### Changes
- updates `react-select` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846