### PR TITLE
Modal: Change modeless approach to only effect pointer events, not layout

### DIFF
--- a/apps/vr-tests/src/stories/Modal.stories.tsx
+++ b/apps/vr-tests/src/stories/Modal.stories.tsx
@@ -20,4 +20,9 @@ storiesOf('Modal', module)
     <Modal isOpen isBlocking={false}>
       Modal content
     </Modal>
+  ))
+  .addStory('Modeless', () => (
+    <Modal isModeless isOpen>
+      Modeless Modal content
+    </Modal>
   ));

--- a/change/@fluentui-react-0bc6cbfc-fbc5-4739-ace3-a84465da4342.json
+++ b/change/@fluentui-react-0bc6cbfc-fbc5-4739-ace3-a84465da4342.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Change modal isModeless to only effect pointer events, not layout",
+  "comment": "fix: Change modal isModeless to only effect pointer events, not layout.",
   "packageName": "@fluentui/react",
   "email": "mgodbolt@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-0bc6cbfc-fbc5-4739-ace3-a84465da4342.json
+++ b/change/@fluentui-react-0bc6cbfc-fbc5-4739-ace3-a84465da4342.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Change modal isModeless to only effect pointer events, not layout",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Modal/Modal.styles.ts
+++ b/packages/react/src/components/Modal/Modal.styles.ts
@@ -37,7 +37,7 @@ export const getStyles = (props: IModalStyleProps): IModalStyles => {
       fonts.medium,
       {
         backgroundColor: 'transparent',
-        position: isModeless ? 'absolute' : 'fixed',
+        position: 'fixed',
         height: '100%',
         width: '100%',
         display: 'flex',
@@ -55,8 +55,12 @@ export const getStyles = (props: IModalStyleProps): IModalStyles => {
       isOpen && classNames.isOpen,
       isVisible && {
         opacity: 1,
-        pointerEvents: 'auto',
       },
+      isVisible &&
+        !isModeless && {
+          pointerEvents: 'auto',
+        },
+
       className,
     ],
     main: [
@@ -75,6 +79,9 @@ export const getStyles = (props: IModalStyleProps): IModalStyles => {
         minWidth: '288px',
         overflowY: 'auto',
         zIndex: isModeless ? ZIndexes.Layer : undefined,
+      },
+      isModeless && {
+        pointerEvents: 'auto',
       },
       topOffsetFixed &&
         typeof modalRectangleTop === 'number' &&
@@ -100,15 +107,7 @@ export const getStyles = (props: IModalStyleProps): IModalStyles => {
       },
       scrollableContentClassName,
     ],
-    layer: isModeless && [
-      layerClassName,
-      classNames.layer,
-      {
-        position: 'static',
-        width: 'unset',
-        height: 'unset',
-      },
-    ],
+    layer: isModeless && [layerClassName, classNames.layer, { pointerEvents: 'none' }],
     keyboardMoveIconContainer: {
       position: 'absolute',
       display: 'flex',

--- a/packages/react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -25,13 +25,12 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            height: unset;
             left: 0px;
-            position: static;
+            pointer-events: none;
+            position: fixed;
             right: 0px;
             top: 0px;
             visibility: hidden;
-            width: unset;
             z-index: 1000000;
           }
       data-portal-element="true"
@@ -81,8 +80,8 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
                   height: 100%;
                   justify-content: center;
                   opacity: 1;
-                  pointer-events: auto;
-                  position: absolute;
+                  pointer-events: none;
+                  position: fixed;
                   transition: opacity 0.267s;
                   width: 100%;
                 }
@@ -103,6 +102,7 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
                     min-width: 288px;
                     outline: 3px solid transparent;
                     overflow-y: auto;
+                    pointer-events: auto;
                     position: relative;
                     text-align: left;
                     z-index: 1000000;
@@ -345,13 +345,12 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            height: unset;
             left: 0px;
-            position: static;
+            pointer-events: none;
+            position: fixed;
             right: 0px;
             top: 0px;
             visibility: hidden;
-            width: unset;
             z-index: 1000000;
           }
       data-portal-element="true"
@@ -401,8 +400,8 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
                   height: 100%;
                   justify-content: center;
                   opacity: 1;
-                  pointer-events: auto;
-                  position: absolute;
+                  pointer-events: none;
+                  position: fixed;
                   transition: opacity 0.267s;
                   width: 100%;
                 }
@@ -422,6 +421,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
                     min-width: 288px;
                     outline: 3px solid transparent;
                     overflow-y: auto;
+                    pointer-events: auto;
                     position: relative;
                     text-align: left;
                     z-index: 1000000;


### PR DESCRIPTION
fixes #22878

Due to moving all layers inside of a div, we can no longer rely on display: static on the layer to allow positioned content to reference the 100% width/height HTML element. 

The alternative is to keep the layouts exactly the same, but simply modify pointer event behavior on any blocking div (modal root and the layer). To do this we need to return normal click events to the main content area. 

I also added a VR test to ensure that our modeless modal does not break again due to some other change.