### PR TITLE
Fluent Provider - convert to useLayoutEffect approach with useInsertionEffect when possible

### DIFF
--- a/change/@fluentui-react-provider-f7af8760-705e-4c2e-add0-9746ee74b04b.json
+++ b/change/@fluentui-react-provider-f7af8760-705e-4c2e-add0-9746ee74b04b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "move to useLayoutEffect or useInsertionEffect for Theme Provider theme insertion",
+  "packageName": "@fluentui/react-provider",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-f7af8760-705e-4c2e-add0-9746ee74b04b.json
+++ b/change/@fluentui-react-provider-f7af8760-705e-4c2e-add0-9746ee74b04b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "move to useLayoutEffect or useInsertionEffect for Theme Provider theme insertion",
+  "comment": "fix: Move to useLayoutEffect or useInsertionEffect for Theme Provider theme insertion.",
   "packageName": "@fluentui/react-provider",
   "email": "mgodbolt@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -23,7 +23,6 @@ const insertSheet = (tag: HTMLStyleElement, rule: string) => {
 
   if (sheet) {
     if (sheet.cssRules.length > 0) {
-      console.log('delete');
       sheet.deleteRule(0);
     }
     sheet.insertRule(rule, 0);

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import type { FluentProviderState } from './FluentProvider.types';
 import { fluentProviderClassNames } from './useFluentProviderStyles';
 
+// String concatenation is used to prevent bundlers to complain with older versions of React
 const useInsertionEffect = (React as never)['useInsertion' + 'Effect']
   ? (React as never)['useInsertion' + 'Effect']
   : useIsomorphicLayoutEffect;

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -1,12 +1,11 @@
-import { useId } from '@fluentui/react-utilities';
+import { useId, useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 import * as React from 'react';
 import type { FluentProviderState } from './FluentProvider.types';
 import { fluentProviderClassNames } from './useFluentProviderStyles';
 
 const useInsertionEffect = (React as never)['useInsertion' + 'Effect']
   ? (React as never)['useInsertion' + 'Effect']
-  : // eslint-disable-next-line no-restricted-properties
-    React.useLayoutEffect;
+  : useIsomorphicLayoutEffect;
 
 const createStyleTag = (target: Document | undefined, id: string) => {
   if (!target) {

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -55,12 +55,12 @@ export const useFluentProviderThemeStyleTag = (options: Pick<FluentProviderState
 
   useInsertionEffect(() => {
     styleTag.current = createStyleTag(targetDocument, styleTagId);
-    styleTag.current && insertSheet(styleTag.current, rule);
-    return () => {
-      if (styleTag.current) {
-        styleTag.current.remove();
-      }
-    };
+    if (styleTag.current) {
+      insertSheet(styleTag.current, rule);
+      return () => {
+        styleTag.current?.remove();
+      };
+    }
   }, [styleTagId, targetDocument, rule]);
 
   return styleTagId;

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -56,8 +56,10 @@ export const useFluentProviderThemeStyleTag = (options: Pick<FluentProviderState
 
   useInsertionEffect(() => {
     styleTag.current = createStyleTag(targetDocument, styleTagId);
+
     if (styleTag.current) {
       insertSheet(styleTag.current, rule);
+
       return () => {
         styleTag.current?.remove();
       };

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -1,7 +1,37 @@
-import { useId, usePrevious } from '@fluentui/react-utilities';
+import { useId } from '@fluentui/react-utilities';
 import * as React from 'react';
 import type { FluentProviderState } from './FluentProvider.types';
 import { fluentProviderClassNames } from './useFluentProviderStyles';
+
+const useInsertionEffect = (React as never)['useInsertion' + 'Effect']
+  ? (React as never)['useInsertion' + 'Effect']
+  : // eslint-disable-next-line no-restricted-properties
+    React.useLayoutEffect;
+
+const createStyleTag = (target: Document | undefined, id: string) => {
+  if (!target) {
+    return undefined;
+  }
+  const tag = target.createElement('style');
+  tag.setAttribute('id', id);
+  target.head.appendChild(tag);
+  return tag;
+};
+
+const insertSheet = (tag: HTMLStyleElement, rule: string) => {
+  const sheet = tag.sheet;
+
+  if (sheet) {
+    if (sheet.cssRules.length > 0) {
+      console.log('delete');
+      sheet.deleteRule(0);
+    }
+    sheet.insertRule(rule, 0);
+  } else if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.error('FluentProvider: No sheet available on styleTag, styles will not be inserted into DOM.');
+  }
+};
 
 /**
  * Writes a theme as css variables in a style tag on the provided targetDocument as a rule applied to a CSS class
@@ -10,54 +40,30 @@ import { fluentProviderClassNames } from './useFluentProviderStyles';
  */
 export const useFluentProviderThemeStyleTag = (options: Pick<FluentProviderState, 'theme' | 'targetDocument'>) => {
   const { targetDocument, theme } = options;
+  const styleTag = React.useRef<HTMLStyleElement>();
 
   const styleTagId = useId(fluentProviderClassNames.root);
-  const styleTag = React.useMemo(() => {
-    if (!targetDocument) {
-      return null;
-    }
 
-    const tag = targetDocument.createElement('style');
-    tag.setAttribute('id', styleTagId);
-    targetDocument.head.appendChild(tag);
-    return tag;
-  }, [styleTagId, targetDocument]);
-
-  const cssRule = React.useMemo(() => {
-    const cssVarsAsString = theme
+  const cssVarsAsString = React.useMemo(() => {
+    return theme
       ? (Object.keys(theme) as (keyof typeof theme)[]).reduce((cssVarRule, cssVar) => {
           cssVarRule += `--${cssVar}: ${theme[cssVar]}; `;
           return cssVarRule;
         }, '')
       : '';
+  }, [theme]);
 
-    // result: .fluent-provider1 { --css-var: '#fff' }
-    return `.${styleTagId} { ${cssVarsAsString} }`;
-  }, [theme, styleTagId]);
-  const previousCssRule = usePrevious(cssRule);
+  const rule = `.${styleTagId} { ${cssVarsAsString} }`;
 
-  if (styleTag && previousCssRule !== cssRule) {
-    const sheet = styleTag.sheet;
-
-    if (sheet) {
-      if (sheet.cssRules.length > 0) {
-        sheet.deleteRule(0);
-      }
-      sheet.insertRule(cssRule, 0);
-    } else if (process.env.NODE_ENV !== 'production') {
-      // eslint-disable-next-line no-console
-      console.error('FluentProvider: No sheet available on styleTag, styles will not be inserted into DOM.');
-    }
-  }
-
-  // Removes the style tag from the targetDocument on unmount or change
-  React.useEffect(() => {
+  useInsertionEffect(() => {
+    styleTag.current = createStyleTag(targetDocument, styleTagId);
+    styleTag.current && insertSheet(styleTag.current, rule);
     return () => {
-      if (styleTag) {
-        styleTag.remove();
+      if (styleTag.current) {
+        styleTag.current.remove();
       }
     };
-  }, [styleTag]);
+  }, [styleTagId, targetDocument, rule]);
 
   return styleTagId;
 };


### PR DESCRIPTION
fixes #23625

Two things happening here: 

1. To support React 18 we need to move to a symmetrical approach where we use useInsertionEffect to both insert the style and remove the style
2. Rather than splitting the logic for 16 vs 18, after a discussion with Shift, we are also changing the default logic to use useLayoutEffect rather than the in-render insertion. This mirrors how [emotionjs currently injects styles](https://github.com/emotion-js/emotion/blob/main/packages/react/src/global.js#L16)