### PR TITLE
react-components: update stories to import from @fluentui/react-components

### DIFF
--- a/packages/react-components/react-components/src/AccessibilityScenarios/Accordion.stories.tsx
+++ b/packages/react-components/react-components/src/AccessibilityScenarios/Accordion.stories.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
 
-import { Accordion, AccordionItem, AccordionHeader, AccordionPanel } from '@fluentui/react-accordion';
-import { Label } from '@fluentui/react-label';
-import { Input } from '@fluentui/react-input';
-import { Button } from '@fluentui/react-button';
+import {
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+  Button,
+  Input,
+  Label,
+} from '@fluentui/react-components';
 
 import { Scenario } from './utils';
 

--- a/packages/react-components/react-components/src/AccessibilityScenarios/AccordionFaq.stories.tsx
+++ b/packages/react-components/react-components/src/AccessibilityScenarios/AccordionFaq.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Accordion, AccordionItem, AccordionHeader, AccordionPanel } from '@fluentui/react-accordion';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@fluentui/react-components';
 
 import { Scenario } from './utils';
 

--- a/packages/react-components/react-components/src/AccessibilityScenarios/Button.stories.tsx
+++ b/packages/react-components/react-components/src/AccessibilityScenarios/Button.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button } from '@fluentui/react-button';
+import { Button } from '@fluentui/react-components';
 
 import { Scenario } from './utils';
 

--- a/packages/react-components/react-components/src/AccessibilityScenarios/Input.stories.tsx
+++ b/packages/react-components/react-components/src/AccessibilityScenarios/Input.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { Input } from '@fluentui/react-input';
-import { Label } from '@fluentui/react-label';
-import { Button } from '@fluentui/react-button';
+import { Button, Input, Label } from '@fluentui/react-components';
 
 import { Scenario } from './utils';
 

--- a/packages/react-components/react-components/src/AccessibilityScenarios/Link.stories.tsx
+++ b/packages/react-components/react-components/src/AccessibilityScenarios/Link.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Link } from '@fluentui/react-link';
+import { Link } from '@fluentui/react-components';
 
 import { Scenario } from './utils';
 

--- a/packages/react-components/react-components/src/AccessibilityScenarios/Menu.stories.tsx
+++ b/packages/react-components/react-components/src/AccessibilityScenarios/Menu.stories.tsx
@@ -1,18 +1,17 @@
 import * as React from 'react';
 
-import { MenuButton } from '@fluentui/react-button';
-
 import {
   Menu,
-  MenuTrigger,
-  MenuList,
-  MenuPopover,
+  MenuButton,
   MenuGroup,
   MenuGroupHeader,
   MenuItem,
   MenuItemCheckbox,
   MenuItemRadio,
-} from '@fluentui/react-menu';
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+} from '@fluentui/react-components';
 
 import { Scenario } from './utils';
 

--- a/packages/react-components/react-components/src/AccessibilityScenarios/MenuSplitGroup.stories.tsx
+++ b/packages/react-components/react-components/src/AccessibilityScenarios/MenuSplitGroup.stories.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
 
-import { MenuButton } from '@fluentui/react-button';
-import { Menu, MenuTrigger, MenuList, MenuPopover, MenuItem, MenuSplitGroup } from '@fluentui/react-menu';
+import {
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuSplitGroup,
+  MenuTrigger,
+} from '@fluentui/react-components';
 
 import { Scenario } from './utils';
 

