### PR TITLE
Fix line chart rendering logic for bigger datasets having lines with more than 1000 datapoints

### DIFF
--- a/change/@fluentui-react-charting-0caef860-4f50-4dd7-931f-65eefe8d5139.json
+++ b/change/@fluentui-react-charting-0caef860-4f50-4dd7-931f-65eefe8d5139.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix visualization UI bugs",
+  "packageName": "@fluentui/react-charting",
+  "email": "atishay.jain@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-0caef860-4f50-4dd7-931f-65eefe8d5139.json
+++ b/change/@fluentui-react-charting-0caef860-4f50-4dd7-931f-65eefe8d5139.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix visualization UI bugs",
+  "comment": "Improve line chart performance for 10k+ datapoints",
   "packageName": "@fluentui/react-charting",
   "email": "atishay.jain@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -43,6 +43,7 @@ enum PointSize {
   invisibleSize = 1,
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const bisect = bisector((d: any) => d.x).left;
 
 const DEFAULT_LINE_STROKE_SIZE = 4;
@@ -565,7 +566,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
         const isLegendSelected: boolean =
           this.state.activeLegend === legendVal || this.state.activeLegend === '' || this.state.isSelectedLegend;
 
-        let lineData: [number, number][] = [];
+        const lineData: [number, number][] = [];
         for (let k = 0; k < this._points[i].data.length; k++) {
           lineData.push([
             this._points[i].data[k].x instanceof Date
@@ -1049,8 +1050,8 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
         activePoint: '',
         activeLine: linenumber,
       });
-    } else {
     }
