### PR TITLE
feat(react-dialog): Updates `DialogTrigger` to support `aria-haspopup` & updates dependencies

### DIFF
--- a/packages/react-components/react-dialog/Spec.md
+++ b/packages/react-components/react-dialog/Spec.md
@@ -150,8 +150,8 @@ export type DialogTriggerProps = {
   /**
    * Explicitly declare if the trigger is responsible for opening or
    * closing a Dialog visibility state.
-   *
-   * @default 'open'
+   * @default 'open' // if it's outside DialogSurface
+   * @default 'close' // if it's inside DialogSurface
    */
   action?: 'open' | 'close';
   /**

--- a/packages/react-components/react-dialog/Spec.md
+++ b/packages/react-components/react-dialog/Spec.md
@@ -148,12 +148,12 @@ In case the trigger is used outside `Dialog` component it'll still provide basic
 ```typescript
 export type DialogTriggerProps = {
   /**
-   * Explicitly declare if the trigger is responsible for opening,
-   * closing or toggling a Dialog visibility state.
+   * Explicitly declare if the trigger is responsible for opening or
+   * closing a Dialog visibility state.
    *
-   * @default 'toggle'
+   * @default 'open'
    */
-  action?: 'open' | 'close' | 'toggle';
+  action?: 'open' | 'close';
   /**
    * Explicitly require single child or render function
    * to inject properties
@@ -496,7 +496,6 @@ The dialog component follows the [Dialog WAI-Aria design pattern](https://www.w3
   - [`aria-modal=true`](https://w3c.github.io/aria/#aria-modal)
   - [`aria-labelledby={dialog-title-idref}`](https://w3c.github.io/aria/#aria-labelledby)
   - [`aria-describedby={dialog-body-idref}`](https://w3c.github.io/aria/#aria-describedby)
-  - [`aria-label="some label"`](https://w3c.github.io/aria/#aria-label)
 
 #### Non-modal
 
@@ -507,16 +506,13 @@ The dialog component follows the [Dialog WAI-Aria design pattern](https://www.w3
   - [`aria-modal=false`](https://w3c.github.io/aria/#aria-modal)
   - [`aria-labelledby={dialog-title-idref}`](https://w3c.github.io/aria/#aria-labelledby)
   - [`aria-describedby={dialog-body-idref}`](https://w3c.github.io/aria/#aria-describedby)
-  - [`aria-label="some label"`](https://w3c.github.io/aria/#aria-label)
 
 #### Alert dialog
 
 - Trigger button
   - [`aria-haspopup="dialog"`](https://w3c.github.io/aria/#aria-haspopup)
-    > ⚠️ This is deprecated, the proper attribute should be [`aria-expanded=true`](https://w3c.github.io/aria/#aria-expanded)
 - Dialog
   - [`role="alertdialog"`](https://w3c.github.io/aria/#dialog)
-  - [`aria-modal=false`](https://w3c.github.io/aria/#aria-modal)
+  - [`aria-modal=true`](https://w3c.github.io/aria/#aria-modal)
   - [`aria-labelledby={dialog-title-idref}`](https://w3c.github.io/aria/#aria-labelledby)
   - [`aria-describedby={dialog-body-idref}`](https://w3c.github.io/aria/#aria-describedby)
-  - [`aria-label="some label"`](https://w3c.github.io/aria/#aria-label)

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -179,7 +179,7 @@ export const renderDialogActions_unstable: (state: DialogActionsState) => JSX.El
 export const renderDialogBody_unstable: (state: DialogBodyState) => JSX.Element;
 
 // @public
-export const renderDialogSurface_unstable: (state: DialogSurfaceState) => JSX.Element;
+export const renderDialogSurface_unstable: (state: DialogSurfaceState, contextValues: DialogSurfaceContextValues) => JSX.Element;
 
 // @public
 export const renderDialogTitle_unstable: (state: DialogTitleState) => JSX.Element;

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -149,10 +149,10 @@ export type DialogTitleState = ComponentState<DialogTitleSlots>;
 export const DialogTrigger: React_2.FC<DialogTriggerProps> & FluentTriggerComponent;
 
 // @public (undocumented)
-export type DialogTriggerAction = 'open' | 'close' | 'toggle';
+export type DialogTriggerAction = 'open' | 'close';
 
 // @public
-export type DialogTriggerChildProps = Required<Pick<React_2.HTMLAttributes<HTMLElement>, 'onClick' | 'onKeyDown' | 'aria-haspopup'>> & {
+export type DialogTriggerChildProps = Pick<React_2.HTMLAttributes<HTMLElement>, 'onClick' | 'onKeyDown' | 'aria-haspopup'> & {
     ref?: React_2.Ref<never>;
 };
 

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
@@ -1,6 +1,6 @@
 import type * as React from 'react';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import type { DialogContextValue } from '../../contexts/dialogContext';
+import type { DialogContextValue, DialogSurfaceContextValue } from '../../contexts';
 
 export type DialogSlots = {
   /**
@@ -27,6 +27,11 @@ export type DialogModalType = 'modal' | 'non-modal' | 'alert';
 
 export type DialogContextValues = {
   dialog: DialogContextValue;
+  /**
+   * dialogSurface context is provided by Dialog as false
+   * to ensure components inside Dialog but outside DialogSurface will consume this as false
+   */
+  dialogSurface: DialogSurfaceContextValue;
 };
 
 export type DialogProps = ComponentProps<Partial<DialogSlots>> & {

--- a/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
 import { Portal } from '@fluentui/react-portal';
+import { DialogProvider, DialogSurfaceProvider } from '../../contexts';
 import type { DialogState, DialogSlots, DialogContextValues } from './Dialog.types';
-import { DialogProvider } from '../../contexts/dialogContext';
 
 /**
  * Render the final JSX of Dialog
@@ -13,13 +13,15 @@ export const renderDialog_unstable = (state: DialogState, contextValues: DialogC
 
   return (
     <DialogProvider value={contextValues.dialog}>
-      {trigger}
-      {open && (
-        <Portal>
-          {slots.overlay && <slots.overlay {...slotProps.overlay} />}
-          {content}
-        </Portal>
-      )}
+      <DialogSurfaceProvider value={contextValues.dialogSurface}>
+        {trigger}
+        {open && (
+          <Portal>
+            {slots.overlay && <slots.overlay {...slotProps.overlay} />}
+            {content}
+          </Portal>
+        )}
+      </DialogSurfaceProvider>
     </DialogProvider>
   );
 };

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialog.test.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialog.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react-hooks';
+import { DialogOpenChangeData } from './Dialog.types';
 import * as React from 'react';
-import type { DialogOpenChangeEvent } from './Dialog.types';
 
 import { useDialog_unstable } from './useDialog';
 
@@ -11,8 +11,13 @@ describe('useDialog_unstable', () => {
     );
 
     expect(result.current.open).toEqual(false);
-    const fakeEvent = { isDefaultPrevented: () => false } as DialogOpenChangeEvent;
-    act(() => result.current.requestOpenChange({ open: true, type: 'triggerClick', event: fakeEvent }));
+    act(() =>
+      result.current.requestOpenChange({
+        open: true,
+        type: 'triggerClick',
+        event: { isDefaultPrevented: () => false },
+      } as DialogOpenChangeData),
+    );
 
     expect(result.current.open).toEqual(true);
   });

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialogContextValues.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialogContextValues.ts
@@ -1,4 +1,4 @@
-import { DialogContextValue } from '../../contexts/dialogContext';
+import type { DialogContextValue, DialogSurfaceContextValue } from '../../contexts';
 import type { DialogContextValues, DialogState } from './Dialog.types';
 
 export function useDialogContextValues_unstable(state: DialogState): DialogContextValues {
@@ -16,5 +16,7 @@ export function useDialogContextValues_unstable(state: DialogState): DialogConte
     contentRef,
   };
 
-  return { dialog };
+  const dialogSurface: DialogSurfaceContextValue = false;
+
+  return { dialog, dialogSurface };
 }

--- a/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.test.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.test.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { DialogSurface } from './DialogSurface';
+import { resetIdsForTests } from '@fluentui/react-utilities';
 import { isConformant } from '../../common/isConformant';
 import type { DialogSurfaceProps } from './DialogSurface.types';
 
 describe('DialogSurface', () => {
+  beforeEach(() => {
+    resetIdsForTests();
+  });
+
   isConformant<DialogSurfaceProps>({
     Component: DialogSurface,
     displayName: 'DialogSurface',

--- a/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.tsx
@@ -4,6 +4,7 @@ import { renderDialogSurface_unstable } from './renderDialogSurface';
 import { useDialogSurfaceStyles_unstable } from './useDialogSurfaceStyles';
 import type { DialogSurfaceProps } from './DialogSurface.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useDialogSurfaceContextValues_unstable } from './useDialogSurfaceContextValues';
 
 /**
  * DialogSurface component represents the visual part of a `Dialog` as a whole,
@@ -11,9 +12,10 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
  */
 export const DialogSurface: ForwardRefComponent<DialogSurfaceProps> = React.forwardRef((props, ref) => {
   const state = useDialogSurface_unstable(props, ref);
+  const contextValues = useDialogSurfaceContextValues_unstable(state);
 
   useDialogSurfaceStyles_unstable(state);
-  return renderDialogSurface_unstable(state);
+  return renderDialogSurface_unstable(state, contextValues);
 });
 
 DialogSurface.displayName = 'DialogSurface';

--- a/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.types.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.types.ts
@@ -1,4 +1,5 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import { DialogSurfaceContextValue } from '../../contexts';
 
 export type DialogSurfaceSlots = {
   root: Slot<'div', 'main'>;
@@ -8,6 +9,10 @@ export type DialogSurfaceSlots = {
  * DialogSurface Props
  */
 export type DialogSurfaceProps = ComponentProps<DialogSurfaceSlots> & {};
+
+export type DialogSurfaceContextValues = {
+  dialogSurface: DialogSurfaceContextValue;
+};
 
 /**
  * State used in rendering DialogSurface

--- a/packages/react-components/react-dialog/src/components/DialogSurface/__snapshots__/DialogSurface.test.tsx.snap
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/__snapshots__/DialogSurface.test.tsx.snap
@@ -3,8 +3,10 @@
 exports[`DialogSurface renders a default state 1`] = `
 <div>
   <div
+    aria-modal="true"
     class="fui-DialogSurface"
-    data-tabster="{\\"deloser\\":{},\\"modalizer\\":{\\"id\\":\\"modal-8\\",\\"isOthersAccessible\\":false}}"
+    data-tabster="{\\"deloser\\":{},\\"modalizer\\":{\\"id\\":\\"modal-1\\",\\"isOthersAccessible\\":false}}"
+    role="dialog"
   >
     Default DialogSurface
   </div>

--- a/packages/react-components/react-dialog/src/components/DialogSurface/renderDialogSurface.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/renderDialogSurface.tsx
@@ -1,12 +1,17 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
-import type { DialogSurfaceState, DialogSurfaceSlots } from './DialogSurface.types';
+import type { DialogSurfaceState, DialogSurfaceSlots, DialogSurfaceContextValues } from './DialogSurface.types';
+import { DialogSurfaceProvider } from '../../contexts';
 
 /**
  * Render the final JSX of DialogSurface
  */
-export const renderDialogSurface_unstable = (state: DialogSurfaceState) => {
+export const renderDialogSurface_unstable = (state: DialogSurfaceState, contextValues: DialogSurfaceContextValues) => {
   const { slots, slotProps } = getSlots<DialogSurfaceSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return (
+    <DialogSurfaceProvider value={contextValues.dialogSurface}>
+      <slots.root {...slotProps.root} />
+    </DialogSurfaceProvider>
+  );
 };

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { getNativeElementProps, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
-import type { DialogSurfaceProps, DialogSurfaceState } from './DialogSurface.types';
-import { useDialogContext_unstable } from '../../contexts/dialogContext';
 import { useModalAttributes } from '@fluentui/react-tabster';
-import { isEscapeKeyDismiss } from '../../utils/isEscapeKeyDown';
+import type { DialogSurfaceProps, DialogSurfaceState } from './DialogSurface.types';
+import { useDialogContext_unstable } from '../../contexts';
+import { isEscapeKeyDismiss } from '../../utils';
 
 /**
  * Create the state required to render DialogSurface.
@@ -40,6 +40,8 @@ export const useDialogSurface_unstable = (
     },
     root: getNativeElementProps(as, {
       ref: useMergedRefs(ref, contentRef),
+      'aria-modal': modalType !== 'non-modal',
+      role: modalType === 'alert' ? 'alertdialog' : 'dialog',
       ...props,
       ...modalAttributes,
       onKeyDown: handleRootKeyDown,

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceContextValues.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceContextValues.ts
@@ -1,0 +1,8 @@
+import type { DialogSurfaceContextValues, DialogSurfaceState } from './DialogSurface.types';
+import type { DialogSurfaceContextValue } from '../../contexts';
+
+export function useDialogSurfaceContextValues_unstable(state: DialogSurfaceState): DialogSurfaceContextValues {
+  const dialogSurface: DialogSurfaceContextValue = true;
+
+  return { dialogSurface };
+}

--- a/packages/react-components/react-dialog/src/components/DialogTitle/renderDialogTitle.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/renderDialogTitle.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
 import type { DialogTitleState, DialogTitleSlots } from './DialogTitle.types';
+import { DialogTrigger } from '../DialogTrigger';
 
 /**
  * Render the final JSX of DialogTitle
@@ -12,8 +13,9 @@ export const renderDialogTitle_unstable = (state: DialogTitleState) => {
     <>
       <slots.root {...slotProps.root}>{slotProps.root.children}</slots.root>
       {slots.closeButton && (
-        // TODO: Wrap around DialogTrigger component
-        <slots.closeButton {...slotProps.closeButton} />
+        <DialogTrigger action="close">
+          <slots.closeButton {...slotProps.closeButton} />
+        </DialogTrigger>
       )}
     </>
   );

--- a/packages/react-components/react-dialog/src/components/DialogTrigger/DialogTrigger.types.ts
+++ b/packages/react-components/react-dialog/src/components/DialogTrigger/DialogTrigger.types.ts
@@ -1,12 +1,13 @@
 import * as React from 'react';
 
-export type DialogTriggerAction = 'open' | 'close' | 'toggle';
+export type DialogTriggerAction = 'open' | 'close';
 
 export type DialogTriggerProps = {
   /**
-   * Explicitly declare if the trigger is responsible for opening,
-   * closing or toggling a Dialog visibility state.
-   * @default toggle
+   * Explicitly declare if the trigger is responsible for opening or
+   * closing a Dialog visibility state.
+   * @default 'open' // if it's outside DialogSurface
+   * @default 'close' // if it's inside DialogSurface
    */
   action?: DialogTriggerAction;
   /**
@@ -21,8 +22,9 @@ export type DialogTriggerProps = {
 /**
  * Props that are passed to the child of the DialogTrigger when cloned to ensure correct behaviour for the Dialog
  */
-export type DialogTriggerChildProps = Required<
-  Pick<React.HTMLAttributes<HTMLElement>, 'onClick' | 'onKeyDown' | 'aria-haspopup'>
+export type DialogTriggerChildProps = Pick<
+  React.HTMLAttributes<HTMLElement>,
+  'onClick' | 'onKeyDown' | 'aria-haspopup'
 > & {
   ref?: React.Ref<never>;
 };

--- a/packages/react-components/react-dialog/src/components/DialogTrigger/useDialogTrigger.ts
+++ b/packages/react-components/react-dialog/src/components/DialogTrigger/useDialogTrigger.ts
@@ -18,10 +18,9 @@ import { useDialogContext_unstable, useDialogSurfaceContext_unstable } from '../
  * @param props - props from this instance of DialogTrigger
  */
 export const useDialogTrigger_unstable = (props: DialogTriggerProps): DialogTriggerState => {
-  const { children, action } = props;
-
   const isInsideSurfaceDialog = useDialogSurfaceContext_unstable();
-  const possibleAction = action ?? isInsideSurfaceDialog ? 'close' : 'open';
+
+  const { children, action = isInsideSurfaceDialog ? 'close' : 'open' } = props;
 
   const child = React.isValidElement(children) ? getTriggerChild<DialogTriggerChildProps>(children) : undefined;
 
@@ -38,7 +37,7 @@ export const useDialogTrigger_unstable = (props: DialogTriggerProps): DialogTrig
       requestOpenChange({
         event,
         type: 'triggerClick',
-        open: updateOpen(possibleAction),
+        open: updateOpen(action),
       });
     }
   });
@@ -55,7 +54,7 @@ export const useDialogTrigger_unstable = (props: DialogTriggerProps): DialogTrig
 
   return {
     children: applyTriggerPropsToChildren<DialogTriggerChildProps>(children, {
-      'aria-haspopup': (isInsideSurfaceDialog && action !== 'open') || action === 'close' ? undefined : 'dialog',
+      'aria-haspopup': action === 'close' ? undefined : 'dialog',
       ref: child?.ref as React.Ref<never>,
       onClick: handleClick,
       onKeyDown: handleKeyDown,

--- a/packages/react-components/react-dialog/src/components/DialogTrigger/useDialogTrigger.ts
+++ b/packages/react-components/react-dialog/src/components/DialogTrigger/useDialogTrigger.ts
@@ -2,12 +2,7 @@ import * as React from 'react';
 import { useModalAttributes } from '@fluentui/react-tabster';
 import { Enter, Space } from '@fluentui/keyboard-keys';
 import { applyTriggerPropsToChildren, getTriggerChild, useEventCallback } from '@fluentui/react-utilities';
-import {
-  DialogTriggerChildProps,
-  DialogTriggerProps,
-  DialogTriggerState,
-  DialogTriggerAction,
-} from './DialogTrigger.types';
+import { DialogTriggerChildProps, DialogTriggerProps, DialogTriggerState } from './DialogTrigger.types';
 import { isTargetDisabled } from '../../utils';
 import { useDialogContext_unstable, useDialogSurfaceContext_unstable } from '../../contexts';
 
@@ -37,7 +32,7 @@ export const useDialogTrigger_unstable = (props: DialogTriggerProps): DialogTrig
       requestOpenChange({
         event,
         type: 'triggerClick',
-        open: updateOpen(action),
+        open: action === 'open',
       });
     }
   });
@@ -62,12 +57,3 @@ export const useDialogTrigger_unstable = (props: DialogTriggerProps): DialogTrig
     }),
   };
 };
