### PR TITLE
feat: implement `Table` and `TableBody` components

### DIFF
--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -10,6 +10,18 @@ import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public
+export const Table: ForwardRefComponent<TableProps>;
+
+// @public
+export const TableBody: ForwardRefComponent<TableBodyProps>;
+
+// @public (undocumented)
+export const tableBodyClassName = "fui-TableBody";
+
+// @public (undocumented)
+export const tableBodyClassNames: SlotClassNames<TableBodySlots>;
+
+// @public
 export const TableCell: ForwardRefComponent<TableCellProps>;
 
 // @public (undocumented)
@@ -17,6 +29,12 @@ export const tableCellClassName = "fui-TableCell";
 
 // @public (undocumented)
 export const tableCellClassNames: SlotClassNames<TableCellSlots>;
+
+// @public (undocumented)
+export const tableClassName = "fui-Table";
+
+// @public (undocumented)
+export const tableClassNames: SlotClassNames<TableSlots>;
 
 // @public
 export const TableRow: ForwardRefComponent<TableRowProps>;

--- a/packages/react-components/react-table/src/Table.ts
+++ b/packages/react-components/react-table/src/Table.ts
@@ -1,0 +1,1 @@
+export * from './components/Table/index';

--- a/packages/react-components/react-table/src/TableBody.ts
+++ b/packages/react-components/react-table/src/TableBody.ts
@@ -1,0 +1,1 @@
+export * from './components/TableBody/index';

