### PR TITLE
fix(TagPicker): focus outline for TagItem remove button now meets required contrast ratio

### DIFF
--- a/change/@fluentui-react-f9e1d4e1-504b-47d8-8442-4f425d4f2ae7.json
+++ b/change/@fluentui-react-f9e1d4e1-504b-47d8-8442-4f425d4f2ae7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(TagPicker): Remove button focus border now meets required contrast ratio.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-f9e1d4e1-504b-47d8-8442-4f425d4f2ae7.json
+++ b/change/@fluentui-react-f9e1d4e1-504b-47d8-8442-4f425d4f2ae7.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix(TagPicker): Remove button focus outline now meets required contrast ratio.",
+  "comment": "fix(TagPicker): focus outline for TagItem remove button now meets required contrast ratio.",
   "packageName": "@fluentui/react",
   "email": "tristan.watanabe@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-f9e1d4e1-504b-47d8-8442-4f425d4f2ae7.json
+++ b/change/@fluentui-react-f9e1d4e1-504b-47d8-8442-4f425d4f2ae7.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix(TagPicker): Remove button focus border now meets required contrast ratio.",
+  "comment": "fix(TagPicker): Remove button focus outline now meets required contrast ratio.",
   "packageName": "@fluentui/react",
   "email": "tristan.watanabe@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
+++ b/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
@@ -93,6 +93,7 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
     ],
     close: [
       classNames.close,
+      getFocusStyle(theme, { borderColor: 'transparent', inset: 1, outlineColor: palette.white }),
       {
         color: palette.neutralSecondary,
         width: 30,

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`TagItem accepts title override 1`] = `
           bottom: 2px;
           content: "";
           left: 2px;
-          outline: 1px solid #605e5c;
+          outline: 1px solid #ffffff;
           position: absolute;
           right: 2px;
           top: 2px;
@@ -367,7 +367,7 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
           bottom: 2px;
           content: "";
           left: 2px;
-          outline: 1px solid #605e5c;
+          outline: 1px solid #ffffff;
           position: absolute;
           right: 2px;
           top: 2px;
@@ -592,7 +592,7 @@ exports[`TagItem renders correctly 1`] = `
           bottom: 2px;
           content: "";
           left: 2px;
-          outline: 1px solid #605e5c;
+          outline: 1px solid #ffffff;
           position: absolute;
           right: 2px;
           top: 2px;

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`TagPicker renders correctly 1`] = `
                   bottom: 2px;
                   content: "";
                   left: 2px;
-                  outline: 1px solid #605e5c;
+                  outline: 1px solid #ffffff;
                   position: absolute;
                   right: 2px;
                   top: 2px;
@@ -588,7 +588,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                   bottom: 2px;
                   content: "";
                   left: 2px;
-                  outline: 1px solid #605e5c;
+                  outline: 1px solid #ffffff;
                   position: absolute;
                   right: 2px;
                   top: 2px;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- Remove button on a `TagItem` has a focus outline with a contrast ratio of 1.425: 1 and does not meet minimum contrast ratio of 3:1.

![TagItemFocusIssue](https://user-images.githubusercontent.com/8649804/181590633-22b542cc-dd5d-4a17-89ee-ab783c32f036.gif)


## New Behavior
- Remove button on a `TagItem` focus outline now meets minimum contrast ratio of 3:1. Changed the outline color to white, similar to `PrimaryButton`'s keyboard focus outline color. 

![TagItemFocusFix](https://user-images.githubusercontent.com/8649804/181590610-3112ad79-6a39-4330-a5ce-3eff7a0b0405.gif)

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #24100
