### PR TITLE
react-combobox: open/close combobox on chevron icon click

### DIFF
--- a/change/@fluentui-react-combobox-ad1b9fd3-1e90-4f60-969e-85774341c610.json
+++ b/change/@fluentui-react-combobox-ad1b9fd3-1e90-4f60-969e-85774341c610.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: open/close combobox on icon click",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -103,6 +103,36 @@ describe('Combobox', () => {
     expect(combobox.getAttribute('aria-expanded')).toEqual('false');
   });
 
+  it('opens the popup on expand icon click', () => {
+    const { getByRole, getByTestId } = render(
+      <Combobox expandIcon={{ 'data-testid': 'icon' } as React.HTMLAttributes<HTMLSpanElement>}>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+
+    fireEvent.click(getByTestId('icon'));
+
+    expect(getByRole('listbox')).not.toBeNull();
+  });
+
+  it('closes the popup on expand icon click', () => {
+    const { getByRole, getByTestId, queryByRole } = render(
+      <Combobox defaultOpen expandIcon={{ 'data-testid': 'icon' } as React.HTMLAttributes<HTMLSpanElement>}>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+
+    fireEvent.mouseDown(getByTestId('icon'));
+    fireEvent.blur(getByRole('combobox'));
+    fireEvent.click(getByTestId('icon'));
+
+    expect(queryByRole('listbox')).toBeNull();
+  });
+
   it('does not close the combobox on click with controlled open', () => {
     const { getByRole } = render(
       <Combobox open>

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -75,18 +75,22 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     ...baseState,
   };
 
+  /* handle open/close + focus change when clicking expandIcon */
+  const { onMouseDown: onIconMouseDown, onClick: onIconClick } = state.expandIcon || {};
+  const onExpandIconMouseDown = useMergedEventCallbacks(onIconMouseDown, () => {
+    // do not dismiss on blur when clicking the icon
+    baseState.ignoreNextBlur.current = true;
+  });
+
+  const onExpandIconClick = useMergedEventCallbacks(onIconClick, (event: React.MouseEvent<HTMLSpanElement>) => {
+    // open and set focus
+    state.setOpen(event, !state.open);
+    triggerRef.current?.focus();
+  });
+
   if (state.expandIcon) {
-    const { onMouseDown: onIconMouseDown, onClick: onIconClick } = state.expandIcon;
-
-    state.expandIcon.onMouseDown = useMergedEventCallbacks(onIconMouseDown, () => {
-      // do not dismiss on blur when clicking the icon
-      baseState.ignoreNextBlur.current = true;
-    });
-
-    state.expandIcon.onClick = useMergedEventCallbacks(onIconClick, (event: React.MouseEvent<HTMLSpanElement>) => {
-      state.setOpen(event, !state.open);
-      triggerRef.current?.focus();
-    });
+    state.expandIcon.onMouseDown = onExpandIconMouseDown;
+    state.expandIcon.onClick = onExpandIconClick;
   }
 
   return state;

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -6,6 +6,7 @@ import { useTriggerListboxSlots } from '../../utils/useTriggerListboxSlots';
 import { useComboboxPopup } from '../../utils/useComboboxPopup';
 import { Listbox } from '../Listbox/Listbox';
 import type { ComboboxProps, ComboboxState } from './Combobox.types';
+import { useMergedRefs } from '@fluentui/react-utilities';
 
 /**
  * Create the state required to render Combobox.
@@ -25,12 +26,15 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     excludedPropNames: ['children', 'size'],
   });
 
+  const triggerRef = React.useRef<HTMLInputElement>(null);
+
   const triggerShorthand = resolveShorthand(props.input, {
     required: true,
     defaultProps: {
       onChange: () => {
         /* Combobox does not yet support allowFreeForm */
       },
+      ref: useMergedRefs(props.input?.ref, triggerRef),
       type: 'text',
       value: baseState.value,
       ...triggerNativeProps,
@@ -66,6 +70,24 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     }),
     ...baseState,
   };
+
+  if (state.expandIcon) {
+    const { onMouseDown: onIconMouseDown, onClick: onIconClick } = state.expandIcon;
+
+    state.expandIcon.onMouseDown = (event: React.MouseEvent<HTMLSpanElement>) => {
+      // do not dismiss on blur when clicking the icon
+      baseState.ignoreNextBlur.current = true;
+
+      onIconMouseDown?.(event);
+    };
+
+    state.expandIcon.onClick = (event: React.MouseEvent<HTMLSpanElement>) => {
+      state.setOpen(event, !state.open);
+      triggerRef.current?.focus();
+
+      onIconClick?.(event);
+    };
+  }
 
   return state;
 };

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import { ChevronDownRegular as ChevronDownIcon } from '@fluentui/react-icons';
-import { getPartitionedNativeProps, resolveShorthand } from '@fluentui/react-utilities';
+import {
+  getPartitionedNativeProps,
+  resolveShorthand,
+  useMergedEventCallbacks,
+  useMergedRefs,
+} from '@fluentui/react-utilities';
 import { useComboboxBaseState } from '../../utils/useComboboxBaseState';
 import { useTriggerListboxSlots } from '../../utils/useTriggerListboxSlots';
 import { useComboboxPopup } from '../../utils/useComboboxPopup';
 import { Listbox } from '../Listbox/Listbox';
 import type { ComboboxProps, ComboboxState } from './Combobox.types';
