### PR TITLE
fix: DetailsList/GroupedList rows respect grid vs. tree semantic requirements

### DIFF
--- a/change/@fluentui-react-64afe613-e952-4ee4-ac2a-2cab4854767d.json
+++ b/change/@fluentui-react-64afe613-e952-4ee4-ac2a-2cab4854767d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: update DetailsRow and GroupHeader to only expose treegrid semantics when used within GroupedList",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -4726,6 +4726,7 @@ export interface IDetailsRowBaseProps extends Pick<IDetailsListProps, 'onRenderI
     getRowAriaLabel?: (item: any) => string;
     group?: IGroup;
     id?: string;
+    isGridRow?: boolean;
     item: any;
     itemIndex: number;
     onDidMount?: (row?: DetailsRowBase) => void;
@@ -5871,6 +5872,7 @@ export interface IGroup {
 // @public (undocumented)
 export interface IGroupDividerProps {
     ariaColSpan?: number;
+    ariaLevel?: number;
     ariaPosInSet?: number;
     ariaRowCount?: number;
     ariaRowIndex?: number;

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -393,6 +393,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
               checkboxVisibility,
               cellStyleProps,
               ariaColSpan: adjustedColumns.length,
+              ariaLevel: undefined,
               ariaPosInSet: undefined,
               ariaSetSize: undefined,
               ariaRowCount: undefined,
@@ -413,6 +414,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
           return defaultRender({
             ...groupHeaderProps,
             ariaColSpan: adjustedColumns.length,
+            ariaLevel: undefined,
             ariaPosInSet: undefined,
             ariaSetSize: undefined,
             ariaRowCount: undefined,
@@ -513,6 +515,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
         rowWidth,
         useFastIcons,
         role: rowRole,
+        isGridRow: true,
       };
 
       if (!item) {

--- a/packages/react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRow.base.tsx
@@ -195,6 +195,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
       getRowAriaLabel,
       getRowAriaDescription,
       getRowAriaDescribedBy,
+      isGridRow,
       checkButtonAriaLabel,
       checkboxCellClassName,
       /** Alias rowFieldsAs as RowFields and default to DetailsRowFields if rowFieldsAs does not exist */
@@ -294,6 +295,16 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     });
     const ariaLabelledby = `${id}-checkbox` + (hasRowHeader ? ` ${id}-header` : '');
 
+    // additional props for rows within a GroupedList
+    // these are needed for treegrid row semantics, but not grid row semantics
+    const groupedListRowProps = isGridRow
+      ? {}
+      : {
+          'aria-level': (groupNestingDepth && groupNestingDepth + 1) || undefined,
+          'aria-posinset': ariaPositionInSet,
+          'aria-setsize': ariaSetSize,
+        };
+
     return (
       <FocusZone
         data-is-focusable={true}
@@ -305,6 +316,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
             }
           : {})}
         {...focusZoneProps}
+        {...groupedListRowProps}
         direction={focusZoneDirection}
         elementRef={this._root}
         componentRef={this._focusZone}
@@ -318,9 +330,6 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         data-selection-disabled={disabled || undefined}
         data-item-index={itemIndex}
         aria-rowindex={ariaPositionInSet === undefined ? itemIndex + flatIndexOffset : undefined}
-        aria-level={(groupNestingDepth && groupNestingDepth + 1) || undefined}
-        aria-posinset={ariaPositionInSet}
-        aria-setsize={ariaSetSize}
         data-automationid="DetailsRow"
         style={{ minWidth: rowWidth }}
         aria-selected={ariaSelected}

--- a/packages/react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsRow.types.ts
@@ -217,6 +217,12 @@ export interface IDetailsRowBaseProps
   role?: string;
 
   /**
+   * Whether the row is rendered within a grid.
+   * In DetailsList this should be true, and in GroupedList this should be false.
+   */
+  isGridRow?: boolean;
+
+  /**
    * Id for row
    */
   id?: string;

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -7813,7 +7813,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       <div
                         aria-expanded={true}
                         aria-labelledby="GroupHeader5"
