### PR TITLE
theme designer: change hue torsion range, change lightCp and darkCp to vibrancy

### DIFF
--- a/packages/react-components/theme-designer/src/components/Sidebar/Form.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/Form.tsx
@@ -64,8 +64,7 @@ export const Form: React.FC<FormProps> = props => {
     const sameForm =
       state.keyColor === action.attributes.keyColor &&
       state.hueTorsion === action.attributes.hueTorsion &&
-      state.darkCp === action.attributes.darkCp &&
-      state.lightCp === action.attributes.lightCp;
+      state.vibrancy === action.attributes.vibrancy;
 
     // only dispatch if form changes
     if (!sameForm) {
@@ -76,14 +75,10 @@ export const Form: React.FC<FormProps> = props => {
 
   const [keyColor, setKeyColor] = React.useState<string>(formState.keyColor);
   const [hueTorsion, setHueTorsion] = React.useState<number>(formState.hueTorsion);
-  const [darkCp, setDarkCp] = React.useState<number>(formState.darkCp * 100);
-  const [lightCp, setLightCp] = React.useState<number>(formState.lightCp * 100);
+  const [vibrancy, setVibrancy] = React.useState<number>(formState.vibrancy * 100);
 
   const [form, dispatchForm] = React.useReducer(formReducer, formState);
-  const debouncedForm = useDebounce(
-    { keyColor, hueTorsion: hueTorsion / 100, darkCp: darkCp / 100, lightCp: lightCp / 100 },
-    10,
-  );
+  const debouncedForm = useDebounce({ keyColor, hueTorsion: hueTorsion / 100, vibrancy: vibrancy / 100 }, 10);
   React.useEffect(() => {
     dispatchForm({ attributes: debouncedForm });
   }, [debouncedForm]);
@@ -96,11 +91,8 @@ export const Form: React.FC<FormProps> = props => {
   const handleHueTorsionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setHueTorsion(parseInt(e.target.value, 10));
   };
-  const handleLightCpChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLightCp(parseInt(e.target.value, 10));
-  };
-  const handleDarkCpChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setDarkCp(parseInt(e.target.value, 10));
+  const handleVibrancyChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setVibrancy(parseInt(e.target.value, 10));
   };
 
   return (
@@ -131,8 +123,8 @@ export const Form: React.FC<FormProps> = props => {
       <div className={styles.slider}>
         <Slider
           size="small"
-          min={-360}
-          max={360}
+          min={-50}
+          max={50}
           id={sidebarId + 'hueTorsion'}
           value={hueTorsion}
           onChange={handleHueTorsionChange}
@@ -140,47 +132,33 @@ export const Form: React.FC<FormProps> = props => {
         <Input
           size="small"
           type="number"
-          min={-360}
-          max={360}
+          min={-50}
+          max={50}
           appearance="outline"
           id={sidebarId + 'hueTorsion input'}
           value={hueTorsion.toString()}
           onChange={handleHueTorsionChange}
         />
       </div>
-      <Label htmlFor={sidebarId + 'lightCp'}>Light Control Point</Label>
+      <Label htmlFor={sidebarId + 'vibrancy'}>Vibrancy</Label>
       <div className={styles.slider}>
         <Slider
           size="small"
-          min={0}
-          max={100}
-          id={sidebarId + 'lightCp'}
-          value={lightCp}
-          onChange={handleLightCpChange}
+          min={-50}
+          max={50}
+          id={sidebarId + 'vibrancy'}
+          value={vibrancy}
+          onChange={handleVibrancyChange}
         />
         <Input
           size="small"
           type="number"
-          min={0}
-          max={100}
+          min={-50}
+          max={50}
           appearance="outline"
-          id={sidebarId + 'lightCp input'}
-          value={lightCp.toString()}
-          onChange={handleLightCpChange}
-        />
-      </div>
-      <Label htmlFor={sidebarId + 'darkCp'}>Dark Control Point</Label>
-      <div className={styles.slider}>
-        <Slider size="small" min={0} max={100} id={sidebarId + 'darkCp'} value={darkCp} onChange={handleDarkCpChange} />
-        <Input
-          size="small"
-          type="number"
-          min={0}
-          max={100}
-          appearance="outline"
-          id={sidebarId + 'darkCp input'}
-          value={darkCp.toString()}
-          onChange={handleDarkCpChange}
+          id={sidebarId + 'vibrancy input'}
+          value={vibrancy.toString()}
+          onChange={handleVibrancyChange}
         />
       </div>
     </div>

--- a/packages/react-components/theme-designer/src/components/Sidebar/Sidebar.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/Sidebar.tsx
@@ -35,8 +35,7 @@ export const Sidebar: React.FC<SidebarProps> = props => {
   const [formState, setFormState] = React.useState<CustomAttributes>({
     keyColor: '#0F6CBD',
     hueTorsion: 0,
-    darkCp: 0.66,
-    lightCp: 0.33,
+    vibrancy: 0,
   });
 
   const handleIsDarkChange = () => {

--- a/packages/react-components/theme-designer/src/useThemeDesignerReducer.ts
+++ b/packages/react-components/theme-designer/src/useThemeDesignerReducer.ts
@@ -8,8 +8,7 @@ import { themeList, themeNames } from './utils/themeList';
 export type CustomAttributes = {
   keyColor: string;
   hueTorsion: number;
-  darkCp: number;
-  lightCp: number;
+  vibrancy: number;
 };
 
 export type DispatchTheme = {
@@ -42,11 +41,11 @@ export const initialAppState = {
 };
 
 export const useThemeDesignerReducer = () => {
-  const createCustomTheme = ({ darkCp, hueTorsion, keyColor, lightCp }: CustomAttributes): BrandVariants => {
+  const createCustomTheme = ({ hueTorsion, keyColor, vibrancy }: CustomAttributes): BrandVariants => {
     const brand = getBrandTokensFromPalette(keyColor, {
-      hueTorsion: hueTorsion,
-      darkCp: darkCp,
-      lightCp: lightCp,
+      hueTorsion,
+      darkCp: vibrancy,
+      lightCp: vibrancy + 0.5,
     });
     return brand;
   };


### PR DESCRIPTION
Restricted the range of the hue torsion slider. Combined lightCp and darkCp sliders into vibrancy slider.

![image](https://user-images.githubusercontent.com/31319479/180882326-afc0d648-3b4b-49bc-b863-495b96beb8f1.png)
![image](https://user-images.githubusercontent.com/31319479/180882345-7c9166f9-c6b0-4016-bcce-54091912437a.png)
![image](https://user-images.githubusercontent.com/31319479/180882360-652f3817-c8d6-423a-a9cc-448dc6231cd7.png)