--- a/packages/react-components/react-table/src/components/Table/Table.test.tsx
+++ b/packages/react-components/react-table/src/components/Table/Table.test.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Table } from './Table';
+import { isConformant } from '../../common/isConformant';
+import { TableProps } from './Table.types';
+import { TableRow } from '../TableRow/TableRow';
+import { TableCell } from '../TableCell/TableCell';
+import { TableBody } from '../TableBody/TableBody';
+
+describe('Table', () => {
+  isConformant({
+    Component: Table as React.FC<TableProps>,
+    displayName: 'Table',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(
+      <Table>
+        <tbody>
+          <tr>
+            <td>Cell</td>
+          </tr>
+        </tbody>
+      </Table>,
+    );
+    expect(result.container).toMatchSnapshot();
+  });
+
+  it('renders as div if `noNativeElements` is set', () => {
+    const { container } = render(
+      <Table noNativeElements>
+        <TableBody>
+          <TableRow>
+            <TableCell>Cell</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-table/src/components/Table/Table.tsx
+++ b/packages/react-components/react-table/src/components/Table/Table.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { useTable_unstable } from './useTable';
+import { renderTable_unstable } from './renderTable';
+import { useTableStyles_unstable } from './useTableStyles';
+import type { TableProps } from './Table.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useTableContextValues_unstable } from './useTableContextValues';
+
+/**
+ * Table component - TODO: add more docs
+ */
+export const Table: ForwardRefComponent<TableProps> = React.forwardRef((props, ref) => {
+  const state = useTable_unstable(props, ref);
+
+  useTableStyles_unstable(state);
+  return renderTable_unstable(state, useTableContextValues_unstable(state));
+});
+
+Table.displayName = 'Table';

--- a/packages/react-components/react-table/src/components/Table/Table.types.ts
+++ b/packages/react-components/react-table/src/components/Table/Table.types.ts
@@ -1,0 +1,20 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import { TableContextValue } from '../../contexts/types';
+
+export type TableSlots = {
+  root: Slot<'table', 'div'>;
+};
+
+export type TableContextValues = {
+  table: TableContextValue;
+};
+
+/**
+ * Table Props
+ */
+export type TableProps = ComponentProps<TableSlots> & {} & Partial<TableContextValue>;
+
+/**
+ * State used in rendering Table
+ */
+export type TableState = ComponentState<TableSlots> & Pick<Required<TableProps>, 'size' | 'noNativeElements'>;

--- a/packages/react-components/react-table/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Table renders a default state 1`] = `
+<div>
+  <table
+    class="fui-Table"
+  >
+    <tbody>
+      <tr>
+        <td>
+          Cell
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Table renders as div if \`noNativeElements\` is set 1`] = `
+<div>
+  <div
+    class="fui-Table"
+    role="table"
+  >
+    <div
+      class="fui-TableBody"
+      role="rowgroup"
+    >
+      <div
+        class="fui-TableRow"
+        role="row"
+      >
+        <div
+          class="fui-TableCell"
+          role="cell"
+        >
+           
+          Cell
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react-components/react-table/src/components/Table/index.ts
+++ b/packages/react-components/react-table/src/components/Table/index.ts
@@ -1,0 +1,5 @@
+export * from './Table';
+export * from './Table.types';
+export * from './renderTable';
+export * from './useTable';
+export * from './useTableStyles';

--- a/packages/react-components/react-table/src/components/Table/renderTable.tsx
+++ b/packages/react-components/react-table/src/components/Table/renderTable.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { TableState, TableSlots, TableContextValues } from './Table.types';
+import { TableContextProvider } from '../../contexts/tableContext';
+
+/**
+ * Render the final JSX of Table
+ */
+export const renderTable_unstable = (state: TableState, contextValues: TableContextValues) => {
+  const { slots, slotProps } = getSlots<TableSlots>(state);
+
+  return (
+    <TableContextProvider value={contextValues.table}>
+      <slots.root {...slotProps.root} />
+    </TableContextProvider>
+  );
+};

--- a/packages/react-components/react-table/src/components/Table/useTable.ts
+++ b/packages/react-components/react-table/src/components/Table/useTable.ts
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { getNativeElementProps } from '@fluentui/react-utilities';
+import type { TableProps, TableState } from './Table.types';
+
+/**
+ * Create the state required to render Table.
+ *
+ * The returned state can be modified with hooks such as useTableStyles_unstable,
+ * before being passed to renderTable_unstable.
+ *
+ * @param props - props from this instance of Table
+ * @param ref - reference to root HTMLElement of Table
+ */
+export const useTable_unstable = (props: TableProps, ref: React.Ref<HTMLElement>): TableState => {
+  const rootComponent = props.as ?? props.noNativeElements ? 'div' : 'table';
+
+  return {
+    components: {
+      root: rootComponent,
+    },
+    root: getNativeElementProps(rootComponent, {
+      ref,
+      role: rootComponent === 'div' ? 'table' : undefined,
+      ...props,
+    }),
+    size: props.size ?? 'medium',
+    noNativeElements: props.noNativeElements ?? false,
+  };
+};

--- a/packages/react-components/react-table/src/components/Table/useTableContextValues.test.ts
+++ b/packages/react-components/react-table/src/components/Table/useTableContextValues.test.ts
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useTable_unstable } from './useTable';
+import { useTableContextValues_unstable } from './useTableContextValues';
+
+describe('useTableContextValues', () => {
+  it('should return context values from state', () => {
+    const { result } = renderHook(() => {
+      const state = useTable_unstable({}, React.createRef());
+      return useTableContextValues_unstable(state);
+    });
+
+    expect(result.current).toMatchInlineSnapshot(`
+      Object {
+        "table": Object {
+          "noNativeElements": false,
+          "size": "medium",
+        },
+      }
+    `);
+  });
+});

--- a/packages/react-components/react-table/src/components/Table/useTableContextValues.ts
+++ b/packages/react-components/react-table/src/components/Table/useTableContextValues.ts
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { TableContextValue } from '../../contexts/types';
+import { TableState } from './Table.types';
+
+export function useTableContextValues_unstable(state: TableState) {
+  const table = React.useMemo<TableContextValue>(
+    () => ({
+      size: state.size,
+      noNativeElements: state.noNativeElements,
+    }),
+    [state.size, state.noNativeElements],
+  );
+
+  return { table };
+}

--- a/packages/react-components/react-table/src/components/Table/useTableStyles.ts
+++ b/packages/react-components/react-table/src/components/Table/useTableStyles.ts
@@ -1,0 +1,27 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { TableSlots, TableState } from './Table.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+export const tableClassName = 'fui-Table';
+export const tableClassNames: SlotClassNames<TableSlots> = {
+  root: 'fui-Table',
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    width: '100%',
+  },
+});
+
+/**
+ * Apply styling to the Table slots based on the state
+ */
+export const useTableStyles_unstable = (state: TableState): TableState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(tableClassName, styles.root, state.root.className);
+
+  return state;
+};

--- a/packages/react-components/react-table/src/components/TableBody/TableBody.test.tsx
+++ b/packages/react-components/react-table/src/components/TableBody/TableBody.test.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { TableBody } from './TableBody';
+import { isConformant } from '../../common/isConformant';
+import { TableBodyProps } from './TableBody.types';
+import { TableContextProvider } from '../../contexts/tableContext';
+
+const table = document.createElement('table');
+describe('TableBody', () => {
+  beforeEach(() => {
+    document.body.appendChild(table);
+  });
+  isConformant({
+    Component: TableBody as React.FC<TableBodyProps>,
+    displayName: 'TableBody',
+    renderOptions: {
+      container: table,
+    },
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(
+      <TableBody>
+        <tr>
+          <td>cell</td>
+        </tr>
+      </TableBody>,
+      { container: table },
+    );
+    expect(result.container).toMatchSnapshot();
+  });
+
+  it('renders as div if `noNativeElements` is set', () => {
+    const { container } = render(
+      <TableContextProvider value={{ size: 'medium', noNativeElements: true }}>
+        <TableBody>
+          <div>
+            <div>Cell</div>
+          </div>
+        </TableBody>
+      </TableContextProvider>,
+    );
+    expect(container.firstElementChild?.tagName).toEqual('DIV');
+    expect(container.firstElementChild?.getAttribute('role')).toEqual('rowgroup');
+  });
+});

--- a/packages/react-components/react-table/src/components/TableBody/TableBody.tsx
+++ b/packages/react-components/react-table/src/components/TableBody/TableBody.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useTableBody_unstable } from './useTableBody';
+import { renderTableBody_unstable } from './renderTableBody';
+import { useTableBodyStyles_unstable } from './useTableBodyStyles';
+import type { TableBodyProps } from './TableBody.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * TableBody component - TODO: add more docs
+ */
+export const TableBody: ForwardRefComponent<TableBodyProps> = React.forwardRef((props, ref) => {
+  const state = useTableBody_unstable(props, ref);
+
+  useTableBodyStyles_unstable(state);
+  return renderTableBody_unstable(state);
+});
+
+TableBody.displayName = 'TableBody';

--- a/packages/react-components/react-table/src/components/TableBody/TableBody.types.ts
+++ b/packages/react-components/react-table/src/components/TableBody/TableBody.types.ts
@@ -1,0 +1,15 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type TableBodySlots = {
+  root: Slot<'tbody', 'div'>;
+};
+
+/**
+ * TableBody Props
+ */
+export type TableBodyProps = ComponentProps<TableBodySlots>;
+
+/**
+ * State used in rendering TableBody
+ */
+export type TableBodyState = ComponentState<TableBodySlots>;

--- a/packages/react-components/react-table/src/components/TableBody/__snapshots__/TableBody.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/TableBody/__snapshots__/TableBody.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableBody renders a default state 1`] = `
+<table>
+  <tbody
+    class="fui-TableBody"
+  >
+    <tr>
+      <td>
+        cell
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;

--- a/packages/react-components/react-table/src/components/TableBody/index.ts
+++ b/packages/react-components/react-table/src/components/TableBody/index.ts
@@ -1,0 +1,5 @@
+export * from './TableBody';
+export * from './TableBody.types';
+export * from './renderTableBody';
+export * from './useTableBody';
+export * from './useTableBodyStyles';

--- a/packages/react-components/react-table/src/components/TableBody/renderTableBody.tsx
+++ b/packages/react-components/react-table/src/components/TableBody/renderTableBody.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { TableBodyState, TableBodySlots } from './TableBody.types';
+
+/**
+ * Render the final JSX of TableBody
+ */
+export const renderTableBody_unstable = (state: TableBodyState) => {
+  const { slots, slotProps } = getSlots<TableBodySlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <slots.root {...slotProps.root} />;
+};

--- a/packages/react-components/react-table/src/components/TableBody/useTableBody.ts
+++ b/packages/react-components/react-table/src/components/TableBody/useTableBody.ts
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { getNativeElementProps } from '@fluentui/react-utilities';
+import type { TableBodyProps, TableBodyState } from './TableBody.types';
+import { useTableContext } from '../../contexts/tableContext';
+
+/**
+ * Create the state required to render TableBody.
+ *
+ * The returned state can be modified with hooks such as useTableBodyStyles_unstable,
+ * before being passed to renderTableBody_unstable.
+ *
+ * @param props - props from this instance of TableBody
+ * @param ref - reference to root HTMLElement of TableBody
+ */
+export const useTableBody_unstable = (props: TableBodyProps, ref: React.Ref<HTMLElement>): TableBodyState => {
+  const { noNativeElements } = useTableContext();
+  const rootComponent = props.as ?? noNativeElements ? 'div' : 'tbody';
+
+  return {
+    components: {
+      root: rootComponent,
+    },
+    root: getNativeElementProps(rootComponent, {
+      ref,
+      role: rootComponent === 'div' ? 'rowgroup' : undefined,
+      ...props,
+    }),
+  };
+};

--- a/packages/react-components/react-table/src/components/TableBody/useTableBodyStyles.ts
+++ b/packages/react-components/react-table/src/components/TableBody/useTableBodyStyles.ts
@@ -1,0 +1,17 @@
+import { mergeClasses } from '@griffel/react';
+import type { TableBodySlots, TableBodyState } from './TableBody.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+export const tableBodyClassName = 'fui-TableBody';
+export const tableBodyClassNames: SlotClassNames<TableBodySlots> = {
+  root: 'fui-TableBody',
+};
+
+/**
+ * Apply styling to the TableBody slots based on the state
+ */
+export const useTableBodyStyles_unstable = (state: TableBodyState): TableBodyState => {
+  state.root.className = mergeClasses(tableBodyClassName, state.root.className);
+
+  return state;
+};

--- a/packages/react-components/react-table/src/index.ts
+++ b/packages/react-components/react-table/src/index.ts
@@ -1,2 +1,4 @@
 export { TableCell, tableCellClassNames, tableCellClassName } from './TableCell';
 export { TableRow, tableRowClassNames, tableRowClassName } from './TableRow';
+export { TableBody, tableBodyClassName, tableBodyClassNames } from './TableBody';
+export { Table, tableClassName, tableClassNames } from './Table';

--- a/packages/react-components/react-table/src/stories/Table/Default.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/Default.stories.tsx
@@ -9,12 +9,12 @@ import {
   Video16Regular as VideoRegular,
 } from '@fluentui/react-icons';
 import { Avatar } from '@fluentui/react-avatar';
-import { TableCell, TableRow } from '../..';
+import { TableBody, TableCell, TableRow, Table } from '../..';
 
 export const Default = () => {
   return (
-    <table style={{ width: '100%' }}>
-      <tbody>
+    <Table>
+      <TableBody>
         <TableRow>
           <TableCell media={<DocumentRegular />}>Meeting notes</TableCell>
           <TableCell media={<Avatar name="Max Mustermann" badge={{ status: 'available' }} />}>Max Mustermann</TableCell>
@@ -39,7 +39,7 @@ export const Default = () => {
           <TableCell>Tue at 9:30 AM</TableCell>
           <TableCell media={<PeopleRegular />}>You shared this in a Teams chat</TableCell>
         </TableRow>
-      </tbody>
-    </table>
+      </TableBody>
+    </Table>
   );
 };

--- a/packages/react-components/react-table/src/stories/Table/NonNativeElements.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/NonNativeElements.stories.tsx
@@ -9,44 +9,37 @@ import {
   Video16Regular as VideoRegular,
 } from '@fluentui/react-icons';
 import { Avatar } from '@fluentui/react-avatar';
-import { TableCell, TableRow } from '../../index';
-import { TableContextProvider } from '../../contexts/tableContext';
+import { TableCell, TableRow, TableBody, Table } from '../../index';
 
 export const NonNativeElements = () => {
   return (
-    <TableContextProvider value={{ size: 'medium', noNativeElements: true }}>
-      <div role="table" style={{ width: '100%' }}>
-        <div role="rolegroup">
-          <TableRow>
-            <TableCell media={<DocumentRegular />}>Meeting notes</TableCell>
-            <TableCell media={<Avatar name="Max Mustermann" badge={{ status: 'available' }} />}>
-              Max Mustermann
-            </TableCell>
-            <TableCell>7h ago</TableCell>
-            <TableCell media={<EditRegular />}>You edited this</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell media={<FolderRegular />}>Thursday presentation</TableCell>
-            <TableCell media={<Avatar name="Erika Mustermann" badge={{ status: 'away' }} />}>
-              Erika Mustermann
-            </TableCell>
-            <TableCell>Yesterday at 1:45 PM</TableCell>
-            <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell media={<VideoRegular />}>Training recording</TableCell>
-            <TableCell media={<Avatar name="John Doe" badge={{ status: 'away' }} />}>John Doe</TableCell>
-            <TableCell>Yesterday at 1:45 PM</TableCell>
-            <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell media={<DocumentPdfRegular />}>Purchase order</TableCell>
-            <TableCell media={<Avatar name="Jane Doe" badge={{ status: 'away' }} />}>Jane Doe</TableCell>
-            <TableCell>Tue at 9:30 AM</TableCell>
-            <TableCell media={<PeopleRegular />}>You shared this in a Teams chat</TableCell>
-          </TableRow>
-        </div>
-      </div>
-    </TableContextProvider>
+    <Table noNativeElements>
+      <TableBody>
+        <TableRow>
+          <TableCell media={<DocumentRegular />}>Meeting notes</TableCell>
+          <TableCell media={<Avatar name="Max Mustermann" badge={{ status: 'available' }} />}>Max Mustermann</TableCell>
+          <TableCell>7h ago</TableCell>
+          <TableCell media={<EditRegular />}>You edited this</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell media={<FolderRegular />}>Thursday presentation</TableCell>
+          <TableCell media={<Avatar name="Erika Mustermann" badge={{ status: 'away' }} />}>Erika Mustermann</TableCell>
+          <TableCell>Yesterday at 1:45 PM</TableCell>
+          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell media={<VideoRegular />}>Training recording</TableCell>
+          <TableCell media={<Avatar name="John Doe" badge={{ status: 'away' }} />}>John Doe</TableCell>
+          <TableCell>Yesterday at 1:45 PM</TableCell>
+          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell media={<DocumentPdfRegular />}>Purchase order</TableCell>
+          <TableCell media={<Avatar name="Jane Doe" badge={{ status: 'away' }} />}>Jane Doe</TableCell>
+          <TableCell>Tue at 9:30 AM</TableCell>
+          <TableCell media={<PeopleRegular />}>You shared this in a Teams chat</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
   );
 };

--- a/packages/react-components/react-table/src/stories/Table/SizeSmall.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/SizeSmall.stories.tsx
@@ -9,44 +9,41 @@ import {
   Video16Regular as VideoRegular,
 } from '@fluentui/react-icons';
 import { Avatar } from '@fluentui/react-avatar';
-import { TableCell, TableRow } from '../../index';
-import { TableContextProvider } from '../../contexts/tableContext';
+import { TableCell, TableRow, TableBody, Table } from '../../index';
 
 export const SizeSmall = () => {
   return (
-    <TableContextProvider value={{ size: 'small', noNativeElements: false }}>
-      <table style={{ width: '100%' }}>
-        <tbody>
-          <TableRow>
-            <TableCell media={<DocumentRegular />}>Meeting notes</TableCell>
-            <TableCell media={<Avatar name="Max Mustermann" badge={{ status: 'available' }} size={24} />}>
-              Max Mustermann
-            </TableCell>
-            <TableCell>7h ago</TableCell>
-            <TableCell media={<EditRegular />}>You edited this</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell media={<FolderRegular />}>Thursday presentation</TableCell>
-            <TableCell media={<Avatar name="Erika Mustermann" badge={{ status: 'away' }} size={24} />}>
-              Erika Mustermann
-            </TableCell>
-            <TableCell>Yesterday at 1:45 PM</TableCell>
-            <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell media={<VideoRegular />}>Training recording</TableCell>
-            <TableCell media={<Avatar name="John Doe" badge={{ status: 'away' }} size={24} />}>John Doe</TableCell>
-            <TableCell>Yesterday at 1:45 PM</TableCell>
-            <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell media={<DocumentPdfRegular />}>Purchase order</TableCell>
-            <TableCell media={<Avatar name="Jane Doe" badge={{ status: 'away' }} size={24} />}>Jane Doe</TableCell>
-            <TableCell>Tue at 9:30 AM</TableCell>
-            <TableCell media={<PeopleRegular />}>You shared this in a Teams chat</TableCell>
-          </TableRow>
-        </tbody>
-      </table>
-    </TableContextProvider>
+    <Table size="small">
+      <TableBody>
+        <TableRow>
+          <TableCell media={<DocumentRegular />}>Meeting notes</TableCell>
+          <TableCell media={<Avatar name="Max Mustermann" badge={{ status: 'available' }} size={24} />}>
+            Max Mustermann
+          </TableCell>
+          <TableCell>7h ago</TableCell>
+          <TableCell media={<EditRegular />}>You edited this</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell media={<FolderRegular />}>Thursday presentation</TableCell>
+          <TableCell media={<Avatar name="Erika Mustermann" badge={{ status: 'away' }} size={24} />}>
+            Erika Mustermann
+          </TableCell>
+          <TableCell>Yesterday at 1:45 PM</TableCell>
+          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell media={<VideoRegular />}>Training recording</TableCell>
+          <TableCell media={<Avatar name="John Doe" badge={{ status: 'away' }} size={24} />}>John Doe</TableCell>
+          <TableCell>Yesterday at 1:45 PM</TableCell>
+          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell media={<DocumentPdfRegular />}>Purchase order</TableCell>
+          <TableCell media={<Avatar name="Jane Doe" badge={{ status: 'away' }} size={24} />}>Jane Doe</TableCell>
+          <TableCell>Tue at 9:30 AM</TableCell>
+          <TableCell media={<PeopleRegular />}>You shared this in a Teams chat</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
   );
 };

--- a/packages/react-components/react-table/src/stories/Table/SizeSmaller.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/SizeSmaller.stories.tsx
@@ -9,44 +9,41 @@ import {
   Video16Regular as VideoRegular,
 } from '@fluentui/react-icons';
 import { Avatar } from '@fluentui/react-avatar';
-import { TableCell, TableRow } from '../../index';
-import { TableContextProvider } from '../../contexts/tableContext';
+import { TableCell, TableRow, TableBody, Table } from '../../index';
 
 export const SizeSmaller = () => {
   return (
-    <TableContextProvider value={{ size: 'smaller', noNativeElements: false }}>
-      <table style={{ width: '100%' }}>
-        <tbody>
-          <TableRow>
-            <TableCell media={<DocumentRegular />}>Meeting notes</TableCell>
-            <TableCell media={<Avatar name="Max Mustermann" badge={{ status: 'available' }} size={20} />}>
-              Max Mustermann
-            </TableCell>
-            <TableCell>7h ago</TableCell>
-            <TableCell media={<EditRegular />}>You edited this</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell media={<FolderRegular />}>Thursday presentation</TableCell>
-            <TableCell media={<Avatar name="Erika Mustermann" badge={{ status: 'away' }} size={20} />}>
-              Erika Mustermann
-            </TableCell>
-            <TableCell>Yesterday at 1:45 PM</TableCell>
-            <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell media={<VideoRegular />}>Training recording</TableCell>
-            <TableCell media={<Avatar name="John Doe" badge={{ status: 'away' }} size={20} />}>John Doe</TableCell>
-            <TableCell>Yesterday at 1:45 PM</TableCell>
-            <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell media={<DocumentPdfRegular />}>Purchase order</TableCell>
-            <TableCell media={<Avatar name="Jane Doe" badge={{ status: 'away' }} size={20} />}>Jane Doe</TableCell>
-            <TableCell>Tue at 9:30 AM</TableCell>
-            <TableCell media={<PeopleRegular />}>You shared this in a Teams chat</TableCell>
-          </TableRow>
-        </tbody>
-      </table>
-    </TableContextProvider>
+    <Table size="smaller">
+      <TableBody>
+        <TableRow>
+          <TableCell media={<DocumentRegular />}>Meeting notes</TableCell>
+          <TableCell media={<Avatar name="Max Mustermann" badge={{ status: 'available' }} size={20} />}>
+            Max Mustermann
+          </TableCell>
+          <TableCell>7h ago</TableCell>
+          <TableCell media={<EditRegular />}>You edited this</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell media={<FolderRegular />}>Thursday presentation</TableCell>
+          <TableCell media={<Avatar name="Erika Mustermann" badge={{ status: 'away' }} size={20} />}>
+            Erika Mustermann
+          </TableCell>
+          <TableCell>Yesterday at 1:45 PM</TableCell>
+          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell media={<VideoRegular />}>Training recording</TableCell>
+          <TableCell media={<Avatar name="John Doe" badge={{ status: 'away' }} size={20} />}>John Doe</TableCell>
+          <TableCell>Yesterday at 1:45 PM</TableCell>
+          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell media={<DocumentPdfRegular />}>Purchase order</TableCell>
+          <TableCell media={<Avatar name="Jane Doe" badge={{ status: 'away' }} size={20} />}>Jane Doe</TableCell>
+          <TableCell>Tue at 9:30 AM</TableCell>
+          <TableCell media={<PeopleRegular />}>You shared this in a Teams chat</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
   );
 };

--- a/packages/react-components/react-table/src/stories/Table/index.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/index.stories.tsx
@@ -1,3 +1,5 @@
+import { Table } from '../..';
+
 export { Default } from './Default.stories';
 export { NonNativeElements } from './NonNativeElements.stories';
 export { SizeSmall } from './SizeSmall.stories';
@@ -5,4 +7,5 @@ export { SizeSmaller } from './SizeSmaller.stories';
 
 export default {
   title: 'Preview Components/Table',
+  component: Table,
 };


### PR DESCRIPTION
`TableBody` component is simply a DOM markup container.

`Table` component now creates the `TableContext` and sets the context
values from props.

Addresses #23983