-                        aria-level={1}
                         aria-rowindex={2}
                         className=
                             ms-GroupHeader
@@ -8047,7 +8046,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                               role="presentation"
                             >
                               <div
-                                aria-level={2}
                                 aria-rowindex={3}
                                 aria-selected={false}
                                 className=
@@ -8353,7 +8351,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                               role="presentation"
                             >
                               <div
-                                aria-level={2}
                                 aria-rowindex={4}
                                 aria-selected={false}
                                 className=
@@ -8680,7 +8677,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       <div
                         aria-expanded={true}
                         aria-labelledby="GroupHeader7"
-                        aria-level={1}
                         aria-rowindex={5}
                         className=
                             ms-GroupHeader
@@ -8914,7 +8910,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                               role="presentation"
                             >
                               <div
-                                aria-level={2}
                                 aria-rowindex={6}
                                 aria-selected={false}
                                 className=
@@ -9220,7 +9215,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                               role="presentation"
                             >
                               <div
-                                aria-level={2}
                                 aria-rowindex={7}
                                 aria-selected={false}
                                 className=
@@ -9526,7 +9520,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                               role="presentation"
                             >
                               <div
-                                aria-level={2}
                                 aria-rowindex={8}
                                 aria-selected={false}
                                 className=

--- a/packages/react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupHeader.base.tsx
@@ -80,6 +80,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       styles,
       className,
       compact,
+      ariaLevel,
       ariaPosInSet,
       ariaSetSize,
       ariaRowIndex,
@@ -118,6 +119,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
         style={viewport ? { minWidth: viewport.width } : {}}
         onClick={this._onHeaderClick}
         role="row"
+        aria-level={ariaLevel}
         aria-setsize={ariaSetSize}
         aria-posinset={ariaPosInSet}
         aria-rowindex={ariaRowIndex}
@@ -127,7 +129,6 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
         aria-labelledby={group.ariaLabel ? undefined : this._id}
         aria-expanded={!this.state.isCollapsed}
         aria-selected={canSelectGroup ? currentlySelected : undefined}
-        aria-level={groupLevel + 1}
       >
         <div className={this._classNames.groupHeaderContainer} role="presentation">
           {isSelectionCheckVisible ? (

--- a/packages/react/src/components/GroupedList/GroupedList.types.ts
+++ b/packages/react/src/components/GroupedList/GroupedList.types.ts
@@ -283,10 +283,13 @@ export interface IGroupDividerProps {
   /** Defines the number of columns a group header needs to span in the case of a grid or treegrid */
   ariaColSpan?: number;
 
-  /** Defines the number of items in the current set of listitems or treeitems */
+  /** Defines an element's nesting depth in the current set of treeitems */
+  ariaLevel?: number;
+
+  /** Defines the number of items in the current set of treeitems */
   ariaSetSize?: number;
 
-  /** Defines an element's number or position in the current set of listitems or treeitems */
+  /** Defines an element's number or position in the current set of treeitems */
   ariaPosInSet?: number;
 
   /** Defines the number of items in the current set of grid items */

--- a/packages/react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/react/src/components/GroupedList/GroupedListSection.tsx
@@ -228,6 +228,7 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
 
     const ariaControlsProps: IGroupHeaderProps = {
       groupedListId: this._id,
+      ariaLevel: group?.level ? group.level + 1 : 1,
       ariaSetSize: groups ? groups.length : undefined,
       ariaPosInSet: groupIndex !== undefined ? groupIndex + 1 : undefined,
     };


### PR DESCRIPTION
Addresses the first item in #24064

This adds a prop to DetailsRow to differentiate whether it is rendered within a DetailsList or GroupedList, so it can apply grid vs. treegrid semantics.

GroupHeader also now takes `ariaLevel` explicitly, so DetailsList can pass in an undefined value for Grouped DetailsList headers.