### PR TITLE
feat: support `items` prop and render function

### DIFF
--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -6,6 +6,7 @@
 
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 

--- a/packages/react-components/react-table/package.json
+++ b/packages/react-components/react-table/package.json
@@ -32,6 +32,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
+    "@fluentui/react-context-selector": "^9.0.2",
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/react-utilities": "^9.0.2",
     "@griffel/react": "^1.2.0",

--- a/packages/react-components/react-table/src/components/Table/Table.types.ts
+++ b/packages/react-components/react-table/src/components/Table/Table.types.ts
@@ -14,11 +14,9 @@ export type TableContextValues = {
  */
 export type TableProps = ComponentProps<TableSlots> & {} & Partial<TableContextValue> & {
     items?: unknown[];
-    columns?: unknown[];
   };
 
 /**
  * State used in rendering Table
  */
-export type TableState = ComponentState<TableSlots> &
-  Pick<Required<TableProps>, 'size' | 'noNativeElements' | 'items' | 'columns'>;
+export type TableState = ComponentState<TableSlots> & Pick<Required<TableProps>, 'size' | 'noNativeElements' | 'items'>;

--- a/packages/react-components/react-table/src/components/Table/Table.types.ts
+++ b/packages/react-components/react-table/src/components/Table/Table.types.ts
@@ -12,9 +12,13 @@ export type TableContextValues = {
 /**
  * Table Props
  */
-export type TableProps = ComponentProps<TableSlots> & {} & Partial<TableContextValue>;
+export type TableProps = ComponentProps<TableSlots> & {} & Partial<TableContextValue> & {
+    items?: unknown[];
+    columns?: unknown[];
+  };
 
 /**
  * State used in rendering Table
  */
-export type TableState = ComponentState<TableSlots> & Pick<Required<TableProps>, 'size' | 'noNativeElements'>;
+export type TableState = ComponentState<TableSlots> &
+  Pick<Required<TableProps>, 'size' | 'noNativeElements' | 'items' | 'columns'>;

--- a/packages/react-components/react-table/src/components/Table/useTable.ts
+++ b/packages/react-components/react-table/src/components/Table/useTable.ts
@@ -26,6 +26,5 @@ export const useTable_unstable = (props: TableProps, ref: React.Ref<HTMLElement>
     size: props.size ?? 'medium',
     noNativeElements: props.noNativeElements ?? false,
     items: props.items ?? [],
-    columns: props.columns ?? [],
   };
 };

--- a/packages/react-components/react-table/src/components/Table/useTable.ts
+++ b/packages/react-components/react-table/src/components/Table/useTable.ts
@@ -25,5 +25,7 @@ export const useTable_unstable = (props: TableProps, ref: React.Ref<HTMLElement>
     }),
     size: props.size ?? 'medium',
     noNativeElements: props.noNativeElements ?? false,
+    items: props.items ?? [],
+    columns: props.columns ?? [],
   };
 };