+
     if (!found) {
       this.setState({
         isCalloutVisible: false,

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { Axis as D3Axis } from 'd3-axis';
-import { select as d3Select } from 'd3-selection';
+import { select as d3Select, clientPoint } from 'd3-selection';
+import { max as d3Max, bisector } from 'd3-array';
 import { ILegend, Legends } from '../Legends/index';
+import { line as d3Line, curveLinear as d3curveLinear } from 'd3-shape';
 import { classNamesFunction, getId, find } from '@fluentui/react/lib/Utilities';
 import {
   IAccessibilityProps,
@@ -30,6 +32,7 @@ import {
   Points,
   pointTypes,
   getMinMaxOfYAxis,
+  getTypeOfAxis,
 } from '../../utilities/index';
 
 type NumericAxis = D3Axis<number | { valueOf(): number }>;
@@ -39,6 +42,8 @@ enum PointSize {
   hoverSize = 11,
   invisibleSize = 1,
 }
+
+const bisect = bisector((d: any) => d.x).left;
 
 const DEFAULT_LINE_STROKE_SIZE = 4;
 // The given shape of a icon must be 2.5 times bigger than line width (known as stroke width)
@@ -126,6 +131,8 @@ export interface ILineChartState extends IBasestate {
   activePoint?: string;
   // x-axis callout accessibility data
   xAxisCalloutAccessibilityData?: IAccessibilityProps;
+
+  nearestCircleToHighlight: number | string | Date | null;
 }
 
 export class LineChartBase extends React.Component<ILineChartProps, ILineChartState> {
@@ -164,6 +171,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
       selectedColorBarLegend: [],
       isSelectedLegend: false,
       activePoint: '',
+      nearestCircleToHighlight: null,
     };
     this._refArray = [];
     this._points = this._injectIndexPropertyInLineChartData(this.props.data.lineChartData);
@@ -536,227 +544,282 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
 
       let gapIndex = 0;
       const gaps = this._points[i].gaps?.sort((a, b) => a.startIndex - b.startIndex) ?? [];
-      let firstXPos = this._xAxisScale(this._points[i].data[0].x);
-      let firstYPos = this._yAxisScale(this._points[i].data[0].y);
-      let ctr = 0;
 
-      /*for (let j = 1; j < this._points[i].data.length; j++) {
-        const gapResult = this._checkInGap(j, gaps, gapIndex);
-        const isInGap = gapResult.isInGap;
-        gapIndex = gapResult.gapIndex;
+      if (this._points[i].data.length < 1000 /* or no gaps.*/) {
+        for (let j = 1; j < this._points[i].data.length; j++) {
+          const gapResult = this._checkInGap(j, gaps, gapIndex);
+          const isInGap = gapResult.isInGap;
+          gapIndex = gapResult.gapIndex;
 
-        const nextXPos = this._xAxisScale(this._points[i].data[j].x)
-      const nextYPos = this._yAxisScale(this._points[i].data[j].y)
+          const lineId = `${this._lineId}${i}${j}`;
+          const borderId = `${this._borderId}${i}${j}`;
+          const circleId = `${this._circleId}${i}${j}`;
+          const { x: x1, y: y1, xAxisCalloutData, xAxisCalloutAccessibilityData } = this._points[i].data[j - 1];
+          const { x: x2, y: y2 } = this._points[i].data[j];
+          let path = this._getPath(
+            this._xAxisScale(x1),
+            this._yAxisScale(y1),
+            circleId,
+            j,
+            false,
+            this._points[i].index,
+          );
+          const strokeWidth =
+            this._points[i].lineOptions?.strokeWidth || this.props.strokeWidth || DEFAULT_LINE_STROKE_SIZE;
 
-      if ((Math.floor(firstXPos) === Math.floor(nextXPos))
-       && (Math.floor(firstYPos) === Math.floor(nextYPos)))
-      {
-        continue;
-      }
-      firstXPos = nextXPos;
-      firstYPos = nextYPos;
-      ctr+=1;
-      console.log(nextXPos, nextYPos, ctr)
-      
-        const lineId = `${this._lineId}${i}${j}`;
-        const borderId = `${this._borderId}${i}${j}`;
-        const circleId = `${this._circleId}${i}${j}`;
-        const { x: x1, y: y1, xAxisCalloutData, xAxisCalloutAccessibilityData } = this._points[i].data[j - 1];
-        const { x: x2, y: y2 } = this._points[i].data[j];
-        let path = this._getPath(this._xAxisScale(x1), this._yAxisScale(y1), circleId, j, false, this._points[i].index);
+          const isLegendSelected: boolean =
+            this.state.activeLegend === legendVal || this.state.activeLegend === '' || this.state.isSelectedLegend;
+
+          const currentPointHidden = this._points[i].hideNonActiveDots && activePoint !== circleId;
+          pointsForLine.push(
+            <path
+              id={circleId}
+              key={circleId}
+              d={path}
+              data-is-focusable={true}
+              onMouseOver={this._handleHover.bind(
+                this,
+                x1,
+                y1,
+                verticaLineHeight,
+                xAxisCalloutData,
+                circleId,
+                xAxisCalloutAccessibilityData,
+              )}
+              onMouseMove={this._handleHover.bind(
+                this,
+                x1,
+                y1,
+                verticaLineHeight,
+                xAxisCalloutData,
+                circleId,
+                xAxisCalloutAccessibilityData,
+              )}
+              onMouseOut={this._handleMouseOut}
+              onFocus={() => this._handleFocus(lineId, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
+              onBlur={this._handleMouseOut}
+              onClick={this._onDataPointClick.bind(this, this._points[i].data[j - 1].onDataPointClick)}
+              opacity={isLegendSelected && !currentPointHidden ? 1 : 0.01}
+              fill={this._getPointFill(lineColor, circleId, j, false)}
+              stroke={lineColor}
+              strokeWidth={strokeWidth}
+            />,
+          );
+          if (j + 1 === this._points[i].data.length) {
+            // If this is last point of the line segment.
+            const lastCircleId = `${circleId}${j}L`;
+            const lastPointHidden = this._points[i].hideNonActiveDots && activePoint !== lastCircleId;
+            path = this._getPath(
+              this._xAxisScale(x2),
+              this._yAxisScale(y2),
+              lastCircleId,
+              j,
+              true,
+              this._points[i].index,
+            );
+            const {
+              xAxisCalloutData: lastCirlceXCallout,
+              xAxisCalloutAccessibilityData: lastCirlceXCalloutAccessibilityData,
+            } = this._points[i].data[j];
+            pointsForLine.push(
+              <path
+                id={lastCircleId}
+                key={lastCircleId}
+                d={path}
+                data-is-focusable={true}
+                onMouseOver={this._handleHover.bind(
+                  this,
+                  x2,
+                  y2,
+                  verticaLineHeight,
+                  lastCirlceXCallout,
+                  lastCircleId,
+                  lastCirlceXCalloutAccessibilityData,
+                )}
+                onMouseMove={this._handleHover.bind(
+                  this,
+                  x2,
+                  y2,
+                  verticaLineHeight,
+                  lastCirlceXCallout,
+                  lastCircleId,
+                  lastCirlceXCalloutAccessibilityData,
+                )}
+                onMouseOut={this._handleMouseOut}
+                onFocus={() =>
+                  this._handleFocus(lineId, x2, lastCirlceXCallout, lastCircleId, lastCirlceXCalloutAccessibilityData)
+                }
+                onBlur={this._handleMouseOut}
+                onClick={this._onDataPointClick.bind(this, this._points[i].data[j].onDataPointClick)}
+                opacity={isLegendSelected && !lastPointHidden ? 1 : 0.01}
+                fill={this._getPointFill(lineColor, lastCircleId, j, true)}
+                stroke={lineColor}
+                strokeWidth={strokeWidth}
+              />,
+            );
+            /* eslint-enable react/jsx-no-bind */
+          }
+
+          if (isLegendSelected) {
+            // don't draw line if it is in a gap
+            if (!isInGap) {
+              const lineBorderWidth = this._points[i].lineOptions?.lineBorderWidth
+                ? Number.parseFloat(this._points[i].lineOptions!.lineBorderWidth!.toString())
+                : 0;
+              if (lineBorderWidth > 0) {
+                bordersForLine.push(
+                  <line
+                    id={borderId}
+                    key={borderId}
+                    x1={this._xAxisScale(x1)}
+                    y1={this._yAxisScale(y1)}
+                    x2={this._xAxisScale(x2)}
+                    y2={this._yAxisScale(y2)}
+                    strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
+                    strokeWidth={Number.parseFloat(strokeWidth.toString()) + lineBorderWidth}
+                    stroke={this._points[i].lineOptions?.lineBorderColor || theme!.palette.white}
+                    opacity={1}
+                  />,
+                );
+              }
+
+              linesForLine.push(
+                <line
+                  id={lineId}
+                  key={lineId}
+                  x1={this._xAxisScale(x1)}
+                  y1={this._yAxisScale(y1)}
+                  x2={this._xAxisScale(x2)}
+                  y2={this._yAxisScale(y2)}
+                  strokeWidth={strokeWidth}
+                  ref={(e: SVGLineElement | null) => {
+                    this._refCallback(e!, lineId);
+                  }}
+                  onMouseOver={this._handleHover.bind(
+                    this,
+                    x1,
+                    y1,
+                    verticaLineHeight,
+                    xAxisCalloutData,
+                    circleId,
+                    xAxisCalloutAccessibilityData,
+                  )}
+                  onMouseMove={this._handleHover.bind(
+                    this,
+                    x1,
+                    y1,
+                    verticaLineHeight,
+                    xAxisCalloutData,
+                    circleId,
+                    xAxisCalloutAccessibilityData,
+                  )}
+                  onMouseOut={this._handleMouseOut}
+                  stroke={lineColor}
+                  strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
+                  strokeDasharray={this._points[i].lineOptions?.strokeDasharray}
+                  strokeDashoffset={this._points[i].lineOptions?.strokeDashoffset}
+                  opacity={1}
+                  onClick={this._onLineClick.bind(this, this._points[i].onLineClick)}
+                />,
+              );
+            }
+          } else {
+            if (!isInGap) {
+              linesForLine.push(
+                <line
+                  id={lineId}
+                  key={lineId}
+                  x1={this._xAxisScale(x1)}
+                  y1={this._yAxisScale(y1)}
+                  x2={this._xAxisScale(x2)}
+                  y2={this._yAxisScale(y2)}
+                  strokeWidth={strokeWidth}
+                  stroke={lineColor}
+                  strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
+                  strokeDasharray={this._points[i].lineOptions?.strokeDasharray}
+                  strokeDashoffset={this._points[i].lineOptions?.strokeDashoffset}
+                  opacity={0.1}
+                />,
+              );
+            }
+          }
+        }
+      } else {
+        const line = d3Line()
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .x((d: any) => this._xAxisScale(d[0]))
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .y((d: any) => this._yAxisScale(d[1]))
+          .curve(d3curveLinear);
+
+        const lineId = `${this._lineId}${i}`;
         const strokeWidth =
           this._points[i].lineOptions?.strokeWidth || this.props.strokeWidth || DEFAULT_LINE_STROKE_SIZE;
 
         const isLegendSelected: boolean =
           this.state.activeLegend === legendVal || this.state.activeLegend === '' || this.state.isSelectedLegend;
 
-        const currentPointHidden = this._points[i].hideNonActiveDots && activePoint !== circleId;
-        /*pointsForLine.push(
-          <path
-            id={circleId}
-            key={circleId}
-            d={path}
-            data-is-focusable={true}
-            onMouseOver={this._handleHover.bind(
-              this,
-              x1,
-              y1,
-              verticaLineHeight,
-              xAxisCalloutData,
-              circleId,
-              xAxisCalloutAccessibilityData,
-            )}
-            onMouseMove={this._handleHover.bind(
-              this,
-              x1,
-              y1,
-              verticaLineHeight,
-              xAxisCalloutData,
-              circleId,
-              xAxisCalloutAccessibilityData,
-            )}
-            onMouseOut={this._handleMouseOut}
-            onFocus={() => this._handleFocus(lineId, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
-            onBlur={this._handleMouseOut}
-            onClick={this._onDataPointClick.bind(this, this._points[i].data[j - 1].onDataPointClick)}
-            opacity={isLegendSelected && !currentPointHidden ? 1 : 0.01}
-            fill={this._getPointFill(lineColor, circleId, j, false)}
-            stroke={lineColor}
-            strokeWidth={strokeWidth}
-          />,
-        );
-        if (j + 1 === this._points[i].data.length) {
-          const lastCircleId = `${circleId}${j}L`;
-          const lastPointHidden = this._points[i].hideNonActiveDots && activePoint !== lastCircleId;
-          path = this._getPath(
-            this._xAxisScale(x2),
-            this._yAxisScale(y2),
-            lastCircleId,
-            j,
-            true,
-            this._points[i].index,
-          );
-          const {
-            xAxisCalloutData: lastCirlceXCallout,
-            xAxisCalloutAccessibilityData: lastCirlceXCalloutAccessibilityData,
-          } = this._points[i].data[j];
-          pointsForLine.push(
+        let lineData: [number, number][] = [];
+        for (let k = 0; k < this._points[i].data.length; k++) {
+          lineData.push([
+            this._points[i].data[k].x instanceof Date
+              ? (this._points[i].data[k].x as Date).getTime()
+              : (this._points[i].data[k].x as number),
+            this._points[i].data[k].y,
+          ]);
+        }
+
+        if (isLegendSelected) {
+          linesForLine.push(
             <path
-              id={lastCircleId}
-              key={lastCircleId}
-              d={path}
+              id={lineId}
+              key={lineId}
+              d={line(lineData)!}
+              fill="transparent"
               data-is-focusable={true}
-              onMouseOver={this._handleHover.bind(
-                this,
-                x2,
-                y2,
-                verticaLineHeight,
-                lastCirlceXCallout,
-                lastCircleId,
-                lastCirlceXCalloutAccessibilityData,
-              )}
-              onMouseMove={this._handleHover.bind(
-                this,
-                x2,
-                y2,
-                verticaLineHeight,
-                lastCirlceXCallout,
-                lastCircleId,
-                lastCirlceXCalloutAccessibilityData,
-              )}
-              onMouseOut={this._handleMouseOut}
-              onFocus={() =>
-                this._handleFocus(lineId, x2, lastCirlceXCallout, lastCircleId, lastCirlceXCalloutAccessibilityData)
-              }
-              onBlur={this._handleMouseOut}
-              onClick={this._onDataPointClick.bind(this, this._points[i].data[j].onDataPointClick)}
-              opacity={isLegendSelected && !lastPointHidden ? 1 : 0.01}
-              fill={this._getPointFill(lineColor, lastCircleId, j, true)}
               stroke={lineColor}
               strokeWidth={strokeWidth}
+              strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
+              onMouseMove={this._onMouseMoveOver.bind(this, i, verticaLineHeight)}
+              onMouseOver={this._onMouseMoveOver.bind(this, i, verticaLineHeight)}
+              onMouseOut={this._handleLargeLineMouseOut.bind(this, i)}
+              onClick={this._onLineClick.bind(this, this._points[i].onLineClick)}
+              opacity={1}
             />,
           );
-          /* eslint-enable react/jsx-no-bind */
-      //}
-
-      /*  if (isLegendSelected) {
-          // don't draw line if it is in a gap
-          if (!isInGap) {
-            const lineBorderWidth = this._points[i].lineOptions?.lineBorderWidth
-              ? Number.parseFloat(this._points[i].lineOptions!.lineBorderWidth!.toString())
-              : 0;
-            if (lineBorderWidth > 0) {
-              bordersForLine.push(
-                <line
-                  id={borderId}
-                  key={borderId}
-                  x1={this._xAxisScale(x1)}
-                  y1={this._yAxisScale(y1)}
-                  x2={this._xAxisScale(x2)}
-                  y2={this._yAxisScale(y2)}
-                  strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
-                  strokeWidth={Number.parseFloat(strokeWidth.toString()) + lineBorderWidth}
-                  stroke={this._points[i].lineOptions?.lineBorderColor || theme!.palette.white}
-                  opacity={1}
-                />,
-              );
-            }
-
-            linesForLine.push(
-              <line
-                id={lineId}
-                key={lineId}
-                x1={this._xAxisScale(x1)}
-                y1={this._yAxisScale(y1)}
-                x2={this._xAxisScale(x2)}
-                y2={this._yAxisScale(y2)}
-                strokeWidth={strokeWidth}
-                ref={(e: SVGLineElement | null) => {
-                  this._refCallback(e!, lineId);
-                }}
-                onMouseOver={this._handleHover.bind(
-                  this,
-                  x1,
-                  y1,
-                  verticaLineHeight,
-                  xAxisCalloutData,
-                  circleId,
-                  xAxisCalloutAccessibilityData,
-                )}
-                onMouseMove={this._handleHover.bind(
-                  this,
-                  x1,
-                  y1,
-                  verticaLineHeight,
-                  xAxisCalloutData,
-                  circleId,
-                  xAxisCalloutAccessibilityData,
-                )}
-                onMouseOut={this._handleMouseOut}
-                stroke={lineColor}
-                strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
-                strokeDasharray={this._points[i].lineOptions?.strokeDasharray}
-                strokeDashoffset={this._points[i].lineOptions?.strokeDashoffset}
-                opacity={1}
-                onClick={this._onLineClick.bind(this, this._points[i].onLineClick)}
-              />,
-            );
-          }
         } else {
-          if (!isInGap) {
-            linesForLine.push(
-              <line
-                id={lineId}
-                key={lineId}
-                x1={this._xAxisScale(x1)}
-                y1={this._yAxisScale(y1)}
-                x2={this._xAxisScale(x2)}
-                y2={this._yAxisScale(y2)}
-                strokeWidth={strokeWidth}
-                stroke={lineColor}
-                strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
-                strokeDasharray={this._points[i].lineOptions?.strokeDasharray}
-                strokeDashoffset={this._points[i].lineOptions?.strokeDashoffset}
-                opacity={0.1}
-              />,
-            );
-          }
+          linesForLine.push(
+            <path
+              id={lineId}
+              key={lineId}
+              d={line(lineData)!}
+              fill="transparent"
+              data-is-focusable={true}
+              stroke={lineColor}
+              strokeWidth={strokeWidth}
+              strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
+              opacity={0.1}
+            />,
+          );
         }
-      }*/
-      const lineId = `${this._lineId}${i}`;
-      const strokeWidth =
-        this._points[i].lineOptions?.strokeWidth || this.props.strokeWidth || DEFAULT_LINE_STROKE_SIZE;
-      pointsForLine.push(
-        <path
-          id={lineId}
-          key={lineId}
-          d={this.constructPath(this._points[i].data)}
-          fill="transparent"
-          stroke={lineColor}
-          strokeWidth={strokeWidth}
-          strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
-        />,
-      );
+
+        pointsForLine.push(
+          <circle
+            id={`staticHighlightCircle_${i}`}
+            key={`staticHighlightCircle_${i}`}
+            r={5.5}
+            cx={0}
+            cy={0}
+            fill={theme!.palette.white}
+            strokeWidth={DEFAULT_LINE_STROKE_SIZE}
+            stroke={lineColor}
+            visibility={'hidden'}
+            onMouseMove={this._onMouseMoveOver.bind(this, i, verticaLineHeight)}
+            onMouseOver={this._onMouseMoveOver.bind(this, i, verticaLineHeight)}
+            onMouseOut={this._handleLargeLineMouseOut.bind(this, i)}
+          />,
+        );
+      }
 
       lines.push(...bordersForLine, ...linesForLine, ...pointsForLine);
     }
@@ -786,16 +849,6 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     }
     return lines;
   }
-
-  private constructPath = (data: ILineChartDataPoint[]) => {
-    let path: string;
-    path = `M ${this._xAxisScale(data[0].x)} ${this._yAxisScale(data[0].y)}`;
-    for (let k = 1; k < data.length; k++) {
-      path = `${path} L ${this._xAxisScale(data[k].x)} ${this._yAxisScale(data[k].y)}`;
-    }
-
-    return path;
-  };
 
   private _createColorFillBars = (containerHeight: number) => {
     const colorFillBars: JSX.Element[] = [];
@@ -877,6 +930,111 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
   private _refCallback(element: SVGGElement, legendTitle: string): void {
     this._refArray.push({ index: legendTitle, refElement: element });
   }
+
+  private _onMouseMoveOver = (
+    linenumber: number,
+    lineHeight: number,
+    mouseEvent: React.MouseEvent<SVGRectElement | SVGPathElement | SVGCircleElement>,
+  ) => {
+    // Run this code for different scenarios. For data and numeric data. Try to satisfy undefined d0/d1 scenario.
+    mouseEvent.persist();
+    const { data } = this.props;
+    const { lineChartData } = data;
+
+    // This will get the value of the X when mouse is on the chart
+    const xOffset = this._xAxisScale.invert(mouseEvent.pageX - 15); //Todo - fix this
+    const i = bisect(lineChartData![linenumber].data, xOffset);
+    const d0 = lineChartData![linenumber].data[i - 1] as ILineChartDataPoint;
+    const d1 = lineChartData![linenumber].data[i] as ILineChartDataPoint;
+    let axisType: XAxisTypes | null = null;
+    let pointToHighlight: string | Date | number | null = null;
+    let index: null | number = null;
+    if (d0 === undefined && d1 !== undefined) {
+      pointToHighlight = d1.x;
+      index = i;
+    } else if (d0 !== undefined && d1 === undefined) {
+      pointToHighlight = d0.x;
+      index = i - 1;
+    } else {
+      axisType = getTypeOfAxis(lineChartData![linenumber].data[0].x, true) as XAxisTypes;
+      let x0;
+      let point0;
+      let point1;
+      switch (axisType) {
+        case XAxisTypes.DateAxis:
+          x0 = new Date(xOffset).getTime();
+          point0 = (d0.x as Date).getTime();
+          point1 = (d1.x as Date).getTime();
+          pointToHighlight = Math.abs(x0 - point0) > Math.abs(x0 - point1) ? d1.x : d0.x;
+          index = Math.abs(x0 - point0) > Math.abs(x0 - point1) ? i : i - 1;
+          break;
+        case XAxisTypes.NumericAxis:
+          x0 = xOffset as number;
+          point0 = d0.x as number;
+          point1 = d1.x as number;
+          pointToHighlight = Math.abs(x0 - point0) > Math.abs(x0 - point1) ? d1.x : d0.x;
+          index = Math.abs(x0 - point0) > Math.abs(x0 - point1) ? i : i - 1;
+          break;
+        default:
+          break;
+      }
+    }
+
+    const { xAxisCalloutData, xAxisCalloutAccessibilityData } = lineChartData![linenumber].data[index as number];
+    const formattedDate = pointToHighlight instanceof Date ? pointToHighlight.toLocaleString() : pointToHighlight;
+    const modifiedXVal = pointToHighlight instanceof Date ? pointToHighlight.getTime() : pointToHighlight;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const found: any = find(this._calloutPoints, (element: { x: string | number }) => {
+      return element.x === modifiedXVal;
+    });
+    const nearestCircleToHighlight =
+      axisType === XAxisTypes.DateAxis ? (pointToHighlight as Date).getTime() : pointToHighlight;
+    const pointToHighlightUpdated = this.state.nearestCircleToHighlight !== nearestCircleToHighlight;
+    // if no points need to be called out then don't show vertical line and callout card
+    if (found && pointToHighlightUpdated) {
+      const coordinateHighlighted: ILineChartDataPoint = lineChartData![linenumber].data[index!];
+      this._uniqueCallOutID = `#staticHighlightCircle_${linenumber}`;
+
+      d3Select(`#staticHighlightCircle_${linenumber}`)
+        .attr('cx', `${this._xAxisScale(coordinateHighlighted.x)}`)
+        .attr('cy', `${this._yAxisScale(coordinateHighlighted.y)}`)
+        .attr('visibility', 'visibility');
+
+      d3Select(`#${this._verticalLine}`)
+        .attr(
+          'transform',
+          () => `translate(${this._xAxisScale(coordinateHighlighted.x)}, ${this._yAxisScale(coordinateHighlighted.y)})`,
+        )
+        .attr('visibility', 'visibility')
+        .attr('y2', `${lineHeight - this._yAxisScale(coordinateHighlighted.y)}`);
+
+      this.setState({
+        nearestCircleToHighlight: nearestCircleToHighlight,
+        isCalloutVisible: true,
+        refSelected: `#staticHighlightCircle_${linenumber}`,
+        stackCalloutProps: found!,
+        YValueHover: found.values,
+        dataPointCalloutProps: found!,
+        hoverXValue: xAxisCalloutData ? xAxisCalloutData : formattedDate,
+        xAxisCalloutAccessibilityData,
+        activePoint: '',
+      });
+    } else {
+    }
+    if (!found) {
+      this.setState({
+        isCalloutVisible: false,
+        nearestCircleToHighlight: nearestCircleToHighlight,
+        activePoint: '',
+      });
+    }
+  };
+
+  private _handleLargeLineMouseOut = (linenumber: number) => {
+    d3Select(`#${this._verticalLine}`).attr('visibility', 'hidden');
+
+    d3Select(`#staticHighlightCircle_${linenumber}`).attr('visibility', 'hidden');
+  };
 
   private _handleFocus = (
     lineId: string,

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -17,6 +17,7 @@ import {
   ILineChartStyleProps,
   ILineChartStyles,
   ILineChartGap,
+  ILineChartDataPoint,
 } from '../../index';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';
 import { EventsAnnotation } from './eventAnnotation/EventAnnotation';
@@ -535,12 +536,28 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
 
       let gapIndex = 0;
       const gaps = this._points[i].gaps?.sort((a, b) => a.startIndex - b.startIndex) ?? [];
+      let firstXPos = this._xAxisScale(this._points[i].data[0].x);
+      let firstYPos = this._yAxisScale(this._points[i].data[0].y);
+      let ctr = 0;
 
-      for (let j = 1; j < this._points[i].data.length; j++) {
+      /*for (let j = 1; j < this._points[i].data.length; j++) {
         const gapResult = this._checkInGap(j, gaps, gapIndex);
         const isInGap = gapResult.isInGap;
         gapIndex = gapResult.gapIndex;
 
+        const nextXPos = this._xAxisScale(this._points[i].data[j].x)
+      const nextYPos = this._yAxisScale(this._points[i].data[j].y)
+
+      if ((Math.floor(firstXPos) === Math.floor(nextXPos))
+       && (Math.floor(firstYPos) === Math.floor(nextYPos)))
+      {
+        continue;
+      }
+      firstXPos = nextXPos;
+      firstYPos = nextYPos;
+      ctr+=1;
+      console.log(nextXPos, nextYPos, ctr)
+      
         const lineId = `${this._lineId}${i}${j}`;
         const borderId = `${this._borderId}${i}${j}`;
         const circleId = `${this._circleId}${i}${j}`;
@@ -554,7 +571,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
           this.state.activeLegend === legendVal || this.state.activeLegend === '' || this.state.isSelectedLegend;
 
         const currentPointHidden = this._points[i].hideNonActiveDots && activePoint !== circleId;
-        pointsForLine.push(
+        /*pointsForLine.push(
           <path
             id={circleId}
             key={circleId}
@@ -640,9 +657,9 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
             />,
           );
           /* eslint-enable react/jsx-no-bind */
-        }
+      //}
 
-        if (isLegendSelected) {
+      /*  if (isLegendSelected) {
           // don't draw line if it is in a gap
           if (!isInGap) {
             const lineBorderWidth = this._points[i].lineOptions?.lineBorderWidth
@@ -725,7 +742,22 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
             );
           }
         }
-      }
+      }*/
+      const lineId = `${this._lineId}${i}`;
+      const strokeWidth =
+        this._points[i].lineOptions?.strokeWidth || this.props.strokeWidth || DEFAULT_LINE_STROKE_SIZE;
+      pointsForLine.push(
+        <path
+          id={lineId}
+          key={lineId}
+          d={this.constructPath(this._points[i].data)}
+          fill="transparent"
+          stroke={lineColor}
+          strokeWidth={strokeWidth}
+          strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
+        />,
+      );
+
       lines.push(...bordersForLine, ...linesForLine, ...pointsForLine);
     }
     const classNames = getClassNames(this.props.styles!, {
@@ -754,6 +786,16 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     }
     return lines;
   }
+
+  private constructPath = (data: ILineChartDataPoint[]) => {
+    let path: string;
+    path = `M ${this._xAxisScale(data[0].x)} ${this._yAxisScale(data[0].y)}`;
+    for (let k = 1; k < data.length; k++) {
+      path = `${path} L ${this._xAxisScale(data[k].x)} ${this._yAxisScale(data[k].y)}`;
+    }
+
+    return path;
+  };
 
   private _createColorFillBars = (containerHeight: number) => {
     const colorFillBars: JSX.Element[] = [];

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Axis as D3Axis } from 'd3-axis';
-import { select as d3Select, clientPoint } from 'd3-selection';
-import { max as d3Max, bisector } from 'd3-array';
+import { select as d3Select } from 'd3-selection';
+import { bisector } from 'd3-array';
 import { ILegend, Legends } from '../Legends/index';
 import { line as d3Line, curveLinear as d3curveLinear } from 'd3-shape';
 import { classNamesFunction, getId, find } from '@fluentui/react/lib/Utilities';
@@ -499,7 +499,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     } else {
       this._points = this._injectIndexPropertyInLineChartData(this.props.data.lineChartData);
     }
-    for (let i = 0; i < this._points.length; i++) {
+    for (let i = this._points.length - 1; i >= 0; i--) {
       const linesForLine: JSX.Element[] = [];
       const bordersForLine: JSX.Element[] = [];
       const pointsForLine: JSX.Element[] = [];

--- a/packages/react-charting/src/components/LineChart/LineChart.types.ts
+++ b/packages/react-charting/src/components/LineChart/LineChart.types.ts
@@ -65,6 +65,13 @@ export interface ILineChartProps extends ICartesianChartProps {
    */
   allowMultipleShapesForPoints?: boolean;
 
+  /*
+   * Optimize line chart rendering for large data set. If this prop is enabled, line chart
+   * can easily render over 10K datapoints with multiple lines smoothly.
+   * This rendering mechanism does not support gaps in lines.
+   */
+  optimizeLargeData?: boolean;
+
   /**
    * The prop used to define the culture to localized the numbers
    */

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx
@@ -87,6 +87,9 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
             },
           ],
           color: DefaultPalette.blue,
+          lineOptions: {
+            lineBorderWidth: '4',
+          },
           onLineClick: () => console.log('From_Legacy_to_O365'),
         },
         {
@@ -122,6 +125,9 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
             },
           ],
           color: DefaultPalette.green,
+          lineOptions: {
+            lineBorderWidth: '4',
+          },
         },
         {
           legend: 'single point',

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx
@@ -38,10 +38,34 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
     let startdate = new Date('2020-03-01T00:00:00.000Z');
     let i = 0;
     for (i = 0; i < 10000; i++) {
-      data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: i * i - 5 * i });
+      //data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: i * i - 5 * i });
+      data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: 500000 });
     }
 
     return data;
