### PR TITLE
feat(react-dialog): adds aria-labelledby and aria-describedby attributes

### DIFF
--- a/change/@fluentui-react-dialog-367c00aa-6cc7-4aef-a44a-ca4bd58bfcd7.json
+++ b/change/@fluentui-react-dialog-367c00aa-6cc7-4aef-a44a-ca4bd58bfcd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: adds aria-labelledby and aria-describedby attributes",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { resolveShorthand, useControllableState, useEventCallback } from '@fluentui/react-utilities';
+import { resolveShorthand, useControllableState, useEventCallback, useId } from '@fluentui/react-utilities';
 import { useFocusFinders } from '@fluentui/react-tabster';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 import { normalizeDefaultPrevented, isEscapeKeyDismiss } from '../../utils';
@@ -76,6 +76,8 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
     triggerRef,
     contentRef,
     requestOpenChange,
+    dialogBodyID: useId('dialog-body-'),
+    dialogTitleID: useId('dialog-title-'),
   };
 };
 

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialogContextValues.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialogContextValues.ts
@@ -2,18 +2,20 @@ import type { DialogContextValue, DialogSurfaceContextValue } from '../../contex
 import type { DialogContextValues, DialogState } from './Dialog.types';
 
 export function useDialogContextValues_unstable(state: DialogState): DialogContextValues {
-  const { modalType, open, requestOpenChange, triggerRef, contentRef } = state;
+  const { modalType, open, triggerRef, contentRef, dialogBodyID, dialogTitleID, requestOpenChange } = state;
 
   /**
    * This context is created with "@fluentui/react-context-selector",
    * there is no sense to memoize it
    */
   const dialog: DialogContextValue = {
-    modalType,
     open,
-    requestOpenChange,
+    modalType,
     triggerRef,
     contentRef,
+    dialogBodyID,
+    dialogTitleID,
+    requestOpenChange,
   };
 
   const dialogSurface: DialogSurfaceContextValue = false;

--- a/packages/react-components/react-dialog/src/components/DialogBody/useDialogBody.ts
+++ b/packages/react-components/react-dialog/src/components/DialogBody/useDialogBody.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { getNativeElementProps } from '@fluentui/react-utilities';
 import type { DialogBodyProps, DialogBodyState } from './DialogBody.types';
+import { useDialogContext_unstable } from '../../contexts';
 
 /**
  * Create the state required to render DialogBody.
@@ -18,6 +19,7 @@ export const useDialogBody_unstable = (props: DialogBodyProps, ref: React.Ref<HT
     },
     root: getNativeElementProps('div', {
       ref,
+      id: useDialogContext_unstable(ctx => ctx.dialogBodyID),
       ...props,
     }),
   };

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
@@ -22,6 +22,8 @@ export const useDialogSurface_unstable = (
   const { as = 'div' } = props;
 
   const contentRef = useDialogContext_unstable(ctx => ctx.contentRef);
+  const dialogTitleID = useDialogContext_unstable(ctx => ctx.dialogTitleID);
+  const dialogBodyID = useDialogContext_unstable(ctx => ctx.dialogBodyID);
   const requestOpenChange = useDialogContext_unstable(ctx => ctx.requestOpenChange);
 
   const { modalAttributes } = useModalAttributes({ trapFocus: modalType !== 'non-modal' });
@@ -41,6 +43,8 @@ export const useDialogSurface_unstable = (
     root: getNativeElementProps(as, {
       ref: useMergedRefs(ref, contentRef),
       'aria-modal': modalType !== 'non-modal',
+      'aria-describedby': dialogBodyID,
+      'aria-labelledby': props['aria-label'] ? undefined : dialogTitleID,
       role: modalType === 'alert' ? 'alertdialog' : 'dialog',
       ...props,
       ...modalAttributes,

--- a/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
@@ -25,6 +25,7 @@ export const useDialogTitle_unstable = (props: DialogTitleProps, ref: React.Ref<
     },
     root: getNativeElementProps(as, {
       ref,
+      id: useDialogContext_unstable(ctx => ctx.dialogTitleID),
       ...props,
     }),
     closeButton: useARIAButton(closeButton, {

--- a/packages/react-components/react-dialog/src/contexts/dialogContext.ts
+++ b/packages/react-components/react-dialog/src/contexts/dialogContext.ts
@@ -11,6 +11,8 @@ export type DialogContextValue = {
   triggerRef: React.RefObject<HTMLElement>;
   contentRef: React.RefObject<HTMLElement>;
   modalType: DialogModalType;
+  dialogTitleID?: string;
+  dialogBodyID?: string;
   open: boolean;
   /**
    * Requests dialog main component to update it's internal open state

--- a/packages/react-components/react-dialog/src/stories/DialogAlert.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogAlert.stories.tsx
@@ -10,7 +10,7 @@ export const AlertDialog = () => {
         <DialogTrigger>
           <Button>Open Alert dialog</Button>
         </DialogTrigger>
-        <DialogSurface aria-label="label">
+        <DialogSurface>
           <DialogTitle>Alert dialog title</DialogTitle>
           <DialogBody>
             This dialog cannot be dismissed by clicking on the overlay nor by pressing Escape. Close button should be

--- a/packages/react-components/react-dialog/src/stories/DialogBestPractices.md
+++ b/packages/react-components/react-dialog/src/stories/DialogBestPractices.md
@@ -8,10 +8,12 @@
 - Dialog boxes consist of a header (`DialogTitle`), body (`DialogBody`), and footer (`DialogActions`).
 - Validate that people’s entries are acceptable before closing the dialog. Show an inline validation error near the field they must correct.
 - Modal dialogs should be used very sparingly—only when it’s critical that people make a choice or provide information before they can proceed. Thee dialogs are generally used for irreversible or potentially destructive tasks. They’re typically paired with an overlay without a light dismiss.
+- `DialogSurface` by default has `aria-describedby="dialog-body-id"`, which might not be ideal with complex `DialogBody`, on those scenarios, it is recommended to set `aria-describedby={null}`
 
 ### Don't
 
 - Don't use more than three buttons between `DialogActions`.
 - Don't open a Dialog from a Dialog
 - Don't use a Dialog with no focusable elements
+
 </details>

--- a/packages/react-components/react-dialog/src/stories/DialogChangeFocus.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogChangeFocus.stories.tsx
@@ -16,7 +16,7 @@ export const CustomFocusedElementOnOpen = () => {
         <DialogTrigger>
           <Button>Open dialog</Button>
         </DialogTrigger>
-        <DialogSurface aria-label="label">
+        <DialogSurface>
           <DialogTitle>Dialog title</DialogTitle>
           <DialogBody>This dialog focus on the second button instead of the first</DialogBody>
           <DialogActions position="start">

--- a/packages/react-components/react-dialog/src/stories/DialogControllingOpenAndClose.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogControllingOpenAndClose.stories.tsx
@@ -11,7 +11,7 @@ export const ControllingOpenAndClose = () => {
         <DialogTrigger>
           <Button>Open dialog</Button>
         </DialogTrigger>
-        <DialogSurface aria-label="label">
+        <DialogSurface>
           <DialogTitle>Dialog title</DialogTitle>
           <DialogBody>
             Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque

--- a/packages/react-components/react-dialog/src/stories/DialogCustomTrigger.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogCustomTrigger.stories.tsx
@@ -18,7 +18,7 @@ export const CustomTrigger = () => {
       <DialogTrigger>
         <CustomDialogTrigger />
       </DialogTrigger>
-      <DialogSurface aria-label="label">
+      <DialogSurface>
         <DialogTitle>Dialog title</DialogTitle>
         <DialogBody>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque est

--- a/packages/react-components/react-dialog/src/stories/DialogDefault.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogDefault.stories.tsx
@@ -9,7 +9,7 @@ export const Default = () => {
         <DialogTrigger>
           <Button>Open dialog</Button>
         </DialogTrigger>
-        <DialogSurface aria-label="label">
+        <DialogSurface>
           <DialogTitle>Dialog title</DialogTitle>
           <DialogBody>
             Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque

--- a/packages/react-components/react-dialog/src/stories/DialogNested.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogNested.stories.tsx
@@ -8,14 +8,14 @@ export const Nested = () => {
       <DialogTrigger>
         <Button>Open dialog</Button>
       </DialogTrigger>
-      <DialogSurface aria-label="label">
+      <DialogSurface>
         <DialogTitle>Dialog title</DialogTitle>
         <DialogActions>
           <Dialog>
             <DialogTrigger>
               <Button appearance="primary">Open inner dialog</Button>
             </DialogTrigger>
-            <DialogSurface aria-label="label">
+            <DialogSurface>
               <DialogTitle>Inner dialog title</DialogTitle>
               <DialogBody>⚠️ just because you can doesn't mean you should have nested dialogs ⚠️</DialogBody>
               <DialogActions>

--- a/packages/react-components/react-dialog/src/stories/DialogNoFocusableElement.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogNoFocusableElement.stories.tsx
@@ -9,7 +9,7 @@ export const NoFocusableElement = () => {
         <DialogTrigger>
           <Button>Open modal dialog</Button>
         </DialogTrigger>
-        <DialogSurface aria-label="label">
+        <DialogSurface>
           <DialogTitle>Dialog Title</DialogTitle>
           <DialogBody>
             <p>⚠️A Dialog without focusable elements is not recommended!⚠️</p>
@@ -21,7 +21,7 @@ export const NoFocusableElement = () => {
         <DialogTrigger>
           <Button>Open non-modal dialog</Button>
         </DialogTrigger>
-        <DialogSurface aria-label="label">
+        <DialogSurface>
           <DialogTitle closeButton={null}>Dialog Title</DialogTitle>
           <DialogBody>
             <p>⚠️A Dialog without focusable elements is not recommended!⚠️</p>

--- a/packages/react-components/react-dialog/src/stories/DialogNonModal.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogNonModal.stories.tsx
@@ -9,7 +9,7 @@ export const NonModal = () => {
       <DialogTrigger>
         <Button>Open non-modal dialog</Button>
       </DialogTrigger>
-      <DialogSurface aria-label="label">
+      <DialogSurface>
         <DialogTitle>Non-modal dialog title</DialogTitle>
         <DialogBody>
           Lorem, ipsum dolor sit amet consectetur adipisicing elit. Aliquid, explicabo repudiandae impedit doloribus

--- a/packages/react-components/react-dialog/src/stories/DialogTriggerOutsideDialog.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogTriggerOutsideDialog.stories.tsx
@@ -11,7 +11,7 @@ export const TriggerOutsideDialog = () => {
         <Button onClick={() => setOpen(true)}>Open Dialog</Button>
       </DialogTrigger>
       <Dialog open={open} onOpenChange={(event, data) => setOpen(data.open)}>
-        <DialogSurface aria-label="label">
+        <DialogSurface>
           <DialogTitle>Dialog title</DialogTitle>
           <DialogBody>
             Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

1. Adds `aria-labelledby` prop to `DialogSurface` with default `id` pointing to `DialogTitle`
2. Adds `aria-describedby` prop to `DialogSurface` with default `id` pointing to `DialogBody`
3. Adds best practices to disable `aria-describedby` in cases of complex `DialogBody`

