### PR TITLE
Overflow: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-overflow/src/stories/Overflow/CustomPriorities.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/CustomPriorities.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
+import { makeStyles, shorthands } from '@fluentui/react-components';
 import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 

--- a/packages/react-components/react-overflow/src/stories/Overflow/Dividers.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/Dividers.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
+import { makeStyles, shorthands } from '@fluentui/react-components';
 import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowGroupDivider, TestOverflowItem } from './utils.stories';
 

--- a/packages/react-components/react-overflow/src/stories/Overflow/DomOrder.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/DomOrder.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
+import { makeStyles, shorthands } from '@fluentui/react-components';
 import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 

--- a/packages/react-components/react-overflow/src/stories/Overflow/MinimumVisible.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/MinimumVisible.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
+import { makeStyles, shorthands } from '@fluentui/react-components';
 import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 

--- a/packages/react-components/react-overflow/src/stories/Overflow/PriorityWithDividers.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/PriorityWithDividers.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
+import { makeStyles, shorthands } from '@fluentui/react-components';
 import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowGroupDivider, TestOverflowItem } from './utils.stories';
 

--- a/packages/react-components/react-overflow/src/stories/Overflow/ReverseDomOrder.stories.tsx
+++ b/packages/react-components/react-overflow/src/stories/Overflow/ReverseDomOrder.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@griffel/react';
+import { makeStyles, shorthands } from '@fluentui/react-components';
 import { Overflow } from '@fluentui/react-overflow';
 import { OverflowMenu, TestOverflowItem } from './utils.stories';
 


### PR DESCRIPTION
### Changes
- updates `react-overflow` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846