### PR TITLE
Added missing roundedCorner CSS vars to common-styles

### DIFF
--- a/change/@fluentui-common-styles-caf28190-1ed1-4256-8aea-6f5a78f3558c.json
+++ b/change/@fluentui-common-styles-caf28190-1ed1-4256-8aea-6f5a78f3558c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added roundedCorner4/6 CSS vars",
+  "packageName": "@fluentui/common-styles",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-common-styles-caf28190-1ed1-4256-8aea-6f5a78f3558c.json
+++ b/change/@fluentui-common-styles-caf28190-1ed1-4256-8aea-6f5a78f3558c.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Added roundedCorner4/6 CSS vars",
+  "comment": "feat: Added roundedCorner4/6 CSS vars.",
   "packageName": "@fluentui/common-styles",
   "email": "gcox@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/common-styles/src/_effects.scss
+++ b/packages/common-styles/src/_effects.scss
@@ -4,3 +4,5 @@ $elevation16: '[theme:elevation16, default: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132
 $elevation64: '[theme:elevation64, default: 0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18)]';
 
 $roundedCorner2: '[theme:roundedCorner2, default: 2px]';
+$roundedCorner4: '[theme:roundedCorner4, default: 4px]';
+$roundedCorner6: '[theme:roundedCorner6, default: 6px]';


### PR DESCRIPTION
## Issue
The common-styles package (new to v8) broke out some SCSS from v7, but missed including roundedCorner4 and roundedCorner6 CSS variables. This causes breaks for folks upgrading from v7 to v8.

## Changes
Added them into _effects.scss