### PR TITLE
chore(react-avatar): Create AvatarGroupOverflow component boilerplate

### DIFF
--- a/change/@fluentui-react-avatar-9e7bf365-19f5-49a7-a21a-32a26018f35d.json
+++ b/change/@fluentui-react-avatar-9e7bf365-19f5-49a7-a21a-32a26018f35d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Creating AvatarGroupOverflow component boilerplate.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-avatar/.storybook/main.js
+++ b/packages/react-components/react-avatar/.storybook/main.js
@@ -2,14 +2,7 @@ const rootMain = require('../../../../.storybook/main');
 
 module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
   ...rootMain,
-  stories: [
-    ...rootMain.stories,
-    '../src/**/*.stories.mdx',
-    '../src/**/index.stories.@(ts|tsx)',
-    // `.beta` was added so AvatarGroup is not shown in the docsite until it's ready for unstable.
-    // Refer to #23216 for more details.
-    '../src/**/*.stories.beta.@(ts|tsx)',
-  ],
+  stories: [...rootMain.stories, '../src/**/*.stories.mdx', '../src/**/index.stories.@(ts|tsx)'],
   addons: [...rootMain.addons],
   webpackFinal: (config, options) => {
     const localConfig = { ...rootMain.webpackFinal(config, options) };

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -53,6 +53,26 @@ export type AvatarGroupItemState = ComponentState<AvatarGroupItemSlots> & {
 };
 
 // @public
+export const AvatarGroupOverflow: ForwardRefComponent<AvatarGroupOverflowProps>;
+
+// @public (undocumented)
+export const avatarGroupOverflowClassName = "fui-AvatarGroupOverflow";
+
+// @public (undocumented)
+export const avatarGroupOverflowClassNames: SlotClassNames<AvatarGroupOverflowSlots>;
+
+// @public
+export type AvatarGroupOverflowProps = ComponentProps<AvatarGroupOverflowSlots> & {};
+
+// @public (undocumented)
+export type AvatarGroupOverflowSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type AvatarGroupOverflowState = ComponentState<AvatarGroupOverflowSlots>;
+
+// @public
 export type AvatarGroupProps = ComponentProps<AvatarGroupSlots> & {
     layout?: 'spread' | 'stack' | 'pie';
     maxAvatars?: number;
@@ -123,6 +143,9 @@ export const renderAvatarGroup_unstable: (state: AvatarGroupState) => JSX.Elemen
 // @public
 export const renderAvatarGroupItem_unstable: (state: AvatarGroupItemState) => JSX.Element;
 
+// @public
+export const renderAvatarGroupOverflow_unstable: (state: AvatarGroupOverflowState) => JSX.Element;
+
 // @public (undocumented)
 export const useAvatar_unstable: (props: AvatarProps, ref: React_2.Ref<HTMLElement>) => AvatarState;
 
@@ -134,6 +157,12 @@ export const useAvatarGroupItem_unstable: (props: AvatarGroupItemProps, ref: Rea
 
 // @public
 export const useAvatarGroupItemStyles_unstable: (state: AvatarGroupItemState) => AvatarGroupItemState;
+
+// @public
+export const useAvatarGroupOverflow_unstable: (props: AvatarGroupOverflowProps, ref: React_2.Ref<HTMLElement>) => AvatarGroupOverflowState;
+
+// @public
+export const useAvatarGroupOverflowStyles_unstable: (state: AvatarGroupOverflowState) => AvatarGroupOverflowState;
 
 // @public
 export const useAvatarGroupStyles_unstable: (state: AvatarGroupState) => AvatarGroupState;

--- a/packages/react-components/react-avatar/src/AvatarGroupOverflow.ts
+++ b/packages/react-components/react-avatar/src/AvatarGroupOverflow.ts
@@ -1,0 +1,1 @@
+export * from './components/AvatarGroupOverflow/index';

--- a/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/AvatarGroupOverflow.test.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/AvatarGroupOverflow.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { AvatarGroupOverflow } from './AvatarGroupOverflow';
+import { isConformant } from '../../common/isConformant';
+
+describe('AvatarGroupOverflow', () => {
+  isConformant({
+    Component: AvatarGroupOverflow,
+    displayName: 'AvatarGroupOverflow',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<AvatarGroupOverflow>Default AvatarGroupOverflow</AvatarGroupOverflow>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/AvatarGroupOverflow.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/AvatarGroupOverflow.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useAvatarGroupOverflow_unstable } from './useAvatarGroupOverflow';
+import { renderAvatarGroupOverflow_unstable } from './renderAvatarGroupOverflow';
+import { useAvatarGroupOverflowStyles_unstable } from './useAvatarGroupOverflowStyles';
+import type { AvatarGroupOverflowProps } from './AvatarGroupOverflow.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * AvatarGroupOverflow component - TODO: add more docs
+ */
+export const AvatarGroupOverflow: ForwardRefComponent<AvatarGroupOverflowProps> = React.forwardRef((props, ref) => {
+  const state = useAvatarGroupOverflow_unstable(props, ref);
+
+  useAvatarGroupOverflowStyles_unstable(state);
+  return renderAvatarGroupOverflow_unstable(state);
+});
+
+AvatarGroupOverflow.displayName = 'AvatarGroupOverflow';

--- a/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/AvatarGroupOverflow.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/AvatarGroupOverflow.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type AvatarGroupOverflowSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * AvatarGroupOverflow Props
+ */
+export type AvatarGroupOverflowProps = ComponentProps<AvatarGroupOverflowSlots> & {};
+
+/**
+ * State used in rendering AvatarGroupOverflow
+ */
+export type AvatarGroupOverflowState = ComponentState<AvatarGroupOverflowSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from AvatarGroupOverflowProps.
+// & Required<Pick<AvatarGroupOverflowProps, 'propName'>>

--- a/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/AvatarGroupOverflow.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/AvatarGroupOverflow.types.ts
@@ -13,5 +13,4 @@ export type AvatarGroupOverflowProps = ComponentProps<AvatarGroupOverflowSlots> 
  * State used in rendering AvatarGroupOverflow
  */
 export type AvatarGroupOverflowState = ComponentState<AvatarGroupOverflowSlots>;
-// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from AvatarGroupOverflowProps.
 // & Required<Pick<AvatarGroupOverflowProps, 'propName'>>

--- a/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/__snapshots__/AvatarGroupOverflow.test.tsx.snap
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/__snapshots__/AvatarGroupOverflow.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AvatarGroupOverflow renders a default state 1`] = `
+<div>
+  <div
+    class="fui-AvatarGroupOverflow"
+  >
+    Default AvatarGroupOverflow
+  </div>
+</div>
+`;

--- a/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/index.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/index.ts
@@ -1,0 +1,5 @@
+export * from './AvatarGroupOverflow';
+export * from './AvatarGroupOverflow.types';
+export * from './renderAvatarGroupOverflow';
+export * from './useAvatarGroupOverflow';
+export * from './useAvatarGroupOverflowStyles';

--- a/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/renderAvatarGroupOverflow.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/renderAvatarGroupOverflow.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { AvatarGroupOverflowState, AvatarGroupOverflowSlots } from './AvatarGroupOverflow.types';
+
+/**
+ * Render the final JSX of AvatarGroupOverflow
+ */
+export const renderAvatarGroupOverflow_unstable = (state: AvatarGroupOverflowState) => {
+  const { slots, slotProps } = getSlots<AvatarGroupOverflowSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <slots.root {...slotProps.root} />;
+};

--- a/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/useAvatarGroupOverflow.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/useAvatarGroupOverflow.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { getNativeElementProps } from '@fluentui/react-utilities';
+import type { AvatarGroupOverflowProps, AvatarGroupOverflowState } from './AvatarGroupOverflow.types';
+
+/**
+ * Create the state required to render AvatarGroupOverflow.
+ *
+ * The returned state can be modified with hooks such as useAvatarGroupOverflowStyles_unstable,
+ * before being passed to renderAvatarGroupOverflow_unstable.
+ *
+ * @param props - props from this instance of AvatarGroupOverflow
+ * @param ref - reference to root HTMLElement of AvatarGroupOverflow
+ */
+export const useAvatarGroupOverflow_unstable = (
+  props: AvatarGroupOverflowProps,
+  ref: React.Ref<HTMLElement>,
+): AvatarGroupOverflowState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: getNativeElementProps('div', {
+      ref,
+      ...props,
+    }),
+  };
+};

--- a/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/useAvatarGroupOverflowStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupOverflow/useAvatarGroupOverflowStyles.ts
@@ -1,0 +1,34 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { AvatarGroupOverflowSlots, AvatarGroupOverflowState } from './AvatarGroupOverflow.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+export const avatarGroupOverflowClassName = 'fui-AvatarGroupOverflow';
+export const avatarGroupOverflowClassNames: SlotClassNames<AvatarGroupOverflowSlots> = {
+  root: 'fui-AvatarGroupOverflow',
+  // TODO: add class names for all slots on AvatarGroupOverflowSlots.
+  // Should be of the form `<slotName>: 'fui-AvatarGroupOverflow__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the AvatarGroupOverflow slots based on the state
+ */
+export const useAvatarGroupOverflowStyles_unstable = (state: AvatarGroupOverflowState): AvatarGroupOverflowState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(avatarGroupOverflowClassName, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-avatar/src/index.ts
+++ b/packages/react-components/react-avatar/src/index.ts
@@ -23,3 +23,4 @@ export {
   useAvatarGroupItem_unstable,
 } from './AvatarGroupItem';
 export type { AvatarGroupItemProps, AvatarGroupItemSlots, AvatarGroupItemState } from './AvatarGroupItem';
+export * from './AvatarGroupOverflow';

--- a/packages/react-components/react-avatar/src/stories/AvatarGroupOverflow/AvatarGroupOverflowBestPractices.md
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroupOverflow/AvatarGroupOverflowBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-avatar/src/stories/AvatarGroupOverflow/AvatarGroupOverflowDefault.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroupOverflow/AvatarGroupOverflowDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { AvatarGroupOverflow, AvatarGroupOverflowProps } from '@fluentui/react-avatar';
+
+export const Default = (props: Partial<AvatarGroupOverflowProps>) => <AvatarGroupOverflow {...props} />;

--- a/packages/react-components/react-avatar/src/stories/AvatarGroupOverflow/index.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroupOverflow/index.stories.tsx
@@ -1,0 +1,18 @@
+import { AvatarGroupOverflow } from '@fluentui/react-avatar';
+
+import descriptionMd from './AvatarGroupOverflowDescription.md';
+import bestPracticesMd from './AvatarGroupOverflowBestPractices.md';
+
+export { Default } from './AvatarGroupOverflowDefault.stories';
+
+export default {
+  title: 'Preview Components/AvatarGroupOverflow',
+  component: AvatarGroupOverflow,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};


### PR DESCRIPTION
This PR only adds what `create-component` generates. It's the boilerplate for AvatarGroupOverflow.