### PR TITLE
Restore minimum width of Details List rows to be that of the container

### DIFF
--- a/change/@fluentui-react-e5a2ed84-a5b1-487d-bfc5-6fc93e0aa37a.json
+++ b/change/@fluentui-react-e5a2ed84-a5b1-487d-bfc5-6fc93e0aa37a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Remove override row width style to fix DetailsList layouts.",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRow.base.tsx
@@ -190,7 +190,6 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
       onRenderField,
       getCellValueKey,
       selectionMode,
-      rowWidth = 0,
       checkboxVisibility,
       getRowAriaLabel,
       getRowAriaDescription,
@@ -331,7 +330,6 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         data-item-index={itemIndex}
         aria-rowindex={ariaPositionInSet === undefined ? itemIndex + flatIndexOffset : undefined}
         data-automationid="DetailsRow"
-        style={{ minWidth: rowWidth }}
         aria-selected={ariaSelected}
         allowFocusRoot={true}
       >

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -8124,11 +8124,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
                                 role="row"
-                                style={
-                                  Object {
-                                    "minWidth": 300,
-                                  }
-                                }
                               >
                                 <span
                                   className="ms-GroupSpacer"
@@ -8426,11 +8421,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
                                 role="row"
-                                style={
-                                  Object {
-                                    "minWidth": 300,
-                                  }
-                                }
                               >
                                 <span
                                   className="ms-GroupSpacer"
@@ -8986,11 +8976,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
                                 role="row"
-                                style={
-                                  Object {
-                                    "minWidth": 300,
-                                  }
-                                }
                               >
                                 <span
                                   className="ms-GroupSpacer"
@@ -9288,11 +9273,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
                                 role="row"
-                                style={
-                                  Object {
-                                    "minWidth": 300,
-                                  }
-                                }
                               >
                                 <span
                                   className="ms-GroupSpacer"
@@ -9590,11 +9570,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
                                 role="row"
-                                style={
-                                  Object {
-                                    "minWidth": 300,
-                                  }
-                                }
                               >
                                 <span
                                   className="ms-GroupSpacer"

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsListV2.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsListV2.test.tsx.snap
@@ -7574,11 +7574,6 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
                       role="row"
-                      style={
-                        Object {
-                          "minWidth": 300,
-                        }
-                      }
                     >
                       <span
                         className="ms-GroupSpacer"
@@ -7876,11 +7871,6 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
                       role="row"
-                      style={
-                        Object {
-                          "minWidth": 300,
-                        }
-                      }
                     >
                       <span
                         className="ms-GroupSpacer"
@@ -8403,11 +8393,6 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
                       role="row"
-                      style={
-                        Object {
-                          "minWidth": 300,
-                        }
-                      }
                     >
                       <span
                         className="ms-GroupSpacer"
@@ -8705,11 +8690,6 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
                       role="row"
-                      style={
-                        Object {
-                          "minWidth": 300,
-                        }
-                      }
                     >
                       <span
                         className="ms-GroupSpacer"
@@ -9007,11 +8987,6 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
                       role="row"
-                      style={
-                        Object {
-                          "minWidth": 300,
-                        }
-                      }
                     >
                       <span
                         className="ms-GroupSpacer"

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -2051,7 +2051,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
         }
       }
     >
-
+      
     </div>
     <div
       className=
@@ -2106,7 +2106,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
         }
       }
     >
-
+      
     </div>
     <div
       className=
@@ -2161,7 +2161,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
         }
       }
     >
-
+      
     </div>
   </div>
   <span

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -1754,11 +1754,6 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
   onKeyDown={[Function]}
   onMouseDownCapture={[Function]}
   role="row"
-  style={
-    Object {
-      "minWidth": 0,
-    }
-  }
 >
   <div
     className=
@@ -2056,7 +2051,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
         }
       }
     >
-      
+
     </div>
     <div
       className=
@@ -2111,7 +2106,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
         }
       }
     >
-      
+
     </div>
     <div
       className=
@@ -2166,7 +2161,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
         }
       }
     >
-      
+
     </div>
   </div>
   <span


### PR DESCRIPTION
## Current Behavior

For a long time, every `DetailsRow` component in a `DetailsList` has applied an override `width: ___px` rule in its root `style` attribute. This had been done in order to fix a render glitch when working with 'justified' layouts. However, the root issue was mitigated in calling apps, and instead this `width` override is producing sub-par visuals in most consumption sites of the list.

The effect has been that details rows always appear to 'under-fill' when using `fixedColumns` mode, even though the header properly stretches across the container.

## New Behavior

Removed the override `style` attribute, so that the details rows fall back to their `min-width: 100%` rules, and thus the details rows nicely stretch across the container and align with the header.

If any components were relying on the input `rowWidth` value, that prop has been preserved, even though the default render behavior no longer uses it.