+  };
+
+  private _getdata2 = () => {
+    let data: ILineChartDataPoint[] = [];
+    let startdate = new Date('2020-03-01T00:00:00.000Z');
+    let i = 0;
+    for (i = 1000; i < 9000; i++) {
+      //data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: 100000000 - i * i });
+      //data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: 5000000 + i * i - 5 * i });
+      data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: this.getY(i) });
+    }
+
+    return data;
+  };
+
+  private getY = (i: number) => {
+    let res: number = 0;
+    const newN = i % 1000;
+    if (newN < 500) res = newN * newN;
+    else res = 1000000 - newN * newN;
+
+    console.log(res, newN);
+    return res;
   };
 
   private _basicExample(): JSX.Element {
@@ -57,36 +81,7 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
         },
         {
           legend: 'All',
-          data: [
-            {
-              x: new Date('2020-03-03T00:00:00.000Z'),
-              y: 297000,
-            },
-            {
-              x: new Date('2020-03-04T00:00:00.000Z'),
-              y: 284000,
-            },
-            {
-              x: new Date('2020-03-05T00:00:00.000Z'),
-              y: 282000,
-            },
-            {
-              x: new Date('2020-03-06T00:00:00.000Z'),
-              y: 294000,
-            },
-            {
-              x: new Date('2020-03-07T00:00:00.000Z'),
-              y: 224000,
-            },
-            {
-              x: new Date('2020-03-08T00:00:00.000Z'),
-              y: 300000,
-            },
-            {
-              x: new Date('2020-03-09T00:00:00.000Z'),
-              y: 298000,
-            },
-          ],
+          data: this._getdata2(),
           color: DefaultPalette.green,
         },
         {

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IChartProps, ILineChartProps, LineChart, ILineChartDataPoint } from '@fluentui/react-charting';
+import { IChartProps, ILineChartProps, LineChart } from '@fluentui/react-charting';
 import { DefaultPalette } from '@fluentui/react/lib/Styling';
 import { Toggle } from '@fluentui/react/lib/Toggle';
 
