### PR TITLE
fix(react-popover): Allow PopoverSurface to trap focus when it's focusable

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
@@ -64,12 +64,7 @@ storiesOf('Popover Converged', module)
 storiesOf('Popover Converged', module)
   .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
-    <Screener
-      steps={new Screener.Steps()
-        .click('#show-popover')
-        .snapshot('PopoverSurface focused', { cropTo: '.testWrapper' })
-        .end()}
-    >
+    <Screener steps={new Screener.Steps().click('#show-popover').snapshot('PopoverSurface focused').end()}>
       {story()}
     </Screener>
   ))

--- a/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
@@ -66,7 +66,7 @@ storiesOf('Popover Converged', module)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
-        .click('#show-popovers')
+        .click('#show-popover')
         .snapshot('PopoverSurface focused', { cropTo: '.testWrapper' })
         .end()}
     >
@@ -75,7 +75,7 @@ storiesOf('Popover Converged', module)
   ))
   .addStory('avoid scrolling', () => {
     return (
-      <Popover>
+      <Popover trapFocus>
         <PopoverTrigger>
           <button id="show-popover">Show Popover</button>
         </PopoverTrigger>
@@ -99,8 +99,8 @@ storiesOf('Popover Converged', module)
     );
   });
 
-const sampleText = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
- dolore magna aliqua. Felis donec et odio pellentesque diam volutpat commodo sed. In pellentesque massa placerat duis
+const sampleText = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+ et dolore magna aliqua. Felis donec et odio pellentesque diam volutpat commodo sed. In pellentesque massa placerat duis
  ultricies lacus sed turpis. Eros donec ac odio tempor. Mattis molestie a iaculis at erat. Aenean euismod elementum nisi
   quis eleifend quam. Penatibus et magnis dis parturient montes nascetur ridiculus mus mauris. Sed euismod nisi porta
   lorem mollis aliquam ut porttitor leo. Lorem ipsum dolor sit amet. Id faucibus nisl tincidunt eget nullam. Fermentum

