### PR TITLE
fix: Griffel conformance test should use user container for render

### DIFF
--- a/change/@fluentui-react-conformance-griffel-3dd81437-a987-4472-b15c-f827662bd237.json
+++ b/change/@fluentui-react-conformance-griffel-3dd81437-a987-4472-b15c-f827662bd237.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Griffel conformance test should use user container for render",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-conformance-griffel/src/overridesWin.ts
+++ b/packages/react-components/react-conformance-griffel/src/overridesWin.ts
@@ -33,7 +33,7 @@ export const overridesWin: ConformanceTest = (componentInfo, testInfo) => {
     | (TestOptions & { [OVERRIDES_WIN_TEST_NAME]?: OverridesWinTestOptions })
     | undefined;
 
-  let container: HTMLDivElement | null = null;
+  let container: HTMLElement | null = null;
   const mergeClasses = jest.fn().mockImplementation(() => '');
 
   jest.mock('@griffel/react', () => {
@@ -45,9 +45,12 @@ export const overridesWin: ConformanceTest = (componentInfo, testInfo) => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
-
-    container = document.createElement('div');
-    document.body.appendChild(container);
+    if (testInfo.renderOptions?.container) {
+      container = testInfo.renderOptions.container;
+    } else {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    }
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Updates react-griffel-conformance to use `renderOptions.container`