### PR TITLE
task: useAsync, cleanup ref after hook return is called

### DIFF
--- a/change/@fluentui-react-hooks-99e51e0b-cdd4-49ad-af7e-7b1dbe90d868.json
+++ b/change/@fluentui-react-hooks-99e51e0b-cdd4-49ad-af7e-7b1dbe90d868.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "task: useAsync: remove stored async when useEffect return is called",
+  "packageName": "@fluentui/react-hooks",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-hooks/src/useAsync.ts
+++ b/packages/react-hooks/src/useAsync.ts
@@ -1,15 +1,19 @@
 import { Async } from '@fluentui/utilities';
 import * as React from 'react';
-import { useConst } from './useConst';
 
 /**
  * Hook to provide an Async instance that is automatically cleaned up on dismount.
  */
 export function useAsync() {
-  const async = useConst<Async>(() => new Async());
-
-  // Function that returns a function in order to dispose the async instance on unmount
-  React.useEffect(() => () => async.dispose(), [async]);
-
-  return async;
+  const asyncRef = React.useRef<Async>();
+  if (!asyncRef.current) {
+    asyncRef.current = new Async();
+  }
+  React.useEffect(() => {
+    return () => {
+      asyncRef.current?.dispose();
+      asyncRef.current = undefined;
+    };
+  }, []);
+  return asyncRef.current;
 }


### PR DESCRIPTION
fixes #24041

a new Async was not being create on each useAsync call, so in React 18 strict mode Async was created, then dispose was called, then useEffect fired again, but the Async remained disposed.