@@ -33,54 +33,94 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
     this.setState({ allowMultipleShapes: checked });
   };
 
-  private _getdata = () => {
-    let data: ILineChartDataPoint[] = [];
-    let startdate = new Date('2020-03-01T00:00:00.000Z');
-    let i = 0;
-    for (i = 0; i < 10000; i++) {
-      //data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: i * i - 5 * i });
-      data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: 500000 });
-    }
-
-    return data;
-  };
-
-  private _getdata2 = () => {
-    let data: ILineChartDataPoint[] = [];
-    let startdate = new Date('2020-03-01T00:00:00.000Z');
-    let i = 0;
-    for (i = 1000; i < 9000; i++) {
-      //data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: 100000000 - i * i });
-      //data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: 5000000 + i * i - 5 * i });
-      data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: this.getY(i) });
-    }
-
-    return data;
-  };
-
-  private getY = (i: number) => {
-    let res: number = 0;
-    const newN = i % 1000;
-    if (newN < 500) res = newN * newN;
-    else res = 1000000 - newN * newN;
-
-    return res;
-  };
-
   private _basicExample(): JSX.Element {
     const data: IChartProps = {
       chartTitle: 'Line Chart',
       lineChartData: [
         {
           legend: 'From_Legacy_to_O365',
-          data: this._getdata(),
+          data: [
+            {
+              x: new Date('2020-03-03T00:00:00.000Z'),
+              y: 216000,
+              onDataPointClick: () => alert('click on 217000'),
+            },
+            {
+              x: new Date('2020-03-03T10:00:00.000Z'),
+              y: 218123,
+              onDataPointClick: () => alert('click on 217123'),
+            },
+            {
+              x: new Date('2020-03-03T11:00:00.000Z'),
+              y: 217124,
+              onDataPointClick: () => alert('click on 217124'),
+            },
+            {
+              x: new Date('2020-03-04T00:00:00.000Z'),
+              y: 248000,
+              onDataPointClick: () => alert('click on 248000'),
+            },
+            {
+              x: new Date('2020-03-05T00:00:00.000Z'),
+              y: 252000,
+              onDataPointClick: () => alert('click on 252000'),
+            },
+            {
+              x: new Date('2020-03-06T00:00:00.000Z'),
+              y: 274000,
+              onDataPointClick: () => alert('click on 274000'),
+            },
+            {
+              x: new Date('2020-03-07T00:00:00.000Z'),
+              y: 260000,
+              onDataPointClick: () => alert('click on 260000'),
+            },
+            {
+              x: new Date('2020-03-08T00:00:00.000Z'),
+              y: 304000,
+              onDataPointClick: () => alert('click on 300000'),
+            },
+            {
+              x: new Date('2020-03-09T00:00:00.000Z'),
+              y: 218000,
+              onDataPointClick: () => alert('click on 218000'),
+            },
+          ],
           color: DefaultPalette.blue,
           onLineClick: () => console.log('From_Legacy_to_O365'),
-          hideNonActiveDots: true,
         },
         {
           legend: 'All',
-          data: this._getdata2(),
+          data: [
+            {
+              x: new Date('2020-03-03T00:00:00.000Z'),
+              y: 297000,
+            },
+            {
+              x: new Date('2020-03-04T00:00:00.000Z'),
+              y: 284000,
+            },
+            {
+              x: new Date('2020-03-05T00:00:00.000Z'),
+              y: 282000,
+            },
+            {
+              x: new Date('2020-03-06T00:00:00.000Z'),
+              y: 294000,
+            },
+            {
+              x: new Date('2020-03-07T00:00:00.000Z'),
+              y: 224000,
+            },
+            {
+              x: new Date('2020-03-08T00:00:00.000Z'),
+              y: 300000,
+            },
+            {
+              x: new Date('2020-03-09T00:00:00.000Z'),
+              y: 298000,
+            },
+          ],
           color: DefaultPalette.green,
         },
         {

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IChartProps, ILineChartProps, LineChart } from '@fluentui/react-charting';
+import { IChartProps, ILineChartProps, LineChart, ILineChartDataPoint } from '@fluentui/react-charting';
 import { DefaultPalette } from '@fluentui/react/lib/Styling';
 import { Toggle } from '@fluentui/react/lib/Toggle';
 
@@ -33,61 +33,27 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
     this.setState({ allowMultipleShapes: checked });
   };
 
+  private _getdata = () => {
+    let data: ILineChartDataPoint[] = [];
+    let startdate = new Date('2020-03-01T00:00:00.000Z');
+    let i = 0;
+    for (i = 0; i < 10000; i++) {
+      data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: i * i - 5 * i });
+    }
+
+    return data;
+  };
+
   private _basicExample(): JSX.Element {
     const data: IChartProps = {
       chartTitle: 'Line Chart',
       lineChartData: [
         {
           legend: 'From_Legacy_to_O365',
-          data: [
-            {
-              x: new Date('2020-03-03T00:00:00.000Z'),
-              y: 216000,
-              onDataPointClick: () => alert('click on 217000'),
-            },
-            {
-              x: new Date('2020-03-03T10:00:00.000Z'),
-              y: 218123,
-              onDataPointClick: () => alert('click on 217123'),
-            },
-            {
-              x: new Date('2020-03-03T11:00:00.000Z'),
-              y: 217124,
-              onDataPointClick: () => alert('click on 217124'),
-            },
-            {
-              x: new Date('2020-03-04T00:00:00.000Z'),
-              y: 248000,
-              onDataPointClick: () => alert('click on 248000'),
-            },
-            {
-              x: new Date('2020-03-05T00:00:00.000Z'),
-              y: 252000,
-              onDataPointClick: () => alert('click on 252000'),
-            },
-            {
-              x: new Date('2020-03-06T00:00:00.000Z'),
-              y: 274000,
-              onDataPointClick: () => alert('click on 274000'),
-            },
-            {
-              x: new Date('2020-03-07T00:00:00.000Z'),
-              y: 260000,
-              onDataPointClick: () => alert('click on 260000'),
-            },
-            {
-              x: new Date('2020-03-08T00:00:00.000Z'),
-              y: 304000,
-              onDataPointClick: () => alert('click on 300000'),
-            },
-            {
-              x: new Date('2020-03-09T00:00:00.000Z'),
-              y: 218000,
-              onDataPointClick: () => alert('click on 218000'),
-            },
-          ],
+          data: this._getdata(),
           color: DefaultPalette.blue,
           onLineClick: () => console.log('From_Legacy_to_O365'),
+          hideNonActiveDots: true,
         },
         {
           legend: 'All',

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.CustomAccessibility.Example.tsx
@@ -114,6 +114,9 @@ export class LineChartCustomAccessibilityExample extends React.Component<
         ],
         legend: 'First',
         color: DefaultPalette.blue,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -146,6 +149,9 @@ export class LineChartCustomAccessibilityExample extends React.Component<
         ],
         legend: 'Second',
         color: DefaultPalette.green,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -158,6 +164,9 @@ export class LineChartCustomAccessibilityExample extends React.Component<
         ],
         legend: 'Third',
         color: DefaultPalette.red,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
     ];

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Events.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Events.Example.tsx
@@ -108,6 +108,9 @@ export class LineChartEventsExample extends React.Component<{}, ILineChartEvents
             },
           ],
           color: DefaultPalette.blue,
