### PR TITLE
feat: Making Fabric component an element to which to attach focus rects classnames and event listeners

### DIFF
--- a/change/@fluentui-react-083a26a4-f8c9-4b12-8885-9faa6227d393.json
+++ b/change/@fluentui-react-083a26a4-f8c9-4b12-8885-9faa6227d393.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: Making Fabric component an element to which to attach focus rects classnames and event listeners.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Button/Button.Default.Example.tsx
+++ b/packages/react-examples/src/react/Button/Button.Default.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Stack, IStackTokens, ThemeProvider } from '@fluentui/react';
+import { Stack, IStackTokens } from '@fluentui/react';
 import { DefaultButton, PrimaryButton } from '@fluentui/react/lib/Button';
 
 export interface IButtonExampleProps {
@@ -15,92 +15,10 @@ export const ButtonDefaultExample: React.FunctionComponent<IButtonExampleProps> 
   const { disabled, checked } = props;
 
   return (
-    <>
-      <ThemeProvider>
-        <Stack horizontal tokens={stackTokens}>
-          <DefaultButton
-            text="Standard"
-            onClick={_alertClicked}
-            allowDisabledFocus
-            disabled={disabled}
-            checked={checked}
-          />
-          <PrimaryButton
-            text="Primary"
-            onClick={_alertClicked}
-            allowDisabledFocus
-            disabled={disabled}
-            checked={checked}
-          />
-          <DefaultButton
-            text="Standard"
-            onClick={_alertClicked}
-            allowDisabledFocus
-            disabled={disabled}
-            checked={checked}
-          />
-          <PrimaryButton
-            text="Primary"
-            onClick={_alertClicked}
-            allowDisabledFocus
-            disabled={disabled}
-            checked={checked}
-          />
-          <DefaultButton
-            text="Standard"
-            onClick={_alertClicked}
-            allowDisabledFocus
-            disabled={disabled}
-            checked={checked}
-          />
-          <PrimaryButton
-            text="Primary"
-            onClick={_alertClicked}
-            allowDisabledFocus
-            disabled={disabled}
-            checked={checked}
-          />
-          <DefaultButton
-            text="Standard"
-            onClick={_alertClicked}
-            allowDisabledFocus
-            disabled={disabled}
-            checked={checked}
-          />
-          <PrimaryButton
-            text="Primary"
-            onClick={_alertClicked}
-            allowDisabledFocus
-            disabled={disabled}
-            checked={checked}
-          />
-        </Stack>
-      </ThemeProvider>
-      <br />
-      <br />
-      <br />
-      <br />
-      Content outside of Fluent code/components <br />
-      Click inside input box then use an arrow key <br />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-      <input className="test" />
-    </>
+    <Stack horizontal tokens={stackTokens}>
+      <DefaultButton text="Standard" onClick={_alertClicked} allowDisabledFocus disabled={disabled} checked={checked} />
+      <PrimaryButton text="Primary" onClick={_alertClicked} allowDisabledFocus disabled={disabled} checked={checked} />
+    </Stack>
   );
 };
 

--- a/packages/react/src/components/Fabric/Fabric.base.tsx
+++ b/packages/react/src/components/Fabric/Fabric.base.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import {
-  getNativeProps,
-  divProperties,
   classNamesFunction,
+  divProperties,
   getDocument,
-  memoizeFunction,
+  getNativeProps,
   getRTL,
-  Customizer,
+  memoizeFunction,
   useFocusRects,
+  Customizer,
+  FocusRectsProvider,
+  IFocusRectsContext,
 } from '../../Utilities';
 import { createTheme } from '../../Styling';
 import { useMergedRefs } from '@fluentui/react-hooks';
@@ -43,7 +45,7 @@ export const FabricBase: React.FunctionComponent<IFabricProps> = React.forwardRe
       className,
     });
 
-    const rootElement = React.useRef<HTMLDivElement | null>(null);
+    const rootElement = React.useRef<HTMLDivElement>(null);
     useApplyThemeToBody(applyThemeToBody, classNames, rootElement);
     useFocusRects(rootElement);
 
@@ -55,7 +57,7 @@ FabricBase.displayName = 'FabricBase';
 function useRenderedContent(
   props: IFabricProps,
   { root }: IProcessedStyleSet<IFabricStyles>,
-  rootElement: React.RefObject<HTMLDivElement | undefined>,
+  rootElement: React.RefObject<HTMLDivElement>,
   ref: React.Ref<HTMLDivElement>,
 ) {
   const { as: Root = 'div', dir, theme } = props;
@@ -63,7 +65,18 @@ function useRenderedContent(
 
   const { rootDir, needsTheme } = getDir(props);
 
-  let renderedContent = <Root dir={rootDir} {...divProps} className={root} ref={useMergedRefs(rootElement, ref)} />;
+  const focusRectsContext = React.useMemo<IFocusRectsContext>(
+    () => ({
+      providerRef: rootElement,
+    }),
+    [rootElement],
+  );
+
+  let renderedContent = (
+    <FocusRectsProvider value={focusRectsContext}>
+      <Root dir={rootDir} {...divProps} className={root} ref={useMergedRefs(rootElement, ref)} />
+    </FocusRectsProvider>
+  );
 
   // Create the contextual theme if component direction does not match parent direction.
   if (needsTheme) {


### PR DESCRIPTION
## PR Description

Follow up of #24025.

This PR applies the same type of changes made to `ThemeProvider` and `Layer` in #24025 to allow the `Fabric` component to be an element that automatically registers itself as a target to attach focus rectangles' classnames and event listeners of everything underneath it.

This PR also reverts changes made to the `Button.Default.Example.tsx` file while testing the changes in #24025.