### PR TITLE
fix(react-dialog): converts Dialog stories to Preview Components

### DIFF
--- a/change/@fluentui-react-dialog-d2597139-d638-4882-98bd-d15e7035b8e6.json
+++ b/change/@fluentui-react-dialog-d2597139-d638-4882-98bd-d15e7035b8e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(react-dialog): converts Dialog stories to Preview Components",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-dialog/src/stories/DialogAlert.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogAlert.stories.tsx
@@ -5,26 +5,24 @@ import story from './DialogAlert.md';
 
 export const AlertDialog = () => {
   return (
-    <>
-      <Dialog modalType="alert">
-        <DialogTrigger>
-          <Button>Open Alert dialog</Button>
-        </DialogTrigger>
-        <DialogSurface>
-          <DialogTitle>Alert dialog title</DialogTitle>
-          <DialogBody>
-            This dialog cannot be dismissed by clicking on the overlay nor by pressing Escape. Close button should be
-            pressed to dismiss this Alert
-          </DialogBody>
-          <DialogActions>
-            <DialogTrigger>
-              <Button appearance="secondary">Close</Button>
-            </DialogTrigger>
-            <Button appearance="primary">Do Something</Button>
-          </DialogActions>
-        </DialogSurface>
-      </Dialog>
-    </>
+    <Dialog modalType="alert">
+      <DialogTrigger>
+        <Button>Open Alert dialog</Button>
+      </DialogTrigger>
+      <DialogSurface aria-label="label">
+        <DialogTitle>Alert dialog title</DialogTitle>
+        <DialogBody>
+          This dialog cannot be dismissed by clicking on the overlay nor by pressing Escape. Close button should be
+          pressed to dismiss this Alert
+        </DialogBody>
+        <DialogActions>
+          <DialogTrigger>
+            <Button appearance="secondary">Close</Button>
+          </DialogTrigger>
+          <Button appearance="primary">Do Something</Button>
+        </DialogActions>
+      </DialogSurface>
+    </Dialog>
   );
 };
 

--- a/packages/react-components/react-dialog/src/stories/DialogChangeFocus.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogChangeFocus.stories.tsx
@@ -11,28 +11,26 @@ export const CustomFocusedElementOnOpen = () => {
     }
   }, [open]);
   return (
-    <>
-      <Dialog open={open} onOpenChange={(event, data) => setOpen(data.open)}>
-        <DialogTrigger>
-          <Button>Open dialog</Button>
-        </DialogTrigger>
-        <DialogSurface>
-          <DialogTitle>Dialog title</DialogTitle>
-          <DialogBody>This dialog focus on the second button instead of the first</DialogBody>
-          <DialogActions position="start">
-            <Button appearance="outline">Third Action</Button>
-          </DialogActions>
-          <DialogActions position="end">
-            <DialogTrigger>
-              <Button ref={buttonRef} appearance="secondary">
-                Close
-              </Button>
-            </DialogTrigger>
-            <Button appearance="primary">Do Something</Button>
-          </DialogActions>
-        </DialogSurface>
-      </Dialog>
-    </>
+    <Dialog open={open} onOpenChange={(event, data) => setOpen(data.open)}>
+      <DialogTrigger>
+        <Button>Open dialog</Button>
+      </DialogTrigger>
+      <DialogSurface aria-label="label">
+        <DialogTitle>Dialog title</DialogTitle>
+        <DialogBody>This dialog focus on the second button instead of the first</DialogBody>
+        <DialogActions position="start">
+          <Button appearance="outline">Third Action</Button>
+        </DialogActions>
+        <DialogActions position="end">
+          <DialogTrigger>
+            <Button ref={buttonRef} appearance="secondary">
+              Close
+            </Button>
+          </DialogTrigger>
+          <Button appearance="primary">Do Something</Button>
+        </DialogActions>
+      </DialogSurface>
+    </Dialog>
   );
 };
 

