### PR TITLE
chore: Re-exporting useIsomorphicLayoutEffect from @fluentui/react-utilities in @fluentui/react-components

### DIFF
--- a/change/@fluentui-react-components-848a0a6a-cdd6-4fd9-9e11-96a011548041.json
+++ b/change/@fluentui-react-components-848a0a6a-cdd6-4fd9-9e11-96a011548041.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: Re-exporting useIsomorphicLayoutEffect from @fluentui/react-utilities in @fluentui/react-components.",
+  "packageName": "@fluentui/react-components",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -452,6 +452,7 @@ import { useImage_unstable } from '@fluentui/react-image';
 import { useImageStyles_unstable } from '@fluentui/react-image';
 import { useInput_unstable } from '@fluentui/react-input';
 import { useInputStyles_unstable } from '@fluentui/react-input';
+import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 import { useIsSSR } from '@fluentui/react-utilities';
 import { useKeyboardNavAttribute } from '@fluentui/react-tabster';
 import { useLabel_unstable } from '@fluentui/react-label';
@@ -1428,6 +1429,8 @@ export { useImageStyles_unstable }
 export { useInput_unstable }
 
 export { useInputStyles_unstable }
+
+export { useIsomorphicLayoutEffect }
 
 export { useIsSSR }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -134,6 +134,7 @@ export {
   resolveShorthand,
   SSRProvider,
   useId,
+  useIsomorphicLayoutEffect,
   useIsSSR,
   useMergedRefs,
 } from '@fluentui/react-utilities';


### PR DESCRIPTION
## PR Description

This PR re-exports `useIsomorphicLayoutEffect` from `@fluentui/react-utilities` in `@fluentui/react-components`. This allows it to be imported directly from `@fluentui/react-components` and fixes an issue with the `ThemeColors.stories.tsx` not loading because it cannot resolve that import.