### PR TITLE
fix: react-combobox -- keyboard should not select disabled options

### DIFF
--- a/change/@fluentui-react-combobox-0037a98c-1e07-4e50-847f-79e97b510301.json
+++ b/change/@fluentui-react-combobox-0037a98c-1e07-4e50-847f-79e97b510301.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: prevent react-combobox keyboard selection of disabled options",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -274,6 +274,22 @@ describe('Combobox', () => {
     expect((getByRole('combobox') as HTMLInputElement).value).toEqual('Green');
   });
 
+  it('does not select a disabled option with the keyboard', () => {
+    const { getByTestId, getByRole } = render(
+      <Combobox open data-testid="combobox">
+        <Option disabled>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+
+    const combobox = getByTestId('combobox');
+
+    fireEvent.keyDown(combobox, { key: 'Enter' });
+
+    expect((getByRole('combobox') as HTMLInputElement).value).toEqual('');
+  });
+
   it('selects an option when tabbing away from an open combobox', () => {
     const { getByTestId, getByRole } = render(
       <Combobox defaultOpen data-testid="combobox">

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
@@ -274,6 +274,22 @@ describe('Dropdown', () => {
     expect(getByRole('combobox').textContent).toEqual('Green');
   });
 
+  it('does not select a disabled option with the keyboard', () => {
+    const { getByTestId, getByRole } = render(
+      <Dropdown open data-testid="combobox">
+        <Option disabled>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Dropdown>,
+    );
+
+    const combobox = getByTestId('combobox');
+
+    fireEvent.keyDown(combobox, { key: ' ' });
+
+    expect((getByRole('combobox') as HTMLInputElement).value).toEqual('');
+  });
+
   it('selects an option when tabbing away from an open combobox', () => {
     const { getByTestId, getByRole } = render(
       <Dropdown defaultOpen data-testid="combobox">

--- a/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
@@ -31,7 +31,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
     setActiveOption(getOptionById(option.id));
 
     // handle selection change
-    selectOption(event, option.value);
+    selectOption(event, option);
   };
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
@@ -43,7 +43,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
     switch (action) {
       case 'Select':
       case 'CloseSelect':
-        activeOption && selectOption(event, activeOption.value);
+        activeOption && selectOption(event, activeOption);
         break;
       default:
         newIndex = getIndexFromAction(action, activeIndex, maxIndex);

--- a/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
@@ -80,7 +80,7 @@ export type ComboboxBaseState = Required<Pick<ComboboxBaseProps, 'appearance' | 
     /* Callback when an option is clicked, for internal use */
     onOptionClick(event: React.MouseEvent, option: OptionValue): void;
 
-    selectOption(event: SelectionEvents, optionValue: string): void;
+    selectOption(event: SelectionEvents, option: OptionValue): void;
 
     setActiveOption(option?: OptionValue): void;
 

--- a/packages/react-components/react-combobox/src/utils/Selection.types.ts
+++ b/packages/react-components/react-combobox/src/utils/Selection.types.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { OptionValue } from './OptionCollection.types';
 
 export type SelectionProps = {
   /* For an uncontrolled component, sets the initial selection */
@@ -27,7 +28,7 @@ export type SelectionState = Required<Pick<SelectionProps, 'selectedOptions'>> &
 /* Values returned by the useSelection hook */
 export type SelectionValue = {
   selectedOptions: string[];
-  selectOption: (event: SelectionEvents, optionValue: string) => void;
+  selectOption: (event: SelectionEvents, option: OptionValue) => void;
 };
 
 /* Data for the onSelect callback */

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -56,7 +56,7 @@ export const useComboboxBaseState = (props: ComboboxBaseProps) => {
     !multiselect && setOpen(event, false);
 
     // handle selection change
-    selectOption(event, option.value);
+    selectOption(event, option);
   };
 
   // update active option based on change in open state

--- a/packages/react-components/react-combobox/src/utils/useSelection.ts
+++ b/packages/react-components/react-combobox/src/utils/useSelection.ts
@@ -1,4 +1,5 @@
 import { useControllableState } from '@fluentui/react-utilities';
+import { OptionValue } from './OptionCollection.types';
 import { SelectionEvents, SelectionProps, SelectionValue } from './Selection.types';
 
 export const useSelection = (props: SelectionProps): SelectionValue => {
@@ -10,24 +11,29 @@ export const useSelection = (props: SelectionProps): SelectionValue => {
     initialState: [],
   });
 
-  const selectOption = (event: SelectionEvents, optionValue: string) => {
+  const selectOption = (event: SelectionEvents, option: OptionValue) => {
+    // if the option is disabled, do nothing
+    if (option.disabled) {
+      return;
+    }
+
     // for single-select, always return the selected option
-    let newSelection = [optionValue];
+    let newSelection = [option.value];
 
     // toggle selected state of the option for multiselect
     if (multiselect) {
-      const selectedIndex = selectedOptions.findIndex(o => o === optionValue);
+      const selectedIndex = selectedOptions.findIndex(o => o === option.value);
       if (selectedIndex > -1) {
         // deselect option
         newSelection = [...selectedOptions.slice(0, selectedIndex), ...selectedOptions.slice(selectedIndex + 1)];
       } else {
         // select option
-        newSelection = [...selectedOptions, optionValue];
+        newSelection = [...selectedOptions, option.value];
       }
     }
 
     setSelectedOptions(newSelection);
-    onSelect?.(event, { optionValue, selectedOptions: newSelection });
+    onSelect?.(event, { optionValue: option.value, selectedOptions: newSelection });
   };
 
   return { selectedOptions, selectOption };

--- a/packages/react-components/react-combobox/src/utils/useTriggerListboxSlots.ts
+++ b/packages/react-components/react-combobox/src/utils/useTriggerListboxSlots.ts
@@ -122,14 +122,14 @@ export function useTriggerListboxSlots(
         setOpen(event, false);
         break;
       case 'CloseSelect':
-        !multiselect && setOpen(event, false);
+        !multiselect && !activeOption?.disabled && setOpen(event, false);
       // fallthrough
       case 'Select':
-        activeOption && selectOption(event, activeOption.value);
+        activeOption && selectOption(event, activeOption);
         event.preventDefault();
         break;
       case 'Tab':
-        activeOption && selectOption(event, activeOption.value);
+        activeOption && selectOption(event, activeOption);
         break;
       default:
         newIndex = getIndexFromAction(action, activeIndex, maxIndex);


### PR DESCRIPTION
Fixes a react-combobox bug where disabled options were getting selected with enter/space. Now enter/space works like click, where the dropdown remains open and the option is not selected.