### PR TITLE
fix: TooltipHost uses onRenderContent prop for generating description text

### DIFF
--- a/change/@fluentui-react-b185f6f5-e21c-42b1-81d0-d1285b5e3bc6.json
+++ b/change/@fluentui-react-b185f6f5-e21c-42b1-81d0-d1285b5e3bc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: updateTooltipHost to use onRenderContent in description text",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-b185f6f5-e21c-42b1-81d0-d1285b5e3bc6.json
+++ b/change/@fluentui-react-b185f6f5-e21c-42b1-81d0-d1285b5e3bc6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: updateTooltipHost to use onRenderContent in description text",
+  "comment": "fix: update TooltipHost to use onRenderContent in description text",
   "packageName": "@fluentui/react",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/react/src/components/Tooltip/TooltipHost.base.tsx
@@ -80,12 +80,9 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
 
     const { isTooltipVisible } = this.state;
     const tooltipId = id || this._defaultTooltipId;
-    const isContentPresent = !!(
-      content ||
-      (tooltipProps && tooltipProps.onRenderContent && tooltipProps.onRenderContent())
-    );
-    const showTooltip = isTooltipVisible && isContentPresent;
-    const ariaDescribedBy = setAriaDescribedBy && isTooltipVisible && isContentPresent ? tooltipId : undefined;
+    const tooltipContent = tooltipProps?.onRenderContent ? tooltipProps.onRenderContent() : content;
+    const showTooltip = isTooltipVisible && !!tooltipContent;
+    const ariaDescribedBy = setAriaDescribedBy && isTooltipVisible && !!tooltipContent ? tooltipId : undefined;
 
     return (
       <div
@@ -120,7 +117,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
           />
         )}
         <div hidden={true} id={tooltipId} style={hiddenContentStyle as React.CSSProperties}>
-          {content}
+          {tooltipContent}
         </div>
       </div>
     );

--- a/packages/react/src/components/Tooltip/TooltipHost.test.tsx
+++ b/packages/react/src/components/Tooltip/TooltipHost.test.tsx
@@ -109,4 +109,14 @@ describe('TooltipHost', () => {
     expect(onTooltipToggleCalled).toEqual(true);
     expect(calloutPropsBefore).toEqual(calloutProps);
   });
+
+  it('uses onRenderContent for description text', () => {
+    const tooltipProps = {
+      onRenderContent: () => <span>test</span>,
+    };
+
+    const component = mount(<TooltipHost content={'should not be used'} id="tooltipId" tooltipProps={tooltipProps} />);
+    const descriptionText = component.find('#tooltipId').at(0).text();
+    expect(descriptionText).toEqual('test');
+  });
 });


### PR DESCRIPTION
Fixes [15083](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15083)

Previously, TooltipHost wasn't using `onRenderContent` for the accessible descriptive text when passed, so if a team used `onRenderContent` instead of `content`, the accessible description didn't match the visuals.