-import { useMergedRefs } from '@fluentui/react-utilities';
 
 /**
  * Create the state required to render Combobox.
@@ -74,19 +78,15 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   if (state.expandIcon) {
     const { onMouseDown: onIconMouseDown, onClick: onIconClick } = state.expandIcon;
 
-    state.expandIcon.onMouseDown = (event: React.MouseEvent<HTMLSpanElement>) => {
+    state.expandIcon.onMouseDown = useMergedEventCallbacks(onIconMouseDown, () => {
       // do not dismiss on blur when clicking the icon
       baseState.ignoreNextBlur.current = true;
+    });
 
-      onIconMouseDown?.(event);
-    };
-
-    state.expandIcon.onClick = (event: React.MouseEvent<HTMLSpanElement>) => {
+    state.expandIcon.onClick = useMergedEventCallbacks(onIconClick, (event: React.MouseEvent<HTMLSpanElement>) => {
       state.setOpen(event, !state.open);
       triggerRef.current?.focus();
-
-      onIconClick?.(event);
-    };
+    });
   }
 
   return state;

--- a/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
@@ -77,6 +77,9 @@ export type ComboboxBaseState = Required<Pick<ComboboxBaseProps, 'appearance' | 
     /* Option data for the currently highlighted option (not the selected option) */
     activeOption?: OptionValue;
 
+    /* Whether the next blur event should be ignored, and the combobox/dropdown will not close.*/
+    ignoreNextBlur: React.MutableRefObject<boolean>;
+
     /* Callback when an option is clicked, for internal use */
     onOptionClick(event: React.MouseEvent, option: OptionValue): void;
 

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -17,6 +17,8 @@ export const useComboboxBaseState = (props: ComboboxBaseProps) => {
   const [activeOption, setActiveOption] = React.useState<OptionValue | undefined>();
   const { selectedOptions, selectOption } = useSelection(props);
 
+  const ignoreNextBlur = React.useRef(false);
+
   // update value based on selectedOptions
   const isFirstMount = useFirstMount();
   const value = React.useMemo(() => {
@@ -85,6 +87,7 @@ export const useComboboxBaseState = (props: ComboboxBaseProps) => {
     ...optionCollection,
     activeOption,
     appearance,
+    ignoreNextBlur,
     inlinePopup,
     onOptionClick,
     open,

--- a/packages/react-components/react-combobox/src/utils/useTriggerListboxSlots.ts
+++ b/packages/react-components/react-combobox/src/utils/useTriggerListboxSlots.ts
@@ -38,6 +38,7 @@ export function useTriggerListboxSlots(
     getCount,
     getIndexOfId,
     getOptionAtIndex,
+    ignoreNextBlur,
     open,
     selectOption,
     setActiveOption,
@@ -46,7 +47,6 @@ export function useTriggerListboxSlots(
 
   // handle trigger focus/blur
   const triggerRef: typeof ref = React.useRef(null);
-  const ignoreTriggerBlur = React.useRef(false);
 
   // resolve listbox shorthand props
   const listbox: typeof listboxSlot = {
@@ -80,7 +80,7 @@ export function useTriggerListboxSlots(
   };
 
   listbox.onMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
-    ignoreTriggerBlur.current = true;
+    ignoreNextBlur.current = true;
 
     onListboxMouseDown?.(event);
   };
@@ -88,11 +88,11 @@ export function useTriggerListboxSlots(
   // the trigger should open/close the popup on click or blur
   const { onBlur: onTriggerBlur, onClick: onTriggerClick, onKeyDown: onTriggerKeyDown } = trigger;
   trigger.onBlur = (event: React.FocusEvent<HTMLButtonElement> & React.FocusEvent<HTMLInputElement>) => {
-    if (!ignoreTriggerBlur.current) {
+    if (!ignoreNextBlur.current) {
       setOpen(event, false);
     }
 
-    ignoreTriggerBlur.current = false;
+    ignoreNextBlur.current = false;
 
     onTriggerBlur?.(event);
   };


### PR DESCRIPTION
Updates Combobox to open/close on chevron click. To do so, I moved `ignoreTriggerBlur` to state, so it can be used outside the `useTriggerListboxSlots` hook.