--- a/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
@@ -60,6 +60,16 @@ storiesOf('Popover Converged', module)
     </Screener>
   ))
   .addStory('positioning', () => <PopoverPositioning />, { includeRtl: true, includeHighContrast: true })
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .click('#show-popovers')
+        .snapshot('container focused popover', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
   .addStory('avoid scrolling', () => {
     return (
       <Popover>

--- a/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
@@ -64,7 +64,7 @@ storiesOf('Popover Converged', module)
     <Screener
       steps={new Screener.Steps()
         .click('#show-popovers')
-        .snapshot('container focused popover', { cropTo: '.testWrapper' })
+        .snapshot('PopoverSurface focused', { cropTo: '.testWrapper' })
         .end()}
     >
       {story()}

--- a/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
-import { Popover, PopoverSurface } from '@fluentui/react-popover';
+import { Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-popover';
 import { tokens } from '@fluentui/react-theme';
 import { TestWrapperDecorator } from '../utilities/index';
 
@@ -59,4 +59,40 @@ storiesOf('Popover Converged', module)
       {story()}
     </Screener>
   ))
-  .addStory('positioning', () => <PopoverPositioning />, { includeRtl: true, includeHighContrast: true });
+  .addStory('positioning', () => <PopoverPositioning />, { includeRtl: true, includeHighContrast: true })
+  .addStory('avoid scrolling', () => {
+    return (
+      <Popover>
+        <PopoverTrigger>
+          <button id="show-popover">Show Popover</button>
+        </PopoverTrigger>
+        <PopoverSurface
+          tabIndex={0}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            maxWidth: '300px',
+            maxHeight: '300px',
+            overflowY: 'scroll',
+          }}
+        >
+          <span>{lorem}</span>
+          <div>
+            <button>close</button>
+            <button>accept</button>
+          </div>
+        </PopoverSurface>
+      </Popover>
+    );
+  });
+
+const lorem = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+ dolore magna aliqua. Felis donec et odio pellentesque diam volutpat commodo sed. In pellentesque massa placerat duis
+ ultricies lacus sed turpis. Eros donec ac odio tempor. Mattis molestie a iaculis at erat. Aenean euismod elementum nisi
+  quis eleifend quam. Penatibus et magnis dis parturient montes nascetur ridiculus mus mauris. Sed euismod nisi porta
+  lorem mollis aliquam ut porttitor leo. Lorem ipsum dolor sit amet. Id faucibus nisl tincidunt eget nullam. Fermentum
+  posuere urna nec tincidunt praesent semper. Dolor sit amet consectetur adipiscing. Ut enim blandit volutpat maecenas
+  volutpat blandit aliquam etiam erat. Aliquam malesuada bibendum arcu vitae elementum curabitur vitae nunc sed.
+  Dignissim convallis aenean et tortor at risus. Tristique senectus et netus et malesuada. Sed blandit libero volutpat
+  sed cras ornare arcu dui. Arcu dictum varius duis at consectetur lorem. Montes nascetur ridiculus mus mauris vitae. Ut
+   ornare lectus sit amet est placerat in egestas.`;

--- a/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
@@ -59,7 +59,10 @@ storiesOf('Popover Converged', module)
       {story()}
     </Screener>
   ))
-  .addStory('positioning', () => <PopoverPositioning />, { includeRtl: true, includeHighContrast: true })
+  .addStory('positioning', () => <PopoverPositioning />, { includeRtl: true, includeHighContrast: true });
+
+storiesOf('Popover Converged', module)
+  .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()

--- a/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Popover.stories.tsx
@@ -77,7 +77,7 @@ storiesOf('Popover Converged', module)
           <button id="show-popover">Show Popover</button>
         </PopoverTrigger>
         <PopoverSurface
-          tabIndex={0}
+          tabIndex={-1}
           style={{
             display: 'flex',
             flexDirection: 'column',
@@ -86,7 +86,7 @@ storiesOf('Popover Converged', module)
             overflowY: 'scroll',
           }}
         >
-          <span>{lorem}</span>
+          <span>{sampleText}</span>
           <div>
             <button>close</button>
             <button>accept</button>
@@ -96,7 +96,7 @@ storiesOf('Popover Converged', module)
     );
   });
 
-const lorem = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+const sampleText = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
  dolore magna aliqua. Felis donec et odio pellentesque diam volutpat commodo sed. In pellentesque massa placerat duis
  ultricies lacus sed turpis. Eros donec ac odio tempor. Mattis molestie a iaculis at erat. Aenean euismod elementum nisi
   quis eleifend quam. Penatibus et magnis dis parturient montes nascetur ridiculus mus mauris. Sed euismod nisi porta

--- a/change/@fluentui-react-popover-20004f36-0fef-42c5-b56e-3d0f618b2371.json
+++ b/change/@fluentui-react-popover-20004f36-0fef-42c5-b56e-3d0f618b2371.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Allow PopoverSurface to trap focus when it's focusable.",
+  "packageName": "@fluentui/react-popover",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/e2e/Popover.e2e.tsx
+++ b/packages/react-components/react-popover/e2e/Popover.e2e.tsx
@@ -378,5 +378,28 @@ describe('Popover', () => {
         cy.contains('Two').should('have.focus');
       });
     });
+
+    describe('trap focus behaviour', () => {
+      it('should focus on PopoverSurface when its tabIndex is a number', () => {
+        mount(
+          <Popover trapFocus legacyTrapFocus>
+            <PopoverTrigger>
+              <button>Popover trigger</button>
+            </PopoverTrigger>
+
+            <PopoverSurface tabIndex={-1} id="popover-surface">
+              <button>One</button>
+              <button>Two</button>
+            </PopoverSurface>
+          </Popover>,
+        );
+
+        cy.get(popoverTriggerSelector).focus().realPress('Enter');
+
+        cy.get('#popover-surface').should('exist').realPress('Tab');
+        cy.contains('One').should('have.focus').realPress('Tab');
+        cy.contains('Two').should('have.focus');
+      });
+    });
   });
 });

--- a/packages/react-components/react-popover/e2e/Popover.e2e.tsx
+++ b/packages/react-components/react-popover/e2e/Popover.e2e.tsx
@@ -396,7 +396,7 @@ describe('Popover', () => {
 
         cy.get(popoverTriggerSelector).focus().realPress('Enter');
 
-        cy.get('#popover-surface').should('exist').realPress('Tab');
+        cy.get('#popover-surface').should('have.focus').realPress('Tab');
         cy.contains('One').should('have.focus').realPress('Tab');
         cy.contains('Two').should('have.focus');
       });

--- a/packages/react-components/react-popover/e2e/Popover.e2e.tsx
+++ b/packages/react-components/react-popover/e2e/Popover.e2e.tsx
@@ -398,6 +398,8 @@ describe('Popover', () => {
 
         cy.get('#popover-surface').should('have.focus').realPress('Tab');
         cy.contains('One').should('have.focus').realPress('Tab');
+        cy.contains('Two').should('have.focus').realPress('Tab');
+        cy.contains('One').should('have.focus').realPress(['Shift', 'Tab']);
         cy.contains('Two').should('have.focus');
       });
     });

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -121,7 +121,10 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
 
   React.useEffect(() => {
     if (open && positioningRefs.contentRef.current) {
-      const firstFocusable = findFirstFocusable(positioningRefs.contentRef.current);
+      const firstFocusable =
+        positioningRefs.contentRef.current.tabIndex !== -1
+          ? positioningRefs.contentRef.current
+          : findFirstFocusable(positioningRefs.contentRef.current);
       firstFocusable?.focus();
     }
   }, [findFirstFocusable, open, positioningRefs.contentRef]);

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -121,9 +121,11 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
 
   React.useEffect(() => {
     if (open && positioningRefs.contentRef.current) {
-      const firstFocusable = !isNaN(Number(positioningRefs.contentRef.current.tabIndex))
-        ? positioningRefs.contentRef.current
-        : findFirstFocusable(positioningRefs.contentRef.current);
+      const containerTabIndex = positioningRefs.contentRef.current.getAttribute('tabIndex');
+      const firstFocusable =
+        containerTabIndex === null || isNaN(containerTabIndex)
+          ? findFirstFocusable(positioningRefs.contentRef.current)
+          : positioningRefs.contentRef.current;
       firstFocusable?.focus();
     }
   }, [findFirstFocusable, open, positioningRefs.contentRef]);

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -122,7 +122,7 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
   React.useEffect(() => {
     if (open && positioningRefs.contentRef.current) {
       const firstFocusable =
-        positioningRefs.contentRef.current.tabIndex !== -1
+        positioningRefs.contentRef.current.tabIndex !== undefined
           ? positioningRefs.contentRef.current
           : findFirstFocusable(positioningRefs.contentRef.current);
       firstFocusable?.focus();

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -121,11 +121,10 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
 
   React.useEffect(() => {
     if (open && positioningRefs.contentRef.current) {
-      const containerTabIndex = positioningRefs.contentRef.current.getAttribute('tabIndex');
-      const firstFocusable =
-        containerTabIndex === null || isNaN(containerTabIndex)
-          ? findFirstFocusable(positioningRefs.contentRef.current)
-          : positioningRefs.contentRef.current;
+      const containerTabIndex = positioningRefs.contentRef.current.getAttribute('tabIndex') ?? undefined;
+      const firstFocusable = isNaN(containerTabIndex)
+        ? findFirstFocusable(positioningRefs.contentRef.current)
+        : positioningRefs.contentRef.current;
       firstFocusable?.focus();
     }
   }, [findFirstFocusable, open, positioningRefs.contentRef]);

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -121,10 +121,9 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
 
   React.useEffect(() => {
     if (open && positioningRefs.contentRef.current) {
-      const firstFocusable =
-        positioningRefs.contentRef.current.tabIndex !== undefined
-          ? positioningRefs.contentRef.current
-          : findFirstFocusable(positioningRefs.contentRef.current);
+      const firstFocusable = !isNaN(Number(positioningRefs.contentRef.current.tabIndex))
+        ? positioningRefs.contentRef.current
+        : findFirstFocusable(positioningRefs.contentRef.current);
       firstFocusable?.focus();
     }
   }, [findFirstFocusable, open, positioningRefs.contentRef]);


### PR DESCRIPTION

## Current Behavior

When PopoverSurface is made focusable and `trapFocus` is set to true, PopoverSurface is not focused after triggering the Popover. This leads to problems where the items in a list are not focusable and the list is the only focusable item (the PopoverSurface should be the container of these items with `role=list`), and therefore nothing is focused.

## New Behavior

Popover now checks if the PopoverSurface is focusable first and traps focus if it is. Otherwise, it has the same behavior of finding the first focusable element inside PopoverSurface.