--- a/packages/react-components/react-components/src/AccessibilityScenarios/Popover.stories.tsx
+++ b/packages/react-components/react-components/src/AccessibilityScenarios/Popover.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-import { Button } from '@fluentui/react-button';
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
+import { Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
 
 import { Scenario } from './utils';
 

--- a/packages/react-components/react-components/src/AccessibilityScenarios/Slider.stories.tsx
+++ b/packages/react-components/react-components/src/AccessibilityScenarios/Slider.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-import { Slider } from '@fluentui/react-slider';
-import { Label } from '@fluentui/react-label';
+import { Label, Slider } from '@fluentui/react-components';
 
 import { Scenario } from './utils';
 

--- a/packages/react-components/react-components/src/AccessibilityScenarios/SplitButton.stories.tsx
+++ b/packages/react-components/react-components/src/AccessibilityScenarios/SplitButton.stories.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 
-import { Menu, MenuTrigger, MenuList, MenuPopover, MenuItem } from '@fluentui/react-menu';
-
-import { Button, MenuButtonProps, SplitButton } from '@fluentui/react-button';
+import { Button, Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, SplitButton } from '@fluentui/react-components';
+import type { MenuButtonProps } from '@fluentui/react-components';
 
 import { Scenario } from './utils';
 

--- a/packages/react-components/react-components/src/AccessibilityScenarios/ToggleButton.stories.tsx
+++ b/packages/react-components/react-components/src/AccessibilityScenarios/ToggleButton.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { ToggleButton } from '@fluentui/react-button';
+import { ToggleButton } from '@fluentui/react-components';
 
 import { Scenario } from './utils';
 

--- a/packages/react-components/react-components/src/AccessibilityScenarios/Tooltip.stories.tsx
+++ b/packages/react-components/react-components/src/AccessibilityScenarios/Tooltip.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { Button } from '@fluentui/react-button';
-
-import { Tooltip } from '@fluentui/react-tooltip';
+import { Button, Tooltip } from '@fluentui/react-components';
 
 import { TextItalic24Regular, TextUnderline24Regular, TextBold24Regular } from '@fluentui/react-icons';
 

--- a/packages/react-components/react-components/src/Concepts/Positioning/PositioningAnchorToTarget.stories.tsx
+++ b/packages/react-components/react-components/src/Concepts/Positioning/PositioningAnchorToTarget.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
-import { Button } from '@fluentui/react-button';
+import { Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
 
 export const AnchorToTarget = () => {
   const [target, setTarget] = React.useState<HTMLElement | null>(null);

--- a/packages/react-components/react-components/src/Concepts/Positioning/PositioningCoverTarget.stories.tsx
+++ b/packages/react-components/react-components/src/Concepts/Positioning/PositioningCoverTarget.stories.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
-import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
-import { Button } from '@fluentui/react-button';
-import { PositioningShorthand } from '@fluentui/react-positioning';
+import {
+  makeStyles,
+  mergeClasses,
+  shorthands,
+  Button,
+  Popover,
+  PopoverSurface,
+  PopoverTrigger,
+} from '@fluentui/react-components';
+import type { PositioningShorthand } from '@fluentui/react-components';
 
 const useExampleStyles = makeStyles({
   popoverSurface: {

--- a/packages/react-components/react-components/src/Concepts/Positioning/PositioningDefault.stories.tsx
+++ b/packages/react-components/react-components/src/Concepts/Positioning/PositioningDefault.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { PositioningProps } from '@fluentui/react-positioning';
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
-import { Button } from '@fluentui/react-button';
+import { Button, Popover, PopoverSurface, PopoverTrigger, PositioningProps } from '@fluentui/react-components';
 
 export const Default = (props: PositioningProps) => {
   return (

--- a/packages/react-components/react-components/src/Concepts/Positioning/PositioningImperativeAnchorTarget.stories.tsx
+++ b/packages/react-components/react-components/src/Concepts/Positioning/PositioningImperativeAnchorTarget.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { PositioningImperativeRef, PositioningVirtualElement, Tooltip } from '@fluentui/react-components';
+import { Tooltip } from '@fluentui/react-components';
+import type { PositioningImperativeRef, PositioningVirtualElement } from '@fluentui/react-components';
 
 export const ImperativeAnchorTarget = () => {
   const positioningRef = React.useRef<PositioningImperativeRef>(null);

--- a/packages/react-components/react-components/src/Concepts/Positioning/PositioningImperativeAnchorTarget.stories.tsx
+++ b/packages/react-components/react-components/src/Concepts/Positioning/PositioningImperativeAnchorTarget.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Tooltip } from '@fluentui/react-components';
-import { PositioningImperativeRef, PositioningVirtualElement } from '@fluentui/react-positioning';
+import { PositioningImperativeRef, PositioningVirtualElement, Tooltip } from '@fluentui/react-components';
 
 export const ImperativeAnchorTarget = () => {
   const positioningRef = React.useRef<PositioningImperativeRef>(null);

--- a/packages/react-components/react-components/src/Concepts/Positioning/PositioningImperativePositionUpdate.stories.tsx
+++ b/packages/react-components/react-components/src/Concepts/Positioning/PositioningImperativePositionUpdate.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Popover, PopoverTrigger, PopoverSurface, PopoverProps } from '@fluentui/react-popover';
-import { Button } from '@fluentui/react-button';
-import { PositioningImperativeRef } from '@fluentui/react-positioning';
+import { Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import type { PopoverProps, PositioningImperativeRef } from '@fluentui/react-components';
 
 export const ImperativePositionUpdate = () => {
   const [loading, setLoading] = React.useState(true);

--- a/packages/react-components/react-components/src/Concepts/Positioning/PositioningOffsetFunction.stories.tsx
+++ b/packages/react-components/react-components/src/Concepts/Positioning/PositioningOffsetFunction.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Button, Popover, PopoverSurface, PopoverTrigger, PositioningProps } from '@fluentui/react-components';
+import { Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import type { PositioningProps } from '@fluentui/react-components';
 
 export const OffsetFunction = () => {
   const offset: PositioningProps['offset'] = ({ positionedRect, targetRect, position, alignment }) => {

--- a/packages/react-components/react-components/src/Concepts/Positioning/PositioningOffsetFunction.stories.tsx
+++ b/packages/react-components/react-components/src/Concepts/Positioning/PositioningOffsetFunction.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
-import { Button } from '@fluentui/react-button';
-import { PositioningProps } from '@fluentui/react-positioning';
+import { Button, Popover, PopoverSurface, PopoverTrigger, PositioningProps } from '@fluentui/react-components';
 
 export const OffsetFunction = () => {
   const offset: PositioningProps['offset'] = ({ positionedRect, targetRect, position, alignment }) => {

--- a/packages/react-components/react-components/src/Concepts/Positioning/PositioningOffsetValue.stories.tsx
+++ b/packages/react-components/react-components/src/Concepts/Positioning/PositioningOffsetValue.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
-import { Button } from '@fluentui/react-button';
+import { Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
 
 export const OffsetValue = () => {
   const [crossAxis, setCrossAxis] = React.useState(10);

--- a/packages/react-components/react-components/src/Concepts/Positioning/PositioningShorthandPositions.stories.tsx
+++ b/packages/react-components/react-components/src/Concepts/Positioning/PositioningShorthandPositions.stories.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
-import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
-import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
-import { Button } from '@fluentui/react-button';
-import { PositioningShorthand } from '@fluentui/react-positioning';
+import {
+  makeStyles,
+  mergeClasses,
+  shorthands,
+  Button,
+  Popover,
+  PopoverSurface,
+  PopoverTrigger,
+} from '@fluentui/react-components';
+import type { PositioningShorthand } from '@fluentui/react-components';
 
 const useExampleStyles = makeStyles({
   popoverSurface: {

--- a/packages/react-components/react-components/src/Concepts/Positioning/utils.stories.tsx
+++ b/packages/react-components/react-components/src/Concepts/Positioning/utils.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PositioningProps } from '@fluentui/react-components';
+import type { PositioningProps } from '@fluentui/react-components';
 
 /**
  * A helper component for storybook to auto generate an args table for positioning props

--- a/packages/react-components/react-components/src/Concepts/Positioning/utils.stories.tsx
+++ b/packages/react-components/react-components/src/Concepts/Positioning/utils.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PositioningProps } from '@fluentui/react-positioning';
+import { PositioningProps } from '@fluentui/react-components';
 
 /**
  * A helper component for storybook to auto generate an args table for positioning props

--- a/packages/react-components/react-components/src/Migrations/utils.stories.tsx
+++ b/packages/react-components/react-components/src/Migrations/utils.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Source } from '@storybook/addon-docs';
-import { makeStyles } from '@griffel/react';
+import { makeStyles } from '@fluentui/react-components';
 
 const useCodeComparisonStyles = makeStyles({
   root: {


### PR DESCRIPTION
### Changes
- updates `react-components` stories to import from `@fluentui/react-components` package suite to demonstrate best practices to users.
- Fixes automatically applied by new `no-restricted-imports` rule.

Part of #23846