### PR TITLE
fix(react-input): adds proper `initialValue` to `useControllableState` on `useInput`

### DIFF
--- a/change/@fluentui-react-input-23c1038e-1ff3-4630-a748-9d709d04a2ad.json
+++ b/change/@fluentui-react-input-23c1038e-1ff3-4630-a748-9d709d04a2ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adds proper initialValue to value on useInput",
+  "packageName": "@fluentui/react-input",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-input/src/components/Input/useInput.ts
+++ b/packages/react-components/react-input/src/components/Input/useInput.ts
@@ -22,7 +22,7 @@ export const useInput_unstable = (props: InputProps, ref: React.Ref<HTMLInputEle
   const [value, setValue] = useControllableState({
     state: props.value,
     defaultState: props.defaultValue,
-    initialState: undefined,
+    initialState: '',
   });
 
   const nativeProps = getPartitionedNativeProps({


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently `Input` component doesn't provide an `initialValue` to `useControllableState` which ends up triggering a console error if no `defaultValue` and no `value` is provided.

Here's a reproduction: https://codesandbox.io/s/red-browser-5f4mwb?file=/index.tsx

## New Behavior

provides empty string (`""`) as the `initialValue`, ensuring that if no `defaultValue` and no `value` is provided the actual state is controlled internally and no error will be shown in the console.

