### PR TITLE
Avatar: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupIndicator.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupIndicator.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
-import { makeStyles } from '@griffel/react';
+import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupLayout.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupLayout.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
-import { makeStyles } from '@griffel/react';
+import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupMaxAvatars.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupMaxAvatars.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
-import { makeStyles } from '@griffel/react';
+import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizePie.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizePie.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
-import { makeStyles } from '@griffel/react';
+import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeSpread.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeSpread.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
-import { makeStyles } from '@griffel/react';
+import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeStack.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeStack.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AvatarGroup, AvatarGroupItem } from '@fluentui/react-avatar';
-import { makeStyles } from '@griffel/react';
+import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {


### PR DESCRIPTION
### Changes
- updates `react-avatar` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846