+          lineOptions: {
+            lineBorderWidth: '4',
+          },
         },
         {
           legend: 'All',
@@ -142,6 +145,9 @@ export class LineChartEventsExample extends React.Component<{}, ILineChartEvents
             },
           ],
           color: DefaultPalette.green,
+          lineOptions: {
+            lineBorderWidth: '4',
+          },
         },
       ],
     };

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Gaps.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Gaps.Example.tsx
@@ -45,6 +45,7 @@ export class LineChartGapsExample extends React.Component<{}, ILineChartGapsStat
             strokeDasharray: '5',
             strokeLinecap: 'butt',
             strokeWidth: '2',
+            lineBorderWidth: '4',
           },
           data: [
             {

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.LargeData.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.LargeData.Example.tsx
@@ -74,6 +74,9 @@ export class LineChartLargeDataExample extends React.Component<{}, ILineChartBas
           color: DefaultPalette.blue,
           onLineClick: () => console.log('From_Legacy_to_O365'),
           hideNonActiveDots: true,
+          lineOptions: {
+            lineBorderWidth: '5',
+          },
         },
         {
           legend: 'All',

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.LargeData.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.LargeData.Example.tsx
@@ -34,10 +34,9 @@ export class LineChartLargeDataExample extends React.Component<{}, ILineChartBas
   };
 
   private _getdata = () => {
-    let data: ILineChartDataPoint[] = [];
-    let startdate = new Date('2020-03-01T00:00:00.000Z');
-    let i = 0;
-    for (i = 0; i < 10000; i++) {
+    const data: ILineChartDataPoint[] = [];
+    const startdate = new Date('2020-03-01T00:00:00.000Z');
+    for (let i = 0; i < 10000; i++) {
       data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: 500000 });
     }
 
@@ -45,21 +44,23 @@ export class LineChartLargeDataExample extends React.Component<{}, ILineChartBas
   };
 
   private _getdata2 = () => {
-    let data: ILineChartDataPoint[] = [];
-    let startdate = new Date('2020-03-01T00:00:00.000Z');
-    let i = 0;
-    for (i = 1000; i < 9000; i++) {
-      data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: this.getY(i) });
+    const data: ILineChartDataPoint[] = [];
+    const startdate = new Date('2020-03-01T00:00:00.000Z');
+    for (let i = 1000; i < 9000; i++) {
+      data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: this._getY(i) });
     }
 
     return data;
   };
 