--- a/packages/react-components/react-dialog/src/stories/DialogControllingOpenAndClose.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogControllingOpenAndClose.stories.tsx
@@ -6,27 +6,25 @@ import story from './DialogControllingOpenAndClose.md';
 export const ControllingOpenAndClose = () => {
   const [open, setOpen] = React.useState(false);
   return (
-    <>
-      <Dialog open={open} onOpenChange={(event, data) => setOpen(data.open)}>
-        <DialogTrigger>
-          <Button>Open dialog</Button>
-        </DialogTrigger>
-        <DialogSurface>
-          <DialogTitle>Dialog title</DialogTitle>
-          <DialogBody>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque
-            est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure
-            cumque eaque?
-          </DialogBody>
-          <DialogActions>
-            <DialogTrigger>
-              <Button appearance="secondary">Close</Button>
-            </DialogTrigger>
-            <Button appearance="primary">Do Something</Button>
-          </DialogActions>
-        </DialogSurface>
-      </Dialog>
-    </>
+    <Dialog open={open} onOpenChange={(event, data) => setOpen(data.open)}>
+      <DialogTrigger>
+        <Button>Open dialog</Button>
+      </DialogTrigger>
+      <DialogSurface aria-label="label">
+        <DialogTitle>Dialog title</DialogTitle>
+        <DialogBody>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque est
+          dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure cumque
+          eaque?
+        </DialogBody>
+        <DialogActions>
+          <DialogTrigger>
+            <Button appearance="secondary">Close</Button>
+          </DialogTrigger>
+          <Button appearance="primary">Do Something</Button>
+        </DialogActions>
+      </DialogSurface>
+    </Dialog>
   );
 };
 

--- a/packages/react-components/react-dialog/src/stories/DialogDefault.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/DialogDefault.stories.tsx
@@ -4,26 +4,24 @@ import { Button } from '@fluentui/react-components';
 
 export const Default = () => {
   return (
-    <>
-      <Dialog>
-        <DialogTrigger>
-          <Button>Open dialog</Button>
-        </DialogTrigger>
-        <DialogSurface>
-          <DialogTitle>Dialog title</DialogTitle>
-          <DialogBody>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque
-            est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure
-            cumque eaque?
-          </DialogBody>
-          <DialogActions>
-            <DialogTrigger>
-              <Button appearance="secondary">Close</Button>
-            </DialogTrigger>
-            <Button appearance="primary">Do Something</Button>
-          </DialogActions>
-        </DialogSurface>
-      </Dialog>
-    </>
+    <Dialog>
+      <DialogTrigger>
+        <Button>Open dialog</Button>
+      </DialogTrigger>
+      <DialogSurface aria-label="label">
+        <DialogTitle>Dialog title</DialogTitle>
+        <DialogBody>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque est
+          dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure cumque
+          eaque?
+        </DialogBody>
+        <DialogActions>
+          <DialogTrigger>
+            <Button appearance="secondary">Close</Button>
+          </DialogTrigger>
+          <Button appearance="primary">Do Something</Button>
+        </DialogActions>
+      </DialogSurface>
+    </Dialog>
   );
 };

--- a/packages/react-components/react-dialog/src/stories/DialogDescription.md
+++ b/packages/react-components/react-dialog/src/stories/DialogDescription.md
@@ -1,1 +1,21 @@
+<!-- Don't allow prettier to collapse code block into single line -->
+<!-- prettier-ignore -->
+> **⚠️ Preview components are considered unstable:**
+>
+> ```jsx
+>
+> import {
+>  Dialog,
+>  DialogBody,
+>  DialogTitle,
+>  DialogSurface,
+>  DialogActions,
+>  DialogTrigger,
+> } from '@fluentui/react-components/unstable';
+>
+> ```
+>
+> - Features and APIs may change before final release
+> - Please contact us if you intend to use this in your product
+
 `Dialog` is a window overlaid on either the primary window or another dialog window. Windows under a modal dialog are inert. That is, users cannot interact with content outside an active dialog window. Inert content outside an active dialog is typically visually obscured or dimmed so it is difficult to discern, and in some implementations, attempts to interact with the inert content cause the dialog to close.

--- a/packages/react-components/react-dialog/src/stories/index.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/index.stories.tsx
@@ -14,7 +14,7 @@ export { TriggerOutsideDialog } from './DialogTriggerOutsideDialog.stories';
 export { CustomTrigger } from './DialogCustomTrigger.stories';
 
 export default {
-  title: 'Components/Dialog',
+  title: 'Preview Components/Dialog',
   component: Dialog,
   parameters: {
     docs: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Addresses: https://github.com/microsoft/fluentui/pull/24140#issuecomment-1199229666, as `Dialog` is still unstable and should be in `Preview Components` and no `Components` documentation.
