### PR TITLE
chore: Disable lint-imports for v9

### DIFF
--- a/change/@fluentui-react-portal-compat-71d7bcf1-f43a-4506-a968-584814a7b0af.json
+++ b/change/@fluentui-react-portal-compat-71d7bcf1-f43a-4506-a968-584814a7b0af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: enable AMD compatible build",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-context-dfd86a39-651e-4b89-b9ef-71dcdf1a110f.json
+++ b/change/@fluentui-react-portal-compat-context-dfd86a39-651e-4b89-b9ef-71dcdf1a110f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Explicitly enable AMD lint-imports rule",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-portal-compat-context/package.json
+++ b/packages/react-components/react-portal-compat-context/package.json
@@ -16,7 +16,7 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
-    "lint": "just-scripts lint",
+    "lint": "just-scripts lint && just-scripts lint-imports",
     "start": "yarn storybook",
     "test": "jest --passWithNoTests",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",

--- a/packages/react-components/react-portal-compat/package.json
+++ b/packages/react-components/react-portal-compat/package.json
@@ -12,11 +12,11 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "just-scripts build",
+    "build": "just-scripts build --module esm,cjs,amd",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
-    "lint": "just-scripts lint",
+    "lint": "just-scripts lint && just-scripts lint-imports",
     "start": "yarn storybook",
     "test": "jest --passWithNoTests",
     "docs": "api-extractor run --config=config/api-extractor.local.json --local",

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -101,7 +101,13 @@ export function preset() {
     condition('jest', () => fs.existsSync(path.join(process.cwd(), 'jest.config.js'))),
   );
 
-  task('lint', parallel('lint-imports', 'eslint'));
+  task(
+    'lint',
+    parallel(
+      condition('lint-imports', () => !isConvergedPackage()),
+      'eslint',
+    ),
+  );
 
   task('code-style', series('prettier', 'lint'));
 


### PR DESCRIPTION
Disables the AMD lint-imports rule for v9

Fixes: #23107