### PR TITLE
fix(docs): add usage warning to CardHeader

### DIFF
--- a/change/@fluentui-react-card-9b222aa1-8f87-4bca-a101-bd24bcd9ba32.json
+++ b/change/@fluentui-react-card-9b222aa1-8f87-4bca-a101-bd24bcd9ba32.json
@@ -1,0 +1,10 @@
+{
+  "type": "none",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "@fluentui/react-card",
+  "email": "popatudor@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-card/src/stories/CardHeader/CardHeaderDescription.md
+++ b/packages/react-components/react-card/src/stories/CardHeader/CardHeaderDescription.md
@@ -1,0 +1,15 @@
+Component to render an image, text and an action in a Card component.
+
+<!-- Don't allow prettier to collapse code block into single line -->
+<!-- prettier-ignore -->
+> **⚠️ Preview components are considered unstable:**
+>
+> ```jsx
+>
+> import { CardHeader } from '@fluentui/react-components/unstable';
+>
+>
+> ```
+>
+> - Features and APIs may change before final release
+> - Please contact us if you intend to use this in your product

--- a/packages/react-components/react-card/src/stories/CardHeader/index.stories.tsx
+++ b/packages/react-components/react-card/src/stories/CardHeader/index.stories.tsx
@@ -1,8 +1,16 @@
 import { CardHeader } from '../../index';
+import descriptionMd from './CardHeaderDescription.md';
 
 export { Default } from './CardHeaderDefault.stories';
 
 export default {
   title: 'Preview Components/CardHeader',
   component: CardHeader,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd].join('\n'),
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Current Behavior

The `CardHeader` storybook doc is missing the unstable usage warning.

## New Behavior

Add unstable usage warning with import example.

## Related Issue(s)

Fixes #23952 
