### PR TITLE
fix(docs): fix styling on Toolbar best practices

### DIFF
--- a/change/@fluentui-react-toolbar-a79099c9-e1bf-41a2-bfe0-d7feaadd9c48.json
+++ b/change/@fluentui-react-toolbar-a79099c9-e1bf-41a2-bfe0-d7feaadd9c48.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(docs): add description and unstable usage warning for Toolbar",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "popatudor@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarBestPractices.md
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarBestPractices.md
@@ -1,9 +1,11 @@
-## Best practices
-
-### Do
+<details>
+<summary>
+ Best Practices
+</summary>
 
 - Use toolbar as a grouping element only if the group contains 3 or more controls. Refer to ['toolbar aria practices'](https://www.w3.org/TR/wai-aria-practices-1.2/#toolbar) for details.
 - Label each toolbar when the application contains more than one toolbar (using `aria-label` or `aria-labelledby` props). Refer to [toolbar(role)](https://www.w3.org/WAI/PF/aria/roles#toolbar) for details.
 - Use `active` prop on a ToolbarMenuItem if you want to have an active icon indicator displayed next to it.
 - If `Toolbar` contains menu, the menu closes after clicking on one of the menu items. To prevent losing focus, move it manually in the `onClick` handler.
 - If `Toolbar` contains multiple radio groups in the menu, consider using role="group" and `aria-label` for radio group shorthands
+</details>

--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarDescription.md
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarDescription.md
@@ -1,0 +1,14 @@
+A toolbar is a container for grouping a set of controls, such as buttons, menu buttons, or checkboxes.
+
+<!-- Don't allow prettier to collapse code block into single line -->
+<!-- prettier-ignore -->
+> **⚠️ Preview components are considered unstable:**
+>
+> ```jsx
+>
+> import { Toolbar } from '@fluentui/react-components/unstable';
+>
+> ```
+>
+> - Features and APIs may change before final release
+> - Please contact us if you intend to use this in your product


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The Toolbar component storybook doesn't have an unstable usage warning sign and the "Best Practices" section isn't styled up correctly.

## New Behavior

Unstable usage warning has been added and "Best Practices" section has been styled.

## Related Issue(s)

Fixes #23958 
