### PR TITLE
fix(docs): add Select usage warning and style best practices

### DIFF
--- a/change/@fluentui-react-select-c465e31a-a10e-4945-82df-d4cef04dbf9a.json
+++ b/change/@fluentui-react-select-c465e31a-a10e-4945-82df-d4cef04dbf9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(docs): add Select usage warning and style best practices",
+  "packageName": "@fluentui/react-select",
+  "email": "popatudor@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-select/src/stories/Select/SelectBestPractices.md
+++ b/packages/react-components/react-select/src/stories/Select/SelectBestPractices.md
@@ -1,4 +1,7 @@
-## Best practices
+<details>
+<summary>
+ Best Practices
+</summary>
 
 ### Do
 
@@ -7,3 +10,4 @@
 ### Don't
 
 - **Don’t place `Select` on a surface which doesn’t have a sufficient contrast.** The colors adjacent to the input should have a sufficient contrast. Particularly, the color of input with filled darker and lighter styles needs to provide greater than 3 to 1 contrast ratio against the immediate surrounding color to pass accessibility requirements.
+</details>

--- a/packages/react-components/react-select/src/stories/Select/SelectDescription.md
+++ b/packages/react-components/react-select/src/stories/Select/SelectDescription.md
@@ -1,1 +1,14 @@
 A Select allows one option to be selected from multiple options. The Select component is a wrapper around the native `<select>` element.
+
+<!-- Don't allow prettier to collapse code block into single line -->
+<!-- prettier-ignore -->
+> **⚠️ Preview components are considered unstable:**
+>
+> ```jsx
+>
+> import { Select } from '@fluentui/react-components/unstable';
+>
+> ```
+>
+> - Features and APIs may change before final release
+> - Please contact us if you intend to use this in your product


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The Select component storybook doesn't have an unstable usage warning sign and the "Best Practices" section isn't styled up correctly.


## New Behavior

Unstable usage warning has been added and "Best Practices" section has been styled.

## Related Issue(s)

Fixes #23956 
