### PR TITLE
Added exports for decorators missing from v7

### DIFF
--- a/change/office-ui-fabric-react-3cf6a1f4-b206-49b1-87d1-91879e08f9c0.json
+++ b/change/office-ui-fabric-react-3cf6a1f4-b206-49b1-87d1-91879e08f9c0.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Added exports for decorators missing from v7",
+  "comment": "chore: Added exports for decorators missing from v7.",
   "packageName": "office-ui-fabric-react",
   "email": "gcox@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/office-ui-fabric-react-3cf6a1f4-b206-49b1-87d1-91879e08f9c0.json
+++ b/change/office-ui-fabric-react-3cf6a1f4-b206-49b1-87d1-91879e08f9c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added exports for decorators missing from v7",
+  "packageName": "office-ui-fabric-react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/office-ui-fabric-react-56d8b231-12d4-4bca-8131-9da8a848954b.json
+++ b/change/office-ui-fabric-react-56d8b231-12d4-4bca-8131-9da8a848954b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Added exports for decorators missing from v7",
+  "comment": "chore: Added exports for decorators missing from v7.",
   "packageName": "office-ui-fabric-react",
   "email": "gcox@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/office-ui-fabric-react-56d8b231-12d4-4bca-8131-9da8a848954b.json
+++ b/change/office-ui-fabric-react-56d8b231-12d4-4bca-8131-9da8a848954b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added exports for decorators missing from v7",
+  "packageName": "office-ui-fabric-react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1355,6 +1355,9 @@ export function getFullColorString(color: IColor): string;
 // @public (undocumented)
 export const getIconContent: (iconName?: string | undefined) => IIconContent | null;
 
+// @public (undocumented)
+export function getInitialResponsiveMode(): ResponsiveMode;
+
 // @public
 export function getMaxHeight(target: Element | MouseEvent | Point | Rectangle, targetEdge: DirectionalHint, gapSpace?: number, bounds?: IRectangle, coverTarget?: boolean): number;
 
@@ -1382,6 +1385,9 @@ export function getOppositeEdge(edge: RectangleEdge): RectangleEdge;
 
 // @public
 export function getPersonaInitialsColor(props: Pick<IPersonaProps, 'primaryText' | 'text' | 'initialsColor'>): string;
+
+// @public (undocumented)
+export function getResponsiveMode(currentWindow: Window | undefined): ResponsiveMode;
 
 // @public
 export function getShade(color: IColor, shade: Shade, isInverted?: boolean): IColor | null;
@@ -3335,8 +3341,6 @@ export interface IContextualMenuListProps {
     totalItemCount: number;
 }
 
-// Warning: (ae-forgotten-export) The symbol "IWithResponsiveModeState" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWithResponsiveModeState {
     alignTargetEdge?: boolean;
@@ -6217,6 +6221,9 @@ export interface INavStyles {
     root: IStyle;
 }
 
+// @public
+export function initializeResponsiveMode(element?: HTMLElement): void;
+
 export { IObjectWithKey }
 
 // @public (undocumented)
@@ -8594,11 +8601,23 @@ export interface IWindowWithSegments extends Window {
     getWindowSegments?: () => DOMRect[];
 }
 
+// @public (undocumented)
+export interface IWithResponsiveModeState {
+    // (undocumented)
+    responsiveMode?: ResponsiveMode;
+}
+
 // @public
 export interface IWithViewportProps {
     delayFirstMeasure?: boolean;
     disableResizeObserver?: boolean;
     skipViewportMeasures?: boolean;
+}
+
+// @public (undocumented)
+export interface IWithViewportState {
+    // (undocumented)
+    viewport?: IViewport;
 }
 
 // @public (undocumented)
@@ -9678,6 +9697,9 @@ export const SeparatorBase: React.FunctionComponent<ISeparatorProps>;
 export function sequencesToID(keySequences: string[]): string;
 
 // @public
+export function setResponsiveMode(responsiveMode: ResponsiveMode | undefined): void;
+
+// @public
 export enum Shade {
     // (undocumented)
     Shade1 = 1,
@@ -10363,6 +10385,16 @@ export class VirtualizedComboBox extends React.Component<IComboBoxProps, {}> imp
     render(): JSX.Element;
     readonly selectedOptions: IComboBoxOption[];
 }
+
+// @public (undocumented)
+export function withResponsiveMode<TProps extends {
+    responsiveMode?: ResponsiveMode;
+}, TState>(ComposedComponent: new (props: TProps, ...args: any[]) => React.Component<TProps, TState>): any;
+
+// @public
+export function withViewport<TProps extends {
+    viewport?: IViewport;
+}, TState>(ComposedComponent: new (props: TProps, ...args: any[]) => React.Component<TProps, TState>): any;
 
 
 export * from "@fluentui/date-time-utilities/lib/dateMath/dateMath";

--- a/packages/office-ui-fabric-react/src/Decorators.ts
+++ b/packages/office-ui-fabric-react/src/Decorators.ts
@@ -1,0 +1,1 @@
+export * from './utilities/decorators/index';

--- a/packages/office-ui-fabric-react/src/index.ts
+++ b/packages/office-ui-fabric-react/src/index.ts
@@ -18,6 +18,7 @@ export * from './CommandBar';
 export * from './ContextualMenu';
 export * from './DatePicker';
 export * from './DateTimeUtilities';
+export * from './Decorators';
 export * from './DetailsList';
 export * from './Dialog';
 export * from './Divider';

--- a/packages/office-ui-fabric-react/src/utilities/decorators/index.ts
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/index.ts
@@ -1,0 +1,13 @@
+export {
+  getInitialResponsiveMode,
+  getResponsiveMode,
+  initializeResponsiveMode,
+  setResponsiveMode,
+  withResponsiveMode,
+} from './withResponsiveMode';
+
+export type { IWithResponsiveModeState, ResponsiveMode } from './withResponsiveMode';
+
+export { withViewport } from './withViewport';
+
+export type { IViewport, IWithViewportProps, IWithViewportState } from './withViewport';

--- a/packages/office-ui-fabric-react/src/utilities/decorators/index.ts
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/index.ts
@@ -4,10 +4,8 @@ export {
   initializeResponsiveMode,
   setResponsiveMode,
   withResponsiveMode,
+  IWithResponsiveModeState,
+  ResponsiveMode,
 } from './withResponsiveMode';
 
-export type { IWithResponsiveModeState, ResponsiveMode } from './withResponsiveMode';
-
-export { withViewport } from './withViewport';
-
-export type { IViewport, IWithViewportProps, IWithViewportState } from './withViewport';
+export { withViewport, IViewport, IWithViewportProps, IWithViewportState } from './withViewport';

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -71,7 +71,7 @@ const MAX_RESIZE_ATTEMPTS = 3;
 /**
  * A decorator to update decorated component on viewport or window resize events.
  *
- * @param ComposedComponent decorated React component reference.
+ * @param ComposedComponent - decorated React component reference.
  */
 export function withViewport<TProps extends { viewport?: IViewport }, TState>(
   ComposedComponent: new (props: TProps, ...args: any[]) => React.Component<TProps, TState>,


### PR DESCRIPTION
## Issue
v7 office-ui-fabric-react allows deep imports of withResponsiveMode and withViewport, but v7 @fluentui/react does not.
ODSP needs these exported in order to move to the modern import name.

## Changes
-- exported withResponsiveMode and withViewport methods and types from @fluentui/react/Decorators