-  private getY = (i: number) => {
+  private _getY = (i: number) => {
     let res: number = 0;
     const newN = i % 1000;
-    if (newN < 500) res = newN * newN;
-    else res = 1000000 - newN * newN;
+    if (newN < 500) {
+      res = newN * newN;
+    } else {
+      res = 1000000 - newN * newN;
+    }
 
     return res;
   };
@@ -75,7 +76,7 @@ export class LineChartLargeDataExample extends React.Component<{}, ILineChartBas
           onLineClick: () => console.log('From_Legacy_to_O365'),
           hideNonActiveDots: true,
           lineOptions: {
-            lineBorderWidth: '5',
+            lineBorderWidth: '4',
           },
         },
         {
@@ -83,7 +84,7 @@ export class LineChartLargeDataExample extends React.Component<{}, ILineChartBas
           data: this._getdata2(),
           color: DefaultPalette.green,
           lineOptions: {
-            lineBorderWidth: '5',
+            lineBorderWidth: '4',
           },
         },
         {

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.LargeData.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.LargeData.Example.tsx
@@ -9,7 +9,7 @@ interface ILineChartBasicState {
   allowMultipleShapes: boolean;
 }
 
-export class LineChartBasicExample extends React.Component<{}, ILineChartBasicState> {
+export class LineChartLargeDataExample extends React.Component<{}, ILineChartBasicState> {
   constructor(props: ILineChartProps) {
     super(props);
     this.state = {
@@ -38,7 +38,6 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
     let startdate = new Date('2020-03-01T00:00:00.000Z');
     let i = 0;
     for (i = 0; i < 10000; i++) {
-      //data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: i * i - 5 * i });
       data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: 500000 });
     }
 
@@ -50,8 +49,6 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
     let startdate = new Date('2020-03-01T00:00:00.000Z');
     let i = 0;
     for (i = 1000; i < 9000; i++) {
-      //data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: 100000000 - i * i });
-      //data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: 5000000 + i * i - 5 * i });
       data.push({ x: new Date(startdate).setHours(startdate.getHours() + i), y: this.getY(i) });
     }
 
@@ -82,6 +79,9 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
           legend: 'All',
           data: this._getdata2(),
           color: DefaultPalette.green,
+          lineOptions: {
+            lineBorderWidth: '5',
+          },
         },
         {
           legend: 'single point',

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Multiple.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Multiple.Example.tsx
@@ -77,6 +77,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
         ],
         legend: 'First',
         color: DefaultPalette.blue,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -90,6 +93,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
         ],
         legend: 'Second',
         color: DefaultPalette.green,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -103,6 +109,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
         ],
         legend: 'Third',
         color: DefaultPalette.red,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -116,6 +125,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
         ],
         legend: 'Fourth',
         color: DefaultPalette.black,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -129,6 +141,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
         ],
         legend: 'Fifth',
         color: DefaultPalette.magentaDark,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -142,6 +157,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
         ],
         legend: 'Sixth',
         color: DefaultPalette.purple,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -155,6 +173,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
         ],
         legend: 'Seventh',
         color: DefaultPalette.yellow,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -168,6 +189,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
         ],
         legend: 'Eight',
         color: DefaultPalette.teal,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -181,6 +205,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
         ],
         legend: 'Ninth',
         color: 'cyan',
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -194,6 +221,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
         ],
         legend: 'Tenth',
         color: DefaultPalette.orangeLighter,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -207,6 +237,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
         ],
         legend: 'Eleventh',
         color: 'magenta',
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
       {
@@ -220,6 +253,9 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
         ],
         legend: 'Tweleth',
         color: DefaultPalette.redDark,
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         onLegendClick: this._onLegendClickHandler,
       },
     ];

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Styled.Example.tsx
@@ -46,6 +46,9 @@ export class LineChartStyledExample extends React.Component<{}, IStyledLineChart
           { x: new Date('2018/01/29'), y: 90 },
         ],
         legend: 'Week',