--- a/packages/react-components/react-table/src/components/Table/useTableContextValues.test.ts
+++ b/packages/react-components/react-table/src/components/Table/useTableContextValues.test.ts
@@ -13,6 +13,8 @@ describe('useTableContextValues', () => {
     expect(result.current).toMatchInlineSnapshot(`
       Object {
         "table": Object {
+          "columns": Array [],
+          "items": Array [],
           "noNativeElements": false,
           "size": "medium",
         },

--- a/packages/react-components/react-table/src/components/Table/useTableContextValues.ts
+++ b/packages/react-components/react-table/src/components/Table/useTableContextValues.ts
@@ -1,15 +1,13 @@
-import * as React from 'react';
-import { TableContextValue } from '../../contexts/types';
 import { TableState } from './Table.types';
 
 export function useTableContextValues_unstable(state: TableState) {
-  const table = React.useMemo<TableContextValue>(
-    () => ({
-      size: state.size,
-      noNativeElements: state.noNativeElements,
-    }),
-    [state.size, state.noNativeElements],
-  );
-
-  return { table };
+  const { size, noNativeElements, items, columns } = state;
+  return {
+    table: {
+      columns,
+      items,
+      noNativeElements,
+      size,
+    },
+  };
 }

--- a/packages/react-components/react-table/src/components/Table/useTableContextValues.ts
+++ b/packages/react-components/react-table/src/components/Table/useTableContextValues.ts
@@ -1,10 +1,9 @@
 import { TableState } from './Table.types';
 
 export function useTableContextValues_unstable(state: TableState) {
-  const { size, noNativeElements, items, columns } = state;
+  const { size, noNativeElements, items } = state;
   return {
     table: {
-      columns,
       items,
       noNativeElements,
       size,

--- a/packages/react-components/react-table/src/components/TableBody/TableBody.test.tsx
+++ b/packages/react-components/react-table/src/components/TableBody/TableBody.test.tsx
@@ -34,7 +34,7 @@ describe('TableBody', () => {
 
   it('renders as div if `noNativeElements` is set', () => {
     const { container } = render(
-      <TableContextProvider value={{ size: 'medium', noNativeElements: true }}>
+      <TableContextProvider value={{ size: 'medium', noNativeElements: true, items: [] }}>
         <TableBody>
           <div>
             <div>Cell</div>

--- a/packages/react-components/react-table/src/components/TableBody/TableBody.types.ts
+++ b/packages/react-components/react-table/src/components/TableBody/TableBody.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type TableBodySlots = {
@@ -7,7 +8,9 @@ export type TableBodySlots = {
 /**
  * TableBody Props
  */
-export type TableBodyProps = ComponentProps<TableBodySlots>;
+export type TableBodyProps = ComponentProps<TableBodySlots> & {
+  children?: React.ReactNode | ((items: unknown) => React.ReactNode);
+};
 
 /**
  * State used in rendering TableBody

--- a/packages/react-components/react-table/src/components/TableBody/TableBody.types.ts
+++ b/packages/react-components/react-table/src/components/TableBody/TableBody.types.ts
@@ -5,11 +5,13 @@ export type TableBodySlots = {
   root: Slot<'tbody', 'div'>;
 };
 
+export type TableRowRenderFunction = (items: unknown) => React.ReactNode;
+
 /**
  * TableBody Props
  */
 export type TableBodyProps = ComponentProps<TableBodySlots> & {
-  children?: React.ReactNode | ((items: unknown) => React.ReactNode);
+  children?: React.ReactNode | TableRowRenderFunction;
 };
 
 /**

--- a/packages/react-components/react-table/src/components/TableBody/useTableBody.ts
+++ b/packages/react-components/react-table/src/components/TableBody/useTableBody.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { getNativeElementProps } from '@fluentui/react-utilities';
 import type { TableBodyProps, TableBodyState } from './TableBody.types';
 import { useTableContext } from '../../contexts/tableContext';
+import { isRenderFunction } from '../../utils';
 
 /**
  * Create the state required to render TableBody.
@@ -13,8 +14,15 @@ import { useTableContext } from '../../contexts/tableContext';
  * @param ref - reference to root HTMLElement of TableBody
  */
 export const useTableBody_unstable = (props: TableBodyProps, ref: React.Ref<HTMLElement>): TableBodyState => {
-  const { noNativeElements } = useTableContext();
+  const noNativeElements = useTableContext(ctx => ctx.noNativeElements);
+  const items = useTableContext(ctx => ctx.items);
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'tbody';
+
+  const children = props.children;
+  let childItems: unknown[] | undefined;
+  if (isRenderFunction(children)) {
+    childItems = items.map(item => children(item));
+  }
 
   return {
     components: {
@@ -24,6 +32,7 @@ export const useTableBody_unstable = (props: TableBodyProps, ref: React.Ref<HTML
       ref,
       role: rootComponent === 'div' ? 'rowgroup' : undefined,
       ...props,
+      children: childItems ?? props.children,
     }),
   };
 };

--- a/packages/react-components/react-table/src/components/TableCell/TableCell.test.tsx
+++ b/packages/react-components/react-table/src/components/TableCell/TableCell.test.tsx
@@ -37,7 +37,7 @@ describe('TableCell', () => {
 
   it('renders as div if `noNativeElements` is set', () => {
     const { container } = render(
-      <TableContextProvider value={{ size: 'medium', noNativeElements: true }}>
+      <TableContextProvider value={{ size: 'medium', noNativeElements: true, items: [] }}>
         <TableCell>Table cell</TableCell>
       </TableContextProvider>,
     );

--- a/packages/react-components/react-table/src/components/TableCell/useTableCell.ts
+++ b/packages/react-components/react-table/src/components/TableCell/useTableCell.ts
@@ -13,7 +13,7 @@ import { useTableContext } from '../../contexts/tableContext';
  * @param ref - reference to root HTMLElement of TableCell
  */
 export const useTableCell_unstable = (props: TableCellProps, ref: React.Ref<HTMLElement>): TableCellState => {
-  const { noNativeElements } = useTableContext();
+  const noNativeElements = useTableContext(ctx => ctx.noNativeElements);
 
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'td';
 

--- a/packages/react-components/react-table/src/components/TableRow/TableRow.test.tsx
+++ b/packages/react-components/react-table/src/components/TableRow/TableRow.test.tsx
@@ -34,7 +34,7 @@ describe('TableRow', () => {
 
   it('renders as div if `noNativeElements` is set', () => {
     const { container } = render(
-      <TableContextProvider value={{ size: 'medium', noNativeElements: true }}>
+      <TableContextProvider value={{ size: 'medium', noNativeElements: true, items: [] }}>
         <TableRow>
           <div>Table cell</div>
         </TableRow>

--- a/packages/react-components/react-table/src/components/TableRow/useTableRow.ts
+++ b/packages/react-components/react-table/src/components/TableRow/useTableRow.ts
@@ -13,7 +13,8 @@ import { useTableContext } from '../../contexts/tableContext';
  * @param ref - reference to root HTMLElement of TableRow
  */
 export const useTableRow_unstable = (props: TableRowProps, ref: React.Ref<HTMLElement>): TableRowState => {
-  const { size, noNativeElements } = useTableContext();
+  const noNativeElements = useTableContext(ctx => ctx.noNativeElements);
+  const size = useTableContext(ctx => ctx.size);
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'tr';
 
   return {

--- a/packages/react-components/react-table/src/contexts/tableContext.ts
+++ b/packages/react-components/react-table/src/contexts/tableContext.ts
@@ -1,12 +1,14 @@
-import * as React from 'react';
+import { createContext, useContextSelector, ContextSelector } from '@fluentui/react-context-selector';
 import type { TableContextValue } from './types';
 
-const tableContext = React.createContext<TableContextValue | undefined>(undefined);
+const tableContext = createContext<TableContextValue | undefined>(undefined);
 
 const tableContextDefaultValue: TableContextValue = {
   size: 'medium',
   noNativeElements: false,
+  items: [],
 };
 
 export const TableContextProvider = tableContext.Provider;
-export const useTableContext = () => React.useContext(tableContext) ?? tableContextDefaultValue;
+export const useTableContext = <T>(selector: ContextSelector<TableContextValue, T>): T =>
+  useContextSelector(tableContext, (ctx = tableContextDefaultValue) => selector(ctx));

--- a/packages/react-components/react-table/src/contexts/types.ts
+++ b/packages/react-components/react-table/src/contexts/types.ts
@@ -2,4 +2,6 @@ export type TableContextValue = {
   size: 'small' | 'smaller' | 'medium';
 
   noNativeElements: boolean;
+
+  items: unknown[];
 };

--- a/packages/react-components/react-table/src/stories/Table/Default.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/Default.stories.tsx
@@ -8,37 +8,64 @@ import {
   DocumentPdf16Regular as DocumentPdfRegular,
   Video16Regular as VideoRegular,
 } from '@fluentui/react-icons';
-import { Avatar } from '@fluentui/react-avatar';
+import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import { TableBody, TableCell, TableRow, Table } from '../..';
+
+const items = [
+  {
+    file: { label: 'Meeting notes', icon: <DocumentRegular /> },
+    author: { label: 'Max Mustermann', status: 'available' },
+    lastUpdated: { label: '7h ago', timestamp: 1 },
+    lastUpdate: {
+      label: 'You edited this',
+      icon: <EditRegular />,
+    },
+  },
+  {
+    file: { label: 'Thursday presentation', icon: <FolderRegular /> },
+    author: { label: 'Erika Mustermann', status: 'busy' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Training recording', icon: <VideoRegular /> },
+    author: { label: 'John Doe', status: 'away' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Purchase order', icon: <DocumentPdfRegular /> },
+    author: { label: 'Jane Doe', status: 'offline' },
+    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 3 },
+    lastUpdate: {
+      label: 'You shared this in a Teams chat',
+      icon: <PeopleRegular />,
+    },
+  },
+];
 
 export const Default = () => {
   return (
-    <Table>
+    <Table items={items}>
       <TableBody>
-        <TableRow>
-          <TableCell media={<DocumentRegular />}>Meeting notes</TableCell>
-          <TableCell media={<Avatar name="Max Mustermann" badge={{ status: 'available' }} />}>Max Mustermann</TableCell>
-          <TableCell>7h ago</TableCell>
-          <TableCell media={<EditRegular />}>You edited this</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell media={<FolderRegular />}>Thursday presentation</TableCell>
-          <TableCell media={<Avatar name="Erika Mustermann" badge={{ status: 'away' }} />}>Erika Mustermann</TableCell>
-          <TableCell>Yesterday at 1:45 PM</TableCell>
-          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell media={<VideoRegular />}>Training recording</TableCell>
-          <TableCell media={<Avatar name="John Doe" badge={{ status: 'away' }} />}>John Doe</TableCell>
-          <TableCell>Yesterday at 1:45 PM</TableCell>
-          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell media={<DocumentPdfRegular />}>Purchase order</TableCell>
-          <TableCell media={<Avatar name="Jane Doe" badge={{ status: 'away' }} />}>Jane Doe</TableCell>
-          <TableCell>Tue at 9:30 AM</TableCell>
-          <TableCell media={<PeopleRegular />}>You shared this in a Teams chat</TableCell>
-        </TableRow>
+        {(item: typeof items[0]) => (
+          <TableRow>
+            <TableCell media={item.file.icon}>{item.file.label}</TableCell>
+            <TableCell
+              media={<Avatar name={item.author.label} badge={{ status: item.author.status as PresenceBadgeStatus }} />}
+            >
+              {item.author.label}
+            </TableCell>
+            <TableCell>{item.lastUpdated.label}</TableCell>
+            <TableCell media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCell>
+          </TableRow>
+        )}
       </TableBody>
     </Table>
   );

--- a/packages/react-components/react-table/src/stories/Table/NonNativeElements.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/NonNativeElements.stories.tsx
@@ -8,37 +8,64 @@ import {
   DocumentPdf16Regular as DocumentPdfRegular,
   Video16Regular as VideoRegular,
 } from '@fluentui/react-icons';
-import { Avatar } from '@fluentui/react-avatar';
-import { TableCell, TableRow, TableBody, Table } from '../../index';
+import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
+import { TableBody, TableCell, TableRow, Table } from '../..';
+
+const items = [
+  {
+    file: { label: 'Meeting notes', icon: <DocumentRegular /> },
+    author: { label: 'Max Mustermann', status: 'available' },
+    lastUpdated: { label: '7h ago', timestamp: 1 },
+    lastUpdate: {
+      label: 'You edited this',
+      icon: <EditRegular />,
+    },
+  },
+  {
+    file: { label: 'Thursday presentation', icon: <FolderRegular /> },
+    author: { label: 'Erika Mustermann', status: 'busy' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Training recording', icon: <VideoRegular /> },
+    author: { label: 'John Doe', status: 'away' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Purchase order', icon: <DocumentPdfRegular /> },
+    author: { label: 'Jane Doe', status: 'offline' },
+    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 3 },
+    lastUpdate: {
+      label: 'You shared this in a Teams chat',
+      icon: <PeopleRegular />,
+    },
+  },
+];
 
 export const NonNativeElements = () => {
   return (
-    <Table noNativeElements>
+    <Table items={items} noNativeElements>
       <TableBody>
-        <TableRow>
-          <TableCell media={<DocumentRegular />}>Meeting notes</TableCell>
-          <TableCell media={<Avatar name="Max Mustermann" badge={{ status: 'available' }} />}>Max Mustermann</TableCell>
-          <TableCell>7h ago</TableCell>
-          <TableCell media={<EditRegular />}>You edited this</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell media={<FolderRegular />}>Thursday presentation</TableCell>
-          <TableCell media={<Avatar name="Erika Mustermann" badge={{ status: 'away' }} />}>Erika Mustermann</TableCell>
-          <TableCell>Yesterday at 1:45 PM</TableCell>
-          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell media={<VideoRegular />}>Training recording</TableCell>
-          <TableCell media={<Avatar name="John Doe" badge={{ status: 'away' }} />}>John Doe</TableCell>
-          <TableCell>Yesterday at 1:45 PM</TableCell>
-          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell media={<DocumentPdfRegular />}>Purchase order</TableCell>
-          <TableCell media={<Avatar name="Jane Doe" badge={{ status: 'away' }} />}>Jane Doe</TableCell>
-          <TableCell>Tue at 9:30 AM</TableCell>
-          <TableCell media={<PeopleRegular />}>You shared this in a Teams chat</TableCell>
-        </TableRow>
+        {(item: typeof items[0]) => (
+          <TableRow>
+            <TableCell media={item.file.icon}>{item.file.label}</TableCell>
+            <TableCell
+              media={<Avatar name={item.author.label} badge={{ status: item.author.status as PresenceBadgeStatus }} />}
+            >
+              {item.author.label}
+            </TableCell>
+            <TableCell>{item.lastUpdated.label}</TableCell>
+            <TableCell media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCell>
+          </TableRow>
+        )}
       </TableBody>
     </Table>
   );

--- a/packages/react-components/react-table/src/stories/Table/SizeSmall.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/SizeSmall.stories.tsx
@@ -8,41 +8,70 @@ import {
   DocumentPdf16Regular as DocumentPdfRegular,
   Video16Regular as VideoRegular,
 } from '@fluentui/react-icons';
-import { Avatar } from '@fluentui/react-avatar';
-import { TableCell, TableRow, TableBody, Table } from '../../index';
+import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
+import { TableBody, TableCell, TableRow, Table } from '../..';
+
+const items = [
+  {
+    file: { label: 'Meeting notes', icon: <DocumentRegular /> },
+    author: { label: 'Max Mustermann', status: 'available' },
+    lastUpdated: { label: '7h ago', timestamp: 1 },
+    lastUpdate: {
+      label: 'You edited this',
+      icon: <EditRegular />,
+    },
+  },
+  {
+    file: { label: 'Thursday presentation', icon: <FolderRegular /> },
+    author: { label: 'Erika Mustermann', status: 'busy' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Training recording', icon: <VideoRegular /> },
+    author: { label: 'John Doe', status: 'away' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Purchase order', icon: <DocumentPdfRegular /> },
+    author: { label: 'Jane Doe', status: 'offline' },
+    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 3 },
+    lastUpdate: {
+      label: 'You shared this in a Teams chat',
+      icon: <PeopleRegular />,
+    },
+  },
+];
 
 export const SizeSmall = () => {
   return (
-    <Table size="small">
+    <Table items={items} size="small">
       <TableBody>
-        <TableRow>
-          <TableCell media={<DocumentRegular />}>Meeting notes</TableCell>
-          <TableCell media={<Avatar name="Max Mustermann" badge={{ status: 'available' }} size={24} />}>
-            Max Mustermann
-          </TableCell>
-          <TableCell>7h ago</TableCell>
-          <TableCell media={<EditRegular />}>You edited this</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell media={<FolderRegular />}>Thursday presentation</TableCell>
-          <TableCell media={<Avatar name="Erika Mustermann" badge={{ status: 'away' }} size={24} />}>
-            Erika Mustermann
-          </TableCell>
-          <TableCell>Yesterday at 1:45 PM</TableCell>
-          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell media={<VideoRegular />}>Training recording</TableCell>
-          <TableCell media={<Avatar name="John Doe" badge={{ status: 'away' }} size={24} />}>John Doe</TableCell>
-          <TableCell>Yesterday at 1:45 PM</TableCell>
-          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell media={<DocumentPdfRegular />}>Purchase order</TableCell>
-          <TableCell media={<Avatar name="Jane Doe" badge={{ status: 'away' }} size={24} />}>Jane Doe</TableCell>
-          <TableCell>Tue at 9:30 AM</TableCell>
-          <TableCell media={<PeopleRegular />}>You shared this in a Teams chat</TableCell>
-        </TableRow>
+        {(item: typeof items[0]) => (
+          <TableRow>
+            <TableCell media={item.file.icon}>{item.file.label}</TableCell>
+            <TableCell
+              media={
+                <Avatar
+                  size={24}
+                  name={item.author.label}
+                  badge={{ status: item.author.status as PresenceBadgeStatus }}
+                />
+              }
+            >
+              {item.author.label}
+            </TableCell>
+            <TableCell>{item.lastUpdated.label}</TableCell>
+            <TableCell media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCell>
+          </TableRow>
+        )}
       </TableBody>
     </Table>
   );

--- a/packages/react-components/react-table/src/stories/Table/SizeSmaller.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/SizeSmaller.stories.tsx
@@ -8,41 +8,70 @@ import {
   DocumentPdf16Regular as DocumentPdfRegular,
   Video16Regular as VideoRegular,
 } from '@fluentui/react-icons';
-import { Avatar } from '@fluentui/react-avatar';
-import { TableCell, TableRow, TableBody, Table } from '../../index';
+import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
+import { TableBody, TableCell, TableRow, Table } from '../..';
+
+const items = [
+  {
+    file: { label: 'Meeting notes', icon: <DocumentRegular /> },
+    author: { label: 'Max Mustermann', status: 'available' },
+    lastUpdated: { label: '7h ago', timestamp: 1 },
+    lastUpdate: {
+      label: 'You edited this',
+      icon: <EditRegular />,
+    },
+  },
+  {
+    file: { label: 'Thursday presentation', icon: <FolderRegular /> },
+    author: { label: 'Erika Mustermann', status: 'busy' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Training recording', icon: <VideoRegular /> },
+    author: { label: 'John Doe', status: 'away' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Purchase order', icon: <DocumentPdfRegular /> },
+    author: { label: 'Jane Doe', status: 'offline' },
+    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 3 },
+    lastUpdate: {
+      label: 'You shared this in a Teams chat',
+      icon: <PeopleRegular />,
+    },
+  },
+];
 
 export const SizeSmaller = () => {
   return (
-    <Table size="smaller">
+    <Table items={items} size="smaller">
       <TableBody>
-        <TableRow>
-          <TableCell media={<DocumentRegular />}>Meeting notes</TableCell>
-          <TableCell media={<Avatar name="Max Mustermann" badge={{ status: 'available' }} size={20} />}>
-            Max Mustermann
-          </TableCell>
-          <TableCell>7h ago</TableCell>
-          <TableCell media={<EditRegular />}>You edited this</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell media={<FolderRegular />}>Thursday presentation</TableCell>
-          <TableCell media={<Avatar name="Erika Mustermann" badge={{ status: 'away' }} size={20} />}>
-            Erika Mustermann
-          </TableCell>
-          <TableCell>Yesterday at 1:45 PM</TableCell>
-          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell media={<VideoRegular />}>Training recording</TableCell>
-          <TableCell media={<Avatar name="John Doe" badge={{ status: 'away' }} size={20} />}>John Doe</TableCell>
-          <TableCell>Yesterday at 1:45 PM</TableCell>
-          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell media={<DocumentPdfRegular />}>Purchase order</TableCell>
-          <TableCell media={<Avatar name="Jane Doe" badge={{ status: 'away' }} size={20} />}>Jane Doe</TableCell>
-          <TableCell>Tue at 9:30 AM</TableCell>
-          <TableCell media={<PeopleRegular />}>You shared this in a Teams chat</TableCell>
-        </TableRow>
+        {(item: typeof items[0]) => (
+          <TableRow>
+            <TableCell media={item.file.icon}>{item.file.label}</TableCell>
+            <TableCell
+              media={
+                <Avatar
+                  size={20}
+                  name={item.author.label}
+                  badge={{ status: item.author.status as PresenceBadgeStatus }}
+                />
+              }
+            >
+              {item.author.label}
+            </TableCell>
+            <TableCell>{item.lastUpdated.label}</TableCell>
+            <TableCell media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCell>
+          </TableRow>
+        )}
       </TableBody>
     </Table>
   );

--- a/packages/react-components/react-table/src/stories/Table/WithChildren.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/WithChildren.stories.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import {
+  Folder16Regular as FolderRegular,
+  Edit16Regular as EditRegular,
+  Open16Regular as OpenRegular,
+  Document16Regular as DocumentRegular,
+  People16Regular as PeopleRegular,
+  DocumentPdf16Regular as DocumentPdfRegular,
+  Video16Regular as VideoRegular,
+} from '@fluentui/react-icons';
+import { Avatar } from '@fluentui/react-avatar';
+import { TableBody, TableCell, TableRow, Table } from '../..';
+
+export const WithChildren = () => {
+  return (
+    <Table>
+      <TableBody>
+        <TableRow>
+          <TableCell media={<DocumentRegular />}>Meeting notes</TableCell>
+          <TableCell media={<Avatar name="Max Mustermann" badge={{ status: 'available' }} />}>Max Mustermann</TableCell>
+          <TableCell>7h ago</TableCell>
+          <TableCell media={<EditRegular />}>You edited this</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell media={<FolderRegular />}>Thursday presentation</TableCell>
+          <TableCell media={<Avatar name="Erika Mustermann" badge={{ status: 'away' }} />}>Erika Mustermann</TableCell>
+          <TableCell>Yesterday at 1:45 PM</TableCell>
+          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell media={<VideoRegular />}>Training recording</TableCell>
+          <TableCell media={<Avatar name="John Doe" badge={{ status: 'away' }} />}>John Doe</TableCell>
+          <TableCell>Yesterday at 1:45 PM</TableCell>
+          <TableCell media={<OpenRegular />}>You recently opened this</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell media={<DocumentPdfRegular />}>Purchase order</TableCell>
+          <TableCell media={<Avatar name="Jane Doe" badge={{ status: 'away' }} />}>Jane Doe</TableCell>
+          <TableCell>Tue at 9:30 AM</TableCell>
+          <TableCell media={<PeopleRegular />}>You shared this in a Teams chat</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+};

--- a/packages/react-components/react-table/src/stories/Table/index.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/index.stories.tsx
@@ -1,6 +1,7 @@
 import { Table } from '../..';
 
 export { Default } from './Default.stories';
+export { WithChildren } from './WithChildren.stories';
 export { NonNativeElements } from './NonNativeElements.stories';
 export { SizeSmall } from './SizeSmall.stories';
 export { SizeSmaller } from './SizeSmaller.stories';

--- a/packages/react-components/react-table/src/utils/index.ts
+++ b/packages/react-components/react-table/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './isRenderFunction';

--- a/packages/react-components/react-table/src/utils/isRenderFunction.ts
+++ b/packages/react-components/react-table/src/utils/isRenderFunction.ts
@@ -1,0 +1,8 @@
+import * as React from 'react';
+
+export function isRenderFunction(children: React.ReactNode): children is (item: unknown) => React.ReactNode {
+  if (typeof children === 'function') {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Rendering with React children is still supported, but this PR enables
the `items` prop with a render function for rows in `TableBody`. This allows the component to receive a `items` prop and a `columns` prop (in the future) which will be quite useful for managing internal state.

Also considering potentially removing the children API later

```tsx
<Table items={items}>
  <TableBody>
    {(item: typeof items[0]) => (
      <TableRow>
        <TableCell media={item.file.icon}>{item.file.label}</TableCell>
        <TableCell
          media={<Avatar name={item.author.label} badge={{ status: item.author.status as PresenceBadgeStatus }} />}
        >
          {item.author.label}
        </TableCell>
        <TableCell>{item.lastUpdated.label}</TableCell>
        <TableCell media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCell>
      </TableRow>
    )}
  </TableBody>
</Table>
```

Addresses #23983