-
-function updateOpen(type: DialogTriggerAction): boolean {
-  switch (type) {
-    case 'close':
-      return false;
-    case 'open':
-      return true;
-  }
-}

--- a/packages/react-components/react-dialog/src/contexts/dialogContext.ts
+++ b/packages/react-components/react-dialog/src/contexts/dialogContext.ts
@@ -3,10 +3,6 @@ import type { Context } from '@fluentui/react-context-selector';
 import type { DialogOpenChangeData, DialogModalType } from '../Dialog';
 import * as React from 'react';
 
-export type DialogRequestOpenChangeData = Omit<DialogOpenChangeData, 'open'> & {
-  open: React.SetStateAction<boolean>;
-};
-
 export type DialogContextValue = {
   /**
    * Reference to trigger element that opened the Dialog
@@ -19,7 +15,7 @@ export type DialogContextValue = {
   /**
    * Requests dialog main component to update it's internal open state
    */
-  requestOpenChange: (data: DialogRequestOpenChangeData) => void;
+  requestOpenChange: (data: DialogOpenChangeData) => void;
 };
 
 const defaultContextValue: DialogContextValue = {

--- a/packages/react-components/react-dialog/src/contexts/dialogSurfaceContext.ts
+++ b/packages/react-components/react-dialog/src/contexts/dialogSurfaceContext.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+export type DialogSurfaceContextValue = boolean;
+
+const defaultContextValue: DialogSurfaceContextValue = false;
+
+export const DialogSurfaceContext = createContext<DialogSurfaceContextValue | undefined>(undefined);
+
+export const DialogSurfaceProvider = DialogSurfaceContext.Provider;
+
+export const useDialogSurfaceContext_unstable = () => useContext(DialogSurfaceContext) ?? defaultContextValue;

--- a/packages/react-components/react-dialog/src/contexts/index.ts
+++ b/packages/react-components/react-dialog/src/contexts/index.ts
@@ -1,0 +1,3 @@
+export * from './constants';
+export * from './dialogContext';
+export * from './dialogSurfaceContext';

--- a/packages/react-components/react-dialog/src/stories/DialogNested.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogNested.stories.tsx
@@ -4,32 +4,30 @@ import { Button } from '@fluentui/react-components';
 
 export const Nested = () => {
   return (
-    <>
-      <Dialog>
-        <DialogTrigger>
-          <Button>Open dialog</Button>
-        </DialogTrigger>
-        <DialogSurface aria-label="label">
-          <DialogTitle>Dialog title</DialogTitle>
-          <DialogActions>
-            <Dialog>
-              <DialogTrigger>
-                <Button appearance="primary">Open inner dialog</Button>
-              </DialogTrigger>
-              <DialogSurface aria-label="label">
-                <DialogTitle>Inner dialog title</DialogTitle>
-                <DialogBody>⚠️ just because you can doesn't mean you should have nested dialogs ⚠️</DialogBody>
-                <DialogActions>
-                  <DialogTrigger action="close">
-                    <Button appearance="primary">Close</Button>
-                  </DialogTrigger>
-                </DialogActions>
-              </DialogSurface>
-            </Dialog>
-          </DialogActions>
-        </DialogSurface>
-      </Dialog>
-    </>
+    <Dialog>
+      <DialogTrigger>
+        <Button>Open dialog</Button>
+      </DialogTrigger>
+      <DialogSurface aria-label="label">
+        <DialogTitle>Dialog title</DialogTitle>
+        <DialogActions>
+          <Dialog>
+            <DialogTrigger>
+              <Button appearance="primary">Open inner dialog</Button>
+            </DialogTrigger>
+            <DialogSurface aria-label="label">
+              <DialogTitle>Inner dialog title</DialogTitle>
+              <DialogBody>⚠️ just because you can doesn't mean you should have nested dialogs ⚠️</DialogBody>
+              <DialogActions>
+                <DialogTrigger>
+                  <Button appearance="primary">Close</Button>
+                </DialogTrigger>
+              </DialogActions>
+            </DialogSurface>
+          </Dialog>
+        </DialogActions>
+      </DialogSurface>
+    </Dialog>
   );
 };
 

--- a/packages/react-components/react-dialog/src/utils/index.ts
+++ b/packages/react-components/react-dialog/src/utils/index.ts
@@ -1,0 +1,4 @@
+export * from './isEscapeKeyDown';
+export * from './isTargetDisabled';
+export * from './localShorthands';
+export * from './normalizeDefaultPrevented';

--- a/packages/react-components/react-dialog/src/utils/normalizeSetStateAction.ts
+++ b/packages/react-components/react-dialog/src/utils/normalizeSetStateAction.ts
@@ -1,8 +1,0 @@
-import * as React from 'react';
-
-/**
- * Normalizes a set state action into a setter function
- */
-export function normalizeSetStateAction<T>(setOpen: React.SetStateAction<T>): (prev: T) => T {
-  return typeof setOpen === 'function' ? (setOpen as (prevState: T) => T) : () => setOpen;
-}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Updates

1. Ensures `DialogTrigger` only has `aria-haspopup` if it's an `open` trigger.
2. Adds `role` and `aria-modal` attributes to `DialogSurface`
3. Removes `toggle` action from `DialogTrigger`
4. Wraps `DialogTitle` closeButton in a `DialogTrigger`