+        lineOptions: {
+          lineBorderWidth: '4',
+        },
         color: DefaultPalette.blue,
       },
     ];

--- a/packages/react-examples/src/react-charting/LineChart/LineChartPage.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChartPage.tsx
@@ -12,12 +12,14 @@ import { LineChartStyledExample } from './LineChart.Styled.Example';
 import { LineChartMultipleExample } from './LineChart.Multiple.Example';
 import { LineChartEventsExample } from './LineChart.Events.Example';
 import { LineChartCustomAccessibilityExample } from './LineChart.CustomAccessibility.Example';
+import { LineChartLargeDataExample } from './LineChart.LargeData.Example';
 
 const LineChartBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx') as string;
 const LineChartStyledExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.Styled.Example.tsx') as string;
 const MultipleLineChartExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.Multiple.Example.tsx') as string;
 const LineChartEventsExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.Events.Example.tsx') as string;
 const LineChartCustomAccessibilityExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.CustomAccessibility.Example.tsx') as string;
+const LineChartLargeDataExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.LargeData.Example.tsx') as string;
 
 export class LineChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -41,6 +43,9 @@ export class LineChartPage extends React.Component<IComponentDemoPageProps, {}> 
             </ExampleCard>
             <ExampleCard title="LineChart Custom Accessibility" code={LineChartCustomAccessibilityExampleCode}>
               <LineChartCustomAccessibilityExample />
+            </ExampleCard>
+            <ExampleCard title="LineChart large data" code={LineChartLargeDataExampleCode}>
+              <LineChartLargeDataExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
Currently, line charts are rendered by drawing 2 things.
1. Small line segments, each connecting adjacent points. For example for each of these pair of points {(x1, y1), (x2, y2)}, {(x2, y2), (x3, y3)}, {(xn-1, yn-1), (xn, yn)} there is a line segment connecting the two.
2. For each point there is a circle that represents the highlighted state. This circle gets activated whenever the mouse is hovered over this point.
This approach works fine if there are small number of data points in the line. As the number of points increase beyond 1000, the dom rendering starts becoming heavy. The performance and responsiveness of the chart starts suffering and the chart becomes very slow.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
With this PR, I have enabled a path based rendering when there are larger number of datapoints.
For lines with points greater than 1000, we render a single path for all the points leveraging d3 line functionality.
To identify the correct circle to highlight and activate, we inverse map the coordinate hovered over with the respective chart point in the domain. Then a circle is rendered at its position.
With this fix, we see that the line chart continues to be light and responsive even after having 10k datapoints.

The peak memory usage also comes down from 1.5GB to 300MB for a 10k datapoint chart.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
