### PR TITLE
fix(docs): add Dropdown usage warning and style best practices

### DIFF
--- a/change/@fluentui-react-combobox-f4d9cbf9-a2e2-4f06-9968-9c6c897c1e6d.json
+++ b/change/@fluentui-react-combobox-f4d9cbf9-a2e2-4f06-9968-9c6c897c1e6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(docs): add Dropdown usage warning and style best practices",
+  "packageName": "@fluentui/react-combobox",
+  "email": "popatudor@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-combobox/src/stories/Dropdown/DropdownBestPractices.md
+++ b/packages/react-components/react-combobox/src/stories/Dropdown/DropdownBestPractices.md
@@ -1,4 +1,7 @@
-## Best practices
+<details>
+<summary>
+ Best Practices
+</summary>
 
 ### Do
 
@@ -7,3 +10,4 @@
 ### Don't
 
 - **Don’t place the Dropdown button on a surface which doesn’t have a sufficient contrast.** The colors adjacent to the input should have a sufficient contrast. Particularly, the color of input with filled darker and lighter styles needs to provide greater than 3 to 1 contrast ratio against the immediate surrounding color to pass accessibility requirements.
+</details>

--- a/packages/react-components/react-combobox/src/stories/Dropdown/DropdownDescription.md
+++ b/packages/react-components/react-combobox/src/stories/Dropdown/DropdownDescription.md
@@ -1,0 +1,14 @@
+A dropdown is a list in which the selected item is always visible while other items are visible on demand by clicking a dropdown button. Dropdowns are typically used for forms.
+
+<!-- Don't allow prettier to collapse code block into single line -->
+<!-- prettier-ignore -->
+> **⚠️ Preview components are considered unstable:**
+>
+> ```jsx
+>
+> import { Dropdown } from '@fluentui/react-components/unstable';
+>
+> ```
+>
+> - Features and APIs may change before final release
+> - Please contact us if you intend to use this in your product


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The Dropdown component storybook doesn't have an unstable usage warning sign and the "Best Practices" section isn't styled up correctly.

## New Behavior

Unstable usage warning has been added and "Best Practices" section has been styled.

## Related Issue(s)

Fixes #23955 
